### PR TITLE
clean up angularVersion input and legacy InjectFlags handling

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -354,7 +354,6 @@ const getDependenciesForDirective = (
     let flags = dependency.flags as InjectOptions;
     let flagToken = '';
     if (flags !== undefined) {
-      // TODO: We need to remove this once the InjectFlags enum is removed from core
       if (typeof flags === 'number') {
         flags = {
           optional: !!(flags & 8),

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -117,7 +117,7 @@ export class DevToolsTabsComponent {
   );
   TOP_LEVEL_FRAME_ID = TOP_LEVEL_FRAME_ID;
 
-  readonly angularVersion = input<string | undefined>(undefined);
+  readonly angularVersion = input<string | undefined>();
   readonly majorAngularVersion = computed(() => {
     const version = this.angularVersion();
     if (!version) {


### PR DESCRIPTION
This PR add the follow commits : 
refactor(devtools): Removes legacy InjectFlags number handling

Simplifies the initialization of the version input by removing an unnecessary undefined

inspired by https://github.com/angular/angular/pull/64676


docs(devtools): Removes comment about enum deprecation


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
