### PR TITLE
feat(forms): expose `markAsUntouched` and `markAsPristine` methods in signal forms public API

### DIFF
--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -315,6 +315,26 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   hasMetadata(key: MetadataKey<any> | AggregateMetadataKey<any, any>): boolean;
 
   /**
+   * Marks this specific field as touched.
+   */
+  markAsTouched(): void;
+
+  /**
+   * Marks this specific field as untouched.
+   */
+  markAsUntouched(): void;
+
+  /**
+   * Marks this specific field as dirty.
+   */
+  markAsDirty(): void;
+
+  /**
+   * Marks this specific field as pristine.
+   */
+  markAsPristine(): void;
+
+  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -192,10 +192,24 @@ export class FieldNode implements FieldState<unknown> {
   }
 
   /**
+   * Marks this specific field as untouched.
+   */
+  markAsUntouched(): void {
+    this.nodeState.markAsUntouched();
+  }
+
+  /**
    * Marks this specific field as dirty.
    */
   markAsDirty(): void {
     this.nodeState.markAsDirty();
+  }
+
+  /**
+   * Marks this specific field as dirty.
+   */
+  markAsPristine(): void {
+    this.nodeState.markAsPristine();
   }
 
   /**

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -129,6 +129,20 @@ describe('FieldNode', () => {
       expect(f().dirty()).toBe(true);
     });
 
+    it('can be marked as pristine', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+      f().markAsDirty();
+      expect(f().dirty()).toBe(true);
+      f().markAsPristine();
+      expect(f().dirty()).toBe(false);
+    });
+
     it('can be reset', () => {
       const model = signal({a: 1, b: 2});
       const f = form(model, {injector: TestBed.inject(Injector)});
@@ -336,6 +350,20 @@ describe('FieldNode', () => {
 
       f().markAsTouched();
       expect(f().touched()).toBe(true);
+    });
+
+    it('can be marked as untouched', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+      f().markAsTouched();
+      expect(f().touched()).toBe(true);
+      f().markAsUntouched();
+      expect(f().touched()).toBe(false);
     });
 
     it('propagates from the children', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently `markAsUntouched()` and `markAsPristine()` are not exposed.

Issue Number: #65031


## What is the new behavior?

Adds `markAsUntouched()` and `markAsPristine()` methods to `FieldState` interface
to allow manual reset of individual field touched/dirty state.
This enables proper handling of dependent fields where field state needs
to be reset when dependencies change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
