### PR TITLE
fix(devtools): property-view-tree layout

### DIFF
--- a/devtools/cypress/integration/property-edit.e2e.js
+++ b/devtools/cypress/integration/property-edit.e2e.js
@@ -27,9 +27,9 @@ describe('edit properties of directive in the property view tab', () => {
 
       cy.get('.explorer-panel:contains("app-todo")')
         .find('ng-property-view mat-tree-node:contains("editMode")')
-        .find('ng-property-editor .editor')
+        .find('ng-property-editor')
         .click({force: true})
-        .find('.editor-input')
+        .find('input')
         .clear()
         .type('true')
         .type('{enter}');
@@ -56,9 +56,9 @@ describe('edit properties of directive in the property view tab', () => {
       // find title variable and run through edit logic
       cy.get('.explorer-panel:contains("app-todos")')
         .find('ng-property-view mat-tree-node:contains("title")')
-        .find('ng-property-editor .editor')
+        .find('ng-property-editor')
         .click()
-        .find('.editor-input')
+        .find('input')
         .clear()
         .type('Hello World')
         .type('{enter}');

--- a/devtools/cypress/integration/property-update.e2e.js
+++ b/devtools/cypress/integration/property-update.e2e.js
@@ -32,7 +32,7 @@ describe('change of the state should reflect in property update', () => {
     cy.contains(
       '.explorer-panel:contains("app-todo") ' +
         'ng-property-view mat-tree-node:contains("completed") ' +
-        'ng-property-editor .editor',
+        'ng-property-editor',
       'true',
     );
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.html
@@ -1,33 +1,29 @@
-<div class="editor" (click)="onClick()">
-  <span class="state-container">
-    @switch (currentPropertyState()) {
-      @case (readState) {
-        <span>
-          @switch (containerType()) {
-            @case ('WritableSignal') {
-              <span class="editable">Signal({{valueToSubmit()}})</span>
-            }
-            @default {
-              <span class="editable">{{ valueToSubmit() }}</span>
-            }
-          }
-        </span>
+@switch (currentPropertyState()) {
+  @case (readState) {
+    @switch (containerType()) {
+      @case ('WritableSignal') {
+        <span class="editable">Signal({{valueToSubmit()}})</span>
       }
-      @case (writeState) {
-        <span>
-          <input
-            #inputEl
-            matInput
-            type="text"
-            class="editor-input editable"
-            (mousedown)="$event.stopPropagation()"
-            [(ngModel)]="valueToSubmit"
-            (keydown.enter)="accept()"
-            (keydown.escape)="reject()"
-            (blur)="onBlur()"
-          />
-        </span>
+      @default {
+        <span class="editable">{{ valueToSubmit() }}</span>
       }
     }
-  </span>
-</div>
+  }
+  @case (writeState) {
+    <div class="value-input">
+      <input
+        #inputEl
+        matInput
+        type="text"
+        (mousedown)="$event.stopPropagation()"
+        [(ngModel)]="valueToSubmit"
+        (keydown.enter)="accept()"
+        (keydown.escape)="reject()"
+        (focus)="onFocus()"
+        (blur)="onBlur()"
+        placeholder="Property value"
+      />
+      <span class="text-span">{{valueToSubmit()}}</span>
+    </div>
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.scss
@@ -1,22 +1,36 @@
 @use '../../../../../../../../styles/typography';
 
-.editor {
+:host {
   cursor: text;
-  border: none;
-  outline: none;
-  white-space: pre;
-  width: fit-content;
-}
+  display: inline;
 
-.editor-input {
-  box-shadow: 0 0 0 1px var(--dynamic-transparent-01);
-}
+  .value-input {
+    position: relative;
+    display: inline-block;
+    margin-right: 0.25rem;
+    text-indent: 0;
 
-input {
-  @extend %monospaced;
-  line-height: 1rem;
-  letter-spacing: normal;
-  width: fit-content;
-  border: none;
-  outline: none;
+    .text-span,
+    input {
+      @extend %monospaced;
+      line-height: 1rem;
+      letter-spacing: normal;
+    }
+
+    input {
+      position: absolute;
+      background: none;
+      outline: 1px solid var(--dynamic-blue-02);
+      border-radius: 0.125rem;
+      width: 100%;
+      border: none;
+      padding: 0;
+      height: 100%;
+      top: -0.25px;
+    }
+
+    .text-span {
+      visibility: hidden;
+    }
+  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.ts
@@ -42,6 +42,9 @@ const parseValue = (value: EditorResult): EditorResult => {
   styleUrls: ['./property-editor.component.scss'],
   imports: [FormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '(click)': 'onClick()',
+  },
 })
 export class PropertyEditorComponent {
   readonly key = input.required<string>();
@@ -69,7 +72,6 @@ export class PropertyEditorComponent {
       const editor = this.inputEl()?.nativeElement;
       if (editor && this.currentPropertyState() === this.writeState) {
         editor.focus();
-        editor.select();
       }
     });
   }
@@ -89,6 +91,13 @@ export class PropertyEditorComponent {
     if (this.currentPropertyState() === this.readState) {
       this.currentPropertyState.set(this.writeState);
     }
+  }
+
+  onFocus() {
+    // A slight timeout is required for text selection.
+    setTimeout(() => {
+      this.inputEl()?.nativeElement.select();
+    });
   }
 
   onBlur(): void {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.html
@@ -2,6 +2,5 @@
   class="value"
   [class.function]="isClickableProp()"
   (click)="isClickableProp() && inspect.emit()"
+  >{{ node().prop.descriptor.preview }}</span
 >
-  {{ node().prop.descriptor.preview }}
-</span>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-preview/property-preview.component.scss
@@ -1,7 +1,11 @@
-.function {
-  &:hover {
-    background: var(--blue-02);
-    color: white;
-    cursor: pointer;
+:host {
+  display: inline;
+
+  .function {
+    &:hover {
+      background: var(--blue-02);
+      color: white;
+      cursor: pointer;
+    }
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
@@ -52,7 +52,7 @@
       class="prop-action-btn show-signal"
       type="button"
       [matTooltip]="tooltip"
-      [ariaLabel]="tooltip"
+      [aria-label]="tooltip"
       (click)="showGraph($event, signalNode)"
     >
       <mat-icon>graph_2</mat-icon>
@@ -66,7 +66,7 @@
     class="prop-action-btn log-value"
     type="button"
     [matTooltip]="tooltip"
-    [ariaLabel]="tooltip"
+    [aria-label]="tooltip"
     (click)="handleLogValue($event, node)"
   >
     <mat-icon>terminal</mat-icon>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
@@ -1,33 +1,35 @@
 @if (treeControl()) {
   <mat-tree class="property-list" [dataSource]="dataSource()" [treeControl]="treeControl()">
     <mat-tree-node matTreeNodePaddingIndent="14" *matTreeNodeDef="let node" matTreeNodePadding>
-      <span class="name non-expandable">{{ node.prop.name }}</span
-      >:&nbsp;
-      @if (!node.prop.descriptor.editable) {
-        <ng-property-preview (inspect)="inspect.emit(node)" [node]="node"></ng-property-preview>
-      } @else {
-        <ng-property-editor
-          [key]="node.prop.name"
-          [initialValue]="node.prop.descriptor.value ?? node.prop.descriptor.preview"
-          [containerType]="node.prop.descriptor.containerType"
-          (updateValue)="handleUpdate(node, $event)"
-        />
-      }
-      <ng-container [ngTemplateOutlet]="signalBtn" [ngTemplateOutletContext]="{ node }" />
-      @if (node.level === 0) {
-        <ng-container [ngTemplateOutlet]="logValueBtn" [ngTemplateOutletContext]="{ node }" />
-      }
+      <div class="prop-row non-expandable-row">
+        <span class="name">{{ node.prop.name }}</span
+        >:
+        @if (!node.prop.descriptor.editable) {
+          <ng-property-preview class="value" (inspect)="inspect.emit(node)" [node]="node" />
+        } @else {
+          <ng-property-editor
+            class="value"
+            [key]="node.prop.name"
+            [initialValue]="node.prop.descriptor.value ?? node.prop.descriptor.preview"
+            [containerType]="node.prop.descriptor.containerType"
+            (updateValue)="handleUpdate(node, $event)"
+          />
+        }
+        <ng-container [ngTemplateOutlet]="signalBtn" [ngTemplateOutletContext]="{ node }" />
+        @if (node.level === 0) {
+          <ng-container [ngTemplateOutlet]="logValueBtn" [ngTemplateOutletContext]="{ node }" />
+        }
+      </div>
     </mat-tree-node>
     <mat-tree-node
       matTreeNodePaddingIndent="14"
       *matTreeNodeDef="let node; when: hasChild"
       matTreeNodePadding
     >
-      <div (click)="toggle(node)">
-        <mat-icon class="mat-icon-rtl-mirror">
+      <button (click)="toggle(node)" class="prop-row expandable-row">
+        <mat-icon class="expand-icon">
           {{ treeControl().isExpanded(node) ? 'expand_more' : 'chevron_right' }}
         </mat-icon>
-        &nbsp;
         <span class="name">{{ node.prop.name }}</span
         >:
         <span class="value">{{ node.prop.descriptor.preview }}</span>
@@ -35,7 +37,7 @@
         @if (node.level === 0) {
           <ng-container [ngTemplateOutlet]="logValueBtn" [ngTemplateOutletContext]="{ node }" />
         }
-      </div>
+      </button>
     </mat-tree-node>
   </mat-tree>
 }
@@ -45,11 +47,12 @@
     supportedApis().signalPropertiesInspection && signalGraphEnabled() && getSignalNode(node);
     as signalNode
   ) {
+    @let tooltip = 'Show \'' + node.prop.name + '\' signal graph';
     <button
-      class="show-signal-btn"
+      class="prop-action-btn show-signal"
       type="button"
-      matTooltip="Show signal graph"
-      aria-label="Show signal graph"
+      [matTooltip]="tooltip"
+      [ariaLabel]="tooltip"
       (click)="showGraph($event, signalNode)"
     >
       <mat-icon>graph_2</mat-icon>
@@ -58,11 +61,12 @@
 </ng-template>
 
 <ng-template #logValueBtn let-node="node">
+  @let tooltip = 'Log \'' + node.prop.name + '\' to console';
   <button
-    class="log-value-btn"
+    class="prop-action-btn log-value"
     type="button"
-    matTooltip="Log value to console"
-    aria-label="Log value to console"
+    [matTooltip]="tooltip"
+    [ariaLabel]="tooltip"
     (click)="handleLogValue($event, node)"
   >
     <mat-icon>terminal</mat-icon>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.scss
@@ -5,80 +5,93 @@
   display: block;
   overflow: auto;
 
-  mat-tree {
-    display: table;
+  .property-list {
+    margin: 0.5rem;
   }
 
-  ::ng-deep {
-    .mat-tree-node,
-    .mat-nested-tree-node {
-      @extend %monospaced;
-    }
+  .prop-row {
+    $margin-left: 1.25rem;
+    $second-row-text-indent: 1rem;
 
-    .mat-tree-node {
-      min-height: 20px !important;
-      cursor: default;
+    @extend %monospaced;
+    display: inline;
+    text-indent: -$second-row-text-indent;
+    margin-left: $margin-left + $second-row-text-indent;
 
-      .mat-icon {
-        font-size: 11px;
-        width: 8px;
-        height: 16px;
-        position: relative;
-        top: 6px;
+    &.expandable-row {
+      position: relative;
+      border: none;
+      background: none;
+      padding: 0;
+      text-align: left;
+
+      .expand-icon {
+        position: absolute;
+        font-size: 12px;
+        width: 12px;
+        height: 12px;
+        top: 0.175rem;
+        left: -0.875rem - $second-row-text-indent;
+        text-indent: 0;
+        cursor: pointer;
       }
     }
   }
-}
 
-.name {
-  margin-left: -9px;
-}
-
-.non-expandable {
-  margin-left: 18px;
-}
-
-.show-signal-btn,
-.log-value-btn {
-  position: relative;
-  border-radius: 50%;
-  width: 16px;
-  height: 16px;
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--dynamic-blue-02);
-  color: var(--septenary-contrast);
-  vertical-align: middle;
-  padding: 0;
-  top: -1px;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
-  cursor: pointer;
-
-  &:hover {
-    background: color-mix(in srgb, var(--dynamic-blue-02) 80%, var(--full-contrast) 20%);
-  }
-
-  mat-icon {
-    width: 11px;
-    height: 11px;
-    font-size: 11px;
-    top: 0;
-  }
-}
-
-.property-list {
-  margin: 5px 5px 5px 15px;
   mat-tree-node {
-    .name {
-      color: var(--color-tree-node-element-name);
+    min-height: 1.375rem !important;
+    cursor: default;
+  }
+
+  .name {
+    color: var(--color-tree-node-element-name);
+  }
+
+  .value:not(:last-child) {
+    margin-right: 0.25rem;
+  }
+
+  .prop-action-btn {
+    position: relative;
+    border-radius: 50%;
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--quaternary-contrast);
+    background-color: transparent;
+    vertical-align: middle;
+    padding: 0;
+    top: -1px;
+    cursor: pointer;
+
+    &:not(:last-child) {
+      margin-right: 0.25rem;
+    }
+
+    &:hover {
+      $color: color-mix(in srgb, var(--dynamic-blue-02) 80%, var(--full-contrast) 20%);
+      background: $color;
+      outline: 2px solid $color;
+      color: var(--septenary-contrast);
+    }
+
+    mat-icon {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+      top: 0;
+    }
+
+    &.show-signal {
+      mat-icon {
+        width: 14px;
+        height: 14px;
+        font-size: 14px;
+      }
     }
   }
-}
-
-.property-list mat-tree-node.disabled .name,
-.disabled {
-  color: var(--secondary-contrast);
 }


### PR DESCRIPTION
The PR fixes various issues related to `property-view-tree` layout.

### Fixes & improvements:

- Transition from `flex` to simple `inline` layout to achieve better wrapping for names, values and prop action buttons
- Make the show signal and log value buttons less obtrusive and increase their `mat-icon` sizes to make them more distinguishable. Use tooltips that include the prop name to avoid any ambiguity when the layout is cramped
- Make row height consistent across expandable and non-expandable rows
- Improve editable value input by using dynamic width and fixing the auto selection on focus
- Clean up redundant CSS and `::ng-deep`

### Screenshots:
<img width="396" height="133" alt="Screenshot 2025-10-10 at 18 32 11" src="https://github.com/user-attachments/assets/a6ec3ad9-bd38-4264-afe4-8000d24158be" />
<img width="363" height="193" alt="Screenshot 2025-10-10 at 19 15 22" src="https://github.com/user-attachments/assets/37b75005-08d8-4885-bdd1-6092dda2b408" />
<img width="284" height="255" alt="Screenshot 2025-10-10 at 19 15 31" src="https://github.com/user-attachments/assets/4b1b215e-1a9c-4df1-b6d4-9afbf536dd9d" />
<img width="282" height="252" alt="Screenshot 2025-10-10 at 19 15 44" src="https://github.com/user-attachments/assets/126c0406-b0d7-4025-928d-12e2984b0eeb" />
<img width="275" height="101" alt="Screenshot 2025-10-10 at 19 20 44" src="https://github.com/user-attachments/assets/69199d4c-890d-4bc7-b32e-d9482c31ffcb" />

