### PR TITLE
refactor(core): use the `ValueEqualityFn` from core

### DIFF
--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -33,5 +33,7 @@ export function isSignal(value: unknown): value is Signal<unknown> {
 
 /**
  * A comparison function which can determine if two values are equal.
+ *
+ * @publicApi 17.0
  */
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -9,7 +9,7 @@
 import {untracked} from '../render3/reactivity/untracked';
 import {computed} from '../render3/reactivity/computed';
 import {signal, signalAsReadonlyFn, WritableSignal} from '../render3/reactivity/signal';
-import {Signal} from '../render3/reactivity/api';
+import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {effect, EffectRef} from '../render3/reactivity/effect';
 import {
   ResourceOptions,
@@ -22,8 +22,6 @@ import {
   ResourceStreamItem,
   ResourceLoaderParams,
 } from './api';
-
-import {ValueEqualityFn} from '../../primitives/signals';
 
 import {Injector} from '../di/injector';
 import {assertInInjectionContext} from '../di/contextual';


### PR DESCRIPTION
Instead of the non-public primitive one.
