### PR TITLE
docs: remove shell language from terminal output block

### DIFF
--- a/adev/src/content/ecosystem/service-workers/getting-started.md
+++ b/adev/src/content/ecosystem/service-workers/getting-started.md
@@ -145,7 +145,7 @@ Now look at how the browser and service worker handle the updated application.
 
    Look at the `http-server` logs to see the service worker requesting `/ngsw.json`.
 
-   ```shell
+   ```text
    [2023-09-07T00:37:24.372Z]  "GET /ngsw.json?ngsw-cache-bust=0.9365263935102124" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
    ```
 

--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -78,7 +78,7 @@ If you don't have any preferences, just hit the enter key to take the default op
 
 After you select the configuration options and the CLI runs through the setup, you should see the following message:
 
-```shell
+```text
 ✔ Packages installed successfully.
     Successfully initialized git.
 ```
@@ -105,7 +105,7 @@ npm start
 
 If everything is successful, you should see a similar confirmation message in your terminal:
 
-```shell
+```text
 Watch mode enabled. Watching for file changes...
 NOTE: Raw file sizes do not reflect development server per-request transformations.
   ➜  Local:   http://localhost:4200/

--- a/adev/src/content/tools/cli/end-to-end.md
+++ b/adev/src/content/tools/cli/end-to-end.md
@@ -14,7 +14,7 @@ ng e2e
 
 The `ng e2e` command will first check your project for the "e2e" target. If it can't locate it, the CLI will then prompt you which e2e package you would like to use and walk you through the setup.
 
-```shell
+```text
 
 Cannot find "e2e" target for the specified project.
 You can add a package that implements these capabilities.


### PR DESCRIPTION
Changed terminal output code block in installation.md from shell language to plain text to prevent rendering of shell prompt ($). The block displays read-only log output that users should not execute as commands.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
