### PR TITLE
build: update `rules_sass` to `1184a80751a21af8348f308abc5b38a41f26850e`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ git_override(
 bazel_dep(name = "rules_sass")
 git_override(
     module_name = "rules_sass",
-    commit = "4a54e0e4e75fc6456ff874e53fb4a78bdfeb44b9",
+    commit = "1184a80751a21af8348f308abc5b38a41f26850e",
     remote = "https://github.com/devversion/rules_sass.git",
 )
 


### PR DESCRIPTION
This included a fix to build the repo on Linux ARM64 which is needed by the Firefox team

https://github.com/devversion/rules_sass/pull/37
