### PR TITLE
refactor(forms): preserve logic order when apply is used on root path

### DIFF
--- a/packages/forms/signals/src/api/async.ts
+++ b/packages/forms/signals/src/api/async.ts
@@ -170,7 +170,7 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
     return opts.factory(params);
   });
 
-  pathNode.logic.addAsyncErrorRule((ctx) => {
+  pathNode.builder.addAsyncErrorRule((ctx) => {
     const res = ctx.state.metadata(RESOURCE)!;
     let errors;
     switch (res.status()) {

--- a/packages/forms/signals/src/api/logic.ts
+++ b/packages/forms/signals/src/api/logic.ts
@@ -40,7 +40,7 @@ export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addDisabledReasonRule((ctx) => {
+  pathNode.builder.addDisabledReasonRule((ctx) => {
     let result: boolean | string = true;
     if (typeof logic === 'string') {
       result = logic;
@@ -73,7 +73,7 @@ export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addReadonlyRule(logic);
+  pathNode.builder.addReadonlyRule(logic);
 }
 
 /**
@@ -103,7 +103,7 @@ export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addHiddenRule(logic);
+  pathNode.builder.addHiddenRule(logic);
 }
 
 /**
@@ -124,7 +124,7 @@ export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addSyncErrorRule((ctx) => {
+  pathNode.builder.addSyncErrorRule((ctx) => {
     return ensureCustomValidationResult(
       addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.field),
     );
@@ -150,7 +150,7 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addSyncTreeErrorRule((ctx) =>
+  pathNode.builder.addSyncTreeErrorRule((ctx) =>
     addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.field),
   );
 }
@@ -180,7 +180,7 @@ export function aggregateMetadata<
   assertPathIsCurrent(path);
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addAggregateMetadataRule(key, logic);
+  pathNode.builder.addAggregateMetadataRule(key, logic);
 }
 
 /**
@@ -235,6 +235,6 @@ export function metadata<TValue, TData, TPathKind extends PathKind = PathKind.Ro
   key ??= createMetadataKey();
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
-  pathNode.logic.addMetadataFactory(key, factory as (ctx: FieldContext<unknown>) => unknown);
+  pathNode.builder.addMetadataFactory(key, factory as (ctx: FieldContext<unknown>) => unknown);
   return key;
 }

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -50,7 +50,7 @@ export class FieldNodeContext implements FieldContext<unknown> {
         // applied schema.
         let field: FieldNode | undefined = this.node;
         let stepsRemaining = getBoundPathDepth();
-        while (stepsRemaining > 0 || !field.structure.logic.hasLogic(targetPathNode.root.logic)) {
+        while (stepsRemaining > 0 || !field.structure.logic.hasLogic(targetPathNode.root.builder)) {
           stepsRemaining--;
           field = field.structure.parent;
           if (field === undefined) {

--- a/packages/forms/signals/src/field/field_adapter.ts
+++ b/packages/forms/signals/src/field/field_adapter.ts
@@ -8,12 +8,12 @@
 
 import {FieldPathNode} from '../schema/path_node';
 
+import {WritableSignal} from '@angular/core';
 import {FormFieldManager} from './manager';
 import {FieldNode} from './node';
 import {FieldNodeState} from './state';
 import {ChildFieldNodeOptions, FieldNodeOptions, FieldNodeStructure} from './structure';
-import {ValidationState, FieldValidationState} from './validation';
-import {WritableSignal} from '@angular/core';
+import {FieldValidationState, ValidationState} from './validation';
 
 /**
  * Adapter allowing customization of the creation logic for a field and its associated

--- a/packages/forms/signals/src/field/field_adapter.ts
+++ b/packages/forms/signals/src/field/field_adapter.ts
@@ -84,7 +84,7 @@ export class BasicFieldAdapter implements FieldAdapter {
       fieldManager,
       value,
       pathNode,
-      logic: pathNode.logic.build(),
+      logic: pathNode.builder.build(),
       fieldAdapter: adapter,
     });
   }

--- a/packages/forms/signals/src/schema/path_node.ts
+++ b/packages/forms/signals/src/schema/path_node.ts
@@ -59,11 +59,11 @@ export class FieldPathNode {
   }
 
   /** The logic builder used to accumulate logic on this path node. */
-  get logic(): LogicNodeBuilder {
+  get builder(): LogicNodeBuilder {
     if (this.logicBuilder) {
       return this.logicBuilder;
     }
-    return this.parent!.logic.getChild(this.keyInParent!);
+    return this.parent!.builder.getChild(this.keyInParent!);
   }
 
   /**
@@ -91,7 +91,7 @@ export class FieldPathNode {
    */
   mergeIn(other: SchemaImpl, predicate?: Predicate) {
     const path = other.compile();
-    this.logic.mergeIn(path.logic, predicate);
+    this.builder.mergeIn(path.builder, predicate);
   }
 
   /** Extracts the underlying path node from the given path proxy. */

--- a/packages/forms/signals/test/node/api/structure.spec.ts
+++ b/packages/forms/signals/test/node/api/structure.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {apply, form, required, schema} from '@angular/forms/signals';
+
+describe('structure APIs', () => {
+  describe('apply', () => {
+    it('should maintain order when applying to child of root path', () => {
+      const s = schema<{a: string}>((p) => {
+        required(p.a, {message: 'before'});
+        apply(p.a, (prop) => {
+          required(prop, {message: 'apply'});
+        });
+        required(p.a, {message: 'after'});
+      });
+
+      const data = signal({a: ''});
+      const f = form(data, s, {injector: TestBed.inject(Injector)});
+
+      expect(f.a().errors()).toEqual([
+        jasmine.objectContaining({message: 'before'}),
+        jasmine.objectContaining({message: 'apply'}),
+        jasmine.objectContaining({message: 'after'}),
+      ]);
+    });
+
+    it('should maintain order when applying to root path', () => {
+      const s = schema<{a: {b: string}}>((p) => {
+        required(p.a.b, {message: 'before'});
+        apply(p, (prop) => {
+          required(prop.a.b, {message: 'apply'});
+        });
+        required(p.a.b, {message: 'after'});
+      });
+
+      const data = signal({a: {b: ''}});
+      const f = form(data, s, {injector: TestBed.inject(Injector)});
+
+      expect(f.a.b().errors()).toEqual([
+        jasmine.objectContaining({message: 'before'}),
+        jasmine.objectContaining({message: 'apply'}),
+        jasmine.objectContaining({message: 'after'}),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
In some cases the logic order was not preserved properly when using `apply`. In particular this occurs when some logic is registered on a child of the root, followed by an apply to the root, followed by further logic registered on a child. In this case the final registered logic wound up running before the applied logic.

This happened because `FieldPathNode` for a child path was caching its `LogicNodeBuilder` at creation time. This meant that if the parent's `LogicNodeBuilder` changed (e.g., due to an `apply` call), the child would still be using the old one.

This commit fixes the issue by dynamically resolving the `LogicNodeBuilder` for a child path whenever it is accessed.