### PR TITLE
docs: remove `error` mentions in signal forms docs

### DIFF
--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -175,7 +175,7 @@ export function form<TValue>(
  * ```
  * const nameForm = form(signal({first: '', last: ''}), (name) => {
  *   required(name.first);
- *   error(name.last, ({value}) => !/^[a-z]+$/i.test(value()), 'Alphabet characters only');
+ *   validate(name.last, ({value}) => !/^[a-z]+$/i.test(value()) ? customError({kind: 'alphabet-only'}) : undefined);
  * });
  * nameForm().valid(); // false
  * nameForm().value.set({first: 'John', last: 'Doe'});
@@ -222,22 +222,6 @@ export function form<TValue>(...args: any[]): FieldTree<TValue> {
  * });
  * const namesForm = form(signal([{first: '', last: ''}]), (names) => {
  *   applyEach(names, nameSchema);
- * });
- * ```
- *
- * When binding logic to the array items, the `FieldTree` for the array item is passed as an
- * additional argument. This can be used to reference other properties on the item.
- *
- * @example
- * ```
- * const namesForm = form(signal([{first: '', last: ''}]), (names) => {
- *   applyEach(names, (name) => {
- *     error(
- *       name.last,
- *       (value, nameField) => value === nameField.first().value(),
- *       'Last name must be different than first name',
- *     );
- *   });
  * });
  * ```
  *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

`error` no longer exists and is called `validate`.
The second example for applyEach is no longer accurate I believe, so I removed it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
