### PR TITLE
build: use snapshot builds for dependencies in `@angular/language-server`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,9 @@ build:release --stamp
 # Snapshots should also be stamped with version control information.
 build:snapshot-build --workspace_status_command="pnpm --silent ng-dev release build-env-stamp --mode=snapshot"
 build:snapshot-build --stamp
-build:snapshot-build --//:enable_snapshot_repo_deps
+# @angular/language-server package depends directly on other Angular framework packages.
+# This flag ensures that the language server uses the snapshot-built framework packages from the repository.
+build:snapshot-build --//:enable_language_server_snapshot_repo_deps
 
 # Angular DevTools for Firefox releases *cannot* be stamped and `--config snapshot-build-firefox` is a no-op.
 # This is because Mozilla requires add-on source code to be uploaded and then they manually reproduce the build.

--- a/.bazelrc
+++ b/.bazelrc
@@ -69,6 +69,7 @@ build:release --stamp
 # Snapshots should also be stamped with version control information.
 build:snapshot-build --workspace_status_command="pnpm --silent ng-dev release build-env-stamp --mode=snapshot"
 build:snapshot-build --stamp
+build:snapshot-build --//:enable_snapshot_repo_deps
 
 # Angular DevTools for Firefox releases *cannot* be stamped and `--config snapshot-build-firefox` is a no-op.
 # This is because Mozilla requires add-on source code to be uploaded and then they manually reproduce the build.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,15 +73,17 @@ alias(
     }),
 )
 
-# If set will replace dependency versions with snapshot repos for packages in this repo
+# When enabled, this flag substitutes dependency versions with snapshot repositories
+# for all packages in this repository. Note that this does not apply to peer
+# dependencies, as they must be installed directly.
 bool_flag(
-    name = "enable_snapshot_repo_deps",
+    name = "enable_language_server_snapshot_repo_deps",
     build_setting_default = False,
 )
 
 config_setting(
-    name = "package_json_use_snapshot_repo_deps",
+    name = "language_server_package_json_use_snapshot_repo_deps",
     flag_values = {
-        ":enable_snapshot_repo_deps": "true",
+        ":enable_language_server_snapshot_repo_deps": "true",
     },
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@devinfra//bazel/validation:defs.bzl", "validate_ts_version_matching")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defaults.bzl", "copy_to_bin")
@@ -70,4 +71,17 @@ alias(
         "@devinfra//bazel/constraints:macos_x64": "@sauce_connect_mac//:bin/sc",
         "@devinfra//bazel/constraints:macos_arm64": "@sauce_connect_mac//:bin/sc",
     }),
+)
+
+# If set will replace dependency versions with snapshot repos for packages in this repo
+bool_flag(
+    name = "enable_snapshot_repo_deps",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "package_json_use_snapshot_repo_deps",
+    flag_values = {
+        ":enable_snapshot_repo_deps": "true",
+    },
 )

--- a/vscode-ng-language-service/server/BUILD.bazel
+++ b/vscode-ng-language-service/server/BUILD.bazel
@@ -61,10 +61,18 @@ esbuild(
 expand_template_rule(
     name = "package_json_expanded",
     out = "package_expanded.json",
-    stamp_substitutions = {
-        "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
-        "workspace:*": "{{STABLE_PROJECT_VERSION}}",
-    },
+    # We only have a single dependency now, which makes this safe.
+    # In the case we add more we should consider adding a JQ filter.
+    stamp_substitutions = select({
+        "//:package_json_use_snapshot_repo_deps": {
+            "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
+            "workspace:*": "github:angular/language-server-builds#{{BUILD_SCM_ABBREV_HASH}}",
+        },
+        "//conditions:default": {
+            "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
+            "workspace:*": "{{STABLE_PROJECT_VERSION}}",
+        },
+    }),
     substitutions = {
         "0.0.0-PLACEHOLDER": "0.0.0",
         "workspace:*": "0.0.0",

--- a/vscode-ng-language-service/server/BUILD.bazel
+++ b/vscode-ng-language-service/server/BUILD.bazel
@@ -64,7 +64,7 @@ expand_template_rule(
     # We only have a single dependency now, which makes this safe.
     # In the case we add more we should consider adding a JQ filter.
     stamp_substitutions = select({
-        "//:package_json_use_snapshot_repo_deps": {
+        "//:language_server_package_json_use_snapshot_repo_deps": {
             "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
             "workspace:*": "github:angular/language-server-builds#{{BUILD_SCM_ABBREV_HASH}}",
         },


### PR DESCRIPTION
This commit introduces a mechanism to use snapshot builds for @angular/language-service dependencies when building the VSCode extension.

A new --//:enable_snapshot_repo_deps flag allows swapping the stable versioned dependency with a snapshot build from the angular/language-server-builds GitHub repository. This enables testing and development against the latest unreleased version of the language service.

