### PR TITLE
fix(core): debounce leave animation instruction calls

### DIFF
--- a/packages/core/src/animation/interfaces.ts
+++ b/packages/core/src/animation/interfaces.ts
@@ -76,9 +76,12 @@ export interface LongestAnimation {
   duration: number;
 }
 
+export type AnimationValue = string | Function | AnimationFunction;
+
 export interface NodeAnimations {
   animateFns: Function[];
   resolvers?: VoidFunction[];
+  timeouts?: Map<AnimationValue, unknown>;
 }
 
 export interface AnimationLViewData {

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -1651,7 +1651,7 @@ describe('Animation', () => {
         encapsulation: ViewEncapsulation.None,
       })
       class TestComponent {
-        show = signal(false);
+        show = signal(true);
         cdr = inject(ChangeDetectorRef);
 
         toggle() {
@@ -1674,8 +1674,16 @@ describe('Animation', () => {
       cmp.toggle();
       fixture.detectChanges();
       tickAnimationFrames(1);
-      const paragraphs = fixture.debugElement.queryAll(By.css('p'));
-      expect(paragraphs.length).toBe(1);
+
+      fixture.debugElement
+        .query(By.css('p'))
+        .nativeElement.dispatchEvent(
+          new AnimationEvent('animationend', {animationName: 'fade-out'}),
+        );
+      fixture.detectChanges();
+      tickAnimationFrames(1);
+
+      expect(fixture.debugElement.queryAll(By.css('p')).length).toBe(0);
     }));
 
     it('should always run animations for `@for` loops when adding and removing quickly', fakeAsync(() => {
@@ -2045,7 +2053,6 @@ describe('Animation', () => {
       cmp.removeSecondToLast();
       fixture.detectChanges();
       tickAnimationFrames(1);
-
       expect(fixture.debugElement.queryAll(By.css('p.fade')).length).toBe(1);
       expect(fixture.debugElement.queryAll(By.css('p')).length).toBe(4);
       fixture.debugElement
@@ -2219,6 +2226,7 @@ describe('Animation', () => {
       const fixture = TestBed.createComponent(TestComponent);
       const cmp = fixture.componentInstance;
       fixture.detectChanges();
+      tick(10);
 
       expect(fixture.debugElement.query(By.css('p.all-there-is'))).not.toBeNull();
       expect(fixture.debugElement.query(By.css('p.not-here.fade-out'))).not.toBeNull();


### PR DESCRIPTION
There are cases where the animation instructions get called in rapid succession. For example:

```
@if (show$ | async) {
  <div animate.leave="class-name">...</div>
}
```

In this situation, the leave instruction may be called several times. With `animate.leave` this causes problems due to the promises that are awaited, but will never resolve. This results in duplicated or nodes that are left behind.

This PR adds a debounce based on the lView, tNode index, and value. The main reason we need to key off of the value is because of host binding composition, which is a legitimate reason we may have multiple calls in rapid succession. We need to still allow those to happen.

`animate.enter` would also be called in rapid succession in this same scenario, but there's no concerns with that situation since there's no promises present. It would resolve on its own.

fixes: #64581
