### PR TITLE
refactor(core): promote the custom track profiler to stable.

### DIFF
--- a/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
+++ b/packages/core/src/render3/debug/chrome_dev_tools_performance.ts
@@ -228,7 +228,7 @@ function getProviderTokenMeasureName<T>(token: any) {
  *
  * Note: integration is enabled in the development mode only, this operation is noop in the production mode.
  *
- * @experimental
+ * @publicApi v21.0
  *
  * @returns a function that can be invoked to stop sending profiling data.
  */


### PR DESCRIPTION
We didn't get much report on the feature itself so we feel confident about promoting it to stable. In parallel we'll also land #62959 but one is not blocking the other.

fixes #64996
