### PR TITLE
refactor(forms): loosen typings for FieldTree<unknown[]>

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -145,7 +145,7 @@ export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = T
 
 // @public
 export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
-    [ɵɵTYPE]: [TValue, TPathKind];
+    [ɵTYPE]: [TValue, TPathKind];
 } & (TValue extends Array<unknown> ? unknown : TValue extends Record<string, any> ? {
     [K in keyof TValue]: MaybeFieldPath<TValue[K], PathKind.Child>;
 } : unknown);
@@ -305,7 +305,7 @@ export class MaxValidationError extends _NgValidationError {
 export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = (TValue & undefined) | FieldPath<Exclude<TValue, undefined>, TPathKind>;
 
 // @public
-export type MaybeFieldTree<TValue, TKey extends string | number = string | number> = (TValue & undefined) | FieldTree<Exclude<TValue, undefined>, TKey>;
+export type MaybeFieldTree<TValue, TKey extends string | number = string | number> = (TValue & TValue extends undefined ? undefined : never) | FieldTree<Exclude<TValue, undefined>, TKey>;
 
 // @public
 export function metadata<TValue, TData, TPathKind extends PathKind = PathKind.Root>(path: FieldPath<TValue, TPathKind>, factory: (ctx: FieldContext<TValue, TPathKind>) => TData): MetadataKey<TData>;
@@ -378,14 +378,14 @@ export function orMetadataKey(): AggregateMetadataKey<boolean, boolean>;
 export namespace PathKind {
     export interface Child extends PathKind.Root {
         // (undocumented)
-        [ɵɵTYPE]: 'child' | 'item';
+        [ɵTYPE]: 'child' | 'item';
     }
     export interface Item extends PathKind.Child {
         // (undocumented)
-        [ɵɵTYPE]: 'item';
+        [ɵTYPE]: 'item';
     }
     export interface Root {
-        [ɵɵTYPE]: 'root' | 'child' | 'item';
+        [ɵTYPE]: 'root' | 'child' | 'item';
     }
 }
 
@@ -457,7 +457,7 @@ export interface RootFieldContext<TValue> {
 
 // @public
 export type Schema<in TValue> = {
-    [ɵɵTYPE]: SchemaFn<TValue, PathKind.Root>;
+    [ɵTYPE]: SchemaFn<TValue, PathKind.Root>;
 };
 
 // @public

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -204,7 +204,7 @@ export type ReadonlyArrayLike<T> = Pick<
  * @experimental 21.0.0
  */
 export type MaybeFieldTree<TValue, TKey extends string | number = string | number> =
-  | (TValue & undefined)
+  | (TValue & TValue extends undefined ? undefined : never)
   | FieldTree<Exclude<TValue, undefined>, TKey>;
 
 /**

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -19,7 +19,7 @@ import type {
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
  */
-declare const ɵɵTYPE: unique symbol;
+declare const ɵTYPE: unique symbol;
 
 /**
  * A type that represents either a single value of type `T` or a readonly array of `T`.
@@ -40,25 +40,25 @@ export declare namespace PathKind {
    */
   export interface Root {
     /**
-     * The `ɵɵTYPE` is constructed to allow the `extends` clause on `Child` and `Item` to narrow the
+     * The `ɵTYPE` is constructed to allow the `extends` clause on `Child` and `Item` to narrow the
      * type. Another way to think about this is, if we have a function that expects this kind of
-     * path, the `ɵɵTYPE` lists the kinds of path we are allowed to pass to it.
+     * path, the `ɵTYPE` lists the kinds of path we are allowed to pass to it.
      */
-    [ɵɵTYPE]: 'root' | 'child' | 'item';
+    [ɵTYPE]: 'root' | 'child' | 'item';
   }
 
   /**
    * The `PathKind` for a `FieldPath` that is a child of another `FieldPath`.
    */
   export interface Child extends PathKind.Root {
-    [ɵɵTYPE]: 'child' | 'item';
+    [ɵTYPE]: 'child' | 'item';
   }
 
   /**
    * The `PathKind` for a `FieldPath` that is an item in a `FieldPath` array.
    */
   export interface Item extends PathKind.Child {
-    [ɵɵTYPE]: 'item';
+    [ɵTYPE]: 'item';
   }
 }
 export type PathKind = PathKind.Root | PathKind.Child | PathKind.Item;
@@ -322,7 +322,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
  * @experimental 21.0.0
  */
 export type FieldPath<TValue, TPathKind extends PathKind = PathKind.Root> = {
-  [ɵɵTYPE]: [TValue, TPathKind];
+  [ɵTYPE]: [TValue, TPathKind];
 } & (TValue extends Array<unknown>
   ? unknown
   : TValue extends Record<string, any>
@@ -354,7 +354,7 @@ export type MaybeFieldPath<TValue, TPathKind extends PathKind = PathKind.Root> =
  * @experimental 21.0.0
  */
 export type Schema<in TValue> = {
-  [ɵɵTYPE]: SchemaFn<TValue, PathKind.Root>;
+  [ɵTYPE]: SchemaFn<TValue, PathKind.Root>;
 };
 
 /**

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -31,4 +31,15 @@ describe('FieldTree proxy', () => {
     // @ts-expect-error
     f.arr[0] = f.arr[0];
   });
+
+  it('should allow accessing state for items of unknown type', () => {
+    const f = form(signal<unknown[]>([1, 2, 3]), {injector: TestBed.inject(Injector)});
+    expect(f[0]().value()).toEqual(1);
+  });
+
+  it('should now allow accessing state for items of known, possibly undefined type', () => {
+    const f = form(signal<(number | undefined)[]>([1, 2, 3]), {injector: TestBed.inject(Injector)});
+    // @ts-expect-error - Can't access state of possibly undefined item.
+    expect(f[0]()).toEqual(jasmine.anything());
+  });
 });


### PR DESCRIPTION
This commit loosens the typing on `FieldTree` slightly, to allow accessing the state of items in a `FieldTree<unknown[]>`, though still disallowing it for known, possibly undefined item types.

This will likely be helpful for users designing dynamic forms, as they can use `unknown[]` to represent the dynamic data.