### PR TITLE
refactor(core): Removes any queueing of animations from instructions

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -77,10 +77,6 @@ export function ɵɵanimateEnter(value: string | Function): typeof ɵɵanimateEn
 
   initializeAnimationQueueScheduler(lView[INJECTOR]);
 
-  // TODO(thePunderWoman): it's unclear why we need to queue animations here, but without this,
-  // animating through host bindings fails
-  queueEnterAnimations(lView[INJECTOR], getLViewEnterAnimations(lView));
-
   return ɵɵanimateEnter; // For chaining
 }
 
@@ -201,10 +197,6 @@ export function ɵɵanimateEnterListener(value: AnimationFunction): typeof ɵɵa
   );
 
   initializeAnimationQueueScheduler(lView[INJECTOR]);
-
-  // TODO(thePunderWoman): it's unclear why we need to queue animations here, but without this,
-  // animating through host bindings fails
-  queueEnterAnimations(lView[INJECTOR], getLViewEnterAnimations(lView));
 
   return ɵɵanimateEnterListener;
 }

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -8,7 +8,6 @@
 import {validateMatchingNode} from '../../hydration/error_handling';
 import {locateNextRNode} from '../../hydration/node_lookup_utils';
 import {canHydrateNode, markRNodeAsClaimedByHydration} from '../../hydration/utils';
-import {assertIndexInRange} from '../../util/assert';
 import {assertTNodeCreationIndex} from '../assert';
 import {createTextNode} from '../dom_node_manipulation';
 import {TElementNode, TNode, TNodeType} from '../interfaces/node';

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -84,6 +84,7 @@ import {getLViewParent, getNativeByTNode, unwrapRNode} from './util/view_utils';
 import {allLeavingAnimations} from '../animation/longest_animation';
 import {Injector} from '../di';
 import {addToAnimationQueue, queueEnterAnimations} from '../animation/queue';
+import {getLViewEnterAnimations} from '../animation/utils';
 
 const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
@@ -705,6 +706,10 @@ export function appendChild(
   const parentTNode: TNode = childTNode.parent || lView[T_HOST]!;
   const anchorNode = getInsertInFrontOfRNode(parentTNode, childTNode, lView);
   if (parentRNode != null) {
+    const targetLView = getLViewEnterAnimations(lView).size > 0 ? lView : getLViewParent(lView);
+    if (targetLView && getLViewEnterAnimations(targetLView).size > 0)
+      queueEnterAnimations(targetLView[INJECTOR], getLViewEnterAnimations(targetLView));
+
     if (Array.isArray(childRNode)) {
       for (let i = 0; i < childRNode.length; i++) {
         nativeAppendOrInsertBefore(renderer, parentRNode, childRNode[i], anchorNode, false);


### PR DESCRIPTION
This logically separates the behavior of setting up animations from actually queueing animations to run.

The instructions now serve as a pure setup. The queueing of animations is now fully handled in `node_manipulation.ts`. When templates are initially rendered, the appendChild function is called, which now houses queuing of enter animations.

