### PR TITLE
fix(docs-infra): allow linking of multiple symbols within single Shiki span

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.md
@@ -11,3 +11,19 @@ this is a code block
 ```
 code block without language
 ```
+
+```typescript
+import { CommonModule, ApplicationRef } from '@angular/core';
+import { Router } from '@angular/router';
+```
+
+```typescript
+const modules = [CommonModule, Router];
+const ref: ApplicationRef;
+```
+
+```typescript
+// This comment mentions CommonModule and Router
+/* Block comment about ApplicationRef */
+const app = bootstrapApplication(MyComponent);
+```

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
@@ -27,10 +27,10 @@ describe('markdown to html', () => {
     expect(codeBlock?.textContent?.trim()).toBe('this is a code block');
   });
 
-  it('should parse all 3 code blocks', () => {
+  it('should parse all 6 code blocks', () => {
     const codeBlocks = markdownDocument.querySelectorAll('.docs-code');
 
-    expect(codeBlocks.length).toBe(3);
+    expect(codeBlocks.length).toBe(6);
   });
 
   it('should deindent code blocks correctly', () => {
@@ -41,5 +41,93 @@ describe('markdown to html', () => {
   it('should handle code blocks without language', () => {
     const codeBlock = markdownDocument.querySelectorAll('.docs-code')[2];
     expect(codeBlock).toBeDefined();
+  });
+
+  describe('API links', () => {
+    it('should convert multiple API symbols in a single span to links', () => {
+      const codeBlock = markdownDocument.querySelectorAll('.docs-code')[3];
+      const links = codeBlock.querySelectorAll('a');
+
+      // Should have links for CommonModule, ApplicationRef, and Router
+      expect(links.length).toBeGreaterThanOrEqual(3);
+
+      const linkTexts = Array.from(links).map((link) => link.textContent);
+      expect(linkTexts).toContain('CommonModule');
+      expect(linkTexts).toContain('ApplicationRef');
+      expect(linkTexts).toContain('Router');
+    });
+
+    it('should generate correct URLs for API symbols', () => {
+      const codeBlock = markdownDocument.querySelectorAll('.docs-code')[3];
+      const links = codeBlock.querySelectorAll('a');
+
+      const commonModuleLink = Array.from(links).find(
+        (link) => link.textContent === 'CommonModule',
+      );
+      expect(commonModuleLink?.getAttribute('href')).toBe('/api/angular/common/CommonModule');
+
+      const applicationRefLink = Array.from(links).find(
+        (link) => link.textContent === 'ApplicationRef',
+      );
+      expect(applicationRefLink?.getAttribute('href')).toBe('/api/angular/core/ApplicationRef');
+
+      const routerLink = Array.from(links).find((link) => link.textContent === 'Router');
+      expect(routerLink?.getAttribute('href')).toBe('/api/angular/router/Router');
+    });
+
+    it('should link all API symbols when multiple appear in the same span', () => {
+      // Test the case where Shiki groups multiple symbols in one span (e.g., "CommonModule, Router")
+      const codeBlock = markdownDocument.querySelectorAll('.docs-code')[4];
+      const links = codeBlock.querySelectorAll('a');
+
+      const linkTexts = Array.from(links).map((link) => link.textContent);
+
+      // Both CommonModule and Router should be linked even if they're in the same span
+      expect(linkTexts).toContain('CommonModule');
+      expect(linkTexts).toContain('Router');
+      expect(linkTexts).toContain('ApplicationRef');
+    });
+
+    it('should preserve surrounding text and punctuation when creating links', () => {
+      const codeBlock = markdownDocument.querySelectorAll('.docs-code')[4];
+      const codeText = codeBlock.textContent || '';
+
+      // Check that array brackets are preserved
+      expect(codeText).toContain('[');
+      expect(codeText).toContain(']');
+
+      // Check that the structure is maintained
+      expect(codeText).toContain('const modules');
+      expect(codeText).toContain('const ref');
+    });
+
+    it('should not convert symbols in comments to links', () => {
+      const codeBlock = markdownDocument.querySelectorAll('.docs-code')[5];
+      const allLinks = codeBlock.querySelectorAll('a');
+      const linkTexts = Array.from(allLinks).map((link) => link.textContent);
+
+      // bootstrapApplication should be linked (it's in actual code)
+      expect(linkTexts).toContain('bootstrapApplication');
+
+      // Verify that symbols mentioned in comments are NOT linked
+      // The comments mention CommonModule, Router, and ApplicationRef, but these should not be links
+      expect(linkTexts).not.toContain('CommonModule');
+      expect(linkTexts).not.toContain('Router');
+      expect(linkTexts).not.toContain('ApplicationRef');
+
+      // Double-check by inspecting comment spans (Shiki marks comments with #6A737D color)
+      const allSpans = codeBlock.querySelectorAll('span');
+      allSpans.forEach((span) => {
+        const style = span.getAttribute('style') || '';
+        // If this is a comment span (gray color #6A737D)
+        if (style.includes('#6A737D') || style.includes('#6a737d')) {
+          const linksInComment = span.querySelectorAll('a');
+          expect(linksInComment.length).toBe(
+            0,
+            `Comment spans should not contain links. Found in: "${span.textContent}"`,
+          );
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes: #65403 
This commit updates `processForApiLinks()` to iterate through all word tokens using `/\w+/g`, creating links for each matching symbol while preserving surrounding whitespace and punctuation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Previously, when Shiki grouped multiple API symbols in one span (e.g., `{signal, computed}`), only the first symbol was converted to a clickable link. This was because the regex `/^(.*?)(\w+)(.*)$/` matched only the first word token.
This was causing issues like: #65403 

## What is the new behavior?
Refactored processForApiLinks to support multiple API links per token (e.g., for generics), replacing the previous single-match logic. Also improved performance and type safety by using DocumentFragment.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The code was rewritten because the previous logic (string.match) was structurally limited to a single symbol per span. To support multiple symbols (e.g., in import lists), it was necessary to switch to a regex.exec loop that scans the entire string.