### PR TITLE
fix(migrations): respect path option in self-closing-tags and signal-i…

### DIFF
--- a/packages/core/schematics/ng-generate/self-closing-tags-migration/index.ts
+++ b/packages/core/schematics/ng-generate/self-closing-tags-migration/index.ts
@@ -9,6 +9,7 @@
 import {Rule} from '@angular-devkit/schematics';
 import {SelfClosingTagsMigration} from '../../migrations/self-closing-tags-migration/self-closing-tags-migration';
 import {MigrationStage, runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {filterSourceFilesByPath} from '../../utils/tsurge/helpers/filter_by_path';
 
 interface Options {
   path: string;
@@ -34,6 +35,9 @@ export function migrate(options: Options): Rule {
         } else {
           context.logger.info(`Running migration for: ${tsconfigPath}...`);
         }
+      },
+      afterProgramCreation: (info, fs) => {
+        info.sourceFiles = filterSourceFilesByPath(info.sourceFiles, options.path, fs);
       },
       beforeUnitAnalysis: (tsconfigPath) => {
         context.logger.info(`Scanning for component tags: ${tsconfigPath}...`);

--- a/packages/core/schematics/test/self_closing_tags_migration_spec.ts
+++ b/packages/core/schematics/test/self_closing_tags_migration_spec.ts
@@ -105,4 +105,32 @@ describe('self-closing-tags migration', () => {
       '  -> Migrated 1 components to self-closing tags in 1 component files.',
     );
   });
+
+  it('should only migrate files in specified path', async () => {
+    writeFile(
+      '/app/app.component.ts',
+      `
+    import {Component} from '@angular/core';
+    @Component({ template: '<my-cmp></my-cmp>' })
+    export class AppComponent {}
+  `,
+    );
+
+    writeFile(
+      '/other/other.component.ts',
+      `
+    import {Component} from '@angular/core';
+    @Component({ template: '<my-other></my-other>' })
+    export class OtherComponent {}
+  `,
+    );
+
+    await runMigration({path: 'app'});
+
+    const appContent = tree.readContent('/app/app.component.ts');
+    expect(appContent).toContain('<my-cmp />');
+
+    const otherContent = tree.readContent('/other/other.component.ts');
+    expect(otherContent).toContain('<my-other></my-other>');
+  });
 });

--- a/packages/core/schematics/test/signal_input_migration_spec.ts
+++ b/packages/core/schematics/test/signal_input_migration_spec.ts
@@ -24,7 +24,7 @@ describe('signal input migration', () => {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
   }
 
-  function runMigration(options?: {bestEffortMode?: boolean}) {
+  function runMigration(options?: {bestEffortMode?: boolean; path?: string}) {
     return runner.runSchematic('signal-input-migration', options, tree);
   }
 
@@ -158,5 +158,37 @@ describe('signal input migration', () => {
     await runMigration({bestEffortMode: true});
 
     expect(messages).toContain(`  -> Migrated 2/2 inputs.`);
+  });
+
+  it('should only migrate inputs in specified path', async () => {
+    writeFile(
+      '/app/test-path/app.component.ts',
+      `
+    import {Component, Input} from '@angular/core';
+    @Component({template: ''})
+    export class AppComponent {
+      @Input() name = '';
+    }
+  `,
+    );
+
+    writeFile(
+      '/app/test-path-not/other.component.ts',
+      `
+    import {Component, Input} from '@angular/core';
+    @Component({template: ''})
+    export class OtherComponent {
+      @Input() title = '';
+    }
+  `,
+    );
+
+    await runMigration({path: 'app/test-path'});
+
+    const appContent = tree.readContent('/app/test-path/app.component.ts');
+    expect(appContent).toContain('readonly name = input');
+
+    const otherContent = tree.readContent('/app/test-path-not/other.component.ts');
+    expect(otherContent).toContain('@Input() title');
   });
 });

--- a/packages/core/schematics/utils/tsurge/helpers/filter_by_path.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/filter_by_path.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FileSystem} from '@angular/compiler-cli';
+import ts from 'typescript';
+
+/**
+ * Filters source files to only include those within the specified path.
+ * Ensures directory boundaries are respected by checking for exact matches
+ * or paths that start with the target path followed by a separator.
+ */
+export function filterSourceFilesByPath(
+  sourceFiles: ts.SourceFile[],
+  path: string,
+  fs: FileSystem,
+): ts.SourceFile[] {
+  const resolvedPath = fs.resolve(path);
+
+  if (resolvedPath === '/') {
+    return sourceFiles;
+  }
+
+  return sourceFiles.filter(
+    (sf) => sf.fileName.startsWith(resolvedPath + '/') || sf.fileName === resolvedPath,
+  );
+}


### PR DESCRIPTION
…nput migrations

The self-closing-tags and signal-input migrations were analyzing all files in the TypeScript program regardless of the --path option. Files were filtered only after analysis via shouldMigrate callbacks, which meant unnecessary template resolution and analysis occurred for files outside the specified path.

Additionally, the path filtering used startsWith() without checking directory boundaries, causing paths like "src/app/test-path-not" to match when filtering for "src/app/test-path".

This change adds proper path filtering in the afterProgramCreation hook before analysis begins, and ensures directory boundaries are respected by appending '/' to the path comparison. This prevents unnecessary analysis and improves migration performance.

Fixes #61039

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #61039


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
