### PR TITLE
refactor(router): add ngDevMode guards to InjectionToken names and cl…

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -434,7 +434,9 @@ class OutletInjector implements Injector {
   }
 }
 
-export const INPUT_BINDER = new InjectionToken<RoutedComponentInputBinder>('');
+export const INPUT_BINDER = new InjectionToken<RoutedComponentInputBinder>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Router Input Binder' : '',
+);
 
 /**
  * Injectable used as a tree-shakable provider for opting in to binding router data to component

--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -24,7 +24,7 @@ import type {RouterConfigLoader} from '../router_config_loader';
 import type {UrlSerializer} from '../url_tree';
 
 const RECOGNIZE_IMPL = new InjectionToken<typeof recognizeFn | typeof recognizeFnRxjs>(
-  'RECOGNIZE_IMPL',
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'RECOGNIZE_IMPL' : '',
   {
     factory: () => {
       const USE_ASYNC_RECOGNIZE = true;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -24,7 +24,6 @@ import {
   InjectionToken,
   Injector,
   makeEnvironmentProviders,
-  NgZone,
   provideAppInitializer,
   Provider,
   runInInjectionContext,
@@ -46,7 +45,6 @@ import {ROUTES} from './router_config_loader';
 import {PreloadingStrategy, RouterPreloader} from './router_preloader';
 import {ROUTER_SCROLLER, RouterScroller} from './router_scroller';
 import {ActivatedRoute} from './router_state';
-import {UrlSerializer} from './url_tree';
 import {afterNextNavigation} from './utils/navigations';
 import {
   CREATE_VIEW_TRANSITION,
@@ -142,9 +140,12 @@ function routerFeature<FeatureKind extends RouterFeatureKind>(
  * An Injection token used to indicate whether `provideRouter` or `RouterModule.forRoot` was ever
  * called.
  */
-export const ROUTER_IS_PROVIDED = new InjectionToken<boolean>('', {
-  factory: () => false,
-});
+export const ROUTER_IS_PROVIDED = new InjectionToken<boolean>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Router is provided' : '',
+  {
+    factory: () => false,
+  },
+);
 
 const routerIsProvidedDevModeCheck = {
   provide: ENVIRONMENT_INITIALIZER,

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -20,7 +20,6 @@ import {
   InjectionToken,
   ModuleWithProviders,
   NgModule,
-  NgZone,
   Provider,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
@@ -31,7 +30,7 @@ import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Routes} from './models';
-import {NAVIGATION_ERROR_HANDLER, NavigationTransitions} from './navigation_transition';
+import {NAVIGATION_ERROR_HANDLER} from './navigation_transition';
 import {
   getBootstrapListener,
   rootRoute,

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -21,9 +21,10 @@ import {
 } from './events';
 import {NavigationTransitions} from './navigation_transition';
 import {UrlSerializer} from './url_tree';
-import {ROUTER_CONFIGURATION} from './router_config';
 
-export const ROUTER_SCROLLER = new InjectionToken<RouterScroller>('');
+export const ROUTER_SCROLLER = new InjectionToken<RouterScroller>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Router Scroller' : '',
+);
 
 @Injectable()
 export class RouterScroller implements OnDestroy {


### PR DESCRIPTION
Wraps InjectionToken names with `typeof ngDevMode !== 'undefined' && ngDevMode` checks to enable tree-shaking of descriptive token names in production builds. This ensures debug-only strings are removed from production bundles, reducing size.

Also removes unused imports found during refactor.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
