### PR TITLE
[Patch port] fix(migrations): remove error for no matching files in control flow migration

### DIFF
--- a/packages/core/schematics/migrations/control-flow-migration/index.ts
+++ b/packages/core/schematics/migrations/control-flow-migration/index.ts
@@ -8,6 +8,7 @@
 
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {join, relative} from 'node:path';
+import ts from 'typescript';
 
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
 
@@ -28,6 +29,12 @@ export function migrate(options: Options): Rule {
     const basePath = process.cwd();
     let pathToMigrate: string | undefined;
     if (options.path) {
+      if (options.path.startsWith('..')) {
+        throw new SchematicsException(
+          'Cannot run control flow migration outside of the current project.',
+        );
+      }
+
       pathToMigrate = normalizePath(join(basePath, options.path));
       if (pathToMigrate.trim() !== '') {
         allPaths.push(pathToMigrate);
@@ -38,60 +45,45 @@ export function migrate(options: Options): Rule {
     }
 
     if (!allPaths.length) {
-      throw new SchematicsException(
-        'Could not find any tsconfig file. Cannot run the http providers migration.',
+      context.logger.warn(
+        'Could not find any tsconfig file. Cannot run the control flow migration.',
       );
+      return;
     }
 
     let errors: string[] = [];
+    let sourceFilesCount = 0;
 
     for (const tsconfigPath of allPaths) {
-      const migrateErrors = runControlFlowMigration(
-        tree,
-        tsconfigPath,
-        basePath,
-        pathToMigrate,
-        options,
-      );
+      const program = createMigrationProgram(tree, tsconfigPath, basePath);
+      const sourceFiles = program
+        .getSourceFiles()
+        .filter(
+          (sourceFile) =>
+            (pathToMigrate ? sourceFile.fileName.startsWith(pathToMigrate) : true) &&
+            canMigrateFile(basePath, sourceFile, program),
+        );
+
+      const migrateErrors = runControlFlowMigration(tree, sourceFiles, basePath, options);
       errors = [...errors, ...migrateErrors];
+      sourceFilesCount += sourceFiles.length;
     }
 
     if (errors.length > 0) {
       context.logger.warn(`WARNING: ${errors.length} errors occurred during your migration:\n`);
-      errors.forEach((err: string) => {
-        context.logger.warn(err);
-      });
+      errors.forEach((err) => context.logger.warn(err));
+    } else if (sourceFilesCount === 0) {
+      context.logger.warn('Control flow migration did not find any files to migrate');
     }
   };
 }
 
 function runControlFlowMigration(
   tree: Tree,
-  tsconfigPath: string,
+  sourceFiles: ts.SourceFile[],
   basePath: string,
-  pathToMigrate?: string,
   schematicOptions?: Options,
 ): string[] {
-  if (schematicOptions?.path?.startsWith('..')) {
-    throw new SchematicsException(
-      'Cannot run control flow migration outside of the current project.',
-    );
-  }
-
-  const program = createMigrationProgram(tree, tsconfigPath, basePath);
-  const sourceFiles = program
-    .getSourceFiles()
-    .filter(
-      (sourceFile) =>
-        (pathToMigrate ? sourceFile.fileName.startsWith(pathToMigrate) : true) &&
-        canMigrateFile(basePath, sourceFile, program),
-    );
-
-  if (sourceFiles.length === 0) {
-    throw new SchematicsException(
-      `Could not find any files to migrate under the path ${pathToMigrate}. Cannot run the control flow migration.`,
-    );
-  }
   const analysis = new Map<string, AnalyzedFile>();
   const migrateErrors = new Map<string, MigrateError[]>();
 

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -6926,9 +6926,7 @@ describe('control flow migration (ng generate)', () => {
   });
 
   describe('path', () => {
-    it('should throw an error if no files match the passed-in path', async () => {
-      let error: string | null = null;
-
+    it('should warn if no files match the passed-in path', async () => {
       writeFile(
         'dir.ts',
         `
@@ -6938,15 +6936,8 @@ describe('control flow migration (ng generate)', () => {
       `,
       );
 
-      try {
-        await runMigration('./foo');
-      } catch (e: any) {
-        error = e.message;
-      }
-
-      expect(error).toMatch(
-        /Could not find any files to migrate under the path .*\/foo\. Cannot run the control flow migration/,
-      );
+      await runMigration('./foo');
+      expect(warnOutput).toContain('Control flow migration did not find any files to migrate');
     });
 
     it('should throw an error if a path outside of the project is passed in', async () => {


### PR DESCRIPTION
This is a patch port of #64253.

Now that the control flow migration is running as a part of `ng update`, we need to be a bit forgiving about there not being any matching files since it can break the entire update process.

These changes switch the error to a warning and it counts the files for the entire workspace, not the individual projects.
