### PR TITLE
fix(docs-infra): prevent icons from being translated in aria guide

### DIFF
--- a/adev/src/content/examples/aria/accordion/src/disabled-focusable/material/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/disabled-focusable/material/app/app.component.html
@@ -6,7 +6,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger1.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -27,7 +27,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger2.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -48,7 +48,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger3.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/accordion/src/disabled-focusable/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/disabled-focusable/retro/app/app.component.html
@@ -5,7 +5,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -21,7 +21,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -37,7 +37,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/accordion/src/multi-expansion/material/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/multi-expansion/material/app/app.component.html
@@ -6,7 +6,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger1.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -27,7 +27,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger2.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -48,7 +48,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger3.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/accordion/src/multi-expansion/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/multi-expansion/retro/app/app.component.html
@@ -5,7 +5,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -21,7 +21,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -37,7 +37,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/accordion/src/single-expansion/material/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/single-expansion/material/app/app.component.html
@@ -6,7 +6,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger1.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -27,7 +27,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger2.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>
@@ -48,7 +48,7 @@
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
         [class.expand-icon__expanded]="trigger3.expanded()"
-        >keyboard_arrow_up</span
+         translate="no">keyboard_arrow_up</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/accordion/src/single-expansion/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/accordion/src/single-expansion/retro/app/app.component.html
@@ -5,7 +5,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger1.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -21,7 +21,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger2.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>
@@ -37,7 +37,7 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
+         translate="no">{{trigger3.expanded() ? 'lock_open_right' : 'lock'}}</span
       >
     </span>
   </h3>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.component.html
@@ -1,6 +1,6 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no">search</span>
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +23,7 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no">check</span>
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/app/app.html
@@ -1,14 +1,14 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
           <input
             ngComboboxInput
             class="combobox-input"
@@ -26,7 +26,7 @@
             @for (option of options(); track option) {
             <div ngOption [value]="option" [label]="option">
               <span class="option-label">{{option}}</span>
-              <span class="material-symbols-outlined icon check-icon">check</span>
+              <span class="material-symbols-outlined icon check-icon" translate="no">check</span>
             </div>
             }
           </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.html
@@ -1,14 +1,14 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true" class="material-combobox">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
           <input
             ngComboboxInput
             class="combobox-input"
@@ -26,7 +26,7 @@
             @for (option of options(); track option) {
             <div ngOption [value]="option" [label]="option">
               <span class="option-label">{{option}}</span>
-              <span class="material-symbols-outlined icon check-icon">check</span>
+              <span class="material-symbols-outlined icon check-icon" translate="no">check</span>
             </div>
             }
           </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.html
@@ -1,14 +1,14 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true" class="retro-combobox">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
           <input
             ngComboboxInput
             class="combobox-input"
@@ -22,7 +22,7 @@
             @for (option of options(); track option) {
             <div ngOption [value]="option" [label]="option">
               <span>{{option}}</span>
-              <span class="material-symbols-outlined icon selected-icon">check</span>
+              <span class="material-symbols-outlined icon selected-icon" translate="no">check</span>
             </div>
             }
           </div>

--- a/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.component.html
@@ -1,11 +1,11 @@
 <div class="calendar basic-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/material/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/material/app/app.component.html
@@ -1,11 +1,11 @@
 <div class="calendar material-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.component.html
@@ -1,11 +1,11 @@
 <div class="calendar retro-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/pill-list/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/pill-list/basic/app/app.component.html
@@ -8,7 +8,7 @@
           aria-label="remove tag"
           class="material-symbols-outlined"
           (click)="removeTag($index)"
-        >
+         translate="no">
           close
         </button>
       </span>

--- a/adev/src/content/examples/aria/grid/src/pill-list/material/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/pill-list/material/app/app.component.html
@@ -8,7 +8,7 @@
           aria-label="remove tag"
           class="material-symbols-outlined"
           (click)="removeTag($index)"
-        >
+         translate="no">
           close
         </button>
       </span>

--- a/adev/src/content/examples/aria/grid/src/pill-list/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/pill-list/retro/app/app.component.html
@@ -8,7 +8,7 @@
           aria-label="remove tag"
           class="material-symbols-outlined"
           (click)="removeTag($index)"
-        >
+         translate="no">
           close
         </button>
       </span>

--- a/adev/src/content/examples/aria/grid/src/table/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/table/basic/app/app.component.html
@@ -19,7 +19,7 @@
           (click)="sortTaskById()"
         >
           ID
-          <span aria-hidden="true" class="material-symbols-outlined">
+          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
             {{sortAscending ? 'arrow_upward' : 'arrow_downward'}}
           </span>
         </button>
@@ -66,7 +66,7 @@
             class="material-symbols-outlined assignee-edit-button"
             (click)="onClickEdit(widget, task, assigneeInput)"
             [class.hidden]="widget.isActivated()"
-          >
+           translate="no">
             edit
           </button>
         </div>

--- a/adev/src/content/examples/aria/grid/src/table/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/grid/src/table/retro/app/app.component.html
@@ -19,7 +19,7 @@
           (click)="sortTaskById()"
         >
           Reward
-          <span aria-hidden="true" class="material-symbols-outlined">
+          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
             {{sortAscending ? 'arrow_upward' : 'arrow_downward'}}
           </span>
         </button>
@@ -66,7 +66,7 @@
             class="material-symbols-outlined assignee-edit-button"
             (click)="onClickEdit(widget, task, assigneeInput)"
             [class.hidden]="widget.isActivated()"
-          >
+           translate="no">
             edit
           </button>
         </div>

--- a/adev/src/content/examples/aria/listbox/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/app/app.html
@@ -3,7 +3,7 @@
     @for (option of options; track option) {
     <div ngOption [value]="option">
       <span class="example-option-text">{{ option }}</span>
-      <span class="example-option-check material-symbols-outlined">check</span>
+      <span class="example-option-check material-symbols-outlined" translate="no">check</span>
     </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/material/app/app.html
@@ -3,7 +3,7 @@
     @for (option of options; track option) {
     <div ngOption [value]="option">
       <span class="example-option-text">{{ option }}</span>
-      <span class="example-option-check material-symbols-outlined">check</span>
+      <span class="example-option-check material-symbols-outlined" translate="no">check</span>
     </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.html
@@ -3,7 +3,7 @@
     @for (option of options; track option) {
     <div ngOption [value]="option">
       <span class="example-option-text">{{ option }}</span>
-      <span class="example-option-check material-symbols-outlined">check</span>
+      <span class="example-option-check material-symbols-outlined" translate="no">check</span>
     </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/horizontal/material/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/horizontal/material/app/app.html
@@ -8,7 +8,7 @@
 >
   @for (amenity of amenities; track amenity) {
   <div ngOption [value]="amenity" [label]="amenity">
-    <span class="check-icon material-symbols-outlined">check</span>
+    <span class="check-icon material-symbols-outlined" translate="no">check</span>
     <span class="option-label">{{ amenity }}</span>
   </div>
   }

--- a/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.html
@@ -1,7 +1,7 @@
 <div ngListbox class="retro-listbox" aria-label="Amenities" orientation="horizontal" selectionMode="explicit" multi>
   @for (amenity of amenities; track amenity) {
     <div ngOption [value]="amenity" [label]="amenity">
-      <span class="check-icon material-symbols-outlined">check</span>
+      <span class="check-icon material-symbols-outlined" translate="no">check</span>
       <span class="option-label">{{ amenity }}</span>
     </div>
   }

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/app/app.html
@@ -4,19 +4,19 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no">security_key</span>
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no">refresh</span>
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -28,17 +28,17 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined">email</span>
+              <span class="icon material-symbols-outlined" translate="no">email</span>
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined">phone</span>
+              <span class="icon material-symbols-outlined" translate="no">phone</span>
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -52,12 +52,12 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined">help</span>
+        <span class="icon material-symbols-outlined" translate="no">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no">feedback</span>
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -65,7 +65,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined">logout</span>
+      <span class="icon material-symbols-outlined" translate="no">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.html
@@ -4,19 +4,19 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no">security_key</span>
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no">refresh</span>
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -28,17 +28,17 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined">email</span>
+              <span class="icon material-symbols-outlined" translate="no">email</span>
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined">phone</span>
+              <span class="icon material-symbols-outlined" translate="no">phone</span>
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -52,12 +52,12 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined">help</span>
+        <span class="icon material-symbols-outlined" translate="no">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no">feedback</span>
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -65,7 +65,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined">logout</span>
+      <span class="icon material-symbols-outlined" translate="no">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.html
@@ -4,19 +4,19 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no">security_key</span>
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no">refresh</span>
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -28,17 +28,17 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined">email</span>
+              <span class="icon material-symbols-outlined" translate="no">email</span>
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined">phone</span>
+              <span class="icon material-symbols-outlined" translate="no">phone</span>
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -52,12 +52,12 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined">help</span>
+        <span class="icon material-symbols-outlined" translate="no">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no">feedback</span>
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -65,7 +65,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined">logout</span>
+      <span class="icon material-symbols-outlined" translate="no">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/app/app.html
@@ -9,12 +9,12 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze" [disabled]="true">
-        <span class="icon material-symbols-outlined">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -28,9 +28,9 @@
         [submenu]="categorizeMenu()"
         [disabled]="true"
       >
-        <span class="icon material-symbols-outlined">category</span>
+        <span class="icon material-symbols-outlined" translate="no">category</span>
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -42,17 +42,17 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no">label_important</span>
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined">star</span>
+              <span class="icon material-symbols-outlined" translate="no">star</span>
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined">label</span>
+              <span class="icon material-symbols-outlined" translate="no">label</span>
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -62,17 +62,17 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined">archive</span>
+        <span class="icon material-symbols-outlined" translate="no">archive</span>
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined">report</span>
+        <span class="icon material-symbols-outlined" translate="no">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined">delete</span>
+        <span class="icon material-symbols-outlined" translate="no">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.html
@@ -10,17 +10,17 @@
     <ng-template ngMenuContent>
       <div class="group">
         <div ngMenuItem value="Mark as read">
-          <span class="icon material-symbols-outlined">mark_email_read</span>
+          <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
           <span class="label">Mark as read</span>
         </div>
 
         <div ngMenuItem value="Snooze">
-          <span class="icon material-symbols-outlined">snooze</span>
+          <span class="icon material-symbols-outlined" translate="no">snooze</span>
           <span class="label">Snooze</span>
         </div>
 
         <div ngMenuItem value="Delete" [disabled]="true">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Delete</span>
         </div>
       </div>
@@ -33,9 +33,9 @@
           #categorizeItem
           [submenu]="categorizeMenu()"
         >
-          <span class="icon material-symbols-outlined">category</span>
+          <span class="icon material-symbols-outlined" translate="no">category</span>
           <span class="label">Categorize</span>
-          <span class="icon material-symbols-outlined arrow">arrow_right</span>
+          <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
         </div>
       </div>
 
@@ -49,17 +49,17 @@
           <ng-template ngMenuContent>
             <div class="group">
               <div ngMenuItem value="Mark as important">
-                <span class="icon material-symbols-outlined">label_important</span>
+                <span class="icon material-symbols-outlined" translate="no">label_important</span>
                 <span class="label">Mark as important</span>
               </div>
 
               <div ngMenuItem value="Star">
-                <span class="icon material-symbols-outlined">star</span>
+                <span class="icon material-symbols-outlined" translate="no">star</span>
                 <span class="label">Star</span>
               </div>
 
               <div ngMenuItem value="Label" [disabled]="true">
-                <span class="icon material-symbols-outlined">label</span>
+                <span class="icon material-symbols-outlined" translate="no">label</span>
                 <span class="label">Label</span>
               </div>
             </div>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.html
@@ -11,12 +11,12 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read" [disabled]="true">
-        <span class="icon material-symbols-outlined">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -29,9 +29,9 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined">category</span>
+        <span class="icon material-symbols-outlined" translate="no">category</span>
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -43,17 +43,17 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no">label_important</span>
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined">star</span>
+              <span class="icon material-symbols-outlined" translate="no">star</span>
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined">label</span>
+              <span class="icon material-symbols-outlined" translate="no">label</span>
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -63,17 +63,17 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined">archive</span>
+        <span class="icon material-symbols-outlined" translate="no">archive</span>
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined">report</span>
+        <span class="icon material-symbols-outlined" translate="no">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined">delete</span>
+        <span class="icon material-symbols-outlined" translate="no">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/app/app.html
@@ -9,12 +9,12 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -27,9 +27,9 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined">category</span>
+        <span class="icon material-symbols-outlined" translate="no">category</span>
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -41,17 +41,17 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no">label_important</span>
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined">star</span>
+              <span class="icon material-symbols-outlined" translate="no">star</span>
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined">label</span>
+              <span class="icon material-symbols-outlined" translate="no">label</span>
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -61,17 +61,17 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined">archive</span>
+        <span class="icon material-symbols-outlined" translate="no">archive</span>
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined">report</span>
+        <span class="icon material-symbols-outlined" translate="no">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined">delete</span>
+        <span class="icon material-symbols-outlined" translate="no">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.html
@@ -10,17 +10,17 @@
     <ng-template ngMenuContent>
       <div class="group">
         <div ngMenuItem value="Mark as read">
-          <span class="icon material-symbols-outlined">mark_email_read</span>
+          <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
           <span class="label">Mark as read</span>
         </div>
 
         <div ngMenuItem value="Snooze">
-          <span class="icon material-symbols-outlined">snooze</span>
+          <span class="icon material-symbols-outlined" translate="no">snooze</span>
           <span class="label">Snooze</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Delete</span>
         </div>
       </div>
@@ -33,9 +33,9 @@
           #categorizeItem
           [submenu]="categorizeMenu()"
         >
-          <span class="icon material-symbols-outlined">category</span>
+          <span class="icon material-symbols-outlined" translate="no">category</span>
           <span class="label">Categorize</span>
-          <span class="icon material-symbols-outlined arrow">arrow_right</span>
+          <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
         </div>
       </div>
 
@@ -49,17 +49,17 @@
           <ng-template ngMenuContent>
             <div class="group">
               <div ngMenuItem value="Mark as important">
-                <span class="icon material-symbols-outlined">label_important</span>
+                <span class="icon material-symbols-outlined" translate="no">label_important</span>
                 <span class="label">Mark as important</span>
               </div>
 
               <div ngMenuItem value="Star">
-                <span class="icon material-symbols-outlined">star</span>
+                <span class="icon material-symbols-outlined" translate="no">star</span>
                 <span class="label">Star</span>
               </div>
 
               <div ngMenuItem value="Label">
-                <span class="icon material-symbols-outlined">label</span>
+                <span class="icon material-symbols-outlined" translate="no">label</span>
                 <span class="label">Label</span>
               </div>
             </div>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.html
@@ -11,12 +11,12 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -29,9 +29,9 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined">category</span>
+        <span class="icon material-symbols-outlined" translate="no">category</span>
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
       </div>
 
       <ng-template
@@ -43,17 +43,17 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no">label_important</span>
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined">star</span>
+              <span class="icon material-symbols-outlined" translate="no">star</span>
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined">label</span>
+              <span class="icon material-symbols-outlined" translate="no">label</span>
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -63,17 +63,17 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined">archive</span>
+        <span class="icon material-symbols-outlined" translate="no">archive</span>
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined">report</span>
+        <span class="icon material-symbols-outlined" translate="no">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined">delete</span>
+        <span class="icon material-symbols-outlined" translate="no">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
@@ -19,28 +19,28 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined">article</span>
+          <span class="icon material-symbols-outlined" translate="no">article</span>
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined">folder</span>
+          <span class="icon material-symbols-outlined" translate="no">folder</span>
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no">person_add</span>
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -52,12 +52,12 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no">person_add</span>
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined">public</span>
+                <span class="icon material-symbols-outlined" translate="no">public</span>
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +65,24 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined">download</span>
+          <span class="icon material-symbols-outlined" translate="no">download</span>
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined">print</span>
+          <span class="icon material-symbols-outlined" translate="no">print</span>
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined">edit</span>
+          <span class="icon material-symbols-outlined" translate="no">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined">delete</span>
+          <span class="icon material-symbols-outlined" translate="no">delete</span>
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +109,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined">undo</span>
+          <span class="icon material-symbols-outlined" translate="no">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined">redo</span>
+          <span class="icon material-symbols-outlined" translate="no">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +123,19 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +143,7 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +171,12 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined">check</span>
+          <span class="icon material-symbols-outlined" translate="no">check</span>
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +221,9 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined">image</span>
+          <span class="icon material-symbols-outlined" translate="no">image</span>
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -235,17 +235,17 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined">upload</span>
+                <span class="icon material-symbols-outlined" translate="no">upload</span>
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined">search</span>
+                <span class="icon material-symbols-outlined" translate="no">search</span>
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined">link</span>
+                <span class="icon material-symbols-outlined" translate="no">link</span>
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +253,14 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -272,22 +272,22 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +295,7 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +322,9 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -336,25 +336,25 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +363,7 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
               </div>
 
               <ng-template
@@ -391,9 +391,9 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -412,9 +412,9 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
         </div>
 
         <ng-template
@@ -426,22 +426,22 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined">format_align_center</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_center</span>
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined">format_align_right</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_right</span>
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined">format_align_justify</span>
+                <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
                 <span class="label">Justify</span>
               </div>
             </ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox multi>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox class="material-select" readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox multi>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox class="retro-select" readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox multi>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/material/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/retro/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/material/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/retro/app/app.html
@@ -4,7 +4,7 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +17,7 @@
           @for (label of labels; track label) {
           <div ngOption [value]="label" [label]="label">
             <span class="example-option-text">{{label}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/material/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox class="material-select" readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/select/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/retro/app/app.html
@@ -1,11 +1,11 @@
 <div ngCombobox class="retro-select" readonly>
   <div #origin class="select">
     <span class="combobox-label">
-      <span class="selected-label-icon material-symbols-outlined">{{ displayIcon() }}</span>
+      <span class="selected-label-icon material-symbols-outlined" translate="no">{{ displayIcon() }}</span>
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,9 +17,9 @@
         <div ngListbox>
           @for (label of labels; track label.value) {
           <div ngOption [value]="label.value" [label]="label.value">
-            <span class="example-option-icon material-symbols-outlined">{{label.icon}}</span>
+            <span class="example-option-icon material-symbols-outlined" translate="no">{{label.icon}}</span>
             <span class="example-option-text">{{label.value}}</span>
-            <span class="example-option-check material-symbols-outlined">check</span>
+            <span class="example-option-check material-symbols-outlined" translate="no">check</span>
           </div>
           }
         </div>

--- a/adev/src/content/examples/aria/tabs/src/vertical/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/app/app.html
@@ -1,8 +1,8 @@
 <div ngTabs>
   <div ngTabList orientation="vertical" selectedTab="movie">
-    <div ngTab value="movie"><span class="material-symbols-outlined">videocam</span></div>
-    <div ngTab value="theatres"><span class="material-symbols-outlined">theater_comedy</span></div>
-    <div ngTab value="showtimes"><span class="material-symbols-outlined">reviews</span></div>
+    <div ngTab value="movie"><span class="material-symbols-outlined" translate="no">videocam</span></div>
+    <div ngTab value="theatres"><span class="material-symbols-outlined" translate="no">theater_comedy</span></div>
+    <div ngTab value="showtimes"><span class="material-symbols-outlined" translate="no">reviews</span></div>
   </div>
 
   <div class="sliding-window">

--- a/adev/src/content/examples/aria/tabs/src/vertical/material/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/material/app/app.html
@@ -1,8 +1,8 @@
 <div ngTabs>
   <div ngTabList class="material-tabs" orientation="vertical" selectedTab="movie">
-    <div ngTab value="movie"><span class="material-symbols-outlined">videocam</span></div>
-    <div ngTab value="theatres"><span class="material-symbols-outlined">theater_comedy</span></div>
-    <div ngTab value="showtimes"><span class="material-symbols-outlined">reviews</span></div>
+    <div ngTab value="movie"><span class="material-symbols-outlined" translate="no">videocam</span></div>
+    <div ngTab value="theatres"><span class="material-symbols-outlined" translate="no">theater_comedy</span></div>
+    <div ngTab value="showtimes"><span class="material-symbols-outlined" translate="no">reviews</span></div>
     <div class="bottom-border"></div>
   </div>
 

--- a/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.html
@@ -1,8 +1,8 @@
 <div ngTabs class="retro-tabs">
   <div ngTabList orientation="vertical" selectedTab="movie">
-    <div ngTab value="movie"><span class="material-symbols-outlined">videocam</span></div>
-    <div ngTab value="theatres"><span class="material-symbols-outlined">theater_comedy</span></div>
-    <div ngTab value="showtimes"><span class="material-symbols-outlined">reviews</span></div>
+    <div ngTab value="movie"><span class="material-symbols-outlined" translate="no">videocam</span></div>
+    <div ngTab value="theatres"><span class="material-symbols-outlined" translate="no">theater_comedy</span></div>
+    <div ngTab value="showtimes"><span class="material-symbols-outlined" translate="no">reviews</span></div>
   </div>
 
   <div ngTabPanel [preserveContent]="true" value="movie">

--- a/adev/src/content/examples/aria/toolbar/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/basic/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/basic/material/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -17,7 +17,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -33,7 +33,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -45,7 +45,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -57,7 +57,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -74,7 +74,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -87,7 +87,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -100,7 +100,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/disabled/app/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/app/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -17,7 +17,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -33,7 +33,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -45,7 +45,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -57,7 +57,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -74,7 +74,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -87,7 +87,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -100,7 +100,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/material/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -17,7 +17,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -33,7 +33,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -45,7 +45,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -57,7 +57,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -74,7 +74,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -87,7 +87,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -100,7 +100,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -17,7 +17,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -33,7 +33,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -45,7 +45,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -57,7 +57,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -74,7 +74,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -87,7 +87,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -100,7 +100,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/rtl/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/rtl/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/rtl/material/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/rtl/material/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>
@@ -73,7 +73,7 @@
       #leftAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="leftAlign.selected()"
-    >
+     translate="no">
       format_align_left
     </button>
 
@@ -86,7 +86,7 @@
       #centerAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="centerAlign.selected()"
-    >
+     translate="no">
       format_align_center
     </button>
 
@@ -99,7 +99,7 @@
       #rightAlign="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-checked]="rightAlign.selected()"
-    >
+     translate="no">
       format_align_right
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/vertical/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/vertical/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/vertical/material/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/vertical/material/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>

--- a/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.html
+++ b/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.html
@@ -6,7 +6,7 @@
       type="button"
       aria-label="undo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       undo
     </button>
 
@@ -16,7 +16,7 @@
       type="button"
       aria-label="redo"
       class="material-symbols-outlined"
-    >
+     translate="no">
       redo
     </button>
   </div>
@@ -32,7 +32,7 @@
       #bold="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="bold.selected()"
-    >
+     translate="no">
       format_bold
     </button>
 
@@ -44,7 +44,7 @@
       #italic="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="italic.selected()"
-    >
+     translate="no">
       format_italic
     </button>
 
@@ -56,7 +56,7 @@
       #underlined="ngToolbarWidget"
       class="material-symbols-outlined"
       [aria-pressed]="underlined.selected()"
-    >
+     translate="no">
       format_underlined
     </button>
   </div>

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.component.html
@@ -19,15 +19,15 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
-        >{{node.children ? 'chevron_right' : ''}}</span
+         translate="no">{{node.children ? 'chevron_right' : ''}}</span
       >
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{node.children ? 'folder' : 'docs'}}</span
+         translate="no">{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.component.html
@@ -56,7 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.component.html
@@ -19,15 +19,15 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
-        >{{node.children ? 'chevron_right' : ''}}</span
+         translate="no">{{node.children ? 'chevron_right' : ''}}</span
       >
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{node.children ? 'folder' : 'docs'}}</span
+         translate="no">{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.component.html
@@ -56,7 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/nav/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/nav/basic/app/app.component.html
@@ -19,12 +19,12 @@
       href="#{{ node.name }}"
       (click)="$event.preventDefault()"
     >
-      <span aria-hidden="true" class="material-symbols-outlined">{{node.icon}}</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no">{{node.icon}}</span>
       {{ node.name }}
       <span
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
-        >{{node.children ? 'keyboard_arrow_up' : ''}}</span
+         translate="no">{{node.children ? 'keyboard_arrow_up' : ''}}</span
       >
     </a>
 

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.component.html
@@ -19,15 +19,15 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
-        >{{node.children ? 'chevron_right' : ''}}</span
+         translate="no">{{node.children ? 'chevron_right' : ''}}</span
       >
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{node.children ? 'folder' : 'docs'}}</span
+         translate="no">{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.component.html
@@ -56,7 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.component.html
@@ -19,15 +19,15 @@
       <span
         aria-hidden="true"
         class="material-symbols-outlined expand-icon"
-        >{{node.children ? 'chevron_right' : ''}}</span
+         translate="no">{{node.children ? 'chevron_right' : ''}}</span
       >
       <span
         aria-hidden="true"
         class="material-symbols-outlined"
-        >{{node.children ? 'folder' : 'docs'}}</span
+         translate="no">{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {

--- a/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.component.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.component.html
@@ -56,7 +56,7 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon">check</span>
+      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no">check</span>
     </li>
 
     @if (node.children) {


### PR DESCRIPTION
This commit adds the `translate="no"` attribute to the icon elements to ensure they are preserved in their original form and not modified by translation tools.

Closes #65406

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Icons in aria guide are translated when using browser translator.

Issue Number: #65406 


## What is the new behavior?
Icons in aria guide are NOT translated when using browser translator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No