### PR TITLE
docs: Add example Unhandled errors in Angular documentation

### DIFF
--- a/adev/src/content/best-practices/error-handling.md
+++ b/adev/src/content/best-practices/error-handling.md
@@ -16,12 +16,32 @@ Angular does _not_ catch errors inside of APIs that are called directly by your 
 
 Angular catches _asynchronous_ errors from user promises or observables only when:
 
-* There is an explicit contract for Angular to wait for and use the result of the asynchronous operation, and
-* When errors are not presented in the return value or state.
+- There is an explicit contract for Angular to wait for and use the result of the asynchronous operation, and
+- When errors are not presented in the return value or state.
 
 For example, `AsyncPipe` and `PendingTasks.run` forward errors to the `ErrorHandler`, whereas `resource` presents the error in the `status` and `error` properties.
 
 Errors that Angular reports to the `ErrorHandler` are _unexpected_ errors. These errors may be unrecoverable or an indication that the state of the application is corrupted. Applications should provide error handling using `try` blocks or appropriate error handling operators (like `catchError` in RxJS) where the error occurs whenever possible rather than relying on the `ErrorHandler`, which is most frequently and appropriately used only as a mechanism to report potentially fatal errors to the error tracking and logging infrastructure.
+
+```ts
+export class GlobalErrorHandler implements ErrorHandler {
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly router = inject(Router);
+
+  handleError(error: any) {
+    const url = this.router.url;
+    const errorMessage = error?.message ?? 'unknown';
+
+    this.analyticsService.trackEvent({
+      eventName: 'exception',
+      description: `Screen: ${url} | ${errorMessage}`,
+    });
+
+    console.error(GlobalErrorHandler.name, { error });
+  }
+}
+
+```
 
 ### `TestBed` rethrows errors by default
 

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -47,6 +47,9 @@ import {NgZone} from './zone/ng_zone';
  * ```
  *
  * @publicApi
+ *
+ * @see [Unhandled errors in Angular](best-practices/error-handling)
+ *
  */
 export class ErrorHandler {
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Tangential question:
I noticed that in adev there are two `ErrorHandler` implementations  `ReportingErrorHandler`  and `CustomErrorHandler`.

However, only `CustomErrorHandler` is provided in `app.config.ts`, and it seems that ReportingErrorHandler isn’t actually used anywhere.

Should I remove it?
