### PR TITLE
docs: standardize package manager commands in guides

### DIFF
--- a/adev/src/content/guide/elements.md
+++ b/adev/src/content/guide/elements.md
@@ -18,11 +18,20 @@ Once a custom element is added to the DOM for any page, it looks and behaves lik
 
 To add the `@angular/elements` package to your workspace, run the following command:
 
-```shell
-
-npm install @angular/elements --save
-
-```
+<docs-code-multifile>
+  <docs-code header="npm" language="shell">
+    npm install @angular/elements
+  </docs-code>
+  <docs-code header="yarn" language="shell">
+    yarn add @angular/elements
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add @angular/elements
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add @angular/elements
+  </docs-code>
+</docs-code-multifile>
 
 ### How it works
 

--- a/adev/src/content/guide/tailwind.md
+++ b/adev/src/content/guide/tailwind.md
@@ -17,9 +17,20 @@ cd my-project
 
 Next, open a terminal in your Angular project's root directory and run the following command to install Tailwind CSS and its peer dependencies:
 
-<docs-code language="shell">
-npm install tailwindcss @tailwindcss/postcss postcss
-</docs-code>
+<docs-code-multifile>
+  <docs-code header="npm" language="shell">
+    npm install tailwindcss @tailwindcss/postcss postcss
+  </docs-code>
+  <docs-code header="yarn" language="shell">
+    yarn add tailwindcss @tailwindcss/postcss postcss
+  </docs-code>
+  <docs-code header="pnpm" language="shell">
+    pnpm add tailwindcss @tailwindcss/postcss postcss
+  </docs-code>
+  <docs-code header="bun" language="shell">
+    bun add tailwindcss @tailwindcss/postcss postcss
+  </docs-code>
+</docs-code-multifile>
 
 ### 3. Configure PostCSS Plugins
 


### PR DESCRIPTION
This commit updates the elements and tailwind guides to use the standardized `docs-code-multifile` format for package manager commands. This change introduces `yarn`, `pnpm`, and `bun` alternatives to the existing `npm` commands, providing a consistent experience for users across different package managers.