### PR TITLE
refactor(devtools): use lighter property-tab bg only when there are directives

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.scss
@@ -20,7 +20,6 @@
   flex: 1;
   overflow: auto;
   width: 100%;
-  background: var(--senary-contrast);
 
   .no-selected-element {
     text-align: center;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.html
@@ -6,23 +6,28 @@
     (showSignalGraph)="showSignalGraph.emit(null)"
   />
 
-  <div class="explorer-panel">
-    @for (directive of currentDirectives(); track $index) {
-      <ng-property-view
-        (inspect)="inspect.emit($event)"
-        (viewSource)="viewSource.emit(directive.name)"
-        (showSignalGraph)="showSignalGraph.emit($event)"
-        [directive]="directive"
-      />
+  <div class="body">
+    @let directives = currentDirectives();
+    @if (directives && directives.length) {
+      <div class="explorer-panel">
+        @for (directive of directives; track $index) {
+          <ng-property-view
+            (inspect)="inspect.emit($event)"
+            (viewSource)="viewSource.emit(directive.name)"
+            (showSignalGraph)="showSignalGraph.emit($event)"
+            [directive]="directive"
+          />
+        }
+      </div>
+    }
+
+    @let hydration = currentSelectedElement.hydration;
+    @if (hydration && hydration.status === 'dehydrated') {
+      <div class="dehydrated-component">This component is dehydrated</div>
+    }
+
+    @if (currentSelectedElement.defer) {
+      <ng-defer-view [defer]="currentSelectedElement.defer" />
     }
   </div>
-
-  @let hydration = currentSelectedElement.hydration;
-  @if (hydration && hydration.status === 'dehydrated') {
-    <div class="dehydrated-component">This component is dehydrated</div>
-  }
-
-  @if (currentSelectedElement.defer) {
-    <ng-defer-view [defer]="currentSelectedElement.defer" />
-  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-tab.component.scss
@@ -1,3 +1,21 @@
-.dehydrated-component {
-  padding: 0.75rem;
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .body {
+    height: 100%;
+    overflow-y: auto;
+
+    .explorer-panel {
+      background: var(--senary-contrast);
+      padding: 0.5rem;
+      min-height: 100%;
+      box-sizing: border-box;
+    }
+
+    .dehydrated-component {
+      padding: 0.75rem;
+    }
+  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/BUILD.bazel
@@ -20,7 +20,6 @@ ng_project(
         ":property-view-body_styles",
     ],
     deps = [
-        "//:node_modules/@angular/cdk",
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/material",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.html
@@ -1,5 +1,5 @@
 @if (controlsLoaded()) {
-  <mat-accordion cdkDropList (cdkDropListDropped)="drop($event)" [multi]="true">
+  <mat-accordion [multi]="true">
     @let deps = dependencies();
     @if (deps && deps.length > 0) {
       <div class="mat-accordion-content">
@@ -19,8 +19,8 @@
       </div>
     }
     @for (panel of panels(); track $index) {
-      <div class="mat-accordion-content" [id]="panel.title()" cdkDrag>
-        @if (panel.controls().dataSource.data.length > 0) {
+      @if (panel.controls().dataSource.data.length > 0) {
+        <div class="mat-accordion-content">
           <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
               <mat-panel-title>{{ panel.title() }}</mat-panel-title>
@@ -34,8 +34,8 @@
               (showSignalGraph)="showSignalGraph.emit($event)"
             />
           </mat-expansion-panel>
-        }
-      </div>
+        </div>
+      }
     }
   </mat-accordion>
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.html
@@ -20,7 +20,7 @@
     }
     @for (panel of panels(); track $index) {
       @if (panel.controls().dataSource.data.length > 0) {
-        <div class="mat-accordion-content">
+        <div class="mat-accordion-content" [id]="panel.title()">
           <mat-expansion-panel [expanded]="true">
             <mat-expansion-panel-header collapsedHeight="28px" expandedHeight="28px">
               <mat-panel-title>{{ panel.title() }}</mat-panel-title>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-body.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CdkDragDrop, moveItemInArray, CdkDropList, CdkDrag} from '@angular/cdk/drag-drop';
+import {CdkDragDrop, moveItemInArray} from '@angular/cdk/drag-drop';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -34,8 +34,6 @@ import {DocsRefButtonComponent} from '../../../../../shared/docs-ref-button/docs
   styleUrls: ['./property-view-body.component.scss'],
   imports: [
     MatExpansionModule,
-    CdkDropList,
-    CdkDrag,
     PropertyViewTreeComponent,
     DocsRefButtonComponent,
     DependencyViewerComponent,
@@ -93,12 +91,6 @@ export class PropertyViewBodyComponent {
 
   logValue(node: FlatNode): void {
     this.controller().logValue(node);
-  }
-
-  drop(event: CdkDragDrop<any, any>): void {
-    const panels = this.panels();
-    moveItemInArray(panels, event.previousIndex, event.currentIndex);
-    this.panels.set(Array.from(panels)); // Clone array for immutable update.
   }
 
   handleInspect(node: FlatNode): void {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view.component.scss
@@ -1,6 +1,9 @@
 :host {
   display: block;
   background: var(--color-background);
-  margin: 0.5rem;
   border-radius: 0.5rem;
+
+  &:not(:last-child) {
+    margin-bottom: 0.5rem;
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the new behavior?


- Use the contrasting background color only when there are directives to inspect. This means that the default background color will be used when inspecting tree nodes that use different `property-tab` layout, like `@defer`
- Drop obsolete CDK drag. Doesn't work and there are no visual indications that it's supported.

How `@defer` property-tab currently looks like (before the change):
<img width="429" height="561" alt="Screenshot 2025-10-14 at 14 05 50" src="https://github.com/user-attachments/assets/42ddab1b-1dfd-4e39-9beb-1aa7a10dee48" />
