### PR TITLE
docs(forms): add FormArrayDirective documentation to reactive forms g…

### DIFF
--- a/adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.html
+++ b/adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.html
@@ -1,0 +1,9 @@
+<form [formArray]="hobbies">
+  @for (hobby of hobbies.controls; track $index) {
+    <div>
+      <input type="text" [formControlName]="$index" />
+      <button type="button" (click)="removeHobby($index)">Remove</button>
+    </div>
+  }
+  <button type="button" (click)="addHobby()">Add Hobby</button>
+</form>

--- a/adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.ts
@@ -1,0 +1,23 @@
+import {Component} from '@angular/core';
+import {FormArray, FormControl, ReactiveFormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'app-standalone-array',
+  templateUrl: './standalone-array.component.html',
+  imports: [ReactiveFormsModule],
+})
+export class StandaloneArrayComponent {
+  hobbies = new FormArray([
+    new FormControl('Reading'),
+    new FormControl('Gaming'),
+    new FormControl('Hiking'),
+  ]);
+
+  addHobby() {
+    this.hobbies.push(new FormControl(''));
+  }
+
+  removeHobby(index: number) {
+    this.hobbies.removeAt(index);
+  }
+}

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -388,6 +388,20 @@ Initially, the form contains one `Alias` field. To add another field, click the 
 
 </docs-workflow>
 
+### Using FormArrayDirective with FormArray
+
+Similar to how `FormControlDirective` syncs a `FormControl` to a form element, `FormArrayDirective` lets you bind a `FormArray` instance directly to a DOM element using the `[formArray]` directive.
+
+This is useful when you want to work with a `FormArray` outside of a parent `FormGroup`, providing consistency across all reactive form control types.
+
+FormGroup would be a better comparison as both FormGroupDirective & FormArrayDirective allow you to have a FormArray as a top-level object for a form.
+
+<docs-code header="standalone-array.component.ts (FormArray)" path="adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.ts" visibleRegion="standalone-array"/>
+
+<docs-code header="standalone-array.component.html (template)" path="adev/src/content/examples/reactive-forms/src/app/standalone-array/standalone-array.component.html" />
+
+The `[formArray]` directive binds the `FormArray` instance directly to the container element, while `formControlName` binds each control within the array by its index.
+
 ## Unified control state change events
 
 All form controls expose a single unified stream of **control state change events** through the `events` observable on `AbstractControl` (`FormControl`, `FormGroup`, `FormArray`, and `FormRecord`).
@@ -542,3 +556,4 @@ For complete syntax details, see the API reference documentation for the [Forms 
 | `FormGroupDirective`   | Syncs an existing `FormGroup` instance to a DOM element.                                   |
 | `FormGroupName`        | Syncs a nested `FormGroup` instance to a DOM element.                                      |
 | `FormArrayName`        | Syncs a nested `FormArray` instance to a DOM element.                                      |
+| `FormArrayDirective`   | Syncs a `FormArray` instance to a DOM element.                                             |


### PR DESCRIPTION
…uide

Adds documentation for the FormArrayDirective that was introduced in v21. Includes usage examples and API reference entry in the reactive forms guide.

Closes #65136

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65136


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
