### PR TITLE
docs: adds guide references to router APIs

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -101,6 +101,8 @@ import {RouterLink} from './router_link';
  *
  * @ngModule RouterModule
  *
+ * @see [Detect active current route with RouterLinkActive](guide/routing/read-route-state#detect-active-current-route-with-routerlinkactive)
+ *
  * @publicApi
  */
 @Directive({

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -26,6 +26,8 @@ export const IMPERATIVE_NAVIGATION = 'imperative';
 /**
  * Identifies the type of a router event.
  *
+ * @see [Router Lifecycle and Events](guide/routing/lifecycle-and-events)
+ *
  * @publicApi
  */
 export enum EventType {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -175,6 +175,7 @@ export type UrlMatchResult = {
  * export const routes = [{ matcher: htmlFiles, component: AnyComponent }];
  * ```
  *
+ * @see [Creating custom route matches](guide/routing/routing-with-urlmatcher)
  * @publicApi
  */
 export type UrlMatcher = (
@@ -334,6 +335,7 @@ export type RedirectFunction = (
  * change or query params have changed. This does not include matrix parameters.
  *
  * @see {@link Route#runGuardsAndResolvers}
+ * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior#control-when-guards-and-resolvers-execute)
  * @publicApi
  */
 export type RunGuardsAndResolvers =
@@ -575,6 +577,7 @@ export interface Route {
    * implements `Resolve`.
    *
    * @see {@link TitleStrategy}
+   * @see [Page titles](guide/routing/define-routes#page-titles)
    */
   title?: string | Type<Resolve<string>> | ResolveFn<string>;
 
@@ -604,10 +607,15 @@ export interface Route {
    * the router would apply the redirect even when navigating
    * to the redirect destination, creating an endless loop.
    *
+   * @see [Redirecting Routes](guide/routing/redirecting-routes)
+   *
    */
   pathMatch?: 'prefix' | 'full';
   /**
    * A custom URL-matching function. Cannot be used together with `path`.
+   *
+   * @see [Creating custom route matches](guide/routing/routing-with-urlmatcher)
+   *
    */
   matcher?: UrlMatcher;
   /**
@@ -642,11 +650,16 @@ export interface Route {
    * required dependencies.
    *
    * When not present, router does not redirect.
+   *
+   * @see [Conditional redirects](guide/routing/redirecting-routes#conditional-redirects)
    */
   redirectTo?: string | RedirectFunction;
   /**
    * Name of a `RouterOutlet` object where the component can be placed
    * when the path matches.
+   *
+   * @see [Show routes with outlets](guide/routing/show-routes-with-outlets)
+   *
    */
   outlet?: string;
   /**
@@ -656,6 +669,9 @@ export interface Route {
    *
    * When using a function rather than DI tokens, the function can call `inject` to get any required
    * dependencies. This `inject` call must be done in a synchronous context.
+   *
+   * @see [CanActivate](guide/routing/route-guards#canactivate)
+   *
    */
   canActivate?: Array<CanActivateFn | DeprecatedGuard>;
   /**
@@ -665,6 +681,9 @@ export interface Route {
    *
    * When using a function rather than DI tokens, the function can call `inject` to get any required
    * dependencies. This `inject` call must be done in a synchronous context.
+   *
+   * @see [CanMatch](guide/routing/route-guards#canmatch)
+   *
    */
   canMatch?: Array<CanMatchFn | DeprecatedGuard>;
   /**
@@ -674,6 +693,9 @@ export interface Route {
    *
    * When using a function rather than DI tokens, the function can call `inject` to get any required
    * dependencies. This `inject` call must be done in a synchronous context.
+   *
+   * @see [CanActivateChild](guide/routing/route-guards#canactivatechild)
+   *
    */
   canActivateChild?: Array<CanActivateChildFn | DeprecatedGuard>;
   /**
@@ -683,6 +705,9 @@ export interface Route {
    *
    * When using a function rather than DI tokens, the function can call `inject` to get any required
    * dependencies. This `inject` call must be done in a synchronous context.
+   *
+   * @see [CanDeactivate](guide/routing/route-guards#candeactivate)
+   *
    */
   canDeactivate?: Array<CanDeactivateFn<any> | DeprecatedGuard>;
   /**
@@ -702,6 +727,8 @@ export interface Route {
   data?: Data;
   /**
    * A map of DI tokens used to look up data resolvers. See `Resolve`.
+   *
+   * @see [Resolve](guide/routing/data-resolvers#what-are-data-resolvers)
    */
   resolve?: ResolveData;
   /**
@@ -733,6 +760,7 @@ export interface Route {
    * change or query params have changed. This does not include matrix parameters.
    *
    * @see {@link RunGuardsAndResolvers}
+   * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior#control-when-guards-and-resolvers-execute)
    */
   runGuardsAndResolvers?: RunGuardsAndResolvers;
 
@@ -743,6 +771,7 @@ export interface Route {
    * `Route` and use it for this `Route` and its `children`. If this
    * route also has a `loadChildren` function which returns an `NgModuleRef`, this injector will be
    * used as the parent of the lazy loaded module.
+   * @see [Route providers](guide/di/defining-dependency-providers#route-providers)
    */
   providers?: Array<Provider | EnvironmentProviders>;
 
@@ -821,6 +850,9 @@ export interface LoadedRouterConfig {
  * class AppModule {}
  * ```
  *
+ * @see [CanActivate](guide/routing/route-guards#canactivate)
+ *
+ *
  * @publicApi
  */
 export interface CanActivate {
@@ -878,6 +910,7 @@ export interface CanActivate {
  *
  * @publicApi
  * @see {@link Route}
+ * @see [CanActivate](guide/routing/route-guards#canactivate)
  */
 export type CanActivateFn = (
   route: ActivatedRouteSnapshot,
@@ -939,7 +972,7 @@ export type CanActivateFn = (
  * })
  * class AppModule {}
  * ```
- *
+ * @see [CanActivateChild](guide/routing/route-guards#canactivatechild)
  * @publicApi
  */
 export interface CanActivateChild {
@@ -963,6 +996,7 @@ export interface CanActivateChild {
  *
  * @publicApi
  * @see {@link Route}
+ * @see [CanActivateChild](guide/routing/route-guards#canactivatechild)
  */
 export type CanActivateChildFn = (
   childRoute: ActivatedRouteSnapshot,
@@ -1021,7 +1055,7 @@ export type CanActivateChildFn = (
  * })
  * class AppModule {}
  * ```
- *
+ * @see [CanDeactivate](guide/routing/route-guards#candeactivate)
  * @publicApi
  */
 export interface CanDeactivate<T> {
@@ -1047,6 +1081,7 @@ export interface CanDeactivate<T> {
  *
  * @publicApi
  * @see {@link Route}
+ * @see [CanDeactivate](guide/routing/route-guards#candeactivate)
  */
 export type CanDeactivateFn<T> = (
   component: T,
@@ -1114,6 +1149,7 @@ export type CanDeactivateFn<T> = (
  * could not be used for a URL match but the catch-all `**` `Route` did instead.
  *
  * @publicApi
+ * @see [CanMatch](guide/routing/route-guards#canmatch)
  */
 export interface CanMatch {
   canMatch(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
@@ -1136,6 +1172,7 @@ export interface CanMatch {
  *
  * @publicApi
  * @see {@link Route}
+ * @see [CanMatch](guide/routing/route-guards#canmatch)
  */
 export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;
 
@@ -1230,6 +1267,7 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<Gu
  *
  * @publicApi
  * @see {@link ResolveFn}
+ * @see [Data resolvers](guide/routing/data-resolvers)
  */
 export interface Resolve<T> {
   resolve(
@@ -1339,6 +1377,7 @@ export interface Resolve<T> {
  *
  * @publicApi
  * @see {@link Route}
+ * @see [Data resolvers](guide/routing/data-resolvers)
  */
 export type ResolveFn<T> = (
   route: ActivatedRouteSnapshot,

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -591,6 +591,8 @@ export type PreloadingFeature = RouterFeature<RouterFeatureKind.PreloadingFeatur
  *     should be used.
  * @returns A set of providers for use with `provideRouter`.
  *
+ * @see [Preloading strategy](guide/routing/customizing-route-behavior#preloading-strategy)
+ *
  * @publicApi
  */
 export function withPreloading(preloadingStrategy: Type<PreloadingStrategy>): PreloadingFeature {
@@ -636,6 +638,8 @@ export type RouterConfigurationFeature =
  * @param options A set of parameters to configure Router, see `RouterConfigOptions` for
  *     additional information.
  * @returns A set of providers for use with `provideRouter`.
+ *
+ * @see [Router configuration options](guide/routing/customizing-route-behavior#router-configuration-options)
  *
  * @publicApi
  */
@@ -724,6 +728,7 @@ export type NavigationErrorHandlerFeature =
  * @see {@link NavigationError}
  * @see {@link /api/core/inject inject}
  * @see {@link runInInjectionContext}
+ * @see [Centralize error handling in withNavigationErrorHandler](guide/routing/data-resolvers#centralize-error-handling-in-withnavigationerrorhandler)
  *
  * @returns A set of providers for use with `provideRouter`.
  *
@@ -834,6 +839,7 @@ export function withComponentInputBinding(): ComponentInputBindingFeature {
  * @returns A set of providers for use with `provideRouter`.
  * @see https://developer.chrome.com/docs/web-platform/view-transitions/
  * @see https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API
+ * @see [Route transition animations](guide/routing/route-transition-animations)
  * @developerPreview 19.0
  */
 export function withViewTransitions(

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -315,6 +315,8 @@ export function getInherited(
  * }
  * ```
  *
+ * @see [Understanding route snapshots](guide/routing/read-route-state#understanding-route-snapshots)
+ *
  * @publicApi
  */
 export class ActivatedRouteSnapshot {


### PR DESCRIPTION
Adds `@see` tags with links to relevant guides in the router documentation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
