### PR TITLE
build: update symbol extractor tests to stabalize the order of the symbols listed

### DIFF
--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -110,6 +110,7 @@
       "DeferBlockBehavior",
       "DeferBlockInternalState",
       "DeferBlockState",
+      "DeferComponent",
       "DeferDependenciesLoadingState",
       "DestroyRef",
       "EFFECTS",
@@ -746,8 +747,7 @@
       "wasLastNodeCreated",
       "writeDirectClass",
       "writeDirectStyle",
-      "writeToDirectiveInput",
-      "DeferComponent"
+      "writeToDirectiveInput"
     ]
   }
 }

--- a/tools/symbol-extractor/cli.mts
+++ b/tools/symbol-extractor/cli.mts
@@ -86,8 +86,10 @@ function main(argv: [string, string, string] | [string, string]): boolean {
   if (doUpdate) {
     const newGolden: GoldenFile = {
       chunks: {
-        main: eagerlyLoadedSymbols,
-        lazy: lazySymbols,
+        // Ensure stability of symbol lists, we need to make sure we resort the lists for because
+        // the ordering of glob results for the bundle files isn't guaranteed.
+        main: eagerlyLoadedSymbols.sort(),
+        lazy: lazySymbols.sort(),
       },
     };
 


### PR DESCRIPTION
Update to ensure that the symbols in the list of extracted symbols is consistent even when multiple bundle files are extracted from.
