### PR TITLE
fix(forms): Set error message of a schema error.

### DIFF
--- a/packages/forms/signals/src/api/validators/standard_schema.ts
+++ b/packages/forms/signals/src/api/validators/standard_schema.ts
@@ -121,5 +121,5 @@ function standardIssueToFormTreeError(
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
     target = target[pathKey] as FieldTree<Record<PropertyKey, unknown>>;
   }
-  return addDefaultField(standardSchemaError(issue), target);
+  return addDefaultField(standardSchemaError(issue, {message: issue.message}), target);
 }

--- a/packages/forms/signals/test/node/api/validators/standard_schema.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/standard_schema.spec.ts
@@ -194,4 +194,19 @@ describe('standard schema integration', () => {
 
     expect(f().errors().length).toBe(1);
   });
+
+  it('should set the error message from the schema issue', () => {
+    const model = signal({age: -5});
+    const f = form(
+      model,
+      (p) => {
+        validateStandardSchema(p.age, z.number().min(0, {message: 'Age must be non-negative'}));
+      },
+      {
+        injector: TestBed.inject(Injector),
+      },
+    );
+
+    expect(f.age().errors()[0].message).toBe('Age must be non-negative');
+  });
 });


### PR DESCRIPTION
Use the error message of the issue as the error message of the error itself.

fixes #65247
