### PR TITLE
docs: replace <docs-code> shell examples with fenced shell code blocks

### DIFF
--- a/adev/src/content/ecosystem/service-workers/app-shell.md
+++ b/adev/src/content/ecosystem/service-workers/app-shell.md
@@ -9,22 +9,18 @@ This gives users a meaningful first paint of your application that appears quick
 <docs-step title="Prepare the application">
 Do this with the following Angular CLI command:
 
-<docs-code language="shell">
-
+```shell
 ng new my-app
-
-</docs-code>
+```
 
 For an existing application, you have to manually add the `Router` and defining a `<router-outlet>` within your application.
 </docs-step>
 <docs-step title="Create the application shell">
 Use the Angular CLI to automatically create the application shell.
 
-<docs-code language="shell">
-
+```shell
 ng generate app-shell
-
-</docs-code>
+```
 
 For more information about this command, see [App shell command](cli/generate/app-shell).
 
@@ -44,19 +40,15 @@ src
 
 <docs-step title="Verify the application is built with the shell content">
 
-<docs-code language="shell">
-
+```shell
 ng build --configuration=development
-
-</docs-code>
+```
 
 Or to use the production configuration.
 
-<docs-code language="shell">
-
+```shell
 ng build
-
-</docs-code>
+```
 
 To verify the build output, open <code class="no-auto-link">dist/my-app/browser/index.html</code>.
 Look for default text `app-shell works!` to show that the application shell route was rendered as part of the output.

--- a/adev/src/content/ecosystem/web-workers.md
+++ b/adev/src/content/ecosystem/web-workers.md
@@ -9,20 +9,16 @@ HELPFUL: The Angular CLI does not support running itself in a web worker.
 
 To add a web worker to an existing project, use the Angular CLI `ng generate` command.
 
-<docs-code language="shell">
-
+```shell
 ng generate web-worker <location>
-
-</docs-code>
+```
 
 You can add a web worker anywhere in your application.
 For example, to add a web worker to the root component, `src/app/app.component.ts`, run the following command.
 
-<docs-code language="shell">
-
+```shell
 ng generate web-worker app
-
-</docs-code>
+```
 
 The command performs the following actions.
 

--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -66,11 +66,9 @@ If you are having issues running this command in Windows or Unix, check out the 
 
 In your terminal, run the CLI command `ng new` with the desired project name. In the following examples, we'll be using the example project name of `my-first-angular-app`.
 
-<docs-code language="shell">
-
+```shell
 ng new <project-name>
-
-</docs-code>
+```
 
 You will be presented with some configuration options for your project. Use the arrow and enter keys to navigate and select which options you desire.
 
@@ -89,19 +87,15 @@ At this point, you're now ready to run your project locally!
 
 In your terminal, switch to your new Angular project.
 
-<docs-code language="shell">
-
+```shell
 cd my-first-angular-app
-
-</docs-code>
+```
 
 All of your dependencies should be installed at this point (which you can verify by checking for the existence of a `node_modules` folder in your project), so you can start your project by running the command:
 
-<docs-code language="shell">
-
+```shell
 npm start
-
-</docs-code>
+```
 
 If everything is successful, you should see a similar confirmation message in your terminal:
 

--- a/adev/src/content/kitchen-sink.md
+++ b/adev/src/content/kitchen-sink.md
@@ -157,9 +157,9 @@ Here's a code example fully styled:
 
 We also have styling for the terminal, just set the language as `shell`:
 
-<docs-code language="shell">
-  npm install @angular/material --save
-</docs-code>
+```shell
+npm install @angular/material --save
+```
 
 #### `<docs-code>` Attributes
 
@@ -261,9 +261,10 @@ Steps must start on a new line, and can contain `docs-code`s and other nested el
 
 To install the Angular CLI, open a terminal window and run the following command:
 
-  <docs-code language="shell">
-    npm install -g @angular/cli
-  </docs-code>
+```shell
+npm install -g @angular/cli
+```
+
 </docs-step>
 
 <docs-step title="Create a workspace and initial application">
@@ -272,9 +273,10 @@ To install the Angular CLI, open a terminal window and run the following command
 To create a new workspace and initial starter app:
 
 - Run the CLI command `ng new` and provide the name `my-app`, as shown here:
-  <docs-code language="shell">
+
+  ```shell
   ng new my-app
-  </docs-code>
+  ```
 
 - The ng new command prompts you for information about features to include in the initial app. Accept the defaults by pressing the Enter or Return key.
 
@@ -288,10 +290,11 @@ To create a new workspace and initial starter app:
 
 1. Navigate to the workspace folder, such as `my-app`.
 2. Run the following command:
-   <docs-code language="shell">
+
+   ```shell
    cd my-app
    ng serve --open
-   </docs-code>
+   ```
 
 The `ng serve` command launches the server, watches your files, and rebuilds the app as you make changes to those files.
 

--- a/adev/src/content/reference/configs/file-structure.md
+++ b/adev/src/content/reference/configs/file-structure.md
@@ -6,11 +6,9 @@ A project is the set of files that comprise an application or a shareable librar
 
 The Angular CLI `ng new` command creates a workspace.
 
-<docs-code language="shell">
-
+```shell
 ng new my-project
-
-</docs-code>
+```
 
 When you run this command, the CLI installs the necessary Angular npm packages and other dependencies in a new workspace, with a root-level application named _my-project_.
 
@@ -105,21 +103,17 @@ A multi-project workspace also supports library development.
 If you intend to have multiple projects in a workspace, you can skip the initial application generation when you create the workspace, and give the workspace a unique name.
 The following command creates a workspace with all of the workspace-wide configuration files, but no root-level application.
 
-<docs-code language="shell">
-
+```shell
 ng new my-workspace --no-create-application
-
-</docs-code>
+```
 
 You can then generate applications and libraries with names that are unique within the workspace.
 
-<docs-code language="shell">
-
+```shell
 cd my-workspace
 ng generate application my-app
 ng generate library my-lib
-
-</docs-code>
+```
 
 ### Multiple project file structure
 

--- a/adev/src/content/reference/migrations/cleanup-unused-imports.md
+++ b/adev/src/content/reference/migrations/cleanup-unused-imports.md
@@ -6,11 +6,9 @@ Running this schematic will clean up all unused imports within the project.
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:cleanup-unused-imports
-
-</docs-code>
+```
 
 #### Before
 

--- a/adev/src/content/reference/migrations/common-to-standalone.md
+++ b/adev/src/content/reference/migrations/common-to-standalone.md
@@ -4,11 +4,9 @@ This migration helps projects remove imports of the `CommonModule` inside compon
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:common-to-standalone
-
-</docs-code>
+```
 
 ## Options
 

--- a/adev/src/content/reference/migrations/control-flow.md
+++ b/adev/src/content/reference/migrations/control-flow.md
@@ -6,8 +6,6 @@ This schematic migrates all existing code in your application to use new Control
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:control-flow
-
-</docs-code>
+```

--- a/adev/src/content/reference/migrations/inject-function.md
+++ b/adev/src/content/reference/migrations/inject-function.md
@@ -6,11 +6,9 @@ This schematic converts constructor-based injection in your classes to use the `
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:inject
-
-</docs-code>
+```
 
 #### Before
 

--- a/adev/src/content/reference/migrations/route-lazy-loading.md
+++ b/adev/src/content/reference/migrations/route-lazy-loading.md
@@ -4,21 +4,17 @@ This schematic helps developers to convert eagerly loaded component routes to la
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:route-lazy-loading
-
-</docs-code>
+```
 
 ### `path` config option
 
 By default, migration will go over the entire application. If you want to apply this migration to a subset of the files, you can pass the path argument as shown below:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:route-lazy-loading --path src/app/sub-component
-
-</docs-code>
+```
 
 The value of the path parameter is a relative path within the project.
 

--- a/adev/src/content/reference/migrations/router-testing-module-migration.md
+++ b/adev/src/content/reference/migrations/router-testing-module-migration.md
@@ -6,11 +6,9 @@ When a test imports `SpyLocation` from `@angular/common/testing` and uses `urlCh
 
 Run the schematic with:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:router-testing-module-migration
-
-</docs-code>
+```
 
 ## Options
 

--- a/adev/src/content/reference/migrations/self-closing-tags.md
+++ b/adev/src/content/reference/migrations/self-closing-tags.md
@@ -6,11 +6,9 @@ This schematic migrates the templates in your application to use self-closing ta
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:self-closing-tag
-
-</docs-code>
+```
 
 #### Before
 

--- a/adev/src/content/reference/migrations/standalone.md
+++ b/adev/src/content/reference/migrations/standalone.md
@@ -8,11 +8,9 @@ This schematic helps to transform components, directive and pipes in existing pr
 
 Run the schematic using the following command:
 
-<docs-code language="shell">
-
+```shell
 ng generate @angular/core:standalone
-
-</docs-code>
+```
 
 ## Before updating
 

--- a/adev/src/content/tutorials/first-app/steps/09-services/README.md
+++ b/adev/src/content/tutorials/first-app/steps/09-services/README.md
@@ -35,9 +35,9 @@ In the **Terminal** pane of your IDE:
 1. In your project directory, navigate to the `first-app` directory.
 1. In the `first-app` directory, run this command to create the new service.
 
-<docs-code language="shell">
+```shell
 ng generate service housing --skip-tests
-</docs-code>
+```
 
 1. Run `ng serve` to build the app and serve it to `http://localhost:4200`.
 1. Confirm that the app builds without error.

--- a/adev/src/content/tutorials/first-app/steps/10-routing/README.md
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/README.md
@@ -23,9 +23,9 @@ In this lesson, you will enable routing in your application to navigate to the d
 <docs-step title="Create a default details component ">
 1. From the terminal, enter the following command to create the `Details`:
 
-    <docs-code language="shell">
+    ```shell
     ng generate component details
-    </docs-code>
+    ```
 
     This component will represent the details page that provides more information on a given housing location.
 
@@ -34,22 +34,22 @@ In this lesson, you will enable routing in your application to navigate to the d
 <docs-step title="Add routing to the application">
 1.  In the `src/app` directory, create a file called `routes.ts`. This file is where we will define the routes in the application.
 
-1. In `main.ts`, make the following updates to enable routing in the application:
+2. In `main.ts`, make the following updates to enable routing in the application:
    1. Import the routes file and the `provideRouter` function:
 
    <docs-code header="Import routing details in src/main.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/main.ts" visibleLines="[7,8]"/>
-   1. Update the call to `bootstrapApplication` to include the routing configuration:
+   2. Update the call to `bootstrapApplication` to include the routing configuration:
 
    <docs-code header="Add router configuration in src/main.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/main.ts" visibleLines="[10,17]"/>
 
-1. In `src/app/app.ts`, update the component to use routing:
+3. In `src/app/app.ts`, update the component to use routing:
    1. Add file level imports for the router directives `RouterOutlet` and `RouterLink`:
 
    <docs-code language="angular-ts" header="Import router directives in src/app/app.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.ts" visibleLines="[3]"/>
-   1. Add `RouterOutlet` and `RouterLink` to the `@Component` metadata imports
+   2. Add `RouterOutlet` and `RouterLink` to the `@Component` metadata imports
 
    <docs-code language="angular-ts" header="Add router directives to component imports in src/app/app.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.ts" visibleLines="[6]"/>
-   1. In the `template` property, replace the `<app-home></app-home>` tag with the `<router-outlet>` directive and add a link back to the home page. Your code should match this code:
+   3. In the `template` property, replace the `<app-home></app-home>` tag with the `<router-outlet>` directive and add a link back to the home page. Your code should match this code:
 
    <docs-code language="angular-ts" header="Add router-outlet in src/app/app.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.ts" visibleLines="[7,18]"/>
 


### PR DESCRIPTION
Updated shell command examples to use fenced code blocks (```shell) instead of components, improving formatting consistency and aligning with current documentation standards.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
