### PR TITLE
feat(platform-browser): allow all global objects in global event listener

### DIFF
--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -56,18 +56,16 @@ export class BrowserDomAdapter extends DomAdapter {
     return node instanceof DocumentFragment;
   }
 
-  /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
-  override getGlobalEventTarget(doc: Document, target: string): EventTarget | null {
-    if (target === 'window') {
-      return window;
-    }
-    if (target === 'document') {
-      return doc;
-    }
-    if (target === 'body') {
+  override getGlobalEventTarget(doc: Document, key: string): EventTarget | null {
+    if (key === 'body') {
       return doc.body;
     }
-    return null;
+
+    const target = key
+      .split('.')
+      .reduce((obj, prop) => (obj?.[prop]), doc.defaultView as any);
+
+    return 'addEventListener' in target ? target : null;
   }
   override getBaseHref(doc: Document): string | null {
     const href = getBaseElementHref();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there are 3 fixed global event targets `(window:click)`, `(document:click)` and `(body:click)`. This is limiting because there are a lot of other global `EventTarget` objects.


## What is the new behavior?
With this change people will be able to write global event listeners for other things which greatly improves DX, such as `(visualViewport:change)`, `(navigator.mediaDevices:devicechange)` or `(cookieStore:change)`, as well as futureproofing global listeners for upcoming changes to the web.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Doing this PR as a proof of concept at the moment to kick off the discussion instead of explaining it, therefore no tests yet. I'll be glad to add them later and refine the PR if this is a welcomed contribution.