### PR TITLE
refactor(docs-infra): automate algolia index name based on angular/core version

### DIFF
--- a/adev/src/app/environment.ts
+++ b/adev/src/app/environment.ts
@@ -6,6 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {VERSION} from '@angular/core';
+const major = VERSION.major;
+
+const isPreRelease =
+  VERSION.full.includes('-next') || VERSION.full.includes('-rc') || VERSION.full === '0.0.0';
+
+// NOTE: Although the index name is determined automatically here, the actual index
+// must be MANUALLY created on the Algolia dashboard for every new major version.
+const indexName = isPreRelease ? 'angular_next_dev' : `angular_v${major}`;
+
 export default {
   production: true,
   // Those values are publicly visible in the search request headers, and presents search-only keys.
@@ -13,9 +23,7 @@ export default {
   algolia: {
     appId: 'L1XWT2UJ7F',
     apiKey: 'dfca7ed184db27927a512e5c6668b968',
-    // The indexName value must match the branch it's on.
-    // So it needs to be updated on release of the new major on the patch branch.
-    indexName: 'angular_next_dev',
+    indexName: indexName,
   },
   googleAnalyticsId: 'G-XB6NEVW32B',
 };


### PR DESCRIPTION
This PR automates the `algolia.indexName` configuration.

It replaces the manual hardcoded string with a dynamic check against @angular/core version.

**Changes:**
- Uses `angular_next_dev` for pre-releases (`-next`, `-rc`) and local snapshots (`0.0.0`).
- Uses `angular_vXX` for stable releases.

Closes #65422

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The algolia indexName is not automatically set.

Issue Number: #65422


## What is the new behavior?
The algolia indexName is now automatically set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No