### PR TITLE
refactor(docs-infra): replace @Input with signal input for ignoredElementsIds in ClickOutside directive

### DIFF
--- a/adev/shared-docs/directives/click-outside/click-outside.directive.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Directive, ElementRef, Input, inject, output} from '@angular/core';
+import {Directive, ElementRef, inject, input, output} from '@angular/core';
 
 @Directive({
   selector: '[docsClickOutside]',
@@ -16,8 +16,7 @@ import {Directive, ElementRef, Input, inject, output} from '@angular/core';
   },
 })
 export class ClickOutside {
-  // TODO: Understand why replacing this @Input with a signal input breaks the tests
-  @Input('docsClickOutsideIgnore') public ignoredElementsIds: string[] = [];
+  readonly ignoredElementsIds = input<string[]>([], {alias: 'docsClickOutsideIgnore'});
   public readonly clickOutside = output<void>({alias: 'docsClickOutside'});
 
   private readonly document = inject(DOCUMENT);
@@ -33,11 +32,11 @@ export class ClickOutside {
   }
 
   private wasClickedOnIgnoredElement(event: MouseEvent): boolean {
-    if (this.ignoredElementsIds.length === 0) {
+    if (this.ignoredElementsIds().length === 0) {
       return false;
     }
 
-    return this.ignoredElementsIds.some((elementId) => {
+    return this.ignoredElementsIds().some((elementId) => {
       const element = this.document.getElementById(elementId);
       const target = event.target as Node;
       const contains = element?.contains(target);


### PR DESCRIPTION
…kOutside directive

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Completed the TODO for migrating the `@Input` decorator to the new signal-based API. Ran all tests locally, and they passed without any failures.
