### PR TITLE
docs: hide temporary prerender tabs and multifile docs sections

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-multifile.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-multifile.mts
@@ -63,7 +63,7 @@ export const docsCodeMultifileExtension = {
   },
   renderer(this: RendererThis, token: DocsCodeMultifileToken) {
     const el = JSDOM.fragment(`
-    <div class="docs-code-multifile">
+    <div class="docs-code-multifile" style="display: none">
     ${this.parser.parse(token.paneTokens)}
     </div>
     `).firstElementChild!;

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-tabs.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-tabs.mts
@@ -44,7 +44,7 @@ export const docsTabGroupExtension = {
   },
   renderer(this: RendererThis, token: DocsTabGroupToken) {
     const el = JSDOM.fragment(`
-    <div class="docs-tab-group">
+    <div class="docs-tab-group" style="display: none;">
       ${this.parser.parse(token.tabTokens)}
     </div>
     `).firstElementChild!;


### PR DESCRIPTION
Hide the pending intermediary format of the multifile and tabs docs content. They get hydrated later into components