### PR TITLE
test(forms): field directive marks field as touched on 'blur' events

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -294,7 +294,6 @@ function listenToNativeControl(lView: LView<{} | null>, tNode: TNode, control: É
   );
 
   const blurListener = () => {
-    // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131860538
     control.state().markAsTouched();
   };
   listenToDomEvent(

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -994,6 +994,28 @@ describe('field directive', () => {
     ]);
   });
 
+  it(`should mark field as touched on native control 'blur' event`, () => {
+    @Component({
+      imports: [Field],
+      template: `<input [field]="f">`,
+    })
+    class TestCmp {
+      f = form(signal(''));
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.firstChild as HTMLInputElement;
+    const field = fixture.componentInstance.f;
+
+    expect(field().touched()).toBe(false);
+
+    act(() => {
+      input.dispatchEvent(new Event('blur'));
+    });
+
+    expect(field().touched()).toBe(true);
+  });
+
   it('should synchronize with custom control touched status', () => {
     @Component({
       selector: 'my-input',


### PR DESCRIPTION
This was implemented but missing a test case.