### PR TITLE
feat(docs-infra): prevent browser save dialog in adev code editor

### DIFF
--- a/adev/src/app/editor/code-editor/constants/code-editor-extensions.ts
+++ b/adev/src/app/editor/code-editor/constants/code-editor-extensions.ts
@@ -85,5 +85,9 @@ export const CODE_EDITOR_EXTENSIONS: Extension[] = [
       run: startCompletion,
       mac: 'Mod-.',
     },
+    {
+      key: 'Mod-s',
+      run: () => true, // Prevent default browser save dialog
+    },
   ]),
 ];


### PR DESCRIPTION
Add Cmd+S/Ctrl+S keyboard shortcut to the adev code editor that prevents the annoying browser save dialog from appearing.

The shortcut is a no-op since the editor already has auto-save functionality that persists changes after 500ms of inactivity.

This improves the user experience by preventing the browser's default save page dialog when users instinctively press Cmd+S while editing code.