### PR TITLE
fix(compiler): handle nth-child with nested pseudo-selectors in SafeS…

### DIFF
--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -100,6 +100,38 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
+    it('should handle :host with :nth-child containing nested pseudo-selectors', () => {
+      // Bug case: nested :not() inside :nth-child()
+      expect(shim(':host:nth-child(1 of *:not(.whatever)) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:nth-child(1 of *:not(.whatever)) {}',
+      );
+
+      // More complex nesting
+      expect(shim(':host:nth-child(2n+1 of :not(.foo, .bar)) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:nth-child(2n+1 of :not(.foo, .bar)) {}',
+      );
+
+      // Deeply nested
+      expect(shim(':host:nth-child(1 of :is(.a, :not(.b))) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:nth-child(1 of :is(.a, :not(.b))) {}',
+      );
+
+      // With descendants
+      expect(
+        shim(':host:nth-child(1 of *:not(.whatever)) .child {}', 'contenta', 'a-host'),
+      ).toEqualCss('[a-host]:nth-child(1 of *:not(.whatever)) .child[contenta] {}');
+    });
+
+    it('should handle regular selectors with :nth-child containing nested pseudo-selectors', () => {
+      expect(shim('.foo:nth-child(1 of *:not(.bar)) {}', 'contenta', 'a-host')).toEqualCss(
+        '.foo[contenta]:nth-child(1 of *:not(.bar)) {}',
+      );
+
+      expect(shim('div:nth-last-child(3 of :is(.a, .b)) {}', 'contenta', 'a-host')).toEqualCss(
+        'div[contenta]:nth-last-child(3 of :is(.a, .b)) {}',
+      );
+    });
+
     // see b/63672152
     it('should handle unexpected selectors in the most reasonable way', () => {
       expect(shim('cmp:host {}', 'contenta', 'a-host')).toEqualCss('cmp[a-host] {}');


### PR DESCRIPTION
…elector

**Problem:**
The SafeSelector class processes CSS selectors by replacing special patterns with placeholders. When :nth-child() or similar pseudo-selectors (e.g., :nth-of-type) contain expressions like "2n + 1", the whitespace and "+" operator could be misinterpreted as selector separators or combinators during the scoping process, especially when nested within :where(), :is(), or other pseudo-selector functions.

**Fix:**
Enhanced the SafeSelector constructor to properly escape nth-child expressions by replacing the parenthetical content with placeholders before selector processing. The regex pattern /(:nth-[-\w]+)(\([^)]+\))/g matches patterns like :nth-child(2n + 1) and replaces the expression with __ph-N__ placeholders. These placeholders are restored after scoping via the restore() method.

**Test Cases:**
- :host:nth-child(8n+1) and :host:nth-of-type(8n+1) with :host selectors
- :where(.two):nth-child(3) within :where() pseudo-selector
- :where(.one, :host .two):nth-child(3):is(.foo, a:where(.bar)) with complex nested pseudo-selectors

Fixes #64913

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
