### PR TITLE
fix(forms): run reset as untracked

### DIFF
--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, linkedSignal, type Signal, type WritableSignal} from '@angular/core';
+import {computed, linkedSignal, type Signal, untracked, type WritableSignal} from '@angular/core';
 import type {Field} from '../api/field_directive';
 import {
   AggregateMetadataKey,
@@ -225,11 +225,15 @@ export class FieldNode implements FieldState<unknown> {
    * Note this does not change the data model, which can be reset directly if desired.
    */
   reset(): void {
+    untracked(() => this._reset());
+  }
+
+  private _reset() {
     this.nodeState.markAsUntouched();
     this.nodeState.markAsPristine();
 
     for (const child of this.structure.children()) {
-      child.reset();
+      child._reset();
     }
   }
 

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Injector, signal} from '@angular/core';
+import {computed, effect, Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
   apply,
@@ -387,6 +387,26 @@ describe('FieldNode', () => {
 
       f().reset();
       expect(f().touched()).toBe(false);
+    });
+
+    it('reset should not track model changes', () => {
+      const f = form(signal(''), {injector: TestBed.inject(Injector)});
+      const spy = jasmine.createSpy();
+      effect(
+        () => {
+          spy();
+          f().reset();
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      TestBed.tick();
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      f().value.set('hi');
+
+      TestBed.tick();
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should not be marked as touched when is readonly', () => {


### PR DESCRIPTION
Run the signal forms `reset()` as untracked so it does not trigger `effect` to rerun when the model changes

Fixes https://github.com/angular/angular/issues/65322