### PR TITLE
docs: update website URL in license banners

### DIFF
--- a/packages/license-banner.txt
+++ b/packages/license-banner.txt
@@ -1,5 +1,5 @@
 /**
  * @license Angular v0.0.0-PLACEHOLDER
- * (c) 2010-2025 Google LLC. https://angular.io/
+ * (c) 2010-2025 Google LLC. https://angular.dev/
  * License: MIT
  */


### PR DESCRIPTION
Replace angular.io with angular.dev

