### PR TITLE
fix(core): prevent duplicate nodes from being retained with fast `animate.leave` calls

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -68,7 +68,6 @@ export function ɵɵanimateEnter(value: string | Function): typeof ɵɵanimateEn
   }
 
   const tNode = getCurrentTNode()!;
-
   cancelLeavingNodes(tNode, lView);
 
   addAnimationToLView(getLViewEnterAnimations(lView), tNode, () =>
@@ -196,7 +195,6 @@ export function ɵɵanimateEnterListener(value: AnimationFunction): typeof ɵɵa
     return ɵɵanimateEnterListener;
   }
   const tNode = getCurrentTNode()!;
-
   cancelLeavingNodes(tNode, lView);
 
   addAnimationToLView(getLViewEnterAnimations(lView), tNode, () =>
@@ -251,6 +249,7 @@ export function ɵɵanimateLeave(value: string | Function): typeof ɵɵanimateLe
   }
 
   const tNode = getCurrentTNode()!;
+  cancelLeavingNodes(tNode, lView);
 
   addAnimationToLView(getLViewLeaveAnimations(lView), tNode, () =>
     runLeaveAnimations(lView, tNode, value),
@@ -383,6 +382,8 @@ export function ɵɵanimateLeaveListener(value: AnimationFunction): typeof ɵɵa
 
   const lView = getLView();
   const tNode = getCurrentTNode()!;
+  cancelLeavingNodes(tNode, lView);
+
   allLeavingAnimations.add(lView);
 
   addAnimationToLView(getLViewLeaveAnimations(lView), tNode, () =>


### PR DESCRIPTION
We were clearing duplicate nodes when both `animate.enter` and `animate.leave` were on a node and were toggled quickly. We didn't account for this same situation, but when solely `animate.leave` is present and rapid toggles occur. This ensures that the `cancelLeavingNodes` function is called in all cases instead of just enter animations.

fixes: #64581
