### PR TITLE
fix(docs-infra): update guide navigation to remain active with query …

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -39,7 +39,7 @@
               <a
                 [routerLink]="'/' + item.path"
                 routerLinkActive="docs-faceted-list-item-active"
-                [routerLinkActiveOptions]="{ exact: true }"
+                [routerLinkActiveOptions]="{ paths: 'exact', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }"
                 (click)="emitClickOnLink()"
                 [matTooltip]="item.label"
                 [matTooltipDisabled]="itemLabel.length < 27"


### PR DESCRIPTION
…params

The navigation list component was using `routerLinkActive` with `{ exact: true }`, which required an exact URL match including query parameters. When visiting `/update-guide?v=19.0-20.0&l=1`, the link `/update-guide` didn't match, so the active class wasn't applied.

Updated `routerLinkActiveOptions` to ignore query parameters while maintaining exact path matching so the navigation item stays highlighted when interacting with the update guide form.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
