### PR TITLE
refactor(forms): reduce boilerplate needed to define custom controls

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -111,8 +111,8 @@ export function ɵɵcontrol<T>(value: T, sanitizer?: SanitizerFn | null): void {
 }
 
 /** A bitmask used to check if a TNode represents a native or custom form control. */
-const HAS_CONTROL_MASK =
-  TNodeFlags.isNativeControl | TNodeFlags.isFormValueControl | TNodeFlags.isFormCheckboxControl;
+const HAS_CONTROL_MASK = /* @__PURE__ */ (() =>
+  TNodeFlags.isNativeControl | TNodeFlags.isFormValueControl | TNodeFlags.isFormCheckboxControl)();
 
 function getControlDirectiveFirstCreatePass<T>(
   tView: TView,

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -110,6 +110,10 @@ export function ɵɵcontrol<T>(value: T, sanitizer?: SanitizerFn | null): void {
   nextBindingIndex();
 }
 
+/** A bitmask used to check if a TNode represents a native or custom form control. */
+const HAS_CONTROL_MASK =
+  TNodeFlags.isNativeControl | TNodeFlags.isFormValueControl | TNodeFlags.isFormCheckboxControl;
+
 function getControlDirectiveFirstCreatePass<T>(
   tView: TView,
   tNode: TNode,
@@ -143,28 +147,31 @@ function getControlDirectiveFirstCreatePass<T>(
 
   if (isComponentHost(tNode)) {
     const componentDef = tView.data[componentIndex] as ComponentDef<unknown>;
-    // TODO: should we check that any additional field state inputs are signal based?
     if (hasModelInput(componentDef, 'value')) {
       tNode.flags |= TNodeFlags.isFormValueControl;
-      return control;
     } else if (hasModelInput(componentDef, 'checked')) {
       tNode.flags |= TNodeFlags.isFormCheckboxControl;
-      return control;
     }
+    // Continue on to check if the host element is also a native control.
   }
 
-  if (control.ɵinteropControl) {
+  // Only check for an interop control if we haven't already found a custom one.
+  if (!(tNode.flags & HAS_CONTROL_MASK) && control.ɵinteropControl) {
     tNode.flags |= TNodeFlags.isInteropControl;
     return control;
   }
 
   if (isNativeControl(tNode)) {
+    tNode.flags |= TNodeFlags.isNativeControl;
     if (isNumericInput(tNode)) {
       tNode.flags |= TNodeFlags.isNativeNumericControl;
     }
     if (isTextControl(tNode)) {
       tNode.flags |= TNodeFlags.isNativeTextControl;
     }
+  }
+
+  if (tNode.flags & HAS_CONTROL_MASK) {
     return control;
   }
 
@@ -457,6 +464,14 @@ function updateCustomControl(
   for (const key of CONTROL_BINDING_KEYS) {
     const inputName = CONTROL_BINDING_NAMES[key];
     maybeUpdateInput(componentDef, component, bindings, state, key, inputName);
+  }
+
+  // If the host node is a native control, we can bind field state properties to attributes for any
+  // that weren't defined as inputs on the custom control. We can reuse the update path for native
+  // controls since any properties with a corresponding input would have just been checked above,
+  // and thus will appear unchanged.
+  if (tNode.flags & TNodeFlags.isNativeControl) {
+    updateNativeControl(tNode, lView, control);
   }
 }
 

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -131,22 +131,22 @@ export function isLetDeclaration(tNode: TNode): boolean {
  */
 export const enum TNodeFlags {
   /** Bit #1 - This bit is set if the node is a host for any directive (including a component) */
-  isDirectiveHost = 0x1,
+  isDirectiveHost = 1 << 0,
 
   /** Bit #2 - This bit is set if the node has been projected */
-  isProjected = 0x2,
+  isProjected = 1 << 1,
 
   /** Bit #3 - This bit is set if any directive on this node has content queries */
-  hasContentQuery = 0x4,
+  hasContentQuery = 1 << 2,
 
   /** Bit #4 - This bit is set if the node has any "class" inputs */
-  hasClassInput = 0x8,
+  hasClassInput = 1 << 3,
 
   /** Bit #5 - This bit is set if the node has any "style" inputs */
-  hasStyleInput = 0x10,
+  hasStyleInput = 1 << 4,
 
   /** Bit #6 - This bit is set if the node has been detached by i18n */
-  isDetached = 0x20,
+  isDetached = 1 << 5,
 
   /**
    * Bit #7 - This bit is set if the node has directives with host bindings.
@@ -154,22 +154,22 @@ export const enum TNodeFlags {
    * This flags allows us to guard host-binding logic and invoke it only on nodes
    * that actually have directives with host bindings.
    */
-  hasHostBindings = 0x40,
+  hasHostBindings = 1 << 6,
 
   /**
    * Bit #8 - This bit is set if the node is a located inside skip hydration block.
    */
-  inSkipHydrationBlock = 0x80,
+  inSkipHydrationBlock = 1 << 7,
 
   /**
    * Bit #9 - This bit is set if the node is a start of a set of control flow blocks.
    */
-  isControlFlowStart = 0x100,
+  isControlFlowStart = 1 << 8,
 
   /**
    * Bit #10 - This bit is set if the node is within a set of control flow blocks.
    */
-  isInControlFlow = 0x200,
+  isInControlFlow = 1 << 9,
 
   /**
    * Bit #11 - This bit is set if the node represents a form control.
@@ -177,42 +177,50 @@ export const enum TNodeFlags {
    * True when the node has an input binding to a `ɵControl` directive (but not also to a custom
    * component).
    */
-  isFormControl = 0x400,
+  isFormControl = 1 << 10,
 
   /**
    * Bit #12 - This bit is set if the node hosts a custom control component.
    *
    * A custom control component's model property is named `value`.
    */
-  isFormValueControl = 0x800,
+  isFormValueControl = 1 << 11,
 
   /**
    * Bit #13 - This bit is set if the node hosts a custom checkbox component.
    *
    * A custom checkbox component's model property is named `checked`.
    */
-  isFormCheckboxControl = 0x1000,
+  isFormCheckboxControl = 1 << 12,
 
   /**
    * Bit #14 - This bit is set if the node hosts an interoperable control implementation.
    *
    * This is used to bind to a `ControlValueAccessor` from `@angular/forms`.
    */
-  isInteropControl = 0x2000,
+  isInteropControl = 1 << 13,
 
   /**
-   * Bit #15 - This bit is set if the node is a native control with a numeric type.
+   * Bit #15 - This bit is set if the node is a native control.
+   *
+   * This is used to determine whether we can bind common control properties to the host element of
+   * a custom control when it doesn't define a corresponding input.
+   */
+  isNativeControl = 1 << 14,
+
+  /**
+   * Bit #16 - This bit is set if the node is a native control with a numeric type.
    *
    * This is used to determine whether the control supports the `min` and `max` properties.
    */
-  isNativeNumericControl = 0x4000,
+  isNativeNumericControl = 1 << 15,
 
   /**
-   * Bit #16 - This bit is set if the node is a native text control.
+   * Bit #17 - This bit is set if the node is a native text control.
    *
    * This is used to determine whether control supports the `minLength` and `maxLength` properties.
    */
-  isNativeTextControl = 0x8000,
+  isNativeTextControl = 1 << 16,
 }
 
 /**

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -155,6 +155,33 @@ describe('field directive', () => {
         expect(component.customControl().disabled()).toBe(true);
       });
 
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<boolean> {
+          readonly value = model(false);
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<input custom [field]="f" />`,
+        })
+        class TestCmp {
+          readonly disabled = signal(false);
+          readonly f = form(signal(false), (p) => {
+            disabled(p, this.disabled);
+          });
+          readonly customControl = viewChild.required(CustomControl);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+        expect(input.disabled).toBe(false);
+
+        act(() => component.disabled.set(true));
+        expect(input.disabled).toBe(true);
+      });
+
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
@@ -256,6 +283,30 @@ describe('field directive', () => {
         expect(control1.name()).toBe('root.1');
         expect(fixture.nativeElement.innerText).toBe('ab');
       });
+
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `
+            @for (item of f; track item) {
+              <input custom [field]="item" />
+            }
+          `,
+        })
+        class TestCmp {
+          readonly f = form(signal(['a', 'b']), {name: 'root'});
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const inputs = fixture.nativeElement.querySelectorAll('input');
+        expect(inputs[0].name).toBe('root.0');
+        expect(inputs[1].name).toBe('root.1');
+      });
     });
 
     describe('readonly', () => {
@@ -304,6 +355,32 @@ describe('field directive', () => {
 
         act(() => component.readonly.set(true));
         expect(component.child().readonly()).toBe(true);
+      });
+
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<input custom [field]="f" />`,
+        })
+        class TestCmp {
+          readonly readonly = signal(false);
+          readonly f = form(signal(''), (p) => {
+            readonly(p, this.readonly);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+        expect(input.readOnly).toBe(false);
+
+        act(() => component.readonly.set(true));
+        expect(input.readOnly).toBe(true);
       });
 
       it('should be reset when field changes on native control', () => {
@@ -403,6 +480,32 @@ describe('field directive', () => {
         expect(component.customControl().required()).toBe(true);
       });
 
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<input custom [field]="f" />`,
+        })
+        class TestCmp {
+          readonly required = signal(false);
+          readonly f = form(signal(''), (p) => {
+            required(p, {when: this.required});
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+        expect(input.required).toBe(false);
+
+        act(() => component.required.set(true));
+        expect(input.required).toBe(true);
+      });
+
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
@@ -498,6 +601,32 @@ describe('field directive', () => {
 
         act(() => component.max.set(5));
         expect(component.customControl().max()).toBe(5);
+      });
+
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<number> {
+          readonly value = model(0);
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<input custom type="number" [field]="f" />`,
+        })
+        class TestCmp {
+          readonly max = signal(10);
+          readonly f = form(signal(5), (p) => {
+            max(p, this.max);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+        expect(input.max).toBe('10');
+
+        act(() => component.max.set(5));
+        expect(input.max).toBe('5');
       });
 
       it('should be reset when field changes on native control', () => {
@@ -597,6 +726,32 @@ describe('field directive', () => {
         expect(component.customControl().min()).toBe(5);
       });
 
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'input[custom]', template: ``})
+        class CustomControl implements FormValueControl<number> {
+          readonly value = model(0);
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<input custom type="number" [field]="f" />`,
+        })
+        class TestCmp {
+          readonly min = signal(10);
+          readonly f = form(signal(15), (p) => {
+            min(p, this.min);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+        expect(input.min).toBe('10');
+
+        act(() => component.min.set(5));
+        expect(input.min).toBe('5');
+      });
+
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
@@ -692,6 +847,32 @@ describe('field directive', () => {
 
         act(() => component.maxLength.set(5));
         expect(component.customControl().maxLength()).toBe(5);
+      });
+
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'textarea[custom]', template: ``})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<textarea custom [field]="f"></textarea>`,
+        })
+        class TestCmp {
+          readonly maxLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            maxLength(p, this.maxLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+        expect(textarea.maxLength).toBe(10);
+
+        act(() => component.maxLength.set(5));
+        expect(textarea.maxLength).toBe(5);
       });
 
       it('should not bind to native control that does not support it', () => {
@@ -805,6 +986,32 @@ describe('field directive', () => {
 
         act(() => component.minLength.set(5));
         expect(component.customControl().minLength()).toBe(5);
+      });
+
+      it('should bind to native control host of custom control without input', () => {
+        @Component({selector: 'textarea[custom]', template: ``})
+        class CustomControl implements FormValueControl<string> {
+          readonly value = model('');
+        }
+
+        @Component({
+          imports: [Field, CustomControl],
+          template: `<textarea custom [field]="f"></textarea>`,
+        })
+        class TestCmp {
+          readonly minLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            minLength(p, this.minLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const component = fixture.componentInstance;
+        const textarea = fixture.nativeElement.querySelector('textarea') as HTMLTextAreaElement;
+        expect(textarea.minLength).toBe(10);
+
+        act(() => component.minLength.set(5));
+        expect(textarea.minLength).toBe(5);
       });
 
       it('should not bind to native control that does not support it', () => {


### PR DESCRIPTION
An early piece of feedback received regarding custom controls hosted on native inputs was that they required a lot of boilerplate to bind `FieldState` properties. Each property required an input to accept the property, and a host binding to forward it to the native control.

The framework now handles this forwarding automatically for properties without corresponding inputs on custom controls hosted by native control elements.