### PR TITLE
docs(core): remove outdated regex template restriction in best-practices.md

### DIFF
--- a/packages/core/resources/best-practices.md
+++ b/packages/core/resources/best-practices.md
@@ -47,7 +47,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Use the async pipe to handle observables
 - Do not assume globals like (`new Date()`) are available.
 - Do not write arrow functions in templates (they are not supported).
-- Do not write Regular expressions in templates (they are not supported).
 
 ## Services
 


### PR DESCRIPTION
## Description

This PR removes an outdated restriction from the best practices guide for AI agents.

The statement "Do not write Regular expressions in templates (they are not supported)." is no longer accurate as of Angular 21, which now supports regular expressions directly in templates (see #63857).

## Changes

- Removed the line about regex restrictions from `packages/core/resources/best-practices.md`

## Motivation

Keeping the outdated restriction in the best practices guide could lead to AI agents generating suboptimal code by avoiding a now-supported feature. With Angular 21 supporting regex in templates, this guidance is counterproductive.

## Type

- [ ] Feature
- [x] Documentation
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Other