### PR TITLE
build: allow any version of @angular/* packages for peer dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,3 +49,8 @@ minimumReleaseAgeExclude:
   - '@ngtools/webpack'
   - '@schematics/*'
   - 'ng-packagr'
+
+# Allow any version of @angular/* packages to satisfy peer dependencies, as these are managed within the monorepo.
+peerDependencyRules:
+  allowAny:
+    - '@angular/*'


### PR DESCRIPTION
This change configures pnpm to allow any version of  `@angular/*` packages to satisfy peer dependencies. This is necessary because `@angular/*` packages are managed within this monorepo, and this rule prevents issues with peer dependency resolution when different versions might be present during development or testing.
