### PR TITLE
docs: remove standalone: true since it's now the default

### DIFF
--- a/adev/src/content/examples/drag-drop/src/boundary/app/app.component.ts
+++ b/adev/src/content/examples/drag-drop/src/boundary/app/app.component.ts
@@ -8,7 +8,6 @@ import {Component} from '@angular/core';
   selector: 'cdk-drag-drop-boundary-example',
   templateUrl: 'app.component.html',
   styleUrl: 'app.component.css',
-  standalone: true,
   imports: [CdkDrag],
 })
 export class CdkDragDropBoundaryExample {}


### PR DESCRIPTION
Removes redundant `standalone: true` declarations from code examples. Standalone components are now the default in Angular, so the flag is no longer necessary in documentation snippets.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
