### PR TITLE
docs: Add prettier ignore comments to code blocks

### DIFF
--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -15,6 +15,7 @@ There are two categories of query: **view queries** and **content queries.**
 
 View queries retrieve results from the elements in the component's _view_ — the elements defined in the component's own template. You can query for a single result with the `viewChild` function.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[14, 15]">
 @Component({
   selector: 'custom-card-header',
@@ -25,14 +26,15 @@ export class CustomCardHeader {
 }
 
 @Component({
-selector: 'custom-card',
-template: '<custom-card-header>Visit sunny California!</custom-card-header>',
+  selector: 'custom-card',
+  template: '<custom-card-header>Visit sunny California!</custom-card-header>',
 })
 export class CustomCard {
-header = viewChild(CustomCardHeader);
-headerText = computed(() => this.header()?.text);
+  header = viewChild(CustomCardHeader);
+  headerText = computed(() => this.header()?.text);
 }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 In this example, the `CustomCard` component queries for a child `CustomCardHeader` and uses the result in a `computed`.
 
@@ -40,6 +42,7 @@ If the query does not find a result, its value is `undefined`. This may occur if
 
 You can also query for multiple results with the `viewChildren` function.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[17, 19, 20, 21, 22, 23]">
 @Component({
   selector: 'custom-card-action',
@@ -50,16 +53,18 @@ export class CustomCardAction {
 }
 
 @Component({
-selector: 'custom-card',
-template: `     <custom-card-action>Save</custom-card-action>
+  selector: 'custom-card',
+  template: `
+    <custom-card-action>Save</custom-card-action>
     <custom-card-action>Cancel</custom-card-action>
   `,
 })
 export class CustomCard {
-actions = viewChildren(CustomCardAction);
-actionsTexts = computed(() => this.actions().map(action => action.text);
+  actions = viewChildren(CustomCardAction);
+  actionsTexts = computed(() => this.actions().map(action => action.text));
 }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 `viewChildren` creates a signal with an `Array` of the query results.
 
@@ -69,6 +74,7 @@ actionsTexts = computed(() => this.actions().map(action => action.text);
 
 Content queries retrieve results from the elements in the component's _content_— the elements nested inside the component in the template where it's used. You can query for a single result with the `contentChild` function.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[14, 15]">
 @Component({
   selector: 'custom-toggle',
@@ -79,24 +85,26 @@ export class CustomToggle {
 }
 
 @Component({
-selector: 'custom-expando',
-/_..._/
+  selector: 'custom-expando',
+  /_..._/
 })
 export class CustomExpando {
-toggle = contentChild(CustomToggle);
-toggleText = computed(() => this.toggle()?.text);
+  toggle = contentChild(CustomToggle);
+  toggleText = computed(() => this.toggle()?.text);
 }
 
 @Component({
-/_ ... _/
-// CustomToggle is used inside CustomExpando as content.  
- template: `     <custom-expando>
+  /_ ... _/
+  // CustomToggle is used inside CustomExpando as content.
+  template: `
+    <custom-expando>
       <custom-toggle>Show</custom-toggle>
     </custom-expando>
-  `
+    `
 })
 export class UserProfile { }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 In this example, the `CustomExpando` component queries for a child `CustomToggle` and accesses the result in a `computed`.
 
@@ -106,7 +114,8 @@ By default, content queries find only _direct_ children of the component and do 
 
 You can also query for multiple results with the `contentChildren` function.
 
-<docs-code language="angular-ts" highlight="[14, 16, 17, 18, 19, 20]">
+<!-- prettier-ignore-start -->
+<docs-code language="angular-ts" highlight="[14, 21, 22, 23, 24]">
 @Component({
   selector: 'custom-menu-item',
   /*...*/
@@ -116,17 +125,18 @@ export class CustomMenuItem {
 }
 
 @Component({
-selector: 'custom-menu',
-/_..._/
+  selector: 'custom-menu',
+  /_..._/
 })
 export class CustomMenu {
-items = contentChildren(CustomMenuItem);
-itemTexts = computed(() => this.items().map(item => item.text));
+  items = contentChildren(CustomMenuItem);
+  itemTexts = computed(() => this.items().map(item => item.text));
 }
 
 @Component({
-selector: 'user-profile',
-template: `     <custom-menu>
+  selector: 'user-profile',
+  template: `
+    <custom-menu>
       <custom-menu-item>Cheese</custom-menu-item>
       <custom-menu-item>Tomato</custom-menu-item>
     </custom-menu>
@@ -134,6 +144,7 @@ template: `     <custom-menu>
 })
 export class UserProfile { }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 `contentChildren` creates a signal with an `Array` of the query results.
 
@@ -229,7 +240,8 @@ Developers most commonly use `read` to retrieve `ElementRef` and `TemplateRef`.
 By default, `contentChildren` queries find only _direct_ children of the component and do not traverse into descendants.
 `contentChild` queries do traverse into descendants by default.
 
-<docs-code language="angular-ts" highlight="[13, 14, 15, 16]">
+<!-- prettier-ignore-start -->
+<docs-code language="angular-ts" highlight="[13, 14, 15, 16, 17]">
 @Component({
   selector: 'custom-expando',
   /*...*/
@@ -240,16 +252,18 @@ export class CustomExpando {
 }
 
 @Component({
-selector: 'user-profile',
-template: `     <custom-expando>
+  selector: 'user-profile',
+  template: `
+    <custom-expando>
       <some-other-component>
         <custom-toggle>Show</custom-toggle>
       </some-other-component>
     </custom-expando>
-  `
+    `
 })
 export class UserProfile { }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 In the example above, `CustomExpando` cannot find `<custom-toggle>` with `contentChildren` because it is not a direct child of `<custom-expando>`. By setting `descendants: true`, you configure the query to traverse all descendants in the same template. Queries, however, _never_ pierce into components to traverse elements in other templates.
 
@@ -266,6 +280,7 @@ You can alternatively declare queries by adding the corresponding decorator to a
 
 You can query for a single result with the `@ViewChild` decorator.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[14, 16, 17, 18]">
 @Component({
   selector: 'custom-card-header',
@@ -276,17 +291,18 @@ export class CustomCardHeader {
 }
 
 @Component({
-selector: 'custom-card',
-template: '<custom-card-header>Visit sunny California!</custom-card-header>',
+  selector: 'custom-card',
+  template: '<custom-card-header>Visit sunny California!</custom-card-header>',
 })
 export class CustomCard {
-@ViewChild(CustomCardHeader) header: CustomCardHeader;
+  @ViewChild(CustomCardHeader) header: CustomCardHeader;
 
-ngAfterViewInit() {
-console.log(this.header.text);
-}
+  ngAfterViewInit() {
+    console.log(this.header.text);
+  }
 }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 In this example, the `CustomCard` component queries for a child `CustomCardHeader` and accesses the result in `ngAfterViewInit`.
 
@@ -296,6 +312,7 @@ Angular keeps the result of `@ViewChild` up to date as your application state ch
 
 You can also query for multiple results with the `@ViewChildren` decorator.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[17, 19, 20, 21, 22, 23]">
 @Component({
   selector: 'custom-card-action',
@@ -306,21 +323,23 @@ export class CustomCardAction {
 }
 
 @Component({
-selector: 'custom-card',
-template: `     <custom-card-action>Save</custom-card-action>
+  selector: 'custom-card',
+  template: `
+    <custom-card-action>Save</custom-card-action>
     <custom-card-action>Cancel</custom-card-action>
   `,
 })
 export class CustomCard {
-@ViewChildren(CustomCardAction) actions: QueryList<CustomCardAction>;
+  @ViewChildren(CustomCardAction) actions: QueryList<CustomCardAction>;
 
-ngAfterViewInit() {
-this.actions.forEach(action => {
-console.log(action.text);
-});
-}
+  ngAfterViewInit() {
+    this.actions.forEach(action => {
+      console.log(action.text);
+    });
+  }
 }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 `@ViewChildren` creates a `QueryList` object that contains the query results. You can subscribe to changes to the query results over time via the `changes` property.
 
@@ -328,6 +347,7 @@ console.log(action.text);
 
 You can query for a single result with the `@ContentChild` decorator.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[14, 16, 17, 18, 25]">
 @Component({
   selector: 'custom-toggle',
@@ -338,26 +358,28 @@ export class CustomToggle {
 }
 
 @Component({
-selector: 'custom-expando',
-/_..._/
+  selector: 'custom-expando',
+  /_..._/
 })
 export class CustomExpando {
-@ContentChild(CustomToggle) toggle: CustomToggle;
+  @ContentChild(CustomToggle) toggle: CustomToggle;
 
-ngAfterContentInit() {
-console.log(this.toggle.text);
-}
+  ngAfterContentInit() {
+    console.log(this.toggle.text);
+  }
 }
 
 @Component({
-selector: 'user-profile',
-template: `     <custom-expando>
+  selector: 'user-profile',
+  template: `
+    <custom-expando>
       <custom-toggle>Show</custom-toggle>
     </custom-expando>
   `
 })
 export class UserProfile { }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 In this example, the `CustomExpando` component queries for a child `CustomToggle` and accesses the result in `ngAfterContentInit`.
 
@@ -367,6 +389,7 @@ Angular keeps the result of `@ContentChild` up to date as your application state
 
 You can also query for multiple results with the `@ContentChildren` decorator.
 
+<!-- prettier-ignore-start -->
 <docs-code language="angular-ts" highlight="[14, 16, 17, 18, 19, 20]">
 @Component({
   selector: 'custom-menu-item',
@@ -377,29 +400,31 @@ export class CustomMenuItem {
 }
 
 @Component({
-selector: 'custom-menu',
-/_..._/
+  selector: 'custom-menu',
+  /_..._/
 })
 export class CustomMenu {
-@ContentChildren(CustomMenuItem) items: QueryList<CustomMenuItem>;
+  @ContentChildren(CustomMenuItem) items: QueryList<CustomMenuItem>;
 
-ngAfterContentInit() {
-this.items.forEach(item => {
-console.log(item.text);
-});
-}
+  ngAfterContentInit() {
+    this.items.forEach(item => {
+      console.log(item.text);
+    });
+  }
 }
 
 @Component({
-selector: 'user-profile',
-template: `     <custom-menu>
-      <custom-menu-item>Cheese</custom-menu-item>
-      <custom-menu-item>Tomato</custom-menu-item>
+  selector: 'user-profile',
+  template: `
+    <custom-menu>
+        <custom-menu-item>Cheese</custom-menu-item>
+        <custom-menu-item>Tomato</custom-menu-item>
     </custom-menu>
-  `
+    `
 })
 export class UserProfile { }
 </docs-code>
+<!-- prettier-ignore-end -->
 
 `@ContentChildren` creates a `QueryList` object that contains the query results. You can subscribe to changes to the query results over time via the `changes` property.
 


### PR DESCRIPTION
Adds `<!-- prettier-ignore-start -->` and `<!-- prettier-ignore-end -->` comments around code blocks in `adev/src/content/guide/components/queries.md` to prevent Prettier from reformatting the examples.

Closes #65148