### PR TITLE
refactor(compiler): check attributes set on `ng-content`

### DIFF
--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -73,6 +73,8 @@ const UNSUPPORTED_SELECTORLESS_TAGS = new Set([
 // TODO(crisbeto): any other attributes that should not be allowed here?
 const UNSUPPORTED_SELECTORLESS_DIRECTIVE_ATTRS = new Set(['ngProjectAs', 'ngNonBindable']);
 
+const SUPPORTED_NG_CONTENT_ATTRS = new Set(['select', 'ngprojectas']);
+
 // Result of the html AST to Ivy AST transformation
 export interface Render3ParseResult {
   nodes: t.Node[];
@@ -191,6 +193,19 @@ class HtmlAstToIvyAst implements html.Visitor {
     if (preparsedElement.type === PreparsedElementType.NG_CONTENT) {
       const selector = preparsedElement.selectAttr;
       const attrs: t.TextAttribute[] = element.attrs.map((attr) => this.visitAttribute(attr));
+      for (const attr of attrs) {
+        // TODO: reconsider supporting structural directives here.
+        if (
+          !SUPPORTED_NG_CONTENT_ATTRS.has(attr.name.toLowerCase()) &&
+          !attr.name.startsWith('*')
+        ) {
+          this.reportError(
+            `The "${attr.name}" attribute is not supported on ng-content.`,
+            attr.sourceSpan,
+          );
+        }
+      }
+
       parsedElement = new t.Content(
         selector,
         attrs,

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2786,4 +2786,31 @@ describe('R3 template transform', () => {
     const errors = parse(template, {ignoreError: true}).errors;
     expect(errors.length).toBe(0);
   });
+
+  it('should report an error if an attribute on ng-content is not select', () => {
+    const template = `<ng-content foo="bar"></ng-content>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(1);
+    expect(errors[0].msg).toBe('The "foo" attribute is not supported on ng-content.');
+  });
+
+  it('should not report an error if select is used on ng-content', () => {
+    const template = `<ng-content select="div"></ng-content>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(0);
+  });
+
+  it('should not report an error if no attributes are used on ng-content', () => {
+    const template = `<ng-content></ng-content>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(0);
+  });
+
+  // TODO: reconsider this and maybe throw if a structural directive is applied to ng-content
+  // NgIf *does* work on ng-content in Angular today
+  it('should not report an error is a structural directive is used on a ng-content', () => {
+    const template = `<ng-content *ngIf="cond"></ng-content>`;
+    const errors = parse(template, {ignoreError: true}).errors;
+    expect(errors.length).toBe(0);
+  });
 });

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -974,7 +974,7 @@ class OuterWithIndirectNestedComponent {}
 @Component({
   selector: 'outer',
   template:
-    'OUTER(<inner><ng-content select=".left" class="left"></ng-content><ng-content></ng-content></inner>)',
+    'OUTER(<inner><ng-content select=".left"></ng-content><ng-content></ng-content></inner>)',
   standalone: false,
 })
 class OuterComponent {}
@@ -982,7 +982,7 @@ class OuterComponent {}
 @Component({
   selector: 'inner',
   template:
-    'INNER(<innerinner><ng-content select=".left" class="left"></ng-content><ng-content></ng-content></innerinner>)',
+    'INNER(<innerinner><ng-content select=".left"></ng-content><ng-content></ng-content></innerinner>)',
   standalone: false,
 })
 class InnerComponent {}

--- a/packages/examples/upgrade/static/ts/full/module.ts
+++ b/packages/examples/upgrade/static/ts/full/module.ts
@@ -45,8 +45,8 @@ export class TextFormatter {
   selector: 'ng2-heroes',
   // This template uses the upgraded `ng1-hero` component
   // Note that because its element is compiled by Angular we must use camelCased attribute names
-  template: `<header><ng-content selector="h1"></ng-content></header>
-    <ng-content selector=".extra"></ng-content>
+  template: `<header><ng-content select="h1"></ng-content></header>
+    <ng-content select=".extra"></ng-content>
     <div *ngFor="let hero of heroes()">
       <ng1-hero [hero]="hero" (onRemove)="removeHero.emit(hero)"
         ><strong>Super Hero</strong></ng1-hero

--- a/packages/examples/upgrade/static/ts/lite/module.ts
+++ b/packages/examples/upgrade/static/ts/lite/module.ts
@@ -67,8 +67,8 @@ class HeroesService {
   // (Note that because its element is compiled by Angular we must use camelCased attribute names.)
   template: `
     <div class="ng2-heroes">
-      <header><ng-content selector="h1"></ng-content></header>
-      <ng-content selector=".extra"></ng-content>
+      <header><ng-content select="h1"></ng-content></header>
+      <ng-content select=".extra"></ng-content>
       <div *ngFor="let hero of this.heroesService.heroes">
           <ng1-hero [hero]="hero" (onRemove)="onRemoveHero(hero)">
             <strong>Super Hero</strong>


### PR DESCRIPTION
This would help catching typos on the `select` attribute for example.
