### PR TITLE
refactor(migrations): exclude all @angular/* packages from schematics bundle

### DIFF
--- a/packages/core/schematics/rollup.config.js
+++ b/packages/core/schematics/rollup.config.js
@@ -13,7 +13,7 @@ const {pathPlugin} = require('../../../tools/bazel/rollup/path-plugin.cjs');
 const stripBannerPlugin = {
   name: 'strip-license-banner',
   transform(code, _filePath) {
-    const banner = /(\/\**\s+\*\s@license.*?\*\/)/s.exec(code);
+    const banner = /(\/\*[\!\*]\s+\*\s@license.*?\*\/)/s.exec(code);
     if (!banner) {
       return;
     }
@@ -55,7 +55,7 @@ const plugins = [
 /** @type {import('rollup').RollupOptions} */
 const config = {
   plugins,
-  external: ['typescript', 'tslib', /@angular-devkit\/.+/, '@angular/compiler'],
+  external: ['typescript', 'tslib', /@angular-devkit\/.+/, /@angular\//],
   output: {
     exports: 'auto',
     chunkFileNames: '[name]-[hash].cjs',

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -7,7 +7,6 @@ ts_project(
     deps = [
         "//:node_modules/@angular-devkit/core",
         "//:node_modules/@angular-devkit/schematics",
-        "//:node_modules/tslint",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tsurge",
     ],
@@ -19,6 +18,7 @@ jasmine_test(
     data = [
         ":test_lib",
         "//:node_modules/@angular/compiler",
+        "//:node_modules/@angular/compiler-cli",
         "//packages/core/schematics:bundles",
         "//packages/core/schematics:schematics_jsons",
         "//packages/core/schematics/migrations/common-to-standalone-migration:static_files",


### PR DESCRIPTION

This change updates the rollup configuration for the core schematics to exclude all `@angular/*` packages from the bundle. This is possible following https://github.com/angular/angular/pull/64703

This significantly reduces the size of the `@angular/core` schematics bundle, resulting in a size reduction to **5.8mb.**
