### PR TITLE
fix(core): debug data causing memory leak for root effects

### DIFF
--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -177,6 +177,9 @@ export class AfterRenderEffectSequence extends AfterRenderSequence {
     AfterRenderPhaseEffectNode | undefined,
   ] = [undefined, undefined, undefined, undefined];
 
+  /** Function to be called when the effect is destroyed. */
+  onDestroyFns: (() => void)[] | null = null;
+
   constructor(
     impl: AfterRenderImpl,
     effectHooks: Array<AfterRenderPhaseEffectHook | undefined>,
@@ -234,6 +237,12 @@ export class AfterRenderEffectSequence extends AfterRenderSequence {
   }
 
   override destroy(): void {
+    if (this.onDestroyFns !== null) {
+      for (const fn of this.onDestroyFns) {
+        fn();
+      }
+    }
+
     super.destroy();
 
     // Run the cleanup functions for each node.

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -23,7 +23,6 @@ import {assertNotInReactiveContext} from './asserts';
 import {assertInInjectionContext} from '../../di/contextual';
 import {DestroyRef, NodeInjectorDestroyRef} from '../../linker/destroy_ref';
 import {ViewContext} from '../view_context';
-import {noop} from '../../util/noop';
 import {
   ChangeDetectionScheduler,
   NotificationSource,
@@ -171,7 +170,7 @@ export function effect(
 
   if (destroyRef !== null) {
     // If we need to register for cleanup, do that here.
-    node.onDestroyFn = destroyRef.onDestroy(() => node.destroy());
+    node.onDestroyFns = [destroyRef.onDestroy(() => node.destroy())];
   }
 
   const effectRef = new EffectRefImpl(node);
@@ -194,7 +193,7 @@ export interface EffectNode extends BaseEffectNode, SchedulableEffect {
   injector: Injector;
   notifier: ChangeDetectionScheduler;
 
-  onDestroyFn: () => void;
+  onDestroyFns: (() => void)[] | null;
 }
 
 export interface ViewEffectNode extends EffectNode {
@@ -210,7 +209,7 @@ export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'noti
     ...BASE_EFFECT_NODE,
     cleanupFns: undefined,
     zone: null,
-    onDestroyFn: noop,
+    onDestroyFns: null,
     run(this: EffectNode): void {
       if (ngDevMode && isInNotificationPhase()) {
         throw new Error(`Schedulers cannot synchronously execute watches while scheduling.`);
@@ -253,7 +252,13 @@ export const ROOT_EFFECT_NODE: Omit<RootEffectNode, 'fn' | 'scheduler' | 'notifi
     },
     destroy(this: RootEffectNode) {
       consumerDestroy(this);
-      this.onDestroyFn();
+
+      if (this.onDestroyFns !== null) {
+        for (const fn of this.onDestroyFns) {
+          fn();
+        }
+      }
+
       this.cleanup();
       this.scheduler.remove(this);
     },
@@ -269,7 +274,13 @@ export const VIEW_EFFECT_NODE: Omit<ViewEffectNode, 'fn' | 'view' | 'injector' |
     },
     destroy(this: ViewEffectNode): void {
       consumerDestroy(this);
-      this.onDestroyFn();
+
+      if (this.onDestroyFns !== null) {
+        for (const fn of this.onDestroyFns) {
+          fn();
+        }
+      }
+
       this.cleanup();
       this.view[EFFECTS]?.delete(this);
     },

--- a/packages/core/test/acceptance/signal_debug_spec.ts
+++ b/packages/core/test/acceptance/signal_debug_spec.ts
@@ -17,6 +17,8 @@ import {
   Injectable,
   signal,
   Injector,
+  ApplicationRef,
+  afterRenderEffect,
 } from '../../src/core';
 import {
   getFrameworkDIDebugData,
@@ -444,5 +446,39 @@ describe('getSignalGraph', () => {
     const edgesWithNodes = mapEdgeIndicesIntoNodes(edges, nodes);
     expect(edgesWithNodes).toContain({consumer: effectBNode!, producer: signalANode!});
     expect(edgesWithNodes).toContain({consumer: effectDNode!, producer: signalCNode!});
+  });
+
+  it('should stop tracking effect when ref is destroyed', () => {
+    @Component({template: ''})
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const injector = TestBed.inject(ApplicationRef).injector;
+    expect(getFrameworkDIDebugData().resolverToEffects.has(injector)).toBe(false);
+
+    const ref = effect(() => {}, {injector});
+    expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(1);
+
+    ref.destroy();
+    expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(0);
+  });
+
+  it('should stop tracking afterRenderEffect when ref is destroyed', () => {
+    @Component({template: ''})
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const injector = TestBed.inject(ApplicationRef).injector;
+    expect(getFrameworkDIDebugData().resolverToEffects.has(injector)).toBe(false);
+
+    const ref = afterRenderEffect(() => {}, {injector});
+    expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(1);
+
+    ref.destroy();
+    expect(getFrameworkDIDebugData().resolverToEffects.get(injector)?.length).toBe(0);
   });
 });


### PR DESCRIPTION
We track all effects that are created for debugging purposes in the `resolverToEffects` map. This ends up leaking memory for effects registered on long-living resolvers (e.g. on the root injector), because they stay in the array, even if the effect itself has been destroyed.

These changes add a callback to clean up the references.

Fixes #65265.
