### PR TITLE
fix(forms): exclude max, maxLength, min, minLength from FieldState fo…

### DIFF
--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -220,6 +220,16 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
   | FieldTree<Exclude<TModel, undefined>, TKey>;
 
 /**
+ * Helper type that conditionally excludes max, maxLength, min, minLength from ɵFieldState
+ * when TValue is not a primitive type (string, number, Date).
+ *
+ * These properties only make sense for primitive field values, not for object or array fields.
+ */
+type FieldStateBase<TValue> = [TValue] extends [string | number | Date]
+  ? ɵFieldState<TValue>
+  : Omit<ɵFieldState<TValue>, 'max' | 'maxLength' | 'min' | 'minLength'>;
+
+/**
  * Contains all of the state (e.g. value, statuses, etc.) associated with a `FieldTree`, exposed as
  * signals.
  *
@@ -227,7 +237,7 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
  * @experimental 21.0.0
  */
 export interface FieldState<TValue, TKey extends string | number = string | number>
-  extends ɵFieldState<TValue> {
+  extends FieldStateBase<TValue> {
   /**
    * A signal indicating whether field value has been changed by user.
    */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

[ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md

[ ] Tests for the changes have been added (for bug fixes / features)

[ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

[x] Bugfix

[ ] Feature

[ ] Code style update (formatting, local variables)

[ ] Refactoring (no functional changes, no api changes)

[ ] Build related changes

[ ] CI related changes

[ ] Documentation content changes

[ ] angular.dev application / infrastructure changes

[ ] Other... Please describe:

## What is the current behavior?
The FieldState type incorrectly includes validation-related properties for fields bound to non-primitive types (objects or arrays), where they are not applicable.

Issue Number: N/A

## What is the new behavior?
The FieldState type now uses a conditional type to ensure that validation-related properties are only included for fields bound to primitive types (string, number, Date). These properties are correctly excluded for object and array fields.

## Does this PR introduce a breaking change?
[ ] Yes
[ ] No
