### PR TITLE
fix(forms): exclude max, maxLength, min, minLength from FieldState fo…

### DIFF
--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -220,6 +220,16 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
   | FieldTree<Exclude<TModel, undefined>, TKey>;
 
 /**
+ * Helper type that conditionally excludes max, maxLength, min, minLength from ɵFieldState
+ * when TValue is not a primitive type (string, number, Date).
+ *
+ * These properties only make sense for primitive field values, not for object or array fields.
+ */
+type FieldStateBase<TValue> = [TValue] extends [string | number | Date]
+  ? ɵFieldState<TValue>
+  : Omit<ɵFieldState<TValue>, 'max' | 'maxLength' | 'min' | 'minLength'>;
+
+/**
  * Contains all of the state (e.g. value, statuses, etc.) associated with a `FieldTree`, exposed as
  * signals.
  *
@@ -227,7 +237,7 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
  * @experimental 21.0.0
  */
 export interface FieldState<TValue, TKey extends string | number = string | number>
-  extends ɵFieldState<TValue> {
+  extends FieldStateBase<TValue> {
   /**
    * A signal indicating whether field value has been changed by user.
    */


### PR DESCRIPTION
## Description
Fixes a regression where `max`, `maxLength`, `min`, and `minLength` properties were incorrectly present on the return type of the `form()` function for non-primitive types.

These validation properties should only be present on primitive field values (string, number, Date), not on object or array fields. The current API only allows binding these rules on individual field items, not on the form itself.

## What Changed
- Added a conditional type helper `FieldStateBase<TValue>` that excludes `max`, `maxLength`, `min`, and `minLength` from `FieldState` when `TValue` is not a primitive type
- Updated `FieldState` interface to use the conditional type helper instead of directly extending `ɵFieldState<TValue>`

## Testing
- Type system now correctly excludes these properties for object/array field types
- Properties remain available for primitive field types (string, number, Date)
