### PR TITLE
 ci: try to resolve vscode extension e2e flakes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -134,11 +134,6 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@f47684669736e28fd77eab64e65b2952c8a948ee
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-      - name: Cache downloaded vscode binary
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: '~/.cache/vscode-test'
-          key: vscode-cache-${{ runner.os }}-${{ hashFiles('vscode-ng-language-service/integration/e2e/index.ts') }} # The version is specified in this file.
       - name: Run tests
         run: pnpm bazel test //vscode-ng-language-service/...
 

--- a/vscode-ng-language-service/integration/e2e/completion_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/completion_spec.ts
@@ -5,7 +5,7 @@ import {activate, COMPLETION_COMMAND, FOO_TEMPLATE_URI} from './helper';
 describe('Angular LS completions', () => {
   beforeAll(async () => {
     await activate(FOO_TEMPLATE_URI);
-  }, 20_000);
+  });
 
   it(`does not duplicate HTML completions in external templates`, async () => {
     const position = new vscode.Position(0, 0);

--- a/vscode-ng-language-service/integration/e2e/definition_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/definition_spec.ts
@@ -10,7 +10,7 @@ const APP_COMPONENT_URI = vscode.Uri.file(APP_COMPONENT);
 describe('Angular LS', () => {
   beforeAll(async () => {
     await activate(APP_COMPONENT_URI);
-  }, 20_000);
+  });
 
   it(`returns definition for variable in template`, async () => {
     // vscode Position is zero-based

--- a/vscode-ng-language-service/integration/e2e/helper.ts
+++ b/vscode-ng-language-service/integration/e2e/helper.ts
@@ -11,33 +11,7 @@ export const FOO_TEMPLATE_URI = vscode.Uri.file(FOO_TEMPLATE);
 
 export async function activate(uri: vscode.Uri): Promise<void> {
   await vscode.window.showTextDocument(uri);
-
   // This is needed for stabilization and to reduce flakes.
   // The timeout gives the language server time to warm up.
   await setTimeout(3_000);
-
-  await waitForDefinitionsToBeAvailable(20);
-}
-
-async function waitForDefinitionsToBeAvailable(maxTries: number) {
-  await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
-
-  let tries = 0;
-  while (tries < maxTries) {
-    const position = new vscode.Position(4, 25);
-    // For a complete list of standard commands, see
-    // https://code.visualstudio.com/api/references/commands
-    const definitions = await vscode.commands.executeCommand<vscode.LocationLink[]>(
-      DEFINITION_COMMAND,
-      APP_COMPONENT_URI,
-      position,
-    );
-
-    if (definitions?.length > 0) {
-      return;
-    }
-
-    tries++;
-    await setTimeout(500);
-  }
 }

--- a/vscode-ng-language-service/integration/e2e/hover_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/hover_spec.ts
@@ -5,7 +5,7 @@ import {activate, FOO_TEMPLATE_URI, HOVER_COMMAND} from './helper';
 describe('Angular LS quick info', () => {
   beforeAll(async () => {
     await activate(FOO_TEMPLATE_URI);
-  }, 20_000);
+  });
 
   it(`returns quick info from built in extension for class in template`, async () => {
     const position = new vscode.Position(1, 8);

--- a/vscode-ng-language-service/integration/e2e/index.ts
+++ b/vscode-ng-language-service/integration/e2e/index.ts
@@ -1,10 +1,8 @@
 import {join} from 'node:path';
-import {homedir, tmpdir} from 'node:os';
 import {promisify} from 'node:util';
 import {runTests} from '@vscode/test-electron';
 
 import {PACKAGE_ROOT, PROJECT_PATH} from '../test_constants';
-import {mkdtemp} from 'node:fs/promises';
 
 // @ts-expect-error no types.
 import Xvfb from 'xvfb';
@@ -13,20 +11,18 @@ async function main() {
   const EXT_DEVELOPMENT_PATH = join(PACKAGE_ROOT, 'development_package');
   const EXT_TESTS_PATH = join(PACKAGE_ROOT, 'integration', 'e2e', 'jasmine');
   const xvfb = new Xvfb();
-
-  // We cannot use `TEST_TMPDIR` as it's longer than 170 characters
-  const vsCodeDataDir = await mkdtemp(join(tmpdir(), 'vscode-e2e-'));
+  const tmpDir = process.env['TEST_TMPDIR']!;
 
   try {
     await promisify(xvfb.start).call(xvfb);
 
     const exitCode = await runTests({
-      // Keep version in sync with vscode engine version in package.json
-      version: '1.74.3',
+      // The current version should align with the VS Code engine version in package.json, but it's several years old.
+      // TODO: We should update the package.json version eventually.
+      version: '1.102.0',
       extensionDevelopmentPath: EXT_DEVELOPMENT_PATH,
       extensionTestsPath: EXT_TESTS_PATH,
-      // Avoid redownloading vscode if the test if flaky.
-      cachePath: join(homedir(), '.cache/vscode-test'),
+      cachePath: join(tmpDir, '.cache'),
       launchArgs: [
         PROJECT_PATH,
         // This disables all extensions except the one being tested
@@ -35,8 +31,8 @@ async function main() {
         '--no-sandbox',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
-        `--extensions-dir=${vsCodeDataDir}/extensions`,
-        `--user-data-dir=${vsCodeDataDir}/user-data`,
+        `--extensions-dir=${join(tmpDir, 'extensions')}`,
+        `--user-data-dir=${join(tmpDir, 'user-data')}`,
       ],
     });
 


### PR DESCRIPTION

    
Update e2e test runner to VS Code 1.102.0, streamline test activation, and manage temporary directories via `TEST_TMPDIR`.