### PR TITLE
fix(core): Prevents early style pruning with leave animations

### DIFF
--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -407,6 +407,8 @@ function runLeaveAnimationsWithCallback(
     return callback(false);
   }
 
+  if (lView) allLeavingAnimations.add(lView);
+
   addToAnimationQueue(injector, () => {
     // it's possible that in the time between when the leave animation was
     // and the time it was executed, the data structure changed. So we need


### PR DESCRIPTION
In some cases, the leave animation stylesheets were getting pruned too early due to the renderer removal happening before the animation function was run. This was fine before, when the animation queue didn't exist because the function was called faster. Now with the function being thrown into a queue, we need to ensure the lView is in the leaving animation set earlier so it's present when the DOM Renderer calls through to prune the stylesheet.

fixes: #64326
