### PR TITLE
fix(core): pass element removal property through in all locations

### DIFF
--- a/packages/animations/browser/src/render/renderer.ts
+++ b/packages/animations/browser/src/render/renderer.ts
@@ -89,7 +89,7 @@ export class BaseAnimationRenderer implements Renderer2 {
     // Elements using the new `animate.leave` API require synchronous removal and should
     // skip the rest of the legacy animation behaviors.
     if (requireSynchronousElementRemoval) {
-      this.delegate.removeChild(parent, oldChild, isHostElement);
+      this.delegate.removeChild(parent, oldChild, isHostElement, requireSynchronousElementRemoval);
       return;
     }
     // Prior to the changes in #57203, this method wasn't being called at all by `core` if the child

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -238,8 +238,13 @@ export class DynamicDelegationRenderer implements Renderer2 {
     this.delegate.insertBefore(parent, newChild, refChild, isMove);
   }
 
-  removeChild(parent: any, oldChild: any, isHostElement?: boolean | undefined): void {
-    this.delegate.removeChild(parent, oldChild, isHostElement);
+  removeChild(
+    parent: any,
+    oldChild: any,
+    isHostElement?: boolean | undefined,
+    requireSynchronousElementRemoval?: boolean,
+  ): void {
+    this.delegate.removeChild(parent, oldChild, isHostElement, requireSynchronousElementRemoval);
   }
 
   selectRootElement(selectorOrNode: any, preserveContent?: boolean | undefined): any {


### PR DESCRIPTION
The `requireSynchronousElementRemoval` property was not being passed in all the locations it was needed. This was preventing leave animation timing from behaving properly in some cases.

fixes: #64525
