### PR TITLE
fix(devtools): forward Angular detection to background

### DIFF
--- a/devtools/projects/shell-browser/src/app/content-script.ts
+++ b/devtools/projects/shell-browser/src/app/content-script.ts
@@ -54,6 +54,9 @@ detectAngularMessageBus.on('detectAngular', (detectionResult) => {
     return;
   }
 
+  // Inform the background page so it can toggle the popup and icon.
+  void chrome.runtime.sendMessage(detectionResult);
+
   const script = document.createElement('script');
   script.src = chrome.runtime.getURL('app/backend_bundle.js');
   document.documentElement.appendChild(script);


### PR DESCRIPTION
Ensure the content script forwards Angular detection results to the service worker so the popup/icon reflects the page state.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
[Angular DevTools](https://angular.dev/tools/devtools) toolbar icon does not turn red when used on a fresh Angular template app and reports no Angular app present. The Angular Devtools panel itself seems to work however.

Issue Number: #65081 


## What is the new behavior?
Toolbar icon now turns red when used on a fresh Angular template.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Closes #65081 