### PR TITLE
build: remove `ANGULAR_PACKAGE` file from snapshot builds

### DIFF
--- a/scripts/ci/publish-snapshot-build-artifacts.sh
+++ b/scripts/ci/publish-snapshot-build-artifacts.sh
@@ -74,7 +74,6 @@ function publishRepo {
   fi
   echo `date` > $REPO_DIR/BUILD_INFO
   echo $SHA >> $REPO_DIR/BUILD_INFO
-  echo 'This file is used by the npm/yarn_install rule to detect APF.' > $REPO_DIR/ANGULAR_PACKAGE
 
   (
     cd $REPO_DIR && \


### PR DESCRIPTION
This was needed for NGCC which has been removed a long time ago.
