### PR TITLE
feat(router): Expose wildcard segments as _splat param

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -85,7 +85,7 @@ export class ApplyRedirects {
   async applyRedirectCommands(
     segments: UrlSegment[],
     redirectTo: string | RedirectFunction,
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
     currentSnapshot: ActivatedRouteSnapshot,
     injector: Injector,
   ): Promise<UrlTree> {
@@ -111,7 +111,7 @@ export class ApplyRedirects {
     redirectTo: string,
     urlTree: UrlTree,
     segments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlTree {
     const newRoot = this.createSegmentGroup(redirectTo, urlTree.root, segments, posParams);
     return new UrlTree(
@@ -139,7 +139,7 @@ export class ApplyRedirects {
     redirectTo: string,
     group: UrlSegmentGroup,
     segments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlSegmentGroup {
     const updatedSegments = this.createSegments(redirectTo, group.segments, segments, posParams);
 
@@ -155,9 +155,9 @@ export class ApplyRedirects {
     redirectTo: string,
     redirectToSegments: UrlSegment[],
     actualSegments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlSegment[] {
-    return redirectToSegments.map((s) =>
+    return redirectToSegments.flatMap((s) =>
       s.path[0] === ':'
         ? this.findPosParam(redirectTo, s, posParams)
         : this.findOrReturn(s, actualSegments),
@@ -167,8 +167,8 @@ export class ApplyRedirects {
   findPosParam(
     redirectTo: string,
     redirectToUrlSegment: UrlSegment,
-    posParams: {[k: string]: UrlSegment},
-  ): UrlSegment {
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
+  ): UrlSegment | UrlSegment[] {
     const pos = posParams[redirectToUrlSegment.path.substring(1)];
     if (!pos)
       throw new RuntimeError(

--- a/packages/router/src/apply_redirects_rxjs.ts
+++ b/packages/router/src/apply_redirects_rxjs.ts
@@ -87,7 +87,7 @@ export class ApplyRedirects {
   applyRedirectCommands(
     segments: UrlSegment[],
     redirectTo: string | RedirectFunction,
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
     currentSnapshot: ActivatedRouteSnapshot,
     injector: Injector,
   ): Observable<UrlTree> {
@@ -116,7 +116,7 @@ export class ApplyRedirects {
     redirectTo: string,
     urlTree: UrlTree,
     segments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlTree {
     const newRoot = this.createSegmentGroup(redirectTo, urlTree.root, segments, posParams);
     return new UrlTree(
@@ -144,7 +144,7 @@ export class ApplyRedirects {
     redirectTo: string,
     group: UrlSegmentGroup,
     segments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlSegmentGroup {
     const updatedSegments = this.createSegments(redirectTo, group.segments, segments, posParams);
 
@@ -160,9 +160,9 @@ export class ApplyRedirects {
     redirectTo: string,
     redirectToSegments: UrlSegment[],
     actualSegments: UrlSegment[],
-    posParams: {[k: string]: UrlSegment},
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
   ): UrlSegment[] {
-    return redirectToSegments.map((s) =>
+    return redirectToSegments.flatMap((s) =>
       s.path[0] === ':'
         ? this.findPosParam(redirectTo, s, posParams)
         : this.findOrReturn(s, actualSegments),
@@ -172,8 +172,8 @@ export class ApplyRedirects {
   findPosParam(
     redirectTo: string,
     redirectToUrlSegment: UrlSegment,
-    posParams: {[k: string]: UrlSegment},
-  ): UrlSegment {
+    posParams: {[k: string]: UrlSegment | UrlSegment[]},
+  ): UrlSegment | UrlSegment[] {
     const pos = posParams[redirectToUrlSegment.path.substring(1)];
     if (!pos)
       throw new RuntimeError(

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -152,7 +152,7 @@ export type Routes = Route[];
  */
 export type UrlMatchResult = {
   consumed: UrlSegment[];
-  posParams?: {[name: string]: UrlSegment};
+  posParams?: {[name: string]: UrlSegment | UrlSegment[]};
 };
 
 /**

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -120,7 +120,7 @@ export function convertToParamMap(params: Params): ParamMap {
 function matchParts(
   routeParts: string[],
   urlSegments: UrlSegment[],
-  posParams: {[key: string]: UrlSegment},
+  posParams: {[key: string]: UrlSegment | UrlSegment[]},
 ): boolean {
   for (let i = 0; i < routeParts.length; i++) {
     const part = routeParts[i];
@@ -199,7 +199,7 @@ export function defaultUrlMatcher(
     return null;
   }
 
-  const posParams: {[key: string]: UrlSegment} = {};
+  const posParams: {[key: string]: UrlSegment | UrlSegment[]} = {};
 
   // Match the segments before the wildcard
   if (!matchParts(pre, segments.slice(0, pre.length), posParams)) {
@@ -210,9 +210,10 @@ export function defaultUrlMatcher(
     return null;
   }
 
-  // TODO(atscott): put the wildcard segments into a _splat param.
-  // this would require a breaking change to the UrlMatchResult to allow UrlSegment[]
-  // since the splat could be multiple segments.
+  const splat = segments.slice(pre.length, segments.length - post.length);
+  if (splat.length > 0) {
+    posParams['_splat'] = splat;
+  }
 
   return {consumed: segments, posParams};
 }

--- a/packages/router/test/integration/redirects.spec.ts
+++ b/packages/router/test/integration/redirects.spec.ts
@@ -35,6 +35,20 @@ export function redirectsIntegrationSuite(browserAPI: 'history' | 'navigation') 
       expect(location.path()).toEqual('/team/22');
     });
 
+    it('should redirect with splat', async () => {
+      const router = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+
+      router.resetConfig([
+        {path: '**/old', redirectTo: ':_splat'},
+        {path: '**', component: TeamCmp},
+      ]);
+
+      await router.navigateByUrl('team/22/old');
+
+      expect(location.path()).toEqual('/team/22');
+    });
+
     it('empty path child redirecting to no match', async () => {
       const router = TestBed.inject(Router);
       router.resetConfig([

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -583,12 +583,17 @@ describe('recognize', () => {
   describe('wildcards', () => {
     it('should support simple wildcards', async () => {
       const s = await recognize([{path: '**', component: ComponentA}], 'a/b/c/d;a1=11');
-      checkActivatedRoute(s.root.firstChild!, 'a/b/c/d', {a1: '11'}, ComponentA);
+      checkActivatedRoute(
+        s.root.firstChild!,
+        'a/b/c/d',
+        {a1: '11', _splat: ['a', 'b', 'c', 'd']},
+        ComponentA,
+      );
     });
 
     it(`should match '**' with pathMatch: 'full' to a non-empty path`, async () => {
       const s = await recognize([{path: '**', pathMatch: 'full', component: ComponentA}], 'a/b/c');
-      checkActivatedRoute(s.root.firstChild!, 'a/b/c', {}, ComponentA);
+      checkActivatedRoute(s.root.firstChild!, 'a/b/c', {_splat: ['a', 'b', 'c']}, ComponentA);
     });
 
     it(`should match '**' with pathMatch: 'full' to an empty path`, async () => {
@@ -604,7 +609,7 @@ describe('recognize', () => {
         [{path: '**', pathMatch: 'full', component: ComponentA}],
         'a/(aux:c)',
       );
-      checkActivatedRoute(s.root.firstChild!, 'a', {}, ComponentA);
+      checkActivatedRoute(s.root.firstChild!, 'a', {_splat: ['a']}, ComponentA);
     });
 
     it('should support segments after a wildcard', async () => {
@@ -627,7 +632,7 @@ describe('recognize', () => {
       checkActivatedRoute(a, 'a', {}, ComponentA);
 
       const wildcard = a.firstChild!;
-      checkActivatedRoute(wildcard, '1/2/b', {}, ComponentB);
+      checkActivatedRoute(wildcard, '1/2/b', {_splat: ['1', '2']}, ComponentB);
     });
 
     describe('with segments after', () => {
@@ -643,12 +648,17 @@ describe('recognize', () => {
 
       it('matches a url with one segment for the wildcard', async () => {
         const s = await recognizer('foo/a/bar');
-        checkActivatedRoute(s.root.firstChild!, 'foo/a/bar', {}, ComponentA);
+        checkActivatedRoute(s.root.firstChild!, 'foo/a/bar', {_splat: ['a']}, ComponentA);
       });
 
       it('matches a url with multiple segments for the wildcard', async () => {
-        const s = await recognizer('foo/a/b/c/bar');
-        checkActivatedRoute(s.root.firstChild!, 'foo/a/b/c/bar', {}, ComponentA);
+        const s = await recognizer('foo/a/b;some=123/c/bar');
+        checkActivatedRoute(
+          s.root.firstChild!,
+          'foo/a/b/c/bar',
+          {_splat: ['a', 'b', 'c'], some: '123'},
+          ComponentA,
+        );
       });
       it('matches a url with no segments for the wildcard', async () => {
         const s = await recognizer('foo/bar');
@@ -668,7 +678,7 @@ describe('recognize', () => {
 
       it('matches a url with segments after the prefix', async () => {
         const s = await recognizer('foo/a/b');
-        checkActivatedRoute(s.root.firstChild!, 'foo/a/b', {}, ComponentA);
+        checkActivatedRoute(s.root.firstChild!, 'foo/a/b', {_splat: ['a', 'b']}, ComponentA);
       });
 
       it('matches a url with no segments after the prefix', async () => {
@@ -685,7 +695,7 @@ describe('recognize', () => {
 
       it('matches a url with segments before the suffix', async () => {
         const s = await recognizer('a/b/bar');
-        checkActivatedRoute(s.root.firstChild!, 'a/b/bar', {}, ComponentA);
+        checkActivatedRoute(s.root.firstChild!, 'a/b/bar', {_splat: ['a', 'b']}, ComponentA);
       });
 
       it('matches a url with no segments before the suffix', async () => {
@@ -929,7 +939,7 @@ describe('recognize', () => {
       checkActivatedRoute(
         s.root.firstChild!,
         'foo/required/a/bar',
-        {anyRequired: 'required'},
+        {anyRequired: 'required', _splat: ['a']},
         ComponentA,
       );
     });
@@ -939,7 +949,7 @@ describe('recognize', () => {
       checkActivatedRoute(
         s.root.firstChild!,
         'foo/required/a/b/c/bar',
-        {anyRequired: 'required'},
+        {anyRequired: 'required', _splat: ['a', 'b', 'c']},
         ComponentA,
       );
     });


### PR DESCRIPTION
BREAKING CHANGE: UrlMatchResult can now return UrlSegment[] for params.
params can be spread across multiple segments.
There is also a new _split param available for wildcard segments

first commit is in https://github.com/angular/angular/pull/64660