### PR TITLE
docs: use shell language for command examples to enable prompt prefix

### DIFF
--- a/adev/src/content/ai/mcp-server-setup.md
+++ b/adev/src/content/ai/mcp-server-setup.md
@@ -27,7 +27,7 @@ Some tools are provided in experimental / preview status since they are new or n
 
 To get started, run the following command in your terminal:
 
-```bash
+```shell
 ng mcp
 ```
 

--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -6,7 +6,7 @@ Services are reusable pieces of code that can be shared across your Angular appl
 
 You can create a service with the [Angular CLI](tools/cli) with the following command:
 
-```bash
+```shell
 ng generate service CUSTOM_NAME
 ```
 

--- a/adev/src/content/guide/routing/route-guards.md
+++ b/adev/src/content/guide/routing/route-guards.md
@@ -8,7 +8,7 @@ Route guards are functions that control whether a user can navigate to or leave 
 
 You can generate a route guard using the Angular CLI:
 
-```bash
+```shell
 ng generate guard CUSTOM_NAME
 ```
 

--- a/adev/src/content/reference/migrations/ngclass-to-class.md
+++ b/adev/src/content/reference/migrations/ngclass-to-class.md
@@ -5,7 +5,7 @@ It will only migrate usages that are considered safe to migrate.
 
 Run the schematic using the following command:
 
-```bash
+```shell
 ng generate @angular/core:ngclass-to-class
 ```
 

--- a/adev/src/content/reference/migrations/ngstyle-to-style.md
+++ b/adev/src/content/reference/migrations/ngstyle-to-style.md
@@ -5,7 +5,7 @@ It will only migrate usages that are considered safe to migrate.
 
 Run the schematic using the following command:
 
-```bash
+```shell
 ng generate @angular/core:ngstyle-to-style
 ```
 

--- a/adev/src/content/reference/migrations/outputs.md
+++ b/adev/src/content/reference/migrations/outputs.md
@@ -9,7 +9,7 @@ provides an automated migration that converts `@Output` custom events to the new
 
 Run the schematic using the following command:
 
-```bash
+```shell
 ng generate @angular/core:output-migration
 ```
 
@@ -73,7 +73,7 @@ references outside this directory are silently skipped, potentially breaking you
 
 Use these options as shown below:
 
-```bash
+```shell
 ng generate @angular/core:output-migration --path src/app/sub-folder
 ```
 

--- a/adev/src/content/reference/migrations/signal-inputs.md
+++ b/adev/src/content/reference/migrations/signal-inputs.md
@@ -9,7 +9,7 @@ provides an automated migration that converts `@Input` fields to the new `input(
 
 Run the schematic using the following command:
 
-```bash
+```shell
 ng generate @angular/core:signal-input-migration
 ```
 

--- a/adev/src/content/reference/migrations/signal-queries.md
+++ b/adev/src/content/reference/migrations/signal-queries.md
@@ -9,7 +9,7 @@ provides an automated migration that converts existing decorator query fields to
 
 Run the schematic using the following command:
 
-```bash
+```shell
 ng generate @angular/core:signal-queries-migration
 ```
 


### PR DESCRIPTION
Updated fenced code blocks from `bash` to `shell` so docs-renderer shows the `$` prompt automatically. This improves consistency across command examples and clarifies user-executed commands.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
