### PR TITLE
feat(router): add `RouterOutletPlaceholder` directive for inactive outlet state (#42489)

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -9,7 +9,6 @@
 import {
   ChangeDetectorRef,
   ComponentRef,
-  Directive,
   EnvironmentInjector,
   EventEmitter,
   inject,
@@ -26,8 +25,12 @@ import {
   Signal,
   SimpleChanges,
   ViewContainerRef,
+  Directive,
+  TemplateRef,
+  Optional,
+  EmbeddedViewRef,
 } from '@angular/core';
-import {combineLatest, of, Subscription} from 'rxjs';
+import {combineLatest, merge, of, Subscription, observeOn, asapScheduler} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from '../errors';
@@ -406,6 +409,87 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     this.changeDetector.markForCheck();
     this.inputBinder?.bindActivatedRouteToOutletComponent(this);
     this.activateEvents.emit(this.activated.instance);
+  }
+}
+
+/**
+ * @description
+ * Structural directive that renders template content **only when the host `RouterOutlet`
+ * has no activated component**.
+ *
+ * Put `*routerOutletPlaceholder` inside the content of a `<router-outlet>` to provide
+ * lightweight fallback/empty-state markup (e.g. skeleton, hint, or CTA) which appears
+ * whenever the outlet is not displaying a routed component. As soon as the outlet
+ * activates a component, the placeholder view is removed; when the outlet deactivates
+ * and no component is attached, the placeholder view is recreated.
+ *
+ * This directive must be used **inside** a `RouterOutlet` content projection. Using it
+ * elsewhere will throw an error.
+ *
+ * @usageNotes
+ *
+ * ### Basic usage
+ * Render a message or skeleton while there is no activated route:
+ * ```html
+ * <router-outlet>
+ *   <app-skeleton *routerOutletPlaceholder />
+ * </router-outlet>
+ * ```
+ *
+ * ### Named outlets
+ * Works the same for named outlets:
+ * ```html
+ * <router-outlet name="details">
+ *   <app-skeleton *routerOutletPlaceholder />
+ * </router-outlet>
+ * ```
+ *
+ * @throws Error if applied outside of a `<router-outlet>` content.
+ *
+ * @see {@link RouterOutlet}
+ * @publicApi
+ */
+@Directive({
+  selector: '[routerOutletPlaceholder]',
+})
+export class RouterOutletPlaceholder implements OnInit, OnDestroy {
+  private readonly subscription: Subscription;
+
+  private viewRef: EmbeddedViewRef<void> | void = undefined;
+
+  constructor(
+    private readonly viewContainer: ViewContainerRef,
+    private readonly templateRef: TemplateRef<void>,
+    @Optional() private readonly routerOutlet: RouterOutlet,
+  ) {
+    if (this.routerOutlet === null) {
+      throw new Error(`*routerOutletPlaceholder can only be applied within <router-outlet />`);
+    }
+
+    this.subscription = merge(
+      this.routerOutlet.activateEvents,
+      this.routerOutlet.deactivateEvents.pipe(observeOn(asapScheduler)),
+    ).subscribe(() => this.updatePlaceholder());
+  }
+
+  ngOnInit() {
+    this.updatePlaceholder();
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  private updatePlaceholder(): void {
+    if (this.routerOutlet.isActivated) {
+      this.viewRef = this.viewRef?.destroy();
+    } else {
+      this.viewRef ??= this.viewContainer.createEmbeddedView(this.templateRef);
+    }
+  }
+
+  static ngTemplateContextGuard(dir: RouterOutletPlaceholder, ctx: any): ctx is void {
+    return true;
   }
 }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -9,7 +9,12 @@
 export {createUrlTreeFromSnapshot} from './create_url_tree';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
-export {RouterOutlet, ROUTER_OUTLET_DATA, RouterOutletContract} from './directives/router_outlet';
+export {
+  RouterOutlet,
+  ROUTER_OUTLET_DATA,
+  RouterOutletContract,
+  RouterOutletPlaceholder,
+} from './directives/router_outlet';
 export {
   ActivationEnd,
   ActivationStart,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, there is no built-in way to display placeholder or fallback content inside a `RouterOutle`t when no route is currently activated.
Developers have to manually manage conditional templates outside the outlet or handle this logic through extra components.

Issue Number: #42489

## What is the new behavior?

This PR introduces a new structural directive — `*routerOutletPlaceholder` — that allows developers to declaratively render template content whenever the host `RouterOutlet` is not activated.

Key characteristics:

- Automatically shows the placeholder content when the outlet has no active component.
- Removes the placeholder when a route is activated and reinstates it on deactivation.
- Supports named outlets and dynamic name changes.
- Handles synchronous activate/deactivate transitions without flicker by scheduling updates via asapScheduler (microtask).
- Throws an error if used outside of a RouterOutlet.

Example usage:

<router-outlet>
  <div *routerOutletPlaceholder>
    loading...
  </div>
</router-outlet>

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
