### PR TITLE
ci: remove `cache-node-modules` from `checkout-and-setup-node`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@56543b10ddb9941c76b4413cc24ec3fa7a43cf5c
-        with:
-          cache-node-modules: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@56543b10ddb9941c76b4413cc24ec3fa7a43cf5c
       - name: Setup Bazel RBE

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@56543b10ddb9941c76b4413cc24ec3fa7a43cf5c
-        with:
-          cache-node-modules: true
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Setup Bazel


### PR DESCRIPTION
This option no longer exists and the new default is to cache the PNPM store.
