### PR TITLE
Improve feature parity between `createApplication` and `bootstrapApplication`

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -52,7 +52,7 @@ export class By {
 }
 
 // @public
-export function createApplication(options?: ApplicationConfig): Promise<ApplicationRef>;
+export function createApplication(options?: ApplicationConfig, context?: BootstrapContext): Promise<ApplicationRef>;
 
 // @public
 export function disableDebugTools(): void;

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -131,8 +131,7 @@ export async function bootstrapApplication(
 ): Promise<ApplicationRef> {
   const config = {
     rootComponent,
-    platformRef: context?.platformRef,
-    ...createProvidersConfig(options),
+    ...createProvidersConfig(options, context),
   };
 
   if ((typeof ngJitMode === 'undefined' || ngJitMode) && typeof fetch === 'function') {
@@ -150,20 +149,27 @@ export async function bootstrapApplication(
  *
  * @param options Extra configuration for the application environment, see `ApplicationConfig` for
  *     additional info.
+ * @param context Optional context object that can be used to provide a pre-existing
+ *     platform injector. This is useful for advanced use-cases, for example, server-side
+ *     rendering, where the platform is created for each request.
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
  */
-export async function createApplication(options?: ApplicationConfig): Promise<ApplicationRef> {
+export async function createApplication(
+  options?: ApplicationConfig,
+  context?: BootstrapContext,
+): Promise<ApplicationRef> {
   if ((typeof ngJitMode === 'undefined' || ngJitMode) && typeof fetch === 'function') {
     await resolveJitResources();
   }
 
-  return internalCreateApplication(createProvidersConfig(options));
+  return internalCreateApplication(createProvidersConfig(options, context));
 }
 
-function createProvidersConfig(options?: ApplicationConfig) {
+function createProvidersConfig(options?: ApplicationConfig, context?: BootstrapContext) {
   return {
+    platformRef: context?.platformRef,
     appProviders: [...BROWSER_MODULE_PROVIDERS, ...(options?.providers ?? [])],
     platformProviders: INTERNAL_BROWSER_PLATFORM_PROVIDERS,
   };

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -47,10 +47,12 @@ import {
   provideNgReflectAttributes,
   ɵSSR_CONTENT_INTEGRITY_MARKER as SSR_CONTENT_INTEGRITY_MARKER,
   provideZoneChangeDetection,
+  signal,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
   bootstrapApplication,
+  createApplication,
   BootstrapContext,
   BrowserModule,
   provideClientHydration,
@@ -765,6 +767,24 @@ class HiddenModule {}
       afterEach(() => {
         doc = '<html><head></head><body><app></app></body></html>';
         TestBed.resetTestingModule();
+      });
+
+      it('should render with `createApplication`', async () => {
+        const output = await renderApplication(
+          async (context) => {
+            const appRef = await createApplication(
+              {
+                providers: [provideZoneChangeDetection()],
+              },
+              context,
+            );
+            appRef.bootstrap(createMyAsyncServerApp(true));
+            return appRef;
+          },
+          {document: doc},
+        );
+
+        expect(output).toBe(expectedOutput);
       });
 
       it('using long form should work', async () => {


### PR DESCRIPTION
I was messing around with `createApplication` the other day and noticed two things it can't do compared to `bootstrapApplication`:

1. You can't use it with JIT components. It renders inline templates, but does not resolve external templates.
2. You can't use it in SSR. It throws an error that `context` / `platformRef` was not provided.

I think it's generally good to ensure that `createApplication` and `bootstrapApplication` have feature parity. Ideally, `bootstrapApplication` would literally just be:

```typescript
const appRef = await createApplication(config, context);
appRef.bootstrap(Component);
```

But that's a slightly larger refactor than what I want to deal with right now. For now, I'm just addressing these two feature gaps by 1. resolving JIT resources and 2. adding a `context` parameter for `createApplication`. This should at least be a step in the right direction.