### PR TITLE
docs: use markdown code fences in service worker docs

### DIFF
--- a/adev/src/content/ecosystem/service-workers/custom-service-worker-scripts.md
+++ b/adev/src/content/ecosystem/service-workers/custom-service-worker-scripts.md
@@ -8,91 +8,83 @@ To create a custom service worker that extends Angular's functionality:
 
 1. Create a custom service worker file (e.g., `custom-sw.js`) in your `src` directory:
 
-<docs-code language="javascript">
-
+```js
 // Import the Angular service worker
 importScripts('./ngsw-worker.js');
 
 (function () {
-'use strict';
+  'use strict';
 
-// Add custom notification click handler
-self.addEventListener('notificationclick', (event) => {
-console.log('Custom notification click handler');
-console.log('Notification details:', event.notification);
+  // Add custom notification click handler
+  self.addEventListener('notificationclick', (event) => {
+    console.log('Custom notification click handler');
+    console.log('Notification details:', event.notification);
 
     // Handle notification click - open URL if provided
     if (clients.openWindow && event.notification.data.url) {
       event.waitUntil(clients.openWindow(event.notification.data.url));
       console.log('Opening URL:', event.notification.data.url);
     }
+  });
 
-});
-
-// Add custom background sync handler
-self.addEventListener('sync', (event) => {
-console.log('Custom background sync handler');
+  // Add custom background sync handler
+  self.addEventListener('sync', (event) => {
+    console.log('Custom background sync handler');
 
     if (event.tag === 'background-sync') {
       event.waitUntil(doBackgroundSync());
     }
+  });
 
-});
-
-function doBackgroundSync() {
-// Implement your background sync logic here
-return fetch('https://example.com/api/sync')
-.then(response => response.json())
-.then(data => console.log('Background sync completed:', data))
-.catch(error => console.error('Background sync failed:', error));
-}
+  function doBackgroundSync() {
+    // Implement your background sync logic here
+    return fetch('https://example.com/api/sync')
+      .then((response) => response.json())
+      .then((data) => console.log('Background sync completed:', data))
+      .catch((error) => console.error('Background sync failed:', error));
+  }
 })();
-
-</docs-code>
+```
 
 2. Update your `angular.json` file to use the custom service worker:
 
-<docs-code language="json">
-
+```json
 {
-"projects": {
-"your-app": {
-"architect": {
-"build": {
-"options": {
-"assets": [
-{
-"glob": "**/*",
-"input": "public"
-},
-"app/src/custom-sw.js"
-]
-},
+  "projects": {
+    "your-app": {
+      "architect": {
+        "build": {
+          "options": {
+            "assets": [
+              {
+                "glob": "**/*",
+                "input": "public"
+              },
+              "app/src/custom-sw.js"
+            ]
+          }
+        }
+      }
+    }
+  }
 }
-}
-}
-}
-}
-
-</docs-code>
+```
 
 3. Configure the service worker registration to use your custom script:
 
-<docs-code language="typescript">
-
+```ts
 import { ApplicationConfig, isDevMode } from '@angular/core';
 import { provideServiceWorker } from '@angular/service-worker';
 
 export const appConfig: ApplicationConfig = {
-providers: [
-provideServiceWorker('custom-sw.js', {
-enabled: !isDevMode(),
-registrationStrategy: 'registerWhenStable:30000'
-}),
-],
+  providers: [
+    provideServiceWorker('custom-sw.js', {
+      enabled: !isDevMode(),
+      registrationStrategy: 'registerWhenStable:30000',
+    }),
+  ],
 };
-
-</docs-code>
+```
 
 ### Best practices for custom service workers
 

--- a/adev/src/content/ecosystem/service-workers/push-notifications.md
+++ b/adev/src/content/ecosystem/service-workers/push-notifications.md
@@ -23,20 +23,18 @@ The default behavior for the `notificationclick` event is to close the notificat
 You can specify an additional operation to be executed on `notificationclick` by adding an `onActionClick` property to the `data` object, and providing a `default` entry.
 This is especially useful for when there are no open clients when a notification is clicked.
 
-<docs-code language="json">
-
+```json
 {
-"notification": {
-"title": "New Notification!",
-"data": {
-"onActionClick": {
-"default": {"operation": "openWindow", "url": "foo"}
+  "notification": {
+    "title": "New Notification!",
+    "data": {
+      "onActionClick": {
+        "default": {"operation": "openWindow", "url": "foo"}
+      }
+    }
+  }
 }
-}
-}
-}
-
-</docs-code>
+```
 
 ### Operations
 
@@ -60,31 +58,29 @@ Each action is represented as an action button that the user can click to intera
 
 In addition, using the `onActionClick` property on the `data` object, you can tie each action to an operation to be performed when the corresponding action button is clicked:
 
-<docs-code language="typescript">
-
+```json
 {
-"notification": {
-"title": "New Notification!",
-"actions": [
-{"action": "foo", "title": "Open new tab"},
-{"action": "bar", "title": "Focus last"},
-{"action": "baz", "title": "Navigate last"},
-{"action": "qux", "title": "Send request in the background"},
-{"action": "other", "title": "Just notify existing clients"}
-],
-"data": {
-"onActionClick": {
-"default": {"operation": "openWindow"},
-"foo": {"operation": "openWindow", "url": "/absolute/path"},
-"bar": {"operation": "focusLastFocusedOrOpen", "url": "relative/path"},
-"baz": {"operation": "navigateLastFocusedOrOpen", "url": "https://other.domain.com/"},
-"qux": {"operation": "sendRequest", "url": "https://yet.another.domain.com/"}
+  "notification": {
+    "title": "New Notification!",
+    "actions": [
+      {"action": "foo", "title": "Open new tab"},
+      {"action": "bar", "title": "Focus last"},
+      {"action": "baz", "title": "Navigate last"},
+      {"action": "qux", "title": "Send request in the background"},
+      {"action": "other", "title": "Just notify existing clients"}
+    ],
+    "data": {
+      "onActionClick": {
+        "default": {"operation": "openWindow"},
+        "foo": {"operation": "openWindow", "url": "/absolute/path"},
+        "bar": {"operation": "focusLastFocusedOrOpen", "url": "relative/path"},
+        "baz": {"operation": "navigateLastFocusedOrOpen", "url": "https://other.domain.com/"},
+        "qux": {"operation": "sendRequest", "url": "https://yet.another.domain.com/"}
+      }
+    }
+  }
 }
-}
-}
-}
-
-</docs-code>
+```
 
 IMPORTANT: If an action does not have a corresponding `onActionClick` entry, then the notification is closed and `SwPush.notificationClicks` is notified on existing clients.
 
@@ -93,7 +89,6 @@ IMPORTANT: If an action does not have a corresponding `onActionClick` entry, the
 You might also be interested in the following:
 
 <docs-pill-row>
-
   <docs-pill href="ecosystem/service-workers/communications" title="Communicating with the Service Worker"/>
   <docs-pill href="ecosystem/service-workers/devops" title="Service Worker devops"/>
 </docs-pill-row>


### PR DESCRIPTION
Replaces the <docs-code> component with standard markdown code fences in the service worker documentation. This improves the readability and maintainability of the documentation.
