### PR TITLE
refactor(common): add ngDevMode guards to InjectionToken names

### DIFF
--- a/packages/core/src/application/application_init.ts
+++ b/packages/core/src/application/application_init.ts
@@ -149,7 +149,7 @@ import {isPromise, isSubscribable} from '../util/lang';
  */
 export const APP_INITIALIZER = new InjectionToken<
   ReadonlyArray<() => Observable<unknown> | Promise<unknown> | void>
->(ngDevMode ? 'Application Initializer' : '');
+>(typeof ngDevMode !== 'undefined' && ngDevMode ? 'Application Initializer' : '');
 
 /**
  * @description

--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -63,7 +63,7 @@ import {TracingAction, TracingService, TracingSnapshot} from './tracing';
  */
 export const APP_BOOTSTRAP_LISTENER = new InjectionToken<
   ReadonlyArray<(compRef: ComponentRef<any>) => void>
->(ngDevMode ? 'appBootstrapListener' : '');
+>(typeof ngDevMode !== 'undefined' && ngDevMode ? 'appBootstrapListener' : '');
 
 export function publishDefaultGlobalUtils() {
   ngDevMode && _publishDefaultGlobalUtils();

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -70,7 +70,7 @@ export function createPlatformFactory(
   providers: StaticProvider[] = [],
 ): (extraProviders?: StaticProvider[]) => PlatformRef {
   const desc = `Platform: ${name}`;
-  const marker = new InjectionToken(desc);
+  const marker = new InjectionToken(typeof ngDevMode !== 'undefined' && ngDevMode ? desc : '');
   return (extraProviders: StaticProvider[] = []) => {
     let platform = getPlatform();
     if (!platform) {

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -54,12 +54,16 @@ interface WaitCallback {
  * should be available, this token is used to add a provider that references the `Testability`
  * class. Otherwise, only this token is retained in a bundle, but the `Testability` class is not.
  */
-export const TESTABILITY = new InjectionToken<Testability>('');
+export const TESTABILITY = new InjectionToken<Testability>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Testability' : '',
+);
 
 /**
  * Internal injection token to retrieve Testability getter class instance.
  */
-export const TESTABILITY_GETTER = new InjectionToken<GetTestability>('');
+export const TESTABILITY_GETTER = new InjectionToken<GetTestability>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Testability Getter' : '',
+);
 
 /**
  * The Testability service provides testing hooks that can be accessed from


### PR DESCRIPTION
Wrap InjectionToken names with the `typeof ngDevMode !== 'undefined' && ngDevMode` guard to enable tree-shaking of descriptive token names in production builds. This ensures debug-only token names are removed from prod bundles, improving overall size efficiency.

Similar to #64943.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
