### PR TITLE
build: use mjs files for ng-dev configuration

### DIFF
--- a/.ng-dev/caretaker.mjs
+++ b/.ng-dev/caretaker.mjs
@@ -1,7 +1,9 @@
-import {CaretakerConfig} from '@angular/ng-dev';
-
-/** The configuration for `ng-dev caretaker` commands. */
-export const caretaker: CaretakerConfig = {
+/**
+ * The configuration for `ng-dev caretaker` commands.
+ *
+ * @type { import("@angular/ng-dev").CaretakerConfig }
+ */
+export const caretaker = {
   g3SyncConfigPath: './.ng-dev/google-sync-config.json',
   githubQueries: [
     {

--- a/.ng-dev/commit-message.mjs
+++ b/.ng-dev/commit-message.mjs
@@ -1,9 +1,9 @@
-import {CommitMessageConfig} from '@angular/ng-dev';
-
 /**
  * The configuration for `ng-dev commit-message` commands.
+ *
+ * @type { import("@angular/ng-dev").CommitMessageConfig }
  */
-export const commitMessage: CommitMessageConfig = {
+export const commitMessage = {
   maxLineLength: Infinity,
   minBodyLength: 20,
   minBodyLengthTypeExcludes: ['docs'],

--- a/.ng-dev/config.mjs
+++ b/.ng-dev/config.mjs
@@ -5,11 +5,4 @@ import {github} from './github.mjs';
 import {pullRequest} from './pull-request.mjs';
 import {release} from './release.mjs';
 
-export {
-  commitMessage,
-  format,
-  github,
-  pullRequest,
-  caretaker,
-  release,
-};
+export {commitMessage, format, github, pullRequest, caretaker, release};

--- a/.ng-dev/format.mjs
+++ b/.ng-dev/format.mjs
@@ -1,9 +1,9 @@
-import {FormatConfig} from '@angular/ng-dev';
-
 /**
  * Configuration for the `ng-dev format` command.
+ *
+ * @type { import("@angular/ng-dev").FormatConfig }
  */
-export const format: FormatConfig = {
+export const format = {
   'prettier': {
     'matchers': [
       '**/*.md',

--- a/.ng-dev/github.mjs
+++ b/.ng-dev/github.mjs
@@ -1,10 +1,10 @@
-import {GithubConfig} from '@angular/ng-dev';
-
 /**
  * Github configuration for the `ng-dev` command. This repository is used as
  * remote for the merge script and other utilities like `ng-dev pr rebase`.
+ *
+ * @type { import("@angular/ng-dev").GithubConfig }
  */
-export const github: GithubConfig = {
+export const github = {
   owner: 'angular',
   name: 'angular',
   mainBranchName: 'main',

--- a/.ng-dev/pull-request.mjs
+++ b/.ng-dev/pull-request.mjs
@@ -1,10 +1,10 @@
-import {PullRequestConfig} from '@angular/ng-dev';
-
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
  * are respected by the merge script (e.g. the target labels).
+ *
+ * @type { import("@angular/ng-dev").PullRequestConfig }
  */
-export const pullRequest: PullRequestConfig = {
+export const pullRequest = {
   githubApiMerge: {
     default: 'auto',
     labels: [{pattern: 'merge: squash commits', method: 'squash'}],

--- a/.ng-dev/release.mjs
+++ b/.ng-dev/release.mjs
@@ -1,7 +1,9 @@
-import {ReleaseConfig} from '@angular/ng-dev';
-
-/** Configuration for the `ng-dev release` command. */
-export const release: ReleaseConfig = {
+/**
+ * Configuration for the `ng-dev release` command.
+ *
+ * @type { import("@angular/ng-dev").ReleaseConfig }
+ */
+export const release = {
   publishRegistry: 'https://wombat-dressing-room.appspot.com',
   representativeNpmPackage: '@angular/core',
   npmPackages: [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "symbol-extractor:check": "node tools/symbol-extractor/run_all_symbols_extractor_tests.js test",
     "symbol-extractor:update": "node tools/symbol-extractor/run_all_symbols_extractor_tests.js accept",
     "ts-circular-deps:check": "pnpm -s ng-dev ts-circular-deps check --config ./packages/circular-deps-test.conf.js",
-    "check-tooling-setup": "tsc --project .ng-dev/tsconfig.json && tsc --project scripts/tsconfig.json",
+    "check-tooling-setup": "tsc --project scripts/tsconfig.json",
     "devtools:devserver": "ibazel run //devtools/src:devserver",
     "devtools:test:e2e": "cypress run --project ./devtools/cypress",
     "devtools:e2e:open": "cypress open --project ./devtools/cypress",


### PR DESCRIPTION
In preperation for ng-dev requiring mjs files for configuration, switch over our usage
