### PR TITLE
fix(core): Clear lView from IcuIteratorState when stack is empty to prevent memory leak

### DIFF
--- a/packages/core/src/render3/i18n/i18n_icu_container_visitor.ts
+++ b/packages/core/src/render3/i18n/i18n_icu_container_visitor.ts
@@ -15,7 +15,7 @@ import {TIcuContainerNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {LView, TVIEW} from '../interfaces/view';
 
-interface IcuIteratorState {
+export interface IcuIteratorState {
   stack: any[];
   index: number;
   lView?: LView;
@@ -35,7 +35,7 @@ function enterIcu(state: IcuIteratorState, tIcu: TIcu, lView: LView) {
   }
 }
 
-function icuContainerIteratorNext(state: IcuIteratorState): RNode | null {
+export function icuContainerIteratorNext(state: IcuIteratorState): RNode | null {
   if (state.index < state.removes!.length) {
     const removeOpCode = state.removes![state.index++] as number;
     ngDevMode && assertNumber(removeOpCode, 'Expecting OpCode number');
@@ -54,6 +54,8 @@ function icuContainerIteratorNext(state: IcuIteratorState): RNode | null {
     }
   } else {
     if (state.stack.length === 0) {
+      // Clear the lView reference when iteration completes to allow garbage collection
+      state.lView = undefined;
       return null;
     } else {
       state.removes = state.stack.pop();

--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -11,6 +11,10 @@ import {
   getTranslationForTemplate,
   i18nStartFirstCreatePass,
 } from '../../../src/render3/i18n/i18n_parse';
+import {
+  icuContainerIteratorNext,
+  IcuIteratorState,
+} from '../../../src/render3/i18n/i18n_icu_container_visitor';
 import {getTIcu} from '../../../src/render3/i18n/i18n_util';
 import {TNodeType} from '../../../src/render3/interfaces/node';
 
@@ -583,6 +587,23 @@ describe('Runtime i18n', () => {
           matchDebug([`remove(lView[${HEADER_OFFSET + 10}])`]),
         ],
       });
+    });
+
+    it('should clear lView reference when ICU iteration completes', () => {
+      const state: IcuIteratorState = {
+        stack: [],
+        index: 0,
+        removes: [] as any,
+        lView: [] as any, // Mock lView
+      };
+
+      // Call icuContainerIteratorNext with an empty removes array and empty stack
+      // This simulates the end of iteration
+      const result = icuContainerIteratorNext(state);
+
+      expect(result).toBeNull();
+      // Verify that lView should be cleared to allow garbage collection
+      expect(state.lView).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
> [!NOTE]  
> Reviving my coworkers PR from https://github.com/angular/angular/pull/58171 but with a test included. Wasn't really sure about the best way to test this as the issue is a memory leak in an internal implementation detail which is kind of hard to test against, but included something to get the ball rolling. Happy to improve with feedback!

If a component template contains an icu expression it is being retained until the next change detection cycle for that template. This results in a net retention of only ever a single copy of the given lView but that creates an opportunity for compounding leaks.

Change the icu i18n_icu_container_visitor to free the IcuIteratorState retained lView when the stack is empty so that garbage collection can occur when the view is discarded.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Component templates with i18n icu expressions are retaining the lView until change detection is run again on that template. This is due to the `IcuIteratorState` establishing a reference to the corresponding lView and then not releasing it when the stack is empty.

Issue Number: N/A


## What is the new behavior?

The IcuIteratorState clears the lView property retainer when the iterator stack is empty. This allows the components to be garbage collected when the component/lView is discarded.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
