### PR TITLE
fix(compiler): throw on invalid `in` expressions

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -17,8 +17,8 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
 import {
   AbsoluteSourceSpan,
   ArrowFunction,
-  ArrowFunctionParameter,
   ArrowFunctionIdentifierParameter,
+  ArrowFunctionParameter,
   AST,
   ASTWithSource,
   Binary,
@@ -969,7 +969,7 @@ class _ParseAST {
     let result = this.parseAdditive();
     while (
       this.next.type == TokenType.Operator ||
-      this.next.isKeywordIn() || // Should be invoked. This is bug here that will be fixed by #65249 when the breaking change window opens.
+      this.next.isKeywordIn() ||
       this.next.isKeywordInstanceOf()
     ) {
       const operator = this.next.strValue;
@@ -1144,9 +1144,6 @@ class _ParseAST {
     } else if (this.next.isKeywordFalse()) {
       this.advance();
       return new LiteralPrimitive(this.span(start), this.sourceSpan(start), false);
-    } else if (this.next.isKeywordIn()) {
-      this.advance();
-      return new LiteralPrimitive(this.span(start), this.sourceSpan(start), 'in');
     } else if (this.next.isKeywordThis()) {
       this.advance();
       return new ThisReceiver(this.span(start), this.sourceSpan(start));

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -126,6 +126,16 @@ describe('parser', () => {
     it('should parse in expressions', () => {
       checkAction(`'key' in obj`, `"key" in obj`);
       checkAction(`('key' in obj) && true`, `("key" in obj) && true`);
+      checkAction(`'in' in {in: foo}`, `"in" in {in: foo}`);
+    });
+
+    it('should throw on invalid in expressions', () => {
+      expectActionError('in', 'Unexpected token in');
+      expectActionError('in foo', 'Unexpected token in');
+      expectActionError(
+        `'foo' in`,
+        `Unexpected end of expression: 'foo' in at the end of the expression ['foo' in]`,
+      );
     });
 
     it('should ignore comments in expressions', () => {

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -833,25 +833,6 @@ describe('standalone components, directives, and pipes', () => {
       expect(fixture.nativeElement.textContent).toBe('standalone: input value');
     });
 
-    it('should allow extending a standalone component and turn it into a regular one', () => {
-      @Component({selector: 'standalone', template: 'standalone: {{in}}'})
-      class StandaloneCmp {
-        @Input() input: string | undefined;
-      }
-
-      @Component({
-        selector: 'regular',
-        template: 'regular: {{input}}',
-        standalone: false,
-      })
-      class RegularCmp extends StandaloneCmp {}
-
-      const fixture = TestBed.createComponent(RegularCmp);
-      fixture.componentInstance.input = 'input value';
-      fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('regular: input value');
-    });
-
     it('should ?', () => {
       @Component({
         selector: 'inner',


### PR DESCRIPTION
`{{in}}` are not interpreted as `'in'` string expressions anymore.

```
<input #in /> // OK
{{in}} // throws
```

fixes https://github.com/angular/angular/issues/65244

BREAKING CHANGE: `in` variables will throw in template expressions.