### PR TITLE
refactor(forms): rename `Field` to `FieldTree`

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -73,9 +73,9 @@ export class Control<T> {
     get cva(): ControlValueAccessor | undefined;
     readonly cvaArray: ControlValueAccessor[] | null;
     readonly el: ElementRef<HTMLElement>;
-    readonly field: i0.WritableSignal<Field<T>>;
+    readonly field: i0.WritableSignal<FieldTree<T>>;
     // (undocumented)
-    set _field(value: Field<T>);
+    set _field(value: FieldTree<T>);
     get ngControl(): NgControl;
     readonly state: i0.Signal<FieldState<T, string | number>>;
     // (undocumented)
@@ -97,7 +97,7 @@ export function customError<E extends Partial<ValidationError>>(obj?: E): Withou
 export class CustomValidationError implements ValidationError {
     constructor(options?: ValidationErrorOptions);
     [key: PropertyKey]: unknown;
-    readonly field: Field<unknown>;
+    readonly field: FieldTree<unknown>;
     readonly kind: string;
     readonly message?: string;
 }
@@ -107,7 +107,7 @@ export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(pat
 
 // @public
 export interface DisabledReason {
-    readonly field: Field<unknown>;
+    readonly field: FieldTree<unknown>;
     readonly message?: string;
 }
 
@@ -125,9 +125,6 @@ export class EmailValidationError extends _NgValidationError {
     // (undocumented)
     readonly kind = "email";
 }
-
-// @public
-export type Field<TValue, TKey extends string | number = string | number> = (() => FieldState<TValue, TKey>) & (TValue extends Array<infer U> ? ReadonlyArrayLike<MaybeField<U, number>> : TValue extends Record<string, any> ? Subfields<TValue> : unknown);
 
 // @public
 export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = TPathKind extends PathKind.Item ? ItemFieldContext<TValue> : TPathKind extends PathKind.Child ? ChildFieldContext<TValue> : RootFieldContext<TValue>;
@@ -166,19 +163,22 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 }
 
 // @public
+export type FieldTree<TValue, TKey extends string | number = string | number> = (() => FieldState<TValue, TKey>) & (TValue extends Array<infer U> ? ReadonlyArrayLike<MaybeFieldTree<U, number>> : TValue extends Record<string, any> ? Subfields<TValue> : unknown);
+
+// @public
 export type FieldValidationResult<E extends ValidationError = ValidationError> = ValidationSuccess | OneOrMany<WithoutField<E>>;
 
 // @public
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, FieldValidationResult, TPathKind>;
 
 // @public
-export function form<TValue>(model: WritableSignal<TValue>): Field<TValue>;
+export function form<TValue>(model: WritableSignal<TValue>): FieldTree<TValue>;
 
 // @public
-export function form<TValue>(model: WritableSignal<TValue>, schemaOrOptions: SchemaOrSchemaFn<TValue> | FormOptions): Field<TValue>;
+export function form<TValue>(model: WritableSignal<TValue>, schemaOrOptions: SchemaOrSchemaFn<TValue> | FormOptions): FieldTree<TValue>;
 
 // @public
-export function form<TValue>(model: WritableSignal<TValue>, schema: SchemaOrSchemaFn<TValue>, options: FormOptions): Field<TValue>;
+export function form<TValue>(model: WritableSignal<TValue>, schema: SchemaOrSchemaFn<TValue>, options: FormOptions): FieldTree<TValue>;
 
 // @public
 export interface FormCheckboxControl extends FormUiControl {
@@ -295,10 +295,10 @@ export class MaxValidationError extends _NgValidationError {
 }
 
 // @public
-export type MaybeField<TValue, TKey extends string | number = string | number> = (TValue & undefined) | Field<Exclude<TValue, undefined>, TKey>;
+export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = (TValue & undefined) | FieldPath<Exclude<TValue, undefined>, TPathKind>;
 
 // @public
-export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = (TValue & undefined) | FieldPath<Exclude<TValue, undefined>, TPathKind>;
+export type MaybeFieldTree<TValue, TKey extends string | number = string | number> = (TValue & undefined) | FieldTree<Exclude<TValue, undefined>, TKey>;
 
 // @public
 export const MIN: AggregateProperty<number | undefined, number | undefined>;
@@ -445,8 +445,8 @@ export class RequiredValidationError extends _NgValidationError {
 
 // @public
 export interface RootFieldContext<TValue> {
-    readonly field: Field<TValue>;
-    readonly fieldOf: <P>(p: FieldPath<P>) => Field<P>;
+    readonly field: FieldTree<TValue>;
+    readonly fieldOf: <P>(p: FieldPath<P>) => FieldTree<P>;
     readonly state: FieldState<TValue>;
     readonly stateOf: <P>(p: FieldPath<P>) => FieldState<P>;
     readonly value: Signal<TValue>;
@@ -484,11 +484,11 @@ export class StandardSchemaValidationError extends _NgValidationError {
 
 // @public
 export type Subfields<TValue> = {
-    readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeField<TValue[K], string>;
+    readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeFieldTree<TValue[K], string>;
 };
 
 // @public
-export function submit<TValue>(form: Field<TValue>, action: (form: Field<TValue>) => Promise<TreeValidationResult>): Promise<void>;
+export function submit<TValue>(form: FieldTree<TValue>, action: (form: FieldTree<TValue>) => Promise<TreeValidationResult>): Promise<void>;
 
 // @public
 export type SubmittedStatus = 'unsubmitted' | 'submitted' | 'submitting';
@@ -516,7 +516,7 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
 
 // @public
 export interface ValidationError {
-    readonly field: Field<unknown>;
+    readonly field: FieldTree<unknown>;
     readonly kind: string;
     readonly message?: string;
 }
@@ -532,12 +532,12 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 
 // @public
 export type WithField<T> = T & {
-    field: Field<unknown>;
+    field: FieldTree<unknown>;
 };
 
 // @public
 export type WithOptionalField<T> = Omit<T, 'field'> & {
-    field?: Field<unknown>;
+    field?: FieldTree<unknown>;
 };
 
 // @public

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -104,14 +104,14 @@ export interface FormUiControl {
 }
 
 /**
- * A contract for a form control that edits a `Field` of type `TValue`. Any component that
+ * A contract for a form control that edits a `FieldTree` of type `TValue`. Any component that
  * implements this contract can be used with the `Control` directive.
  *
  * Many of the properties declared on this contract are optional. They do not need to be
  * implemented, but if they are will be kept in sync with the field state of the field bound to the
  * `Control` directive.
  *
- * @template TValue The type of `Field` that the implementing component can edit.
+ * @template TValue The type of `FieldTree` that the implementing component can edit.
  *
  * @category control
  * @experimental 21.0.0
@@ -120,7 +120,7 @@ export interface FormValueControl<TValue> extends FormUiControl {
   /**
    * The value is the only required property in this contract. A component that wants to integrate
    * with the `Control` directive via this contract, *must* provide a `model()` that will be kept in
-   * sync with the value of the bound `Field`.
+   * sync with the value of the bound `FieldTree`.
    */
   readonly value: ModelSignal<TValue>;
   // TODO: We currently require that a `checked` input not be present, as we may want to introduce a
@@ -135,7 +135,7 @@ export interface FormValueControl<TValue> extends FormUiControl {
 }
 
 /**
- * A contract for a form control that edits a boolean checkbox `Field`. Any component that
+ * A contract for a form control that edits a boolean checkbox `FieldTree`. Any component that
  * implements this contract can be used with the `Control` directive.
  *
  * Many of the properties declared on this contract are optional. They do not need to be
@@ -149,7 +149,7 @@ export interface FormCheckboxControl extends FormUiControl {
   /**
    * The checked is the only required property in this contract. A component that wants to integrate
    * with the `Control` directive, *must* provide a `model()` that will be kept in sync with the
-   * value of the bound `Field`.
+   * value of the bound `FieldTree`.
    */
   readonly checked: ModelSignal<boolean>;
   // TODO: maybe this doesn't have to be strictly `undefined`? It just can't be a model signal.

--- a/packages/forms/signals/src/api/control_directive.ts
+++ b/packages/forms/signals/src/api/control_directive.ts
@@ -40,7 +40,7 @@ import {
 } from '../util/private';
 import {FormCheckboxControl, FormUiControl, FormValueControl} from './control';
 import {AggregateProperty, MAX, MAX_LENGTH, MIN, MIN_LENGTH, PATTERN, REQUIRED} from './property';
-import type {Field} from './types';
+import type {FieldTree} from './types';
 
 /**
  * Lightweight DI token provided by the {@link Control} directive.
@@ -50,7 +50,7 @@ export const CONTROL = new InjectionToken<Control<unknown>>(
 );
 
 /**
- * Binds a form `Field` to a UI control that edits it. A UI control can be one of several things:
+ * Binds a form `FieldTree` to a UI control that edits it. A UI control can be one of several things:
  * 1. A native HTML input or textarea
  * 2. A signal forms custom control that implements `FormValueControl` or `FormCheckboxControl`
  * 3. A component that provides a ControlValueAccessor. This should only be used to backwards
@@ -89,7 +89,7 @@ export class Control<T> {
   private initialized = false;
 
   /** The field that is bound to this control. */
-  readonly field = signal<Field<T>>(undefined as any);
+  readonly field = signal<FieldTree<T>>(undefined as any);
 
   // If `[control]` is applied to a custom UI control, it wants to synchronize state in the field w/
   // the inputs of that custom control. This is difficult to do in user-land. We use `effect`, but
@@ -103,7 +103,7 @@ export class Control<T> {
   // before the important lifecycle hooks of the UI control. We can then initialize all our effects
   // and force them to run immediately, ensuring all required inputs have values.
   @Input({required: true, alias: 'control'})
-  set _field(value: Field<T>) {
+  set _field(value: FieldTree<T>) {
     this.field.set(value);
     if (!this.initialized) {
       this.initialize();

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -83,7 +83,7 @@ export type SubmittedStatus = 'unsubmitted' | 'submitted' | 'submitting';
  */
 export interface DisabledReason {
   /** The field that is disabled. */
-  readonly field: Field<unknown>;
+  readonly field: FieldTree<unknown>;
   /** A user-facing message describing the reason for the disablement. */
   readonly message?: string;
 }
@@ -166,11 +166,11 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
   | 'pending';
 
 /**
- * An object that represents a single field in a form. This includes both primitive value fields
+ * An object that represents a tree of fields in a form. This includes both primitive value fields
  * (e.g. fields that contain a `string` or `number`), as well as "grouping fields" that contain
- * sub-fields. `Field` objects are arranged in a tree whose structure mimics the structure of the
- * underlying data. For example a `Field<{x: number}>` has a property `x` which contains a
- * `Field<number>`. To access the state associated with a field, call it as a function.
+ * sub-fields. `FieldTree` objects are arranged in a tree whose structure mimics the structure of the
+ * underlying data. For example a `FieldTree<{x: number}>` has a property `x` which contains a
+ * `FieldTree<number>`. To access the state associated with a field, call it as a function.
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
@@ -178,25 +178,25 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
  * @category types
  * @experimental 21.0.0
  */
-export type Field<TValue, TKey extends string | number = string | number> = (() => FieldState<
+export type FieldTree<TValue, TKey extends string | number = string | number> = (() => FieldState<
   TValue,
   TKey
 >) &
   (TValue extends Array<infer U>
-    ? ReadonlyArrayLike<MaybeField<U, number>>
+    ? ReadonlyArrayLike<MaybeFieldTree<U, number>>
     : TValue extends Record<string, any>
       ? Subfields<TValue>
       : unknown);
 
 /**
- * The sub-fields that a user can navigate to from a `Field<TValue>`.
+ * The sub-fields that a user can navigate to from a `FieldTree<TValue>`.
  *
  * @template TValue The type of the data which the parent field is wrapped around.
  *
  * @experimental 21.0.0
  */
 export type Subfields<TValue> = {
-  readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeField<
+  readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeFieldTree<
     TValue[K],
     string
   >;
@@ -215,23 +215,23 @@ export type ReadonlyArrayLike<T> = Pick<
 >;
 
 /**
- * Helper type for defining `Field`. Given a type `TValue` that may include `undefined`, it extracts
- * the `undefined` outside the `Field` type.
+ * Helper type for defining `FieldTree`. Given a type `TValue` that may include `undefined`, it extracts
+ * the `undefined` outside the `FieldTree` type.
  *
  * For example `MaybeField<{a: number} | undefined, TKey>` would be equivalent to
- * `undefined | Field<{a: number}, TKey>`.
+ * `undefined | FieldTree<{a: number}, TKey>`.
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
  *
  * @experimental 21.0.0
  */
-export type MaybeField<TValue, TKey extends string | number = string | number> =
+export type MaybeFieldTree<TValue, TKey extends string | number = string | number> =
   | (TValue & undefined)
-  | Field<Exclude<TValue, undefined>, TKey>;
+  | FieldTree<Exclude<TValue, undefined>, TKey>;
 
 /**
- * Contains all of the state (e.g. value, statuses, etc.) associated with a `Field`, exposed as
+ * Contains all of the state (e.g. value, statuses, etc.) associated with a `FieldTree`, exposed as
  * signals.
  *
  * @category structure
@@ -369,7 +369,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 }
 
 /**
- * An object that represents a location in the `Field` tree structure and is used to bind logic to a
+ * An object that represents a location in the `FieldTree` tree structure and is used to bind logic to a
  * particular part of the structure prior to the creation of the form. Because the `FieldPath`
  * exists prior to the form's creation, it cannot be used to access any of the field state.
  *
@@ -392,7 +392,7 @@ export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
  * extracts the `undefined` outside the `FieldPath` type.
  *
  * For example `MaybeFieldPath<{a: number} | undefined, PathKind.Child>` would be equivalent to
- * `undefined | Field<{a: number}, PathKind.child>`.
+ * `undefined | FieldTree<{a: number}, PathKind.child>`.
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TPathKind The kind of path (root field, child field, or item of an array)
@@ -532,13 +532,13 @@ export interface RootFieldContext<TValue> {
   /** The state of the current field. */
   readonly state: FieldState<TValue>;
   /** The current field. */
-  readonly field: Field<TValue>;
+  readonly field: FieldTree<TValue>;
   /** Gets the value of the field represented by the given path. */
   readonly valueOf: <P>(p: FieldPath<P>) => P;
   /** Gets the state of the field represented by the given path. */
   readonly stateOf: <P>(p: FieldPath<P>) => FieldState<P>;
   /** Gets the field represented by the given path. */
-  readonly fieldOf: <P>(p: FieldPath<P>) => Field<P>;
+  readonly fieldOf: <P>(p: FieldPath<P>) => FieldTree<P>;
 }
 
 /**

--- a/packages/forms/signals/src/api/validation_errors.ts
+++ b/packages/forms/signals/src/api/validation_errors.ts
@@ -7,7 +7,7 @@
  */
 
 import type {StandardSchemaV1} from '@standard-schema/spec';
-import {Field} from './types';
+import {FieldTree} from './types';
 
 /**
  * Options used to create a `ValidationError`.
@@ -23,7 +23,7 @@ interface ValidationErrorOptions {
  *
  * @experimental 21.0.0
  */
-export type WithField<T> = T & {field: Field<unknown>};
+export type WithField<T> = T & {field: FieldTree<unknown>};
 
 /**
  * A type that allows the given type `T` to optionally have a `field` property.
@@ -31,7 +31,7 @@ export type WithField<T> = T & {field: Field<unknown>};
  *
  * @experimental 21.0.0
  */
-export type WithOptionalField<T> = Omit<T, 'field'> & {field?: Field<unknown>};
+export type WithOptionalField<T> = Omit<T, 'field'> & {field?: FieldTree<unknown>};
 
 /**
  * A type that ensures the given type `T` does not have a `field` property.
@@ -310,7 +310,7 @@ export interface ValidationError {
   /** Identifies the kind of error. */
   readonly kind: string;
   /** The field associated with this error. */
-  readonly field: Field<unknown>;
+  readonly field: FieldTree<unknown>;
   /** Human readable error message. */
   readonly message?: string;
 }
@@ -334,7 +334,7 @@ export class CustomValidationError implements ValidationError {
   readonly kind: string = '';
 
   /** The field associated with this error. */
-  readonly field!: Field<unknown>;
+  readonly field!: FieldTree<unknown>;
 
   /** Human readable error message. */
   readonly message?: string;
@@ -360,7 +360,7 @@ abstract class _NgValidationError implements ValidationError {
   readonly kind: string = '';
 
   /** The field associated with this error. */
-  readonly field!: Field<unknown>;
+  readonly field!: FieldTree<unknown>;
 
   /** Human readable error message. */
   readonly message?: string;

--- a/packages/forms/signals/src/api/validators/standard_schema.ts
+++ b/packages/forms/signals/src/api/validators/standard_schema.ts
@@ -11,7 +11,7 @@ import type {StandardSchemaV1} from '@standard-schema/spec';
 import {addDefaultField} from '../../field/validation';
 import {validateAsync} from '../async';
 import {property, validateTree} from '../logic';
-import {Field, FieldPath} from '../types';
+import {FieldPath, FieldTree} from '../types';
 import {standardSchemaError, StandardSchemaValidationError} from '../validation_errors';
 
 /**
@@ -101,13 +101,13 @@ export function validateStandardSchema<TSchema, TValue extends IgnoreUnknownProp
  * @returns A `ValidationError` representing the issue.
  */
 function standardIssueToFormTreeError(
-  field: Field<unknown>,
+  field: FieldTree<unknown>,
   issue: StandardSchemaV1.Issue,
 ): StandardSchemaValidationError {
-  let target = field as Field<Record<PropertyKey, unknown>>;
+  let target = field as FieldTree<Record<PropertyKey, unknown>>;
   for (const pathPart of issue.path ?? []) {
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
-    target = target[pathKey] as Field<Record<PropertyKey, unknown>>;
+    target = target[pathKey] as FieldTree<Record<PropertyKey, unknown>>;
   }
   return addDefaultField(standardSchemaError(issue), target);
 }

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -7,7 +7,7 @@
  */
 
 import {computed, Signal, untracked, WritableSignal} from '@angular/core';
-import {Field, FieldContext, FieldPath, FieldState} from '../api/types';
+import {FieldContext, FieldPath, FieldState, FieldTree} from '../api/types';
 import {FieldPathNode} from '../schema/path_node';
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
@@ -25,7 +25,7 @@ export class FieldNodeContext implements FieldContext<unknown> {
    * actually change, as they only place we currently track fields moving within the parent
    * structure is for arrays, and paths do not currently support array indexing.
    */
-  private readonly cache = new WeakMap<FieldPath<unknown>, Signal<Field<unknown>>>();
+  private readonly cache = new WeakMap<FieldPath<unknown>, Signal<FieldTree<unknown>>>();
 
   constructor(
     /** The field node this context corresponds to. */
@@ -37,9 +37,9 @@ export class FieldNodeContext implements FieldContext<unknown> {
    * @param target The path to resolve
    * @returns The field corresponding to the target path.
    */
-  private resolve<U>(target: FieldPath<U>): Field<U> {
+  private resolve<U>(target: FieldPath<U>): FieldTree<U> {
     if (!this.cache.has(target)) {
-      const resolver = computed<Field<unknown>>(() => {
+      const resolver = computed<FieldTree<unknown>>(() => {
         const targetPathNode = FieldPathNode.unwrapFieldPath(target);
 
         // First, find the field where the root our target path was merged in.
@@ -77,10 +77,10 @@ export class FieldNodeContext implements FieldContext<unknown> {
 
       this.cache.set(target, resolver);
     }
-    return this.cache.get(target)!() as Field<U>;
+    return this.cache.get(target)!() as FieldTree<U>;
   }
 
-  get field(): Field<unknown> {
+  get field(): FieldTree<unknown> {
     return this.node.fieldProxy;
   }
 

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -9,7 +9,7 @@
 import type {Signal, WritableSignal} from '@angular/core';
 import type {Control} from '../api/control_directive';
 import {AggregateProperty, Property} from '../api/property';
-import type {DisabledReason, Field, FieldContext, FieldState} from '../api/types';
+import type {DisabledReason, FieldContext, FieldState, FieldTree} from '../api/types';
 import type {ValidationError} from '../api/validation_errors';
 import {LogicNode} from '../schema/logic_node';
 import {FieldPathNode} from '../schema/path_node';
@@ -58,7 +58,7 @@ export class FieldNode implements FieldState<unknown> {
   /**
    * Proxy to this node which allows navigation of the form graph below it.
    */
-  readonly fieldProxy = new Proxy(() => this, FIELD_PROXY_HANDLER) as unknown as Field<any>;
+  readonly fieldProxy = new Proxy(() => this, FIELD_PROXY_HANDLER) as unknown as FieldTree<any>;
 
   constructor(options: FieldNodeOptions) {
     this.fieldAdapter = options.fieldAdapter;

--- a/packages/forms/signals/src/field/proxy.ts
+++ b/packages/forms/signals/src/field/proxy.ts
@@ -11,7 +11,7 @@ import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
 
 /**
- * Proxy handler which implements `Field<T>` on top of `FieldNode`.
+ * Proxy handler which implements `FieldTree<T>` on top of `FieldNode`.
  */
 export const FIELD_PROXY_HANDLER: ProxyHandler<() => FieldNode> = {
   get(getTgt: () => FieldNode, p: string | symbol) {
@@ -20,8 +20,8 @@ export const FIELD_PROXY_HANDLER: ProxyHandler<() => FieldNode> = {
     // First, check whether the requested property is a defined child node of this node.
     const child = tgt.structure.getChild(p);
     if (child !== undefined) {
-      // If so, return the child node's `Field` proxy, allowing the developer to continue navigating
-      // the form structure.
+      // If so, return the child node's `FieldTree` proxy, allowing the developer to continue
+      // navigating the form structure.
       return child.fieldProxy;
     }
 

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -7,7 +7,7 @@
  */
 
 import {computed, Signal} from '@angular/core';
-import type {Field, Mutable, TreeValidationResult, ValidationResult} from '../api/types';
+import type {FieldTree, Mutable, TreeValidationResult, ValidationResult} from '../api/types';
 import type {ValidationError, WithOptionalField} from '../api/validation_errors';
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
@@ -359,15 +359,15 @@ function normalizeErrors(error: ValidationResult): readonly ValidationError[] {
  */
 export function addDefaultField<E extends ValidationError>(
   error: WithOptionalField<E>,
-  field: Field<unknown>,
+  field: FieldTree<unknown>,
 ): E;
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  field: Field<unknown>,
+  field: FieldTree<unknown>,
 ): ValidationResult<E>;
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  field: Field<unknown>,
+  field: FieldTree<unknown>,
 ): ValidationResult<E> {
   if (isArray(errors)) {
     for (const error of errors) {

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -10,7 +10,7 @@ import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form} from '../../public_api';
 
-describe('Field proxy', () => {
+describe('FieldTree proxy', () => {
   it('should not forward methods through the proxy', () => {
     const f = form(signal(new Date()), {injector: TestBed.inject(Injector)});
     // @ts-expect-error

--- a/packages/forms/signals/test/node/recursive_logic.spec.ts
+++ b/packages/forms/signals/test/node/recursive_logic.spec.ts
@@ -11,7 +11,7 @@ import {TestBed} from '@angular/core/testing';
 import {customError} from '../../public_api';
 import {disabled, validate} from '../../src/api/logic';
 import {applyEach, applyWhen, applyWhenValue, form, schema} from '../../src/api/structure';
-import type {Field, Schema} from '../../src/api/types';
+import type {FieldTree, Schema} from '../../src/api/types';
 
 interface TreeData {
   level: number;
@@ -19,11 +19,11 @@ interface TreeData {
 }
 
 function narrowed<TValue, TNarrowed extends TValue>(
-  field: Field<TValue> | undefined,
+  field: FieldTree<TValue> | undefined,
   guard: (value: TValue) => value is TNarrowed,
-): Signal<Field<TNarrowed> | undefined> {
+): Signal<FieldTree<TNarrowed> | undefined> {
   return computed(
-    () => field && (guard(field().value()) ? (field as Field<TNarrowed>) : undefined),
+    () => field && (guard(field().value()) ? (field as FieldTree<TNarrowed>) : undefined),
   );
 }
 

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -10,7 +10,7 @@ import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/cor
 import {TestBed} from '@angular/core/testing';
 import {
   customError,
-  Field,
+  FieldTree,
   form,
   NgValidationError,
   patternError,
@@ -28,7 +28,7 @@ function validateValue(value: string): WithoutField<ValidationError>[] {
 
 function validateValueForChild(
   value: string,
-  field: Field<unknown> | undefined,
+  field: FieldTree<unknown> | undefined,
 ): ValidationError[] {
   return value === 'INVALID' ? [customError({field})] : [];
 }

--- a/packages/forms/signals/test/web/control_directive.spec.ts
+++ b/packages/forms/signals/test/web/control_directive.spec.ts
@@ -31,7 +31,7 @@ import {
   readonly,
   required,
   type DisabledReason,
-  type Field,
+  type FieldTree,
   type FormCheckboxControl,
   type FormValueControl,
   type ValidationError,
@@ -44,7 +44,7 @@ import {
   imports: [Control],
 })
 class TestStringControl {
-  readonly control = input.required<Field<string>>();
+  readonly control = input.required<FieldTree<string>>();
   readonly controlDirective = viewChild.required(Control);
 }
 
@@ -333,7 +333,7 @@ describe('control directive', () => {
       template: `{{ control()().value() }}`,
     })
     class WrapperCmp {
-      readonly control = input.required<Field<string>>();
+      readonly control = input.required<FieldTree<string>>();
     }
 
     @Component({


### PR DESCRIPTION
There are two primary reasons for this renaming:
1. It better reflects the actual nature of the proxy object, namely that the form is represented as a tree, and that this object is used for navigating the tree structure (while `FieldState` is used for getting the state at a particular point in the structure).
2. This frees up the name `Field` to be used for the directive that binds a `FieldTree` to a UI control.
