### PR TITLE
docs: update MDN reference links to main documentation pages

### DIFF
--- a/adev/src/content/tools/cli/setup-local.md
+++ b/adev/src/content/tools/cli/setup-local.md
@@ -16,9 +16,9 @@ You don't need to set up your local environment until you're ready.
 To use Angular CLI, you should be familiar with the following:
 
 <docs-pill-row>
-  <docs-pill href="https://developer.mozilla.org/docs/Web/JavaScript/A_re-introduction_to_JavaScript" title="JavaScript"/>
-  <docs-pill href="https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML" title="HTML"/>
-  <docs-pill href="https://developer.mozilla.org/docs/Learn/CSS/First_steps" title="CSS"/>
+  <docs-pill href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" title="JavaScript"/>
+  <docs-pill href="https://developer.mozilla.org/en-US/docs/Web/HTML" title="HTML"/>
+  <docs-pill href="https://developer.mozilla.org/en-US/docs/Web/CSS" title="CSS"/>
 </docs-pill-row>
 
 You should also be familiar with usage of command line interface (CLI) tools and have a general understanding of command shells.


### PR DESCRIPTION
Replaces old deep-linked MDN tutorial URLs with top-level documentation links for JavaScript, HTML, and CSS to provide more general and reliable references.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
