### PR TITLE
refactor(forms): indicate field key in assertPathIsCurrent error

### DIFF
--- a/packages/forms/signals/src/schema/schema.ts
+++ b/packages/forms/signals/src/schema/schema.ts
@@ -104,10 +104,11 @@ export function isSchemaOrSchemaFn(value: unknown): value is SchemaOrSchemaFn<un
 
 /** Checks that a path node belongs to the schema function currently being compiled. */
 export function assertPathIsCurrent(path: FieldPath<unknown>): void {
-  if (currentCompilingNode !== FieldPathNode.unwrapFieldPath(path).root) {
+  const fieldPathNode = FieldPathNode.unwrapFieldPath(path);
+  if (currentCompilingNode !== fieldPathNode.root) {
     throw new Error(
       `A FieldPath can only be used directly within the Schema that owns it,` +
-        ` **not** outside of it or within a sub-schema.`,
+        ` **not** outside of it or within a sub-schema: ${fieldPathNode.keys.join('.')}`,
     );
   }
 }

--- a/packages/forms/signals/test/node/api/when.spec.ts
+++ b/packages/forms/signals/test/node/api/when.spec.ts
@@ -47,15 +47,19 @@ describe('when', () => {
   });
 
   it('Disallows using non-local paths', () => {
-    const data = signal({first: '', needLastName: false, last: ''});
+    const data = signal({first: '', needLastName: false, inside: {last: ''}});
 
     const f = form(
       data,
       (path) => {
         applyWhen(path, needsLastNamePredicate, (/* UNUSED */) => {
           expect(() => {
-            validate(path.last, ({value}) => (value().length > 0 ? undefined : requiredError()));
-          }).toThrowError();
+            validate(path.inside.last, ({value}) =>
+              value().length > 0 ? undefined : requiredError(),
+            );
+          }).toThrowError(
+            'A FieldPath can only be used directly within the Schema that owns it, **not** outside of it or within a sub-schema: inside.last',
+          );
         });
       },
       {injector: TestBed.inject(Injector)},


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

The error now displays the key of path in error, making it easier to troubleshoot while developing.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
