### PR TITLE
Signal forms type checking fixes

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -975,7 +975,7 @@ class TcbCustomFieldDirectiveTypeOp extends TcbFieldDirectiveTypeBaseOp {
     const id = this.tcb.allocateId();
     const targetType = ts.factory.createTypeReferenceNode(
       targetTypeRef.typeName,
-      isCheckbox ? undefined : [ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword)],
+      isCheckbox ? undefined : [ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)],
     );
     this.scope.addStatement(tsDeclareVariable(id, targetType));
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -747,26 +747,12 @@ class TcbGenericDirectiveTypeWithAnyParamsOp extends TcbDirectiveTypeOpBase {
 abstract class TcbFieldDirectiveTypeBaseOp extends TcbOp {
   /** Bindings that aren't supported on signal form fields. */
   protected readonly unsupportedBindingFields = new Set([
-    // Should be kept in sync with the `FormUiControl` bindings,
-    // defined in `packages/forms/signals/src/api/control.ts`.
+    ...formControlInputFields,
     'value',
     'checked',
-    'errors',
-    'invalid',
-    'disabled',
-    'disabledReasons',
-    'name',
-    'readonly',
-    'touched',
-    'max',
-    'maxlength',
-    'maxLength',
-    'min',
-    'minLength',
-    'minlength',
-    'pattern',
-    'required',
     'type',
+    'maxlength',
+    'minlength',
   ]);
 
   constructor(
@@ -3144,10 +3130,14 @@ class Scope {
     if (allDirectiveMatches.some(isFieldDirective)) {
       const customFieldType = getCustomFieldDirectiveType(dir);
 
-      if (customFieldType === 'value') {
-        ignoredRequiredInputs = new Set(['value']);
-      } else if (customFieldType === 'checkbox') {
-        ignoredRequiredInputs = new Set(['checked']);
+      if (customFieldType !== null) {
+        ignoredRequiredInputs = new Set(formControlInputFields);
+
+        if (customFieldType === 'value') {
+          ignoredRequiredInputs.add('value');
+        } else if (customFieldType === 'checkbox') {
+          ignoredRequiredInputs.add('checked');
+        }
       }
     }
 
@@ -4123,6 +4113,25 @@ function hasModel(name: string, meta: TypeCheckableDirectiveMeta): boolean {
     meta.outputs.hasBindingPropertyName(name + 'Change')
   );
 }
+
+/** Names of the input fields on custom controls. */
+const formControlInputFields = [
+  // Should be kept in sync with the `FormUiControl` bindings,
+  // defined in `packages/forms/signals/src/api/control.ts`.
+  'errors',
+  'invalid',
+  'disabled',
+  'disabledReasons',
+  'name',
+  'readonly',
+  'touched',
+  'max',
+  'maxLength',
+  'min',
+  'minLength',
+  'pattern',
+  'required',
+] as const;
 
 function getCustomFieldDirectiveType(
   meta: TypeCheckableDirectiveMeta,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -4095,8 +4095,25 @@ function getComponentTagName(node: TmplAstComponent): string {
 }
 
 function isFieldDirective(meta: TypeCheckableDirectiveMeta): boolean {
+  if (meta.name !== 'Field') {
+    return false;
+  }
+
+  // Fast path, relevant for all external users.
+  if (meta.ref.bestGuessOwningModule?.specifier === '@angular/forms/signals') {
+    return true;
+  }
+
+  // Slightly slower, but more accurate path.
   return (
-    meta.name === 'Field' && meta.ref.bestGuessOwningModule?.specifier === '@angular/forms/signals'
+    ts.isClassDeclaration(meta.ref.node) &&
+    meta.ref.node.members.some(
+      (member) =>
+        ts.isPropertyDeclaration(member) &&
+        ts.isComputedPropertyName(member.name) &&
+        ts.isIdentifier(member.name.expression) &&
+        member.name.expression.text === 'ɵCONTROL',
+    )
   );
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -2658,7 +2658,7 @@ describe('type check blocks', () => {
       expect(block).toContain(
         'var _t1 = null! as i0.Field<i1.ɵExtractFormControlValue<i0.CustomControl>>;',
       );
-      expect(block).toContain('var _t2 = null! as i2.FormValueControl<unknown>;');
+      expect(block).toContain('var _t2 = null! as i2.FormValueControl<any>;');
       expect(block).toContain('if (_t2) _t2 = null! as i0.CustomControl;');
       expect(block).toContain('_t1.field = (((this).f));');
     });

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -271,6 +271,33 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should allow binding to `value` on radio controls', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {Field, form} from '@angular/forms/signals';
+
+          @Component({
+            template: \`
+              <form>
+                <input type="radio" value="a" [field]="f">
+                <input type="radio" value="b" [field]="f">
+                <input type="radio" value="c" [field]="f">
+              </form>
+            \`,
+            imports: [Field]
+          })
+          export class Comp {
+            f = form(signal('a'), {name: 'test'});
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
     it('should report unsupported static attributes of a field', () => {
       env.write(
         'test.ts',

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -360,5 +360,57 @@ runInEachFileSystem(() => {
         `The types of 'required[SIGNAL].transformFn' are incompatible between these types.`,
       );
     });
+
+    it('should not report `value` as a missing required input when the `Field` directive is present', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal, model} from '@angular/core';
+          import {Field, form, FormValueControl} from '@angular/forms/signals';
+
+          @Component({selector: 'custom-control', template: ''})
+          export class CustomControl implements FormValueControl<string> {
+            readonly value = model.required<string>();
+          }
+
+          @Component({
+            template: '<custom-control [field]="f"/>',
+            imports: [Field, CustomControl]
+          })
+          export class Comp {
+            f = form(signal(''));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not report `checked` as a missing required input when the `Field` directive is present', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal, model} from '@angular/core';
+          import {Field, form, FormCheckboxControl} from '@angular/forms/signals';
+
+          @Component({selector: 'custom-control', template: ''})
+          export class CustomControl implements FormCheckboxControl {
+            readonly checked = model.required<boolean>();
+          }
+
+          @Component({
+            template: '<custom-control [field]="f"/>',
+            imports: [Field, CustomControl]
+          })
+          export class Comp {
+            f = form(signal(false));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
   });
 });

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -19,7 +19,11 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({strictTemplates: true});
+      env.tsconfig({
+        // This is the default in Angular apps so we enable it to ensure consistent behavior.
+        strict: true,
+        strictTemplates: true,
+      });
     });
 
     function extractMessage(diag: ts.Diagnostic) {
@@ -191,6 +195,33 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should not report a custom control that conforms to `FormValueControl`', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal, model} from '@angular/core';
+          import {Field, form, FormValueControl} from '@angular/forms/signals';
+
+          @Component({ selector: 'string-control', template: '' })
+          class StringControl implements FormValueControl<string> {
+            value = model('');
+          }
+
+          @Component({
+            selector: 'app-root',
+            imports: [Field, StringControl],
+            template: '<string-control [field]="field" />',
+          })
+          class App {
+            field = form(signal(''));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
     it('should report unsupported property bindings on a field', () => {
       env.write(
         'test.ts',
@@ -290,10 +321,10 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
       expect(extractMessage(diags[0])).toBe(
-        `Type 'UserControl' is not assignable to type 'FormValueControl<unknown>'.`,
+        `Type 'UserControl' is not assignable to type 'FormValueControl<any>'.`,
       );
       expect((diags[0].messageText as ts.DiagnosticMessageChain).next?.[0].messageText).toBe(
-        `Types of property 'required' are incompatible.`,
+        `The types of 'required[SIGNAL].transformFn' are incompatible between these types.`,
       );
     });
 
@@ -326,7 +357,7 @@ runInEachFileSystem(() => {
         `Type 'UserControl' is not assignable to type 'FormCheckboxControl'.`,
       );
       expect((diags[0].messageText as ts.DiagnosticMessageChain).next?.[0].messageText).toBe(
-        `Types of property 'required' are incompatible.`,
+        `The types of 'required[SIGNAL].transformFn' are incompatible between these types.`,
       );
     });
   });

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -115,7 +115,7 @@ describe('field directive', () => {
         })
         class TestCmp {
           readonly disabled = signal(false);
-          readonly f = form(signal(false), (p) => {
+          readonly f = form(signal(''), (p) => {
             disabled(p, this.disabled);
           });
         }
@@ -376,26 +376,6 @@ describe('field directive', () => {
         expect(element.required).toBe(true);
       });
 
-      it('should bind to native control and override attribute', () => {
-        @Component({
-          imports: [Field],
-          template: `<input [field]="f" required>`,
-        })
-        class TestCmp {
-          readonly required = signal(false);
-          readonly f = form(signal(''), (p) => {
-            required(p, {when: this.required});
-          });
-        }
-
-        const fixture = act(() => TestBed.createComponent(TestCmp));
-        const element = fixture.nativeElement.firstChild;
-        expect(element.required).withContext("'required' should be overridden").toBe(false);
-
-        act(() => fixture.componentInstance.required.set(true));
-        expect(element.required).toBe(true);
-      });
-
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
@@ -520,22 +500,6 @@ describe('field directive', () => {
         expect(component.customControl().max()).toBe(5);
       });
 
-      it('should not bind to native control that does not support it', () => {
-        @Component({
-          imports: [Field],
-          template: `<input type="text" [field]="f">`,
-        })
-        class TestCmp {
-          readonly f = form(signal(5), (p) => {
-            max(p, 10);
-          });
-        }
-
-        const fixture = act(() => TestBed.createComponent(TestCmp));
-        const element = fixture.nativeElement.firstChild as HTMLInputElement;
-        expect(element.max).toBe('');
-      });
-
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
@@ -631,22 +595,6 @@ describe('field directive', () => {
 
         act(() => component.min.set(5));
         expect(component.customControl().min()).toBe(5);
-      });
-
-      it('should not bind to native control that does not support it', () => {
-        @Component({
-          imports: [Field],
-          template: `<input type="text" [field]="f">`,
-        })
-        class TestCmp {
-          readonly f = form(signal(15), (p) => {
-            min(p, 10);
-          });
-        }
-
-        const fixture = act(() => TestBed.createComponent(TestCmp));
-        const element = fixture.nativeElement.firstChild as HTMLInputElement;
-        expect(element.min).toBe('');
       });
 
       it('should be reset when field changes on native control', () => {
@@ -1268,7 +1216,7 @@ describe('field directive', () => {
 
     @Component({
       imports: [Field, CustomInput],
-      template: `<my-input [field]="f" value />`,
+      template: `<my-input [field]="f" />`,
     })
     class TestCmp {
       f = form<string>(signal('test'));


### PR DESCRIPTION
Includes the following fixes for type checking in signal forms:

### fix(compiler-cli): use any when checking field interface conformance
Switches to checking against `FormValueControl<any>` instead of `FormValueControl<unknown>` when checking whether custom controls conform to the interface.

### fix(compiler-cli): do not flag custom control required inputs as missing when field is present
Adds some logic that won't report the `value` or `checked` inputs as missing when the `Field` directive is present since it will bind to the inputs implicitly.

### fix(compiler-cli): allow value to be set on radio fields
Updates the logic that checks for unsupported bindigns to allow `value` to be set on `radio` controls.

### fix(compiler-cli): make field detection logic more robust
Currently the logic for detecting `Field` directives only works if it's imported from `@angular/forms/signals` which doesn't cover our own tests.

These changes make the check more robust.

### test(forms): fix type checking errors in signal form tests
Fixes some type checking errors in the signal forms tests that accumulated while there wasn't any type checking.

Fixes #64946.
