### PR TITLE
docs: fix closing tag for whitespace examples

### DIFF
--- a/adev/src/content/guide/templates/whitespace.md
+++ b/adev/src/content/guide/templates/whitespace.md
@@ -8,7 +8,7 @@ Most developers prefer to format their templates with newlines and indentation t
 
 ```angular-html
 <section>
-  <h3>User profile</p>
+  <h3>User profile</h3>
   <label>
     User name
     <input>
@@ -20,7 +20,7 @@ This template contains whitespace between all of the elements. The following sni
 
 ```angular-html
 <!-- Total Whitespace: 20 -->
-<section>###<h3>User profile</p>###<label>#####User name#####<input>###</label>#</section>
+<section>###<h3>User profile</h3>###<label>#####User name#####<input>###</label>#</section>
 ```
 
 Preserving the whitespace as written in the template would result in many unnecessary [text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Text) and increase page rendering overhead. By ignoring this whitespace between elements, Angular performs less work when rendering the template on the page, improving overall performance.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently the opening and closing tags not matching.

Issue Number: N/A


## What is the new behavior?

fixed HTML markup for closing tags in whitespace examples.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
