### PR TITLE
fix(docs-infra): avoid double slash in sitemap urls

### DIFF
--- a/.github/actions/deploy-docs-site/lib/sitemap.mts
+++ b/.github/actions/deploy-docs-site/lib/sitemap.mts
@@ -3,6 +3,10 @@ import {join} from 'path';
 import {readFileSync, writeFileSync} from 'fs';
 
 export async function generateSitemap(deployment: Deployment, distDir: string) {
+  const servingUrlWithoutEndingSlash = deployment.servingUrl.endsWith('/')
+    ? deployment.servingUrl.slice(0, -1)
+    : deployment.servingUrl;
+
   /** Timestamp string used to of the last file update. */
   const lastModifiedTimestamp = new Date().toISOString();
   /** An object containing all of the routes available within the application. */
@@ -11,16 +15,17 @@ export async function generateSitemap(deployment: Deployment, distDir: string) {
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   ${Object.keys(routes.routes)
-    .map(
-      (route) => `
+    .map((route) => {
+      const routeWithoutLeadingSlash = route.startsWith('/') ? route.slice(1) : route;
+      return `
     <url>
-      <loc>${deployment.servingUrl}${route}</loc>
+      <loc>${servingUrlWithoutEndingSlash}/${routeWithoutLeadingSlash}</loc>
       <lastmod>${lastModifiedTimestamp}</lastmod>
       <changefreq>daily</changefreq>
       <priority>1.0</priority>
     </url>
-  `,
-    )
+        `;
+    })
     .join('')}
   </urlset>`;
   writeFileSync(join(distDir, 'browser', 'sitemap.xml'), sitemap, 'utf-8');

--- a/.github/actions/deploy-docs-site/main.js
+++ b/.github/actions/deploy-docs-site/main.js
@@ -48194,18 +48194,22 @@ async function getDeployments() {
 import { join as join4 } from "path";
 import { readFileSync as readFileSync4, writeFileSync } from "fs";
 async function generateSitemap(deployment, distDir) {
+  const servingUrlWithoutEndingSlash = deployment.servingUrl.endsWith("/") ? deployment.servingUrl.slice(0, -1) : deployment.servingUrl;
   const lastModifiedTimestamp = (/* @__PURE__ */ new Date()).toISOString();
   const routes = JSON.parse(readFileSync4(join4(distDir, "prerendered-routes.json"), "utf-8"));
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  ${Object.keys(routes.routes).map((route) => `
+  ${Object.keys(routes.routes).map((route) => {
+    const routeWithoutLeadingSlash = route.startsWith("/") ? route.slice(1) : route;
+    return `
     <url>
-      <loc>${deployment.servingUrl}${route}</loc>
+      <loc>${servingUrlWithoutEndingSlash}/${routeWithoutLeadingSlash}</loc>
       <lastmod>${lastModifiedTimestamp}</lastmod>
       <changefreq>daily</changefreq>
       <priority>1.0</priority>
     </url>
-  `).join("")}
+        `;
+  }).join("")}
   </urlset>`;
   writeFileSync(join4(distDir, "browser", "sitemap.xml"), sitemap, "utf-8");
   console.log(`Generated sitemap with ${Object.keys(routes.routes).length} entries.`);


### PR DESCRIPTION
fix #65022

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65022


## What is the new behavior?

sitemap URLs now shouldn't contain double slashes anymore

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
