### PR TITLE
fix(language-service): fix directory renaming on Windows

### DIFF
--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -192,7 +192,15 @@ export class Session {
       watchOptions: {
         // Used as watch options when not specified by user's `tsconfig`.
         watchFile: ts.WatchFileKind.UseFsEvents,
-        watchDirectory: ts.WatchDirectoryKind.UseFsEvents,
+        // On Windows, fs.watch() can hold a lock on the watched directory, which
+        // causes problems when users try to rename/move/delete folders.
+        // It's better to use polling instead.
+        // https://github.com/angular/vscode-ng-language-service/issues/1398
+        // More history here: https://github.com/angular/vscode-ng-language-service/commit/6eb2984cbe2112d9f4284192ffa11d40ee6b2f74
+        watchDirectory:
+          process.platform === 'win32'
+            ? ts.WatchDirectoryKind.DynamicPriorityPolling
+            : ts.WatchDirectoryKind.UseFsEvents,
         fallbackPolling: ts.PollingWatchKind.DynamicPriority,
       },
     });


### PR DESCRIPTION
Hopefully addresses issues on Windows where fs.watch on a directory
locks that directory.

fixes https://github.com/angular/vscode-ng-language-service/issues/1398