### PR TITLE
fix(docs-infra): Cannot find module message

### DIFF
--- a/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
+++ b/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
@@ -218,8 +218,17 @@ export class CodeMirrorEditor {
       return;
     }
 
-    // Send message to tsVfsWorker only when current file is TypeScript file.
-    if (!this.currentFile()?.filename.endsWith('.ts')) return;
+    // Always allow infrastructure/setup requests to go through, regardless of current file type.
+    const infraActions = new Set<unknown>([
+      TsVfsWorkerActions.CREATE_VFS_ENV_REQUEST,
+      TsVfsWorkerActions.UPDATE_VFS_ENV_REQUEST,
+      TsVfsWorkerActions.DEFINE_TYPES_REQUEST,
+    ]);
+
+    if (!infraActions.has(request.action)) {
+      // For language-service operations, ensure the current file is a TypeScript file.
+      if (!this.currentFile()?.filename.endsWith('.ts')) return;
+    }
 
     this.tsVfsWorker.postMessage(request);
   };

--- a/adev/src/app/editor/typings-loader.service.spec.ts
+++ b/adev/src/app/editor/typings-loader.service.spec.ts
@@ -64,11 +64,13 @@ describe('TypingsLoader', () => {
     ).toBeTrue();
   });
 
-  it('should only contain type definitions files', async () => {
+  it('should only contain type definitions files or package metadata', async () => {
     await service.retrieveTypeDefinitions(fakeWebContainer);
 
     for (const {path} of service.typings()) {
-      expect(path.endsWith('.d.ts')).toBeTrue();
+      const isDts = path.endsWith('.d.ts');
+      const isPackageJson = path.endsWith('/package.json');
+      expect(isDts || isPackageJson).toBeTrue();
     }
   });
 


### PR DESCRIPTION
Fixed the import error message in the editor section. The build would complete successfully, but an error message would be incorrectly reported.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

<img width="778" height="467" alt="errore" src="https://github.com/user-attachments/assets/e403d2d6-1e6b-4792-b3f9-84ebe89d7be5" />


## What is the new behavior?

Fixed the import error message in the editor section.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
