### PR TITLE
fix(language-service): address potential memory leak during project c…

### DIFF
--- a/packages/language-service/plugin-factory.ts
+++ b/packages/language-service/plugin-factory.ts
@@ -17,12 +17,12 @@ interface PluginModule extends ts.server.PluginModule {
 }
 
 export const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
-  let plugin: PluginModule;
+  const plugin: PluginModule = require(`@angular/language-service/bundles/language-service.js`)(
+    tsModule,
+  );
 
   return {
     create(info: ts.server.PluginCreateInfo): NgLanguageService {
-      // Use a module name based import path to allow it to be marked external.
-      plugin = require(`@angular/language-service/bundles/language-service.js`)(tsModule);
       return plugin.create(info);
     },
     getExternalFiles(project: ts.server.Project): string[] {

--- a/packages/language-service/plugin-factory.ts
+++ b/packages/language-service/plugin-factory.ts
@@ -17,12 +17,11 @@ interface PluginModule extends ts.server.PluginModule {
 }
 
 export const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
-  const plugin: PluginModule = require(`@angular/language-service/bundles/language-service.js`)(
-    tsModule,
-  );
+  let plugin: PluginModule;
 
   return {
     create(info: ts.server.PluginCreateInfo): NgLanguageService {
+      plugin ??= require(`@angular/language-service/bundles/language-service.js`)(tsModule);
       return plugin.create(info);
     },
     getExternalFiles(project: ts.server.Project): string[] {

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -706,6 +706,11 @@ export class Session {
         this.triggerDiagnostics(event.data.openFiles, event.eventName);
         break;
       case ts.server.ProjectLanguageServiceStateEvent:
+        this.logger.info(
+          `Project language service state changed for ${event.data.project.getProjectName()}. Enabled: ${
+            event.data.languageServiceEnabled
+          }`,
+        );
         this.connection.sendNotification(ProjectLanguageService, {
           projectName: event.data.project.getProjectName(),
           languageServiceEnabled: event.data.languageServiceEnabled,
@@ -969,6 +974,7 @@ export class Session {
     if (!filePath) {
       return;
     }
+    this.logger.info(`Closing file: ${filePath}`);
     this.openFiles.delete(filePath);
     this.projectService.closeClientFile(filePath);
   }


### PR DESCRIPTION
…reation

This addresses a potential memory leak in plugin-factory.ts. The require call inside the create function reloads the entire language service module for every new project, which is inefficient and could be a cause of the memory leak during branch switching. This ensures the module is loaded only once and the same instance is shared across all projects.

potentially related to https://github.com/angular/angular/issues/65484
