### PR TITLE
refactor(platform-server): avoid token descriptions in production bundle

### DIFF
--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -33,7 +33,9 @@ export interface PlatformConfig {
  *
  * @publicApi
  */
-export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL_CONFIG');
+export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'Server.INITIAL_CONFIG' : '',
+);
 
 /**
  * A function that will be executed when calling `renderApplication` or
@@ -42,7 +44,9 @@ export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL
  * @publicApi
  */
 export const BEFORE_APP_SERIALIZED = new InjectionToken<ReadonlyArray<() => void | Promise<void>>>(
-  'Server.RENDER_MODULE_HOOK',
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'Server.RENDER_MODULE_HOOK' : '',
 );
 
-export const ENABLE_DOM_EMULATION = new InjectionToken<boolean>('ENABLE_DOM_EMULATION');
+export const ENABLE_DOM_EMULATION = new InjectionToken<boolean>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'ENABLE_DOM_EMULATION' : '',
+);

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -244,7 +244,9 @@ const DEFAULT_SERVER_CONTEXT = 'other';
  * (e.g. whether SSR or SSG was used). The value is a string and characters other
  * than [a-zA-Z0-9\-] are removed. See the default value in `DEFAULT_SERVER_CONTEXT` const.
  */
-export const SERVER_CONTEXT = new InjectionToken<string>('SERVER_CONTEXT');
+export const SERVER_CONTEXT = new InjectionToken<string>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'SERVER_CONTEXT' : '',
+);
 
 /**
  * Sanitizes provided server context:


### PR DESCRIPTION
This change makes InjectionToken descriptions conditional on ngDevMode to reduce production bundle size

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
