### PR TITLE
fix(core): fixes regression in `animate.leave` function bindings

### DIFF
--- a/packages/core/src/animation/utils.ts
+++ b/packages/core/src/animation/utils.ts
@@ -280,3 +280,15 @@ export function clearLViewNodeAnimationResolvers(lView: LView, tNode: TNode) {
   const nodeAnimations = getLViewLeaveAnimations(lView).get(tNode.index);
   if (nodeAnimations) nodeAnimations.resolvers = undefined;
 }
+
+export function leaveAnimationFunctionCleanup(
+  lView: LView,
+  tNode: TNode,
+  nativeElement: HTMLElement,
+  resolvers: VoidFunction[] | undefined,
+  cleanupFns: Function[],
+) {
+  clearLeavingNodes(tNode, nativeElement as HTMLElement);
+  cleanupAfterLeaveAnimations(resolvers, cleanupFns);
+  clearLViewNodeAnimationResolvers(lView, tNode);
+}


### PR DESCRIPTION
When adding and removing items in a `@for` loop, the `animate.leave` event binding instruction was not updated to use the same logic as the class function when the animation queue was added. We were not returning the correct signature for the `animate.leave` function, which caused the animation to not trigger correctly. This updates the event binding instruction to use the same logic as the class function when adding the animation to the queue.

fixes: #64336
