### PR TITLE
Feat/forms getall method

### DIFF
--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -220,6 +220,16 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
   | FieldTree<Exclude<TModel, undefined>, TKey>;
 
 /**
+ * Helper type that conditionally excludes max, maxLength, min, minLength from ɵFieldState
+ * when TValue is not a primitive type (string, number, Date).
+ *
+ * These properties only make sense for primitive field values, not for object or array fields.
+ */
+type FieldStateBase<TValue> = [TValue] extends [string | number | Date]
+  ? ɵFieldState<TValue>
+  : Omit<ɵFieldState<TValue>, 'max' | 'maxLength' | 'min' | 'minLength'>;
+
+/**
  * Contains all of the state (e.g. value, statuses, etc.) associated with a `FieldTree`, exposed as
  * signals.
  *
@@ -227,7 +237,7 @@ export type MaybeFieldTree<TModel, TKey extends string | number = string | numbe
  * @experimental 21.0.0
  */
 export interface FieldState<TValue, TKey extends string | number = string | number>
-  extends ɵFieldState<TValue> {
+  extends FieldStateBase<TValue> {
   /**
    * A signal indicating whether field value has been changed by user.
    */


### PR DESCRIPTION
## Description
Adds `getAll()` method to `AbstractControl` that supports wildcard patterns to retrieve multiple controls matching a path pattern. This is particularly useful for validators that need to validate multiple controls in a FormArray.

## What Changed
- Added `getAll()` method to `AbstractControl` class
- Supports wildcard patterns using `*` to match all FormArray elements
- Works with both string paths (e.g., `'*.prop1'`) and array paths
- Handles nested arrays and complex paths
- Optional `results` parameter for result accumulation
- Added comprehensive test coverage (18 test cases)
- Includes real-world validator examples

## Usage Example
const form = this.fb.array([
  this.fb.group({ prop1: this.fb.control('a') }),
  this.fb.group({ prop1: this.fb.control('b') }),
]);
const controls = form.getAll('*.prop1'); // Returns all prop1 controls## Validator Example
function sumLessThan100(control: AbstractControl): ValidationErrors | null {
  const prices = control.getAll('*.price') as FormControl<number>[];
  const sum = prices.reduce((acc, c) => acc + (c.value || 0), 0);
  return sum < 100 ? null : {sumTooHigh: {actual: sum, max: 100}};
}## Testing
- 18 comprehensive test cases covering all edge cases
- Tests for validator use cases
- Tests for nested arrays, multiple wildcards, and error handling
