### PR TITLE
fix(docs-infra): link all symbols in import statements to API pages

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/test/code/code.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/code/code.md
@@ -1,1 +1,5 @@
 `CommonModule`, `ApplicationRef.tick`, `Router.lastSuccessfulNavigation()`.
+
+```typescript
+import {signal, computed} from '@angular/core';
+```

--- a/adev/shared-docs/pipeline/shared/marked/test/code/code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/code/code.spec.mts
@@ -35,4 +35,18 @@ describe('markdown to html', () => {
       ' <a href="/api/angular/router/Router#lastSuccessfulNavigation"><code>Router.lastSuccessfulNavigation()</code></a>',
     );
   });
+
+  it('should render multiple symbols in import statement with links', () => {
+    // Both signal and computed should be linked when they appear together in an import
+    expect(parsedMarkdown).toContain('<a href="/api/core/signal">');
+    expect(parsedMarkdown).toContain('<a href="/api/core/computed">');
+    // Verify they appear in the same import line
+    const importLineMatch = parsedMarkdown.match(/import\s*\{[^}]*\}.*from/);
+    expect(importLineMatch).toBeTruthy();
+    if (importLineMatch) {
+      const importLine = importLineMatch[0];
+      expect(importLine).toContain('signal');
+      expect(importLine).toContain('computed');
+    }
+  });
 });

--- a/adev/shared-docs/pipeline/shared/marked/test/renderer-context.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/renderer-context.mts
@@ -23,6 +23,8 @@ export const rendererContext: RendererContext = {
     bootstrapApplication: 'angular/platform-browser',
     ApplicationRef: 'angular/core',
     Router: 'angular/router',
+    signal: 'core',
+    computed: 'core',
   },
 };
 


### PR DESCRIPTION
## Problem

When code examples contained import statements with multiple symbols (e.g., `import {signal, computed} from '@angular/core'`), only the first symbol was linked to its API documentation page. Subsequent symbols like `computed` were rendered as plain text and not clickable.

Example from https://angular.dev/essentials/signals#computed-expressions:
- ✅ `signal` was clickable and linked to /api/core/signal
- ❌ `computed` was not clickable (should link to /api/core/computed)

## Solution

Updated the `processForApiLinks` function in the documentation rendering pipeline to:
- Find **all** JavaScript/TypeScript identifiers in each code span (not just the first one)
- Filter to symbols that have API entries
- Rebuild the span content with links for all matching symbols
- Preserve the original text structure (commas, braces, etc.)

## Changes

- **Modified**: `adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts` - Rewrote the linking logic to handle multiple symbols
- **Added**: Test case in `code.md` with import statement example
- **Added**: Test assertion in `code.spec.mts` to verify multiple symbols are linked
- **Updated**: Test context to include `signal` and `computed` in API entries

## Testing

- Added unit test to verify multiple symbols in import statements are properly linked
- Test verifies both `signal` and `computed` are linked in the same import line

## Impact

This fix ensures all symbols in import statements and other code contexts are properly linked to their API documentation pages, improving the developer experience when reading Angular documentation.

Fixes the issue where multiple symbols in import statements were not all linked to their respective API pages.