### PR TITLE
docs: add missing code formatting around `@defer` in templates/defer guide

### DIFF
--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -35,7 +35,7 @@ Angular's compiler produces a [dynamic import](https://developer.mozilla.org/en-
 
 This is the primary block that defines the section of content that is lazily loaded. It is not rendered initially– deferred content loads and renders once the specified [trigger](/guide/templates/defer#triggers) occurs or the `when` condition is met.
 
-By default, a @defer block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).
+By default, a `@defer` block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).
 
 ```angular-html
 @defer {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://angular.dev/guide/templates/defer

<img width="1710" height="919" alt="image" src="https://github.com/user-attachments/assets/e788926d-3161-4015-b677-f750110e0de1" />

In the **Deferred Loading (`@defer`)** documentation, the directive name `@defer` is missing code-style backticks in this sentence:

> By default, a @defer block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).


## What is the new behavior?

Adds the missing backticks around `@defer` for consistency with Angular documentation style:

> By default, a `@defer` block is triggered when the browser state becomes [idle](/guide/templates/defer#idle).

This improves readability and matches the formatting used for other directives (e.g., `*ngIf`, `@for`, `@switch`).


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A
