### PR TITLE
fix(core): ensure default path is set for control flow migration

### DIFF
--- a/packages/core/schematics/migrations/control-flow-migration/index.ts
+++ b/packages/core/schematics/migrations/control-flow-migration/index.ts
@@ -26,17 +26,24 @@ interface Options {
 
 export function migrate(options: Options): Rule {
   return async (tree: Tree, context: SchematicContext) => {
+    // Apply default values from schema when not provided by the migration system
+    const resolvedOptions = {
+      path: options.path ?? './',
+      format: options.format ?? true,
+    };
+
     let allPaths = [];
     const basePath = process.cwd();
     let pathToMigrate: string | undefined;
-    if (options.path) {
-      if (options.path.startsWith('..')) {
+
+    if (resolvedOptions.path) {
+      if (resolvedOptions.path.startsWith('..')) {
         throw new SchematicsException(
           'Cannot run control flow migration outside of the current project.',
         );
       }
 
-      pathToMigrate = normalizePath(join(basePath, options.path));
+      pathToMigrate = normalizePath(join(basePath, resolvedOptions.path));
       if (pathToMigrate.trim() !== '') {
         allPaths.push(pathToMigrate);
       }


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue occurred because `ng update` doesn't apply schema defaults like `ng generate` does. This fix handles both cases by explicitly setting default values in the migration code.

Issue Number: #63294


## What is the new behavior?
This change ensures a default value of './' is used when no path is explicitly provided, making the migration work consistently between `ng update` and `ng generate` commands.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
