### PR TITLE
fix(compiler): correctly compile long numeric HTML entities

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -692,7 +692,7 @@ class _Tokenizer {
       this._cursor.advance();
       try {
         const charCode = parseInt(strNum, isHex ? 16 : 10);
-        this._endToken([String.fromCharCode(charCode), this._cursor.getChars(start)]);
+        this._endToken([String.fromCodePoint(charCode), this._cursor.getChars(start)]);
       } catch {
         throw this._createError(
           _unknownEntityErrorMsg(this._cursor.getChars(start)),

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -52,6 +52,22 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should parse text nodes with HTML entities (5+ hex digits)', () => {
+        // Test with 🛈 (U+1F6C8 - Circled Information Source)
+        expect(humanizeDom(parser.parse('<div>&#x1F6C8;</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, '\u{1F6C8}', 1, [''], ['\u{1F6C8}', '&#x1F6C8;'], ['']],
+        ]);
+      });
+
+      it('should parse text nodes with decimal HTML entities (5+ digits)', () => {
+        // Test with 🛈 (U+1F6C8 - Circled Information Source) as decimal 128712
+        expect(humanizeDom(parser.parse('<div>&#128712;</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, '\u{1F6C8}', 1, [''], ['\u{1F6C8}', '&#128712;'], ['']],
+        ]);
+      });
+
       it('should normalize line endings within CDATA', () => {
         const parsed = parser.parse('<![CDATA[ line 1 \r\n line 2 ]]>', 'TestComp');
         expect(humanizeDom(parsed)).toEqual([
@@ -323,6 +339,22 @@ describe('HtmlParser', () => {
         expect(humanizeDom(parser.parse('<div foo="&amp;"></div>', 'TestComp'))).toEqual([
           [html.Element, 'div', 0],
           [html.Attribute, 'foo', '&', [''], ['&', '&amp;'], ['']],
+        ]);
+      });
+
+      it('should parse attributes containing encoded entities (5+ hex digits)', () => {
+        // Test with 🛈 (U+1F6C8 - Circled Information Source)
+        expect(humanizeDom(parser.parse('<div foo="&#x1F6C8;"></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '\u{1F6C8}', [''], ['\u{1F6C8}', '&#x1F6C8;'], ['']],
+        ]);
+      });
+
+      it('should parse attributes containing encoded decimal entities (5+ digits)', () => {
+        // Test with 🛈 (U+1F6C8 - Circled Information Source) as decimal 128712
+        expect(humanizeDom(parser.parse('<div foo="&#128712;"></div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Attribute, 'foo', '\u{1F6C8}', [''], ['\u{1F6C8}', '&#128712;'], ['']],
         ]);
       });
 
@@ -1628,6 +1660,25 @@ describe('HtmlParser', () => {
               '{{&amp (no semi-colon)}}' +
               '{{&#xyz; (invalid hex)}}' +
               '{{&#25BE; (invalid decimal)}}',
+          ],
+        ]);
+      });
+
+      it('should decode HTML entities with 5+ hex digits in interpolations', () => {
+        // Test with 🛈 (U+1F6C8 - Circled Information Source)
+        expect(
+          humanizeDomSourceSpans(parser.parse('{{&#x1F6C8;}}' + '{{&#128712;}}', 'TestComp')),
+        ).toEqual([
+          [
+            html.Text,
+            '{{\u{1F6C8}}}' + '{{\u{1F6C8}}}',
+            0,
+            [''],
+            ['{{', '&#x1F6C8;', '}}'],
+            [''],
+            ['{{', '&#128712;', '}}'],
+            [''],
+            '{{&#x1F6C8;}}' + '{{&#128712;}}',
           ],
         ]);
       });

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -2136,6 +2136,26 @@ describe('HtmlLexer', () => {
       ]);
     });
 
+    it('should parse entities with more than 4 hex digits', () => {
+      // Test 5 hex digit entity: &#x1F6C8; (🛈 - Circled Information Source)
+      expect(tokenizeAndHumanizeParts('&#x1F6C8;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '\u{1F6C8}', '&#x1F6C8;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse entities with more than 4 decimal digits', () => {
+      // Test decimal entity: &#128712; (🛈 - Circled Information Source)
+      expect(tokenizeAndHumanizeParts('&#128712;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '\u{1F6C8}', '&#128712;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should store the locations', () => {
       expect(tokenizeAndHumanizeSourceSpans('a&amp;b')).toEqual([
         [TokenType.TEXT, 'a'],


### PR DESCRIPTION
Fixes an issue where long numeric HTML entities (e.g. &#x1F6C8;) were incorrectly compiled due to the use of 4-digit

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  https://github.com/angular/angular/issues/51274


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
