### PR TITLE
refactor(forms): use `AbortSignal` to cancel debounced updates

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -111,7 +111,7 @@ export class CustomValidationError implements ValidationError {
 export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, durationOrDebouncer: number | Debouncer<TValue, TPathKind>): void;
 
 // @public
-export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (context: FieldContext<TValue, TPathKind>) => Promise<void> | void;
+export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (context: FieldContext<TValue, TPathKind>, abortSignal: AbortSignal) => Promise<void> | void;
 
 // @public
 export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic?: string | NoInfer<LogicFn<TValue, boolean | string, TPathKind>>): void;

--- a/packages/forms/signals/src/api/debounce.ts
+++ b/packages/forms/signals/src/api/debounce.ts
@@ -40,8 +40,11 @@ export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(
 }
 
 function debounceForDuration(durationInMilliseconds: number): Debouncer<unknown> {
-  return () => {
-    return new Promise((resolve) => setTimeout(resolve, durationInMilliseconds));
+  return (_context, abortSignal) => {
+    return new Promise((resolve) => {
+      const timeoutId = setTimeout(resolve, durationInMilliseconds);
+      abortSignal.addEventListener('abort', () => clearTimeout(timeoutId));
+    });
   };
 }
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -615,9 +615,9 @@ export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number
 /**
  * A function that defines custom debounce logic for a field.
  *
- * This function receives the {@link FieldContext} for the field and should return a `Promise<void>`
- * to delay an update, or `void` to apply an update immediately.
- *
+ * @param context The field context.
+ * @param abortSignal An `AbortSignal` used to communicate that the debounced operation was aborted.
+ * @returns A `Promise<void>` to debounce an update, or `void` to apply an update immediately.
  * @template TValue The type of value stored in the field.
  * @template TPathKind The kind of path the debouncer is applied to (root field, child field, or item of an array).
  *
@@ -625,4 +625,5 @@ export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number
  */
 export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (
   context: FieldContext<TValue, TPathKind>,
+  abortSignal: AbortSignal,
 ) => Promise<void> | void;

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -8,7 +8,7 @@
 
 import {computed, signal, Signal} from '@angular/core';
 import type {Field} from '../api/field_directive';
-import type {DisabledReason} from '../api/types';
+import type {Debouncer, DisabledReason} from '../api/types';
 import {DEBOUNCER} from './debounce';
 import type {FieldNode} from './node';
 import {reduceChildren, shortCircuitTrue} from './util';
@@ -158,23 +158,27 @@ export class FieldNodeState {
     return `${parent.name()}.${this.node.structure.keyInParent()}`;
   });
 
-  debouncer(): Promise<void> | void {
-    if (this.node.logicNode.logic.hasAggregateMetadata(DEBOUNCER)) {
-      const debouncerLogic = this.node.logicNode.logic.getAggregateMetadata(DEBOUNCER);
+  /**
+   * An optional {@link Debouncer} factory for this field.
+   */
+  readonly debouncer: Signal<((signal: AbortSignal) => Promise<void> | void) | undefined> =
+    computed(() => {
+      if (this.node.logicNode.logic.hasAggregateMetadata(DEBOUNCER)) {
+        const debouncerLogic = this.node.logicNode.logic.getAggregateMetadata(DEBOUNCER);
+        const debouncer = debouncerLogic.compute(this.node.context);
 
-      // Even if this field has a `debounce()` rule, it could be applied conditionally and currently
-      // inactive, in which case `compute()` will return undefined.
-      const debouncer = debouncerLogic.compute(this.node.context);
-      if (debouncer) {
-        return debouncer(this.node.context);
+        // Even if this field has a `debounce()` rule, it could be applied conditionally and currently
+        // inactive, in which case `compute()` will return undefined.
+        if (debouncer) {
+          return (signal) => debouncer(this.node.context, signal);
+        }
       }
-    }
 
-    // Inherit its parent's debouncer, if any. If there is no debouncer configured all the way up
-    // to the root field, this simply returns `undefined` indicating that the operation should not
-    // be debounced.
-    return this.node.structure.parent?.nodeState.debouncer();
-  }
+      // Fallback to the parent's debouncer, if any. If there is no debouncer configured all the way
+      // up to the root field, this simply returns `undefined` indicating that the operation should
+      // not be debounced.
+      return this.node.structure.parent?.nodeState.debouncer?.();
+    });
 
   /** Whether this field is considered non-interactive.
    *


### PR DESCRIPTION
Add an `AbortSignal` parameter to `Debouncer`. Implementations may choose to accept this parameter to be informed when a debounced operation is aborted. This may be useful for canceling pending timers or avoiding unnecessary work.