### PR TITLE
refactor(core) add debugName option to rxjs-interop toSignal

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -71,6 +71,7 @@ export function toSignal<T, const U extends T>(source: Observable<T> | Subscriba
 
 // @public
 export interface ToSignalOptions<T> {
+    debugName?: string;
     equal?: ValueEqualityFn_2<T>;
     initialValue?: unknown;
     injector?: Injector;

--- a/packages/core/rxjs-interop/test/BUILD.bazel
+++ b/packages/core/rxjs-interop/test/BUILD.bazel
@@ -7,6 +7,7 @@ ts_project(
     deps = [
         "//:node_modules/rxjs",
         "//packages/core",
+        "//packages/core/primitives/signals",
         "//packages/core/rxjs-interop",
         "//packages/core/testing",
         "//packages/private/testing",

--- a/packages/core/rxjs-interop/test/to_signal_spec.ts
+++ b/packages/core/rxjs-interop/test/to_signal_spec.ts
@@ -26,6 +26,7 @@ import {
   Subscribable,
   Unsubscribable,
 } from 'rxjs';
+import {ReactiveNode, SIGNAL} from '../../primitives/signals';
 
 describe('toSignal()', () => {
   it(
@@ -39,6 +40,28 @@ describe('toSignal()', () => {
       expect(counter()).toBe(1);
       counter$.next(3);
       expect(counter()).toBe(3);
+    }),
+  );
+
+  it(
+    'should set debugName when a debugName is provided',
+    test(() => {
+      const counter$ = new BehaviorSubject(0);
+      const counter = toSignal(counter$, {debugName: 'counterSignal'});
+      const node = counter[SIGNAL] as ReactiveNode;
+
+      expect(node.debugName).toBe('toSignal#counterSignal.source');
+    }),
+  );
+
+  it(
+    'should set debugName when a debugName is provided together with requireSync',
+    test(() => {
+      const counter$ = new BehaviorSubject(0);
+      const counter = toSignal(counter$, {debugName: 'counterSignal', requireSync: true});
+      const node = counter[SIGNAL] as ReactiveNode;
+
+      expect(node.debugName).toBe('toSignal#counterSignal.source');
     }),
   );
 


### PR DESCRIPTION
toSignal predates the debugName option for signals to name the signals in the Angular dev-tools This adds the debugName option to toSignal.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the rxjs-interop function `toSignal` doesn't support the debugName option, which for signals can be used to identify a signal in de Angular dev-tools



## What is the new behavior?
Support for the debugname option in the `toSignal` function, as is supported in signals.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

