### PR TITLE
refactor(http): `HttpResponseBase.statusText`

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2195,6 +2195,7 @@ export abstract class HttpResponseBase {
     readonly headers: HttpHeaders;
     readonly ok: boolean;
     readonly status: number;
+    // @deprecated
     readonly statusText: string;
     readonly type: HttpEventType.Response | HttpEventType.ResponseHeader;
     readonly url: string | null;

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -167,6 +167,8 @@ export abstract class HttpResponseBase {
    * Textual description of response status code, defaults to OK.
    *
    * Do not depend on this.
+   *
+   * @deprecated With HTTP/2 and later versions, this will incorrectly remain set to 'OK' even when the status code of a response is not 200.
    */
   readonly statusText: string;
 
@@ -363,6 +365,7 @@ export class HttpErrorResponse extends HttpResponseBase implements Error {
     if (this.status >= 200 && this.status < 300) {
       this.message = `Http failure during parsing for ${init.url || '(unknown url)'}`;
     } else {
+      // TODO: Cleanup G3 to update the tests that rely on having the status text in the Error message.
       this.message = `Http failure response for ${init.url || '(unknown url)'}: ${init.status} ${
         init.statusText
       }`;


### PR DESCRIPTION
Since HTTP/2, responses no longer contain a status text besides the status code, which caused our default value of 'OK' to be used in HttpErrorResponse.message.

DEPRECATED: `HttpResponseBase.statusText` is deprecated