### PR TITLE
build: add `@babel/core` to list of `rollup_runtime_deps`

### DIFF
--- a/tools/bazel/npm_packages.bzl
+++ b/tools/bazel/npm_packages.bzl
@@ -51,6 +51,7 @@ def ng_package(readme_md = None, license_banner = None, license = None, deps = [
     })
 
     rollup_runtime_deps = [
+        "//:node_modules/@babel/core",
         "//:node_modules/@rollup/plugin-commonjs",
         "//:node_modules/@rollup/plugin-node-resolve",
         "//:node_modules/magic-string",


### PR DESCRIPTION
This will be needed following https://github.com/devversion/rules_angular/pull/72
