### PR TITLE
refactor(common): replace deprecated getLocaleId with Intl.Locale API

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -21,7 +21,6 @@ import {
   getLocaleEraNames,
   getLocaleExtraDayPeriodRules,
   getLocaleExtraDayPeriods,
-  getLocaleId,
   getLocaleMonthNames,
   getLocaleNumberSymbol,
   getLocaleTimeFormat,
@@ -188,7 +187,8 @@ function createDate(year: number, month: number, date: number): Date {
 }
 
 function getNamedFormat(locale: string, format: string): string {
-  const localeId = getLocaleId(locale);
+  const localeId = new Intl.Locale(locale).language;
+
   NAMED_FORMATS[localeId] ??= {};
 
   if (NAMED_FORMATS[localeId][format]) {


### PR DESCRIPTION
- Remove usage of Angular's deprecated getLocaleId function
- Use native Intl.Locale().language for locale extraction
- Aligns with Angular's recommendation to rely on Intl API

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
