### PR TITLE
build: reduce package size of `@angular/core`

### DIFF
--- a/packages/core/schematics/rollup.config.js
+++ b/packages/core/schematics/rollup.config.js
@@ -55,7 +55,7 @@ const plugins = [
 /** @type {import('rollup').RollupOptions} */
 const config = {
   plugins,
-  external: ['typescript', 'tslib', /@angular-devkit\/.+/],
+  external: ['typescript', 'tslib', /@angular-devkit\/.+/, '@angular/compiler'],
   output: {
     exports: 'auto',
     chunkFileNames: '[name]-[hash].cjs',

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -18,6 +18,7 @@ jasmine_test(
     timeout = "moderate",
     data = [
         ":test_lib",
+        "//:node_modules/@angular/compiler",
         "//packages/core/schematics:bundles",
         "//packages/core/schematics:schematics_jsons",
         "//packages/core/schematics/migrations/common-to-standalone-migration:static_files",


### PR DESCRIPTION
The schematics bundle size is reduced by externalizing `@angular/compiler`. This reduces the package size from 11mb to 9.1mb.
