### PR TITLE
fix(core): fix typing for `providePlatformInitializer` (#64277)

### DIFF
--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -11,14 +11,7 @@ import {
   publishSignalConfiguration,
 } from '../application/application_ref';
 import {PLATFORM_INITIALIZER} from '../application/application_tokens';
-import {
-  EnvironmentProviders,
-  InjectionToken,
-  Injector,
-  makeEnvironmentProviders,
-  runInInjectionContext,
-  StaticProvider,
-} from '../di';
+import {InjectionToken, Injector, runInInjectionContext, StaticProvider} from '../di';
 import {INJECTOR_SCOPE} from '../di/scope';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 
@@ -193,14 +186,14 @@ export function createOrReusePlatformInjector(providers: StaticProvider[] = []):
  *
  * @publicApi
  */
-export function providePlatformInitializer(initializerFn: () => void): EnvironmentProviders {
-  return makeEnvironmentProviders([
+export function providePlatformInitializer(initializerFn: () => void): StaticProvider[] {
+  return [
     {
       provide: PLATFORM_INITIALIZER,
       useValue: initializerFn,
       multi: true,
     },
-  ]);
+  ];
 }
 
 function runPlatformInitializers(injector: Injector): void {


### PR DESCRIPTION
Currently we cannot provide platform initializer to platform, only to application :) This PR should fix it.

PR Close #64277

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently we can provide platform initializer only to application :laughing:

Issue Number: #64277


## What is the new behavior?

Allow provide platform initializer to platform


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Idk, seems breaking change, but this never works before


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
