### PR TITLE
refactor(core): fix ZoneJS-by-default providers for async downgradeMo…

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -542,6 +542,7 @@
       "fromPromise",
       "fromReadableStreamLike",
       "getActiveConsumer",
+      "getAndClearAdditionalProviders",
       "getBaseElementHref",
       "getBeforeNodeForView",
       "getBindingsEnabled",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -543,6 +543,7 @@
       "fromPromise",
       "fromReadableStreamLike",
       "getActiveConsumer",
+      "getAndClearAdditionalProviders",
       "getBaseElementHref",
       "getBeforeNodeForView",
       "getBindingsEnabled",


### PR DESCRIPTION
…dule

This fixes the code to retain ZoneJS by default in the providers for downgradeModule when the `bootstrapModule` is used. Prior to this change, the async `bootstrapModule`/`compileNgModuleFactory` could be called multiple times through `downgradeModule` before `bootstrapModuleFactory` got called and used the zone providers.

Note: marked refactor since this only applies to the -next release and we shouldn't have this change in the changelog as a fix.
