### PR TITLE
docs: correct v21 LTS end date and v20 active end date

### DIFF
--- a/adev/src/content/reference/releases.md
+++ b/adev/src/content/reference/releases.md
@@ -97,8 +97,8 @@ The following table provides the status for Angular versions under support.
 
 | Version | Status | Released   | Active ends | LTS ends   |
 | :------ | :----- | :--------- | :---------- | :--------- |
-| ^21.0.0 | Active | 2025-11-19 | 2026-05-20  | 2026-11-18 |
-| ^20.0.0 | LTS    | 2025-05-28 | 2025-11-21  | 2026-11-21 |
+| ^21.0.0 | Active | 2025-11-19 | 2026-05-19  | 2027-05-19 |
+| ^20.0.0 | LTS    | 2025-05-28 | 2025-11-19  | 2026-11-28 |
 | ^19.0.0 | LTS    | 2024-11-19 | 2025-05-28  | 2026-05-19 |
 
 Angular versions v2 to v18 are no longer supported.


### PR DESCRIPTION
Updated to align the v20 active end date with the v21 release date and fix the v21 LTS to be 1-year after the active period ends.

I'm not 100% on how the day-of-month is decided normally, I just maintained the same day-of-month as the release date.