### PR TITLE
fix(devtools): stop second component tree traversal, if devtools meta…

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
@@ -11,9 +11,10 @@ import {getInjectorFromElementNode, getRootElements} from './component-tree';
 
 type Ng = ɵGlobalDevModeUtils['ng'];
 const NG_VERSION = 'ng-version';
+const VERSION = '0.0.0-PLACEHOLDER';
 
 function setNgVersion(element: Element) {
-  element.setAttribute(NG_VERSION, '');
+  element.setAttribute(NG_VERSION, VERSION);
 }
 
 function createRoot() {

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
@@ -7,9 +7,20 @@
  */
 
 import {Injector, ɵGlobalDevModeUtils} from '@angular/core';
-import {getInjectorFromElementNode} from './component-tree';
+import {getInjectorFromElementNode, getRootElements} from './component-tree';
 
 type Ng = ɵGlobalDevModeUtils['ng'];
+const NG_VERSION = 'ng-version';
+
+function setNgVersion(element: Element) {
+  element.setAttribute(NG_VERSION, '');
+}
+
+function createRoot() {
+  const root = document.createElement('div');
+  setNgVersion(root);
+  return root;
+}
 
 describe('component-tree', () => {
   afterEach(() => {
@@ -37,6 +48,57 @@ describe('component-tree', () => {
 
       const el = document.createElement('div');
       expect(getInjectorFromElementNode(el)).toBeNull();
+    });
+  });
+
+  describe('getRootElements', () => {
+    beforeEach(() => {
+      const ng: Partial<Ng> = {
+        getComponent: jasmine.createSpy('getComponent').and.returnValue({}),
+      };
+      (window as any).ng = ng;
+    });
+
+    afterEach(() => {
+      document.body.replaceChildren();
+      document.body.removeAttribute(NG_VERSION);
+      delete (window as any).ng;
+    });
+
+    it('should return root element', () => {
+      const rootElement = createRoot();
+      const childElement = createRoot();
+
+      rootElement.appendChild(childElement);
+      document.body.appendChild(rootElement);
+
+      const roots = getRootElements();
+
+      expect(roots.length).toEqual(1);
+      expect(roots.pop()).toEqual(rootElement);
+    });
+
+    it('should return multiple sibling roots', () => {
+      const firstRoot = createRoot();
+      const secondRoot = createRoot();
+
+      document.body.appendChild(firstRoot);
+      document.body.appendChild(secondRoot);
+
+      const roots = getRootElements();
+
+      expect(roots.length).toEqual(2);
+      expect(roots).toContain(firstRoot);
+      expect(roots).toContain(secondRoot);
+    });
+
+    it('should only return document.body when document.body is the root', () => {
+      setNgVersion(document.body);
+      const child1 = createRoot();
+      document.body.appendChild(child1);
+      const roots = getRootElements();
+      expect(roots.length).toEqual(1);
+      expect(roots).toContain(document.body);
     });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -552,7 +552,8 @@ const getRootLViewsHelper = (element: Element, rootLViews = new Set<any>()): Set
   return rootLViews;
 };
 
-function getRootElements(): Element[] {
+/** Gets the all the root components in the Dom, including those outside the application root */
+export function getRootElements(): Element[] {
   if (!ngDebugClient().getComponent) {
     // If the ngDebugClient does not support getComponent, we cannot proceed.
     return [];
@@ -631,6 +632,9 @@ function getRootElements(): Element[] {
  * @param roots A set of root elements found during the traversal.
  */
 function discoverNonApplicationRootComponents(element: Element, roots: Set<Element>): void {
+  if (roots.has(element)) {
+    return;
+  }
   const children = Array.from(element.children);
   for (const child of children) {
     if (roots.has(child)) {


### PR DESCRIPTION
…data is placed on the body tag

Stop multiple component tree traversals if the app root is the body tag. This caused the devtools ui to duplicate the component information, if the app root was the body tag. SFCs used the document.body as the app root because there is not concept of an app root in SFCs. This change makes the devtools ui display the component tree correctly when the app root is document.body.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The dom will be traversed twice if the app root is document.body

Issue Number: N/A


## What is the new behavior?

The dom will only be traversed once if the app root is document.body


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
