### PR TITLE
refactor(router): use takeUntilDestroyed() for automatic cleanup

### DIFF
--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -44,7 +44,7 @@ export interface TracingService<T extends TracingSnapshot> {
    * @param linkedSnapshot Optional snapshot to use link to the current context.
    * The caller is no longer responsible for calling dispose on the linkedSnapshot.
    *
-   * @return The tracing snapshot. The caller is responsible for diposing of the
+   * @return The tracing snapshot. The caller is responsible for disposing of the
    * snapshot.
    */
   snapshot(linkedSnapshot: T | null): T;

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -11,7 +11,6 @@ import {Injectable} from './di';
 @Injectable({providedIn: 'platform'})
 export class Console {
   log(message: string): void {
-    // tslint:disable-next-line:no-console
     console.log(message);
   }
   // Note: for reporting errors use `DOM.logError()` as it is platform specific

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -30,6 +30,7 @@ import {Router} from '../router';
 import {IsActiveMatchOptions} from '../url_tree';
 
 import {RouterLink} from './router_link';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 /**
  *
@@ -111,7 +112,6 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   @ContentChildren(RouterLink, {descendants: true}) links!: QueryList<RouterLink>;
 
   private classes: string[] = [];
-  private routerEventsSubscription: Subscription;
   private linkInputChangesSubscription?: Subscription;
   private _isActive = false;
 
@@ -162,7 +162,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     private readonly cdr: ChangeDetectorRef,
     @Optional() private link?: RouterLink,
   ) {
-    this.routerEventsSubscription = router.events.subscribe((s: Event) => {
+    router.events.pipe(takeUntilDestroyed()).subscribe((s: Event) => {
       if (s instanceof NavigationEnd) {
         this.update();
       }
@@ -206,7 +206,6 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
   /** @docs-private */
   ngOnDestroy(): void {
-    this.routerEventsSubscription.unsubscribe();
     this.linkInputChangesSubscription?.unsubscribe();
   }
 

--- a/packages/router/upgrade/src/upgrade.ts
+++ b/packages/router/upgrade/src/upgrade.ts
@@ -96,7 +96,7 @@ export function setUpLocationSync(
         newState?: {[k: string]: unknown} | RestoredState,
         oldState?: {[k: string]: unknown} | RestoredState,
       ) => {
-        // Navigations coming from Angular router have a navigationId state
+        // navigation's coming from Angular router have a navigationId state
         // property. Don't trigger Angular router navigation again if it is
         // caused by a URL change from the current Angular router
         // navigation.


### PR DESCRIPTION
Replaces manual subscription tracking and explicit unsubscribe calls with the takeUntilDestroyed() operator to simplify code and ensure proper teardown.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
