### PR TITLE
docs: replace <docs-code> block with standard fenced code block for t…

### DIFF
--- a/adev/src/content/reference/extended-diagnostics/NG8105.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8105.md
@@ -2,19 +2,17 @@
 
 This diagnostic is emitted when an expression used in `*ngFor` is missing the `let` keyword.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// The `let` keyword is missing in the `*ngFor` expression.
-template: `<div *ngFor="item of items">{{ item }}</div>`,
+  // The `let` keyword is missing in the `*ngFor` expression.
+  template: `<div *ngFor="item of items">{{ item }}</div>`,
 })
 class MyComponent {
-items = [1, 2, 3];
+  items = [1, 2, 3];
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -24,20 +22,18 @@ A missing `let` is indicative of a syntax error in the `*ngFor` string. It also 
 
 Add the missing `let` keyword.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// The `let` keyword is now present in the `*ngFor` expression,
-// no diagnostic messages are emitted in this case.
-template: `<div *ngFor="let item of items">{{ item }}</div>`,
+  // The `let` keyword is now present in the `*ngFor` expression,
+  // no diagnostic messages are emitted in this case.
+  template: `<div *ngFor="let item of items">{{ item }}</div>`,
 })
 class MyComponent {
-items = [1, 2, 3];
+  items = [1, 2, 3];
 }
-
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8107.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8107.md
@@ -2,20 +2,18 @@
 
 This diagnostic detects when the left side of an optional chain operation (`.?`) does not include `null` or `undefined` in its type in Angular templates.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// Print the user's name safely, even if `user` is `null` or `undefined`.
-template: `<div>User name: {{ user?.name }}</div>`,
+  // Print the user's name safely, even if `user` is `null` or `undefined`.
+  template: `<div>User name: {{ user?.name }}</div>`,
 })
 class MyComponent {
-// `user` is declared as an object which _cannot_ be `null` or `undefined`.
-user: { name: string } = { name: 'Angelino' };
+  // `user` is declared as an object which _cannot_ be `null` or `undefined`.
+  user: { name: string } = { name: 'Angelino' };
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -30,37 +28,33 @@ Double-check the type of the input and confirm whether it is actually expected t
 
 If the input should be nullable, add `null` or `undefined` to its type to indicate this.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// If `user` is nullish, `name` won't be evaluated and the expression will
-// return the nullish value (`null` or `undefined`).
-template: `<div>{{ user?.name }}</div>`,
+  // If `user` is nullish, `name` won't be evaluated and the expression will
+  // return the nullish value (`null` or `undefined`).
+  template: `<div>{{ user?.name }}</div>`,
 })
 class MyComponent {
-user: { name: string } | null = { name: 'Angelino' };
+  user: { name: string } | null = { name: 'Angelino' };
 }
-
-</docs-code>
+```
 
 If the input should not be nullable, delete the `?` operator.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// Template always displays `name` as `user` is guaranteed to never be `null`
-// or `undefined`.
-template: `<div>{{ foo.bar }}</div>`,
+  // Template always displays `name` as `user` is guaranteed to never be `null`
+  // or `undefined`.
+  template: `<div>{{ foo.bar }}</div>`,
 })
 class MyComponent {
-user: { name: string } = { name: 'Angelino' };
+  user: { name: string } = { name: 'Angelino' };
 }
-
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8108.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8108.md
@@ -3,18 +3,16 @@
 `ngSkipHydration` is a special attribute which indicates to Angular that a particular component should be opted-out of [hydration](guide/hydration).
 This diagnostic ensures that this attribute `ngSkipHydration` is set statically and the value is either set to `"true"` or an empty value.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `<user-viewer ngSkipHydration="hasUser" />`,
+  template: `<user-viewer ngSkipHydration="hasUser" />`,
 })
 class MyComponent {
-hasUser = true;
+  hasUser = true;
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -24,18 +22,17 @@ As a special attribute implemented by Angular, `ngSkipHydration` needs to be sta
 
 When using the `ngSkipHydration`, ensure that it's set as a static attribute (i.e. you do not use the Angular template binding syntax).
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `     <user-viewer ngSkipHydration />
+  template: `
+    <user-viewer ngSkipHydration />
     <user-viewer ngSkipHydration="true" />
   `,
 })
 class MyComponent {}
-
-</docs-code>
+```
 
 If a conditional is necessary, you can wrap the component in an `*ngIf`.
 

--- a/adev/src/content/reference/extended-diagnostics/NG8109.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8109.md
@@ -2,18 +2,16 @@
 
 This diagnostic detects uninvoked signals in template interpolations.
 
-<docs-code language="typescript">
-
-import {Component, signal, Signal} from '@angular/core';
+```typescript
+import { Component, signal, Signal } from '@angular/core';
 
 @Component({
-template: `<div>{{ mySignal }}/div>`,
+  template: `<div>{{ mySignal }}</div>`,
 })
 class MyComponent {
-mySignal: Signal<number> = signal(0);
+  mySignal: Signal<number> = signal(0);
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -24,18 +22,16 @@ This means they are meant to be invoked when used in template interpolations to 
 
 Ensure to invoke the signal when you use it within a template interpolation to render its value.
 
-<docs-code language="typescript">
-
-import {Component, signal, Signal} from '@angular/core';
+```typescript
+import { Component, signal, Signal } from '@angular/core';
 
 @Component({
-template: `<div>{{ mySignal() }}/div>`,
+  template: `<div>{{ mySignal() }}</div>`,
 })
 class MyComponent {
-mySignal: Signal<number> = signal(0)
+  mySignal: Signal<number> = signal(0);
 }
-
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8111.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8111.md
@@ -2,20 +2,18 @@
 
 This diagnostic detects uninvoked functions in event bindings.
 
-<docs-code language="typescript">
-
-import {Component, signal, Signal} from '@angular/core';
+```typescript
+import { Component, signal, Signal } from '@angular/core';
 
 @Component({
-template: `<button (click)="onClick">Click me</button>`,
+  template: `<button (click)="(onClick)">Click me</button>`,
 })
 class MyComponent {
-onClick() {
-console.log('clicked');
+  onClick() {
+    console.log('clicked');
+  }
 }
-}
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -26,20 +24,18 @@ If the function is not invoked, it will not execute when the event is triggered.
 
 Ensure to invoke the function when you use it in an event binding to execute the function when the event is triggered.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `<button (click)="onClick()">Click me</button>`,
+  template: `<button (click)="onClick()">Click me</button>`,
 })
 class MyComponent {
-onClick() {
-console.log('clicked');
+  onClick() {
+    console.log('clicked');
+  }
 }
-}
-
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8113.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8113.md
@@ -3,14 +3,13 @@
 This diagnostic detects cases where the `imports` array of a `@Component` contains symbols that
 aren't used within the template.
 
-<docs-code language="typescript">
-
+```typescript
 @Component({
-imports: [UsedDirective, UnusedPipe]
+  imports: [UsedDirective, UnusedPipe],
 })
 class AwesomeCheckbox {}
 
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -20,14 +19,12 @@ The unused imports add unnecessary noise to your code and can increase your comp
 
 Delete the unused import.
 
-<docs-code language="typescript">
-
+```typescript
 @Component({
-imports: [UsedDirective]
+  imports: [UsedDirective]
 })
 class AwesomeCheckbox {}
-
-</docs-code>
+```
 
 ## What if I can't avoid this?
 

--- a/adev/src/content/reference/extended-diagnostics/NG8114.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8114.md
@@ -3,22 +3,21 @@
 This diagnostic detects cases where the nullish coalescing operator (`??`) is mixed with the logical
 or (`||`) or logical and (`&&`) operators without parentheses to disambiguate precedence.
 
-<docs-code language="typescript">
-
-import {Component, signal, Signal} from '@angular/core';
+```typescript
+import { Component, signal, Signal } from '@angular/core';
 
 @Component({
-template: `     <button [disabled]="hasPermission() && task()?.disabled ?? true">
+  template: `
+    <button [disabled]="hasPermission() && (task()?.disabled ?? true)">
       Run
     </button>
   `,
 })
 class MyComponent {
-hasPermission = input(false);
-task = input<Task|undefined>(undefined);
+  hasPermission = input(false);
+  task = input<Task | undefined>(undefined);
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -32,19 +31,18 @@ Always use parentheses to disambiguate in theses situations. If you're unsure wh
 intent of the code was but want to keep the behavior the same, place the parentheses around the `??`
 operator.
 
-<docs-code language="typescript">
-
-import {Component, signal, Signal} from '@angular/core';
+```typescript
+import { Component, signal, Signal } from '@angular/core';
 
 @Component({
-template: `     <button [disabled]="hasPermission() && (task()?.disabled ?? true)">
+  template: `
+    <button [disabled]="hasPermission() && (task()?.disabled ?? true)">
       Run
     </button>
   `,
 })
 class MyComponent {
-hasPermission = input(false);
-task = input<Task|undefined>(undefined);
+  hasPermission = input(false);
+  task = input<Task | undefined>(undefined);
 }
-
-</docs-code>
+```

--- a/adev/src/content/reference/extended-diagnostics/NG8115.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8115.md
@@ -2,18 +2,18 @@
 
 This diagnostic detects when a track function is not invoked in `@for` blocks.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `@for (item of items; track trackByName) {}`,
+  template: `@for (item of items; track trackByName) {}`,
 })
 class Items {
-protected trackByName(item) { return item.name; }
+  protected trackByName(item) {
+    return item.name;
+  }
 }
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -24,18 +24,18 @@ When you don't invoke the function, the reconcialiation algorithm will use the f
 
 Ensure to invoke the track function when you use it in a `@for` block to execute the function so the loop can uniquely identify items.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `@for (item of items; track trackByName(item)) {}`,
+  template: `@for (item of items; track trackByName(item)) {}`,
 })
 class Items {
-protected trackByName(item) { return item.name; }
+  protected trackByName(item) {
+    return item.name;
+  }
 }
-
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8116.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8116.md
@@ -2,18 +2,16 @@
 
 This diagnostic ensures that a standalone component using custom structural directives (e.g., `*select` or `*featureFlag`) in a template has the necessary imports for those directives.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-// Template uses `*select`, but no corresponding directive imported.
-imports: [],
-template: `<p *select="let data from source">{{data}}</p>`,
+  // Template uses `*select`, but no corresponding directive imported.
+  imports: [],
+  template: `<p *select="let data from source">{{ data }}</p>`,
 })
 class MyComponent {}
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -23,19 +21,18 @@ Using a structural directive without importing it will fail at runtime, as Angul
 
 Make sure that the corresponding structural directive is imported into the component:
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
-import {SelectDirective} from 'my-directives';
+```typescript
+import { Component } from '@angular/core';
+import { SelectDirective } from 'my-directives';
 
 @Component({
-// Add `SelectDirective` to the `imports` array to make it available in the template.
-imports: [SelectDirective],
-template: `<p *select="let data from source">{{data}}</p>`,
+  // Add `SelectDirective` to the `imports` array to make it available in the template.
+  imports: [SelectDirective],
+  template: `<p *select="let data from source">{{ data }}</p>`,
 })
 class MyComponent {}
 
-</docs-code>
+```
 
 ## Configuration requirements
 

--- a/adev/src/content/reference/extended-diagnostics/NG8117.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8117.md
@@ -2,20 +2,18 @@
 
 This diagnostic detects uninvoked functions in text interpolation.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `{{ getValue }}`,
+  template: `{{ getValue }}`,
 })
 class MyComponent {
-getValue() {
-return 'value';
+  getValue() {
+    return 'value';
+  }
 }
-}
-
-</docs-code>
+```
 
 ## What's wrong with that?
 
@@ -26,20 +24,18 @@ If the function is not invoked, it will not return any value and the interpolati
 
 Ensure to invoke the function when you use it in text interpolation to return the value.
 
-<docs-code language="typescript">
-
-import {Component} from '@angular/core';
+```typescript
+import { Component } from '@angular/core';
 
 @Component({
-template: `{{ getValue() }}`,
+  template: `{{ getValue() }}`,
 })
 class MyComponent {
-getValue() {
-return 'value';
+  getValue() {
+    return 'value';
+  }
 }
-}
-
-</docs-code>
+```
 
 ## Configuration requirements
 


### PR DESCRIPTION
…ypescript example

Replaced the <docs-code> wrapper with a Markdown fenced code block to improve copy/paste usability, syntax highlighting consistency, and alignment with current documentation formatting standards.

Inspired by #65043

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
