### PR TITLE
fix(core): ensure missing leave animations don't queue leave animations

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -397,7 +397,7 @@ function runLeaveAnimationsWithCallback(
   callback: Function,
 ) {
   const animations = lView?.[ANIMATIONS];
-  if (animations == null || (animations.leave && !animations.leave.has(tNode.index)))
+  if (animations == null || animations.leave == undefined || !animations.leave.has(tNode.index))
     return callback(false);
 
   // this is solely for move operations to prevent leave animations from running


### PR DESCRIPTION
There was a bug in the logic for checking if a leave animation exists for a node. This was affecting timing of nodes with enter animations.
