### PR TITLE
Fix links in new Signal Forms guides

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -422,7 +422,9 @@ accountForm = form(this.accountModel, schemaPath => {
 
 This guide covered building custom controls that integrate with Signal Forms. Related guides explore other aspects of Signal Forms:
 
-- [Form Models guide](guide/forms/signals/models) - Creating and updating form models
-  <!-- TODO: Uncomment when guides are available -->
-  <!-- - [Field State Management guide](guide/forms/signals/field-state-management) - Using form state signals -->
-  <!-- - [Validation guide](guide/forms/signals/validation) - Adding validation to your forms -->
+<docs-pill-row>
+  <docs-pill href="guide/forms/signals/models" title="Form models" />
+  <docs-pill href="guide/forms/signals/field-state-management" title="Field state management" />
+  <docs-pill href="guide/forms/signals/validation" title="Validation" />
+  <!-- <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" /> -->
+</docs-pill-row>

--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -74,7 +74,7 @@ These signals enable you to build responsive form user experiences that react to
 
 Validation state signals tell you whether a field is valid and what errors it contains.
 
-NOTE: This guide focuses on **using** validation state in your templates and logic (such as reading `valid()`, `invalid()`, `errors()` to display feedback). For information on **defining** validation rules and creating custom validators, see the Validation guide (coming soon).
+NOTE: This guide focuses on **using** validation state in your templates and logic (such as reading `valid()`, `invalid()`, `errors()` to display feedback). For information on **defining** validation rules and creating custom validators, see the [Validation guide](guide/forms/signals/validation).
 
 ### Checking validity
 
@@ -689,7 +689,12 @@ Checking both `touched()` and validation state ensures styles only appear after 
 
 ## Next steps
 
-Here are other related guides on Signal Forms:
+This guide covered validation and availability status handling, interaction tracking and field state propagation. Related guides explore other aspects of Signal Forms:
 
-- [Form Models guide](guide/forms/signals/models) - Creating models and updating values
-- Validation guide - Defining validation rules and custom validators (coming soon)
+<!-- TODO: UNCOMMENT WHEN THE GUIDES ARE AVAILABLE -->
+<docs-pill-row>
+  <docs-pill href="guide/forms/signals/models" title="Form models" />
+  <docs-pill href="guide/forms/signals/validation" title="Validation" />
+  <docs-pill href="guide/forms/signals/custom-controls" title="Custom controls" />
+  <!-- <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" /> -->
+</docs-pill-row>

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -526,11 +526,14 @@ async loadExistingUser() {
 
 For forms that always start with existing data, you might wait to render the form until data loads in order to avoid a flash of empty fields.
 
-<!-- TODO: UNCOMMENT WHEN THE GUIDES ARE AVAILABLE -->
-<!-- ## Next steps
+## Next steps
 
+This guide covered creating models and updating values. Related guides explore other aspects of Signal Forms:
+
+<!-- TODO: UNCOMMENT WHEN THE GUIDES ARE AVAILABLE -->
 <docs-pill-row>
-  <docs-pill href="guide/forms/signals/field-state-management" title="Field State Management" />
+  <docs-pill href="guide/forms/signals/field-state-management" title="Field state management" />
   <docs-pill href="guide/forms/signals/validation" title="Validation" />
-  <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" />
-</docs-pill-row> -->
+  <docs-pill href="guide/forms/signals/custom-controls" title="Custom controls" />
+  <!-- <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" /> -->
+</docs-pill-row>

--- a/adev/src/content/guide/forms/signals/overview.md
+++ b/adev/src/content/guide/forms/signals/overview.md
@@ -45,15 +45,16 @@ The `Field` directive must be imported into any component that binds form fields
 })
 ```
 
-<!-- TODO: UNCOMMENT SECTION BELOW WHEN AVAILABLE -->
-<!-- ## Next steps
+## Next steps
 
 To learn more about how Signal Forms work, check out the following guides:
 
+<!-- TODO: UNCOMMENT SECTION BELOW WHEN AVAILABLE -->
 <docs-pill-row>
   <docs-pill href="essentials/signal-forms" title="Signal forms essentials" />
   <docs-pill href="guide/forms/signals/models" title="Form models" />
   <docs-pill href="guide/forms/signals/field-state-management" title="Field state management" />
   <docs-pill href="guide/forms/signals/validation" title="Validation" />
   <docs-pill href="guide/forms/signals/custom-controls" title="Custom controls" />
-</docs-pill-row> -->
+  <!-- <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" /> -->
+</docs-pill-row>

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -624,6 +624,10 @@ The `valid()` signal returns `false` while validation is pending, even if there 
 
 This guide covered creating and applying validation rules. Related guides explore other aspects of Signal Forms:
 
-- [Form Models guide](guide/forms/signals/models) - Creating and updating form models
-  <!-- TODO: Uncomment when Field State Management guide is published -->
-  <!-- - [Field State Management guide](guide/forms/signals/field-state-management) - Using validation state in templates and displaying errors -->
+<!-- TODO: UNCOMMENT WHEN THE GUIDES ARE AVAILABLE -->
+<docs-pill-row>
+  <docs-pill href="guide/forms/signals/field-state-management" title="Field state management" />
+  <docs-pill href="guide/forms/signals/models" title="Form models" />
+  <docs-pill href="guide/forms/signals/custom-controls" title="Custom controls" />
+  <!-- <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" /> -->
+</docs-pill-row>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some links were missing or broken in the new Signal Forms guides. 

Issue Number: N/A

## What is the new behavior?
Every page has a Next step section that contains related documentation pages presented in a docs-pill-row.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No