### PR TITLE
add hooks for propagating traces across XHR callbacks.

### DIFF
--- a/adev/src/app/features/playground/playground.component.spec.ts
+++ b/adev/src/app/features/playground/playground.component.spec.ts
@@ -14,6 +14,7 @@ import {NodeRuntimeSandbox} from '../../editor/node-runtime-sandbox.service';
 
 import TutorialPlayground from './playground.component';
 import {provideRouter} from '@angular/router';
+import {mockAsyncProvider} from '../../core/services/inject-async';
 
 describe('TutorialPlayground', () => {
   let component: TutorialPlayground;
@@ -26,6 +27,14 @@ describe('TutorialPlayground', () => {
   };
 
   beforeEach(() => {
+    class FakeEmbeddedTutorialManager {
+      fetchAndSetTutorialFiles() {}
+    }
+
+    class FakeNodeRuntimeSandbox {
+      init() {}
+    }
+
     TestBed.configureTestingModule({
       imports: [TutorialPlayground],
       providers: [
@@ -34,18 +43,8 @@ describe('TutorialPlayground', () => {
           provide: WINDOW,
           useValue: fakeWindow,
         },
-        {
-          provide: EmbeddedTutorialManager,
-          useValue: {
-            fetchAndSetTutorialFiles: () => {},
-          },
-        },
-        {
-          provide: NodeRuntimeSandbox,
-          useVaue: {
-            init: () => {},
-          },
-        },
+        mockAsyncProvider(NodeRuntimeSandbox, FakeNodeRuntimeSandbox),
+        mockAsyncProvider(EmbeddedTutorialManager, FakeEmbeddedTutorialManager),
       ],
     });
 

--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -83,7 +83,7 @@ export default class PlaygroundComponent {
       )
       .subscribe(() => {
         this.changeDetectorRef.markForCheck();
-        this.nodeRuntimeSandbox!.init();
+        this.nodeRuntimeSandbox?.init();
       });
   }
 
@@ -99,7 +99,7 @@ export default class PlaygroundComponent {
     });
     this.selectedTemplate = template;
     await this.loadTemplate(template.path);
-    await this.nodeRuntimeSandbox!.reset();
+    await this.nodeRuntimeSandbox?.reset();
   }
 
   private async loadTemplate(tutorialPath: string) {

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
@@ -12,7 +12,6 @@ import ApiItemLabel from './api-item-label.component';
 import {ApiItemType} from '../interfaces/api-item-type';
 
 describe('ApiItemLabel', () => {
-  let component: ApiItemLabel;
   let fixture: ComponentFixture<ApiItemLabel>;
 
   beforeEach(() => {
@@ -20,12 +19,10 @@ describe('ApiItemLabel', () => {
       imports: [ApiItemLabel],
     });
     fixture = TestBed.createComponent(ApiItemLabel);
-    component = fixture.componentInstance;
   });
 
   it('should by default display short label for Class', () => {
     fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.componentRef.setInput('mode', 'short');
     fixture.detectChanges();
 
     const label = fixture.nativeElement.innerText;

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -8,9 +8,12 @@
 
 import {XhrFactory} from '../../index';
 import {
+  inject,
   Injectable,
   ɵRuntimeError as RuntimeError,
   ɵformatRuntimeError as formatRuntimeError,
+  ɵTracingService as TracingService,
+  ɵTracingSnapshot as TracingSnapshot,
 } from '@angular/core';
 import {from, Observable, Observer, of} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
@@ -103,7 +106,17 @@ function validateXhrCompatibility(req: HttpRequest<any>) {
  */
 @Injectable({providedIn: 'root'})
 export class HttpXhrBackend implements HttpBackend {
-  constructor(private xhrFactory: XhrFactory) {}
+
+  private readonly tracingService: TracingService<TracingSnapshot> | null =
+    inject(TracingService, {optional: true});
+
+  constructor(
+    private xhrFactory: XhrFactory
+  ) {}
+
+  private maybePropagateTrace<T extends Function>(fn: T): T {
+    return this.tracingService?.propagate ? this.tracingService.propagate(fn) : fn;
+  }
 
   /**
    * Processes a request and returns a stream of response events.
@@ -219,7 +232,7 @@ export class HttpXhrBackend implements HttpBackend {
           // emit. This allows them to be unregistered as event listeners later.
 
           // First up is the load event, which represents a response being fully available.
-          const onLoad = () => {
+          const onLoad = this.maybePropagateTrace(() => {
             // Read response state from the memoized partial data.
             let {headers, status, statusText, url} = partialFromXhr();
 
@@ -296,12 +309,12 @@ export class HttpXhrBackend implements HttpBackend {
                 }),
               );
             }
-          };
+          });
 
           // The onError callback is called when something goes wrong at the network level.
           // Connection timeout, DNS error, offline, etc. These are actual errors, and are
           // transmitted on the error channel.
-          const onError = (error: ProgressEvent) => {
+          const onError = this.maybePropagateTrace((error: ProgressEvent) => {
             const {url} = partialFromXhr();
             const res = new HttpErrorResponse({
               error,
@@ -310,12 +323,12 @@ export class HttpXhrBackend implements HttpBackend {
               url: url || undefined,
             });
             observer.error(res);
-          };
+          });
 
           let onTimeout = onError;
 
           if (req.timeout) {
-            onTimeout = (_: ProgressEvent) => {
+            onTimeout = this.maybePropagateTrace((_: ProgressEvent) => {
               const {url} = partialFromXhr();
               const res = new HttpErrorResponse({
                 error: new DOMException('Request timed out', 'TimeoutError'),
@@ -324,7 +337,7 @@ export class HttpXhrBackend implements HttpBackend {
                 url: url || undefined,
               });
               observer.error(res);
-            };
+            });
           }
 
           // The sentHeaders flag tracks whether the HttpResponseHeaders event
@@ -335,7 +348,7 @@ export class HttpXhrBackend implements HttpBackend {
 
           // The download progress event handler, which is only registered if
           // progress events are enabled.
-          const onDownProgress = (event: ProgressEvent) => {
+          const onDownProgress = this.maybePropagateTrace((event: ProgressEvent) => {
             // Send the HttpResponseHeaders event if it hasn't been sent already.
             if (!sentHeaders) {
               observer.next(partialFromXhr());
@@ -363,11 +376,11 @@ export class HttpXhrBackend implements HttpBackend {
 
             // Finally, fire the event.
             observer.next(progressEvent);
-          };
+          });
 
           // The upload progress event handler, which is only registered if
           // progress events are enabled.
-          const onUpProgress = (event: ProgressEvent) => {
+          const onUpProgress = this.maybePropagateTrace((event: ProgressEvent) => {
             // Upload progress events are simpler. Begin building the progress
             // event.
             let progress: HttpUploadProgressEvent = {
@@ -383,7 +396,7 @@ export class HttpXhrBackend implements HttpBackend {
 
             // Send the event.
             observer.next(progress);
-          };
+          });
 
           // By default, register for load and error events.
           xhr.addEventListener('load', onLoad);

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {XhrFactory} from '../../index';
 import {HttpRequest} from '../src/request';
 import {
   HttpDownloadProgressEvent,
@@ -19,6 +20,7 @@ import {
   HttpUploadProgressEvent,
 } from '../src/response';
 import {HttpXhrBackend} from '../src/xhr';
+import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {toArray} from 'rxjs/operators';
 
@@ -53,8 +55,11 @@ describe('XhrBackend', () => {
   let factory: MockXhrFactory = null!;
   let backend: HttpXhrBackend = null!;
   beforeEach(() => {
-    factory = new MockXhrFactory();
-    backend = new HttpXhrBackend(factory);
+    TestBed.configureTestingModule({
+      providers: [{provide: XhrFactory, useClass: MockXhrFactory}],
+    });
+    factory = TestBed.inject(XhrFactory) as MockXhrFactory;
+    backend = TestBed.inject(HttpXhrBackend);
   });
   it('emits status immediately', () => {
     const events = trackEvents(backend.handle(TEST_POST));

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -50,6 +50,13 @@ export interface TracingService<T extends TracingSnapshot> {
   snapshot(linkedSnapshot: T | null): T;
 
   /**
+   * Propagate the current tracing context to the provided function.
+   * @param fn A function.
+   * @return A function that will propagate the current tracing context.
+   */
+  propagate?<T extends Function>(fn: T): T;
+
+  /**
    * Wrap an event listener bound by the framework for tracing.
    * @param element Element on which the event is bound.
    * @param eventName Name of the event.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This enables instrumenting traces across XHR callbacks by capturing the trace context on the callback functions from the send context. Current behavior is that context is not propagated when the callback is called.

Issue Number: N/A


## What is the new behavior?

If implemented in the TracingService, context can now be propagated to XHR callbacks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
