### PR TITLE
refactor(forms): track arrays in a parent array by index

### DIFF
--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -20,9 +20,9 @@ import {LogicNode} from '../schema/logic_node';
 import type {FieldPathNode} from '../schema/path_node';
 import {deepSignal} from '../util/deep_signal';
 import {isArray, isObject} from '../util/type_guards';
+import type {FieldAdapter} from './field_adapter';
 import type {FormFieldManager} from './manager';
 import type {FieldNode, ParentFieldNode} from './node';
-import type {FieldAdapter} from './field_adapter';
 
 /**
  * Key by which a parent `FieldNode` tracks its children.
@@ -406,7 +406,7 @@ function makeChildrenMapSignal(
           continue;
         }
 
-        if (isValueArray && isObject(childValue)) {
+        if (isValueArray && isObject(childValue) && !isArray(childValue)) {
           // For object values in arrays, assign a synthetic identity instead.
           trackingId = (childValue[identitySymbol] as TrackingKey) ??= Symbol(
             ngDevMode ? `id:${globalId++}` : '',

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -614,6 +614,30 @@ describe('FieldNode', () => {
         expect(f[0] === kirill).toBeTrue();
         expect(f[1] === alex).toBeTrue();
       });
+
+      it('uses index as identity for primitive values', () => {
+        const value = signal([1, 'two']);
+        const f = form(value, {injector: TestBed.inject(Injector)});
+        const first = f[0];
+        const second = f[1];
+
+        value.update((old) => [old[1], old[0]]);
+
+        expect(f[0] === first).toBeTrue();
+        expect(f[1] === second).toBeTrue();
+      });
+
+      it('uses index as identity for array values', () => {
+        const value = signal([[1], ['two']]);
+        const f = form(value, {injector: TestBed.inject(Injector)});
+        const first = f[0];
+        const second = f[1];
+
+        value.update((old) => [old[1], old[0]]);
+
+        expect(f[0] === first).toBeTrue();
+        expect(f[1] === second).toBeTrue();
+      });
     });
   });
 


### PR DESCRIPTION
This commit changes arrays in a parent array to be tracked the same way as primitive values like strings and numbers. This is necessary because the tracking key symbol used to maintain identity for objects in an array does not survive the array spread operation:

```
return {...oldValue} // tracking symbol preserved ✅
return [...oldValue] // tracking symbol lost ❌
```
