### PR TITLE
refactor(forms): expose pathKeys as part of the API

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -454,10 +454,9 @@ export class RequiredValidationError extends _NgValidationError {
 // @public
 export interface RootFieldContext<TValue> {
     readonly field: FieldTree<TValue>;
-    // (undocumented)
     fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): FieldTree<PModel>;
+    readonly pathKeys: Signal<readonly string[]>;
     readonly state: FieldState<TValue>;
-    // (undocumented)
     stateOf<PControl extends AbstractControl>(p: CompatSchemaPath<PControl>): CompatFieldState<PControl>;
     // (undocumented)
     stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): FieldState<PValue>;

--- a/packages/forms/signals/compat/src/compat_structure.ts
+++ b/packages/forms/signals/compat/src/compat_structure.ts
@@ -18,8 +18,8 @@ import {
 
 import {toSignal} from '@angular/core/rxjs-interop';
 import {AbstractControl} from '@angular/forms';
-import {extractControlPropToSignal} from './compat_field_node';
 import {map, takeUntil} from 'rxjs/operators';
+import {extractControlPropToSignal} from './compat_field_node';
 
 /**
  * Child Field Node options also exposing control property.
@@ -105,7 +105,7 @@ export class CompatStructure extends FieldNodeStructure {
     throw new Error('Compat nodes do not use keyInParent.');
   }) as unknown as Signal<string>;
   override root: FieldNode;
-  override pathKeys: Signal<readonly PropertyKey[]>;
+  override pathKeys: Signal<readonly string[]>;
   override readonly children = signal([]);
   override readonly childrenMap = signal(undefined);
   override readonly parent: ParentFieldNode | undefined;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -7,10 +7,10 @@
  */
 
 import {Signal, ɵFieldState} from '@angular/core';
+import {AbstractControl} from '@angular/forms';
 import type {Field} from './field_directive';
 import {AggregateMetadataKey, MetadataKey} from './metadata';
 import type {ValidationError} from './validation_errors';
-import {AbstractControl} from '@angular/forms';
 
 /**
  * Symbol used to retain generic type information when it would otherwise be lost.
@@ -566,13 +566,15 @@ export interface RootFieldContext<TValue> {
   /** Gets the value of the field represented by the given path. */
   valueOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): PValue;
 
+  /** Gets the state of the field represented by the given path. */
   stateOf<PControl extends AbstractControl>(
     p: CompatSchemaPath<PControl>,
   ): CompatFieldState<PControl>;
-
   stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): FieldState<PValue>;
-
+  /** Gets the field represented by the given path. */
   fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): FieldTree<PModel>;
+  /** The list of keys that lead from the root field to the current field. */
+  readonly pathKeys: Signal<readonly string[]>;
 }
 
 /**

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -107,6 +107,10 @@ export class FieldNodeContext implements FieldContext<unknown> {
     return this.node.structure.keyInParent;
   }
 
+  get pathKeys(): Signal<readonly string[]> {
+    return this.node.structure.pathKeys;
+  }
+
   readonly index = computed(() => {
     // Attempt to read the key first, this will throw an error if we're on a root field.
     const key = this.key();

--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -53,7 +53,7 @@ export abstract class FieldNodeStructure {
   abstract readonly root: FieldNode;
 
   /** The list of property keys to follow to get from the `root` to this field. */
-  abstract readonly pathKeys: Signal<readonly PropertyKey[]>;
+  abstract readonly pathKeys: Signal<readonly string[]>;
 
   /** The parent field of this field. */
   abstract readonly parent: FieldNode | undefined;
@@ -121,7 +121,7 @@ export class RootFieldNodeStructure extends FieldNodeStructure {
     return this.node;
   }
 
-  override get pathKeys(): Signal<readonly PropertyKey[]> {
+  override get pathKeys(): Signal<readonly string[]> {
     return ROOT_PATH_KEYS;
   }
 
@@ -168,7 +168,7 @@ export class RootFieldNodeStructure extends FieldNodeStructure {
 /** The structural component of a child `FieldNode` within a field tree. */
 export class ChildFieldNodeStructure extends FieldNodeStructure {
   override readonly root: FieldNode;
-  override readonly pathKeys: Signal<readonly PropertyKey[]>;
+  override readonly pathKeys: Signal<readonly string[]>;
   override readonly keyInParent: Signal<string>;
   override readonly value: WritableSignal<unknown>;
 
@@ -319,7 +319,7 @@ export interface ChildFieldNodeOptions {
 export type FieldNodeOptions = RootFieldNodeOptions | ChildFieldNodeOptions;
 
 /** A signal representing an empty list of path keys, used for root fields. */
-const ROOT_PATH_KEYS = computed<readonly PropertyKey[]>(() => []);
+const ROOT_PATH_KEYS = computed<readonly string[]>(() => []);
 
 /**
  * A signal representing a non-existent key of the field in its parent, used for root fields which

--- a/packages/forms/signals/test/node/logic_node.spec.ts
+++ b/packages/forms/signals/test/node/logic_node.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal} from '@angular/core';
+import {computed, signal} from '@angular/core';
 import {customError, FieldContext} from '../../public_api';
 import {DYNAMIC} from '../../src/schema/logic';
 import {LogicNodeBuilder} from '../../src/schema/logic_node';
@@ -22,6 +22,7 @@ const fakeFieldContext: FieldContext<unknown> = {
   field: undefined!,
   state: undefined!,
   value: undefined!,
+  pathKeys: computed(() => []),
 };
 
 describe('LogicNodeBuilder', () => {


### PR DESCRIPTION
Currently we maintain the pathKeys internally, but do not expose them through the `FieldContext`, this PR updates the `FieldContext` to expose this property.
