### PR TITLE
fix(router): Fix outlet serialization and parsing with no primary chi…

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -728,7 +728,7 @@ class UrlParser {
 
       const children = this.parseChildren();
       segments[outletName] =
-        Object.keys(children).length === 1
+        Object.keys(children).length === 1 && children[PRIMARY_OUTLET]
           ? children[PRIMARY_OUTLET]
           : new UrlSegmentGroup([], children);
       this.consumeOptional('//');

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {exactMatchOptions, subsetMatchOptions} from '../src/router';
+import {TestBed} from '@angular/core/testing';
+import {exactMatchOptions, Router, subsetMatchOptions} from '../src/router';
 import {containsTree, DefaultUrlSerializer} from '../src/url_tree';
 
 describe('UrlTree', () => {
@@ -30,6 +31,14 @@ describe('UrlTree', () => {
     it('should allow question marks in query param values', () => {
       const tree = serializer.parse('/path/to?first=http://foo/bar?baz=true&second=123');
       expect(tree.queryParams).toEqual({'first': 'http://foo/bar?baz=true', 'second': '123'});
+    });
+
+    it('create, serialize, parse, serialize results in same serialized tree with outlet and no primary children', () => {
+      const router = TestBed.inject(Router);
+      const th = router.createUrlTree(['/', {outlets: {a: ['a'], b: [{outlets: {a: ['b1']}}]}}]);
+      const serialized = router.serializeUrl(th);
+      const p = router.parseUrl(serialized);
+      expect(router.serializeUrl(p)).toBe(serialized);
     });
   });
 


### PR DESCRIPTION
…ldren

this fixes tree creation, serialization, and parsing of trees created with children outlets and no primary path

fixes #62384
