### PR TITLE
refactor(compiler-cli): remove deprecated signature usage

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_manager.ts
@@ -411,7 +411,7 @@ export class ImportManager
       namespaceImports.forEach((namespaceImport, moduleName) => {
         const newImport = ts.factory.createImportDeclaration(
           undefined,
-          ts.factory.createImportClause(false, undefined, namespaceImport),
+          ts.factory.createImportClause(undefined, undefined, namespaceImport),
           ts.factory.createStringLiteral(moduleName, useSingleQuotes),
         );
 
@@ -435,7 +435,7 @@ export class ImportManager
           const newImport = ts.factory.createImportDeclaration(
             undefined,
             ts.factory.createImportClause(
-              false,
+              undefined,
               undefined,
               ts.factory.createNamedImports(filteredSpecifiers),
             ),

--- a/packages/language-service/src/utils/ts_utils.ts
+++ b/packages/language-service/src/utils/ts_utils.ts
@@ -579,7 +579,7 @@ export function generateImport(
   }
   return ts.factory.createImportDeclaration(
     undefined,
-    ts.factory.createImportClause(false, importClauseName, importBindings),
+    ts.factory.createImportClause(undefined, importClauseName, importBindings),
     moduleSpec,
     undefined,
   );


### PR DESCRIPTION
The signature for `createImportClause` was deprecated in TS 5.9. These changes switch to the non-deprecated one.
