### PR TITLE
perf(forms): only update interop controls when bound field changes

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -27,6 +27,7 @@ import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
+import { ɵInteropControl } from '@angular/core';
 
 // @public
 export function aggregateMetadata<TValue, TMetadataItem, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, key: AggregateMetadataKey<any, TMetadataItem>, logic: NoInfer<LogicFn<TValue, TMetadataItem, TPathKind>>): void;
@@ -139,19 +140,14 @@ export class Field<T> implements ɵControl<T> {
     readonly [ɵCONTROL]: undefined;
     // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
+    protected getOrCreateNgControl(): InteropNgControl;
     // (undocumented)
     readonly state: i0.Signal<[T] extends [_angular_forms.AbstractControl<any, any, any>] ? CompatFieldState<T, string | number> : FieldState<T, string | number>>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<Field<any>, "[field]", never, { "field": { "alias": "field"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Field<any>, never>;
-    ɵgetOrCreateNgControl(): InteropNgControl;
-    // (undocumented)
-    get ɵhasInteropControl(): boolean;
-    // (undocumented)
-    ɵinteropControlCreate(): void;
-    // (undocumented)
-    ɵinteropControlUpdate(): void;
+    get ɵinteropControl(): ɵInteropControl | undefined;
     // (undocumented)
     ɵregister(): void;
 }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -244,7 +244,7 @@ export {
 } from './render3/index';
 export {CONTAINER_HEADER_OFFSET as ɵCONTAINER_HEADER_OFFSET} from './render3/interfaces/container';
 export {LContext as ɵLContext} from './render3/interfaces/context';
-export {ɵCONTROL, ɵControl, ɵFieldState} from './render3/interfaces/control';
+export {ɵCONTROL, ɵControl, ɵFieldState, ɵInteropControl} from './render3/interfaces/control';
 export {setDocument as ɵsetDocument} from './render3/interfaces/document';
 export {
   compileComponent as ɵcompileComponent,

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -15,10 +15,14 @@ export const ɵCONTROL: unique symbol = Symbol('CONTROL');
  * A directive that binds a {@link ɵFieldState} to a form control.
  */
 export interface ɵControl<T> {
+  /** The presence of this property is used to identify {@link ɵControl} implementations. */
   readonly [ɵCONTROL]: undefined;
 
   /** The state of the field bound to this control. */
   readonly state: Signal<ɵFieldState<T>>;
+
+  /** A reference to the interoperable control, if one is present. */
+  readonly ɵinteropControl: ɵInteropControl | undefined;
 
   /**
    * Registers this directive as a control of its associated form field.
@@ -29,29 +33,21 @@ export interface ɵControl<T> {
    * and do nothing.
    */
   ɵregister(): void;
+}
 
-  /**
-   * Indicates whether this field is bound to an interoperable control.
-   *
-   * This is used for interoperability between signal forms and reactive forms.
-   */
-  readonly ɵhasInteropControl: boolean;
+/** Mirrors the `ControlValueAccessor` interface for interoperability.  */
+export interface ɵInteropControl {
+  /** Registers a callback function that is called when the control's value changes. */
+  registerOnChange(fn: Function): void;
 
-  /**
-   * Adds event listeners to the associated interoperable control.
-   *
-   * This method should only be called from a template function in create mode if this
-   * {@link ɵhasInteropControl}.
-   */
-  ɵinteropControlCreate(): void;
+  /** Registers a callback function that is called when the control is touched. */
+  registerOnTouched(fn: Function): void;
 
-  /**
-   * Updates the associated interoperable control.
-   *
-   * This method should only be called from a template function in update mode if this
-   * {@link ɵhasInteropControl}.
-   */
-  ɵinteropControlUpdate(): void;
+  /** Writes a new value to the control. */
+  writeValue(value: unknown): void;
+
+  /** Sets the disabled status of the control. */
+  setDisabledState?(value: boolean): void;
 }
 
 /**


### PR DESCRIPTION
https://github.com/angular/angular/pull/64590 implemented change detection for field bindings, but only for those bound to native or custom form controls. This change extends that optimization to apply to field bindings on interoperable controls built using Reactive Forms as well.