### PR TITLE
fix(core): update animation scheduling

### DIFF
--- a/packages/core/src/animation/interfaces.ts
+++ b/packages/core/src/animation/interfaces.ts
@@ -18,27 +18,6 @@ export const ANIMATIONS_DISABLED = new InjectionToken<boolean>(
   },
 );
 
-export interface AnimationQueue {
-  queue: Set<Function>;
-  isScheduled: boolean;
-}
-
-/**
- * A [DI token](api/core/InjectionToken) for the queue of all animations.
- */
-export const ANIMATION_QUEUE = new InjectionToken<AnimationQueue>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'AnimationQueue' : '',
-  {
-    providedIn: 'root',
-    factory: () => {
-      return {
-        queue: new Set(),
-        isScheduled: false,
-      };
-    },
-  },
-);
-
 /**
  * The event type for when `animate.enter` and `animate.leave` are used with function
  * callbacks.

--- a/packages/core/src/animation/queue.ts
+++ b/packages/core/src/animation/queue.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {afterNextRender} from '../render3/after_render/hooks';
+import {InjectionToken, Injector} from '../di';
+import {NodeAnimations} from './interfaces';
+
+export interface AnimationQueue {
+  queue: Set<Function>;
+  isScheduled: boolean;
+  scheduler: Function | null;
+}
+
+/**
+ * A [DI token](api/core/InjectionToken) for the queue of all animations.
+ */
+export const ANIMATION_QUEUE = new InjectionToken<AnimationQueue>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'AnimationQueue' : '',
+  {
+    providedIn: 'root',
+    factory: () => {
+      return {
+        queue: new Set(),
+        isScheduled: false,
+        scheduler: null,
+      };
+    },
+  },
+);
+
+export function addToAnimationQueue(injector: Injector, animationFns: Function | Function[]) {
+  const animationQueue = injector.get(ANIMATION_QUEUE);
+  if (Array.isArray(animationFns)) {
+    for (const animateFn of animationFns) {
+      animationQueue.queue.add(animateFn);
+    }
+  } else {
+    animationQueue.queue.add(animationFns);
+  }
+  animationQueue.scheduler && animationQueue.scheduler(injector);
+}
+
+export function scheduleAnimationQueue(injector: Injector) {
+  const animationQueue = injector.get(ANIMATION_QUEUE);
+  // We only want to schedule the animation queue if it hasn't already been scheduled.
+  if (!animationQueue.isScheduled) {
+    afterNextRender(
+      () => {
+        animationQueue.isScheduled = false;
+        for (let animateFn of animationQueue.queue) {
+          animateFn();
+        }
+        animationQueue.queue.clear();
+      },
+      {injector},
+    );
+    animationQueue.isScheduled = true;
+  }
+}
+
+export function initializeAnimationQueueScheduler(injector: Injector) {
+  const animationQueue = injector.get(ANIMATION_QUEUE);
+  animationQueue.scheduler = scheduleAnimationQueue;
+  animationQueue.scheduler(injector);
+}
+
+export function queueEnterAnimations(
+  injector: Injector,
+  enterAnimations: Map<number, NodeAnimations>,
+) {
+  for (const [_, nodeAnimations] of enterAnimations) {
+    addToAnimationQueue(injector, nodeAnimations.animateFns);
+  }
+}

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -82,8 +82,8 @@ import {profiler} from './profiler';
 import {ProfilerEvent} from './profiler_types';
 import {getLViewParent, getNativeByTNode, unwrapRNode} from './util/view_utils';
 import {allLeavingAnimations} from '../animation/longest_animation';
-import {ANIMATION_QUEUE} from '../animation/interfaces';
 import {Injector} from '../di';
+import {addToAnimationQueue, queueEnterAnimations} from '../animation/queue';
 
 const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
@@ -110,10 +110,7 @@ function maybeQueueEnterAnimation(
 ): void {
   const enterAnimations = parentLView?.[ANIMATIONS]?.enter;
   if (parent !== null && enterAnimations && enterAnimations.has(tNode.index)) {
-    const animationQueue = injector.get(ANIMATION_QUEUE);
-    for (const animateFn of enterAnimations.get(tNode.index)!.animateFns) {
-      animationQueue.queue.add(animateFn);
-    }
+    queueEnterAnimations(injector, enterAnimations);
   }
 }
 
@@ -179,17 +176,6 @@ function applyToElementOrContainer(
     if (lContainer != null) {
       applyContainer(renderer, action, injector, lContainer, tNode, parent, beforeNode);
     }
-  }
-}
-
-function addToAnimationQueue(injector: Injector, animationFns: Function | Function[]) {
-  const animationQueue = injector.get(ANIMATION_QUEUE);
-  if (Array.isArray(animationFns)) {
-    for (const animateFn of animationFns) {
-      animationQueue.queue.add(animateFn);
-    }
-  } else {
-    animationQueue.queue.add(animationFns);
   }
 }
 

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -48,7 +48,7 @@ import {ComponentFixture, TestBed, TestComponentRenderer} from '../../testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
 import {By, DomSanitizer} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
-import {ANIMATION_QUEUE} from '../../src/animation/interfaces';
+import {ANIMATION_QUEUE} from '../../src/animation/queue';
 
 describe('ViewContainerRef', () => {
   /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -748,6 +748,7 @@
       "providerToFactory",
       "providerToRecord",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "refreshContentQueries",
       "refreshView",
       "registerFailed",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -650,6 +650,7 @@
       "providerToFactory",
       "providerToRecord",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "refreshContentQueries",
       "refreshView",
       "registerHostBindingOpCodes",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -865,6 +865,7 @@
       "providerToRecord",
       "providersResolver",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "readableStreamLikeToAsyncGenerator",
       "refreshContentQueries",
       "refreshView",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -863,6 +863,7 @@
       "providerToRecord",
       "providersResolver",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "readableStreamLikeToAsyncGenerator",
       "refreshContentQueries",
       "refreshView",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -686,6 +686,7 @@
       "providerToFactory",
       "providerToRecord",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "readableStreamLikeToAsyncGenerator",
       "refreshContentQueries",
       "refreshView",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -974,6 +974,7 @@
       "providerToFactory",
       "providerToRecord",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "readableStreamLikeToAsyncGenerator",
       "recognize",
       "recognize",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -545,6 +545,7 @@
       "providerToFactory",
       "providerToRecord",
       "publishSignalConfiguration",
+      "queueEnterAnimations",
       "refreshContentQueries",
       "refreshView",
       "registerHostBindingOpCodes",


### PR DESCRIPTION
In some rare cases, the injection context that houses the `afterEveryRender` for the animation queue gets destroyed. This results in any subsequent animations getting queued, but never run. To prevent this from happening, this PR updates the queuing mechanism to use `afterNextRender` and to trigger the scheduling at the time of adding animations to that queue. This has a nice side effect of optimizing the animation queue to only run animations when needed.

fixes: #64423