### PR TITLE
refactor(core): flip ngDevMode condition for formatter

### DIFF
--- a/packages/core/primitives/signals/index.ts
+++ b/packages/core/primitives/signals/index.ts
@@ -70,7 +70,9 @@ export {installDevToolsSignalFormatter} from './src/formatter';
 declare const ngDevMode: boolean | undefined;
 
 // We're using a top-level access to enable signal formatting whenever the signals package is loaded.
-if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+// ngDevMode might not have been init correctly yet, checking for `undefined` ensures that in case
+// it is not defined yet, we still install the formatter.
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
   // tslint:disable-next-line: no-toplevel-property-access
   installDevToolsSignalFormatter();
 }


### PR DESCRIPTION
In cases the `ngDevMode` flag hasn't been set, still enable the formatter. What matters is if `ngDevMode` is `false ` we tree shake that away.
