### PR TITLE
build: bump core zone.js version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0 || ~0.16.0"
   },
   "peerDependenciesMeta": {
     "@angular/compiler": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,7 +1036,7 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
       zone.js:
-        specifier: ~0.15.0
+        specifier: ~0.15.0 || ~0.16.0
         version: 0.15.1
 
   packages/core/test/bundling:


### PR DESCRIPTION
this bumps the core dep on zone.js to 0.16.0.
