### PR TITLE
fix(docs-infra): extract header attribute as title in multifile code …

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -222,6 +222,7 @@ export class DocViewer {
       sanitizedContent: this.sanitizer.bypassSecurityTrustHtml(tab.innerHTML),
       visibleLinesRange: tab.getAttribute('visibleLines') ?? undefined,
       shell: tab.classList.contains('shell'),
+      title: tab.getAttribute('header') ?? undefined,
     }));
   }
 


### PR DESCRIPTION
…snippets

The DocViewer component's getCodeSnippetsFromMultifileWrapper method was not extracting the header attribute from nested <docs-code> elements, causing the ExampleViewer to fall back to displaying file paths instead of custom headers in tab labels.

This change adds title extraction from the header attribute when processing multifile code snippets, ensuring that custom headers are properly displayed in the code viewer tabs.

Fixes #64760
