### PR TITLE
fix(migrations): migrating input with more than 1 usage in a method

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/multiple_references_in_method.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/multiple_references_in_method.ts
@@ -1,0 +1,12 @@
+// tslint:disable
+
+import {Input} from '@angular/core';
+
+export class TestMigrationComponent {
+  @Input() public model: any;
+
+  public onSaveClick(): void {
+    this.model.requisitionId = 145;
+    this.model.comment = 'value';
+  }
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -848,6 +848,21 @@ class ModifierScenarios {
   @CustomDecorator()
 protected readonly usingCustomDecorator = input(true);
 }
+@@@@@@ multiple_references_in_method.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TestMigrationComponent {
+  public readonly model = input<any>();
+
+  public onSaveClick(): void {
+    const model = this.model();
+    model.requisitionId = 145;
+    model.comment = 'value';
+  }
+}
 @@@@@@ mutate.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -815,6 +815,21 @@ class ModifierScenarios {
   @CustomDecorator()
 protected readonly usingCustomDecorator = input(true);
 }
+@@@@@@ multiple_references_in_method.ts @@@@@@
+
+// tslint:disable
+
+import {input} from '@angular/core';
+
+export class TestMigrationComponent {
+  public readonly model = input<any>();
+
+  public onSaveClick(): void {
+    const model = this.model();
+    model.requisitionId = 145;
+    model.comment = 'value';
+  }
+}
 @@@@@@ mutate.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION
When the migration command was run for inputs, if the input had more than one reference in a method the migration would generate incorrect code

Fixes #63018

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #63018 


## What is the new behavior?
New code after migration:

```
public onSaveClick(): void {
     const model = this.model();
     
     model.requisitionId = 145;
     model.comment = 'value';
     model.status = 8;
     model.finilizeReasonId = 4
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
