### PR TITLE
refactor(forms): tree-shake `ngControlStatusHost` and `ngGroupStatusHost`

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -814,8 +814,6 @@
       "nextBindingIndex",
       "nextNgElementId",
       "nextNotification",
-      "ngControlStatusHost",
-      "ngGroupStatusHost",
       "ngOnChangesSetInput",
       "ngZoneInstanceId",
       "noSideEffects",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -813,8 +813,6 @@
       "nextContextImpl",
       "nextNgElementId",
       "nextNotification",
-      "ngControlStatusHost",
-      "ngGroupStatusHost",
       "ngOnChangesSetInput",
       "ngZoneInstanceId",
       "noSideEffects",

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -81,11 +81,6 @@ export const ngControlStatusHost = {
   '[class.ng-pending]': 'isPending',
 };
 
-export const ngGroupStatusHost = {
-  ...ngControlStatusHost,
-  '[class.ng-submitted]': 'isSubmitted',
-};
-
 /**
  * @description
  * Directive automatically applied to Angular form controls that sets CSS classes
@@ -135,7 +130,13 @@ export class NgControlStatus extends AbstractControlStatus {
 @Directive({
   selector:
     '[formGroupName],[formArrayName],[ngModelGroup],[formGroup],[formArray],form:not([ngNoForm]),[ngForm]',
-  host: ngGroupStatusHost,
+  // Note: having this object here to ensure that the spread assignment is not considered
+  // a side-effect, ending up preserving `ngControlStatusHost` and `ngGroupStatusHost`.
+  // Do not move it to a separate const (`ngGroupStatusHost`).
+  host: {
+    ...ngControlStatusHost,
+    '[class.ng-submitted]': 'isSubmitted',
+  },
   standalone: false,
 })
 export class NgControlStatusGroup extends AbstractControlStatus {


### PR DESCRIPTION
This commit removes `ngGroupStatusHost` variable because it's a side-effect, ending up preserving `ngControlStatusHost` and `ngGroupStatusHost`.