### PR TITLE
docs: add experimental warning for enableProfiling function

### DIFF
--- a/adev/src/content/best-practices/runtime-performance/profiling-with-chrome-devtools.md
+++ b/adev/src/content/best-practices/runtime-performance/profiling-with-chrome-devtools.md
@@ -1,5 +1,8 @@
 # Profiling with the Chrome DevTools
 
+NOTE:
+The `enableProfiling()` function used in this guide is currently experimental and may change in future versions of Angular.
+
 Angular integrates with the [Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension) to present framework-specific data and insights directly in the [Chrome DevTools performance panel](https://developer.chrome.com/docs/devtools/performance/overview).
 
 With the integration enabled, you can [record a performance profile](https://developer.chrome.com/docs/devtools/performance#record) containing two sets of data:


### PR DESCRIPTION
Add note about enableProfiling() being experimental in the profiling documentation page.

Fixes #64996

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The profiling documentation page at https://angular.dev/best-practices/profiling-with-chrome-devtools does not mention that the `enableProfiling()` function is experimental, even though it is marked as `@experimental` in the source code.

Issue Number: #64996

## What is the new behavior?

Added a prominent NOTE at the top of the profiling documentation page informing users that the `enableProfiling()` function is currently experimental and may change in future versions of Angular.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a documentation-only change that adds transparency about the experimental status of the `enableProfiling()` function. The change ensures users are properly informed before using this feature in their applications.
