### PR TITLE
build: update typescript dependency for vscode-ng-language-service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,9 @@ importers:
       '@angular/language-service':
         specifier: workspace:*
         version: link:../packages/language-service
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
     devDependencies:
       '@types/jasmine':
         specifier: ~5.1.9
@@ -1335,9 +1338,6 @@ importers:
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
       vscode-jsonrpc:
         specifier: 6.0.0
         version: 6.0.0

--- a/vscode-ng-language-service/BUILD.bazel
+++ b/vscode-ng-language-service/BUILD.bazel
@@ -55,7 +55,8 @@ npm_package(
         # this set was determined manually by running `bazel build //:vsix` and burning down missing packages.
         # We do this so that we don't have to run an additional `npm install` action to create a node_modules within the
         # //:npm npm_package where the vsce build takes place.
-        "//vscode-ng-language-service:node_modules/@angular/language-service",
+        ":node_modules/@angular/language-service",
+        ":node_modules/typescript",
     ],
     exclude_srcs_patterns = [
         "*.map",

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -258,7 +258,8 @@
     "test:inspect-syntaxes": "bazel run --config=debug //vscode-ng-language-service/syntaxes/test:test"
   },
   "dependencies": {
-    "@angular/language-service": "workspace:*"
+    "@angular/language-service": "workspace:*",
+    "typescript": "5.9.3"
   },
   "devDependencies": {
     "@types/jasmine": "~5.1.9",
@@ -271,7 +272,6 @@
     "jasmine-core": "~5.12.0",
     "jasmine-reporters": "~2.5.2",
     "source-map-support": "^0.5.21",
-    "typescript": "5.9.3",
     "vscode-jsonrpc": "6.0.0",
     "vscode-languageclient": "7.0.0",
     "vscode-languageserver": "7.0.0",


### PR DESCRIPTION
Updates the typescript dependency to 5.9.3 in vscode-ng-language-service/package.json and updates pnpm-lock.yaml accordingly.


```
npx @vscode/vsce ls       
package.json
index.js
angular.png
README.md
CHANGELOG.md
syntaxes/tsconfig.json
syntaxes/template.json
syntaxes/template-tag.json
syntaxes/template-blocks.json
syntaxes/let-declaration.json
syntaxes/inline-template.json
syntaxes/inline-styles.json
syntaxes/host-object-literal.json
syntaxes/expression.json
server/package.json
server/index.js
server/README.md
server/bin/ngserver
node_modules/@angular/language-service/plugin-factory.d.ts
node_modules/@angular/language-service/package.json
node_modules/@angular/language-service/index.js
node_modules/@angular/language-service/index.d.ts
node_modules/@angular/language-service/factory_bundle.js
node_modules/@angular/language-service/api_bundle.js
node_modules/@angular/language-service/api.d.ts
node_modules/@angular/language-service/bundles/language-service.js
node_modules/typescript/package.json
node_modules/typescript/ThirdPartyNoticeText.txt
node_modules/typescript/SECURITY.md
node_modules/typescript/README.md
node_modules/typescript/LICENSE.txt
node_modules/typescript/bin/tsserver
node_modules/typescript/bin/tsc
node_modules/typescript/lib/watchGuard.js
node_modules/typescript/lib/typingsInstaller.js
node_modules/typescript/lib/typescript.js
node_modules/typescript/lib/typescript.d.ts
node_modules/typescript/lib/typesMap.json
node_modules/typescript/lib/tsserverlibrary.js
node_modules/typescript/lib/tsserverlibrary.d.ts
node_modules/typescript/lib/tsserver.js
node_modules/typescript/lib/tsc.js
node_modules/typescript/lib/lib.webworker.iterable.d.ts
node_modules/typescript/lib/lib.webworker.importscripts.d.ts
node_modules/typescript/lib/lib.webworker.d.ts
node_modules/typescript/lib/lib.webworker.asynciterable.d.ts
node_modules/typescript/lib/lib.scripthost.d.ts
node_modules/typescript/lib/lib.esnext.sharedmemory.d.ts
node_modules/typescript/lib/lib.esnext.promise.d.ts
node_modules/typescript/lib/lib.esnext.iterator.d.ts
node_modules/typescript/lib/lib.esnext.intl.d.ts
node_modules/typescript/lib/lib.esnext.full.d.ts
node_modules/typescript/lib/lib.esnext.float16.d.ts
node_modules/typescript/lib/lib.esnext.error.d.ts
node_modules/typescript/lib/lib.esnext.disposable.d.ts
node_modules/typescript/lib/lib.esnext.decorators.d.ts
node_modules/typescript/lib/lib.esnext.d.ts
node_modules/typescript/lib/lib.esnext.collection.d.ts
node_modules/typescript/lib/lib.esnext.array.d.ts
node_modules/typescript/lib/lib.es6.d.ts
node_modules/typescript/lib/lib.es5.d.ts
node_modules/typescript/lib/lib.es2024.string.d.ts
node_modules/typescript/lib/lib.es2024.sharedmemory.d.ts
node_modules/typescript/lib/lib.es2024.regexp.d.ts
node_modules/typescript/lib/lib.es2024.promise.d.ts
node_modules/typescript/lib/lib.es2024.object.d.ts
node_modules/typescript/lib/lib.es2024.full.d.ts
node_modules/typescript/lib/lib.es2024.d.ts
node_modules/typescript/lib/lib.es2024.collection.d.ts
node_modules/typescript/lib/lib.es2024.arraybuffer.d.ts
node_modules/typescript/lib/lib.es2023.intl.d.ts
node_modules/typescript/lib/lib.es2023.full.d.ts
node_modules/typescript/lib/lib.es2023.d.ts
node_modules/typescript/lib/lib.es2023.collection.d.ts
node_modules/typescript/lib/lib.es2023.array.d.ts
node_modules/typescript/lib/lib.es2022.string.d.ts
node_modules/typescript/lib/lib.es2022.regexp.d.ts
node_modules/typescript/lib/lib.es2022.object.d.ts
node_modules/typescript/lib/lib.es2022.intl.d.ts
node_modules/typescript/lib/lib.es2022.full.d.ts
node_modules/typescript/lib/lib.es2022.error.d.ts
node_modules/typescript/lib/lib.es2022.d.ts
node_modules/typescript/lib/lib.es2022.array.d.ts
node_modules/typescript/lib/lib.es2021.weakref.d.ts
node_modules/typescript/lib/lib.es2021.string.d.ts
node_modules/typescript/lib/lib.es2021.promise.d.ts
node_modules/typescript/lib/lib.es2021.intl.d.ts
node_modules/typescript/lib/lib.es2021.full.d.ts
node_modules/typescript/lib/lib.es2021.d.ts
node_modules/typescript/lib/lib.es2020.symbol.wellknown.d.ts
node_modules/typescript/lib/lib.es2020.string.d.ts
node_modules/typescript/lib/lib.es2020.sharedmemory.d.ts
node_modules/typescript/lib/lib.es2020.promise.d.ts
node_modules/typescript/lib/lib.es2020.number.d.ts
node_modules/typescript/lib/lib.es2020.intl.d.ts
node_modules/typescript/lib/lib.es2020.full.d.ts
node_modules/typescript/lib/lib.es2020.date.d.ts
node_modules/typescript/lib/lib.es2020.d.ts
node_modules/typescript/lib/lib.es2020.bigint.d.ts
node_modules/typescript/lib/lib.es2019.symbol.d.ts
node_modules/typescript/lib/lib.es2019.string.d.ts
node_modules/typescript/lib/lib.es2019.object.d.ts
node_modules/typescript/lib/lib.es2019.intl.d.ts
node_modules/typescript/lib/lib.es2019.full.d.ts
node_modules/typescript/lib/lib.es2019.d.ts
node_modules/typescript/lib/lib.es2019.array.d.ts
node_modules/typescript/lib/lib.es2018.regexp.d.ts
node_modules/typescript/lib/lib.es2018.promise.d.ts
node_modules/typescript/lib/lib.es2018.intl.d.ts
node_modules/typescript/lib/lib.es2018.full.d.ts
node_modules/typescript/lib/lib.es2018.d.ts
node_modules/typescript/lib/lib.es2018.asynciterable.d.ts
node_modules/typescript/lib/lib.es2018.asyncgenerator.d.ts
node_modules/typescript/lib/lib.es2017.typedarrays.d.ts
node_modules/typescript/lib/lib.es2017.string.d.ts
node_modules/typescript/lib/lib.es2017.sharedmemory.d.ts
node_modules/typescript/lib/lib.es2017.object.d.ts
node_modules/typescript/lib/lib.es2017.intl.d.ts
node_modules/typescript/lib/lib.es2017.full.d.ts
node_modules/typescript/lib/lib.es2017.date.d.ts
node_modules/typescript/lib/lib.es2017.d.ts
node_modules/typescript/lib/lib.es2017.arraybuffer.d.ts
node_modules/typescript/lib/lib.es2016.intl.d.ts
node_modules/typescript/lib/lib.es2016.full.d.ts
node_modules/typescript/lib/lib.es2016.d.ts
node_modules/typescript/lib/lib.es2016.array.include.d.ts
node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts
node_modules/typescript/lib/lib.es2015.symbol.d.ts
node_modules/typescript/lib/lib.es2015.reflect.d.ts
node_modules/typescript/lib/lib.es2015.proxy.d.ts
node_modules/typescript/lib/lib.es2015.promise.d.ts
node_modules/typescript/lib/lib.es2015.iterable.d.ts
node_modules/typescript/lib/lib.es2015.generator.d.ts
node_modules/typescript/lib/lib.es2015.d.ts
node_modules/typescript/lib/lib.es2015.core.d.ts
node_modules/typescript/lib/lib.es2015.collection.d.ts
node_modules/typescript/lib/lib.dom.iterable.d.ts
node_modules/typescript/lib/lib.dom.d.ts
node_modules/typescript/lib/lib.dom.asynciterable.d.ts
node_modules/typescript/lib/lib.decorators.legacy.d.ts
node_modules/typescript/lib/lib.decorators.d.ts
node_modules/typescript/lib/lib.d.ts
node_modules/typescript/lib/_typingsInstaller.js
node_modules/typescript/lib/_tsserver.js
node_modules/typescript/lib/_tsc.js
node_modules/typescript/lib/zh-tw/diagnosticMessages.generated.json
node_modules/typescript/lib/zh-cn/diagnosticMessages.generated.json
node_modules/typescript/lib/tr/diagnosticMessages.generated.json
node_modules/typescript/lib/ru/diagnosticMessages.generated.json
node_modules/typescript/lib/pt-br/diagnosticMessages.generated.json
node_modules/typescript/lib/ko/diagnosticMessages.generated.json
node_modules/typescript/lib/pl/diagnosticMessages.generated.json
node_modules/typescript/lib/ja/diagnosticMessages.generated.json
node_modules/typescript/lib/it/diagnosticMessages.generated.json
node_modules/typescript/lib/fr/diagnosticMessages.generated.json
node_modules/typescript/lib/es/diagnosticMessages.generated.json
node_modules/typescript/lib/de/diagnosticMessages.generated.json
node_modules/typescript/lib/cs/diagnosticMessages.generated.json
```