### PR TITLE
docs(docs-infra): Prevent empty extends clause in interface documenta…

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/code-transforms.spec.mts
@@ -6,7 +6,31 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {makeGenericsText} from '../../transforms/code-transforms.mjs';
+import {formatExtendsClause, makeGenericsText} from '../../transforms/code-transforms.mjs';
+
+describe('formatExtendsClause', () => {
+  it('should return an empty string when extendsValue is undefined', () => {
+    expect(formatExtendsClause(undefined)).toBe('');
+  });
+
+  it('should return an empty string when extendsValue is an empty array', () => {
+    expect(formatExtendsClause([])).toBe('');
+  });
+
+  it('should format a single string extends value', () => {
+    expect(formatExtendsClause('BaseClass')).toBe(' extends BaseClass');
+  });
+
+  it('should format a single item array', () => {
+    expect(formatExtendsClause(['BaseInterface'])).toBe(' extends BaseInterface');
+  });
+
+  it('should format multiple items in an array', () => {
+    expect(formatExtendsClause(['IAwesome1', 'IAwesome2', 'IAwesome3'])).toBe(
+      ' extends IAwesome1, IAwesome2, IAwesome3',
+    );
+  });
+});
 
 describe('makeGenericsText', () => {
   it('should return an empty string if no generics are provided', () => {

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -474,6 +474,18 @@ export function printInitializerFunctionSignatureLine(
   return `function ${res}`;
 }
 
+export function formatExtendsClause(extendsValue: string | string[] | undefined): string {
+  if (!extendsValue) {
+    return '';
+  }
+
+  if (typeof extendsValue === 'string') {
+    return ` extends ${extendsValue}`;
+  }
+
+  return extendsValue.length > 0 ? ` extends ${extendsValue.join(', ')}` : '';
+}
+
 function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContentsData): void {
   const appendFirstAndLastLines = (
     data: CodeTableOfContentsData,
@@ -485,11 +497,7 @@ function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContents
 
   if (isClassEntry(entry) || isInterfaceEntry(entry)) {
     const generics = makeGenericsText(entry.generics);
-    const extendsStr = entry.extends
-      ? typeof entry.extends === 'string'
-        ? ` extends ${entry.extends}`
-        : ` extends ${entry.extends.join(', ')}`
-      : '';
+    const extendsStr = formatExtendsClause(entry.extends);
     const implementsStr =
       entry.implements.length > 0 ? ` implements ${entry.implements.join(' ,')}` : '';
 


### PR DESCRIPTION
…tion

Interfaces with no extends clause were incorrectly rendered with a trailing extends keyword followed by nothing, resulting in invalid TypeScript syntax

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
 
<img width="891" height="520" alt="image" src="https://github.com/user-attachments/assets/0828ab40-7b24-4b21-82b5-b428bc928a5e" />


Issue Number: N/A


## What is the new behavior?

<img width="887" height="545" alt="image" src="https://github.com/user-attachments/assets/08afe232-4f43-416b-b13c-3c2b2fbe1b9e" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
