### PR TITLE
docs: wrap CLI commands in <docs-code> for copyable shell examples

### DIFF
--- a/adev/src/content/ai/mcp-server-setup.md
+++ b/adev/src/content/ai/mcp-server-setup.md
@@ -8,18 +8,20 @@ The Angular CLI MCP server provides several tools to assist you in your developm
 
 | Name                   | Description                                                                                                                                                                                        | `local-only` | `read-only` |
 | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------: | :---------: |
-| `ai_tutor`             | Launches an interactive AI-powered Angular tutor. Recommended to run from a new Angular project using v20 or later. [Learn more](https://github.com/angular/ai-tutor/blob/main/README.md).         |      ✅      |      ✅     |
-| `get_best_practices`   | Retrieves the Angular Best Practices Guide. This guide is essential for ensuring that all code adheres to modern standards, including standalone components, typed forms, and modern control flow. |      ✅      |      ✅     |
-| `list_projects`        | Lists the names of all applications and libraries defined within an Angular workspace. It reads the `angular.json` configuration file to identify the projects.                                    |      ✅      |      ✅     |
-| `search_documentation` | Searches the official Angular documentation at https://angular.dev. This tool should be used to answer any questions about Angular, such as for APIs, tutorials, and best practices.               |      ❌      |      ✅     |
+| `ai_tutor`             | Launches an interactive AI-powered Angular tutor. Recommended to run from a new Angular project using v20 or later. [Learn more](https://github.com/angular/ai-tutor/blob/main/README.md).         |      ✅      |     ✅      |
+| `get_best_practices`   | Retrieves the Angular Best Practices Guide. This guide is essential for ensuring that all code adheres to modern standards, including standalone components, typed forms, and modern control flow. |      ✅      |     ✅      |
+| `list_projects`        | Lists the names of all applications and libraries defined within an Angular workspace. It reads the `angular.json` configuration file to identify the projects.                                    |      ✅      |     ✅      |
+| `search_documentation` | Searches the official Angular documentation at https://angular.dev. This tool should be used to answer any questions about Angular, such as for APIs, tutorials, and best practices.               |      ❌      |     ✅      |
 
 ## Get Started
 
 To get started, run the following command in your terminal:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng mcp
-```
+</docs-code>
 
 When run from an interactive terminal, this command displays instructions on how to configure a host environment to use the MCP server. The following sections provide example configurations for several popular editors and tools.
 
@@ -118,11 +120,10 @@ For other IDEs, check your IDE's documentation for the proper location of the MC
 
 The `mcp` command can be configured with the following options passed as arguments in your IDE's MCP configuration:
 
-| Option         | Type      | Description                                                                                                | Default |
-| :------------- | :-------- | :--------------------------------------------------------------------------------------------------------- | :------ |
-| `--read-only`  | `boolean` | Only register tools that do not make changes to the project. Your editor or coding agent may still perform edits. | `false` |
+| Option         | Type      | Description                                                                                                                       | Default |
+| :------------- | :-------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------ |
+| `--read-only`  | `boolean` | Only register tools that do not make changes to the project. Your editor or coding agent may still perform edits.                 | `false` |
 | `--local-only` | `boolean` | Only register tools that do not require an internet connection. Your editor or coding agent may still send data over the network. | `false` |
-
 
 For example, to run the server in read-only mode in VS Code, you would update your `mcp.json` like this:
 

--- a/adev/src/content/guide/routing/route-guards.md
+++ b/adev/src/content/guide/routing/route-guards.md
@@ -8,9 +8,11 @@ Route guards are functions that control whether a user can navigate to or leave 
 
 You can generate a route guard using the Angular CLI:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate guard CUSTOM_NAME
-```
+</docs-code>
 
 This will prompt you to select which [type of route guard](#types-of-route-guards) to use and then create the corresponding `CUSTOM_NAME-guard.ts` file.
 

--- a/adev/src/content/reference/migrations/ngclass-to-class.md
+++ b/adev/src/content/reference/migrations/ngclass-to-class.md
@@ -5,17 +5,17 @@ It will only migrate usages that are considered safe to migrate.
 
 Run the schematic using the following command:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:ngclass-to-class
-```
-
+</docs-code>
 
 #### Before
 
 ```html
 <div [ngClass]="{admin: isAdmin, dense: density === 'high'}">
 ```
-
 
 #### After
 
@@ -31,7 +31,6 @@ The migration supports a few options for fine tuning the migration to your speci
 
 By default, the migration avoids migrating usages of `NgClass` in which object literal keys contain space-separated class names.
 When the --migrate-space-separated-key flag is enabled, a binding is created for each individual key.
-
 
 ```html
 <div [ngClass]="{'class1 class2': condition}"></div>

--- a/adev/src/content/reference/migrations/ngstyle-to-style.md
+++ b/adev/src/content/reference/migrations/ngstyle-to-style.md
@@ -5,17 +5,17 @@ It will only migrate usages that are considered safe to migrate.
 
 Run the schematic using the following command:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:ngstyle-to-style
-```
-
+</docs-code>
 
 #### Before
 
 ```html
 <div [ngStyle]="{'background-color': 'red'}">
 ```
-
 
 #### After
 
@@ -30,9 +30,8 @@ The migration supports a few options for fine tuning the migration to your speci
 ### `--best-effort-mode`
 
 By default, the migration avoids migrating object references usages of `NgStyle`
-When the `--best-effort-mode` flag is enabled, `ngStyle` instances binded to object references are also migrated. 
+When the `--best-effort-mode` flag is enabled, `ngStyle` instances binded to object references are also migrated.
 This can be unsafe to migrate, for example if the binded object is mutated.
-
 
 ```html
 <div [ngStyle]="styleObject"></div>

--- a/adev/src/content/reference/migrations/outputs.md
+++ b/adev/src/content/reference/migrations/outputs.md
@@ -9,9 +9,11 @@ provides an automated migration that converts `@Output` custom events to the new
 
 Run the schematic using the following command:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:output-migration
-```
+</docs-code>
 
 ## What does the migration change?
 
@@ -73,9 +75,11 @@ references outside this directory are silently skipped, potentially breaking you
 
 Use these options as shown below:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:output-migration --path src/app/sub-folder
-```
+</docs-code>
 
 ## Exceptions
 

--- a/adev/src/content/reference/migrations/signal-inputs.md
+++ b/adev/src/content/reference/migrations/signal-inputs.md
@@ -9,9 +9,11 @@ provides an automated migration that converts `@Input` fields to the new `input(
 
 Run the schematic using the following command:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:signal-input-migration
-```
+</docs-code>
 
 Alternatively, the migration is available as a [code refactor action](https://code.visualstudio.com/docs/typescript/typescript-refactoring#_refactoring) in VSCode.
 Install the latest version of the VSCode extension and click on an `@Input` field.
@@ -49,18 +51,18 @@ export class MyComponent {
 import {Component, input} from '@angular/core';
 
 @Component({
-  template: `Name: {{name() ?? ''}}`
+template: `Name: {{name() ?? ''}}`
 })
 export class MyComponent {
-  readonly name = input<string>();
+readonly name = input<string>();
 
-  someMethod(): number {
-    const name = this.name();
-    if (name) {
-      return name.length;
-    }
-    return -1;
-  }
+someMethod(): number {
+const name = this.name();
+if (name) {
+return name.length;
+}
+return -1;
+}
 }
 </docs-code>
 
@@ -103,7 +105,7 @@ references outside this directory are silently skipped, potentially breaking you
 
 ## VSCode extension
 
-![Screenshot of the VSCode extension and clicking on an `@Input` field](assets/images/migrations/signal-inputs-vscode.png "Screenshot of the VSCode extension and clicking on an `@Input` field.")
+![Screenshot of the VSCode extension and clicking on an `@Input` field](assets/images/migrations/signal-inputs-vscode.png 'Screenshot of the VSCode extension and clicking on an `@Input` field.')
 
 The migration is available as a [code refactor action](https://code.visualstudio.com/docs/typescript/typescript-refactoring#_refactoring) in VSCode.
 

--- a/adev/src/content/reference/migrations/signal-queries.md
+++ b/adev/src/content/reference/migrations/signal-queries.md
@@ -9,9 +9,11 @@ provides an automated migration that converts existing decorator query fields to
 
 Run the schematic using the following command:
 
-```bash
+<docs-code
+    language="shell"
+    >
 ng generate @angular/core:signal-queries-migration
-```
+</docs-code>
 
 Alternatively, the migration is available as a [code refactor action](https://code.visualstudio.com/docs/typescript/typescript-refactoring#_refactoring) in VSCode.
 Install the latest version of the VSCode extension and click onto e.g. a `@ViewChild` field.
@@ -102,7 +104,7 @@ references outside this directory are silently skipped, potentially breaking you
 
 ## VSCode extension
 
-![Screenshot of the VSCode extension and clicking on an `@ViewChild` field](assets/images/migrations/signal-queries-vscode.png "Screenshot of the VSCode extension and clicking on an `@ViewChild` field.")
+![Screenshot of the VSCode extension and clicking on an `@ViewChild` field](assets/images/migrations/signal-queries-vscode.png 'Screenshot of the VSCode extension and clicking on an `@ViewChild` field.')
 
 The migration is available as a [code refactor action](https://code.visualstudio.com/docs/typescript/typescript-refactoring#_refactoring) in VSCode.
 


### PR DESCRIPTION
Replaced fenced code blocks for shell commands with <docs-code language="shell"> to ensure users can easily copy CLI instructions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
