### PR TITLE
docs: fix import statement to use "inject" function instead of "Inject"

### DIFF
--- a/adev/src/content/guide/di/di-in-action.md
+++ b/adev/src/content/guide/di/di-in-action.md
@@ -9,7 +9,7 @@ The following example uses an `InjectionToken` to provide the [localStorage](htt
 
 <docs-code header="src/app/storage.service.ts" language="typescript"
            highlight="[[3,6],[12]]">
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 
 export const BROWSER_STORAGE = new InjectionToken<Storage>('Browser Storage', {
   providedIn: 'root',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The import statement on the [DI inaction](https://angular.dev/guide/di/di-in-action#custom-providers-with-inject) page example includes Inject, but should be inject(I -> i)
<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/fefa9c1c-b448-4bd5-8cc3-054c2c835024" />


Issue Number: 1


## What is the new behavior?
Fix the wrong spelling from "Inject" to "inject"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
