### PR TITLE
fix(devtools): message bus URI conflict between dev and prod apps

### DIFF
--- a/devtools/src/BUILD.bazel
+++ b/devtools/src/BUILD.bazel
@@ -97,3 +97,8 @@ ng_project(
         "//devtools/projects/protocol",
     ],
 )
+
+ng_project(
+    name = "communication",
+    srcs = ["communication.ts"],
+)

--- a/devtools/src/app/app.config.ts
+++ b/devtools/src/app/app.config.ts
@@ -21,7 +21,7 @@ import {
 import {DemoApplicationEnvironment} from '../demo-application-environment';
 import {DemoApplicationOperations} from '../demo-application-operations';
 import {serializeTransferState} from './transfer-state';
-import {provideHttpClient, ɵwithHttpTransferCache} from '@angular/common/http';
+import {provideHttpClient} from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/devtools/src/app/demo-app/BUILD.bazel
+++ b/devtools/src/app/demo-app/BUILD.bazel
@@ -58,6 +58,7 @@ ng_project(
         "//:node_modules/@angular/elements",
         "//:node_modules/@angular/router",
         "//devtools/projects/ng-devtools-backend",
+        "//devtools/src:communication",
         "//devtools/src:zone-unaware-iframe_message_bus",
         "//devtools/src/app/demo-app/todo",
     ],

--- a/devtools/src/app/demo-app/demo-app.routes.ts
+++ b/devtools/src/app/demo-app/demo-app.routes.ts
@@ -12,6 +12,7 @@ import {Routes} from '@angular/router';
 import {initializeMessageBus} from '../../../projects/ng-devtools-backend';
 
 import {ZoneUnawareIFrameMessageBus} from '../../zone-unaware-iframe-message-bus';
+import {DEVTOOLS_BACKEND_URI, DEVTOOLS_FRONTEND_URI} from '../../communication';
 
 import {DemoAppComponent} from './demo-app.component';
 import {ZippyComponent} from './zippy.component';
@@ -36,9 +37,5 @@ export const DEMO_ROUTES: Routes = [
 ];
 
 initializeMessageBus(
-  new ZoneUnawareIFrameMessageBus(
-    'angular-devtools-backend',
-    'angular-devtools',
-    () => window.parent,
-  ),
+  new ZoneUnawareIFrameMessageBus(DEVTOOLS_BACKEND_URI, DEVTOOLS_FRONTEND_URI, () => window.parent),
 );

--- a/devtools/src/app/devtools-app/BUILD.bazel
+++ b/devtools/src/app/devtools-app/BUILD.bazel
@@ -25,6 +25,7 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/application-services:frame_manager",
         "//devtools/projects/ng-devtools/src/lib/shared/split",
         "//devtools/projects/protocol",
+        "//devtools/src:communication",
         "//devtools/src:iframe_message_bus",
     ],
 )

--- a/devtools/src/app/devtools-app/devtools-app.routes.ts
+++ b/devtools/src/app/devtools-app/devtools-app.routes.ts
@@ -12,6 +12,7 @@ import {AppDevToolsComponent} from './devtools-app.component';
 import {FrameManager} from '../../../projects/ng-devtools/src/lib/application-services/frame_manager';
 import {Events, MessageBus, PriorityAwareMessageBus} from '../../../projects/protocol';
 import {IFrameMessageBus} from '../../iframe-message-bus';
+import {DEVTOOLS_BACKEND_URI, DEVTOOLS_FRONTEND_URI} from '../../communication';
 
 export const DEVTOOL_ROUTES: Routes = [
   {
@@ -24,8 +25,8 @@ export const DEVTOOL_ROUTES: Routes = [
         useFactory(): MessageBus<Events> {
           return new PriorityAwareMessageBus(
             new IFrameMessageBus(
-              'angular-devtools',
-              'angular-devtools-backend',
+              DEVTOOLS_FRONTEND_URI,
+              DEVTOOLS_BACKEND_URI,
               () => (document.querySelector('#sample-app') as HTMLIFrameElement).contentWindow!,
             ),
           );

--- a/devtools/src/communication.ts
+++ b/devtools/src/communication.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const DEVTOOLS_FRONTEND_URI = 'angular-devtools-dev';
+export const DEVTOOLS_BACKEND_URI = 'angular-devtools-dev-backend';


### PR DESCRIPTION
#64806 drops the `href` part of `SamePageMessageBus` URIs. This creates a conflict, which breaks the directive explorer, between the prod Devtools (i.e. the extension) and the dev Devtools app due to the backend URIs using the same string for both prod and dev.