### PR TITLE
docs: remove unnecessary @ts-ignore from signal forms playground

### DIFF
--- a/adev/src/content/tutorials/playground/4-signal-forms/src/main.ts
+++ b/adev/src/content/tutorials/playground/4-signal-forms/src/main.ts
@@ -1,7 +1,6 @@
 import {bootstrapApplication} from '@angular/platform-browser';
 import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
-// @ts-ignore There's a known issue with type support in the playground editor for signal forms
-import {form, Field, required, email, submit} from '@angular/forms/signals';
+import {form, Field, required, email, debounce, submit} from '@angular/forms/signals';
 
 interface LoginData {
   email: string;


### PR DESCRIPTION
Removes the  comment from the signal forms playground example as it's no longer needed after the module resolution fix.