### PR TITLE
fix(compiler-cli): ignore non-existent files

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/ts_read_directory.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/ts_read_directory.ts
@@ -90,10 +90,18 @@ export function createFileSystemTsReadDirectoryFn(
         const directories: string[] = [];
 
         for (const child of children) {
-          if (fs.stat(fs.join(resolvedPath, child))?.isDirectory()) {
-            directories.push(child);
-          } else {
-            files.push(child);
+          try {
+            if (fs.stat(fs.join(resolvedPath, child))?.isDirectory()) {
+              directories.push(child);
+            } else {
+              files.push(child);
+            }
+          } catch (error) {
+            if (error instanceof Error && error.message.includes('ENOENT')) {
+              // may be a dangling link or other file system error, ignore
+              continue;
+            }
+            throw error;
           }
         }
 


### PR DESCRIPTION
Ignore files that fail fs.exists() rather than throw ENOENT.  Some applications deliberately create "broken" symbolic links that are not relevant to compilation (e.g. emacs lock files that link to owner "user@host").

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When compiling a project with a dangling symbolic link (such as an emacs lock file (.#...) or just deliberately creating a broken symbolic link) then compilation fails with:

`✘ [ERROR] TS500: Error: ENOENT: no such file or directory, stat '/home/user42/my-angular-project/jjff'
`

This is especially annoying when doing automatic builds as with `ng serve`, as saving a file in emacs while another file is still open and dirty leaves a lock file, and ng serve never recovers even when the dirty file is saved.  The only workaround is to kill `ng serve` and restart it.

Issue that seems relevant but for a very old version:
https://github.com/angular/angular-cli/issues/18342


## What is the new behavior?

The compilation ignores any broken symbolic links and automatic builds continue normally.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
