### PR TITLE
feat(router): allow router outlet to be set on ng-container

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -901,7 +901,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     readonly routerOutletData: i0.InputSignal<unknown>;
     readonly supportsBindingToComponentInputs = true;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], { "name": { "alias": "name"; "required": false; }; "routerOutletData": { "alias": "routerOutletData"; "required": false; "isSignal": true; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet, ng-container[routerOutlet]", ["outlet"], { "name": { "alias": "name"; "required": false; }; "routerOutletData": { "alias": "routerOutletData"; "required": false; "isSignal": true; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterOutlet, never>;
 }

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -204,7 +204,7 @@ export interface RouterOutletContract {
  * @publicApi
  */
 @Directive({
-  selector: 'router-outlet',
+  selector: 'router-outlet, ng-container[routerOutlet]',
   exportAs: 'outlet',
 })
 export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -194,6 +194,31 @@ describe('router outlet name', () => {
     // Not contain because route was changed back to parent
     expect(fixture.nativeElement.innerHTML).not.toContain('child component');
   });
+
+  it('should be able to use a router outlet on an ng-container', async () => {
+    @Component({
+      template: '<ng-container routerOutlet [name]="name"/>',
+      imports: [RouterOutlet],
+    })
+    class RootCmp {
+      name = 'popup';
+    }
+
+    @Component({
+      template: 'popup component',
+    })
+    class PopupCmp {}
+
+    TestBed.configureTestingModule({
+      imports: [RouterModule.forRoot([{path: '', outlet: 'popup', component: PopupCmp}])],
+    });
+    const router = TestBed.inject(Router);
+    const fixture = await createRoot(router, RootCmp);
+
+    expect(fixture.nativeElement.innerHTML.trim()).toBe(
+      '<ng-component>popup component</ng-component><!--ng-container-->',
+    );
+  });
 });
 
 describe('component input binding', () => {


### PR DESCRIPTION
Updates the selector for `RouterOutlet` to allow for it to be set on an `ng-container`. This allows it to not render the host node which can affect the layout.

Fixes #64553.
