### PR TITLE
fix(platform-browser): handle undefined allLeavingAnimations in destroy method

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -629,7 +629,7 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
     if (!this.removeStylesOnCompDestroy) {
       return;
     }
-    if (allLeavingAnimations.size === 0) {
+    if (allLeavingAnimations?.size === 0) {
       this.sharedStylesHost.removeStyles(this.styles, this.styleUrls);
     }
   }


### PR DESCRIPTION
fix(platform-browser): handle undefined allLeavingAnimations in destroy method

Prevents TypeError when animations are tree-shaken out of applications. When animations are not imported or are tree-shaken away, the allLeavingAnimations variable may be undefined, causing 'Cannot read properties of undefined (reading size)' error in NoneEncapsulationDomRenderer.destroy(). Added optional chaining to safely access the size property.

Fixes #64678

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #64678

When Angular applications are built for production without animations (tree-shaken), the `allLeavingAnimations` variable becomes undefined in the compiled bundle. This causes a TypeError when `NoneEncapsulationDomRenderer.destroy()` attempts to access `allLeavingAnimations.size`.

The error occurs in production builds where animations are not imported, causing the tree-shaker to remove animation-related exports, but the dom_renderer still references the undefined variable.

## What is the new behavior?

Added optional chaining (`allLeavingAnimations?.size === 0`) to safely handle cases where `allLeavingAnimations` is undefined due to tree-shaking. This prevents the TypeError while maintaining the same functionality when animations are present.

The change is backward compatible:
- **With animations**: Condition works as before (`Set.size === 0`)
- **Without animations**: Condition safely evaluates to falsy without throwing an error

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This fix addresses a tree-shaking edge case that affects production applications optimizing for minimal bundle size by excluding animations. The optional chaining approach is safe and maintains existing behavior while preventing runtime errors.