### PR TITLE
refactor(forms): remove a TODO and simplify update on `<select>` mutations

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -375,9 +375,7 @@ function observeSelectMutations(
 ): MutationObserver {
   const observer = new MutationObserver((mutations) => {
     if (mutations.some((m) => isRelevantSelectMutation(m))) {
-      // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131711472
-      // * check if bindings changed before writing.
-      setNativeControlValue(select, controlDirective.state().value());
+      select.value = controlDirective.state().value();
     }
   });
   observer.observe(select, {


### PR DESCRIPTION
Remove an unnecessary TODO comment. The native `<select>` tracks its `value` by keeping track of the selected `<option>`. Thus if the value was set *before* the corresponding option is created, the `<select>` will ignore it, but the framework doesn't know that and will cache the bound value anyways. Therefore, checking if the value changed since it was last bound when the mutation that creates the selected `<option>` occurs would in fact prevent a needed update, leaving the `<select>` and field values out of sync.

Furthermore, we know the control type is a native `<select>` element, so we can update its value directly instead of going through `updateNativeControl()` which would perform a redundant input type check.