### PR TITLE
docs: fix typo in route-guards guide

### DIFF
--- a/adev/src/content/guide/routing/route-guards.md
+++ b/adev/src/content/guide/routing/route-guards.md
@@ -187,7 +187,7 @@ const routes: Routes = [
     children: [
       // /users/list - PROTECTED
       { path: 'list', component: UserListComponent },
-      // /useres/detail/:id - PROTECTED
+      // /users/detail/:id - PROTECTED
       { path: 'detail/:id', component: UserDetailComponent }
     ]
   },


### PR DESCRIPTION
Fix typo in route-guards guide: “useres” → “users”

Fixes #64363

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


Issue Number: #64363


## What is the new behavior?
Fix typo in route-guards guide: “useres” → “users”

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
