### PR TITLE
docs: update APF docs for new `.d.ts` layout

### DIFF
--- a/adev/src/content/tools/libraries/angular-package-format.md
+++ b/adev/src/content/tools/libraries/angular-package-format.md
@@ -28,14 +28,14 @@ The following example shows a simplified version of the `@angular/core` package'
 node_modules/@angular/core
 ├── README.md
 ├── package.json
-├── index.d.ts
 ├── fesm2022
 │   ├── core.mjs
 │   ├── core.mjs.map
 │   ├── testing.mjs
 │   └── testing.mjs.map
-└── testing
-    └── index.d.ts
+└── types
+│   ├── core.d.ts
+│   ├── testing.d.ts
 ```
 
 This table describes the file layout under `node_modules/@angular/core` annotated to describe the purpose of files and directories:
@@ -44,10 +44,8 @@ This table describes the file layout under `node_modules/@angular/core` annotate
 |:---                                                                                                                                                       |:---     |
 | `README.md`                                                                                                                                               | Package README, used by npmjs web UI.                                                                                                                                                                          |
 | `package.json`                                                                                                                                            | Primary `package.json`, describing the package itself as well as all available entrypoints and code formats. This file contains the "exports" mapping used by runtimes and tools to perform module resolution. |
-| `index.d.ts`                                                                                                                                               | Bundled `.d.ts` for the primary entrypoint `@angular/core`.                                                                                                                                                    |
 | `fesm2022/` <br /> &nbsp;&nbsp;─ `core.mjs` <br /> &nbsp;&nbsp;─ `core.mjs.map` <br /> &nbsp;&nbsp;─ `testing.mjs` <br /> &nbsp;&nbsp;─ `testing.mjs.map` | Code for all entrypoints in flattened \(FESM\) ES2022 format, along with source maps.                                                                                                                           |
-| `testing/`                                                                                                                                                | Directory representing the "testing" entrypoint.                                                                                                                                                               |
-| `testing/index.d.ts`                                                                                                                                    | Bundled `.d.ts` for the `@angular/core/testing` entrypoint.                                                                                                                                                     |
+| `types/` <br /> &nbsp;&nbsp;─ `core.d.ts` <br /> &nbsp;&nbsp;─ `testing.d.ts`                                                                              | Bundled TypeScript type definitions for all public entrypoints.                                                                                                                                                |
 
 ## `package.json`
 
@@ -88,11 +86,11 @@ The `"exports"` field has the following structure:
     "default": "./package.json"
   },
   ".": {
-    "types": "./core.d.ts",
+    "types": "./types/core.d.ts",
     "default": "./fesm2022/core.mjs"
   },
   "./testing": {
-    "types": "./testing/testing.d.ts",
+    "types": "./types/testing.d.ts",
     "default": "./fesm2022/testing.mjs"
   }
 }
@@ -122,7 +120,7 @@ For `@angular/core` these are:
 
 {
   "module": "./fesm2022/core.mjs",
-  "typings": "./core.d.ts",
+  "typings": "./types/core.d.ts",
 }
 
 </docs-code>


### PR DESCRIPTION
The Angular Package Format has been updated to group all TypeScript declaration files (`.d.ts`) under a single `types/` directory within the package. Previously, these files were located at the package root or within entry-point specific directories.

This commit updates the APF documentation to reflect this new structure, including:
- The example file layout.
- The file purpose description table.
- The `package.json` exports field example.
- The legacy typings field example.

This brings the documentation in line with the current package structure, providing accurate guidance for library authors and tool developers.
