### PR TITLE
fix(docs-infra): add moduleResolution to TypeScript compiler options for playground

### DIFF
--- a/adev/src/app/editor/code-editor/workers/utils/compiler-opts.ts
+++ b/adev/src/app/editor/code-editor/workers/utils/compiler-opts.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export const getCompilerOpts = (ts: {ScriptTarget: {ES2021: number; ES2020: number}}) => ({
+export const getCompilerOpts = (ts: {
+  ScriptTarget: {ES2021: number; ES2020: number};
+  ModuleResolutionKind: {Bundler: number};
+}) => ({
   target: ts.ScriptTarget.ES2021,
   module: ts.ScriptTarget.ES2020,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
   lib: ['es2021', 'es2020', 'dom'],
   esModuleInterop: true,
   experimentalDecorators: true,


### PR DESCRIPTION
This fixes signal forms, but idk if it breas other things