### PR TITLE
Revert "fix(compiler): support commas in :host() argument"

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -511,13 +511,11 @@ export class ShadowCss {
     return cssText.replace(_cssColonHostRe, (_, hostSelectors: string, otherSelectors: string) => {
       if (hostSelectors) {
         const convertedSelectors: string[] = [];
-        for (const hostSelector of this._splitOnTopLevelCommas(hostSelectors)) {
-          const trimmedHostSelector = hostSelector.trim();
-          if (!trimmedHostSelector) break;
+        const hostSelectorArray = hostSelectors.split(',').map((p) => p.trim());
+        for (const hostSelector of hostSelectorArray) {
+          if (!hostSelector) break;
           const convertedSelector =
-            _polyfillHostNoCombinator +
-            trimmedHostSelector.replace(_polyfillHost, '') +
-            otherSelectors;
+            _polyfillHostNoCombinator + hostSelector.replace(_polyfillHost, '') + otherSelectors;
           convertedSelectors.push(convertedSelector);
         }
         return convertedSelectors.join(',');

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -101,12 +101,6 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host:not(.foo, .bar) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(.foo, .bar) {}',
       );
-      expect(shim(':host:not(:has(p, a)) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:not(:has(p, a)) {}',
-      );
-      expect(shim(':host(:not(.foo, .bar)) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:not(.foo, .bar) {}',
-      );
     });
 
     // see b/63672152


### PR DESCRIPTION
This reverts commit 1e09bdc114c364aad70ba1c6b20d2889f5fbf555.

Revert reason: the change relies on helper functions that do not exist in `20.3.x` branch (only exist in `main`).


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No