### PR TITLE
build: bump leftover dependency of typescript

### DIFF
--- a/adev/src/content/tutorials/signals/common/package.json
+++ b/adev/src/content/tutorials/signals/common/package.json
@@ -23,6 +23,6 @@
     "@angular/build": "^21.0.0-next",
     "@angular/cli": "^21.0.0-next",
     "@angular/compiler-cli": "^21.0.0-next",
-    "typescript": "~5.8.2"
+    "typescript": "~5.9.3"
   }
 }


### PR DESCRIPTION
This package json was missed when we recently bumped ts versions.
