### PR TITLE
docs: Add mentions of the `autoCsp` option

### DIFF
--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -51,7 +51,7 @@ For this reason, it is strongly encouraged to take advantage of these features. 
 
 ### Sanitization and security contexts
 
-*Sanitization* is the inspection of an untrusted value, turning it into a value that's safe to insert into the DOM.
+_Sanitization_ is the inspection of an untrusted value, turning it into a value that's safe to insert into the DOM.
 In many cases, sanitization doesn't change a value at all.
 Sanitization depends on a context.
 For example, a value that's harmless in CSS is potentially dangerous in a URL.
@@ -107,11 +107,11 @@ If in doubt, find a professional security reviewer.
 
 To mark a value as trusted, inject `DomSanitizer` and call one of the following methods:
 
-* `bypassSecurityTrustHtml`
-* `bypassSecurityTrustScript`
-* `bypassSecurityTrustStyle`
-* `bypassSecurityTrustUrl`
-* `bypassSecurityTrustResourceUrl`
+- `bypassSecurityTrustHtml`
+- `bypassSecurityTrustScript`
+- `bypassSecurityTrustStyle`
+- `bypassSecurityTrustUrl`
+- `bypassSecurityTrustResourceUrl`
 
 Remember, whether a value is safe depends on context, so choose the right context for your intended use of the value.
 Imagine that the following template needs to bind a URL to a `javascript:alert(...)` call:
@@ -142,21 +142,19 @@ Read more about content security policy at the [Web Fundamentals guide](https://
 
 The minimal policy required for a brand-new Angular application is:
 
-<docs-code language="text">
-
+```txt
 default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; script-src 'self' 'nonce-randomNonceGoesHere';
+```
 
-</docs-code>
-
-When serving your Angular application, the server should include a  randomly-generated nonce in the HTTP header for each request.
+When serving your Angular application, the server should include a randomly-generated nonce in the HTTP header for each request.
 You must provide this nonce to Angular so that the framework can render `<style>` elements.
 You can set the nonce for Angular in one of two ways:
 
+1. Set the `autoCsp` option to `true` the [workspace configuration](workspace-config#extra-build-and-test-options).
 1. Set the `ngCspNonce` attribute on the root application element as `<app ngCspNonce="randomNonceGoesHere"></app>`. Use this approach if you have access to server-side templating that can add the nonce both to the header and the `index.html` when constructing the response.
-2. Provide the nonce using the `CSP_NONCE` injection token. Use this approach if you have access to the nonce at runtime and you want to be able to cache the `index.html`.
+1. Provide the nonce using the `CSP_NONCE` injection token. Use this approach if you have access to the nonce at runtime and you want to be able to cache the `index.html`.
 
-<docs-code language="typescript">
-
+```ts
 import {bootstrapApplication, CSP_NONCE} from '@angular/core';
 import {AppComponent} from './app/app.component';
 
@@ -166,8 +164,7 @@ bootstrapApplication(AppComponent, {
     useValue: globalThis.myRandomNonceValue
   }]
 });
-
-</docs-code>
+```
 
 <docs-callout title="Unique nonces">
 
@@ -175,6 +172,8 @@ Always ensure that the nonces you provide are <strong>unique per request</strong
 If an attacker can predict future nonces, they can circumvent the protections offered by CSP.
 
 </docs-callout>
+
+NOTE: If you want to inline the critical CSS of your application, you can not use the `CSP_NONCE` Injection token, and should prefer the `autoCsp` option.
 
 If you cannot generate nonces in your project, you can allow inline styles by adding `'unsafe-inline'` to the `style-src` section of the CSP header.
 
@@ -209,45 +208,37 @@ To enforce Trusted Types for your application, you must configure your applicati
 | `angular#bundler`        | This policy is used by the Angular CLI bundler when creating lazy chunk files.                                                                                                                                                                                                             |
 | `angular#unsafe-bypass`  | This policy is used for applications that use any of the methods in Angular's [DomSanitizer](api/platform-browser/DomSanitizer) that bypass security, such as `bypassSecurityTrustHtml`. Any application that uses these methods must enable this policy.                                  |
 | `angular#unsafe-jit`     | This policy is used by the [Just-In-Time (JIT) compiler](api/core/Compiler). You must enable this policy if your application interacts directly with the JIT compiler or is running in JIT mode using the [platform browser dynamic](api/platform-browser-dynamic/platformBrowserDynamic). |
-| `angular#unsafe-upgrade` | This policy is used by the [@angular/upgrade](api/upgrade/static/UpgradeModule) package. You must enable this policy if your application is an AngularJS hybrid. |
+| `angular#unsafe-upgrade` | This policy is used by the [@angular/upgrade](api/upgrade/static/UpgradeModule) package. You must enable this policy if your application is an AngularJS hybrid.                                                                                                                           |
 
 You should configure the HTTP headers for Trusted Types in the following locations:
 
-* Production serving infrastructure
-* Angular CLI \(`ng serve`\), using the `headers` property in the `angular.json` file, for local development and end-to-end testing
-* Karma \(`ng test`\), using the `customHeaders` property in the `karma.config.js` file, for unit testing
+- Production serving infrastructure
+- Angular CLI \(`ng serve`\), using the `headers` property in the `angular.json` file, for local development and end-to-end testing
+- Karma \(`ng test`\), using the `customHeaders` property in the `karma.config.js` file, for unit testing
 
 The following is an example of a header specifically configured for Trusted Types and Angular:
 
-<docs-code language="html">
-
+```html
 Content-Security-Policy: trusted-types angular; require-trusted-types-for 'script';
-
-</docs-code>
+```
 
 An example of a header specifically configured for Trusted Types and Angular applications that use any of Angular's methods in [DomSanitizer](api/platform-browser/DomSanitizer) that bypasses security:
 
-<docs-code language="html">
-
+```html
 Content-Security-Policy: trusted-types angular angular#unsafe-bypass; require-trusted-types-for 'script';
-
-</docs-code>
+```
 
 The following is an example of a header specifically configured for Trusted Types and Angular applications using JIT:
 
-<docs-code language="html">
-
+```html
 Content-Security-Policy: trusted-types angular angular#unsafe-jit; require-trusted-types-for 'script';
-
-</docs-code>
+```
 
 The following is an example of a header specifically configured for Trusted Types and Angular applications that use lazy loading of modules:
 
-<docs-code language="html">
-
+```html
 Content-Security-Policy: trusted-types angular angular#bundler; require-trusted-types-for 'script';
-
-</docs-code>
+```
 
 <docs-callout title="Community contributions">
 
@@ -328,7 +319,7 @@ If your backend service uses different names for the XSRF token cookie or header
 
 Add it to the `provideHttpClient` call as follows:
 
-<docs-code language="ts">
+```ts
 export const appConfig: ApplicationConfig = {
   providers: [
     provideHttpClient(
@@ -339,13 +330,13 @@ export const appConfig: ApplicationConfig = {
     ),
   ]
 };
-</docs-code>
+```
 
 ### Disabling XSRF protection
 
 If the built-in XSRF protection mechanism doesn't work for your application, you can disable it using the `withNoXsrfProtection` feature:
 
-<docs-code language="ts">
+```ts
 export const appConfig: ApplicationConfig = {
   providers: [
     provideHttpClient(
@@ -353,12 +344,12 @@ export const appConfig: ApplicationConfig = {
     ),
   ]
 };
-</docs-code>
+```
 
 For information about CSRF at the Open Web Application Security Project \(OWASP\), see [Cross-Site Request Forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) and [Cross-Site Request Forgery (CSRF) Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
 The Stanford University paper [Robust Defenses for Cross-Site Request Forgery](https://seclab.stanford.edu/websec/csrf/csrf.pdf) is a rich source of detail.
 
-See also Dave Smith's [talk on XSRF at AngularConnect 2016](https://www.youtube.com/watch?v=9inczw6qtpY "Cross Site Request Funkery Securing Your Angular Apps From Evil Doers").
+See also Dave Smith's [talk on XSRF at AngularConnect 2016](https://www.youtube.com/watch?v=9inczw6qtpY 'Cross Site Request Funkery Securing Your Angular Apps From Evil Doers').
 
 ### Cross-site script inclusion (XSSI)
 

--- a/adev/src/content/reference/configs/workspace-config.md
+++ b/adev/src/content/reference/configs/workspace-config.md
@@ -83,21 +83,19 @@ For example, the schematic for generating a component with `ng generate componen
 The fields given in the schematic's schema correspond to the allowed command-line argument values and defaults for the Angular CLI sub-command options.
 You can update your workspace schema file to set a different default for a sub-command option. For example, to disable `standalone` in `ng generate component` by default:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"schematics": {
-"@schematics/angular:component": {
-"standalone": false
+  "projects": {
+    "my-app": {
+      "schematics": {
+        "@schematics/angular:component": {
+          "standalone": false
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-
-</docs-code>
+```
 
 ## Configuring CLI builders
 
@@ -145,24 +143,22 @@ Each target under `architect` has the following properties:
 
 For example, to configure a build with optimizations disabled:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"optimization": false
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "optimization": false
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 ### Alternate build configurations
 
@@ -179,29 +175,27 @@ You can select an alternate configuration by passing its name to the `--configur
 
 For example, to configure a build where optimization is enabled only for production builds (`ng build --configuration production`):
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"optimization": false
-},
-"configurations": {
-"production": {
-"optimization": true
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "optimization": false
+          },
+          "configurations": {
+            "production": {
+              "optimization": true
+            }
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 You can also pass in more than one configuration name as a comma-separated list.
 For example, to apply both `staging` and `french` build configurations, use the command `ng build --configuration staging,french`.
@@ -223,6 +217,7 @@ For details of those options and their possible values, see the [Angular CLI Ref
 | `budgets`                  | Default size-budget type and thresholds for all or parts of your application. You can configure the builder to report a warning or an error when the output reaches or exceeds a threshold size. See [Configure size budgets](tools/cli/build#configure-size-budgets). |
 | `fileReplacements`         | An object containing files and their compile-time replacements. See more in [Configure target-specific file replacements](tools/cli/build#configure-target-specific-file-replacements).                                                                                |
 | `index`                    | A base HTML document which loads the application. See more in [Index configuration](#index-configuration).                                                                                                                                                             |
+| `security`                 | An object containing the key `autoCsp` that can be set to `true` or `false`                                                                                                                                                                                            |
 
 ### Extra serve options
 
@@ -259,63 +254,59 @@ An asset specification object can have the following fields.
 
 For example, the default asset paths can be represented in more detail using the following objects.
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"assets": [
-{
-"glob": "**/*",
-"input": "src/assets/",
-"output": "/assets/"
-},
-{
-"glob": "favicon.ico",
-"input": "src/",
-"output": "/"
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "src/assets/",
+                "output": "/assets/"
+              },
+              {
+                "glob": "favicon.ico",
+                "input": "src/",
+                "output": "/"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
 }
-]
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 The following example uses the `ignore` field to exclude certain files in the assets directory from being copied into the build:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"assets": [
-{
-"glob": "**/\*",
-"input": "src/assets/",
-"ignore": ["**/\*.svg"],
-"output": "/assets/"
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "src/assets/",
+                "ignore": ["**/*.svg"],
+                "output": "/assets/"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
 }
-]
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 ### Styles and scripts configuration
 
@@ -326,37 +317,35 @@ With a configuration object, you have the option of naming the bundle for the en
 The bundle is injected by default, but you can set `inject` to `false` to exclude the bundle from injection.
 For example, the following object values create and name a bundle that contains styles and scripts, and excludes it from injection:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"styles": [
-{
-"input": "src/external-module/styles.scss",
-"inject": false,
-"bundleName": "external-module"
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "styles": [
+              {
+                "input": "src/external-module/styles.scss",
+                "inject": false,
+                "bundleName": "external-module"
+              }
+            ],
+            "scripts": [
+              {
+                "input": "src/external-module/main.js",
+                "inject": false,
+                "bundleName": "external-module"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
 }
-],
-"scripts": [
-{
-"input": "src/external-module/main.js",
-"inject": false,
-"bundleName": "external-module"
-}
-]
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 #### Style preprocessor options
 
@@ -364,41 +353,37 @@ In Sass, you can make use of the `includePaths` feature for both component and g
 
 To add paths, use the `stylePreprocessorOptions` option:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"stylePreprocessorOptions": {
-"includePaths": [
-"src/style-paths"
-]
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/style-paths"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 Files in that directory, such as `src/style-paths/_variables.scss`, can be imported from anywhere in your project without the need for a relative path:
 
-<docs-code language="scss">
-
+```scss
 // src/app/app.component.scss
 // A relative path works
 @import '../style-paths/variables';
 
 // But now this works as well
 @import 'variables';
-
-</docs-code>
+```
 
 HELPFUL: You also need to add any styles or scripts to the `test` builder if you need them for unit tests.
 See also [Using runtime-global libraries inside your application](tools/libraries/using-libraries#using-runtime-global-libraries-inside-your-app).
@@ -438,31 +423,26 @@ Several options can be used to fine-tune the optimization of an application.
 
 You can supply a value such as the following to apply optimization to one or the other:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"optimization": {
-"scripts": true,
-"styles": {
-"minify": true,
-"inlineCritical": true
-},
-"fonts": true
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/style-paths"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 ### Source map configuration
 
@@ -477,29 +457,27 @@ The `sourceMap` builder option can be either a boolean or an object for more fin
 
 The example below shows how to toggle one or more values to configure the source map outputs:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"my-app": {
-"architect": {
-"build": {
-"builder": "@angular-devkit/build-angular:application",
-"options": {
-"sourceMap": {
-"scripts": true,
-"styles": false,
-"hidden": true,
-"vendor": true
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "sourceMap": {
+              "scripts": true,
+              "styles": false,
+              "hidden": true,
+              "vendor": true
+            }
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-}
-}
-
-</docs-code>
+```
 
 HELPFUL: When using hidden source maps, source maps are not referenced in the bundle.
 These are useful if you only want source maps to map stack traces in error reporting tools without showing up in browser developer tools.


### PR DESCRIPTION
And also in the incompatibility of `CSP_NONCE` with `inlineCritical`.

fixes #61037

Notes: We don't have a doc for critical inlining. I'll put something up for #42682 and improve cross-linking afterwards. 