### PR TITLE
fix(devtools): show profiler exec details only if there are directives

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.html
@@ -24,7 +24,7 @@
         <p class="total-time">
           Total time spent: <span>{{ entry.value | number }} ms</span>
         </p>
-        @if (entry.value > 0) {
+        @if (selectedDirectives().length) {
           <ng-execution-details [data]="selectedDirectives()" />
         }
         @if (parentHierarchy().length > 0) {


### PR DESCRIPTION
Show the execution details of a captured frame entry only if there are recorded directives.