### PR TITLE
refactor(compiler-cli): rework type checking for signal forms 

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -2597,8 +2597,10 @@ describe('type check blocks', () => {
 
     it('should generate a string field for an input without a type', () => {
       const block = tcb('<input [field]="f"/>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as i0.Field<string>;');
-      expect(block).toContain('_t1.field = (((this).f));');
+      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
 
     [
@@ -2616,21 +2618,27 @@ describe('type check blocks', () => {
     ].forEach(({inputType, expectedType}) => {
       it(`should generate a '${expectedType}' field for an input with a '${inputType}' type`, () => {
         const block = tcb(`<input type="${inputType}" [field]="f"/>`, [FieldMock]);
-        expect(block).toContain(`var _t1 = null! as i0.Field<${expectedType}>;`);
-        expect(block).toContain('_t1.field = (((this).f));');
+        expect(block).toContain(`var _t1 = null! as ${expectedType};`);
+        expect(block).toContain('_t1 = ((this).f)().value();');
+        expect(block).toContain('var _t2 = null! as i0.Field;');
+        expect(block).toContain('_t2.field = (((this).f));');
       });
     });
 
     it('should generate a string field for a textarea', () => {
       const block = tcb('<textarea [field]="f"></textarea>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as i0.Field<string>;');
-      expect(block).toContain('_t1.field = (((this).f));');
+      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
 
     it('should generate a string field for a select', () => {
       const block = tcb('<select [field]="f"></select>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as i0.Field<string>;');
-      expect(block).toContain('_t1.field = (((this).f));');
+      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('_t1 = ((this).f)().value();');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
 
     it('should generate a custom value control', () => {
@@ -2655,12 +2663,12 @@ describe('type check blocks', () => {
         },
       ]);
 
+      expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        'var _t1 = null! as i0.Field<i1.ɵExtractFormControlValue<i0.CustomControl>>;',
+        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
-      expect(block).toContain('var _t2 = null! as i2.FormValueControl<any>;');
-      expect(block).toContain('if (_t2) _t2 = null! as i0.CustomControl;');
-      expect(block).toContain('_t1.field = (((this).f));');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
 
     it('should generate a custom checkbox control', () => {
@@ -2685,12 +2693,112 @@ describe('type check blocks', () => {
         },
       ]);
 
+      expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        'var _t1 = null! as i0.Field<i1.ɵExtractFormControlValue<i0.CustomControl>>;',
+        '_t1.checked[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
-      expect(block).toContain('var _t2 = null! as i2.FormCheckboxControl;');
-      expect(block).toContain('if (_t2) _t2 = null! as i0.CustomControl;');
-      expect(block).toContain('_t1.field = (((this).f));');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
+    });
+
+    it('should add implicit bindings to other field-related inputs on a custom control', () => {
+      const block = tcb('<custom-control [field]="f"/>', [
+        FieldMock,
+        {
+          type: 'directive',
+          name: 'CustomControl',
+          selector: 'custom-control',
+          inputs: {
+            value: {
+              classPropertyName: 'value',
+              bindingPropertyName: 'value',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+            required: {
+              classPropertyName: 'required',
+              bindingPropertyName: 'required',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+            disabled: {
+              classPropertyName: 'disabled',
+              bindingPropertyName: 'disabled',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+            name: {
+              classPropertyName: 'name',
+              bindingPropertyName: 'name',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+          },
+          outputs: {
+            valueChange: 'valueChange',
+          },
+        },
+      ]);
+
+      expect(block).toContain('var _t1 = null! as i0.CustomControl;');
+      expect(block).toContain(
+        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+      );
+      expect(block).toContain(
+        '_t1.required[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).required());',
+      );
+      expect(block).toContain(
+        '_t1.disabled[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).disabled());',
+      );
+      expect(block).toContain(
+        '_t1.name[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).name());',
+      );
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
+    });
+
+    it('should produce safe reads for the fields that are optional', () => {
+      const block = tcb('<custom-control [field]="f"/>', [
+        FieldMock,
+        {
+          type: 'directive',
+          name: 'CustomControl',
+          selector: 'custom-control',
+          inputs: {
+            value: {
+              classPropertyName: 'value',
+              bindingPropertyName: 'value',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+            max: {
+              classPropertyName: 'max',
+              bindingPropertyName: 'max',
+              required: false,
+              isSignal: true,
+              transform: null,
+            },
+          },
+          outputs: {
+            valueChange: 'valueChange',
+          },
+        },
+      ]);
+
+      expect(block).toContain('var _t1 = null! as i0.CustomControl;');
+      expect(block).toContain(
+        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+      );
+      expect(block).toContain(
+        '_t1.max[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((0 as any ? (((((this).f)()).max))!() : undefined));',
+      );
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
   });
 });

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -489,7 +489,6 @@ export class Identifiers {
   // type-checking
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
   static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
-  static ExtractFormControlValue = {name: 'ɵExtractFormControlValue', moduleName: CORE};
   static unwrapWritableSignal = {name: 'ɵunwrapWritableSignal', moduleName: CORE};
   static assertType = {name: 'ɵassertType', moduleName: CORE};
 }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -95,7 +95,6 @@ export {
   ɵɵcontentQuerySignal,
   ɵɵcontrol,
   ɵɵcontrolCreate,
-  ɵExtractFormControlValue,
   ɵɵcomponentInstance,
   ɵɵdefineComponent,
   ɵɵdefineDirective,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -96,7 +96,6 @@ export {
   ɵɵproperty,
   ɵɵcontrol,
   ɵɵcontrolCreate,
-  ɵExtractFormControlValue,
   ɵɵcontentQuery,
   ɵɵcontentQuerySignal,
   ɵɵloadQuery,

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -33,18 +33,6 @@ import {listenToOutput} from '../view/directive_outputs';
 import {listenToDomEvent, wrapListener} from '../view/listeners';
 import {setPropertyAndInputs, storePropertyBindingMetadata} from './shared';
 import {writeToDirectiveInput} from './write_to_directive_input';
-import {ModelSignal} from '../../authoring/model/model_signal';
-
-/**
- * Used during template type checking to extract the type of a custom form control.
- *
- * @codeGenApi
- */
-export type ɵExtractFormControlValue<T> = T extends {value: ModelSignal<infer V>}
-  ? V
-  : T extends {checked: ModelSignal<boolean>}
-    ? boolean
-    : unknown;
 
 /**
  * Possibly sets up a {@link ɵControl} to manage a native or custom form control.

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -38,7 +38,6 @@ const AOT_ONLY = new Set<string>([
 
   // used in type-checking.
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
-  'ɵExtractFormControlValue',
   'ɵUnwrapDirectiveSignalInputs',
   'ɵunwrapWritableSignal',
   'ɵassertType',


### PR DESCRIPTION
Reworks the way we approach type checking of signal forms to be closer to the behavior at runtime. There are a couple of scenarios that we handle:

1. For native controls, we now produce simplified type checking code that looks as follows:

```
var t1 = null! as number | string; // Type depends on the input `type`.
t1 = someField().value();
```

2. For custom controls we generate bindings to the individual inputs, rather than checking conformance against `FormValueControl`/`FormCheckboxControl`. This is closer to the behavior at runtime and it allows us to handle generic directives properly.