### PR TITLE
build: force angular cli to run in non-TTY mode for adev and devapp

### DIFF
--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -103,6 +103,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_PARTIAL_SSR": "1",
+        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",
@@ -129,6 +130,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
+        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",

--- a/dev-app/BUILD.bazel
+++ b/dev-app/BUILD.bazel
@@ -39,6 +39,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_PARTIAL_SSR": "1",
+        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",
@@ -58,6 +59,7 @@ ng_application(
     ],
     env = {
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
+        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",


### PR DESCRIPTION
Force adev and devapp to run in non-TTY mode so it doesn't create a prompt that can't be interacted with. This will initially have no effect, but the fix is expected to land in CLI to make this work as expected in the next few days.
