### PR TITLE
refactor(devtools): Router viz is only from 20.3.5 onward

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -163,7 +163,7 @@
   <div class="unsupported-version">
     <p>
       Router tree visualization is available for Angular applications using the latest Angular
-      20.2.x release and above. Please upgrade your application to Angular 20.2.x or newer to use
+      20.3.5 release and above. Please upgrade your application to Angular 20.3.5 or newer to use
       this feature.
     </p>
   </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
@@ -109,7 +109,7 @@ describe('RouterTreeComponent', () => {
       const unsupportedMsg = fixture.nativeElement.querySelector('.unsupported-version');
       expect(unsupportedMsg).toBeTruthy();
       expect(unsupportedMsg.textContent).toContain(
-        'Router tree visualization is available for Angular applications using the latest Angular 20.2.x release and above.',
+        'Router tree visualization is available for Angular applications using the latest Angular 20.3.5 release and above.',
       );
     });
   });


### PR DESCRIPTION
This is following some updates in #64411
