### PR TITLE
refactor(devtools): use preview value in property editor

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.html
@@ -1,13 +1,6 @@
 @switch (currentPropertyState()) {
   @case (readState) {
-    @switch (containerType()) {
-      @case ('WritableSignal') {
-        <span class="editable">Signal({{valueToSubmit()}})</span>
-      }
-      @default {
-        <span class="editable">{{ valueToSubmit() }}</span>
-      }
-    }
+    <span class="editable">{{ previewValue() }}</span>
   }
   @case (writeState) {
     <div class="value-input">

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-editor/property-editor.component.ts
@@ -16,6 +16,7 @@ import {
   signal,
   viewChild,
   ChangeDetectionStrategy,
+  linkedSignal,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {ContainerType} from '../../../../../../../../../../protocol';
@@ -49,6 +50,8 @@ const parseValue = (value: EditorResult): EditorResult => {
 export class PropertyEditorComponent {
   readonly key = input.required<string>();
   readonly initialValue = input.required<EditorResult>();
+  readonly previewValue = input.required<string>();
+
   readonly containerType = input<ContainerType>();
 
   readonly updateValue = output<EditorResult>();
@@ -58,16 +61,10 @@ export class PropertyEditorComponent {
   readState = PropertyEditorState.Read;
   writeState = PropertyEditorState.Write;
 
-  readonly valueToSubmit = signal<EditorResult | undefined>(undefined);
+  readonly valueToSubmit = linkedSignal<EditorResult | undefined>(this.initialValue);
   readonly currentPropertyState = signal(this.readState);
 
   constructor() {
-    afterNextRender({
-      read: () => {
-        this.valueToSubmit.set(this.initialValue());
-      },
-    });
-
     effect(() => {
       const editor = this.inputEl()?.nativeElement;
       if (editor && this.currentPropertyState() === this.writeState) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/property-view-tree/property-view-tree.component.html
@@ -10,7 +10,8 @@
           <ng-property-editor
             class="value"
             [key]="node.prop.name"
-            [initialValue]="node.prop.descriptor.value ?? node.prop.descriptor.preview"
+            [initialValue]="node.prop.descriptor.value"
+            [previewValue]="node.prop.descriptor.preview"
             [containerType]="node.prop.descriptor.containerType"
             (updateValue)="handleUpdate(node, $event)"
           />


### PR DESCRIPTION
This way only the `preview` property handles the `Signal()` wrapper (and not individual components anymore)
