### PR TITLE
docs: add the version of angular being used to the footer

### DIFF
--- a/.github/workflows/adev-preview-build.yml
+++ b/.github/workflows/adev-preview-build.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Build adev
-        run: pnpm bazel build //adev:build.production
+        # `snapshot-build` config is used to stamp the exact version with sha in the footer.
+        run: pnpm bazel build //adev:build.production --config=snapshot-build
       - uses: angular/dev-infra/github-actions/previews/pack-and-upload-artifact@a41a2ae61301b2a8ec47d98f73ca5309a7cea932
         with:
           workflow-artifact-name: 'adev-preview'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,8 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Build adev
-        run: pnpm bazel build //adev:build.production --config=release
+        # `snapshot-build` config is used to stamp the exact version with sha in the footer.
+        run: pnpm bazel build //adev:build.production --config=snapshot-build
       - name: Deploy to firebase
         uses: ./.github/actions/deploy-docs-site
         with:

--- a/adev/src/app/core/layout/footer/footer.component.html
+++ b/adev/src/app/core/layout/footer/footer.component.html
@@ -115,6 +115,6 @@
     <a routerLink="/license" title="License text">MIT-style License</a>
     . Documentation licensed under
     <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>
-    .
+    . Built by Angular at v{{angularVersion}}.
   </p>
 </div>

--- a/adev/src/app/core/layout/footer/footer.component.ts
+++ b/adev/src/app/core/layout/footer/footer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, VERSION} from '@angular/core';
 import {ExternalLink} from '@angular/docs';
 import {RouterLink} from '@angular/router';
 import {ANGULAR_LINKS} from '../../constants/links';
@@ -19,5 +19,6 @@ import {ANGULAR_LINKS} from '../../constants/links';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Footer {
+  protected angularVersion = VERSION.full;
   protected ngLinks = ANGULAR_LINKS;
 }


### PR DESCRIPTION
Include the version of angular being used for the build in the footer of the application
