### PR TITLE
docs(docs-infra): remove unnecessary CSS units from zero values

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -9,7 +9,7 @@
 .docs-viewer {
   display: flex;
   flex-direction: column;
-  padding: 0px;
+  padding: 0;
   box-sizing: border-box;
   padding-inline: var(--layout-padding);
 

--- a/adev/shared-docs/styles/docs/_mermaid.scss
+++ b/adev/shared-docs/styles/docs/_mermaid.scss
@@ -76,7 +76,7 @@
   .checkedNode {
     rect {
       color: white !important;
-      filter: drop-shadow(5px 5px 0px var(--hot-pink));
+      filter: drop-shadow(5px 5px 0 var(--hot-pink));
       stroke: var(--hot-pink) !important;
     }
 

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.scss
@@ -37,7 +37,7 @@
   }
 
   &>* {
-    padding-inline: 0px;
+    padding-inline: 0;
 
     @include mq.for-extra-large-desktop-up {
       width: var(--page-width);

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.scss
@@ -34,7 +34,7 @@
     width: 100%;
 
     @include mq.for-desktop-up {
-      padding-inline: 0px;
+      padding-inline: 0;
       width: var(--page-width);
     }
   }

--- a/adev/src/app/features/tutorial/tutorial.component.scss
+++ b/adev/src/app/features/tutorial/tutorial.component.scss
@@ -96,7 +96,7 @@ $column-width: calc(50% - #{$resizer-width} - var(--layout-padding));
     //applying styles when TOC position got translated to the top right 
     @include mq.for-large-desktop-up {
       // take the available space except a reserved area for TOC
-      margin-left: 0rem;
+      margin-left: 0;
       width: unset;
     }
   }

--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -6,7 +6,7 @@ $ver-dropdown-width: 200px;
   display: flex;
   flex-flow: column;
   align-items: center;
-  padding: var(--layout-padding) 0px;
+  padding: var(--layout-padding) 0;
   container: update-guide-page / inline-size;
 
   .docs-viewer {
@@ -21,7 +21,7 @@ $ver-dropdown-width: 200px;
     }
 
     .page-header {
-      margin-top: 0px;
+      margin-top: 0;
     }
   }
 }
@@ -31,7 +31,7 @@ $ver-dropdown-width: 200px;
 
   & > * {
     @include mq.for-extra-large-desktop-up {
-      padding-inline: 0px;
+      padding-inline: 0;
     }
   }
 

--- a/adev/src/assets/images/ang_illustrations-04.svg
+++ b/adev/src/assets/images/ang_illustrations-04.svg
@@ -7,7 +7,7 @@
       }
 
       .cls-1, .cls-3, .cls-4, .cls-5, .cls-6, .cls-7, .cls-8, .cls-9 {
-        stroke-width: 0px;
+        stroke-width: 0;
       }
 
       .cls-10, .cls-11, .cls-12, .cls-13, .cls-2 {

--- a/adev/src/content/examples/animations/src/app/animations-package/insert-remove.component.css
+++ b/adev/src/content/examples/animations/src/app/animations-package/insert-remove.component.css
@@ -5,7 +5,7 @@
 .insert-remove-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   color: #000000;
   font-weight: bold;
   font-size: 20px;

--- a/adev/src/content/examples/animations/src/app/animations-package/open-close.component.css
+++ b/adev/src/content/examples/animations/src/app/animations-package/open-close.component.css
@@ -6,7 +6,7 @@
 .open-close-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   color: #000000;
   font-weight: bold;
   font-size: 20px;

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
@@ -6,7 +6,7 @@
 .enter-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
@@ -6,7 +6,7 @@
 .enter-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/insert-remove.component.css
+++ b/adev/src/content/examples/animations/src/app/insert-remove.component.css
@@ -5,7 +5,7 @@
 .insert-remove-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   color: #000000;
   font-weight: bold;
   font-size: 20px;

--- a/adev/src/content/examples/animations/src/app/native-css/insert.component.css
+++ b/adev/src/content/examples/animations/src/app/native-css/insert.component.css
@@ -5,7 +5,7 @@
 .insert-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
 }

--- a/adev/src/content/examples/animations/src/app/native-css/open-close.component.css
+++ b/adev/src/content/examples/animations/src/app/native-css/open-close.component.css
@@ -6,7 +6,7 @@
 .open-close-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
   height: 100px;

--- a/adev/src/content/examples/animations/src/app/native-css/remove.component.css
+++ b/adev/src/content/examples/animations/src/app/native-css/remove.component.css
@@ -5,7 +5,7 @@
 .insert-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;

--- a/adev/src/content/examples/animations/src/app/open-close.component.css
+++ b/adev/src/content/examples/animations/src/app/open-close.component.css
@@ -6,7 +6,7 @@
 .open-close-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px 20px 0 20px;
   color: #000000;
   font-weight: bold;
   font-size: 20px;

--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/02-Home/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/02-Home/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/app.css
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/app.css
@@ -5,7 +5,7 @@ header {
   display: block;
   height: 60px;
   padding: var(--content-padding);
-  box-shadow: 0px 5px 25px var(--shadow-color);
+  box-shadow: 0 5px 25px var(--shadow-color);
 }
 .content {
   padding: var(--content-padding);

--- a/adev/src/content/tutorials/playground/3-minigame/src/game.css
+++ b/adev/src/content/tutorials/playground/3-minigame/src/game.css
@@ -133,7 +133,7 @@ a.gradient-button:focus span:nth-of-type(2) {
   transform: rotate(45deg);
   width: 4px;
   background-color: black;
-  border-radius: 0px 0px 5px 5px;
+  border-radius: 0 0 5px 5px;
 }
 
 .arrow::after {
@@ -317,7 +317,7 @@ svg.personified  {
   margin: 0 4px;
   background-color: #fff;
   transition: all 0.3s ease;
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.3607843137);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3607843137);
 }
 
 .accessibility button:focus:enabled, .accessibility button:hover:enabled {


### PR DESCRIPTION
Removes redundant units like `px`, `rem`, and `em` from zero values across stylesheets. This simplifies the code and aligns with CSS best practices since zero values don't require units.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
