### PR TITLE
ci: fix typings on exit

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deploy.mts
+++ b/.github/actions/deploy-docs-site/lib/deploy.mts
@@ -115,6 +115,6 @@ function firebase(cmd: string, cwd?: string) {
   });
   if (status !== 0) {
     console.error('Firebase command failed, see log above for details.');
-    process.exit(status);
+    process.exit(status ?? undefined);
   }
 }

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -33497,7 +33497,7 @@ function firebase(cmd, cwd) {
   });
   if (status !== 0) {
     console.error("Firebase command failed, see log above for details.");
-    process.exit(status);
+    process.exit(status ?? void 0);
   }
 }
 


### PR DESCRIPTION
`exit` doesn't accept `null` as argument
