### PR TITLE
fix(compiler): don't choke on unbalanced parens in declaration block

### DIFF
--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -339,6 +339,13 @@ describe('ShadowCss', () => {
     expect(css).toEqualCss('div[contenta] {background-image:url("a.jpg"); color:red;}');
   });
 
+  it('should handle when quoted content contains a closing parenthesis', () => {
+    // Regression test for https://github.com/angular/angular/issues/65137
+    expect(shim('p { background-image: url(")") } p { color: red }', 'contenta')).toEqualCss(
+      'p[contenta] { background-image: url(")") } p[contenta] { color: red }',
+    );
+  });
+
   it('should shim rules with an escaped quote inside quoted content', () => {
     const styleStr = 'div::after { content: "\\"" }';
     const css = shim(styleStr, 'contenta');


### PR DESCRIPTION
Following https://github.com/angular/angular/pull/64509 we started choking on unbalanced closing parentheses in declaration blocks, specifically in quoted background-image urls. This was reported in https://github.com/angular/angular/issues/65137.

This occured because we previously (and now again) traverse the entire declaration block when selecting for :host-context() selectors to shim. This is an oddity of how we parse styles today, and is likely something we'd want to remove if we parsed selectors properly.

This change adds a new flag to _splitOnTopLevelCommas which allows it to continue past unbalanced closing parentheses in the declaration block, returning _convertColonHostContext to its previous behavior while keeping support for the extra nesting in :host-context().