### PR TITLE
docs(core): reorder linked signal function overload

### DIFF
--- a/packages/core/src/render3/reactivity/linked_signal.ts
+++ b/packages/core/src/render3/reactivity/linked_signal.ts
@@ -22,16 +22,6 @@ const identityFn = <T>(v: T) => v;
 
 /**
  * Creates a writable signal whose value is initialized and reset by the linked, reactive computation.
- *
- * @publicApi 20.0
- */
-export function linkedSignal<D>(
-  computation: () => D,
-  options?: {equal?: ValueEqualityFn<NoInfer<D>>; debugName?: string},
-): WritableSignal<D>;
-
-/**
- * Creates a writable signal whose value is initialized and reset by the linked, reactive computation.
  * This is an advanced API form where the computation has access to the previous value of the signal and the computation result.
  *
  * Note: The computation is reactive, meaning the linked signal will automatically update whenever any of the signals used within the computation change.
@@ -44,6 +34,16 @@ export function linkedSignal<S, D>(options: {
   equal?: ValueEqualityFn<NoInfer<D>>;
   debugName?: string;
 }): WritableSignal<D>;
+
+/**
+ * Creates a writable signal whose value is initialized and reset by the linked, reactive computation.
+ *
+ * @publicApi 20.0
+ */
+export function linkedSignal<D>(
+  computation: () => D,
+  options?: {equal?: ValueEqualityFn<NoInfer<D>>; debugName?: string},
+): WritableSignal<D>;
 
 export function linkedSignal<S, D>(
   optionsOrComputation:


### PR DESCRIPTION
Reorder linked signal function overloads to enable proper intellisense suggestions,

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Linked signal function overloads is incorrect order. When using the extended overload (source + computation), vscode intellisense tries to display all props of the computation function instead.

<img width="445" height="186" alt="image" src="https://github.com/user-attachments/assets/944d3a8f-0c9d-4e6f-8910-4d90e9ec1e55" />

Issue Number: N/A

## What is the new behavior?
With object as a first argument the intellisense displays the correct properties

<img width="416" height="154" alt="image" src="https://github.com/user-attachments/assets/27fde6ba-f527-4a5c-8251-1acd99311bc1" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
