### PR TITLE
feat(core): Support optional timeout for idle deferred triggers

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -207,7 +207,18 @@ export class BoundDeferredTrigger extends DeferredTrigger {
 
 export class NeverDeferredTrigger extends DeferredTrigger {}
 
-export class IdleDeferredTrigger extends DeferredTrigger {}
+export class IdleDeferredTrigger extends DeferredTrigger {
+  constructor(
+    nameSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan,
+    prefetchSpan: ParseSourceSpan | null,
+    onSourceSpan: ParseSourceSpan | null,
+    hydrateSpan: ParseSourceSpan | null,
+    public timeout: number | null,
+  ) {
+    super(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  }
+}
 
 export class ImmediateDeferredTrigger extends DeferredTrigger {}
 

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -458,11 +458,26 @@ function createIdleTrigger(
   onSourceSpan: ParseSourceSpan | null,
   hydrateSpan: ParseSourceSpan | null,
 ): t.IdleDeferredTrigger {
-  if (parameters.length > 0) {
-    throw new Error(`"${OnTriggerType.IDLE}" trigger cannot have parameters`);
+  if (parameters.length > 1) {
+    throw new Error(`"${OnTriggerType.IDLE}" trigger can only have zero or one parameters`);
   }
 
-  return new t.IdleDeferredTrigger(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  let timeout: number | null = null;
+  if (parameters[0]) {
+    timeout = parseDeferredTime(parameters[0]);
+    if (timeout === null) {
+      throw new Error(`Could not parse time value of trigger "${OnTriggerType.IDLE}"`);
+    }
+  }
+
+  return new t.IdleDeferredTrigger(
+    nameSpan,
+    sourceSpan,
+    prefetchSpan,
+    onSourceSpan,
+    hydrateSpan,
+    timeout,
+  );
 }
 
 function createTimerTrigger(

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1381,6 +1381,8 @@ interface DeferTriggerWithTargetBase extends DeferTriggerBase {
 
 interface DeferIdleTrigger extends DeferTriggerBase {
   kind: DeferTriggerKind.Idle;
+
+  timeout: number | null;
 }
 
 interface DeferImmediateTrigger extends DeferTriggerBase {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -754,7 +754,7 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
     deferOnOps.push(
       ir.createDeferOnOp(
         deferXref,
-        {kind: ir.DeferTriggerKind.Idle},
+        {kind: ir.DeferTriggerKind.Idle, timeout: null},
         ir.DeferOpModifierKind.NONE,
         null!,
       ),
@@ -783,7 +783,7 @@ function ingestDeferTriggers(
   if (triggers.idle !== undefined) {
     const deferOnOp = ir.createDeferOnOp(
       deferXref,
-      {kind: ir.DeferTriggerKind.Idle},
+      {kind: ir.DeferTriggerKind.Idle, timeout: triggers.idle.timeout ?? null},
       modifier,
       triggers.idle.sourceSpan,
     );

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -378,11 +378,16 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         let args: (number | null)[] = [];
         switch (op.trigger.kind) {
           case ir.DeferTriggerKind.Never:
-          case ir.DeferTriggerKind.Idle:
           case ir.DeferTriggerKind.Immediate:
             break;
+          case ir.DeferTriggerKind.Idle:
+            // Use timeout if specified, otherwise default to null to preserve normal behavior on IDLE
+            args = [op.trigger.timeout ?? null];
+            break;
+
           case ir.DeferTriggerKind.Timer:
             args = [op.trigger.delay];
+
             break;
           case ir.DeferTriggerKind.Interaction:
           case ir.DeferTriggerKind.Hover:

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -144,7 +144,13 @@ class R3AstHumanizer implements t.Visitor<void> {
     } else if (trigger instanceof t.HoverDeferredTrigger) {
       this.result.push(['HoverDeferredTrigger', trigger.reference]);
     } else if (trigger instanceof t.IdleDeferredTrigger) {
-      this.result.push(['IdleDeferredTrigger']);
+      // Idle triggers may optionally include a delay. Preserve previous
+      // behavior of only reporting the trigger name when no delay is set.
+      if ((trigger as t.IdleDeferredTrigger).timeout != null) {
+        this.result.push(['IdleDeferredTrigger', (trigger as t.IdleDeferredTrigger).timeout]);
+      } else {
+        this.result.push(['IdleDeferredTrigger']);
+      }
     } else if (trigger instanceof t.TimerDeferredTrigger) {
       this.result.push(['TimerDeferredTrigger', trigger.delay]);
     } else if (trigger instanceof t.InteractionDeferredTrigger) {
@@ -1187,6 +1193,28 @@ describe('R3 template transform', () => {
       ]);
     });
 
+    it('should parse prefetch `on idle(100)` trigger and preserve timeout', () => {
+      const html = '@defer (on idle; prefetch on idle(100)){hello}';
+
+      expectFromHtml(html).toEqual([
+        ['DeferredBlock'],
+        ['IdleDeferredTrigger'],
+        ['IdleDeferredTrigger', 100],
+        ['Text', 'hello'],
+      ]);
+    });
+
+    it('should parse hydrate `on idle(100)` trigger and preserve timeout', () => {
+      const html = '@defer (on idle; hydrate on idle(100)){hello}';
+
+      expectFromHtml(html).toEqual([
+        ['DeferredBlock'],
+        ['IdleDeferredTrigger', 100],
+        ['IdleDeferredTrigger'],
+        ['Text', 'hello'],
+      ]);
+    });
+
     it('should allow arbitrary number of spaces after the `prefetch` keyword', () => {
       const html =
         '@defer (on idle; prefetch         on viewport(button), hover(button); prefetch    when shouldPrefetch()){hello}';
@@ -1456,9 +1484,23 @@ describe('R3 template transform', () => {
         expect(() => parse('@defer (on viewport[]) {hello}')).toThrowError(/Unexpected token/);
       });
 
-      it('should report if parameters are passed to `idle` trigger', () => {
-        expect(() => parse('@defer (on idle(1)) {hello}')).toThrowError(
-          /"idle" trigger cannot have parameters/,
+      it('should allow optional parameter on `idle` trigger and parse timeout', () => {
+        expectFromHtml('@defer (on idle(1)) {hello}').toEqual([
+          ['DeferredBlock'],
+          ['IdleDeferredTrigger', 1],
+          ['Text', 'hello'],
+        ]);
+      });
+
+      it('should report if `idle` trigger value cannot be parsed', () => {
+        expect(() => parse('@defer (on idle(123abc)) {hello}')).toThrowError(
+          /Could not parse time value of trigger "idle"/,
+        );
+      });
+
+      it('should report if `idle` trigger has more than one parameter', () => {
+        expect(() => parse('@defer (on idle(a, b)) {hello}')).toThrowError(
+          /"idle" trigger can only have zero or one parameters/,
         );
       });
 

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -29,7 +29,7 @@ import {performanceMarkFeature} from '../util/performance';
 import {invokeAllTriggerCleanupFns, storeTriggerCleanupFn} from './cleanup';
 import {onViewportWrapper, registerDomTrigger} from './dom_triggers';
 import {onHover, onInteraction} from '../../primitives/defer/src/triggers';
-import {onIdle} from './idle_scheduler';
+import {onIdleWrapper} from './idle_scheduler';
 import {
   DEFER_BLOCK_STATE,
   DeferBlockInternalState,
@@ -361,46 +361,48 @@ export function ɵɵdeferHydrateNever() {
  * Sets up logic to handle the `on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferOnIdle() {
+export function ɵɵdeferOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
-
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'on idle');
+    const expression = timeout ? `on idle(${timeout})` : 'on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
-  scheduleDelayedTrigger(onIdle);
+  scheduleDelayedTrigger(onIdleWrapper({timeout}));
 }
 
 /**
  * Sets up logic to handle the `prefetch on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferPrefetchOnIdle() {
+export function ɵɵdeferPrefetchOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'prefetch on idle');
+    const expression = timeout ? `prefetch on idle(${timeout})` : 'prefetch on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
-  scheduleDelayedPrefetching(onIdle, DeferBlockTrigger.Idle);
+  scheduleDelayedPrefetching(onIdleWrapper({timeout}), DeferBlockTrigger.Idle);
 }
 
 /**
  * Sets up logic to handle the `on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferHydrateOnIdle() {
+export function ɵɵdeferHydrateOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on idle');
+    const expression = timeout ? `hydrate on idle(${timeout})` : 'hydrate on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
@@ -412,7 +414,7 @@ export function ɵɵdeferHydrateOnIdle() {
     // We are on the server and SSR for defer blocks is enabled.
     triggerDeferBlock(TriggerType.Hydrate, lView, tNode);
   } else {
-    scheduleDelayedHydrating(onIdle, lView, tNode);
+    scheduleDelayedHydrating(onIdleWrapper({timeout}), lView, tNode);
   }
 }
 

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -58,6 +58,7 @@
       "shimStylesContent"
     ],
     "lazy": [
+      "DeferComponent",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS",
       "APP_BOOTSTRAP_LISTENER",
@@ -744,8 +745,7 @@
       "wasLastNodeCreated",
       "writeDirectClass",
       "writeDirectStyle",
-      "writeToDirectiveInput",
-      "DeferComponent"
+      "writeToDirectiveInput"
     ]
   }
 }


### PR DESCRIPTION
This change allows developers to supply a timeout value in the `on idle` trigger of an Angular `@defer` block, which translates into passing the `timeout` option to `requestIdleCallback`. That way, if the browser doesn’t schedule the callback soon enough, the work will run no later than the specified timeout ([MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#options)).

## Benefits 
- **Predictable execution**: Ensures deferred blocks run even when the browser never enters an idle state due to heavy workloads (e.g., apps using **Three.js**, animations, or large computations).  
- **Graceful fallback**: Provides a safety net so work is executed within the timeout even if idle periods never occur.  
- **Better user experience**: Prevents critical UI from being postponed indefinitely in busy rendering or computation scenarios.  
- **Standards alignment**: Matches the native `requestIdleCallback` behavior developers are familiar with.


### Usage
```html
@defer (on idle(500)) {
  <heavy-component />
}

@defer (prefetch on idle(500)) {
  <heavy-component />
}

@defer (hydrate on idle(500)) {
  <heavy-component />
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Another alternative is to allow an object as a configuration like the following, I'm not sure considering that currently there is only `timeout` as an option


```html
@defer (on idle({ timeout : 500 })) {
  <heavy-component />
}
```