### PR TITLE
fix(core): skip Angular formatting when formatting signals recursively

### DIFF
--- a/packages/core/primitives/signals/src/formatter.ts
+++ b/packages/core/primitives/signals/src/formatter.ts
@@ -47,7 +47,7 @@ const formatter = {
     try {
       value = sig();
     } catch {
-      // In case the signl throws, we don't want to break the formatting.
+      // In case the signal throws, we don't want to break the formatting.
       return ['span', 'Signal(⚠️ Error)'];
     }
 
@@ -103,7 +103,7 @@ const formatter = {
       [
         'div',
         {style: `padding-left: .5rem;`},
-        ['object', {object: sig, config: {...config, skipFormatting: true}}],
+        ['object', {object: sig, config: {...config, ngSkipFormatting: true}}],
       ],
     ];
   },
@@ -137,7 +137,7 @@ function prettifyPreview(
       }
     }
     default: {
-      return ['object', {object: value, config: {skipFormatting: true}}];
+      return ['object', {object: value, config: {ngSkipFormatting: true}}];
     }
   }
 }


### PR DESCRIPTION
The flag `skipFormatting` got renamed to `ngSkipFormatting` during review of https://github.com/angular/angular/pull/64000, but a couple usages got missed, causing some unfortunate UI recursion.

<img width="593" height="691" alt="Screenshot of Chrome DevTools, paused at a breakpoint and inspecting local application state. A `user` variable is highlighted. It is a signal and nicely previewed as `Signal('Doug')`. The user has expanded this preview which breaks down to two values, the signal value (`Doug` as a string) and the signal function, previewed identically as before like `Signal('Doug')`. The user has expanded this signal function recursively, each expansion revealing a new signal function preview which expands to another signal function preview. " src="https://github.com/user-attachments/assets/388f01e8-11ac-4788-a8cb-37803e5a41d8" />