### PR TITLE
refactor(forms): Add a lightweight DI token for Control

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -10,6 +10,7 @@ import { ElementRef } from '@angular/core';
 import { HttpResourceOptions } from '@angular/common/http';
 import { HttpResourceRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
+import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { InputSignal } from '@angular/core';
 import { ModelSignal } from '@angular/core';
@@ -63,6 +64,9 @@ export interface AsyncValidatorOptions<TValue, TParams, TResult, TPathKind exten
 export interface ChildFieldContext<TValue> extends RootFieldContext<TValue> {
     readonly key: Signal<string>;
 }
+
+// @public
+export const CONTROL: InjectionToken<Control<unknown>>;
 
 // @public
 export class Control<T> {

--- a/packages/forms/signals/src/api/control_directive.ts
+++ b/packages/forms/signals/src/api/control_directive.ts
@@ -15,6 +15,7 @@ import {
   ElementRef,
   EventEmitter,
   inject,
+  InjectionToken,
   Injector,
   Input,
   InputSignal,
@@ -42,6 +43,11 @@ import {AggregateProperty, MAX, MAX_LENGTH, MIN, MIN_LENGTH, PATTERN, REQUIRED} 
 import type {Field} from './types';
 
 /**
+ * Lightweight DI token provided by the {@link Control} directive.
+ */
+export const CONTROL = new InjectionToken<Control<unknown>>('CONTROL');
+
+/**
  * Binds a form `Field` to a UI control that edits it. A UI control can be one of several things:
  * 1. A native HTML input or textarea
  * 2. A signal forms custom control that implements `FormValueControl` or `FormCheckboxControl`
@@ -65,6 +71,10 @@ import type {Field} from './types';
     {
       provide: NgControl,
       useFactory: () => inject(Control).ngControl,
+    },
+    {
+      provide: CONTROL,
+      useExisting: Control,
     },
   ],
 })

--- a/packages/forms/signals/src/api/control_directive.ts
+++ b/packages/forms/signals/src/api/control_directive.ts
@@ -45,7 +45,9 @@ import type {Field} from './types';
 /**
  * Lightweight DI token provided by the {@link Control} directive.
  */
-export const CONTROL = new InjectionToken<Control<unknown>>('CONTROL');
+export const CONTROL = new InjectionToken<Control<unknown>>(
+  typeof ngDevMode !== undefined && ngDevMode ? 'CONTROL' : '',
+);
 
 /**
  * Binds a form `Field` to a UI control that edits it. A UI control can be one of several things:


### PR DESCRIPTION
This will allow optionally injecting the Control directive without importing the full directive.
