### PR TITLE
refactor(core): mark `VERSION` as `@__PURE__` for better tree-shaking

### DIFF
--- a/packages/common/src/version.ts
+++ b/packages/common/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/elements/src/version.ts
+++ b/packages/elements/src/version.ts
@@ -11,4 +11,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/forms/src/version.ts
+++ b/packages/forms/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/platform-browser-dynamic/src/version.ts
+++ b/packages/platform-browser-dynamic/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/platform-browser/src/version.ts
+++ b/packages/platform-browser/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/platform-server/src/version.ts
+++ b/packages/platform-server/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/router/src/version.ts
+++ b/packages/router/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');

--- a/packages/upgrade/src/common/src/version.ts
+++ b/packages/upgrade/src/common/src/version.ts
@@ -17,4 +17,4 @@ import {Version} from '@angular/core';
 /**
  * @publicApi
  */
-export const VERSION = new Version('0.0.0-PLACEHOLDER');
+export const VERSION = /* @__PURE__ */ new Version('0.0.0-PLACEHOLDER');


### PR DESCRIPTION
Annotate the `new Version(...)` call with `/* @__PURE__ */` to signal to optimizers that the constructor is side-effect free.

Without this hint, bundlers such as Terser or ESBuild may conservatively retain the `VERSION` instantiation even when unused. With the annotation, the constant can be tree-shaken away in production builds if not referenced, reducing bundle size.