### PR TITLE
test(compiler): add test for :host:has(> .foo)

### DIFF
--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -107,6 +107,9 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host(:not(.foo, .bar)) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(.foo, .bar) {}',
       );
+      expect(shim(':host:has(> child-element:not(.foo)) {}', 'contenta', 'a-host')).toEqualCss(
+        '[a-host]:has(> child-element:not(.foo)) {}',
+      );
     });
 
     // see b/63672152


### PR DESCRIPTION
I took a quick look at my recent changes to see if I had inadvertently fixed this bug, but I couldn't seem to reproduce it even before my changes. Seems like it's working, though.

Closes #58436