### PR TITLE
refactor(platform-browser): simplify DomSanitizerImpl constructor

### DIFF
--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -9,7 +9,6 @@
 import {DOCUMENT} from '@angular/common';
 import {
   forwardRef,
-  Inject,
   Injectable,
   Sanitizer,
   SecurityContext,
@@ -25,6 +24,7 @@ import {
   ɵRuntimeError as RuntimeError,
   ɵunwrapSafeValue as unwrapSafeValue,
   ɵXSS_SECURITY_URL as XSS_SECURITY_URL,
+  inject,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
@@ -164,9 +164,7 @@ export abstract class DomSanitizer implements Sanitizer {
 
 @Injectable({providedIn: 'root'})
 export class DomSanitizerImpl extends DomSanitizer {
-  constructor(@Inject(DOCUMENT) private _doc: any) {
-    super();
-  }
+  private readonly _doc = inject(DOCUMENT);
 
   override sanitize(ctx: SecurityContext, value: SafeValue | string | null): string | null {
     if (value == null) return null;

--- a/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
+++ b/packages/platform-browser/test/security/dom_sanitization_service_spec.ts
@@ -7,12 +7,18 @@
  */
 
 import {SecurityContext} from '@angular/core';
-import {DomSanitizerImpl} from '../../src/security/dom_sanitization_service';
+import {DomSanitizer, DomSanitizerImpl} from '../../src/security/dom_sanitization_service';
+import {TestBed} from '@angular/core/testing';
 
 describe('DOM Sanitization Service', () => {
+  let sanitizer: DomSanitizer;
+
+  beforeEach(() => {
+    sanitizer = TestBed.inject(DomSanitizerImpl);
+  });
+
   it('accepts resource URL values for resource contexts', () => {
-    const svc = new DomSanitizerImpl(null);
-    const resourceUrl = svc.bypassSecurityTrustResourceUrl('http://hello/world');
-    expect(svc.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
+    const resourceUrl = sanitizer.bypassSecurityTrustResourceUrl('http://hello/world');
+    expect(sanitizer.sanitize(SecurityContext.URL, resourceUrl)).toBe('http://hello/world');
   });
 });


### PR DESCRIPTION
Refactors the DomSanitizerImpl constructor to use the `inject` function

I understand this is used internally for implementation; I believe it shouldn't generate any breaking changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
