### PR TITLE
feat(forms): add CSS status classes to signal forms Field directive

### DIFF
--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -28,6 +28,24 @@ export const FIELD = new InjectionToken<Field<unknown>>(
 );
 
 /**
+ * CSS classes that reflect the status of the control.
+ * These classes are applied to the host element of the {@link Field} directive.
+ * They mirror the classes applied by Angular's reactive forms and template-driven forms.
+ * @internal
+ * @category control
+ * @experimental 21.0.0
+ */
+export const ngControlStatusHost = {
+  '[class.ng-untouched]': 'isUntouched',
+  '[class.ng-touched]': 'isTouched',
+  '[class.ng-pristine]': 'isPristine',
+  '[class.ng-dirty]': 'isDirty',
+  '[class.ng-valid]': 'isValid',
+  '[class.ng-invalid]': 'isInvalid',
+  '[class.ng-pending]': 'isPending',
+};
+
+/**
  * Binds a form `FieldTree` to a UI control that edits it. A UI control can be one of several things:
  * 1. A native HTML input or textarea
  * 2. A signal forms custom control that implements `FormValueControl` or `FormCheckboxControl`
@@ -48,7 +66,13 @@ export const FIELD = new InjectionToken<Field<unknown>>(
  * @category control
  * @experimental 21.0.0
  */
-@Directive({selector: '[field]', providers: [{provide: FIELD, useExisting: Field}]})
+@Directive({
+  selector: '[field]',
+  host: {
+    ...ngControlStatusHost,
+  },
+  providers: [{provide: FIELD, useExisting: Field}],
+})
 export class Field<T> implements ɵControl<T> {
   private readonly injector = inject(Injector);
   readonly field = input.required<FieldTree<T>>();
@@ -75,5 +99,33 @@ export class Field<T> implements ɵControl<T> {
       },
       {injector: this.injector},
     );
+  }
+
+  protected get isTouched() {
+    return this.state().touched();
+  }
+
+  protected get isUntouched() {
+    return !this.state().touched();
+  }
+
+  protected get isDirty() {
+    return this.state().dirty();
+  }
+
+  protected get isPristine() {
+    return !this.state().dirty();
+  }
+
+  protected get isValid() {
+    return this.state().valid();
+  }
+
+  protected get isInvalid() {
+    return !this.state().valid();
+  }
+
+  protected get isPending() {
+    return this.state().pending();
   }
 }

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -1328,6 +1328,99 @@ describe('field directive', () => {
       /'<div>' is an invalid \[field\] directive host\./,
     );
   });
+
+  describe('field status classes', () => {
+    it('should apply initial status classes', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => required(p));
+      }
+
+      const fixture = TestBed.createComponent(TestCmp);
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector('input');
+      expect(input.classList.contains('ng-untouched')).toBe(true);
+      expect(input.classList.contains('ng-pristine')).toBe(true);
+      expect(input.classList.contains('ng-invalid')).toBe(true);
+    });
+
+    it('should update touched classes on blur', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => required(p));
+      }
+
+      const fixture = TestBed.createComponent(TestCmp);
+      fixture.detectChanges();
+      const input = fixture.nativeElement.querySelector('input');
+
+      input.dispatchEvent(new Event('blur'));
+      fixture.detectChanges();
+
+      expect(input.classList.contains('ng-touched')).toBe(true);
+      expect(input.classList.contains('ng-untouched')).toBe(false);
+    });
+
+    it('should update dirty classes on value change', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => required(p));
+      }
+
+      const fixture = TestBed.createComponent(TestCmp);
+      fixture.detectChanges();
+      const input = fixture.nativeElement.firstChild as HTMLInputElement;
+
+      input.value = 'test';
+      input.dispatchEvent(new Event('input'));
+      fixture.componentInstance.f().markAsDirty();
+      fixture.detectChanges();
+
+      expect(input.classList.contains('ng-dirty')).toBe(true);
+      expect(input.classList.contains('ng-pristine')).toBe(false);
+    });
+
+    it('should reset classes when reset() is called', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(''), (p) => required(p));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const field = fix.componentInstance.f;
+
+      // Make it dirty and touched
+      act(() => {
+        input.value = 'test';
+        input.dispatchEvent(new Event('input'));
+        field().markAsDirty();
+        input.dispatchEvent(new Event('blur'));
+      });
+
+      expect(input.classList.contains('ng-dirty')).toBe(true);
+      expect(input.classList.contains('ng-touched')).toBe(true);
+
+      // Reset
+      act(() => field().reset());
+
+      expect(input.classList.contains('ng-pristine')).toBe(true);
+      expect(input.classList.contains('ng-untouched')).toBe(true);
+    });
+  });
 });
 
 function setupRadioGroup() {


### PR DESCRIPTION
Add automatic CSS status class application (.ng-valid, .ng-invalid, .ng-dirty, .ng-pristine, .ng-touched, .ng-untouched, .ng-pending) to the signal forms Control directive. This brings signal forms to feature parity with reactive forms and template-driven forms, which already apply these classes automatically for styling form controls based on their validation and interaction state.

I'll make another PR with token based classes.  

Fixes: #64246

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
