### PR TITLE
docs(docs-infra): Add page that lists all the pages we can navigate to.

### DIFF
--- a/adev/src/app/features/all-links.ts
+++ b/adev/src/app/features/all-links.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, input} from '@angular/core';
+import {RouterLink} from '@angular/router';
+import {SUB_NAVIGATION_DATA} from '../routing/sub-navigation-data';
+import {NavigationItem} from '@angular/docs';
+
+// The goal of this page is to help the indexation of all pages by Algolia
+
+const routeData = SUB_NAVIGATION_DATA;
+
+@Component({
+  selector: 'app-link-list',
+  imports: [RouterLink],
+  template: `
+    <ul>
+      @for (item of items(); track $index) {
+        <li>
+          @if (item.path && !item.path.startsWith('http')) {
+            <a [routerLink]="item.path.startsWith('/') ? item.path : '/'+item.path">{{ item.label }}</a>
+          }
+          @if (item.children) {
+            <app-link-list [items]="item.children" />
+          }
+        </li>
+      }
+    </ul>
+  `,
+})
+export class LinkListComponent {
+  items = input.required<NavigationItem[]>();
+}
+
+@Component({
+  imports: [LinkListComponent],
+  template: `
+    <h1>All Links</h1>
+    <h2>Docs</h2>
+    <app-link-list [items]="routeData.docs" />
+    <h2>Reference</h2>
+    <app-link-list [items]="routeData.reference" />
+    <h2>Tutorials</h2>
+    <app-link-list [items]="routeData.tutorials" />
+    <h2>Footer</h2>
+    <app-link-list [items]="routeData.footer" />
+  `,
+})
+export class AllLinks {
+  routeData = routeData;
+}

--- a/adev/src/app/routing/routes.ts
+++ b/adev/src/app/routing/routes.ts
@@ -150,6 +150,10 @@ export const routes: Route[] = [
       ...FOOTER_ROUTES,
       updateGuidePageRoute,
       ...REDIRECT_ROUTES,
+      {
+        path: 'all-links',
+        loadComponent: () => import('../features/all-links').then((m) => m.AllLinks),
+      },
     ],
   },
   // Error page


### PR DESCRIPTION
This will help Algolia index pages that were missing today like the `provideAnimationsAsync` symbol that is deprecated (so not visible by default on the API page)
