### PR TITLE
ci: update symbol golden file for `@defer` test case

### DIFF
--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -58,7 +58,6 @@
       "shimStylesContent"
     ],
     "lazy": [
-      "DeferComponent",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS",
       "ANIMATION_QUEUE",


### PR DESCRIPTION
This commit updates the golden file, which got affected by this change: https://github.com/angular/angular/commit/eb80c3075f546c43f0ed2636bc6323d4b9d0a898
