### PR TITLE
fix(core): handle undefined CSS time values in parseCssTimeUnitsToMs function

### DIFF
--- a/packages/core/src/animation/longest_animation.ts
+++ b/packages/core/src/animation/longest_animation.ts
@@ -10,7 +10,8 @@ import {LView} from '../render3/interfaces/view';
 import {LongestAnimation} from './interfaces';
 
 /** Parses a CSS time value to milliseconds. */
-function parseCssTimeUnitsToMs(value: string): number {
+function parseCssTimeUnitsToMs(value: string | undefined): number {
+  if (!value) return 0;
   // Some browsers will return it in seconds, whereas others will return milliseconds.
   const multiplier = value.toLowerCase().indexOf('ms') > -1 ? 1 : 1000;
   return parseFloat(value) * multiplier;


### PR DESCRIPTION
Improve error handling when `rawDelays` contains fewer items than `transitionedProperties`, preventing a toLowerCase of undefined error in `parseCssTimeUnitsToMs`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`parseCssTimeUnitsToMs` throws "Cannot read properties of undefined" when value parameter is undefined due to not existing index passed.

<img height="144" alt="image" src="https://github.com/user-attachments/assets/1d38a876-0052-411e-818e-3b08b06c4f7b" />

Issue Number: N/A

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
