### PR TITLE
ci: make the github action fail when a firebase command fails

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deploy.mts
+++ b/.github/actions/deploy-docs-site/lib/deploy.mts
@@ -103,7 +103,7 @@ export async function setupRedirect(deployment: Deployment) {
 }
 
 function firebase(cmd: string, cwd?: string) {
-  spawnSync('npx', `-y firebase-tools@13.15.1 ${cmd}`.split(' '), {
+  const {status} = spawnSync('npx', `-y firebase-tools@13.15.1 ${cmd}`.split(' '), {
     cwd,
     encoding: 'utf-8',
     shell: true,
@@ -113,4 +113,8 @@ function firebase(cmd: string, cwd?: string) {
       GOOGLE_APPLICATION_CREDENTIALS: getCredentialFilePath(),
     },
   });
+  if (status !== 0) {
+    console.error('Firebase command failed, see log above for details.');
+    process.exit(status);
+  }
 }

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -33485,7 +33485,7 @@ async function setupRedirect(deployment) {
   await rm(tmpRedirectDir, { recursive: true });
 }
 function firebase(cmd, cwd) {
-  spawnSync("npx", `-y firebase-tools@13.15.1 ${cmd}`.split(" "), {
+  const { status } = spawnSync("npx", `-y firebase-tools@13.15.1 ${cmd}`.split(" "), {
     cwd,
     encoding: "utf-8",
     shell: true,
@@ -33495,6 +33495,10 @@ function firebase(cmd, cwd) {
       GOOGLE_APPLICATION_CREDENTIALS: getCredentialFilePath()
     }
   });
+  if (status !== 0) {
+    console.error("Firebase command failed, see log above for details.");
+    process.exit(status);
+  }
 }
 
 // 

--- a/.github/actions/deploy-docs-site/tsconfig.json
+++ b/.github/actions/deploy-docs-site/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "target": "ES2021",
+    "types": ["node"],
     "lib": ["es2021"],
     "experimentalDecorators": true,
     "strict": true,
@@ -11,6 +12,5 @@
     "noImplicitReturns": true,
     "declaration": true,
     "sourceMap": true
-    
   }
 }


### PR DESCRIPTION
When a firebase command line execution fails, the github action should be shown as failing instead of continuing to attempt to run and resulting in an exit code of 0 and success