### PR TITLE
build: remove unused commit message scopes

### DIFF
--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -11,9 +11,7 @@ export const commitMessage: CommitMessageConfig = {
   // https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md#scope
   scopes: [
     'animations',
-    'bazel',
     'benchpress',
-    'changelog',
     'common',
     'compiler',
     'compiler-cli',
@@ -28,7 +26,6 @@ export const commitMessage: CommitMessageConfig = {
     'language-server',
     'localize',
     'migrations',
-    'packaging',
     'platform-browser',
     'platform-browser-dynamic',
     'platform-server',

--- a/.ng-dev/release.mts
+++ b/.ng-dev/release.mts
@@ -29,7 +29,14 @@ export const release: ReleaseConfig = {
     return performNpmReleaseBuild();
   },
   releaseNotes: {
-    hiddenScopes: ['bazel', 'dev-infra', 'docs-infra', 'zone.js', 'devtools'],
+    hiddenScopes: [
+      'dev-infra',
+      'docs-infra',
+      'zone.js',
+      'devtools',
+      'vscode-extension',
+      'benchpress',
+    ],
   },
   releasePrLabels: ['area: build & ci', 'action: merge', 'PullApprove: disable'],
 };

--- a/contributing-docs/commit-message-guidelines.md
+++ b/contributing-docs/commit-message-guidelines.md
@@ -63,9 +63,7 @@ The scope should be the name of the npm package affected (as perceived by the pe
 The following is the list of supported scopes:
 
 * `animations`
-* `bazel`
 * `benchpress`
-* `changelog`
 * `common`
 * `compiler`
 * `compiler-cli`
@@ -77,22 +75,19 @@ The following is the list of supported scopes:
 * `forms`
 * `http`
 * `language-service`
+* `language-server`
 * `localize`
 * `migrations`
-* `packaging`
 * `platform-browser`
 * `platform-browser-dynamic`
 * `platform-server`
 * `router`
 * `service-worker`
 * `upgrade`
+* `vscode-extension`
 * `zone.js`
 
 There are currently a few exceptions to the "use package name" rule:
-
-* `packaging`: used for changes that change the npm package layout in all of our packages, e.g. public path changes, package.json changes done to all packages, d.ts file/format changes, changes to bundles, etc.
-
-* `changelog`: used for updating the release notes in CHANGELOG.md
 
 * `dev-infra`: used for dev-infra related changes within the directories /scripts and /tools
 


### PR DESCRIPTION
Removes a number of commit message scopes that are no longer in use.

- `bazel`: Now part of `dev-infra`
- `changelog`: The changelog is autogenerated and doesn't have dedicated commits.
- `packaging`: Is handled by `dev-infra` as well.
