### PR TITLE
fix(forms): debounce updates from interop controls

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -271,11 +271,7 @@ function listenToCustomControl(
  */
 function listenToInteropControl(control: ɵControl<unknown>): void {
   const interopControl = control.ɵinteropControl!;
-  interopControl.registerOnChange((value: unknown) => {
-    const state = control.state();
-    state.value.set(value);
-    state.markAsDirty();
-  });
+  interopControl.registerOnChange((value: unknown) => control.state().setControlValue(value));
   interopControl.registerOnTouched(() => control.state().markAsTouched());
 }
 


### PR DESCRIPTION
* Apply any debounce rules to updates from interop controls (if configured).
* Add tests to ensure debouncing works for all control types (native, custom, and interop).