### PR TITLE
refactor(forms): add better support for Object.keys and Symbol.iterator

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -487,6 +487,8 @@ export class StandardSchemaValidationError extends _NgValidationError {
 // @public
 export type Subfields<TValue> = {
     readonly [K in keyof TValue as TValue[K] extends Function ? never : K]: MaybeFieldTree<TValue[K], string>;
+} & {
+    [Symbol.iterator](): Iterator<[string, MaybeFieldTree<TValue[keyof TValue], string>]>;
 };
 
 // @public

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -178,6 +178,8 @@ export type Subfields<TValue> = {
     TValue[K],
     string
   >;
+} & {
+  [Symbol.iterator](): Iterator<[string, MaybeFieldTree<TValue[keyof TValue], string>]>;
 };
 
 /**

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -31,4 +31,64 @@ describe('FieldTree proxy', () => {
     // @ts-expect-error
     f.arr[0] = f.arr[0];
   });
+
+  it('should get keys and values for object field', () => {
+    const f = form(signal({x: 1, y: 2}), {injector: TestBed.inject(Injector)});
+    expect(Object.keys(f)).toEqual(['x', 'y']);
+    expect(Object.getOwnPropertyNames(f)).toEqual(['x', 'y']);
+    expect(Object.entries(f).map(([key, child]) => [key, child().value()])).toEqual([
+      ['x', 1],
+      ['y', 2],
+    ]);
+    expect(Object.values(f).map((child) => child().value())).toEqual([1, 2]);
+  });
+
+  it('should get keys and values for array field', () => {
+    const f = form(signal([1, 2]), {injector: TestBed.inject(Injector)});
+    expect(Object.keys(f)).toEqual(['0', '1']);
+    expect(Object.getOwnPropertyNames(f)).toEqual(['0', '1', 'length']);
+    expect(Object.entries(f).map(([key, child]) => [key, child().value()])).toEqual([
+      ['0', 1],
+      ['1', 2],
+    ]);
+    expect(Object.values(f).map((child) => child().value())).toEqual([1, 2]);
+  });
+
+  it('should get keys and values for primitive field', () => {
+    const f = form(signal(1), {injector: TestBed.inject(Injector)});
+    expect(Object.keys(f)).toEqual([]);
+    expect(Object.getOwnPropertyNames(f)).toEqual([]);
+    expect(Object.entries(f)).toEqual([]);
+    expect(Object.values(f)).toEqual([]);
+  });
+
+  it('should iterate over object field', () => {
+    const f = form(signal({x: 1, y: 2}), {injector: TestBed.inject(Injector)});
+    const result: [string, number][] = [];
+    for (const [key, child] of f) {
+      result.push([key, child().value()]);
+    }
+    expect(result).toEqual([
+      ['x', 1],
+      ['y', 2],
+    ]);
+  });
+
+  it('should iterate over array field', () => {
+    const f = form(signal([1, 2]), {injector: TestBed.inject(Injector)});
+    const result: number[] = [];
+    for (const child of f) {
+      result.push(child().value());
+    }
+    expect(result).toEqual([1, 2]);
+  });
+
+  it('should not iterate over primitive field', () => {
+    const f = form(signal(1), {injector: TestBed.inject(Injector)});
+    expect(() => {
+      // @ts-expect-error - not iterable
+      for (const child of f) {
+      }
+    }).toThrow();
+  });
 });


### PR DESCRIPTION
Improves support for using `Object.keys` (and related methods) and `Symbol.iterator` to work with a `FieldTree` of unknown shape.
