### PR TITLE
refactor(router): Update pre/post wildcard matching to retain 0 or mo…

### DIFF
--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -193,16 +193,6 @@ export function defaultUrlMatcher(
     // The actual URL is shorter than the config, no match
     return null;
   }
-  if (
-    // If the wildcard is not at the end of the path, it must match at least one segment.
-    // e.g. `foo/**/bar` does not match `foo/bar`.
-    wildcardIndex > -1 &&
-    pre.length > 0 &&
-    post.length > 0 &&
-    pre.length + post.length === segments.length
-  ) {
-    return null;
-  }
 
   if (route.pathMatch === 'full' && segmentGroup.hasChildren() && route.path !== '**') {
     // The config is longer than the actual URL but we are looking for a full match, return null


### PR DESCRIPTION
…re segment match meaning

Prior to the change to support defining required segments before and after the wildcard, the meaning of the wildcard path was '0 or more' so path: foo with a child of ** will still match the ** route when the URL is only 'foo'. If developers want to _require_ something, they can still use path: foo/:anyRequired/**/bar
