### PR TITLE
fix(migrations): Do not remove a template if it is referenced with a trailing semicolon

### DIFF
--- a/packages/core/schematics/migrations/control-flow-migration/util.ts
+++ b/packages/core/schematics/migrations/control-flow-migration/util.ts
@@ -520,7 +520,7 @@ function analyzeTemplateUsage(nodes: any[], templateName: string): TemplateUsage
         for (const attr of node.attrs) {
           if (
             (attr.name === '*ngTemplateOutlet' || attr.name === '[ngTemplateOutlet]') &&
-            attr.value === templateName
+            attr.value?.split(';')[0] === templateName
           ) {
             isReferencedInTemplateOutlet = true;
           }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Under a specific condition described in #64741 the migration is wrongly removing a template that is used.

Issue Number: #64741 

## What is the new behavior?
It should not remove the template that is still used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No