### PR TITLE
build: correctly use snapshot build repo

### DIFF
--- a/vscode-ng-language-service/server/BUILD.bazel
+++ b/vscode-ng-language-service/server/BUILD.bazel
@@ -66,7 +66,7 @@ expand_template_rule(
     stamp_substitutions = select({
         "//:language_server_package_json_use_snapshot_repo_deps": {
             "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
-            "workspace:*": "github:angular/language-server-builds#{{BUILD_SCM_ABBREV_HASH}}",
+            "workspace:*": "github:angular/language-service-builds#{{BUILD_SCM_ABBREV_HASH}}",
         },
         "//conditions:default": {
             "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",


### PR DESCRIPTION
This package depends on `@angular/language-service` and not `@angular/language-server`.
