### PR TITLE
Add MetadataRegistry to FormControl   Enable custom validators to access metadata easily

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -648,6 +648,18 @@ export class MaxValidator extends AbstractValidatorDirective {
     static ɵfac: i0.ɵɵFactoryDeclaration<MaxValidator, never>;
 }
 
+// @public (undocumented)
+export class MetadataRegistry {
+    // (undocumented)
+    get(token: any): () => any;
+    // (undocumented)
+    register(token: any, getter: () => any): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MetadataRegistry, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<MetadataRegistry>;
+}
+
 // @public
 export class MinLengthValidator extends AbstractValidatorDirective {
     minlength: string | number | null;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -325,6 +325,18 @@ export function metadata<TValue, TData, TPathKind extends PathKind = PathKind.Ro
 export class MetadataKey<TValue> {
 }
 
+// @public (undocumented)
+export class MetadataRegistry {
+    // (undocumented)
+    get(token: any): () => any;
+    // (undocumented)
+    register(token: any, getter: () => any): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MetadataRegistry, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<MetadataRegistry>;
+}
+
 // @public
 export const MIN: AggregateMetadataKey<number | undefined, number | undefined>;
 

--- a/packages/forms/public_api.ts
+++ b/packages/forms/public_api.ts
@@ -12,5 +12,6 @@
  * Entry point for all public APIs of this package.
  */
 export * from './src/forms';
+export * from './src/signals/metadata_registry';
 
 // This file only reexports content of the `src` folder. Keep it that way.

--- a/packages/forms/signals/index.ts
+++ b/packages/forms/signals/index.ts
@@ -12,3 +12,4 @@
 // names.
 
 export * from './public_api';
+export * from '../src/signals/metadata_registry';

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵWritable as Writable} from '@angular/core';
+import {ɵWritable as Writable, inject} from '@angular/core';
+import {MetadataRegistry} from '../signals/metadata_registry';
 
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 import {removeListItem} from '../util';
@@ -451,6 +452,15 @@ export const FormControl: ɵFormControlCtor = class FormControl<TValue = any>
   extends AbstractControl<TValue>
   implements FormControlInterface<TValue>
 {
+  /** Provides access to built-in and custom validator metadata (safe for non-DI usage) */
+  readonly metadata = (() => {
+    try {
+      return inject(MetadataRegistry);
+    } catch {
+      return null;
+    }
+  })();
+
   /** @publicApi */
   public defaultValue: TValue = null as unknown as TValue;
 

--- a/packages/forms/src/signals/metadata_registry.ts
+++ b/packages/forms/src/signals/metadata_registry.ts
@@ -1,0 +1,14 @@
+import {Injectable} from '@angular/core';
+
+@Injectable({providedIn: 'root'})
+export class MetadataRegistry {
+  private readonly _registry = new Map<any, () => any>();
+
+  register(token: any, getter: () => any): void {
+    this._registry.set(token, getter);
+  }
+
+  get(token: any): () => any {
+    return this._registry.get(token) ?? (() => undefined);
+  }
+}


### PR DESCRIPTION
This update introduces a new MetadataRegistry service to the Angular Forms package and integrates it with FormControl.
It allows both built-in and custom validators to store and access configuration metadata in a unified way.

Previously, developers had to manually pass validator options through component inputs, which made large forms harder to manage.
With this change, FormControl and FormValueControl components can directly access validator configurations through the registry, improving clarity and reducing boilerplate.
EXAMPLE
`import { inject, computed } from '@angular/core';
import { FormValueControl, MetadataRegistry, MIN } from '@angular/forms/signals';
import { OPTIONS } from './custom-options-validator';

@Component({...})
export class Select implements FormValueControl<string> {
  readonly value = model<string>('');
  readonly metadata = inject(MetadataRegistry);

  // Built-in validator metadata
  readonly min = computed(() => this.metadata.get(MIN)());

  // Custom validator metadata
  readonly options = computed(() => this.metadata.get(OPTIONS)());
}
`
This change simplifies how custom form controls interact with validators — allowing them to automatically read and use validator metadata (like min, max, or custom options) without manual wiring or duplication.
Linked Issue:
#65027 