### PR TITLE
refactor(devtools): add matcher and runGuardsAndResolvers support in …

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -350,6 +350,65 @@ describe('parseRoutes', () => {
     expect(parsedRoutes.children![0].canDeactivateGuards).toEqual(['CanDeactivateGuard']);
   });
 
+  it('should handle matcher function', () => {
+    function customMatcher() {
+      return null;
+    }
+
+    const nestedRouter = {
+      config: [
+        {
+          matcher: customMatcher,
+          component: {name: 'MatcherComponent'},
+        },
+      ],
+    };
+
+    const parsedRoutes = parseRoutes(nestedRouter as any);
+    expect(parsedRoutes.children![0].matcher).toEqual('customMatcher()');
+    expect(parsedRoutes.children![0].path).toEqual('[Matcher]');
+  });
+
+  it('should handle runGuardsAndResolvers with string values', () => {
+    const nestedRouter = {
+      config: [
+        {
+          path: 'always',
+          component: {name: 'Component'},
+          runGuardsAndResolvers: 'always',
+        },
+        {
+          path: 'params',
+          component: {name: 'Component2'},
+          runGuardsAndResolvers: 'paramsOrQueryParamsChange',
+        },
+      ],
+    };
+
+    const parsedRoutes = parseRoutes(nestedRouter as any);
+    expect(parsedRoutes.children![0].runGuardsAndResolvers).toEqual('always');
+    expect(parsedRoutes.children![1].runGuardsAndResolvers).toEqual('paramsOrQueryParamsChange');
+  });
+
+  it('should handle runGuardsAndResolvers with function', () => {
+    function customRerunLogic() {
+      return true;
+    }
+
+    const nestedRouter = {
+      config: [
+        {
+          path: 'custom',
+          component: {name: 'Component'},
+          runGuardsAndResolvers: customRerunLogic,
+        },
+      ],
+    };
+
+    const parsedRoutes = parseRoutes(nestedRouter as any);
+    expect(parsedRoutes.children![0].runGuardsAndResolvers).toEqual('customRerunLogic()');
+  });
+
   it('should handle resolvers with named functions', () => {
     function userResolver() {
       return {id: 1, name: 'User'};

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -49,15 +49,27 @@
           <!-- TODO: Convert to a description list (<dl>) -->
           <div class="scrollable-wrapper">
             <table class="ng-table">
-              <tr
-                ng-route-details-row
-                label="Path"
-                dataKey="path"
-                [data]="data"
-                actionBtnType="navigate"
-                [actionBtnTooltip]="'Navigate to ' + data.path"
-                (actionBtnClick)="navigateRoute(route)"
-              ></tr>
+              @if (!data.matcher) {
+                <tr
+                  ng-route-details-row
+                  label="Path"
+                  dataKey="path"
+                  [data]="data"
+                  actionBtnType="navigate"
+                  [actionBtnTooltip]="'Navigate to ' + data.path"
+                  (actionBtnClick)="navigateRoute(route)"
+                ></tr>
+              } @else {
+                <tr
+                  ng-route-details-row
+                  label="Matcher"
+                  dataKey="matcher"
+                  [data]="data"
+                  actionBtnType="view-source"
+                  actionBtnTooltip="View source"
+                  (actionBtnClick)="viewFunctionSource(data.matcher, 'matcher')"
+                ></tr>
+              }
 
               @if (!data.redirectTo) {
                 <tr
@@ -176,6 +188,19 @@
                   (actionBtnClick)="viewFunctionSource(data.title, 'title')"
                 ></tr>
               }
+
+              @if (data.runGuardsAndResolvers) {
+                <tr
+                  ng-route-details-row
+                  label="RunGuardsAndResolvers"
+                  dataKey="runGuardsAndResolvers"
+                  [data]="data"
+                  actionBtnTooltip="View source"
+                  [actionBtnType]="hasStaticOptionRunGuardsAndResolvers() ? 'none' : 'view-source'"
+                  (actionBtnClick)="viewFunctionSource(data.runGuardsAndResolvers, 'runGuardsAndResolvers')"
+                ></tr>
+              }
+
               <tr
                 ng-route-details-row
                 label="Active"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -24,7 +24,7 @@ import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 import {ApplicationOperations} from '../../application-operations/index';
 import {RouteDetailsRowComponent} from './route-details-row.component';
 import {FrameManager} from '../../application-services/frame_manager';
-import {Events, MessageBus, Route} from '../../../../../protocol';
+import {Events, MessageBus, Route, RunGuardsAndResolvers} from '../../../../../protocol';
 import {SvgD3Node, TreeVisualizerConfig} from '../../shared/tree-visualizer/tree-visualizer';
 import {
   RouterTreeD3Node,
@@ -39,6 +39,13 @@ import {SplitAreaDirective} from '../../shared/split/splitArea.directive';
 import {Debouncer} from '../../shared/utils/debouncer';
 
 const SEARCH_DEBOUNCE = 250;
+const RUN_GUARDS_AND_RESOLVERS_OPTIONS: RunGuardsAndResolvers[] = [
+  'pathParamsChange',
+  'pathParamsOrQueryParamsChange',
+  'always',
+  'paramsChange',
+  'paramsOrQueryParamsChange',
+];
 
 @Component({
   selector: 'ng-router-tree',
@@ -69,8 +76,14 @@ export class RouterTreeComponent {
     return this.selectedRoute()?.data;
   });
 
-  readonly routes = input.required<Route[]>();
-  readonly routerDebugApiSupport = input(false);
+  protected hasStaticOptionRunGuardsAndResolvers = computed(() =>
+    RUN_GUARDS_AND_RESOLVERS_OPTIONS.includes(
+      this.routeData()?.runGuardsAndResolvers as RunGuardsAndResolvers,
+    ),
+  );
+
+  routes = input.required<Route[]>();
+  routerDebugApiSupport = input<boolean>(false);
 
   private readonly showFullPath = signal(false);
   protected readonly d3RootNode = linkedSignal<RouterTreeNode | null>(() => {
@@ -150,7 +163,10 @@ export class RouterTreeComponent {
     );
   }
 
-  viewFunctionSource(functionName: string, type: 'title' | 'redirectTo'): void {
+  viewFunctionSource(
+    functionName: string,
+    type: 'title' | 'redirectTo' | 'matcher' | 'runGuardsAndResolvers',
+  ): void {
     if (functionName === '[Function]') {
       const message =
         'Cannot view the source of redirect functions defined inline (arrow or anonymous).';

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -330,7 +330,18 @@ export interface Route {
   isActive: boolean;
   isAux: boolean;
   isLazy: boolean;
+  matcher?: string;
+  runGuardsAndResolvers?:
+    | 'pathParamsChange'
+    | 'pathParamsOrQueryParamsChange'
+    | 'paramsChange'
+    | 'paramsOrQueryParamsChange'
+    | 'always'
+    | (string & {});
 }
+
+type OnlyLiterals<T> = T extends string ? (string extends T ? never : T) : never;
+export type RunGuardsAndResolvers = OnlyLiterals<Route['runGuardsAndResolvers']>;
 
 export interface AngularDetection {
   // This is necessary because the runtime

--- a/devtools/src/app/demo-app/todo/routes/routes.module.ts
+++ b/devtools/src/app/demo-app/todo/routes/routes.module.ts
@@ -15,6 +15,7 @@ import {
   ActivatedRouteSnapshot,
   Resolve,
   ResolveFn,
+  UrlSegment,
 } from '@angular/router';
 
 import {
@@ -42,6 +43,17 @@ export const activateGuard: CanActivateFn = (
   return true;
 };
 
+export const customMatcher = (url: UrlSegment[]) => {
+  if (url.length === 1 && url[0].path === 'custom-matcher') {
+    return {consumed: url};
+  }
+  return null;
+};
+
+export function customRerunLogic() {
+  return true;
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -67,6 +79,21 @@ export const activateGuard: CanActivateFn = (
         path: 'route-standalone',
         providers: [Service1, Service2, Service3, Service4],
         loadComponent: () => import('./routes.component').then((x) => x.RoutesStandaloneComponent),
+      },
+      {
+        matcher: customMatcher,
+        component: RoutesHomeComponent,
+      },
+      {
+        path: 'route-run-guards-and-resolvers',
+        component: RoutesHomeComponent,
+        canActivate: [activateGuard],
+        runGuardsAndResolvers: 'always',
+      },
+      {
+        path: 'route-run-guards-and-resolvers-function',
+        component: RoutesHomeComponent,
+        runGuardsAndResolvers: customRerunLogic,
       },
       {
         path: 'route-data',


### PR DESCRIPTION
…router viewer

Enhance the Angular DevTools router viewer to display routes that use custom `matcher` functions and reflect the `runGuardsAndResolvers` configuration

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<img width="359" height="296" alt="image" src="https://github.com/user-attachments/assets/fbfaa383-f32e-4e1a-97c3-a80073f06db3" />
<img width="356" height="325" alt="image" src="https://github.com/user-attachments/assets/f7113867-25e0-4937-8284-c8a071e4d33a" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Question : 
When a `matcher` is used, the `path` property is not allowed. However, in the router viewer, it currently displays as `/undefined`.
We should consider replacing `/undefined` with a more descriptive label.
<img width="272" height="287" alt="image" src="https://github.com/user-attachments/assets/a6f20877-8364-4912-af95-a3496b8bec32" />

