### PR TITLE
feat(router): Add scroll behavior controls on router navigation

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -415,6 +415,7 @@ export interface NavigationBehaviorOptions {
     readonly info?: unknown;
     onSameUrlNavigation?: OnSameUrlNavigation;
     replaceUrl?: boolean;
+    readonly scroll?: 'manual' | 'after-transition';
     skipLocationChange?: boolean;
     state?: {
         [k: string]: any;
@@ -982,13 +983,16 @@ export class Scroll {
     constructor(
     routerEvent: NavigationEnd | NavigationSkipped,
     position: [number, number] | null,
-    anchor: string | null);
+    anchor: string | null,
+    scrollBehavior?: "manual" | "after-transition" | undefined);
     // (undocumented)
     readonly anchor: string | null;
     // (undocumented)
     readonly position: [number, number] | null;
     // (undocumented)
     readonly routerEvent: NavigationEnd | NavigationSkipped;
+    // (undocumented)
+    readonly scrollBehavior?: "manual" | "after-transition" | undefined;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -608,6 +608,9 @@ export class Scroll {
 
     /** @docsNotRequired */
     readonly anchor: string | null,
+
+    /** @docsNotRequired */
+    readonly scrollBehavior?: 'manual' | 'after-transition',
   ) {}
 
   toString(): string {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1529,4 +1529,18 @@ export interface NavigationBehaviorOptions {
    * state, such as `skipLocationChange`.
    */
   readonly browserUrl?: UrlTree | string;
+
+  /**
+   * Configures how scrolling is handled for an individual navigation when scroll restoration
+   * is enabled in the router.
+   *
+   * - When 'manual', the router will not perform scrolling when the navigation is complete,
+   * even if scroll restoration is enabled.
+   * - When 'after-transition', scrolling will be performed after the `NavigationEnd` event,
+   * according to the behavior configured in the router scrolling feature.
+   *
+   * @see withInMemoryRouterScroller
+   * @see InMemoryScrollingOptions
+   */
+  readonly scroll?: 'manual' | 'after-transition';
 }

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -221,13 +221,7 @@ export function withInMemoryScrolling(
   const providers = [
     {
       provide: ROUTER_SCROLLER,
-      useFactory: () => {
-        const viewportScroller = inject(ViewportScroller);
-        const zone = inject(NgZone);
-        const transitions = inject(NavigationTransitions);
-        const urlSerializer = inject(UrlSerializer);
-        return new RouterScroller(urlSerializer, transitions, viewportScroller, zone, options);
-      },
+      useFactory: () => new RouterScroller(options),
     },
   ];
   return routerFeature(RouterFeatureKind.InMemoryScrollingFeature, providers);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -223,6 +223,7 @@ export class Router {
               currentTransition.currentRawUrl,
             );
             const extras = {
+              scroll: currentTransition.extras.scroll,
               browserUrl: currentTransition.extras.browserUrl,
               info: currentTransition.extras.info,
               skipLocationChange: currentTransition.extras.skipLocationChange,

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -124,9 +124,11 @@ export interface RouterConfigOptions {
 
 /**
  * Configuration options for the scrolling feature which can be used with `withInMemoryScrolling`
- * function.
+ * function or `RouterModule.forRoot`.
  *
  * @publicApi
+ * @see withInMemoryScrolling
+ * @see RouterModule#forRoot
  */
 export interface InMemoryScrollingOptions {
   /**

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -202,14 +202,11 @@ export function provideRouterScroller(): Provider {
     provide: ROUTER_SCROLLER,
     useFactory: () => {
       const viewportScroller = inject(ViewportScroller);
-      const zone = inject(NgZone);
       const config: ExtraOptions = inject(ROUTER_CONFIGURATION);
-      const transitions = inject(NavigationTransitions);
-      const urlSerializer = inject(UrlSerializer);
       if (config.scrollOffset) {
         viewportScroller.setOffset(config.scrollOffset);
       }
-      return new RouterScroller(urlSerializer, transitions, viewportScroller, zone, config);
+      return new RouterScroller(config);
     },
   };
 }


### PR DESCRIPTION
This commit adds the ability to control the behavior of scrolling in the `NavigationBehaviorOptions`. The options directly correlate with the intercept options of the Navigation API `NavigateEvent#intercept`: https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent/intercept#scroll

While we do not currently have an integration with the navigation API, this change would be necessary to provide the ability to configure that behavior if/when we do. In the meantime, this option is also useful to control the behavior of scrolling when the in memory scroller is enabled.

resolves #26744

Also relates to https://github.com/angular/angular/issues/64578 since we don't have a way to skip scrolling on initial navigation

This API is also similar to the [tanstack router resetScroll](https://tanstack.com/router/v1/docs/framework/react/guide/scroll-restoration#preventing-scroll-restoration). I could see an argument for a true/false property instead of the string (e.g. `scrollPositionRestoration: false`). Commence bikesheding discussion
