### PR TITLE
fix(forms): removed max, maxLength, min, minLength from return of form function return type

### DIFF
--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -78,7 +78,9 @@ export interface FormOptions {
  * @category structure
  * @experimental 21.0.0
  */
-export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
+export function form<TModel>(
+  model: WritableSignal<TModel>,
+): Omit<FieldTree<TModel>, 'max' | 'maxLength' | 'min' | 'minLength'>;
 
 /**
  * Creates a form wrapped around the given model data. A form is represented as simply a `FieldTree`
@@ -128,7 +130,7 @@ export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
 export function form<TModel>(
   model: WritableSignal<TModel>,
   schemaOrOptions: SchemaOrSchemaFn<TModel> | FormOptions,
-): FieldTree<TModel>;
+): Omit<FieldTree<TModel>, 'max' | 'maxLength' | 'min' | 'minLength'>;
 
 /**
  * Creates a form wrapped around the given model data. A form is represented as simply a `FieldTree`
@@ -177,7 +179,7 @@ export function form<TModel>(
   model: WritableSignal<TModel>,
   schema: SchemaOrSchemaFn<TModel>,
   options: FormOptions,
-): FieldTree<TModel>;
+): Omit<FieldTree<TModel>, 'max' | 'maxLength' | 'min' | 'minLength'>;
 
 export function form<TModel>(...args: any[]): FieldTree<TModel> {
   const [model, schema, options] = normalizeFormArgs<TModel>(args);

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -181,7 +181,9 @@ export function form<TModel>(
   options: FormOptions,
 ): Omit<FieldTree<TModel>, 'max' | 'maxLength' | 'min' | 'minLength'>;
 
-export function form<TModel>(...args: any[]): FieldTree<TModel> {
+export function form<TModel>(
+  ...args: any[]
+): Omit<FieldTree<TModel>, 'max' | 'maxLength' | 'min' | 'minLength'> {
   const [model, schema, options] = normalizeFormArgs<TModel>(args);
   const injector = options?.injector ?? inject(Injector);
   const pathNode = runInInjectionContext(injector, () => SchemaImpl.rootCompile(schema));


### PR DESCRIPTION
Fixes [#65053](https://github.com/angular/angular/issues/65053)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [65053](https://github.com/angular/angular/issues/65053)


## What is the new behavior?
The type is fixed now.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
