### PR TITLE
docs: release notes for the v20.3.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="20.3.9"></a>
+# 20.3.9 (2025-10-29)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.0-next.9"></a>
 # 21.0.0-next.9 (2025-10-22)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).