### PR TITLE
refactor(common): remove unused code and migrate to provideHttpClient

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -12,12 +12,10 @@ import {HttpRequest} from './request';
 import {HttpEvent} from './response';
 import {FetchBackend} from './fetch';
 import {HttpXhrBackend} from './xhr';
-import {isPlatformServer} from '@angular/common';
 import {
   EnvironmentInjector,
   inject,
   Injectable,
-  PLATFORM_ID,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
   PendingTasks,

--- a/packages/common/http/test/module_spec.ts
+++ b/packages/common/http/test/module_spec.ts
@@ -13,12 +13,12 @@ import {HTTP_INTERCEPTORS, HttpInterceptor} from '../src/interceptor';
 import {HttpRequest} from '../src/request';
 import {HttpEvent, HttpResponse} from '../src/response';
 import {HttpTestingController} from '../testing/src/api';
-import {HttpClientTestingModule} from '../testing/src/module';
 import {TestRequest} from '../testing/src/request';
 import {Injectable, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {provideHttpClientTesting} from '../testing/src/provider';
 
 const IS_INTERCEPTOR_C_ENABLED = new HttpContextToken<boolean | undefined>(() => undefined);
 
@@ -80,11 +80,12 @@ describe('HttpClientModule', () => {
   let injector: Injector;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [],
       providers: [
         {provide: HTTP_INTERCEPTORS, useClass: InterceptorA, multi: true},
         {provide: HTTP_INTERCEPTORS, useClass: InterceptorB, multi: true},
         {provide: HTTP_INTERCEPTORS, useClass: InterceptorC, multi: true},
+        provideHttpClientTesting(),
       ],
     });
     injector = TestBed.inject(Injector);
@@ -134,8 +135,10 @@ describe('HttpClientModule', () => {
   it('allows interceptors to inject HttpClient', (done) => {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
-      providers: [{provide: HTTP_INTERCEPTORS, useClass: ReentrantInterceptor, multi: true}],
+      providers: [
+        {provide: HTTP_INTERCEPTORS, useClass: ReentrantInterceptor, multi: true},
+        provideHttpClientTesting(),
+      ],
     });
     injector = TestBed.inject(Injector);
     injector

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -21,7 +21,7 @@ import {
   HttpXhrBackend,
   JsonpClientBackend,
 } from '../index';
-import {HttpClientTestingModule, HttpTestingController, provideHttpClientTesting} from '../testing';
+import {HttpTestingController, provideHttpClientTesting} from '../testing';
 import {
   ApplicationRef,
   createEnvironmentInjector,
@@ -438,8 +438,8 @@ describe('provideHttpClient', () => {
 
         it('should be able to connect to a legacy-provided HttpClient context', () => {
           TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule],
-            providers: [provideLegacyInterceptor('parent')],
+            imports: [],
+            providers: [provideLegacyInterceptor('parent'), provideHttpClientTesting()],
           });
 
           const child = createEnvironmentInjector(

--- a/packages/common/http/testing/src/module.ts
+++ b/packages/common/http/testing/src/module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpClientModule} from '../../index';
+import {provideHttpClient, withInterceptorsFromDi} from '../../index';
 import {NgModule} from '@angular/core';
 
 import {provideHttpClientTesting} from './provider';
@@ -21,7 +21,7 @@ import {provideHttpClientTesting} from './provider';
  * @deprecated Add `provideHttpClientTesting()` to your providers instead.
  */
 @NgModule({
-  imports: [HttpClientModule],
-  providers: [provideHttpClientTesting()],
+  imports: [],
+  providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting(), ],
 })
 export class HttpClientTestingModule {}

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -12,7 +12,6 @@ import {
   Injector,
   Input,
   OnChanges,
-  SimpleChange,
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -9,7 +9,6 @@
 import {CommonModule} from '../../index';
 import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
 import {
-  Compiler,
   Component,
   ComponentRef,
   createEnvironmentInjector,
@@ -19,7 +18,6 @@ import {
   Injector,
   Input,
   NgModule,
-  NgModuleFactory,
   NO_ERRORS_SCHEMA,
   Optional,
   QueryList,

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -9,12 +9,6 @@
 import {EmptyError} from 'rxjs';
 
 import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchFn} from '../models';
-import {
-  NAVIGATION_CANCELING_ERROR,
-  NavigationCancelingError,
-  RedirectingNavigationCancelingError,
-} from '../navigation_canceling_error';
-import {isUrlTree} from '../url_tree';
 
 /**
  * Simple function check, but generic so type inference will flow. Example:


### PR DESCRIPTION
Replaces deprecated `HttpClientModule` with `provideHttpClient` and cleans up unused code

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
