### PR TITLE
docs: update testing guides for Vitest and reorder navigation

### DIFF
--- a/adev/src/app/routing/sub-navigation-data.ts
+++ b/adev/src/app/routing/sub-navigation-data.ts
@@ -522,21 +522,6 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'guide/testing/overview',
           },
           {
-            label: 'Code coverage',
-            path: 'guide/testing/code-coverage',
-            contentPath: 'guide/testing/code-coverage',
-          },
-          {
-            label: 'Testing with Karma and Jasmine',
-            path: 'guide/testing/karma',
-            contentPath: 'guide/testing/karma',
-          },
-          {
-            label: 'Testing services',
-            path: 'guide/testing/services',
-            contentPath: 'guide/testing/services',
-          },
-          {
             label: 'Basics of testing components',
             path: 'guide/testing/components-basics',
             contentPath: 'guide/testing/components-basics',
@@ -545,6 +530,11 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             label: 'Component testing scenarios',
             path: 'guide/testing/components-scenarios',
             contentPath: 'guide/testing/components-scenarios',
+          },
+          {
+            label: 'Testing services',
+            path: 'guide/testing/services',
+            contentPath: 'guide/testing/services',
           },
           {
             label: 'Testing attribute directives',
@@ -568,14 +558,14 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             contentPath: 'guide/testing/debugging',
           },
           {
+            label: 'Code coverage',
+            path: 'guide/testing/code-coverage',
+            contentPath: 'guide/testing/code-coverage',
+          },
+          {
             label: 'Testing utility APIs',
             path: 'guide/testing/utility-apis',
             contentPath: 'guide/testing/utility-apis',
-          },
-          {
-            label: 'Migrating from Karma to Vitest',
-            path: 'guide/testing/unit-tests',
-            contentPath: 'guide/testing/migrating-to-vitest',
           },
           {
             label: 'Component harnesses overview',
@@ -596,6 +586,16 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             label: 'Adding harness support for additional testing environments',
             path: 'guide/testing/component-harnesses-testing-environments',
             contentPath: 'guide/testing/component-harnesses-testing-environments',
+          },
+          {
+            label: 'Migrating from Karma to Vitest',
+            path: 'guide/testing/migrating-to-vitest',
+            contentPath: 'guide/testing/migrating-to-vitest',
+          },
+          {
+            label: 'Testing with Karma and Jasmine',
+            path: 'guide/testing/karma',
+            contentPath: 'guide/testing/karma',
           },
         ],
       },

--- a/adev/src/content/guide/testing/code-coverage.md
+++ b/adev/src/content/guide/testing/code-coverage.md
@@ -7,14 +7,17 @@ Code coverage reports show you any parts of your code base that might not be pro
 To generate code coverage reports with Vitest, you must install the `@vitest/coverage-v8` package:
 
 <docs-code-multifile>
-  <docs-code header="pnpm" language="shell">
-    pnpm add -D @vitest/coverage-v8
-  </docs-code>
   <docs-code header="npm" language="shell">
     npm install --save-dev @vitest/coverage-v8
   </docs-code>
   <docs-code header="yarn" language="shell">
     yarn add --dev @vitest/coverage-v8
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add -D @vitest/coverage-v8
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add --dev @vitest/coverage-v8
   </docs-code>
 </docs-code-multifile>
 

--- a/adev/src/content/guide/testing/code-coverage.md
+++ b/adev/src/content/guide/testing/code-coverage.md
@@ -1,18 +1,34 @@
-# Find out how much code you're testing
+# Code coverage
 
-The Angular CLI can run unit tests and create code coverage reports.
 Code coverage reports show you any parts of your code base that might not be properly tested by your unit tests.
 
-To generate a coverage report run the following command in the root of your project.
+## Prerequisites
+
+To generate code coverage reports with Vitest, you must install the `@vitest/coverage-v8` package:
+
+<docs-code-multifile>
+  <docs-code header="pnpm" language="shell">
+    pnpm add -D @vitest/coverage-v8
+  </docs-code>
+  <docs-code header="npm" language="shell">
+    npm install --save-dev @vitest/coverage-v8
+  </docs-code>
+  <docs-code header="yarn" language="shell">
+    yarn add --dev @vitest/coverage-v8
+  </docs-code>
+</docs-code-multifile>
+
+## Generating a report
+
+To generate a coverage report, add the `--coverage` flag to the `ng test` command:
 
 ```shell
-ng test --no-watch --coverage
+ng test --coverage
 ```
 
-When the tests are complete, the command creates a new `/coverage` directory in the project.
-Open the `index.html` file to see a report with your source code and code coverage values.
+After the tests run, the command creates a new `coverage/` directory in the project. Open the `index.html` file to see a report with your source code and code coverage values.
 
-If you want to create code-coverage reports every time you test, set the following option in the Angular CLI configuration file, `angular.json`:
+If you want to create code-coverage reports every time you test, you can set the `coverage` option to `true` in your `angular.json` file:
 
 ```json
 {
@@ -20,6 +36,7 @@ If you want to create code-coverage reports every time you test, set the followi
     "your-project-name": {
       "architect": {
         "test": {
+          "builder": "@angular/build:unit-test",
           "options": {
             "coverage": true
           }
@@ -30,13 +47,11 @@ If you want to create code-coverage reports every time you test, set the followi
 }
 ```
 
-## Code coverage enforcement
+## Enforcing code coverage thresholds
 
-The code coverage percentages let you estimate how much of your code is tested.
-If your team decides on a set minimum amount to be unit tested, you can enforce this minimum directly in your Angular CLI configuration.
+The code coverage percentages let you estimate how much of your code is tested. If your team decides on a minimum amount to be unit tested, you can enforce this minimum in your configuration.
 
-For example, suppose you want the code base to have a minimum of 80% code coverage.
-To enable this, open the `angular.json` file and add the `coverageThresholds` option to your test configuration:
+For example, suppose you want the code base to have a minimum of 80% code coverage. To enable this, add the `coverageThresholds` option to your `angular.json` file:
 
 ```json
 {
@@ -44,6 +59,7 @@ To enable this, open the `angular.json` file and add the `coverageThresholds` op
     "your-project-name": {
       "architect": {
         "test": {
+          "builder": "@angular/build:unit-test",
           "options": {
             "coverage": true,
             "coverageThresholds": {
@@ -60,4 +76,36 @@ To enable this, open the `angular.json` file and add the `coverageThresholds` op
 }
 ```
 
-Now, when you run `ng test`, the tool will throw an error if the coverage drops below 80%.
+Now, if your coverage drops below 80% when you run your tests, the command will fail.
+
+## Advanced configuration
+
+You can configure several other coverage options in your `angular.json` file:
+
+- `coverageInclude`: Glob patterns of files to include in the coverage report.
+- `coverageReporters`: An array of reporters to use (e.g., `html`, `lcov`, `json`).
+- `coverageWatermarks`: An object specifying `[low, high]` watermarks for the HTML reporter, which can affect the color-coding of the report.
+
+```json
+{
+  "projects": {
+    "your-project-name": {
+      "architect": {
+        "test": {
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "coverage": true,
+            "coverageReporters": ["html", "lcov"],
+            "coverageWatermarks": {
+              "statements": [50, 80],
+              "branches": [50, 80],
+              "functions": [50, 80],
+              "lines": [50, 80]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/adev/src/content/guide/testing/debugging.md
+++ b/adev/src/content/guide/testing/debugging.md
@@ -1,19 +1,30 @@
 # Debugging tests
 
-If your tests aren't working as you expect them to, you can inspect and debug them in the browser.
+If your tests aren't working as you expect, you can debug them in both the default Node.js environment and in a real browser.
 
-NOTE: This guide describes debugging with the Karma test runner.
+## Debugging in Node.js
 
-To debug an application with the Karma test runner:
+Debugging in the default Node.js environment is often the quickest way to diagnose issues that are not related to browser-specific APIs or rendering.
 
-1. Reveal the Karma browser window.
-   See [Set up testing](guide/testing#set-up-testing) if you need help with this step.
+1.  Run the `ng test` command with the `--debug` flag:
+    ```shell
+    ng test --debug
+    ```
+2.  The test runner will start in debug mode and wait for a debugger to attach.
+3.  You can now attach your preferred debugger. For example, you can use the built-in Node.js debugger in VS Code or the Chrome DevTools for Node.js.
 
-1. Click the **DEBUG** button to open a new browser tab and re-run the tests.
-1. Open the browser's **Developer Tools**. On Windows, press `Ctrl-Shift-I`. On macOS, press `Command-Option-I`.
-1. Pick the **Sources** section.
-1. Press `Control/Command-P`, and then start typing the name of your test file to open it.
-1. Set a breakpoint in the test.
-1. Refresh the browser, and notice how it stops at the breakpoint.
+## Debugging in a browser
 
-<img alt="Karma debugging" src="assets/images/guide/testing/karma-1st-spec-debug.png">
+Debugging in a browser is recommended for tests that rely on the DOM or other browser-specific APIs. This approach allows you to use the browser's own developer tools.
+
+1.  Ensure you have a browser provider installed. See [Running tests in a browser](guide/testing/overview#running-tests-in-a-browser) for setup instructions.
+2.  Run the `ng test` command with both the `--browsers` and `--debug` flags:
+    ```shell
+    ng test --browsers=chromium --debug
+    ```
+3.  This command runs the tests in a headed browser and keeps it open after the tests finish, allowing you to inspect the output.
+4.  Open the browser's **Developer Tools**. On Windows, press `Ctrl-Shift-I`. On macOS, press `Command-Option-I`.
+5.  Go to the **Sources** tab.
+6.  Use `Control/Command-P` to search for and open your test file.
+7.  Set a breakpoint in your test.
+8.  Reload the test runner UI in the browser. The execution will now stop at your breakpoint.

--- a/adev/src/content/guide/testing/karma.md
+++ b/adev/src/content/guide/testing/karma.md
@@ -180,3 +180,19 @@ ng test --no-watch --no-progress --browsers=ChromeHeadless
 ```
 
 NOTE: The `--no-watch` and `--no-progress` flags are crucial for Karma in CI environments to ensure tests run once and exit cleanly. The `--browsers=ChromeHeadless` flag is also essential for running tests in a browser environment without a graphical interface.
+
+## Debugging tests
+
+If your tests aren't working as you expect, you can inspect and debug them in the browser.
+
+To debug an application with the Karma test runner:
+
+1.  Reveal the Karma browser window. See [Set up for testing](guide/testing/overview#set-up-for-testing) if you need help with this step.
+2.  Click the **DEBUG** button to open a new browser tab and re-run the tests.
+3.  Open the browser's **Developer Tools**. On Windows, press `Ctrl-Shift-I`. On macOS, press `Command-Option-I`.
+4.  Pick the **Sources** section.
+5.  Press `Control/Command-P`, and then start typing the name of your test file to open it.
+6.  Set a breakpoint in the test.
+7.  Refresh the browser, and notice how it stops at the breakpoint.
+
+<img alt="Karma debugging" src="assets/images/guide/testing/karma-1st-spec-debug.png">

--- a/adev/src/content/guide/testing/karma.md
+++ b/adev/src/content/guide/testing/karma.md
@@ -21,14 +21,17 @@ To add Karma and Jasmine to an existing project, follow these steps:
 1.  **Install the necessary packages:**
 
     <docs-code-multifile>
-      <docs-code header="pnpm" language="shell">
-        pnpm add -D karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter jasmine-core @types/jasmine
-      </docs-code>
       <docs-code header="npm" language="shell">
         npm install --save-dev karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter jasmine-core @types/jasmine
       </docs-code>
       <docs-code header="yarn" language="shell">
         yarn add --dev karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter jasmine-core @types/jasmine
+      </docs-code>
+      <docs-code header="pnpm" language="shell">
+        pnpm add -D karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter jasmine-core @types/jasmine
+      </docs-code>
+      <docs-code header="bun" language="shell">
+        bun add --dev karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter jasmine-core @types/jasmine
       </docs-code>
     </docs-code-multifile>
 

--- a/adev/src/content/guide/testing/migrating-to-vitest.md
+++ b/adev/src/content/guide/testing/migrating-to-vitest.md
@@ -13,14 +13,17 @@ Before using the automated refactoring schematic, you must manually update your 
 Install `vitest` and a DOM emulation library. While browser testing is still possible (see [step 5](#5-configure-browser-mode-optional)), Vitest uses a DOM emulation library by default to simulate a browser environment within Node.js for faster test execution. The CLI automatically detects and uses `happy-dom` if it's installed; otherwise, it falls back to `jsdom`. You must have one of these packages installed.
 
 <docs-code-multifile>
-  <docs-code header="pnpm" language="shell">
-    pnpm add -D vitest jsdom
-  </docs-code>
   <docs-code header="npm" language="shell">
     npm install --save-dev vitest jsdom
   </docs-code>
   <docs-code header="yarn" language="shell">
     yarn add --dev vitest jsdom
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add -D vitest jsdom
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add --dev vitest jsdom
   </docs-code>
 </docs-code-multifile>
 
@@ -65,14 +68,17 @@ For other settings, consult the official [Vitest documentation](https://vitest.d
 You can now delete `karma.conf.js` and `src/test.ts` from your project and uninstall the Karma-related packages. The following commands are based on the packages installed in a new Angular CLI project; your project may have other Karma-related packages to remove.
 
 <docs-code-multifile>
-  <docs-code header="pnpm" language="shell">
-    pnpm remove karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter
-  </docs-code>
   <docs-code header="npm" language="shell">
     npm uninstall karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter
   </docs-code>
   <docs-code header="yarn" language="shell">
     yarn remove karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm remove karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun remove karma karma-chrome-launcher karma-coverage karma-jasmine karma-jasmine-html-reporter
   </docs-code>
 </docs-code-multifile>
 
@@ -89,14 +95,17 @@ Choose one of the following browser providers based on your needs:
 - **Preview**: `@vitest/browser-preview` for Webcontainer environments (like StackBlitz).
 
 <docs-code-multifile>
-  <docs-code header="pnpm" language="shell">
-    pnpm add -D @vitest/browser-playwright
-  </docs-code>
   <docs-code header="npm" language="shell">
     npm install --save-dev @vitest/browser-playwright
   </docs-code>
   <docs-code header="yarn" language="shell">
     yarn add --dev @vitest/browser-playwright
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add -D @vitest/browser-playwright
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add --dev @vitest/browser-playwright
   </docs-code>
 </docs-code-multifile>
 

--- a/adev/src/content/guide/testing/overview.md
+++ b/adev/src/content/guide/testing/overview.md
@@ -1,10 +1,8 @@
 # Unit testing
 
-Testing your Angular application helps you check that it is working as you expect.
+Testing your Angular application helps you check that it is working as you expect. Unit tests are crucial for catching bugs early, ensuring code quality, and facilitating safe refactoring.
 
-NOTE: This guide focuses on the default testing setup for new Angular CLI projects. If you are migrating an existing project from Karma to Vitest, see the [Migrating from Karma to Vitest guide](guide/testing/migrating-to-vitest).
-
-NOTE: While Vitest is the default test runner, Karma is still fully supported. For information on testing with Karma, see the [Karma testing guide](guide/testing/karma).
+NOTE: This guide focuses on the default testing setup for new Angular CLI projects. If you are migrating an existing project from Karma to Vitest, see the [Migrating from Karma to Vitest guide](guide/testing/migrating-to-vitest). While Vitest is the default test runner, Karma is still fully supported. For information on testing with Karma, see the [Karma testing guide](guide/testing/karma).
 
 ## Set up for testing
 
@@ -45,8 +43,8 @@ You can change the following options in the `test` target of your `angular.json`
 
 - `include`: Glob patterns for files to include for testing. Defaults to `['**/*.spec.ts', '**/*.test.ts']`.
 - `exclude`: Glob patterns for files to exclude from testing.
-- `setupFiles`: A list of paths to global setup files that are executed before your tests.
-- `providersFile`: The path to a file that exports a default array of Angular providers for the test environment. This is useful for setting up global test providers.
+- `setupFiles`: A list of paths to global setup files (e.g., polyfills or global mocks) that are executed before your tests.
+- `providersFile`: The path to a file that exports a default array of Angular providers for the test environment. This is useful for setting up global test providers which are injected into your tests.
 - `coverage`: A boolean to enable or disable code coverage reporting. Defaults to `false`.
 - `browsers`: An array of browser names to run tests in (e.g., `["chromium"]`). Requires a browser provider to be installed.
 
@@ -94,7 +92,7 @@ For advanced use cases, you can provide a custom Vitest configuration file.
 
 IMPORTANT: While using a custom configuration enables advanced options, the Angular team does not provide direct support for the specific contents of the configuration file or for any third-party plugins used within it. The CLI will also override certain properties (`test.projects`, `test.include`) to ensure proper operation.
 
-You can create a Vitest configuration file (e.g., `vitest.config.ts`) and reference it in your `angular.json` using the `runnerConfig` option.
+You can create a Vitest configuration file (e.g., `vitest-base.config.ts`) and reference it in your `angular.json` using the `runnerConfig` option.
 
 ```json
 {
@@ -104,7 +102,7 @@ You can create a Vitest configuration file (e.g., `vitest.config.ts`) and refere
         "test": {
           "builder": "@angular/build:unit-test",
           "options": {
-            "runnerConfig": "vitest.config.ts"
+            "runnerConfig": "vitest-base.config.ts"
           }
         }
       }
@@ -141,14 +139,17 @@ Choose one of the following browser providers based on your needs:
 - **Preview**: `@vitest/browser-preview` for Webcontainer environments (like StackBlitz).
 
 <docs-code-multifile>
-  <docs-code header="pnpm" language="shell">
-    pnpm add -D @vitest/browser-playwright playwright
-  </docs-code>
   <docs-code header="npm" language="shell">
     npm install --save-dev @vitest/browser-playwright playwright
   </docs-code>
   <docs-code header="yarn" language="shell">
     yarn add --dev @vitest/browser-playwright playwright
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add -D @vitest/browser-playwright playwright
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add --dev @vitest/browser-playwright playwright
   </docs-code>
 </docs-code-multifile>
 
@@ -167,32 +168,6 @@ Headless mode is enabled automatically if the `CI` environment variable is set. 
 ## Other test frameworks
 
 You can also unit test an Angular application with other testing libraries and test runners. Each library and runner has its own distinctive installation procedures, configuration, and syntax.
-
-## Test file name and location
-
-Inside the `src/app` folder, the Angular CLI generates a test file for the `App` named `app.spec.ts`.
-
-IMPORTANT: The test file extension **must be `.spec.ts` or `.test.ts`** so that tooling can identify it as a file with tests (also known as a _spec_ file).
-
-The `app.ts` and `app.spec.ts` files are siblings in the same folder. The root file names (`app`) are the same for both files.
-
-Adopt these two conventions in your own projects for every kind of test file.
-
-### Place your spec file next to the file it tests
-
-It's a good practice to put unit test spec files in the same folder as the application source code files that they test:
-
-- Such tests are painless to find.
-- You see at a glance if a part of your application lacks tests.
-- Nearby tests can reveal how a part works in context.
-- When you move the source, you remember to move the test.
-- When you rename the source file, you remember to rename the test file.
-
-### Place your spec files in a test folder
-
-Application integration specs can test the interactions of multiple parts spread across folders and modules. They don't belong to any single part, so they don't have a natural home next to any one file.
-
-It's often better to create an appropriate folder for them in the `tests` directory.
 
 ## Testing in continuous integration
 

--- a/adev/src/content/guide/testing/pipes.md
+++ b/adev/src/content/guide/testing/pipes.md
@@ -13,8 +13,7 @@ Here's an implementation with a regular expression.
 
 <docs-code header="app/shared/title-case.pipe.ts" path="adev/src/content/examples/testing/src/app/shared/title-case.pipe.ts"/>
 
-Anything that uses a regular expression is worth testing thoroughly.
-Use simple Jasmine to explore the expected cases and the edge cases.
+Anything that uses a regular expression is worth testing thoroughly. You can use standard unit testing techniques to explore the expected cases and the edge cases.
 
 <docs-code header="app/shared/title-case.pipe.spec.ts" path="adev/src/content/examples/testing/src/app/shared/title-case.pipe.spec.ts" visibleRegion="excerpt"/>
 


### PR DESCRIPTION
This commit updates the unit testing, code coverage, and debugging guides to align with the Vitest test runner, which is now the default for new Angular CLI projects.

Key changes include:
- **Unit Testing Overview**: Revised to focus on Vitest, including details on DOM emulation (jsdom/happy-dom), browser testing setup, and custom Vitest configuration via `runnerConfig`. A prominent note links to the Karma-to-Vitest migration guide.
- **Code Coverage**: Updated to reflect Vitest-specific prerequisites (`@vitest/coverage-v8`), command-line flags, and `angular.json` configuration for coverage reporting and threshold enforcement.
- **Debugging**: Completely rewritten to provide instructions for debugging Vitest tests in both Node.js and browser environments using the `--debug` flag.
- **Navigation Reordering**: The 'Testing' section in `sub-navigation-data.ts` has been reordered to present a more logical educational flow, starting with core concepts and progressing to advanced topics and migration.