### PR TITLE
Revert 20.3.11 CSS changes

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -512,13 +512,11 @@ export class ShadowCss {
     return cssText.replace(_cssColonHostRe, (_, hostSelectors: string, otherSelectors: string) => {
       if (hostSelectors) {
         const convertedSelectors: string[] = [];
-        for (const hostSelector of this._splitOnTopLevelCommas(hostSelectors)) {
-          const trimmedHostSelector = hostSelector.trim();
-          if (!trimmedHostSelector) break;
+        const hostSelectorArray = hostSelectors.split(',').map((p) => p.trim());
+        for (const hostSelector of hostSelectorArray) {
+          if (!hostSelector) break;
           const convertedSelector =
-            _polyfillHostNoCombinator +
-            trimmedHostSelector.replace(_polyfillHost, '') +
-            otherSelectors;
+            _polyfillHostNoCombinator + hostSelector.replace(_polyfillHost, '') + otherSelectors;
           convertedSelectors.push(convertedSelector);
         }
         return convertedSelectors.join(',');

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -1045,13 +1045,7 @@ const _cssContentUnscopedRuleRe =
 const _polyfillHost = '-shadowcsshost';
 // note: :host-context pre-processed to -shadowcsshostcontext.
 const _polyfillHostContext = '-shadowcsscontext';
-// Matches text content with no parentheses, e.g., "foo"
-const _noParens = '[^)(]*';
-// Matches content with at most ONE level of nesting, e.g., "a(b)c"
-const _level1Parens = String.raw`(?:\(${_noParens}\)|${_noParens})+?`;
-// Matches content with at most TWO levels of nesting, e.g., "a(b(c)d)e"
-const _level2Parens = String.raw`(?:\(${_level1Parens}\)|${_noParens})+?`;
-const _parenSuffix = String.raw`(?:\((${_level2Parens})\))`;
+const _parenSuffix = '(?:\\((' + '(?:\\([^)(]*\\)|[^)(]*)+?' + ')\\))';
 const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix + '?([^,{]*)', 'gim');
 // note: :host-context patterns are terminated with `{`, as opposed to :host which
 // is both `{` and `,` because :host-context handles top-level commas differently.

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -1029,9 +1029,9 @@ class SafeSelector {
 
     // Replaces the expression in `:nth-child(2n + 1)` with a placeholder.
     // WS and "+" would otherwise be interpreted as selector separators.
-    this._content = selector.replace(nthRegex, (_, pseudo, exp) => {
+    this._content = selector.replace(/(:nth-[-\w]+)(\([^)]+\))/g, (_, pseudo, exp) => {
       const replaceBy = `__ph-${this.index}__`;
-      this.placeholders.push(`(${exp})`);
+      this.placeholders.push(exp);
       this.index++;
       return pseudo + replaceBy;
     });
@@ -1076,7 +1076,6 @@ const _level1Parens = String.raw`(?:\(${_noParens}\)|${_noParens})+?`;
 // Matches content with at most TWO levels of nesting, e.g., "a(b(c)d)e"
 const _level2Parens = String.raw`(?:\(${_level1Parens}\)|${_noParens})+?`;
 const _parenSuffix = String.raw`(?:\((${_level2Parens})\))`;
-const nthRegex = new RegExp(String.raw`(:nth-[-\w]+)` + _parenSuffix, 'g');
 const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix + '?([^,{]*)', 'gim');
 // note: :host-context patterns are terminated with `{`, as opposed to :host which
 // is both `{` and `,` because :host-context handles top-level commas differently.

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -83,9 +83,6 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host(:not(p)):before {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(p):before {}',
       );
-      expect(shim(':host(:not(:has(p))) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:not(:has(p)) {}',
-      );
       expect(shim(':host:not(:host.foo) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not([a-host].foo) {}',
       );

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -172,20 +172,6 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
-    it('should transform :host-context with nested pseudo selectors', () => {
-      expect(shim(':host-context(:where(.foo:not(.bar))) {}', 'contenta', 'hosta')).toEqualCss(
-        ':where(.foo:not(.bar))[hosta], :where(.foo:not(.bar)) [hosta] {}',
-      );
-      expect(shim(':host-context(:is(.foo:not(.bar))) {}', 'contenta', 'hosta')).toEqualCss(
-        ':is(.foo:not(.bar))[hosta], :is(.foo:not(.bar)) [hosta] {}',
-      );
-      expect(
-        shim(':host-context(:where(.foo:not(.bar, .baz))) .inner {}', 'contenta', 'hosta'),
-      ).toEqualCss(
-        ':where(.foo:not(.bar, .baz))[hosta] .inner[contenta], :where(.foo:not(.bar, .baz)) [hosta] .inner[contenta] {}',
-      );
-    });
-
     it('should handle tag selector', () => {
       expect(shim(':host-context(div) {}', 'contenta', 'a-host')).toEqualCss(
         'div[a-host], div [a-host] {}',
@@ -259,9 +245,6 @@ describe('ShadowCss, :host and :host-context', () => {
       );
       expect(shim(':host-context() .inner {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host] .inner[contenta] {}',
-      );
-      expect(shim(':host-context :host-context(.a) {}', 'contenta', 'host-a')).toEqualCss(
-        '.a[host-a], .a [host-a] {}',
       );
     });
 

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -71,9 +71,6 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host:nth-child(8n+1) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:nth-child(8n+1) {}',
       );
-      expect(shim(':host(:nth-child(3n of :not(p, a))) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:nth-child(3n of :not(p, a)) {}',
-      );
       expect(shim(':host:nth-of-type(8n+1) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:nth-of-type(8n+1) {}',
       );

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -101,15 +101,6 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host:not(.foo, .bar) {}', 'contenta', 'a-host')).toEqualCss(
         '[a-host]:not(.foo, .bar) {}',
       );
-      expect(shim(':host:not(:has(p, a)) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:not(:has(p, a)) {}',
-      );
-      expect(shim(':host(:not(.foo, .bar)) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:not(.foo, .bar) {}',
-      );
-      expect(shim(':host:has(> child-element:not(.foo)) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host]:has(> child-element:not(.foo)) {}',
-      );
     });
 
     // see b/63672152

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -214,20 +214,6 @@ describe('ShadowCss', () => {
       'table[contenta] [contenta]:where(td, th):hover { color:lime;}',
     );
 
-    // :nth
-    expect(shim(':nth-child(3n of :not(p, a), :is(.foo)) {}', 'contenta', 'hosta')).toEqualCss(
-      '[contenta]:nth-child(3n of :not(p, a), :is(.foo)) {}',
-    );
-    expect(shim('li:nth-last-child(-n + 3) {}', 'contenta', 'a-host')).toEqualCss(
-      'li[contenta]:nth-last-child(-n + 3) {}',
-    );
-    expect(shim('dd:nth-last-of-type(3n) {}', 'contenta', 'a-host')).toEqualCss(
-      'dd[contenta]:nth-last-of-type(3n) {}',
-    );
-    expect(shim('dd:nth-of-type(even) {}', 'contenta', 'a-host')).toEqualCss(
-      'dd[contenta]:nth-of-type(even) {}',
-    );
-
     // complex selectors
     expect(shim(':host:is([foo],[foo-2])>div.example-2 {}', 'contenta', 'a-host')).toEqualCss(
       '[a-host]:is([foo],[foo-2]) > div.example-2[contenta] {}',


### PR DESCRIPTION
This PR reverts all commits affecting style encapsulation in the 20.3.11 patch. Note that these commits still exist in main and v21. To be merged pending the decision on https://github.com/angular/angular/issues/65137.