### PR TITLE
refactor(http): migrate XSRF classes to use inject() function

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -9,7 +9,6 @@
 import {DOCUMENT, ɵparseCookieValue as parseCookieValue} from '../../index';
 import {
   EnvironmentInjector,
-  Inject,
   inject,
   Injectable,
   InjectionToken,
@@ -52,6 +51,9 @@ export const XSRF_HEADER_NAME = new InjectionToken<string>(
  */
 @Injectable({providedIn: 'root'})
 export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
+  private readonly cookieName = inject(XSRF_COOKIE_NAME);
+  private readonly doc = inject(DOCUMENT);
+
   private lastCookieString: string = '';
   private lastToken: string | null = null;
 
@@ -59,11 +61,6 @@ export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
    * @internal for testing
    */
   parseCount: number = 0;
-
-  constructor(
-    @Inject(DOCUMENT) private doc: any,
-    @Inject(XSRF_COOKIE_NAME) private cookieName: string,
-  ) {}
 
   getToken(): string | null {
     if (typeof ngServerMode !== 'undefined' && ngServerMode) {
@@ -128,7 +125,7 @@ export function xsrfInterceptorFn(
  */
 @Injectable()
 export class HttpXsrfInterceptor implements HttpInterceptor {
-  constructor(private injector: EnvironmentInjector) {}
+  private readonly injector = inject(EnvironmentInjector);
 
   intercept(initialRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return runInInjectionContext(this.injector, () =>

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {DOCUMENT} from '../..';
 import {HttpHeaders} from '../src/headers';
 import {HttpRequest} from '../src/request';
 import {
@@ -122,7 +123,15 @@ describe('HttpXsrfCookieExtractor', () => {
     document = {
       cookie: 'XSRF-TOKEN=test',
     };
-    extractor = new HttpXsrfCookieExtractor(document, 'XSRF-TOKEN');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: document,
+        },
+      ],
+    });
+    extractor = TestBed.inject(HttpXsrfCookieExtractor);
   });
   it('parses the cookie from document.cookie', () => {
     expect(extractor.getToken()).toEqual('test');


### PR DESCRIPTION
Remove constructor injection in favor of inject() calls


It shouldn't cause breaking changes since, as I understand it, it's only used internally; additionally, the unit test is updated to use dependency injection.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
