### PR TITLE
fix(migrations): Prevent removal of templates referenced with preceding whitespace characters

### DIFF
--- a/packages/core/schematics/migrations/control-flow-migration/util.ts
+++ b/packages/core/schematics/migrations/control-flow-migration/util.ts
@@ -520,7 +520,7 @@ function analyzeTemplateUsage(nodes: any[], templateName: string): TemplateUsage
         for (const attr of node.attrs) {
           if (
             (attr.name === '*ngTemplateOutlet' || attr.name === '[ngTemplateOutlet]') &&
-            attr.value?.split(';')[0] === templateName
+            attr.value?.split(';')[0]?.trim() === templateName
           ) {
             isReferencedInTemplateOutlet = true;
           }


### PR DESCRIPTION
In https://github.com/angular/angular/pull/64745, a control flow migration fix was introduced to handle cases where templates are referenced with a trailing semicolon. However, I missed a case where templates are referenced with preceding whitespace characters — these are still incorrectly removed during the migration.

This PR should fix this.

Fixes #64854