### PR TITLE
build: enable auto merge strategy for pull requests

### DIFF
--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -5,7 +5,10 @@ import {PullRequestConfig} from '@angular/ng-dev';
  * are respected by the merge script (e.g. the target labels).
  */
 export const pullRequest: PullRequestConfig = {
-  githubApiMerge: false,
+  githubApiMerge: {
+    default: 'auto',
+    labels: [{pattern: 'merge: squash commits', method: 'squash'}],
+  },
   requiredBaseCommits: {
     // PRs that target either `main` or the patch branch, need to be rebased
     // on top of the latest commit message validation fix.
@@ -13,10 +16,8 @@ export const pullRequest: PullRequestConfig = {
     'main': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
     '10.0.x': '27b95ba64a5d99757f4042073fd1860e20e3ed24',
   },
-  // `dev-infra` and `docs-infra` are not affecting the public NPM packages. Similarly,
-  // the `bazel` package is not considered part of the public API so that features
-  // can land in patch branches.
-  targetLabelExemptScopes: ['dev-infra', 'docs-infra', 'bazel'],
+  // `docs-infra` are not affecting the public NPM packages.
+  targetLabelExemptScopes: ['docs-infra'],
   // enables specific validations during the pull request merge process
   validators: {
     assertEnforceTested: true,


### PR DESCRIPTION
This commit enables the 'auto' merge strategy for pull requests. This strategy automatically determines the best merge method based on the pull request's commits.

The auto merge strategy can:
- Delegate to the autosquash merge strategy if the PR has fixup/squash commits against multiple normal commits.
- Squash commits if the PR has only one normal commit and some fixup/squash commits.
- Rebase commits if the PR has no fixup/squash commits.

This improves the developer experience by automating the merge process. A key benefit is that PRs that can be cleanly rebased will now appear as 'merged' in GitHub's UI, providing a clearer history than the previous 'unmerged' status that could occur with squashing.

Additionally, `dev-infra` and `bazel` are removed from the exempted scopes for target labels as they are no longer necessary.
