### PR TITLE
feat(forms): add `debounce()` rule for signal forms

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -108,6 +108,12 @@ export class CustomValidationError implements ValidationError {
 }
 
 // @public
+export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, durationOrDebouncer: number | Debouncer<TValue, TPathKind>): void;
+
+// @public
+export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (context: FieldContext<TValue, TPathKind>) => Promise<void> | void;
+
+// @public
 export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic?: string | NoInfer<LogicFn<TValue, boolean | string, TPathKind>>): void;
 
 // @public

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -428,7 +428,7 @@ export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(pat
 export type ReadonlyArrayLike<T> = Pick<ReadonlyArray<T>, number | 'length' | typeof Symbol.iterator>;
 
 // @public
-export function reducedMetadataKey<TAcc, TItem>(reduce: (acc: TAcc, item: TItem) => TAcc, getInitial: () => TAcc): AggregateMetadataKey<TAcc, TItem>;
+export function reducedMetadataKey<TAcc, TItem>(reduce: (acc: TAcc, item: TItem) => TAcc, getInitial: NoInfer<() => TAcc>): AggregateMetadataKey<TAcc, TItem>;
 
 // @public
 export type RemoveStringIndexUnknownKey<K, V> = string extends K ? unknown extends V ? never : K : K;

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -128,10 +128,23 @@ export interface ɵFieldState<T> {
   readonly touched: Signal<boolean>;
 
   /**
-   * A writable signal containing the value for this field. Updating this signal will update the
-   * data model that the field is bound to.
+   * A writable signal containing the value for this field.
+   *
+   * Updating this signal will update the data model that the field is bound to.
+   *
+   * While updates from the UI control are eventually reflected here, they may be delayed if
+   * debounced.
    */
   readonly value: WritableSignal<T>;
+
+  /**
+   * A signal containing the value of the control to which this field is bound.
+   *
+   * This differs from {@link value} in that it's not subject to debouncing, and thus is used to
+   * buffer debounced updates from the control to the field. This will also not take into account
+   * the {@link controlValue} of children.
+   */
+  readonly controlValue: Signal<T>;
 
   /**
    * Sets the dirty status of the field to `true`.
@@ -142,4 +155,9 @@ export interface ɵFieldState<T> {
    * Sets the touched status of the field to `true`.
    */
   markAsTouched(): void;
+
+  /**
+   * Sets {@link controlValue} immediately and triggers synchronization to {@link value}.
+   */
+  setControlValue(value: T): void;
 }

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -13,6 +13,7 @@
  */
 export * from './src/api/async';
 export * from './src/api/control';
+export * from './src/api/debounce';
 export * from './src/api/field_directive';
 export * from './src/api/logic';
 export * from './src/api/metadata';

--- a/packages/forms/signals/src/api/debounce.ts
+++ b/packages/forms/signals/src/api/debounce.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DEBOUNCER} from '../field/debounce';
+import {FieldPathNode} from '../schema/path_node';
+import {assertPathIsCurrent} from '../schema/schema';
+import type {Debouncer, PathKind, SchemaPath, SchemaPathRules} from './types';
+
+/**
+ * Configures the frequency at which a form field is updated by UI events.
+ *
+ * When this rule is applied, updates from the UI to the form model will be delayed until either
+ * the field is touched, or the most recently debounced update resolves.
+ *
+ * @param path The target path to debounce.
+ * @param durationOrDebouncer Either a debounce duration in milliseconds, or a custom
+ *     {@link Debouncer} function.
+ *
+ * @experimental 21.0.0
+ */
+export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  durationOrDebouncer: number | Debouncer<TValue, TPathKind>,
+): void {
+  assertPathIsCurrent(path);
+
+  const pathNode = FieldPathNode.unwrapFieldPath(path);
+  const debouncer =
+    typeof durationOrDebouncer === 'function'
+      ? durationOrDebouncer
+      : durationOrDebouncer > 0
+        ? debounceForDuration(durationOrDebouncer)
+        : immediate;
+  pathNode.builder.addAggregateMetadataRule(DEBOUNCER, () => debouncer);
+}
+
+function debounceForDuration(durationInMilliseconds: number): Debouncer<unknown> {
+  return () => {
+    return new Promise((resolve) => setTimeout(resolve, durationInMilliseconds));
+  };
+}
+
+function immediate() {}

--- a/packages/forms/signals/src/api/metadata.ts
+++ b/packages/forms/signals/src/api/metadata.ts
@@ -57,7 +57,7 @@ export class AggregateMetadataKey<TAcc, TItem> {
  */
 export function reducedMetadataKey<TAcc, TItem>(
   reduce: (acc: TAcc, item: TItem) => TAcc,
-  getInitial: () => TAcc,
+  getInitial: NoInfer<() => TAcc>,
 ): AggregateMetadataKey<TAcc, TItem> {
   return new (AggregateMetadataKey as new (
     reduce: (acc: TAcc, item: TItem) => TAcc,
@@ -71,7 +71,7 @@ export function reducedMetadataKey<TAcc, TItem>(
  * @experimental 21.0.0
  */
 export function listMetadataKey<TItem>(): AggregateMetadataKey<TItem[], TItem | undefined> {
-  return reducedMetadataKey<TItem[], TItem | undefined>(
+  return reducedMetadataKey(
     (acc, item) => (item === undefined ? acc : [...acc, item]),
     () => [],
   );
@@ -83,7 +83,7 @@ export function listMetadataKey<TItem>(): AggregateMetadataKey<TItem[], TItem | 
  * @experimental 21.0.0
  */
 export function minMetadataKey(): AggregateMetadataKey<number | undefined, number | undefined> {
-  return reducedMetadataKey<number | undefined, number | undefined>(
+  return reducedMetadataKey(
     (prev, next) => {
       if (prev === undefined) {
         return next;
@@ -103,7 +103,7 @@ export function minMetadataKey(): AggregateMetadataKey<number | undefined, numbe
  * @experimental 21.0.0
  */
 export function maxMetadataKey(): AggregateMetadataKey<number | undefined, number | undefined> {
-  return reducedMetadataKey<number | undefined, number | undefined>(
+  return reducedMetadataKey(
     (prev, next) => {
       if (prev === undefined) {
         return next;
@@ -191,5 +191,4 @@ export const MAX_LENGTH: AggregateMetadataKey<number | undefined, number | undef
  * @category validation
  * @experimental 21.0.0
  */
-export const PATTERN: AggregateMetadataKey<RegExp[], RegExp | undefined> =
-  listMetadataKey<RegExp>();
+export const PATTERN: AggregateMetadataKey<RegExp[], RegExp | undefined> = listMetadataKey();

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -611,3 +611,18 @@ export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
  * @experimental 21.0.0
  */
 export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number] : T[keyof T];
+
+/**
+ * A function that defines custom debounce logic for a field.
+ *
+ * This function receives the {@link FieldContext} for the field and should return a `Promise<void>`
+ * to delay an update, or `void` to apply an update immediately.
+ *
+ * @template TValue The type of value stored in the field.
+ * @template TPathKind The kind of path the debouncer is applied to (root field, child field, or item of an array).
+ *
+ * @experimental 21.0.0
+ */
+export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (
+  context: FieldContext<TValue, TPathKind>,
+) => Promise<void> | void;

--- a/packages/forms/signals/src/field/debounce.ts
+++ b/packages/forms/signals/src/field/debounce.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AggregateMetadataKey, reducedMetadataKey} from '../api/metadata';
+import {Debouncer} from '../api/types';
+
+/**
+ * A private {@link AggregateMetadataKey} used to aggregate `debounce()` rules.
+ *
+ * This will pick the last `debounce()` rule on a field that is currently applied, if conditional.
+ */
+export const DEBOUNCER: AggregateMetadataKey<
+  Debouncer<any> | undefined,
+  Debouncer<any>
+> = reducedMetadataKey(
+  (_, item) => item,
+  () => undefined,
+);

--- a/packages/forms/signals/src/schema/logic.ts
+++ b/packages/forms/signals/src/schema/logic.ts
@@ -311,7 +311,7 @@ export class LogicContainer {
    * @param key The `AggregateMetadataKey` for which to get the logic.
    * @returns The `AbstractLogic` associated with the key.
    */
-  getAggregateMetadata<T>(key: AggregateMetadataKey<unknown, T>): AbstractLogic<T> {
+  getAggregateMetadata<T>(key: AggregateMetadataKey<any, T>): AbstractLogic<T> {
     if (!this.aggregateMetadataKeys.has(key as AggregateMetadataKey<unknown, unknown>)) {
       this.aggregateMetadataKeys.set(
         key as AggregateMetadataKey<unknown, unknown>,

--- a/packages/forms/signals/src/schema/logic_node.ts
+++ b/packages/forms/signals/src/schema/logic_node.ts
@@ -132,7 +132,7 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
   }
 
   override addAggregateMetadataRule<T>(
-    key: AggregateMetadataKey<unknown, T>,
+    key: AggregateMetadataKey<any, T>,
     logic: LogicFn<any, T>,
   ): void {
     this.getCurrent().addAggregateMetadataRule(key, logic);

--- a/packages/forms/signals/test/node/api/debounce.spec.ts
+++ b/packages/forms/signals/test/node/api/debounce.spec.ts
@@ -1,0 +1,419 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {applyWhenValue, debounce, form} from '@angular/forms/signals';
+
+describe('debounce', () => {
+  describe('by duration', () => {
+    it('should synchronize value immediately if non-positive', () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, 0);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should synchronize value after duration', async () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, 1);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      await timeout(0);
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should synchronize value immediately on touch', () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, 1);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      street.markAsTouched();
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+  });
+
+  describe('by function', () => {
+    it('should synchronize value immediately by default', () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, () => {});
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should synchronize value immediately on touch', () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, forever);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      street.markAsTouched();
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should synchronize value after promise resolves', async () => {
+      const {promise, resolve} = promiseWithResolvers<void>();
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, () => promise);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      resolve();
+      await promise;
+
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should synchronize value after most recently returned promise resolves', async () => {
+      const first = promiseWithResolvers();
+      const second = promiseWithResolvers();
+      const debounceFn = jasmine
+        .createSpy('debounceFn')
+        .and.returnValues(first.promise, second.promise);
+
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, debounceFn);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      street.setControlValue('2000 N Shoreline Blvd');
+      expect(street.value()).toBe('');
+
+      first.resolve();
+      await first.promise;
+      expect(street.value()).toBe('');
+
+      second.resolve();
+      await second.promise;
+      expect(street.value()).toBe('2000 N Shoreline Blvd');
+    });
+
+    it('should be ignored if value is directly set before it resolves', async () => {
+      const debounceResult = promiseWithResolvers();
+      const debounceFn = jasmine.createSpy('debounceFn').and.returnValues(debounceResult.promise);
+
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, debounceFn);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      // Set `controlValue` which will trigger a debounce update.
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      // Directly set value during debounce duration.
+      street.value.set('2000 N Shoreline Blvd');
+      expect(street.value()).toBe('2000 N Shoreline Blvd');
+      expect(street.controlValue()).toBe('2000 N Shoreline Blvd');
+
+      // Wait for the debounced update, which should be ignored.
+      await debounceResult.resolve;
+      expect(street.value()).toBe('2000 N Shoreline Blvd');
+    });
+  });
+
+  describe('inheritance', () => {
+    it('should inherit debounce from parent', async () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address, 1);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      await timeout(0);
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('can override inherited debounce', async () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address, 1);
+          debounce(address.street, 0);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it(`should not affect parent's debounce`, async () => {
+      const address = signal({street: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address, 1);
+          debounce(address.street, 0);
+        },
+        options(),
+      );
+
+      addressForm().setControlValue({street: '1600 Amphitheatre Pkwy'});
+      expect(addressForm().controlValue()).toEqual({street: '1600 Amphitheatre Pkwy'});
+      expect(addressForm().value()).toEqual({street: ''});
+
+      await timeout(0);
+      expect(addressForm().value()).toEqual({street: '1600 Amphitheatre Pkwy'});
+    });
+
+    it(`should not affect a sibling's debounce`, async () => {
+      const address = signal({street: '', city: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, 1);
+        },
+        options(),
+      );
+
+      addressForm.street().setControlValue('1600 Amphitheatre Pkwy');
+      expect(addressForm().value()).toEqual({street: '', city: ''});
+
+      addressForm.city().setControlValue('Mountain View');
+      expect(addressForm().value()).toEqual({street: '', city: 'Mountain View'});
+
+      await timeout(0);
+      expect(addressForm().value()).toEqual({
+        street: '1600 Amphitheatre Pkwy',
+        city: 'Mountain View',
+      });
+    });
+  });
+
+  describe('aggregation', () => {
+    it('should apply the last debounce rule', () => {
+      const address = signal({street: '', city: ''});
+      const addressForm = form(
+        address,
+        (address) => {
+          debounce(address.street, 1);
+          debounce(address.street, 0);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should apply the last debounce rule from schemas', async () => {
+      const address = signal({street: '', city: ''});
+      const schema1 = (address: any) => {
+        debounce(address.street, 0);
+      };
+      const schema2 = (address: any) => {
+        debounce(address.street, 1);
+      };
+      const addressForm = form(
+        address,
+        (address) => {
+          schema1(address);
+          schema2(address);
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      await timeout(0);
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+    });
+
+    it('should apply the last debounce rule from conditional schemas', async () => {
+      const address = signal({street: '', city: ''});
+      const debounced = signal(false);
+      const addressForm = form(
+        address,
+        (address) => {
+          applyWhenValue(
+            address,
+            () => debounced(),
+            (address) => {
+              debounce(address.street, 0);
+            },
+          );
+          applyWhenValue(
+            address,
+            () => debounced(),
+            (address) => {
+              debounce(address.street, 1);
+            },
+          );
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+
+      debounced.set(true);
+      street.setControlValue('2000 N Shoreline Blvd');
+      expect(street.controlValue()).toBe('2000 N Shoreline Blvd');
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+
+      await timeout(0);
+      expect(street.value()).toBe('2000 N Shoreline Blvd');
+    });
+
+    it('should apply debounce rule conditionally', async () => {
+      const address = signal({street: '', city: ''});
+      const debounced = signal(true);
+      const addressForm = form(
+        address,
+        (address) => {
+          applyWhenValue(
+            address.street,
+            () => debounced(),
+            (street) => {
+              debounce(street, 1);
+            },
+          );
+        },
+        options(),
+      );
+      const street = addressForm.street();
+
+      street.setControlValue('1600 Amphitheatre Pkwy');
+      expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
+      expect(street.value()).toBe('');
+
+      await timeout(0);
+      expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+
+      debounced.set(false);
+      street.setControlValue('2000 N Shoreline Blvd');
+      expect(street.value()).toBe('2000 N Shoreline Blvd');
+    });
+  });
+});
+
+/** Options for testing. */
+function options() {
+  return {injector: TestBed.inject(Injector)};
+}
+
+/** Returns a promise that will resolve after {@link durationInMilliseconds}.  */
+function timeout(durationInMilliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationInMilliseconds));
+}
+
+/** Returns a promise that will never resolve. */
+function forever(): Promise<never> {
+  return new Promise(() => {});
+}
+
+/**
+ * Replace with `Promise.withResolvers()` once it's available.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers.
+ */
+// TODO: share this with submit.spec.ts
+function promiseWithResolvers<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {promise, resolve, reject};
+}


### PR DESCRIPTION
The `debounce()` rule allows developers to control when changes to a form control are synchronized to the form model.

This feature necessitated some changes to `FieldState`:

  * `controlValue` is a new signal property that represents the current value of a form field and control.
  * `value` conceptually remains unchanged; however, its value may lag behind that of `controlValue` if a `debounce()` rule is applied.

The `debounce()` rule essentially manages when changes to `controlValue` are synchronized to `value`. The intent is that an expensive or slow validation rule can react to the debounced `value`, rather than a more frequently changing `controlValue`.

Directly updating `value` immediately updates `controlValue`, and cancels any pending debounced updates.

A field will automatically inherit the debounce rule of its parent, and can override that rule for itself. If multiple rules are applied to the same field (not including inherited ones), the latest enabled (if conditional) debounce rule will be used.