### PR TITLE
perf(forms): implement change detection for field control bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
@@ -2,7 +2,7 @@ MyComponent.ɵcmp = /* @__PURE__ */i0.ɵɵdefineComponent({
   type: MyComponent,
   selectors: [["ng-component"]],
   decls: 4,
-  vars: 2,
+  vars: 3,
   consts: [["field", "Not a form control"], [3, "field"]],
   template: function MyComponent_Template(rf, ctx) {
     if (rf & 1) {

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -119,7 +119,6 @@ function varsUsedByOp(op: (ir.CreateOp | ir.UpdateOp) & ir.ConsumesVarsTrait): n
       return slots;
     case ir.OpKind.Property:
     case ir.OpKind.DomProperty:
-    case ir.OpKind.Control:
       slots = 1;
 
       // We need to assign a slot even for singleton interpolations, because the
@@ -128,6 +127,10 @@ function varsUsedByOp(op: (ir.CreateOp | ir.UpdateOp) & ir.ConsumesVarsTrait): n
         slots += op.expression.expressions.length;
       }
       return slots;
+    case ir.OpKind.Control:
+      // 1 for the [field] binding itself.
+      // 1 for the control bindings object containing bound field states properties.
+      return 2;
     case ir.OpKind.TwoWayProperty:
       // Two-way properties can only have expressions so they only need one variable slot.
       return 1;

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -114,7 +114,7 @@ export interface ɵFieldState<T> {
   /**
    * A signal indicating the patterns the field must match.
    */
-  readonly pattern?: Signal<readonly RegExp[]>;
+  readonly pattern: Signal<readonly RegExp[]>;
 
   /**
    * A signal indicating whether the field is currently readonly.
@@ -124,7 +124,7 @@ export interface ɵFieldState<T> {
   /**
    * A signal indicating whether the field is required.
    */
-  readonly required?: Signal<boolean>;
+  readonly required: Signal<boolean>;
 
   /**
    * A signal indicating whether the field has been touched by the user.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {Signal, WritableSignal} from '@angular/core';
+import {computed, type Signal, type WritableSignal} from '@angular/core';
 import type {Field} from '../api/field_directive';
 import {
   AggregateMetadataKey,
@@ -37,6 +37,7 @@ import {
 } from './structure';
 import {FieldSubmitState} from './submit';
 import {ValidationState} from './validation';
+
 /**
  * Internal node in the form tree for a given field.
  *
@@ -166,12 +167,12 @@ export class FieldNode implements FieldState<unknown> {
     return this.metadataOrUndefined(MIN_LENGTH);
   }
 
-  get pattern(): Signal<readonly RegExp[]> | undefined {
-    return this.metadataOrUndefined(PATTERN);
+  get pattern(): Signal<readonly RegExp[]> {
+    return this.metadataOrUndefined(PATTERN) ?? EMPTY;
   }
 
-  get required(): Signal<boolean> | undefined {
-    return this.metadataOrUndefined(REQUIRED);
+  get required(): Signal<boolean> {
+    return this.metadataOrUndefined(REQUIRED) ?? FALSE;
   }
 
   metadata<M>(key: AggregateMetadataKey<M, any>): Signal<M>;
@@ -253,6 +254,9 @@ export class FieldNode implements FieldState<unknown> {
         );
   }
 }
+
+const EMPTY = computed(() => []);
+const FALSE = computed(() => false);
 
 /**
  * Field node of a field that has children.


### PR DESCRIPTION
For each field state property, check if it has changed since the last time it was checked before writing it the corresponding form control property.