### PR TITLE
refactor(core): replace deprecated ENVIRONMENT_INITIALIZER with provi…

### DIFF
--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ENVIRONMENT_INITIALIZER} from './di/initializer_token';
 import {InjectionToken} from './di/injection_token';
 import {inject} from './di/injector_compatibility';
 import type {EnvironmentProviders} from './di/interface/provider';
@@ -89,7 +88,7 @@ export const INTERNAL_APPLICATION_ERROR_HANDLER = new InjectionToken<(e: any) =>
 );
 
 export const errorHandlerEnvironmentInitializer = {
-  provide: ENVIRONMENT_INITIALIZER,
+  provide: provideEnvironmentInitializer,
   useValue: () => {
     const handler = inject(ErrorHandler, {optional: true});
     if ((typeof ngDevMode === 'undefined' || ngDevMode) && handler === null) {


### PR DESCRIPTION
Updated errorHandlerEnvironmentInitializer to use the new provideEnvironmentInitializer
API introduced in Angular v19, replacing the deprecated ENVIRONMENT_INITIALIZER token.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
