### PR TITLE
refactor(forms): allow FieldTree of recursive type

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -178,7 +178,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 }
 
 // @public
-export type FieldTree<TModel, TKey extends string | number = string | number> = (() => [TModel] extends [AbstractControl] ? CompatFieldState<TModel, TKey> : FieldState<TModel, TKey>) & (TModel extends AbstractControl ? unknown : TModel extends Array<infer U> ? ReadonlyArrayLike<MaybeFieldTree<U, number>> : TModel extends Record<string, any> ? Subfields<TModel> : unknown);
+export type FieldTree<TModel, TKey extends string | number = string | number> = (() => [TModel] extends [AbstractControl] ? CompatFieldState<TModel, TKey> : FieldState<TModel, TKey>) & ([TModel] extends [AbstractControl] ? unknown : [TModel] extends [Array<infer U>] ? ReadonlyArrayLike<MaybeFieldTree<U, number>> : TModel extends Record<string, any> ? Subfields<TModel> : unknown);
 
 // @public
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, ValidationResult<ValidationError.WithoutField>, TPathKind>;

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -13,10 +13,10 @@ import {FormFieldManager} from '../field/manager';
 import {FieldNode} from '../field/node';
 import {addDefaultField} from '../field/validation';
 import {FieldPathNode} from '../schema/path_node';
-import {assertPathIsCurrent, isSchemaOrSchemaFn, SchemaImpl} from '../schema/schema';
+import {assertPathIsCurrent, SchemaImpl} from '../schema/schema';
+import {normalizeFormArgs} from '../util/normalize_form_args';
 import {isArray} from '../util/type_guards';
 import type {
-  SchemaPath,
   FieldTree,
   LogicFn,
   OneOrMany,
@@ -24,10 +24,10 @@ import type {
   Schema,
   SchemaFn,
   SchemaOrSchemaFn,
+  SchemaPath,
   TreeValidationResult,
 } from './types';
 import type {ValidationError} from './validation_errors';
-import {normalizeFormArgs} from '../util/normalize_form_args';
 
 /**
  * Options that may be specified when creating a form.

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {WritableSignal} from '@angular/core';
+import {signal, WritableSignal} from '@angular/core';
 import {form, required, schema, SchemaFn} from '../../public_api';
 
 interface Order {
@@ -81,6 +81,11 @@ function typeVerificationOnlyDoNotRunMe() {
         // @ts-expect-error
         required(p.c);
       });
+    });
+
+    it('should allow FieldTree of recursive type', () => {
+      type RecursiveType = (number | RecursiveType)[];
+      form(signal<RecursiveType>([5]));
     });
   });
 }


### PR DESCRIPTION
Adjusts our typings to work better with recursive types and avoid infinite recursion in the type system.
