### PR TITLE
refactor(devtools): remove redirecting flag from router tree

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -20,7 +20,6 @@ describe('parseRoutes', () => {
       isAux: false,
       isLazy: false,
       isActive: true,
-      isRedirect: false,
     });
   });
 
@@ -37,11 +36,16 @@ describe('parseRoutes', () => {
       'isAux': false,
       'isLazy': false,
       'isActive': true,
-      isRedirect: false,
     });
   });
 
   it('should work with nested routes', () => {
+    function titleResolver() {
+      return 'title';
+    }
+
+    const redirectResolver = () => 'redirect';
+
     const nestedRouter = {
       config: [
         {
@@ -59,22 +63,31 @@ describe('parseRoutes', () => {
           data: {
             name: 'component-two',
           },
+          title: 'Component Two',
           children: [
+            {
+              path: 'component-two-one',
+              component: {
+                name: 'component-two-one',
+              },
+              title: () => 'Component Two One',
+              _loadedConfig: {
+                routes: [
+                  {
+                    path: 'component-two-one-one',
+                    component: {
+                      name: 'component-two-one-one',
+                    },
+                  },
+                ],
+              },
+            },
             {
               path: 'component-two-two',
               component: {
                 name: 'component-two-two',
               },
-              _loadedConfig: {
-                routes: [
-                  {
-                    path: 'component-two-two-two',
-                    component: {
-                      name: 'component-two-two-two',
-                    },
-                  },
-                ],
-              },
+              title: titleResolver,
             },
           ],
         },
@@ -89,6 +102,10 @@ describe('parseRoutes', () => {
         {
           path: 'redirect-fn',
           redirectTo: () => '/target',
+        },
+        {
+          path: 'redirect-named-fn',
+          redirectTo: redirectResolver,
         },
       ],
     };
@@ -110,7 +127,6 @@ describe('parseRoutes', () => {
           'isAux': true,
           'isLazy': false,
           'isActive': undefined,
-          'isRedirect': false,
         },
         {
           'component': 'component-two',
@@ -121,12 +137,27 @@ describe('parseRoutes', () => {
           'providers': [],
           'path': '/component-two',
           'pathMatch': undefined,
+          'title': 'Component Two',
           'data': [{'key': 'name', 'value': 'component-two'}],
           'isAux': false,
           'isLazy': false,
           'isActive': undefined,
-          'isRedirect': false,
           'children': [
+            {
+              'component': 'component-two-one',
+              'canActivateGuards': [],
+              'canActivateChildGuards': [],
+              'canMatchGuards': [],
+              'canDeactivateGuards': [],
+              'providers': [],
+              'path': '/component-two/component-two-one',
+              'pathMatch': undefined,
+              'title': '[Function]',
+              'data': [],
+              'isAux': false,
+              'isLazy': false,
+              'isActive': undefined,
+            },
             {
               'component': 'component-two-two',
               'canActivateGuards': [],
@@ -136,11 +167,11 @@ describe('parseRoutes', () => {
               'providers': [],
               'path': '/component-two/component-two-two',
               'pathMatch': undefined,
+              'title': 'titleResolver()',
               'data': [],
               'isAux': false,
               'isLazy': false,
               'isActive': undefined,
-              'isRedirect': false,
             },
           ],
         },
@@ -157,7 +188,6 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': true,
           'isActive': undefined,
-          'isRedirect': false,
         },
         {
           'component': 'no-name-route',
@@ -172,7 +202,6 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': false,
           'isActive': undefined,
-          'isRedirect': true,
           'redirectTo': 'redirectTo',
         },
         {
@@ -188,13 +217,26 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': false,
           'isActive': undefined,
-          'isRedirect': true,
           'redirectTo': '[Function]',
+        },
+        {
+          'component': 'no-name-route',
+          'canActivateGuards': [],
+          'canActivateChildGuards': [],
+          'canMatchGuards': [],
+          'canDeactivateGuards': [],
+          'providers': [],
+          'path': '/redirect-named-fn',
+          'pathMatch': undefined,
+          'data': [],
+          'isAux': false,
+          'isLazy': false,
+          'isActive': undefined,
+          'redirectTo': 'redirectResolver()',
         },
       ],
       'isAux': false,
       'isLazy': false,
-      'isRedirect': false,
       'data': [],
       'isActive': true,
     } as any);

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
@@ -29,7 +29,6 @@ export function parseRoutes(router: Router): Route {
     children: rootChildren ? assignChildrenToParent(null, rootChildren, currentUrl) : [],
     isAux: false,
     isLazy: false,
-    isRedirect: false,
     isActive: true, // Root is always active.
     data: [],
   };
@@ -65,7 +64,6 @@ function assignChildrenToParent(
 
     // only found in aux routes, otherwise property will be undefined
     const isAux = Boolean(child.outlet);
-    const isRedirect = Boolean(child.redirectTo);
     const isLazy = Boolean(child.loadChildren || child.loadComponent);
 
     const pathWithoutParams = routePath.split('/:')[0];
@@ -84,7 +82,6 @@ function assignChildrenToParent(
       isAux,
       isLazy,
       isActive,
-      isRedirect,
     };
 
     if (child.title) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -179,13 +179,6 @@
                 [data]="data"
               ></tr>
               <tr ng-route-details-row label="Lazy" type="flag" dataKey="isLazy" [data]="data"></tr>
-              <tr
-                ng-route-details-row
-                label="Redirecting"
-                type="flag"
-                dataKey="isRedirect"
-                [data]="data"
-              ></tr>
             </table>
           </div>
         </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -118,7 +118,7 @@ export class RouterTreeComponent {
     const data = this.selectedRoute()?.data;
     // Check if the selected route is a lazy loaded route or a redirecting route.
     // These routes have no component associated with them.
-    if (data?.isLazy || data?.isRedirect) {
+    if (data?.isLazy || data?.redirectTo) {
       const message = 'Cannot view source for lazy loaded routes or redirecting routes.';
       this.snackBar.open(message, 'Dismiss', {duration: 5000, horizontalPosition: 'left'});
       return;
@@ -131,7 +131,7 @@ export class RouterTreeComponent {
     const data = this.selectedRoute()?.data;
     // Check if the selected route is a lazy loaded route or a redirecting route.
     // These routes have no component associated with them.
-    if (data?.isLazy || data?.isRedirect) {
+    if (data?.isLazy || data?.redirectTo) {
       const message = 'Cannot view source for lazy loaded routes or redirecting routes.';
       this.snackBar.open(message, 'Dismiss', {duration: 5000, horizontalPosition: 'left'});
       return;

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -329,7 +329,6 @@ export interface Route {
   isActive: boolean;
   isAux: boolean;
   isLazy: boolean;
-  isRedirect: boolean;
 }
 
 export interface AngularDetection {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the new behavior?

Drops `isRedirect` due to its redundancy in light of the newly introduced `redirectTo`. Additionally, the PR adds some extra test cases to the router-tree spec.