### PR TITLE
refactor(core): export types from primitives

### DIFF
--- a/goldens/public-api/core/primitives/signals/index.api.md
+++ b/goldens/public-api/core/primitives/signals/index.api.md
@@ -20,10 +20,7 @@ export interface BaseEffectNode extends ReactiveNode {
 }
 
 // @public (undocumented)
-export type ComputationFn<S, D> = (source: S, previous?: {
-    source: S;
-    value: D;
-}) => D;
+export type ComputationFn<S, D> = (source: S, previous?: PreviousValue<S, D>) => D;
 
 // @public
 export interface ComputedNode<T> extends ReactiveNode {
@@ -100,6 +97,12 @@ export function linkedSignalSetFn<S, D>(node: LinkedSignalNode<S, D>, newValue: 
 
 // @public (undocumented)
 export function linkedSignalUpdateFn<S, D>(node: LinkedSignalNode<S, D>, updater: (value: D) => D): void;
+
+// @public (undocumented)
+export type PreviousValue<S, D> = {
+    source: S;
+    value: D;
+};
 
 // @public
 export function producerAccessed(node: ReactiveNode): void;
@@ -219,6 +222,11 @@ export function untracked<T>(nonReactiveReadsFn: () => T): T;
 
 // @public
 export type ValueEqualityFn<T> = (a: T, b: T) => boolean;
+
+// @public (undocumented)
+export type Version = number & {
+    __brand: 'Version';
+};
 
 // @public (undocumented)
 export interface Watch {

--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -13,6 +13,7 @@ export {
   ComputationFn,
   LinkedSignalNode,
   LinkedSignalGetter,
+  PreviousValue,
   createLinkedSignal,
   linkedSignalSetFn,
   linkedSignalUpdateFn,
@@ -45,6 +46,7 @@ export {
   runPostProducerCreatedFn,
   setActiveConsumer,
   setPostProducerCreatedFn,
+  Version,
 } from './src/graph';
 export {
   SIGNAL_NODE,

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -18,7 +18,7 @@ declare const ngDevMode: boolean | undefined;
 let activeConsumer: ReactiveNode | null = null;
 let inNotificationPhase = false;
 
-type Version = number & {__brand: 'Version'};
+export type Version = number & {__brand: 'Version'};
 
 /**
  * Global epoch counter. Incremented whenever a source signal is set.

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -25,7 +25,8 @@ import {signalSetFn, signalUpdateFn} from './signal';
 // global `ngDevMode` type is defined.
 declare const ngDevMode: boolean | undefined;
 
-export type ComputationFn<S, D> = (source: S, previous?: {source: S; value: D}) => D;
+export type ComputationFn<S, D> = (source: S, previous?: PreviousValue<S, D>) => D;
+export type PreviousValue<S, D> = {source: S; value: D};
 
 export interface LinkedSignalNode<S, D> extends ReactiveNode {
   /**


### PR DESCRIPTION
export Version type and a type for linkedSignal previous value so they can be used for the Wiz implementations

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The types are not exported from primitives.

Issue Number: N/A


## What is the new behavior?

The types are exported from primitives


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
