### PR TITLE
fix(docs-infra): add bash language support for shell prompt rendering

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
@@ -126,12 +126,15 @@ function applyContainerAttributesAndClasses(el: Element, token: CodeToken) {
   if (token.hideCode) {
     el.setAttribute('hideCode', 'true');
   }
-  if (token.language === 'mermaid') {
+
+  const language = token.language;
+
+  if (language === 'mermaid') {
     el.setAttribute('mermaid', 'true');
   }
 
   // Classes
-  if (token.language === 'shell') {
+  if (language === 'shell' || language === 'bash') {
     el.classList.add('shell');
   }
 


### PR DESCRIPTION
Code blocks with `bash` language identifier were not rendering the `$` prefix, while `shell` blocks did. This adds support for `bash` by:
- Adding `.bash` class in the code formatting pipeline
- Updating CSS to style `.bash` blocks identically to `.shell`

This ensures consistent command-line prompt rendering across both `bash` and `shell` code blocks in the documentation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
