### PR TITLE
refactor(docs-infra): streamline adev build configuration

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -31,38 +31,38 @@ APPLICATION_FILES = [
 )
 
 APPLICATION_DEPS = [
-    "//adev:node_modules/@angular-devkit/build-angular",
-    "//adev:node_modules/@codemirror/autocomplete",
-    "//adev:node_modules/@codemirror/commands",
-    "//adev:node_modules/@codemirror/lang-angular",
-    "//adev:node_modules/@codemirror/lang-css",
-    "//adev:node_modules/@codemirror/lang-html",
-    "//adev:node_modules/@codemirror/lang-javascript",
-    "//adev:node_modules/@codemirror/lang-sass",
-    "//adev:node_modules/@codemirror/language",
-    "//adev:node_modules/@codemirror/lint",
-    "//adev:node_modules/@codemirror/search",
-    "//adev:node_modules/@codemirror/state",
-    "//adev:node_modules/@codemirror/view",
-    "//adev:node_modules/@lezer/common",
-    "//adev:node_modules/@lezer/highlight",
-    "//adev:node_modules/@lezer/javascript",
-    "//adev:node_modules/@stackblitz/sdk",
-    "//adev:node_modules/@typescript/vfs",
-    "//adev:node_modules/@webcontainer/api",
-    "//adev:node_modules/@xterm/addon-fit",
-    "//adev:node_modules/@xterm/xterm",
-    "//adev:node_modules/algoliasearch",
-    "//adev:node_modules/angular-split",
-    "//adev:node_modules/fflate",
-    "//adev:node_modules/marked",
-    "//adev:node_modules/ngx-progressbar",
-    "//adev:node_modules/open-in-idx",
-    "//adev:node_modules/tailwindcss",
-    "//adev:node_modules/typescript",
-    "//adev:node_modules/xhr2",
-    "//adev:node_modules/@types/node",
-    "//adev:node_modules/@types/dom-navigation",
+    ":node_modules/@angular-devkit/build-angular",
+    ":node_modules/@codemirror/autocomplete",
+    ":node_modules/@codemirror/commands",
+    ":node_modules/@codemirror/lang-angular",
+    ":node_modules/@codemirror/lang-css",
+    ":node_modules/@codemirror/lang-html",
+    ":node_modules/@codemirror/lang-javascript",
+    ":node_modules/@codemirror/lang-sass",
+    ":node_modules/@codemirror/language",
+    ":node_modules/@codemirror/lint",
+    ":node_modules/@codemirror/search",
+    ":node_modules/@codemirror/state",
+    ":node_modules/@codemirror/view",
+    ":node_modules/@lezer/common",
+    ":node_modules/@lezer/highlight",
+    ":node_modules/@lezer/javascript",
+    ":node_modules/@stackblitz/sdk",
+    ":node_modules/@typescript/vfs",
+    ":node_modules/@webcontainer/api",
+    ":node_modules/@xterm/addon-fit",
+    ":node_modules/@xterm/xterm",
+    ":node_modules/algoliasearch",
+    ":node_modules/angular-split",
+    ":node_modules/fflate",
+    ":node_modules/marked",
+    ":node_modules/ngx-progressbar",
+    ":node_modules/open-in-idx",
+    ":node_modules/tailwindcss",
+    ":node_modules/typescript",
+    ":node_modules/xhr2",
+    ":node_modules/@types/node",
+    ":node_modules/@types/dom-navigation",
 
     # The imports below are packages that our code does not directly import, but our upstream deps import from
     # these locations directly. By design, rather than hoisting these packages into the "root" node_modules the
@@ -70,17 +70,17 @@ APPLICATION_DEPS = [
     # a "hoisted" location within the `.aspect_rules_js/` directories in the node_modules directory. This prevents
     # the bundler from being able to find it as expected. We instead specifically provide it as a dep within bazel
     # as a mechanism of "hoisting" the package for our usage by this target.
-    "//adev:node_modules/@algolia/client-common",
-    "//adev:node_modules/@algolia/requester-browser-xhr",
-    "//adev:node_modules/@algolia/requester-node-http",
-    "//adev:node_modules/@lezer/css",
-    "//adev:node_modules/@lezer/html",
-    "//adev:node_modules/@lezer/lr",
-    "//adev:node_modules/@lezer/sass",
-    "//adev:node_modules/@marijn/find-cluster-break",
-    "//adev:node_modules/crelt",
-    "//adev:node_modules/style-mod",
-    "//adev:node_modules/w3c-keyname",
+    ":node_modules/@algolia/client-common",
+    ":node_modules/@algolia/requester-browser-xhr",
+    ":node_modules/@algolia/requester-node-http",
+    ":node_modules/@lezer/css",
+    ":node_modules/@lezer/html",
+    ":node_modules/@lezer/lr",
+    ":node_modules/@lezer/sass",
+    ":node_modules/@marijn/find-cluster-break",
+    ":node_modules/crelt",
+    ":node_modules/style-mod",
+    ":node_modules/w3c-keyname",
 ]
 
 TEST_FILES = APPLICATION_FILES + [
@@ -91,7 +91,7 @@ TEST_FILES = APPLICATION_FILES + [
 TEST_DEPS = [
     dep
     for dep in APPLICATION_DEPS
-    if dep != "//adev:node_modules/@types/node"
+    if dep != ":node_modules/@types/node"
 ] + [
     "@rules_browsers//browsers/chromium",
     "@rules_browsers//browsers/firefox",
@@ -111,7 +111,7 @@ ng_application(
         "NG_BUILD_PARTIAL_SSR": "1",
     },
     ng_config = ":ng_config",
-    node_modules = "//adev:node_modules",
+    node_modules = ":node_modules",
     project_name = "angular-dev",
     serve_args = [
         "--port",
@@ -137,7 +137,7 @@ ng_application(
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
     },
     ng_config = ":ng_config",
-    node_modules = "//adev:node_modules",
+    node_modules = ":node_modules",
     project_name = "angular-dev",
     serve_args = [
         "--port",
@@ -161,7 +161,7 @@ ng_test(
         "CHROMEDRIVER_BIN": "../" + "$(CHROMEDRIVER)",
     },
     ng_config = ":ng_config",
-    node_modules = "//adev:node_modules",
+    node_modules = ":node_modules",
     project_name = "angular-dev",
     toolchains = [
         "@rules_browsers//browsers/chromium:toolchain_alias",

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -14,7 +14,6 @@ exports_files([
 ])
 
 APPLICATION_FILES = [
-    "//adev/src/context:llms_full",
     "//adev/src/assets/images",
     "//adev/src/assets/others",
     "//adev/src/assets/previews",

--- a/adev/angular.json
+++ b/adev/angular.json
@@ -31,9 +31,8 @@
             "assets": [
               "src/favicon.ico",
               "src/robots.txt",
-              "src/assets",
-              "src/context/llm-files",
-              "src/llms.txt"
+              "src/llms.txt",
+              "src/assets"
             ],
             "styles": ["@angular/docs/styles/global-styles.scss", "./src/local-styles.scss"],
             "scripts": [],

--- a/adev/angular.json
+++ b/adev/angular.json
@@ -32,6 +32,7 @@
               "src/favicon.ico",
               "src/robots.txt",
               "src/assets",
+              "src/context/llm-files",
               "src/llms.txt"
             ],
             "styles": ["@angular/docs/styles/global-styles.scss", "./src/local-styles.scss"],

--- a/adev/angular.json
+++ b/adev/angular.json
@@ -32,7 +32,6 @@
               "src/favicon.ico",
               "src/robots.txt",
               "src/assets",
-              "src/context",
               "src/llms.txt"
             ],
             "styles": ["@angular/docs/styles/global-styles.scss", "./src/local-styles.scss"],

--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -136,6 +136,6 @@ copy_to_directory(
         "//adev/src/context:llms_full",
     ],
     replace_prefixes = {
-        "**/context/": "",
+        "**/": "",
     },
 )

--- a/adev/src/assets/BUILD.bazel
+++ b/adev/src/assets/BUILD.bazel
@@ -133,8 +133,9 @@ copy_to_directory(
     name = "context",
     srcs = [
         "//adev/src/context",
+        "//adev/src/context:llms_full",
     ],
     replace_prefixes = {
-        "**/": "",
+        "**/context/": "",
     },
 )

--- a/adev/src/assets/images/BUILD.bazel
+++ b/adev/src/assets/images/BUILD.bazel
@@ -6,7 +6,10 @@ exports_files(
 
 copy_to_bin(
     name = "images",
-    srcs = glob(["**/*"]),
+    srcs = glob(
+        include = ["**/*"],
+        exclude = ["BUILD.bazel"],
+    ),
     visibility = [
         "//visibility:public",
     ],

--- a/adev/src/assets/others/BUILD.bazel
+++ b/adev/src/assets/others/BUILD.bazel
@@ -6,7 +6,10 @@ exports_files(
 
 copy_to_bin(
     name = "others",
-    srcs = glob(["**/*"]),
+    srcs = glob(
+        include = ["**/*"],
+        exclude = ["BUILD.bazel"],
+    ),
     visibility = [
         "//visibility:public",
     ],

--- a/adev/src/content/ai/develop-with-ai.md
+++ b/adev/src/content/ai/develop-with-ai.md
@@ -36,7 +36,7 @@ The Angular CLI includes an experimental [Model Context Protocol (MCP) server](h
 
 
 * <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources.
-* <a href="/assets/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
+* <a href="/assets/context/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
 
 Be sure [to check out the overview page](/ai) for more information on how to integrate AI into your Angular applications.
 

--- a/adev/src/content/ai/develop-with-ai.md
+++ b/adev/src/content/ai/develop-with-ai.md
@@ -12,7 +12,7 @@ Here is a set of instructions to help LLMs generate correct code that follows An
 
 <docs-code language="md" path="adev/src/context/best-practices.md" class="compact"/>
 
-<a download href="/assets/context/best-practices.md" target="_blank">Click here to download the best-practices.md file.</a> 
+<a download href="/assets/context/best-practices.md" target="_blank">Click here to download the best-practices.md file.</a>
 
 ## Rules Files
 Several editors, such as <a href="https://studio.firebase.google.com?utm_source=adev&utm_medium=website&utm_campaign=BUILD_WITH_AI_ANGULAR&utm_term=angular_devrel&utm_content=build_with_ai_angular_firebase_studio">Firebase Studio</a> have rules files useful for providing critical context to LLMs.
@@ -35,8 +35,8 @@ The Angular CLI includes an experimental [Model Context Protocol (MCP) server](h
 `llms.txt` is a proposed standard for websites designed to help LLMs better understand and process their content. The Angular team has developed two versions of this file to help LLMs and tools that use LLMs for code generation to create better modern Angular code.
 
 
-* <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources. 
-* <a href="/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
+* <a href="/llms.txt" target="_blank">llms.txt</a> - an index file providing links to key files and resources.
+* <a href="/assets/context/llm-files/llms-full.txt" target="_blank">llms-full.txt</a> - a more robust compiled set of resources describing how Angular works and how to build Angular applications.
 
 Be sure [to check out the overview page](/ai) for more information on how to integrate AI into your Angular applications.
 

--- a/adev/src/context/BUILD.bazel
+++ b/adev/src/context/BUILD.bazel
@@ -4,7 +4,11 @@ package(default_visibility = ["//adev:__subpackages__"])
 
 filegroup(
     name = "context",
-    srcs = glob(["**"]),
+    srcs = glob([
+        "**/*.md",
+        "**/*.txt",
+        "**/*.mdc",
+    ]),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This commit introduces a number of changes to streamline the build configuration for adev, the documentation application.

The main changes are:
- Use relative paths for node_modules dependencies in `adev/BUILD.bazel`.
- Exclude `BUILD.bazel` files from being included as assets.
- Remove the `src/context` directory from the assets in `angular.json`, as it's handled by bazel.
- The filegroup for `context` now only includes markdown, text and mdc files.

These changes help to make the build more efficient and maintainable.
