### PR TITLE
refactor(forms): support dynamic object logic

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -46,7 +46,10 @@ export function andMetadataKey(): AggregateMetadataKey<boolean, boolean>;
 export function apply<TValue>(path: SchemaPath<TValue>, schema: NoInfer<SchemaOrSchemaFn<TValue>>): void;
 
 // @public
-export function applyEach<TValue>(path: SchemaPath<TValue[]>, schema: NoInfer<SchemaOrSchemaFn<TValue, PathKind.Item>>): void;
+export function applyEach<TValue extends ReadonlyArray<any>>(path: SchemaPath<TValue>, schema: NoInfer<SchemaOrSchemaFn<TValue[number], PathKind.Item>>): void;
+
+// @public (undocumented)
+export function applyEach<TValue extends Object>(path: SchemaPath<TValue>, schema: NoInfer<SchemaOrSchemaFn<ItemType<TValue>, PathKind.Child>>): void;
 
 // @public
 export function applyWhen<TValue>(path: SchemaPath<TValue>, logic: LogicFn<TValue, boolean>, schema: NoInfer<SchemaOrSchemaFn<TValue>>): void;
@@ -252,6 +255,9 @@ export type IgnoreUnknownProperties<T> = T extends Record<PropertyKey, unknown> 
 export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
     readonly index: Signal<number>;
 }
+
+// @public
+export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number] : T[keyof T];
 
 // @public
 export function listMetadataKey<TItem>(): AggregateMetadataKey<TItem[], TItem | undefined>;

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -12,22 +12,24 @@ import {BasicFieldAdapter, FieldAdapter} from '../field/field_adapter';
 import {FormFieldManager} from '../field/manager';
 import {FieldNode} from '../field/node';
 import {addDefaultField} from '../field/validation';
+import {DYNAMIC} from '../schema/logic';
 import {FieldPathNode} from '../schema/path_node';
-import {assertPathIsCurrent, isSchemaOrSchemaFn, SchemaImpl} from '../schema/schema';
+import {assertPathIsCurrent, SchemaImpl} from '../schema/schema';
+import {normalizeFormArgs} from '../util/normalize_form_args';
 import {isArray} from '../util/type_guards';
 import type {
-  SchemaPath,
   FieldTree,
+  ItemType,
   LogicFn,
   OneOrMany,
   PathKind,
   Schema,
   SchemaFn,
   SchemaOrSchemaFn,
+  SchemaPath,
   TreeValidationResult,
 } from './types';
 import type {ValidationError} from './validation_errors';
-import {normalizeFormArgs} from '../util/normalize_form_args';
 
 /**
  * Options that may be specified when creating a form.
@@ -227,13 +229,21 @@ export function form<TModel>(...args: any[]): FieldTree<TModel> {
  * @category structure
  * @experimental 21.0.0
  */
-export function applyEach<TValue>(
-  path: SchemaPath<TValue[]>,
-  schema: NoInfer<SchemaOrSchemaFn<TValue, PathKind.Item>>,
+export function applyEach<TValue extends ReadonlyArray<any>>(
+  path: SchemaPath<TValue>,
+  schema: NoInfer<SchemaOrSchemaFn<TValue[number], PathKind.Item>>,
+): void;
+export function applyEach<TValue extends Object>(
+  path: SchemaPath<TValue>,
+  schema: NoInfer<SchemaOrSchemaFn<ItemType<TValue>, PathKind.Child>>,
+): void;
+export function applyEach<TValue extends Object>(
+  path: SchemaPath<TValue>,
+  schema: NoInfer<SchemaOrSchemaFn<ItemType<TValue>, PathKind.Item>>,
 ): void {
   assertPathIsCurrent(path);
 
-  const elementPath = FieldPathNode.unwrapFieldPath(path).element.fieldPathProxy;
+  const elementPath = FieldPathNode.unwrapFieldPath(path).getChild(DYNAMIC).fieldPathProxy;
   apply(elementPath, schema as Schema<TValue>);
 }
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -7,10 +7,10 @@
  */
 
 import {Signal, ɵFieldState} from '@angular/core';
+import {AbstractControl} from '@angular/forms';
 import type {Field} from './field_directive';
 import {AggregateMetadataKey, MetadataKey} from './metadata';
 import type {ValidationError} from './validation_errors';
-import {AbstractControl} from '@angular/forms';
 
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
@@ -595,3 +595,10 @@ export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
   /** The index of the current field in its parent field. */
   readonly index: Signal<number>;
 }
+
+/**
+ * Gets the item type of an object that is possibly an array.
+ *
+ * @experimental 21.0.0
+ */
+export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number] : T[keyof T];

--- a/packages/forms/signals/src/schema/logic_node.ts
+++ b/packages/forms/signals/src/schema/logic_node.ts
@@ -149,8 +149,17 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
     // Close off the current builder if the key is DYNAMIC and the current builder already has logic
     // for some non-DYNAMIC key. This guarantees that all of the DYNAMIC logic always comes before
     // all of the specific-key logic for any given instance of `NonMergeableLogicNodeBuilder`.
+    // We rely on this fact in `getAllChildBuilder` to know that we can return the DYNAMIC logic,
+    // followed by the property-specific logic, in that order.
     if (key === DYNAMIC) {
       const children = this.getCurrent().children;
+      // Use the children size to determine if there is logic registered for a property other than
+      // the DYNAMIC property.
+      // - If the children map doesn't have DYNAMIC logic, but the size is still >0 then we know it
+      //   has logic for some other property.
+      // - If the children map does have DYNAMIC logic then its size is going to be at least 1,
+      //   because it has the DYNAMIC key. However if it is >1, then we again know it contains other
+      //   keys.
       if (children.size > (children.has(DYNAMIC) ? 1 : 0)) {
         this.current = undefined;
       }
@@ -447,6 +456,8 @@ function getAllChildBuilders(
     return [
       // DYNAMIC logic always comes first for any individual `NonMergeableLogicNodeBuilder`.
       // This assumption is guaranteed by the behavior of `LogicNodeBuilder.getChild`.
+      // Therefore we can return all of the DYNAMIC logic, followed by all of the property-specific
+      // logic.
       ...(key !== DYNAMIC && builder.children.has(DYNAMIC)
         ? [{builder: builder.getChild(DYNAMIC), predicates: []}]
         : []),

--- a/packages/forms/signals/src/schema/path_node.ts
+++ b/packages/forms/signals/src/schema/path_node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {SchemaPath, SchemaPathRules} from '../api/types';
-import {DYNAMIC, Predicate} from './logic';
+import {Predicate} from './logic';
 import {LogicNodeBuilder} from './logic_node';
 import type {SchemaImpl} from './schema';
 
@@ -64,13 +64,6 @@ export class FieldPathNode {
       return this.logicBuilder;
     }
     return this.parent!.builder.getChild(this.keyInParent!);
-  }
-
-  /**
-   * Gets the special path node containing the per-element logic that applies to *all* children paths.
-   */
-  get element(): FieldPathNode {
-    return this.getChild(DYNAMIC);
   }
 
   /**


### PR DESCRIPTION
extends `applyEach` to work on objects as well, conditionally applying logic to each property of the object.
