### PR TITLE
fix(devtools): ensure external docs link opens correctly from extension popup

### DIFF
--- a/devtools/projects/shell-browser/src/popups/production.html
+++ b/devtools/projects/shell-browser/src/popups/production.html
@@ -56,7 +56,12 @@
         <section>
           <p>
             Angular application running in
-            <a href="https://angular.dev/api/core/enableProdMode">production mode</a>.
+            <a
+              href="https://angular.dev/api/core/enableProdMode"
+              target="_blank"
+              rel="noopener noreferrer"
+              >production mode</a
+            >.
           </p>
           <p>We recommend using DevTools with apps in dev mode, running <code>ng serve</code>.</p>
         </section>


### PR DESCRIPTION
Adds target="_blank" and rel="noopener noreferrer" to fix the issue preventing tab-nabbing and following modern security best practices.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The link to the enableProdMode documentation does not open when clicked in the Angular DevTools popup.

Issue Number: N/A


## What is the new behavior?
The link to the enableProdMode documentation works correctly when clicked in the Angular DevTools popup.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No