### PR TITLE
refactor(forms): remove Mutable from signal forms public API

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -341,11 +341,6 @@ export class MinValidationError extends _NgValidationError {
 }
 
 // @public
-export type Mutable<T> = {
-    -readonly [P in keyof T]: T[P];
-};
-
-// @public
 export const NgValidationError: abstract new () => NgValidationError;
 
 // @public (undocumented)

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -17,16 +17,6 @@ import type {ValidationError, WithOptionalField, WithoutField} from './validatio
 declare const ɵɵTYPE: unique symbol;
 
 /**
- * Creates a type based on the given type T, but with all readonly properties made writable.
- * @template T The type to create a mutable version of.
- *
- * @experimental 21.0.0
- */
-export type Mutable<T> = {
-  -readonly [P in keyof T]: T[P];
-};
-
-/**
  * A type that represents either a single value of type `T` or a readonly array of `T`.
  * @template T The type of the value(s).
  *

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal} from '@angular/core';
-import type {FieldTree, Mutable, TreeValidationResult, ValidationResult} from '../api/types';
+import {computed, Signal, ɵWritable} from '@angular/core';
+import type {FieldTree, TreeValidationResult, ValidationResult} from '../api/types';
 import type {ValidationError, WithOptionalField} from '../api/validation_errors';
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
@@ -371,10 +371,10 @@ export function addDefaultField<E extends ValidationError>(
 ): ValidationResult<E> {
   if (isArray(errors)) {
     for (const error of errors) {
-      (error as Mutable<ValidationError>).field ??= field;
+      (error as ɵWritable<ValidationError>).field ??= field;
     }
   } else if (errors) {
-    (errors as Mutable<ValidationError>).field ??= field;
+    (errors as ɵWritable<ValidationError>).field ??= field;
   }
   return errors as ValidationResult<E>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `Mutable` type is only used internally in the `addDefaultField` function, so it can be avoided to be publicly exposed.

## What is the new behavior?

Removes it from public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
