### PR TITLE
refactor(docs-infra): extend ErrorHandler in CustomErrorHandler

### DIFF
--- a/adev/src/app/core/services/errors-handling/error-handler.ts
+++ b/adev/src/app/core/services/errors-handling/error-handler.ts
@@ -13,10 +13,10 @@ import {AnalyticsService} from '../analytics/analytics.service';
 import {ErrorSnackBar, ErrorSnackBarData} from './error-snack-bar';
 
 export class CustomErrorHandler implements ErrorHandler {
-  snackBar = inject(MatSnackBar);
-  document = inject(DOCUMENT);
-  isServer = isPlatformServer(inject(PLATFORM_ID));
-  analyticsService = inject(AnalyticsService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly document = inject(DOCUMENT);
+  private readonly isServer = isPlatformServer(inject(PLATFORM_ID));
+  private readonly analyticsService = inject(AnalyticsService);
 
   get isOnline(): boolean {
     if (this.isServer) return false;
@@ -42,7 +42,7 @@ export class CustomErrorHandler implements ErrorHandler {
     console.error(error);
   }
 
-  openErrorSnackBar(): void {
+  private openErrorSnackBar(): void {
     this.snackBar
       .openFromComponent(ErrorSnackBar, {
         panelClass: 'docs-invert-mode',


### PR DESCRIPTION
Switch CustomErrorHandler from implementing the ErrorHandler interface to extending the base class. This allows using `override` for type safety and ensures consistency with Angular's error handling design.

Also:
- Marked injected dependencies as `private readonly`.
- Scoped `openErrorSnackBar` as private for better encapsulation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
