### PR TITLE
refactor(forms): Make reset take value

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -177,7 +177,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     metadata<M>(key: AggregateMetadataKey<M, any>): Signal<M>;
     metadata<M>(key: MetadataKey<M>): M | undefined;
     readonly pending: Signal<boolean>;
-    reset(): void;
+    reset(value?: TValue): void;
     readonly submitting: Signal<boolean>;
     readonly valid: Signal<boolean>;
 }

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -318,8 +318,10 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.
+   *
+   * @param value Optional value to set to the form. If not passed, the value will not be changed.
    */
-  reset(): void;
+  reset(value?: TValue): void;
 }
 
 /**

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -223,12 +223,18 @@ export class FieldNode implements FieldState<unknown> {
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.
+   *
+   * @param value Optional value to set to the form. If not passed, the value will not be changed.
    */
-  reset(): void {
-    untracked(() => this._reset());
+  reset(value?: unknown): void {
+    untracked(() => this._reset(value));
   }
 
-  private _reset() {
+  private _reset(value?: unknown) {
+    if (value) {
+      this.value.set(value);
+    }
+
     this.nodeState.markAsUntouched();
     this.nodeState.markAsPristine();
 

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -102,6 +102,28 @@ describe('FieldNode', () => {
     expect(childA()).toBeDefined();
   });
 
+  describe('resetting', () => {
+    it('can be reset with a value', () => {
+      const model = signal({a: 1, b: 2});
+      const f = form(model, {injector: TestBed.inject(Injector)});
+      f.a().markAsDirty();
+      f.a().markAsTouched();
+
+      f().reset({a: 5, b: 8});
+      expect(f.a().value()).toBe(5);
+      expect(f.a().dirty()).toBe(false);
+      expect(f.a().touched()).toBe(false);
+    });
+
+    it('can be reset without a value', () => {
+      const model = signal({a: 1, b: 2});
+      const f = form(model, {injector: TestBed.inject(Injector)});
+
+      f().reset();
+      expect(f.a().value()).toBe(1);
+    });
+  });
+
   describe('dirty', () => {
     it('is not dirty initially', () => {
       const f = form(


### PR DESCRIPTION
Now you can do form.reset({name: 'cat', age: 4});
 