### PR TITLE
fix(forms): bind invalid input in custom controls

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -335,6 +335,7 @@ function updateCustomControl(
   // * cache which inputs exist.
   writeToDirectiveInput(componentDef, component, modelName, state.value());
   maybeWriteToDirectiveInput(componentDef, component, 'errors', state.errors);
+  maybeWriteToDirectiveInput(componentDef, component, 'invalid', state.invalid);
   maybeWriteToDirectiveInput(componentDef, component, 'disabled', state.disabled);
   maybeWriteToDirectiveInput(componentDef, component, 'disabledReasons', state.disabledReasons);
   maybeWriteToDirectiveInput(componentDef, component, 'max', state.max);

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -41,6 +41,11 @@ export interface ɵFieldState<T> {
   readonly errors: Signal<unknown>;
 
   /**
+   * A signal indicating whether the field is valid.
+   */
+  readonly invalid: Signal<boolean>;
+
+  /**
    * A signal indicating whether the field is currently disabled.
    */
   readonly disabled: Signal<boolean>;

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -940,6 +940,36 @@ describe('field directive', () => {
     ]);
   });
 
+  it('should synchronize validity status', () => {
+    @Component({
+      selector: 'my-input',
+      template: '<input #i [value]="value()" (input)="value.set(i.value)" />',
+    })
+    class CustomInput implements FormValueControl<string> {
+      value = model('');
+      invalid = input(false);
+    }
+
+    @Component({
+      template: `
+        <my-input [field]="f" />
+      `,
+      imports: [CustomInput, Field],
+    })
+    class ReadonlyTestCmp {
+      myInput = viewChild.required<CustomInput>(CustomInput);
+      data = signal('');
+      f = form(this.data, (p) => {
+        required(p);
+      });
+    }
+
+    const comp = act(() => TestBed.createComponent(ReadonlyTestCmp)).componentInstance;
+    expect(comp.myInput().invalid()).toBe(true);
+    act(() => comp.f().value.set('valid'));
+    expect(comp.myInput().invalid()).toBe(false);
+  });
+
   it(`should mark field as touched on native control 'blur' event`, () => {
     @Component({
       imports: [Field],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

`FormUiControl` has an `invalid` input signal, but it was not bound by the control instructions.

## What is the new behavior?

It is now bound.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
