### PR TITLE
fix(devtools): revert router tree dashed edges for lazy routes

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -16,7 +16,6 @@
     <aside class="legend" aria-hidden="true">
       <ul>
         <li class="active">Active route</li>
-        <li class="dashed-line">Lazy-loading</li>
       </ul>
     </aside>
     <as-split-area size="70">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -101,15 +101,6 @@
             border-color: var(--green-02);
             background-color: var(--green-03);
           }
-
-          &.dashed-line::before {
-            border-color: var(--quaternary-contrast);
-            background-color: transparent;
-            border-style: dashed;
-            border-width: 1px;
-            width: 16px;
-            height: 0;
-          }
         }
       }
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -104,7 +104,6 @@ export class RouterTreeComponent {
   protected readonly routerTreeConfig: Partial<TreeVisualizerConfig<RouterTreeNode>> = {
     nodeSeparation: () => 1,
     d3NodeModifier: (n) => this.d3NodeModifier(n),
-    d3LinkModifier: (l) => this.d3LinkModifier(l),
   };
 
   constructor() {
@@ -191,13 +190,6 @@ export class RouterTreeComponent {
       }
 
       return nodeClasses.join(' ');
-    });
-  }
-
-  private d3LinkModifier(d3Link: SvgD3Link<RouterTreeNode>) {
-    d3Link.attr('stroke-dasharray', (node: RouterTreeD3Node) => {
-      // Make edges to lazy loaded routes dashed
-      return node.data.isLazy ? '5,5' : 'none';
     });
   }
 }


### PR DESCRIPTION
Reverting this because it causes serious performance degradation in large graphs (see adev).

From my investigation what I know for sure:
- when the graph pans or zooms it updates the transform property on the g element, which in turn causes the browser to repaint the visible space in the g element
- stroke-dasharray is the cause of major performance issues in large graphs.
- The proportion to which stroke-dasharray affects performance seems related to how granular it makes the line (less dashes = better performance)

What I suspect:
- When the g element repaints, it also has to repaint all of the child svg elements. When the dashed line path svgs repaint, the stroke-dasharray calculation is not run on the GPU, but instead occurs on the CPU, causing extreme lag whenever the svg graph is panned or zoomed on graphs with hundreds of path elements with stroke-dasharray.

Temporary solution: remove this dashed edge functionality. We can investigate alternatives for communicating that a path is lazy loaded.

Future long term solution: migrate to canvas based graph renderer for router tree and injector graph.
