### PR TITLE
fix(docs-infra): prevent example resets from affecting CDK

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
@@ -96,37 +96,3 @@
     top: 0.31rem;
   }
 }
-
-// stylelint-disable-next-line
-::ng-deep {
-  .docs-example-viewer-preview {
-    // stylelint-disable-next-line
-    all: initial;
-    display: block;
-    padding: 1rem;
-    border-block-start: 1px solid var(--senary-contrast);
-
-    *,
-    code::before,
-    code,
-    pre,
-    a,
-    i,
-    p,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    ol,
-    ul,
-    li,
-    hr,
-    input,
-    select,
-    table {
-      all: revert;
-    }
-  }
-}

--- a/adev/src/local-styles.scss
+++ b/adev/src/local-styles.scss
@@ -1,5 +1,7 @@
 @use './styles/xterm';
+@use './styles/resets';
 
+@include resets.resets();
 @include xterm.xterm();
 
 @tailwind base;

--- a/adev/src/styles/_resets.scss
+++ b/adev/src/styles/_resets.scss
@@ -1,0 +1,36 @@
+@mixin resets {
+  .docs-example-viewer-preview {
+    // stylelint-disable-next-line
+    all: initial;
+    display: block;
+    padding: 1rem;
+    border-block-start: 1px solid var(--senary-contrast);
+
+    // These styles reset the example styles so that global styles from the rest of the
+    // page don't affect them, however they can be somewhat aggressive. To prevent them from
+    // affecting structural styles like the CDK overlay's positioning CSS, we include
+    // them in the global stylesheet, as early as possible.
+    *,
+    code::before,
+    code,
+    pre,
+    a,
+    i,
+    p,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    ol,
+    ul,
+    li,
+    hr,
+    input,
+    select,
+    table {
+      all: revert;
+    }
+  }
+}


### PR DESCRIPTION
The example viewer has some `::ng-deep` styles that are used to reset global styles that leak into the live examples. It works by applying a style like `.docs-example-viewer-preview * {all: revert;}`.

The problem with this is that depending on when the first example is rendered, the styles will be lower or higher in the cascade, thus making the reset unreliable. Furthermore, it can affect structural styles from the CDK which intentionally have low specificity.

These changes move the resets into the global stylesheet to make them more predictable.
