### PR TITLE
fix(language-service): prevent interpolation from superseding block b…

### DIFF
--- a/vscode-ng-language-service/syntaxes/src/template.ts
+++ b/vscode-ng-language-service/syntaxes/src/template.ts
@@ -10,7 +10,7 @@ import {GrammarDefinition} from './types';
 
 export const Template: GrammarDefinition = {
   scopeName: 'template.ng',
-  injectionSelector: 'L:text.html -comment',
+  injectionSelector: 'L:text.html -comment -control.block.ng',
   patterns: [{include: '#interpolation'}],
   repository: {
     interpolation: {

--- a/vscode-ng-language-service/syntaxes/template.json
+++ b/vscode-ng-language-service/syntaxes/template.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "template.ng",
-  "injectionSelector": "L:text.html -comment",
+  "injectionSelector": "L:text.html -comment -control.block.ng",
   "patterns": [
     {
       "include": "#interpolation"


### PR DESCRIPTION
…races

This change omits the injection of the template syntaxes inside any existing block scope. The injection is not needed because the template and expression scopes are included explicitly as patterns where appropriate under the template-blocks definitions.

This change prevents the interpolation curly braces from superseding the match for the open curly of the block body. This issue also happens with ICUs (#62697), but those do not have any named scopes to exclude as of today.

fixes https://github.com/angular/vscode-ng-language-service/issues/1991
