### PR TITLE
fix(docs-infra): link to the snippet location at the proper commit for examples

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -49,8 +49,7 @@ export const DOCS_CODE_SELECTOR = '.docs-code';
 export const DOCS_CODE_MUTLIFILE_SELECTOR = '.docs-code-multifile';
 export const DOCS_CODE_TAB_GROUP_SELECTOR = '.docs-tab-group';
 export const DOCS_CODE_TAB_SELECTOR = '.docs-tab';
-// TODO: Update the branch/sha
-export const GITHUB_CONTENT_URL = 'https://github.com/angular/angular/blob/main/';
+const GITHUB_CONTENT_URL = 'https://github.com/angular/angular/blob/{{BUILD_SCM_ABBREV_HASH}}';
 
 @Component({
   selector: DOCS_VIEWER_SELECTOR,


### PR DESCRIPTION
Within examples, we now link to the github URL using the commit that was made to create adev, rather than always on main, which may change over time.


e.g. Previously we linked to `https://github.com/angular/angular/blob/main/adev/src/content/examples/drag-drop/src/overview/app/app.component.html` but now would link to `https://github.com/angular/angular/blob/be6f2f066f/adev/src/content/examples/drag-drop/src/overview/app/app.component.html`