### PR TITLE
docs: add shell language to CLI installation examples

### DIFF
--- a/adev/src/content/tools/cli/setup-local.md
+++ b/adev/src/content/tools/cli/setup-local.md
@@ -40,21 +40,25 @@ To install the Angular CLI, open a terminal window and run the following command
 <docs-code-multifile>
    <docs-code
      header="npm"
+     language="shell"
      >
      npm install -g @angular/cli
      </docs-code>
    <docs-code
      header="pnpm"
+     language="shell"
      >
      pnpm install -g @angular/cli
      </docs-code>
    <docs-code
      header="yarn"
+     language="shell"
      >
      yarn global add @angular/cli
      </docs-code>
    <docs-code
      header="bun"
+     language="shell"
      >
      bun install -g @angular/cli
      </docs-code>
@@ -82,21 +86,25 @@ Run with `sudo` to execute the command as the root user and enter your password 
 <docs-code-multifile>
    <docs-code
      header="npm"
+     language="shell"
      >
      sudo npm install -g @angular/cli
      </docs-code>
    <docs-code
      header="pnpm"
+     language="shell"
      >
      sudo pnpm install -g @angular/cli
      </docs-code>
    <docs-code
      header="yarn"
+     language="shell"
      >
      sudo yarn global add @angular/cli
      </docs-code>
    <docs-code
      header="bun"
+     language="shell"
      >
      sudo bun install -g @angular/cli
      </docs-code>


### PR DESCRIPTION
Added `language="shell"` to installation command examples to display the shell prompt `$` icon consistently across npm, pnpm, yarn, and bun code blocks.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
