### PR TITLE
fix(forms): mark field as dirty when value is changed by a bound control

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -221,7 +221,9 @@ function listenToCustomControl(
     outputName,
     outputName,
     wrapListener(tNode, lView, (newValue: unknown) => {
-      control.state().value.set(newValue);
+      const state = control.state();
+      state.value.set(newValue);
+      state.markAsDirty();
     }),
   );
 
@@ -279,8 +281,9 @@ function listenToNativeControl(lView: LView<{} | null>, tNode: TNode, control: É
   const renderer = lView[RENDERER];
   const inputListener = () => {
     const element = getNativeByTNode(tNode, lView) as NativeControlElement;
-    const value = control.state().value;
-    value.set(getNativeControlValue(element, value));
+    const state = control.state();
+    state.value.set(getNativeControlValue(element, state.value));
+    state.markAsDirty();
   };
   listenToDomEvent(
     tNode,

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -565,7 +565,7 @@ describe('field directive', () => {
     });
   });
 
-  it('synchronizes a basic form with a custom control', () => {
+  it('synchronizes with a value control', () => {
     @Component({
       imports: [Field],
       template: `
@@ -907,60 +907,6 @@ describe('field directive', () => {
     act(() => control.set(f2));
     expect(f1().fieldBindings()).toEqual([]);
     expect(f2().fieldBindings()).toEqual([fixture.componentInstance.fieldDirective()]);
-  });
-
-  it('should synchronize custom properties', () => {
-    @Component({
-      template: `
-        <input #text type="text" [field]="f.text">
-        <input #number type="number" [field]="f.number">
-      `,
-      imports: [Field],
-    })
-    class CustomPropsTestCmp {
-      textInput = viewChild.required<ElementRef<HTMLInputElement>>('text');
-      numberInput = viewChild.required<ElementRef<HTMLInputElement>>('number');
-      data = signal({
-        number: 0,
-        text: '',
-      });
-      f = form(this.data, (p) => {
-        required(p.text);
-        minLength(p.text, 0);
-        maxLength(p.text, 100);
-        min(p.number, 0);
-        max(p.number, 100);
-      });
-    }
-
-    const comp = act(() => TestBed.createComponent(CustomPropsTestCmp)).componentInstance;
-
-    expect(comp.textInput().nativeElement.required).toBe(true);
-    expect(comp.textInput().nativeElement.minLength).toBe(0);
-    expect(comp.textInput().nativeElement.maxLength).toBe(100);
-    expect(comp.numberInput().nativeElement.required).toBe(false);
-    expect(comp.numberInput().nativeElement.min).toBe('0');
-    expect(comp.numberInput().nativeElement.max).toBe('100');
-  });
-
-  it('should synchronize readonly', () => {
-    @Component({
-      template: `
-        <input #text type="text" [field]="f">
-      `,
-      imports: [Field],
-    })
-    class ReadonlyTestCmp {
-      textInput = viewChild.required<ElementRef<HTMLInputElement>>('text');
-      data = signal('');
-      f = form(this.data, (p) => {
-        readonly(p);
-      });
-    }
-
-    const comp = act(() => TestBed.createComponent(ReadonlyTestCmp)).componentInstance;
-
-    expect(comp.textInput().nativeElement.readOnly).toBe(true);
   });
 
   it('should synchronize disabled reasons', () => {

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -1261,6 +1261,62 @@ describe('field directive', () => {
     });
   });
 
+  describe('should be marked dirty by user interaction', () => {
+    it('native control', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(''));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.firstChild as HTMLInputElement;
+      const field = fixture.componentInstance.f;
+
+      expect(field().dirty()).toBe(false);
+
+      act(() => {
+        input.value = 'typing';
+        input.dispatchEvent(new Event('input'));
+      });
+
+      expect(field().dirty()).toBe(true);
+    });
+
+    it('custom control', () => {
+      @Component({
+        selector: 'my-input',
+        template: '<input #i [value]="value()" (input)="value.set(i.value)" />',
+      })
+      class CustomInput implements FormValueControl<string> {
+        value = model('');
+      }
+
+      @Component({
+        imports: [Field, CustomInput],
+        template: `<my-input [field]="f" />`,
+      })
+      class TestCmp {
+        f = form<string>(signal(''));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+      const field = fixture.componentInstance.f;
+
+      expect(field().dirty()).toBe(false);
+
+      act(() => {
+        input.value = 'typing';
+        input.dispatchEvent(new Event('input'));
+      });
+
+      expect(field().dirty()).toBe(true);
+    });
+  });
+
   it('should throw for invalid field directive host', () => {
     @Component({
       imports: [Field],


### PR DESCRIPTION
Fix https://github.com/angular/angular/issues/64465.
Fix https://github.com/angular/angular/issues/63623.