### PR TITLE
refactor(compiler): desambiguate and export `RegularExpressionLiteral…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -189,7 +189,7 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     return this.setSourceMapRange(this.factory.createLiteral(ast.value), ast.sourceSpan);
   }
 
-  visitRegularExpressionLiteral(ast: o.outputAst.RegularExpressionLiteral, context: any) {
+  visitRegularExpressionLiteral(ast: o.RegularExpressionLiteralExpr, context: any) {
     return this.setSourceMapRange(
       this.factory.createRegularExpressionLiteral(ast.body, ast.flags),
       ast.sourceSpan,

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -185,11 +185,11 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     throw new Error('Method not implemented.');
   }
 
-  visitDynamicImportExpr(ast: o.outputAst.DynamicImportExpr, context: any) {
+  visitDynamicImportExpr(ast: o.DynamicImportExpr, context: any) {
     throw new Error('Method not implemented.');
   }
 
-  visitRegularExpressionLiteral(ast: o.outputAst.RegularExpressionLiteral, context: any) {
+  visitRegularExpressionLiteral(ast: o.RegularExpressionLiteralExpr, context: any) {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -99,6 +99,7 @@ export {
   ReadKeyExpr,
   ReadPropExpr,
   ReadVarExpr,
+  RegularExpressionLiteralExpr,
   ReturnStatement,
   Statement,
   StatementVisitor,

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -311,7 +311,7 @@ export class GenericKeyFn implements ExpressionKeyFn {
       return `"${expr.value}"`;
     } else if (expr instanceof o.LiteralExpr) {
       return String(expr.value);
-    } else if (expr instanceof o.RegularExpressionLiteral) {
+    } else if (expr instanceof o.RegularExpressionLiteralExpr) {
       return `/${expr.body}/${expr.flags ?? ''}`;
     } else if (expr instanceof o.LiteralArrayExpr) {
       const entries: string[] = [];

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -353,7 +353,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     return null;
   }
 
-  visitRegularExpressionLiteral(ast: o.RegularExpressionLiteral, ctx: EmitterVisitorContext): any {
+  visitRegularExpressionLiteral(
+    ast: o.RegularExpressionLiteralExpr,
+    ctx: EmitterVisitorContext,
+  ): any {
     ctx.print(ast, `/${ast.body}/${ast.flags || ''}`);
     return null;
   }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -538,7 +538,7 @@ export class InstantiateExpr extends Expression {
   }
 }
 
-export class RegularExpressionLiteral extends Expression {
+export class RegularExpressionLiteralExpr extends Expression {
   constructor(
     public body: string,
     public flags: string | null,
@@ -548,7 +548,9 @@ export class RegularExpressionLiteral extends Expression {
   }
 
   override isEquivalent(e: Expression): boolean {
-    return e instanceof RegularExpressionLiteral && this.body === e.body && this.flags === e.flags;
+    return (
+      e instanceof RegularExpressionLiteralExpr && this.body === e.body && this.flags === e.flags
+    );
   }
 
   override isConstant() {
@@ -559,8 +561,8 @@ export class RegularExpressionLiteral extends Expression {
     return visitor.visitRegularExpressionLiteral(this, context);
   }
 
-  override clone(): RegularExpressionLiteral {
-    return new RegularExpressionLiteral(this.body, this.flags, this.sourceSpan);
+  override clone(): RegularExpressionLiteralExpr {
+    return new RegularExpressionLiteralExpr(this.body, this.flags, this.sourceSpan);
   }
 }
 
@@ -1426,7 +1428,7 @@ export interface ExpressionVisitor {
   visitVoidExpr(ast: VoidExpr, context: any): any;
   visitArrowFunctionExpr(ast: ArrowFunctionExpr, context: any): any;
   visitParenthesizedExpr(ast: ParenthesizedExpr, context: any): any;
-  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any;
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteralExpr, context: any): any;
 }
 
 export const NULL_EXPR = new LiteralExpr(null, null, null);
@@ -1654,7 +1656,7 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
   visitLiteralExpr(ast: LiteralExpr, context: any): any {
     return this.visitExpression(ast, context);
   }
-  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any {
+  visitRegularExpressionLiteral(ast: RegularExpressionLiteralExpr, context: any): any {
     return this.visitExpression(ast, context);
   }
   visitLocalizedString(ast: LocalizedString, context: any): any {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1323,7 +1323,7 @@ export function transformExpressionsInExpression(
     expr instanceof o.ReadVarExpr ||
     expr instanceof o.ExternalExpr ||
     expr instanceof o.LiteralExpr ||
-    expr instanceof o.RegularExpressionLiteral
+    expr instanceof o.RegularExpressionLiteralExpr
   ) {
     // No action for these types.
   } else {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1202,7 +1202,7 @@ function convertAst(
       convertSourceSpan(ast.span, baseSourceSpan),
     );
   } else if (ast instanceof e.RegularExpressionLiteral) {
-    return new o.RegularExpressionLiteral(ast.body, ast.flags, baseSourceSpan);
+    return new o.RegularExpressionLiteralExpr(ast.body, ast.flags, baseSourceSpan);
   } else {
     throw new Error(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,

--- a/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
@@ -20,7 +20,7 @@ export function optimizeRegularExpressions(job: CompilationJob): void {
         op,
         (expr) => {
           if (
-            expr instanceof o.RegularExpressionLiteral &&
+            expr instanceof o.RegularExpressionLiteralExpr &&
             // We can't optimize global regexes, because they're stateful.
             (expr.flags === null || !expr.flags.includes('g'))
           ) {


### PR DESCRIPTION
…Expr`

This allows all symbols used by `ExpressionVisitor` to be accessible.
