### PR TITLE
refactor(core): expose `isWritableSignal` to the publicApi

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1046,6 +1046,9 @@ export function isSignal(value: unknown): value is Signal<unknown>;
 export function isStandalone(type: Type<unknown>): boolean;
 
 // @public
+export function isWritableSignal(value: unknown): value is WritableSignal<unknown>;
+
+// @public
 export interface IterableChangeRecord<V> {
     readonly currentIndex: number | null;
     readonly item: V;

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -8,7 +8,7 @@
 
 export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
 
-export {isSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
+export {isSignal, isWritableSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
 export {
   CreateSignalOptions,

--- a/packages/core/src/render3/instructions/two_way.ts
+++ b/packages/core/src/render3/instructions/two_way.ts
@@ -10,7 +10,8 @@ import type {EventCallback} from '../../event_delegation_utils';
 import {bindingUpdated} from '../bindings';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {RENDERER} from '../interfaces/view';
-import {isWritableSignal, WritableSignal} from '../reactivity/signal';
+import {isWritableSignal} from '../reactivity/api';
+import {WritableSignal} from '../reactivity/signal';
 import {getCurrentTNode, getLView, getSelectedTNode, getTView, nextBindingIndex} from '../state';
 
 import {listenerInternal} from './listener';

--- a/packages/core/src/render3/reactivity/api.ts
+++ b/packages/core/src/render3/reactivity/api.ts
@@ -7,6 +7,7 @@
  */
 
 import {SIGNAL} from '../../../primitives/signals';
+import type {WritableSignal} from './signal';
 
 /**
  * A reactive value which notifies consumers of any changes.
@@ -37,3 +38,12 @@ export function isSignal(value: unknown): value is Signal<unknown> {
  * @publicApi 17.0
  */
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
+
+/**
+ * Checks if the given `value` is a writeable signal.
+ *
+ * @publicApi 21.1
+ */
+export function isWritableSignal(value: unknown): value is WritableSignal<unknown> {
+  return isSignal(value) && typeof (value as any).set === 'function';
+}

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -6,16 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  createSignal,
-  SIGNAL,
-  SignalGetter,
-  SignalNode,
-  signalSetFn,
-  signalUpdateFn,
-} from '../../../primitives/signals';
+import {createSignal, SIGNAL, SignalGetter, SignalNode} from '../../../primitives/signals';
 
-import {isSignal, Signal, ValueEqualityFn} from './api';
+import {Signal, ValueEqualityFn} from './api';
 
 /** Symbol used distinguish `WritableSignal` from other non-writable signals and functions. */
 export const ɵWRITABLE_SIGNAL: unique symbol = /* @__PURE__ */ Symbol('WRITABLE_SIGNAL');
@@ -101,11 +94,4 @@ export function signalAsReadonlyFn<T>(this: SignalGetter<T>): Signal<T> {
     node.readonlyFn = readonlyFn as Signal<T>;
   }
   return node.readonlyFn;
-}
-
-/**
- * Checks if the given `value` is a writeable signal.
- */
-export function isWritableSignal(value: unknown): value is WritableSignal<unknown> {
-  return isSignal(value) && typeof (value as any).set === 'function';
 }

--- a/packages/core/test/signals/is_signal_spec.ts
+++ b/packages/core/test/signals/is_signal_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, isSignal, signal} from '../../src/core';
+import {computed, isSignal, isWritableSignal, signal} from '../../src/core';
 
 describe('isSignal', () => {
   it('should return true for writable signal', () => {
@@ -32,5 +32,32 @@ describe('isSignal', () => {
   it('should return false for function', () => {
     const fn = () => {};
     expect(isSignal(fn)).toBe(false);
+  });
+});
+
+describe('isWritableSignal', () => {
+  it('should return true for writable signal', () => {
+    const writableSignal = signal('Angular');
+    expect(isWritableSignal(writableSignal)).toBe(true);
+  });
+
+  it('should return false for readonly signal', () => {
+    const readonlySignal = computed(() => 10);
+    expect(isWritableSignal(readonlySignal)).toBe(false);
+  });
+
+  it('should return false for primitive', () => {
+    const primitive = 0;
+    expect(isWritableSignal(primitive)).toBe(false);
+  });
+
+  it('should return false for object', () => {
+    const object = {name: 'Angular'};
+    expect(isWritableSignal(object)).toBe(false);
+  });
+
+  it('should return false for function', () => {
+    const fn = () => {};
+    expect(isWritableSignal(fn)).toBe(false);
   });
 });


### PR DESCRIPTION
This is alongside the already exisiting `isSignal()`

fixes #64763