### PR TITLE
build: align git tags with package.json version for snapshot builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - run: echo "https://${{secrets.SNAPSHOT_BUILDS_GITHUB_TOKEN}}:@github.com" > ${HOME}/.git_credentials
       - run: pnpm build
-      - run: ./scripts/ci/publish-build-artifacts.sh
+      - run: ./scripts/ci/publish-snapshot-build-artifacts.sh
 
   zone-js:
     runs-on:

--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -184,13 +184,13 @@ First time, you need to create the GitHub repositories:
 
 ``` shell
 $ export TOKEN=[get one from https://github.com/settings/tokens]
-$ CREATE_REPOS=1 ./scripts/ci/publish-build-artifacts.sh [GitHub username]
+$ CREATE_REPOS=1 ./scripts/ci/publish-snapshot-build-artifacts.sh [GitHub username]
 ```
 
 For subsequent snapshots, just run:
 
 ``` shell
-$ ./scripts/ci/publish-build-artifacts.sh [GitHub username]
+$ ./scripts/ci/publish-snapshot-build-artifacts.sh [GitHub username]
 ```
 
 The script will publish the build snapshot to a branch with the same name as your current branch,

--- a/vscode-ng-language-service/server/BUILD.bazel
+++ b/vscode-ng-language-service/server/BUILD.bazel
@@ -66,7 +66,8 @@ expand_template_rule(
     stamp_substitutions = select({
         "//:language_server_package_json_use_snapshot_repo_deps": {
             "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",
-            "workspace:*": "github:angular/language-service-builds#{{BUILD_SCM_ABBREV_HASH}}",
+            # Example of `STABLE_PROJECT_VERSION` for snapshots is: `21.0.0-next.7+sha-7134dfe`
+            "workspace:*": "github:angular/language-service-builds#{{STABLE_PROJECT_VERSION}}",
         },
         "//conditions:default": {
             "0.0.0-PLACEHOLDER": "{{STABLE_PROJECT_VERSION}}",


### PR DESCRIPTION
 This commit updates the scripts to use the version from `package.json` for snapshot builds, ensuring that the git tags are aligned with the package version. This change simplifies referencing snapshot builds in the  `package.json` file.
