### PR TITLE
refactor(forms): allow passing number|string|null paths to min & max

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -274,7 +274,7 @@ export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind
 export const MAX: AggregateMetadataKey<number | undefined, number | undefined>;
 
 // @public
-export function max<TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<number, SchemaPathRules.Supported, TPathKind>, maxValue: number | LogicFn<number, number | undefined, TPathKind>, config?: BaseValidatorConfig<number, TPathKind>): void;
+export function max<TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>, maxValue: number | LogicFn<number | string | null, number | undefined, TPathKind>, config?: BaseValidatorConfig<number | string | null, TPathKind>): void;
 
 // @public
 export const MAX_LENGTH: AggregateMetadataKey<number | undefined, number | undefined>;
@@ -335,7 +335,7 @@ export class MetadataKey<TValue> {
 export const MIN: AggregateMetadataKey<number | undefined, number | undefined>;
 
 // @public
-export function min<TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<number, SchemaPathRules.Supported, TPathKind>, minValue: number | LogicFn<number, number | undefined, TPathKind>, config?: BaseValidatorConfig<number, TPathKind>): void;
+export function min<TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>, minValue: number | LogicFn<number | string | null, number | undefined, TPathKind>, config?: BaseValidatorConfig<number | string | null, TPathKind>): void;
 
 // @public
 export const MIN_LENGTH: AggregateMetadataKey<number | undefined, number | undefined>;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -335,7 +335,7 @@ export class MetadataKey<TValue> {
 export const MIN: AggregateMetadataKey<number | undefined, number | undefined>;
 
 // @public
-export function min<TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>, minValue: number | LogicFn<number | string | null, number | undefined, TPathKind>, config?: BaseValidatorConfig<number | string | null, TPathKind>): void;
+export function min<TValue extends number | string | null, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, minValue: number | LogicFn<TValue, number | undefined, TPathKind>, config?: BaseValidatorConfig<TValue, TPathKind>): void;
 
 // @public
 export const MIN_LENGTH: AggregateMetadataKey<number | undefined, number | undefined>;
@@ -505,7 +505,7 @@ export namespace SchemaPathRules {
 }
 
 // @public
-export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = (TModel extends AbstractControl ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & (TModel extends AbstractControl ? unknown : TModel extends Array<any> ? unknown : TModel extends Record<string, any> ? {
+export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = ([TModel] extends [AbstractControl] ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & (TModel extends AbstractControl ? unknown : TModel extends Array<any> ? unknown : TModel extends Record<string, any> ? {
     [K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>;
 } : unknown);
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -405,23 +405,25 @@ export type CompatSchemaPath<
  *
  * @experimental 21.0.0
  */
-export type SchemaPathTree<
-  TModel,
-  TPathKind extends PathKind = PathKind.Root,
-> = (TModel extends AbstractControl
-  ? CompatSchemaPath<TModel, TPathKind>
-  : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) &
-  // Subpaths
-  (TModel extends AbstractControl
-    ? unknown
-    : // Array paths have no subpaths
-      TModel extends Array<any>
+export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
+  // Note: We use `[TModel]` here to avoid distributing over a union type model.
+  // (e.g. if we have a model of `number | string`, we want a `SchemaPath<number | string>`,
+  // not a `SchemaPath<number> | SchemaPath<string>`.
+  // See https://typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types)
+  ([TModel] extends [AbstractControl]
+    ? CompatSchemaPath<TModel, TPathKind>
+    : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) &
+    // Subpaths
+    (TModel extends AbstractControl
       ? unknown
-      : // Object subfields
-        TModel extends Record<string, any>
-        ? {[K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>}
-        : // Primitive or other type - no subpaths
-          unknown);
+      : // Array paths have no subpaths
+        TModel extends Array<any>
+        ? unknown
+        : // Object subfields
+          TModel extends Record<string, any>
+          ? {[K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>}
+          : // Primitive or other type - no subpaths
+            unknown);
 
 /**
  * Helper type for defining `FieldPath`. Given a type `TValue` that may include `undefined`, it

--- a/packages/forms/signals/src/api/validators/max.ts
+++ b/packages/forms/signals/src/api/validators/max.ts
@@ -9,7 +9,7 @@
 import {computed} from '@angular/core';
 import {aggregateMetadata, metadata, validate} from '../logic';
 import {MAX} from '../metadata';
-import {SchemaPath, SchemaPathRules, LogicFn, PathKind} from '../types';
+import {LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
 import {maxError} from '../validation_errors';
 import {BaseValidatorConfig, getOption, isEmpty} from './util';
 
@@ -30,9 +30,9 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  * @experimental 21.0.0
  */
 export function max<TPathKind extends PathKind = PathKind.Root>(
-  path: SchemaPath<number, SchemaPathRules.Supported, TPathKind>,
-  maxValue: number | LogicFn<number, number | undefined, TPathKind>,
-  config?: BaseValidatorConfig<number, TPathKind>,
+  path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>,
+  maxValue: number | LogicFn<number | string | null, number | undefined, TPathKind>,
+  config?: BaseValidatorConfig<number | string | null, TPathKind>,
 ) {
   const MAX_MEMO = metadata(path, (ctx) =>
     computed(() => (typeof maxValue === 'number' ? maxValue : maxValue(ctx))),
@@ -46,7 +46,9 @@ export function max<TPathKind extends PathKind = PathKind.Root>(
     if (max === undefined || Number.isNaN(max)) {
       return undefined;
     }
-    if (ctx.value() > max) {
+    const value = ctx.value();
+    const numValue = !value && value !== 0 ? NaN : Number(value); // Treat `''` and `null` as `NaN`
+    if (numValue > max) {
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {

--- a/packages/forms/signals/src/api/validators/min.ts
+++ b/packages/forms/signals/src/api/validators/min.ts
@@ -9,7 +9,7 @@
 import {computed} from '@angular/core';
 import {aggregateMetadata, metadata, validate} from '../logic';
 import {MIN} from '../metadata';
-import {SchemaPath, LogicFn, PathKind, SchemaPathRules} from '../types';
+import {LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
 import {minError} from '../validation_errors';
 import {BaseValidatorConfig, getOption, isEmpty} from './util';
 
@@ -30,9 +30,9 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  * @experimental 21.0.0
  */
 export function min<TPathKind extends PathKind = PathKind.Root>(
-  path: SchemaPath<number, SchemaPathRules.Supported, TPathKind>,
-  minValue: number | LogicFn<number, number | undefined, TPathKind>,
-  config?: BaseValidatorConfig<number, TPathKind>,
+  path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>,
+  minValue: number | LogicFn<number | string | null, number | undefined, TPathKind>,
+  config?: BaseValidatorConfig<number | string | null, TPathKind>,
 ) {
   const MIN_MEMO = metadata(path, (ctx) =>
     computed(() => (typeof minValue === 'number' ? minValue : minValue(ctx))),
@@ -46,7 +46,9 @@ export function min<TPathKind extends PathKind = PathKind.Root>(
     if (min === undefined || Number.isNaN(min)) {
       return undefined;
     }
-    if (ctx.value() < min) {
+    const value = ctx.value();
+    const numValue = !value && value !== 0 ? NaN : Number(value); // Treat `''` and `null` as `NaN`
+    if (numValue < min) {
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {

--- a/packages/forms/signals/src/api/validators/min.ts
+++ b/packages/forms/signals/src/api/validators/min.ts
@@ -29,10 +29,13 @@ import {BaseValidatorConfig, getOption, isEmpty} from './util';
  * @category validation
  * @experimental 21.0.0
  */
-export function min<TPathKind extends PathKind = PathKind.Root>(
-  path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>,
-  minValue: number | LogicFn<number | string | null, number | undefined, TPathKind>,
-  config?: BaseValidatorConfig<number | string | null, TPathKind>,
+export function min<
+  TValue extends number | string | null,
+  TPathKind extends PathKind = PathKind.Root,
+>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  minValue: number | LogicFn<TValue, number | undefined, TPathKind>,
+  config?: BaseValidatorConfig<TValue, TPathKind>,
 ) {
   const MIN_MEMO = metadata(path, (ctx) =>
     computed(() => (typeof minValue === 'number' ? minValue : minValue(ctx))),

--- a/packages/forms/signals/test/node/api/validators/max.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max.spec.ts
@@ -59,7 +59,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             error: ({value}) => {
-              return customError({kind: 'special-max', message: value().toString()});
+              return customError({kind: 'special-max', message: value()?.toString()});
             },
           });
         },
@@ -104,7 +104,7 @@ describe('max validator', () => {
             error: ({value, valueOf}) => {
               return valueOf(p.name) === 'disabled'
                 ? []
-                : customError({kind: 'special-max', message: value().toString()});
+                : customError({kind: 'special-max', message: value()?.toString()});
             },
           });
         },
@@ -155,7 +155,7 @@ describe('max validator', () => {
         (p) => {
           max(p.age, 5, {
             error: ({value}) => {
-              return customError({kind: 'special-max', message: value().toString()});
+              return customError({kind: 'special-max', message: value()?.toString()});
             },
           });
         },
@@ -298,5 +298,31 @@ describe('max validator', () => {
 
       expect(f.age().errors()).toEqual([]);
     });
+  });
+
+  it('should validate properly formatted strings', () => {
+    const f = form(
+      signal<number | string | null>('4'),
+      (p) => {
+        max(p, -10);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    expect(f().errors()).toEqual([jasmine.objectContaining({kind: 'max'})]);
+  });
+
+  it('should not validate improperly formatted strings or null', () => {
+    const f = form(
+      signal<number | string | null>('4f'),
+      (p) => {
+        max(p, -10);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    expect(f().errors()).toEqual([]);
+    f().value.set(null);
+    expect(f().errors()).toEqual([]);
+    f().value.set(4);
+    expect(f().errors()).toEqual([jasmine.objectContaining({kind: 'max'})]);
   });
 });

--- a/packages/forms/signals/test/node/api/validators/min.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min.spec.ts
@@ -59,7 +59,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             error: ({value}) => {
-              return customError({kind: 'special-min', message: value().toString()});
+              return customError({kind: 'special-min', message: value()?.toString()});
             },
           });
         },
@@ -84,7 +84,7 @@ describe('min validator', () => {
             error: ({value}) => {
               return {
                 kind: 'special-min',
-                message: value().toString(),
+                message: value()?.toString(),
               };
             },
           });
@@ -130,7 +130,7 @@ describe('min validator', () => {
             error: ({value, valueOf}) => {
               return valueOf(p.name) === 'disabled'
                 ? []
-                : customError({kind: 'special-min', message: value().toString()});
+                : customError({kind: 'special-min', message: value()?.toString()});
             },
           });
         },
@@ -307,5 +307,31 @@ describe('min validator', () => {
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });
+  });
+
+  it('should validate properly formatted strings', () => {
+    const f = form(
+      signal<number | string | null>('4'),
+      (p) => {
+        min(p, 10);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    expect(f().errors()).toEqual([jasmine.objectContaining({kind: 'min'})]);
+  });
+
+  it('should not validate improperly formatted strings or null', () => {
+    const f = form(
+      signal<number | string | null>('4f'),
+      (p) => {
+        min(p, 10);
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+    expect(f().errors()).toEqual([]);
+    f().value.set(null);
+    expect(f().errors()).toEqual([]);
+    f().value.set(4);
+    expect(f().errors()).toEqual([jasmine.objectContaining({kind: 'min'})]);
   });
 });

--- a/packages/forms/signals/test/node/api/validators/min.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min.spec.ts
@@ -59,7 +59,7 @@ describe('min validator', () => {
         (p) => {
           min(p.age, 5, {
             error: ({value}) => {
-              return customError({kind: 'special-min', message: value()?.toString()});
+              return customError({kind: 'special-min', message: value().toString()});
             },
           });
         },
@@ -84,7 +84,7 @@ describe('min validator', () => {
             error: ({value}) => {
               return {
                 kind: 'special-min',
-                message: value()?.toString(),
+                message: value().toString(),
               };
             },
           });
@@ -130,7 +130,7 @@ describe('min validator', () => {
             error: ({value, valueOf}) => {
               return valueOf(p.name) === 'disabled'
                 ? []
-                : customError({kind: 'special-min', message: value()?.toString()});
+                : customError({kind: 'special-min', message: value().toString()});
             },
           });
         },

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -13,7 +13,6 @@ import {
   applyEach,
   customError,
   disabled,
-  SchemaPath,
   form,
   hidden,
   readonly,
@@ -23,6 +22,7 @@ import {
   Schema,
   schema,
   SchemaOrSchemaFn,
+  SchemaPath,
   SchemaPathTree,
   validate,
   validateTree,
@@ -1228,7 +1228,7 @@ describe('FieldNode', () => {
     });
 
     it('should error on resolving predefined schema path that is not part of the form', () => {
-      let otherP: SchemaPath<any>;
+      let otherP: SchemaPath<string>;
       const s = schema<string>((p) => (otherP = p));
       SchemaImpl.rootCompile(s);
 


### PR DESCRIPTION
Relaxes the constraints on which paths can be used with the `min` & `max` validation rules, since people may want to validate a potentially-null number, or a numeric value represented as a string

Fixes #63789