### PR TITLE
fix(docs-infra): properly expose the prerendered routes for sitemap generation

### DIFF
--- a/.github/actions/deploy-docs-site/lib/deploy.mts
+++ b/.github/actions/deploy-docs-site/lib/deploy.mts
@@ -23,7 +23,7 @@ export async function deployToFirebase(
   const config = JSON.parse(await readFile(configPath, {encoding: 'utf-8'})) as {
     hosting: {public: string};
   };
-  config['hosting']['public'] = './dist';
+  config['hosting']['public'] = './browser';
 
   await writeFile(deployConfigPath, JSON.stringify(config, null, 2));
 

--- a/.github/actions/deploy-docs-site/lib/main.mts
+++ b/.github/actions/deploy-docs-site/lib/main.mts
@@ -36,7 +36,7 @@ async function deployDocs() {
   const stagingDir = await mkdtemp(join(tmpdir(), 'deploy-directory'));
 
   // Copy all files from the distDir into stagingDir and modify the permissions for editing
-  await cp(getInput('distDir'), join(stagingDir, 'dist'), {recursive: true});
+  await cp(getInput('distDir'), stagingDir, {recursive: true});
   spawnSync(`chmod 777 -R ${stagingDir}`, {encoding: 'utf-8', shell: true});
 
   const deployment = (await getDeployments()).get(currentBranch);

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -33445,7 +33445,7 @@ async function deployToFirebase(deployment, configPath, stagingDir) {
   console.log("Preparing for deployment to firebase...");
   const deployConfigPath = join(stagingDir, "firebase.json");
   const config = JSON.parse(await readFile(configPath, { encoding: "utf-8" }));
-  config["hosting"]["public"] = "./dist";
+  config["hosting"]["public"] = "./browser";
   await writeFile(deployConfigPath, JSON.stringify(config, null, 2));
   firebase(`target:clear --config ${deployConfigPath} --project angular-dev-site hosting angular-docs`, stagingDir);
   firebase(`target:apply --config ${deployConfigPath} --project angular-dev-site hosting angular-docs ${deployment.destination}`, stagingDir);
@@ -42823,7 +42823,7 @@ async function deployDocs() {
   const currentBranch = matchedRef[1];
   const configPath = (0, import_core3.getInput)("configPath");
   const stagingDir = await mkdtemp2(join4(tmpdir2(), "deploy-directory"));
-  await cp((0, import_core3.getInput)("distDir"), join4(stagingDir, "dist"), { recursive: true });
+  await cp((0, import_core3.getInput)("distDir"), stagingDir, { recursive: true });
   spawnSync3(`chmod 777 -R ${stagingDir}`, { encoding: "utf-8", shell: true });
   const deployment = (await getDeployments()).get(currentBranch);
   if (deployment === void 0) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,4 +209,4 @@ jobs:
           serviceKey: ${{ secrets.ANGULAR_DEV_SITE_DEPLOY }}
           githubReleaseTrainReadToken: ${{ secrets.DOCS_DEPLOY_GITHUB_RELEASE_TRAIN_TOKEN }}
           configPath: 'adev/firebase.json'
-          distDir: 'dist/bin/adev/dist/browser'
+          distDir: 'dist/bin/adev/dist'


### PR DESCRIPTION
Properly expose the prerendered routes for sitemap generation rather than only copying the browser directory
