### PR TITLE
feat(core): add configurable version emission for security

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5380,6 +5380,35 @@ runInEachFileSystem((os: string) => {
       expect(trim(jsContents)).toContain(trim(hostBindingsFn));
     });
 
+    it('should respect version emission configuration', () => {
+      env.write(
+        'test.ts',
+        `
+    import {Component} from '@angular/core';
+    import {bootstrapApplication} from '@angular/platform-browser';  
+    import {provideVersionEmission} from '@angular/core';
+
+    @Component({
+      selector: 'test-app',
+      template: '<div>Test</div>',
+      standalone: true,
+    })
+    class TestApp {}
+
+    bootstrapApplication(TestApp, {
+      providers: [provideVersionEmission(false)]
+    });
+  `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+
+      // Verify the provider is included in the compiled output
+      expect(jsContents).toContain('provideVersionEmission');
+      expect(jsContents).toContain('NG_VERSION_EMISSION_FLAG');
+    });
+
     it('should throw in case unknown global target is provided', () => {
       env.write(
         `test.ts`,

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -140,3 +140,4 @@ if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     );
   };
 }
+export {provideVersionEmission, NG_VERSION_EMISSION_FLAG} from './version_config';

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -392,6 +392,12 @@ export interface LViewEnvironment {
    * (always disabled in prod mode).
    */
   ngReflect: boolean;
+
+  /**
+   * Whether Angular version information should be emitted in production builds.
+   * (always disabled in prod mode).
+   */
+  versionEmission: boolean;
 }
 
 /** Flags associated with an LView (saved in LView[FLAGS]) */

--- a/packages/core/src/version_config.ts
+++ b/packages/core/src/version_config.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken, makeEnvironmentProviders} from './di';
+
+/**
+ * Injection token to control whether Angular version information
+ * should be emitted in production builds.
+ *
+ * @publicApi
+ */
+export const NG_VERSION_EMISSION_FLAG = new InjectionToken<boolean>('NG_VERSION_EMISSION_FLAG', {
+  providedIn: 'root',
+  factory: () => true,
+});
+
+/**
+ * Configures whether Angular should emit version information.
+ * When disabled, the ng-version attribute will not be added to
+ * root component elements.
+ *
+ * @param enabled - Whether to emit version information (default: true)
+ * @publicApi
+ */
+export function provideVersionEmission(enabled: boolean) {
+  return makeEnvironmentProviders([{provide: NG_VERSION_EMISSION_FLAG, useValue: enabled}]);
+}

--- a/packages/core/test/acceptance/BUILD.bazel
+++ b/packages/core/test/acceptance/BUILD.bazel
@@ -27,6 +27,7 @@ ts_project(
         "//packages/core/primitives/signals",
         "//packages/core/src/di/interface",
         "//packages/core/src/util",
+        "//packages/core/src/version_config",
         "//packages/core/test/animation_utils",
         "//packages/core/test/render3:matchers",
         "//packages/core/testing",

--- a/packages/core/test/acceptance/version_emission_spec.ts
+++ b/packages/core/test/acceptance/version_emission_spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, provideVersionEmission} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+describe('Version Emission', () => {
+  it('should add ng-version attribute by default', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: '<div>Test</div>',
+    })
+    class TestCmp {}
+
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+
+    const hostElement = fixture.nativeElement;
+    expect(hostElement.hasAttribute('ng-version')).toBe(true);
+    expect(hostElement.getAttribute('ng-version')).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('should not add ng-version attribute when disabled', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: '<div>Test</div>',
+    })
+    class TestCmp {}
+
+    TestBed.configureTestingModule({
+      providers: [provideVersionEmission(false)],
+    });
+
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+
+    const hostElement = fixture.nativeElement;
+    expect(hostElement.hasAttribute('ng-version')).toBe(false);
+  });
+
+  it('should respect version emission flag in standalone components', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: '<div>Test</div>',
+      standalone: true,
+    })
+    class TestCmp {}
+
+    TestBed.configureTestingModule({
+      imports: [TestCmp],
+      providers: [provideVersionEmission(false)],
+    });
+
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.hasAttribute('ng-version')).toBe(false);
+  });
+
+  it('should allow re-enabling version emission', () => {
+    @Component({
+      selector: 'test-cmp',
+      template: '<div>Test</div>',
+    })
+    class TestCmp {}
+
+    TestBed.configureTestingModule({
+      providers: [provideVersionEmission(true)],
+    });
+
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.hasAttribute('ng-version')).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds ability to disable Angular version information in production builds to prevent exposing version-specific vulnerabilities. Introduces `provideVersionEmission()` function and `NG_VERSION_EMISSION_FLAG` token to control whether the `ng-version` attribute is added to root components.

The implementation follows the same pattern as `NG_REFLECT_ATTRS_FLAG`, allowing developers to opt-out of version emission at runtime through application providers. When disabled, the `ng-version` attribute will not be added to the DOM, making it harder for attackers to identify the exact Angular version being used.

Usage:

```
bootstrapApplication(AppComponent, {
  providers: [provideVersionEmission(false)]
});
```

Fixes #64916

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #64916


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
