### PR TITLE
fix(docs-infra): update firebase caching regex for generated files

### DIFF
--- a/adev/firebase.json
+++ b/adev/firebase.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "source": "/**/*-[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z].*",
+        "source": "/**/*-[0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_][0-9A-Za-z_].*",
         "headers": [
           {
             "key": "Cache-Control",
@@ -69,7 +69,6 @@
             "key": "Cross-Origin-Opener-Policy",
             "value": "same-origin"
           },
-
           {
             "key": "Cross-Origin-Embedder-Policy",
             "value": "require-corp"


### PR DESCRIPTION
The regex for caching generated files in firebase.json has been updated to include lowercase letters and underscores in the 8-character hash. This ensures that files with names like `chunk-CrXHmw_W.js` are correctly cached.
