### PR TITLE
refactor(http): add hooks for propagating traces across XHR callbacks.

### DIFF
--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {XhrFactory} from '../../index';
 import {HttpRequest} from '../src/request';
 import {
   HttpDownloadProgressEvent,
@@ -19,6 +20,7 @@ import {
   HttpUploadProgressEvent,
 } from '../src/response';
 import {HttpXhrBackend} from '../src/xhr';
+import {TestBed} from '@angular/core/testing';
 import {Observable} from 'rxjs';
 import {toArray} from 'rxjs/operators';
 
@@ -53,8 +55,11 @@ describe('XhrBackend', () => {
   let factory: MockXhrFactory = null!;
   let backend: HttpXhrBackend = null!;
   beforeEach(() => {
-    factory = new MockXhrFactory();
-    backend = new HttpXhrBackend(factory);
+    TestBed.configureTestingModule({
+      providers: [{provide: XhrFactory, useClass: MockXhrFactory}],
+    });
+    factory = TestBed.inject(XhrFactory) as MockXhrFactory;
+    backend = TestBed.inject(HttpXhrBackend);
   });
   it('emits status immediately', () => {
     const events = trackEvents(backend.handle(TEST_POST));

--- a/packages/core/src/application/tracing.ts
+++ b/packages/core/src/application/tracing.ts
@@ -50,6 +50,13 @@ export interface TracingService<T extends TracingSnapshot> {
   snapshot(linkedSnapshot: T | null): T;
 
   /**
+   * Propagate the current tracing context to the provided function.
+   * @param fn A function.
+   * @return A function that will propagate the current tracing context.
+   */
+  propagate?<T extends Function>(fn: T): T;
+
+  /**
    * Wrap an event listener bound by the framework for tracing.
    * @param element Element on which the event is bound.
    * @param eventName Name of the event.


### PR DESCRIPTION
Enables propagating a trace across XHR callbacks by providing a hook for wrapping the callback with a function bound to the send trace context.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X ] Tests for the changes have been added (for bug fixes / features)
- [X ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This enables instrumenting traces across XHR callbacks by capturing the trace context on the callback functions from the send context. Current behavior is that context is not propagated when the callback is called.


Issue Number: N/A


## What is the new behavior?

If implemented in the TracingService, context can now be propagated to XHR callbacks.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
