### PR TITLE
fix(forms): implement interoperability between signal forms and reactive forms

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
+import { AbstractControl } from '@angular/forms';
+import { ControlValueAccessor } from '@angular/forms';
 import { DestroyableInjector } from '@angular/core';
+import { FormControlStatus } from '@angular/forms';
 import { HttpResourceOptions } from '@angular/common/http';
 import { HttpResourceRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
@@ -12,10 +15,13 @@ import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
 import { InputSignal } from '@angular/core';
 import { ModelSignal } from '@angular/core';
+import { NgControl } from '@angular/forms';
 import { OutputRef } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { StandardSchemaV1 } from '@standard-schema/spec';
+import { ValidationErrors } from '@angular/forms';
+import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
@@ -116,6 +122,13 @@ export class Field<T> implements ɵControl<T> {
     readonly [ɵCONTROL]: undefined;
     // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
+    getOrCreateNgControl(): InteropNgControl;
+    // (undocumented)
+    get hasInteropControl(): boolean;
+    // (undocumented)
+    interopControlCreate(): void;
+    // (undocumented)
+    interopControlUpdate(): void;
     // (undocumented)
     register(): void;
     // (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -122,21 +122,21 @@ export class Field<T> implements ɵControl<T> {
     readonly [ɵCONTROL]: undefined;
     // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
-    getOrCreateNgControl(): InteropNgControl;
-    // (undocumented)
-    get hasInteropControl(): boolean;
-    // (undocumented)
-    interopControlCreate(): void;
-    // (undocumented)
-    interopControlUpdate(): void;
-    // (undocumented)
-    register(): void;
     // (undocumented)
     readonly state: i0.Signal<FieldState<T, string | number>>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<Field<any>, "[field]", never, { "field": { "alias": "field"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Field<any>, never>;
+    ɵgetOrCreateNgControl(): InteropNgControl;
+    // (undocumented)
+    get ɵhasInteropControl(): boolean;
+    // (undocumented)
+    ɵinteropControlCreate(): void;
+    // (undocumented)
+    ɵinteropControlUpdate(): void;
+    // (undocumented)
+    ɵregister(): void;
 }
 
 // @public

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -49,12 +49,12 @@ export function ɵɵcontrolCreate(): void {
   } else if (tNode.flags & TNodeFlags.isFormCheckboxControl) {
     listenToCustomControl(lView, tNode, control, 'checked');
   } else if (tNode.flags & TNodeFlags.isInteropControl) {
-    control.interopControlCreate();
+    control.ɵinteropControlCreate();
   } else {
     listenToNativeControl(lView, tNode, control);
   }
 
-  control.register();
+  control.ɵregister();
 }
 
 /**
@@ -86,7 +86,7 @@ export function ɵɵcontrol<T>(value: T, sanitizer?: SanitizerFn | null): void {
     } else if (tNode.flags & TNodeFlags.isFormCheckboxControl) {
       updateCustomControl(tNode, lView, control, 'checked');
     } else if (tNode.flags & TNodeFlags.isInteropControl) {
-      control.interopControlUpdate();
+      control.ɵinteropControlUpdate();
     } else {
       updateNativeControl(tNode, lView, control);
     }
@@ -136,7 +136,7 @@ function getControlDirectiveFirstCreatePass<T>(
     }
   }
 
-  if (control.hasInteropControl) {
+  if (control.ɵhasInteropControl) {
     tNode.flags |= TNodeFlags.isInteropControl;
     return control;
   }

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -48,6 +48,8 @@ export function ɵɵcontrolCreate(): void {
     listenToCustomControl(lView, tNode, control, 'value');
   } else if (tNode.flags & TNodeFlags.isFormCheckboxControl) {
     listenToCustomControl(lView, tNode, control, 'checked');
+  } else if (tNode.flags & TNodeFlags.isInteropControl) {
+    control.interopControlCreate();
   } else {
     listenToNativeControl(lView, tNode, control);
   }
@@ -83,6 +85,8 @@ export function ɵɵcontrol<T>(value: T, sanitizer?: SanitizerFn | null): void {
       updateCustomControl(tNode, lView, control, 'value');
     } else if (tNode.flags & TNodeFlags.isFormCheckboxControl) {
       updateCustomControl(tNode, lView, control, 'checked');
+    } else if (tNode.flags & TNodeFlags.isInteropControl) {
+      control.interopControlUpdate();
     } else {
       updateNativeControl(tNode, lView, control);
     }
@@ -130,6 +134,11 @@ function getControlDirectiveFirstCreatePass<T>(
       tNode.flags |= TNodeFlags.isFormCheckboxControl;
       return control;
     }
+  }
+
+  if (control.hasInteropControl) {
+    tNode.flags |= TNodeFlags.isInteropControl;
+    return control;
   }
 
   if (isNativeControl(tNode)) {

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -29,6 +29,29 @@ export interface ɵControl<T> {
    * and do nothing.
    */
   register(): void;
+
+  /**
+   * Indicates whether this field is bound to an interoperable control.
+   *
+   * This is used for interoperability between signal forms and reactive forms.
+   */
+  readonly hasInteropControl: boolean;
+
+  /**
+   * Adds event listeners to the associated interoperable control.
+   *
+   * This method should only be called from a template function in create mode if this
+   * {@link hasInteropControl}.
+   */
+  interopControlCreate(): void;
+
+  /**
+   * Updates the associated interoperable control.
+   *
+   * This method should only be called from a template function in update mode if this
+   * {@link hasInteropControl}.
+   */
+  interopControlUpdate(): void;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -28,30 +28,30 @@ export interface ɵControl<T> {
    * the component will forward the bound field to another field directive in its own template,
    * and do nothing.
    */
-  register(): void;
+  ɵregister(): void;
 
   /**
    * Indicates whether this field is bound to an interoperable control.
    *
    * This is used for interoperability between signal forms and reactive forms.
    */
-  readonly hasInteropControl: boolean;
+  readonly ɵhasInteropControl: boolean;
 
   /**
    * Adds event listeners to the associated interoperable control.
    *
    * This method should only be called from a template function in create mode if this
-   * {@link hasInteropControl}.
+   * {@link ɵhasInteropControl}.
    */
-  interopControlCreate(): void;
+  ɵinteropControlCreate(): void;
 
   /**
    * Updates the associated interoperable control.
    *
    * This method should only be called from a template function in update mode if this
-   * {@link hasInteropControl}.
+   * {@link ɵhasInteropControl}.
    */
-  interopControlUpdate(): void;
+  ɵinteropControlUpdate(): void;
 }
 
 /**

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -194,18 +194,25 @@ export const enum TNodeFlags {
   isFormCheckboxControl = 0x1000,
 
   /**
-   * Bit #14 - This bit is set if the node is a native control with a numeric type.
+   * Bit #14 - This bit is set if the node hosts an interoperable control implementation.
+   *
+   * This is used to bind to a `ControlValueAccessor` from `@angular/forms`.
+   */
+  isInteropControl = 0x2000,
+
+  /**
+   * Bit #15 - This bit is set if the node is a native control with a numeric type.
    *
    * This is used to determine whether the control supports the `min` and `max` properties.
    */
-  isNativeNumericControl = 0x2000,
+  isNativeNumericControl = 0x4000,
 
   /**
-   * Bit #15 - This bit is set if the node is a native text control.
+   * Bit #16 - This bit is set if the node is a native text control.
    *
    * This is used to determine whether control supports the `minLength` and `maxLength` properties.
    */
-  isNativeTextControl = 0x4000,
+  isNativeTextControl = 0x8000,
 }
 
 /**

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -33,7 +33,7 @@ export const FIELD = new InjectionToken<Field<unknown>>(
  * Binds a form `FieldTree` to a UI control that edits it. A UI control can be one of several things:
  * 1. A native HTML input or textarea
  * 2. A signal forms custom control that implements `FormValueControl` or `FormCheckboxControl`
- * 3. A component that provides a `ControlValueAccessor`. This should only be used to backwards
+ * 3. A component that provides a `ControlValueAccessor`. This should only be used for backwards
  *    compatibility with reactive forms. Prefer options (1) and (2).
  *
  * This directive has several responsibilities:

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -52,7 +52,7 @@ export const FIELD = new InjectionToken<Field<unknown>>(
   selector: '[field]',
   providers: [
     {provide: FIELD, useExisting: Field},
-    {provide: NgControl, useFactory: () => inject(Field).getOrCreateNgControl()},
+    {provide: NgControl, useFactory: () => inject(Field).ɵgetOrCreateNgControl()},
   ],
 })
 export class Field<T> implements ɵControl<T> {
@@ -67,27 +67,27 @@ export class Field<T> implements ɵControl<T> {
   /** A lazily instantiated fake `NgControl`. */
   private interopNgControl: InteropNgControl | undefined;
 
-  /** Lazily instantiates a fake `NgControl` for this field. */
-  getOrCreateNgControl(): InteropNgControl {
-    return (this.interopNgControl ??= new InteropNgControl(this.state));
-  }
-
   /** A `ControlValueAccessor`, if configured, for the host component. */
   private get controlValueAccessor(): ControlValueAccessor | undefined {
     return this.controlValueAccessors?.[0] ?? this.interopNgControl?.valueAccessor ?? undefined;
   }
 
-  get hasInteropControl() {
+  get ɵhasInteropControl() {
     return this.controlValueAccessor !== undefined;
   }
 
-  interopControlCreate() {
+  /** Lazily instantiates a fake `NgControl` for this field. */
+  ɵgetOrCreateNgControl(): InteropNgControl {
+    return (this.interopNgControl ??= new InteropNgControl(this.state));
+  }
+
+  ɵinteropControlCreate() {
     const controlValueAccessor = this.controlValueAccessor!;
     controlValueAccessor.registerOnChange((value: T) => this.state().value.set(value));
     controlValueAccessor.registerOnTouched(() => this.state().markAsTouched());
   }
 
-  interopControlUpdate() {
+  ɵinteropControlUpdate() {
     const controlValueAccessor = this.controlValueAccessor!;
     // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131711472
     // * check if values changed since last update before writing.
@@ -96,7 +96,7 @@ export class Field<T> implements ɵControl<T> {
   }
 
   // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131861631
-  register() {
+  ɵregister() {
     // Register this control on the field it is currently bound to. We do this at the end of
     // initialization so that it only runs if we are actually syncing with this control
     // (as opposed to just passing the field through to its `field` input).

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -83,7 +83,11 @@ export class Field<T> implements ɵControl<T> {
 
   ɵinteropControlCreate() {
     const controlValueAccessor = this.controlValueAccessor!;
-    controlValueAccessor.registerOnChange((value: T) => this.state().value.set(value));
+    controlValueAccessor.registerOnChange((value: T) => {
+      const state = this.state();
+      state.value.set(value);
+      state.markAsDirty();
+    });
     controlValueAccessor.registerOnTouched(() => this.state().markAsTouched());
   }
 

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -92,6 +92,29 @@ describe('ControlValueAccessor', () => {
     expect(fixture.componentInstance.f().value()).toBe('typing');
   });
 
+  it('should mark field dirty on changes', () => {
+    @Component({
+      imports: [Field, CustomControl],
+      template: `<custom-control [field]="f" />`,
+    })
+    class TestCmp {
+      f = form<string>(signal(''));
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const field = fixture.componentInstance.f;
+
+    expect(field().dirty()).toBe(false);
+
+    act(() => {
+      input.value = 'typing';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(field().dirty()).toBe(true);
+  });
+
   it('should propagate touched events to field', () => {
     @Component({
       imports: [Field, CustomControl],

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, inject, signal, provideZonelessChangeDetection, viewChild} from '@angular/core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
+import {disabled, Field, form} from '@angular/forms/signals';
+import {TestBed} from '@angular/core/testing';
+
+describe('ControlValueAccessor', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+  });
+
+  @Component({
+    selector: 'custom-control',
+    template: `
+        <input
+          [value]="value"
+          [disabled]="disabled"
+          (blur)="onBlur()"
+          (input)="onInput($event.target.value)"
+        />
+      `,
+    providers: [{provide: NG_VALUE_ACCESSOR, useExisting: CustomControl, multi: true}],
+  })
+  class CustomControl implements ControlValueAccessor {
+    value = '';
+    disabled = false;
+
+    private onChangeFn?: (value: string) => void;
+    private onTouchedFn?: () => void;
+
+    writeValue(newValue: string): void {
+      this.value = newValue;
+    }
+
+    registerOnChange(fn: (value: string) => void): void {
+      this.onChangeFn = fn;
+    }
+
+    registerOnTouched(fn: () => void): void {
+      this.onTouchedFn = fn;
+    }
+
+    setDisabledState(disabled: boolean): void {
+      this.disabled = disabled;
+    }
+
+    onBlur() {
+      this.onTouchedFn?.();
+    }
+
+    onInput(newValue: string) {
+      this.value = newValue;
+      this.onChangeFn?.(newValue);
+    }
+  }
+
+  it('synchronizes value', () => {
+    @Component({
+      imports: [CustomControl, Field],
+      template: `<custom-control [field]="f" />`,
+    })
+    class TestCmp {
+      readonly f = form(signal('test'));
+      readonly control = viewChild.required(CustomControl);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const control = fixture.componentInstance.control;
+    const input = fixture.nativeElement.firstChild.firstChild;
+
+    // Initial state
+    expect(control().value).toBe('test');
+
+    // Model -> View
+    act(() => fixture.componentInstance.f().value.set('testing'));
+    expect(control().value).toBe('testing');
+
+    // View -> Model
+    act(() => {
+      input.value = 'typing';
+      input.dispatchEvent(new Event('input'));
+    });
+    expect(fixture.componentInstance.f().value()).toBe('typing');
+  });
+
+  it('should propagate touched events to field', () => {
+    @Component({
+      imports: [Field, CustomControl],
+      template: `<custom-control [field]="f" />`,
+    })
+    class TestCmp {
+      f = form<string>(signal('test'));
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.firstChild.firstChild;
+    expect(fixture.componentInstance.f().touched()).toBe(false);
+
+    act(() => input.dispatchEvent(new Event('blur')));
+    expect(fixture.componentInstance.f().touched()).toBe(true);
+  });
+
+  it('should propagate disabled status from field', () => {
+    const enabled = signal(true);
+    @Component({
+      imports: [Field, CustomControl],
+      template: `<custom-control [field]="f" />`,
+    })
+    class TestCmp {
+      f = form<string>(signal('test'), (p) => {
+        disabled(p, () => !enabled());
+      });
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.firstChild.firstChild;
+    expect(input.disabled).toBe(false);
+
+    act(() => enabled.set(false));
+    expect(input.disabled).toBe(true);
+
+    act(() => enabled.set(true));
+    expect(input.disabled).toBe(false);
+  });
+
+  it(`should use 'NgControl.valueAccessor' if 'NG_VALUE_ACCESSOR' was not provided`, () => {
+    @Component({
+      selector: 'custom-control',
+      template: `
+        <input [value]="value" (blur)="onBlur()" (input)="onInput($event.target.value)"/>
+      `,
+    })
+    class CustomControl implements ControlValueAccessor {
+      constructor() {
+        inject(NgControl).valueAccessor = this;
+      }
+
+      value = '';
+      private onChangeFn?: (value: string) => void;
+      private onTouchedFn?: () => void;
+
+      writeValue(newValue: string): void {
+        this.value = newValue;
+      }
+
+      registerOnChange(fn: (value: string) => void): void {
+        this.onChangeFn = fn;
+      }
+
+      registerOnTouched(fn: () => void): void {
+        this.onTouchedFn = fn;
+      }
+
+      onBlur() {
+        this.onTouchedFn?.();
+      }
+
+      onInput(newValue: string) {
+        this.value = newValue;
+        this.onChangeFn?.(newValue);
+      }
+    }
+
+    @Component({
+      imports: [CustomControl, Field],
+      template: `<custom-control [field]="f" />`,
+    })
+    class TestCmp {
+      readonly f = form(signal('test'));
+      readonly control = viewChild.required(CustomControl);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const control = fixture.componentInstance.control;
+    const input = fixture.nativeElement.firstChild.firstChild;
+
+    // Initial state
+    expect(control().value).toBe('test');
+
+    // Model -> View
+    act(() => fixture.componentInstance.f().value.set('testing'));
+    expect(control().value).toBe('testing');
+
+    // View -> Model
+    act(() => {
+      input.value = 'typing';
+      input.dispatchEvent(new Event('input'));
+    });
+    expect(fixture.componentInstance.f().value()).toBe('typing');
+  });
+});
+
+function act<T>(fn: () => T): T {
+  try {
+    return fn();
+  } finally {
+    TestBed.tick();
+  }
+}

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -75,7 +75,7 @@ describe('ControlValueAccessor', () => {
 
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const control = fixture.componentInstance.control;
-    const input = fixture.nativeElement.firstChild.firstChild;
+    const input = fixture.nativeElement.querySelector('input');
 
     // Initial state
     expect(control().value).toBe('test');
@@ -102,7 +102,7 @@ describe('ControlValueAccessor', () => {
     }
 
     const fixture = act(() => TestBed.createComponent(TestCmp));
-    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const input = fixture.nativeElement.querySelector('input');
     const field = fixture.componentInstance.f;
 
     expect(field().dirty()).toBe(false);
@@ -125,7 +125,7 @@ describe('ControlValueAccessor', () => {
     }
 
     const fixture = act(() => TestBed.createComponent(TestCmp));
-    const input = fixture.nativeElement.firstChild.firstChild;
+    const input = fixture.nativeElement.querySelector('input');
     expect(fixture.componentInstance.f().touched()).toBe(false);
 
     act(() => input.dispatchEvent(new Event('blur')));
@@ -145,7 +145,7 @@ describe('ControlValueAccessor', () => {
     }
 
     const fixture = act(() => TestBed.createComponent(TestCmp));
-    const input = fixture.nativeElement.firstChild.firstChild;
+    const input = fixture.nativeElement.querySelector('input');
     expect(input.disabled).toBe(false);
 
     act(() => enabled.set(false));
@@ -204,7 +204,7 @@ describe('ControlValueAccessor', () => {
 
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const control = fixture.componentInstance.control;
-    const input = fixture.nativeElement.firstChild.firstChild;
+    const input = fixture.nativeElement.querySelector('input');
 
     // Initial state
     expect(control().value).toBe('test');


### PR DESCRIPTION


Add support for interoperability between signal forms and reactive forms that commit effccffde0c5aa8f8f8d9e67013b88d1ccc762d7 had removed.

A signal forms field can once again be bound to any element or component with a `ControlValueAccessor`.