### PR TITLE
refactor(animations): tree-shake `BROWSER_NOOP_ANIMATIONS_PROVIDERS`

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -38,7 +38,6 @@
       "BLOOM_SIZE",
       "BROWSER_ANIMATIONS_PROVIDERS",
       "BROWSER_MODULE_PROVIDERS",
-      "BROWSER_NOOP_ANIMATIONS_PROVIDERS",
       "BaseAnimationRenderer",
       "BehaviorSubject",
       "BrowserDomAdapter",

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -70,30 +70,40 @@ const SHARED_ANIMATION_PROVIDERS: Provider[] = [
 /**
  * Separate providers from the actual module so that we can do a local modification in Google3 to
  * include them in the BrowserTestingModule.
+ * Note: Using an IIFE here to ensure that the spread assignment is not considered
+ * a side-effect, ending up preserving `BROWSER_NOOP_ANIMATIONS_PROVIDERS` and `SHARED_ANIMATION_PROVIDERS`.
  */
-export const BROWSER_NOOP_ANIMATIONS_PROVIDERS: Provider[] = [
-  {provide: AnimationDriver, useClass: NoopAnimationDriver},
-  {provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations'},
-  ...SHARED_ANIMATION_PROVIDERS,
-];
+export const BROWSER_NOOP_ANIMATIONS_PROVIDERS: Provider[] = /* @__PURE__ */ (() => {
+  return [
+    {provide: AnimationDriver, useClass: NoopAnimationDriver},
+    {provide: ANIMATION_MODULE_TYPE, useValue: 'NoopAnimations'},
+    ...SHARED_ANIMATION_PROVIDERS,
+  ];
+})();
 
 /**
  * Separate providers from the actual module so that we can do a local modification in Google3 to
  * include them in the BrowserModule.
+ * Note: Using an IIFE here to ensure that the spread assignment is not considered
+ * a side-effect, ending up preserving `BROWSER_ANIMATIONS_PROVIDERS` and `SHARED_ANIMATION_PROVIDERS`.
  */
-export const BROWSER_ANIMATIONS_PROVIDERS: Provider[] = [
-  // Note: the `ngServerMode` happen inside factories to give the variable time to initialize.
-  {
-    provide: AnimationDriver,
-    useFactory: () =>
-      typeof ngServerMode !== 'undefined' && ngServerMode
-        ? new NoopAnimationDriver()
-        : new WebAnimationsDriver(),
-  },
-  {
-    provide: ANIMATION_MODULE_TYPE,
-    useFactory: () =>
-      typeof ngServerMode !== 'undefined' && ngServerMode ? 'NoopAnimations' : 'BrowserAnimations',
-  },
-  ...SHARED_ANIMATION_PROVIDERS,
-];
+export const BROWSER_ANIMATIONS_PROVIDERS: Provider[] = /* @__PURE__ */ (() => {
+  return [
+    // Note: the `ngServerMode` happen inside factories to give the variable time to initialize.
+    {
+      provide: AnimationDriver,
+      useFactory: () =>
+        typeof ngServerMode !== 'undefined' && ngServerMode
+          ? new NoopAnimationDriver()
+          : new WebAnimationsDriver(),
+    },
+    {
+      provide: ANIMATION_MODULE_TYPE,
+      useFactory: () =>
+        typeof ngServerMode !== 'undefined' && ngServerMode
+          ? 'NoopAnimations'
+          : 'BrowserAnimations',
+    },
+    ...SHARED_ANIMATION_PROVIDERS,
+  ];
+})();


### PR DESCRIPTION
Wraps `BROWSER_ANIMATIONS_PROVIDERS` and `BROWSER_NOOP_ANIMATIONS_PROVIDERS` in IIFEs with `@__PURE__` annotations to ensure proper tree-shaking by bundlers.

Without the IIFE, the spread operator (`...SHARED_ANIMATION_PROVIDERS`) can be considered a side-effect by bundlers, preventing them from tree-shaking unused animation providers. This can result in unnecessary code being included in the bundle even when animations are not used.