### PR TITLE
docs: fix alignment of anchors containing code blocks

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -9,7 +9,7 @@
 .docs-viewer {
   display: flex;
   flex-direction: column;
-  padding: 0px;
+  padding: 0;
   box-sizing: border-box;
   padding-inline: var(--layout-padding);
 
@@ -63,27 +63,49 @@
         overflow: hidden;
         text-overflow: ellipsis;
       }
+
+      &:has(code) {
+        display: inline-flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
     }
   }
 
   h1 {
     font-size: 2.5rem;
     margin-block-end: 0;
+
+    @include mq.for-phone-only {
+      font-size: 2rem;
+    }
   }
 
   h2 {
     font-size: 2rem;
     margin-block-end: 0.5rem;
+
+    @include mq.for-phone-only {
+      font-size: 1.5rem;
+    }
   }
 
   h3 {
     font-size: 1.5rem;
     margin-block-end: 0.5rem;
+
+    @include mq.for-phone-only {
+      font-size: 1.25rem;
+    }
   }
 
   h4 {
     font-size: 1.25rem;
     margin-block-end: 0.5rem;
+
+    @include mq.for-phone-only {
+      font-size: 1rem;
+    }
   }
 
   h5 {
@@ -132,6 +154,10 @@
   h1 {
     margin-block: 0;
     font-size: 2.25rem;
+
+    @include mq.for-phone-only {
+      font-size: 1.75rem;
+    }
   }
 
   a {


### PR DESCRIPTION
Anchors that included `<code>` elements rendered higher than surrounding text due to `inline-block` layout. Updated `.docs-anchor` to use `inline-flex` when a code block is present (`&:has(code)`), ensuring the anchor text and code align properly on the baseline.

Also added a small gap for better visual spacing between text and code.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<img width="1039" height="580" alt="image" src="https://github.com/user-attachments/assets/f0554ec4-d954-4224-91bb-7115d84c1e9c" />


Issue Number: N/A


## What is the new behavior?
<img width="1172" height="785" alt="Screenshot 2025-11-11 at 9 36 38 PM" src="https://github.com/user-attachments/assets/176ca5ba-5496-4c94-b41f-ec04d90a61d4" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
