### PR TITLE
fix(common): properly type ngComponentOutlet

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -503,7 +503,7 @@ export class NgClass implements DoCheck {
 export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy {
     constructor(_viewContainerRef: ViewContainerRef);
     get componentInstance(): T | null;
-    ngComponentOutlet: Type<any> | null;
+    ngComponentOutlet: Type<T> | null;
     // (undocumented)
     ngComponentOutletContent?: Node[][];
     // (undocumented)

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -100,10 +100,8 @@ import {
   exportAs: 'ngComponentOutlet',
 })
 export class NgComponentOutlet<T = any> implements OnChanges, DoCheck, OnDestroy {
-  // TODO(crisbeto): this should be `Type<T>`, but doing so broke a few
-  // targets in a TGP so we need to do it in a major version.
   /** Component that should be rendered in the outlet. */
-  @Input() ngComponentOutlet: Type<any> | null = null;
+  @Input() ngComponentOutlet: Type<T> | null = null;
 
   @Input() ngComponentOutletInputs?: Record<string, unknown>;
   @Input() ngComponentOutletInjector?: Injector;


### PR DESCRIPTION
Resolves an older TODO about properly typing the `ngComponentOutlet` input.
