### PR TITLE
[20.3.x] Revert "refactor(http): migrate XSRF classes to use inject() function"

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -9,6 +9,7 @@
 import {DOCUMENT, ɵparseCookieValue as parseCookieValue} from '../../index';
 import {
   EnvironmentInjector,
+  Inject,
   inject,
   Injectable,
   InjectionToken,
@@ -54,9 +55,6 @@ export abstract class HttpXsrfTokenExtractor {
  */
 @Injectable()
 export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
-  private readonly cookieName = inject(XSRF_COOKIE_NAME);
-  private readonly doc = inject(DOCUMENT);
-
   private lastCookieString: string = '';
   private lastToken: string | null = null;
 
@@ -64,6 +62,11 @@ export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
    * @internal for testing
    */
   parseCount: number = 0;
+
+  constructor(
+    @Inject(DOCUMENT) private doc: any,
+    @Inject(XSRF_COOKIE_NAME) private cookieName: string,
+  ) {}
 
   getToken(): string | null {
     if (typeof ngServerMode !== 'undefined' && ngServerMode) {
@@ -113,7 +116,7 @@ export function xsrfInterceptorFn(
  */
 @Injectable()
 export class HttpXsrfInterceptor implements HttpInterceptor {
-  private readonly injector = inject(EnvironmentInjector);
+  constructor(private injector: EnvironmentInjector) {}
 
   intercept(initialRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return runInInjectionContext(this.injector, () =>

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT} from '../..';
 import {HttpHeaders} from '../src/headers';
 import {HttpRequest} from '../src/request';
 import {
@@ -123,15 +122,7 @@ describe('HttpXsrfCookieExtractor', () => {
     document = {
       cookie: 'XSRF-TOKEN=test',
     };
-    TestBed.configureTestingModule({
-      providers: [
-        {
-          provide: DOCUMENT,
-          useValue: document,
-        },
-      ],
-    });
-    extractor = TestBed.inject(HttpXsrfCookieExtractor);
+    extractor = new HttpXsrfCookieExtractor(document, 'XSRF-TOKEN');
   });
   it('parses the cookie from document.cookie', () => {
     expect(extractor.getToken()).toEqual('test');


### PR DESCRIPTION
This reverts commit 2ad6b729a1033fe354072893dd9686a5e9217cf7.

Revert reason: the change relies on the code that is not available in the `20.3.x` branch (the `HttpXsrfCookieExtractor` class is not marked as `providedIn: "root"`).
