### PR TITLE
feat(forms): add DI option for classes on `Field` directive

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -52,6 +52,9 @@ export class CompatValidationError<T = unknown> implements ValidationError {
     readonly message?: string;
 }
 
+// @public
+export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -380,9 +380,6 @@ export class MinValidationError extends _NgValidationError {
 }
 
 // @public
-export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];
-
-// @public
 export const NgValidationError: abstract new () => NgValidationError;
 
 // @public (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -18,6 +18,7 @@ import { InputSignal } from '@angular/core';
 import { ModelSignal } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { OutputRef } from '@angular/core';
+import { Provider } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { StandardSchemaV1 } from '@standard-schema/spec';
@@ -144,6 +145,8 @@ export const FIELD: InjectionToken<Field<unknown>>;
 export class Field<T> implements ɵControl<T> {
     // (undocumented)
     readonly [ɵCONTROL]: undefined;
+    // (undocumented)
+    readonly classes: (readonly [string, i0.Signal<boolean>])[];
     // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
     protected getOrCreateNgControl(): InteropNgControl;
@@ -377,6 +380,9 @@ export class MinValidationError extends _NgValidationError {
 }
 
 // @public
+export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];
+
+// @public
 export const NgValidationError: abstract new () => NgValidationError;
 
 // @public (undocumented)
@@ -426,6 +432,9 @@ export class PatternValidationError extends _NgValidationError {
     // (undocumented)
     readonly pattern: RegExp;
 }
+
+// @public
+export function provideSignalFormsConfig(config: SignalFormsConfig): Provider[];
 
 // @public
 export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic?: NoInfer<LogicFn<TValue, boolean, TPathKind>>): void;
@@ -508,6 +517,13 @@ export namespace SchemaPathRules {
 export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = ([TModel] extends [AbstractControl] ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & (TModel extends AbstractControl ? unknown : TModel extends Array<any> ? unknown : TModel extends Record<string, any> ? {
     [K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>;
 } : unknown);
+
+// @public
+export interface SignalFormsConfig {
+    classes?: {
+        [className: string]: (state: FieldState<unknown>) => boolean;
+    };
+}
 
 // @public
 export function standardSchemaError(issue: StandardSchemaV1.Issue, options: WithField<ValidationErrorOptions>): StandardSchemaValidationError;

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -467,8 +467,9 @@ function updateControlClasses(lView: LView, tNode: TNode, control: ɵControl<unk
     const element = getNativeByTNode(tNode, lView) as HTMLElement;
 
     for (const [className, enabled] of control.classes) {
-      if (controlClassBindingUpdated(bindings.classes, className, enabled())) {
-        if (enabled()) {
+      const isEnabled = enabled();
+      if (controlClassBindingUpdated(bindings.classes, className, isEnabled)) {
+        if (isEnabled) {
           renderer.addClass(element, className);
         } else {
           renderer.removeClass(element, className);
@@ -869,7 +870,7 @@ type ControlBindingKeys = Exclude<
 type ControlBindings = {
   [K in ControlBindingKeys]?: unknown;
 } & {
-  classes: {[cls: string]: boolean};
+  classes: {[className: string]: boolean};
 };
 
 /**

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -95,6 +95,8 @@ export function ɵɵcontrol<T>(value: T, sanitizer?: SanitizerFn | null): void {
 
   const control = getControlDirective(tNode, lView);
   if (control) {
+    updateControlClasses(lView, tNode, control);
+
     if (tNode.flags & TNodeFlags.isFormValueControl) {
       updateCustomControl(tNode, lView, control, 'value');
     } else if (tNode.flags & TNodeFlags.isFormCheckboxControl) {
@@ -447,6 +449,33 @@ function isRelevantSelectMutation(mutation: MutationRecord) {
   }
   // Everything else is not relevant.
   return false;
+}
+
+/**
+ * Updates the configured classes for the control.
+ *
+ * @param lView The `LView` that contains the control.
+ * @param tNode The `TNode` of the control.
+ * @param control The `ɵControl` directive instance.
+ */
+function updateControlClasses(lView: LView, tNode: TNode, control: ɵControl<unknown>) {
+  if (control.classes) {
+    const bindings = getControlBindings(lView);
+    bindings.classes ??= {};
+    const state = control.state();
+    const renderer = lView[RENDERER];
+    const element = getNativeByTNode(tNode, lView) as HTMLElement;
+
+    for (const [className, enabled] of control.classes) {
+      if (controlClassBindingUpdated(bindings.classes, className, enabled())) {
+        if (enabled()) {
+          renderer.addClass(element, className);
+        } else {
+          renderer.removeClass(element, className);
+        }
+      }
+    }
+  }
 }
 
 /**
@@ -839,6 +868,8 @@ type ControlBindingKeys = Exclude<
  */
 type ControlBindings = {
   [K in ControlBindingKeys]?: unknown;
+} & {
+  classes: {[cls: string]: boolean};
 };
 
 /**
@@ -893,7 +924,7 @@ function getControlBindings(lView: LView): ControlBindings {
  */
 function controlBindingUpdated(
   bindings: ControlBindings,
-  key: ControlBindingKeys,
+  key: Exclude<ControlBindingKeys, 'classes'>,
   value: unknown,
 ): boolean {
   const oldValue = bindings[key];
@@ -901,6 +932,27 @@ function controlBindingUpdated(
     return false;
   }
   bindings[key] = value;
+  return true;
+}
+
+/**
+ * Updates a control class binding if changed, then returns whether it was updated.
+ *
+ * @param bindings The control class bindings to check.
+ * @param className The class name to check.
+ * @param value The new value to check against.
+ * @returns `true` if the class binding has changed.
+ */
+function controlClassBindingUpdated(
+  bindings: {[className: string]: boolean},
+  className: string,
+  value: boolean,
+): boolean {
+  const oldValue = bindings[className];
+  if (Object.is(oldValue, value)) {
+    return false;
+  }
+  bindings[className] = value;
   return true;
 }
 

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -21,6 +21,9 @@ export interface ɵControl<T> {
   /** The state of the field bound to this control. */
   readonly state: Signal<ɵFieldState<T>>;
 
+  /** Options for the control. */
+  readonly classes: ReadonlyArray<readonly [string, Signal<boolean>]>;
+
   /** A reference to the interoperable control, if one is present. */
   readonly ɵinteropControl: ɵInteropControl | undefined;
 

--- a/packages/forms/signals/compat/public_api.ts
+++ b/packages/forms/signals/compat/public_api.ts
@@ -13,3 +13,4 @@
  */
 export * from './src/api/compat_form';
 export * from './src/api/compat_validation_error';
+export * from './src/api/di';

--- a/packages/forms/signals/compat/src/api/di.ts
+++ b/packages/forms/signals/compat/src/api/di.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type {SignalFormsConfig} from '../../../src/api/di';
+
+/**
+ * A value that can be used for {@link SignalFormsConfig.classes} to automatically add
+ * the `ng-*` status classes from reactive forms.
+ *
+ * @experimental 21.0.1
+ */
+export const NG_STATUS_CLASSES: SignalFormsConfig['classes'] = {
+  'ng-touched': (state) => state.touched(),
+  'ng-untouched': (state) => !state.touched(),
+  'ng-dirty': (state) => state.dirty(),
+  'ng-pristine': (state) => !state.dirty(),
+  'ng-valid': (state) => state.valid(),
+  'ng-invalid': (state) => state.invalid(),
+  'ng-pending': (state) => state.pending(),
+};

--- a/packages/forms/signals/compat/src/api/di.ts
+++ b/packages/forms/signals/compat/src/api/di.ts
@@ -9,7 +9,7 @@
 import type {SignalFormsConfig} from '../../../src/api/di';
 
 /**
- * A value that can be used for {@link SignalFormsConfig.classes} to automatically add
+ * A value that can be used for `SignalFormsConfig.classes` to automatically add
  * the `ng-*` status classes from reactive forms.
  *
  * @experimental 21.0.1

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -14,6 +14,7 @@
 export * from './src/api/async';
 export * from './src/api/control';
 export * from './src/api/debounce';
+export * from './src/api/di';
 export * from './src/api/field_directive';
 export * from './src/api/logic';
 export * from './src/api/metadata';

--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {type Provider} from '@angular/core';
+import {SIGNAL_FORMS_CONFIG} from '../field/di';
+import type {FieldState} from './types';
+
+/**
+ * Configuration options for signal forms.
+ *
+ * @experimental 21.0.1
+ */
+export interface SignalFormsConfig {
+  /** A map of CSS class names to predicate functions that determine when to apply them. */
+  classes?: {[className: string]: (state: FieldState<unknown>) => boolean};
+}
+
+/**
+ * A value that can be used for {@link SignalFormsConfig.classes} to automatically add
+ * the `ng-*` status classes from reactive forms.
+ *
+ * @experimental 21.0.1
+ */
+export const NG_STATUS_CLASSES: SignalFormsConfig['classes'] = {
+  'ng-touched': (state) => state.touched(),
+  'ng-untouched': (state) => !state.touched(),
+  'ng-dirty': (state) => state.dirty(),
+  'ng-pristine': (state) => !state.dirty(),
+  'ng-valid': (state) => state.valid(),
+  'ng-invalid': (state) => state.invalid(),
+  'ng-pending': (state) => state.pending(),
+};
+
+/**
+ * Provides configuration options for signal forms.
+ *
+ * @experimental 21.0.1
+ */
+export function provideSignalFormsConfig(config: SignalFormsConfig): Provider[] {
+  return [{provide: SIGNAL_FORMS_CONFIG, useValue: config}];
+}

--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -21,22 +21,6 @@ export interface SignalFormsConfig {
 }
 
 /**
- * A value that can be used for {@link SignalFormsConfig.classes} to automatically add
- * the `ng-*` status classes from reactive forms.
- *
- * @experimental 21.0.1
- */
-export const NG_STATUS_CLASSES: SignalFormsConfig['classes'] = {
-  'ng-touched': (state) => state.touched(),
-  'ng-untouched': (state) => !state.touched(),
-  'ng-dirty': (state) => state.dirty(),
-  'ng-pristine': (state) => !state.dirty(),
-  'ng-valid': (state) => state.valid(),
-  'ng-invalid': (state) => state.invalid(),
-  'ng-pending': (state) => state.pending(),
-};
-
-/**
  * Provides configuration options for signal forms.
  *
  * @experimental 21.0.1

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
 import {InteropNgControl} from '../controls/interop_ng_control';
+import {SIGNAL_FORMS_CONFIG} from '../field/di';
 import type {FieldNode} from '../field/node';
 import type {FieldTree} from './types';
 
@@ -61,6 +62,10 @@ export const FIELD = new InjectionToken<Field<unknown>>(
 })
 export class Field<T> implements ɵControl<T> {
   private readonly injector = inject(Injector);
+  private options = inject(SIGNAL_FORMS_CONFIG, {optional: true});
+  readonly classes = Object.entries(this.options?.classes ?? {}).map(
+    ([className, computation]) => [className, computed(() => computation(this.state()))] as const,
+  );
   readonly field = input.required<FieldTree<T>>();
   readonly state = computed(() => this.field()());
   readonly [ɵCONTROL] = undefined;

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -62,8 +62,8 @@ export const FIELD = new InjectionToken<Field<unknown>>(
 })
 export class Field<T> implements ɵControl<T> {
   private readonly injector = inject(Injector);
-  private options = inject(SIGNAL_FORMS_CONFIG, {optional: true});
-  readonly classes = Object.entries(this.options?.classes ?? {}).map(
+  private config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
+  readonly classes = Object.entries(this.config?.classes ?? {}).map(
     ([className, computation]) => [className, computed(() => computation(this.state()))] as const,
   );
   readonly field = input.required<FieldTree<T>>();

--- a/packages/forms/signals/src/field/di.ts
+++ b/packages/forms/signals/src/field/di.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '@angular/core';
+import type {SignalFormsConfig} from '../api/di';
+
+/** Injection token for the signal forms configuration. */
+export const SIGNAL_FORMS_CONFIG = new InjectionToken<SignalFormsConfig>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'SIGNAL_FORMS_CONFIG' : '',
+);

--- a/packages/forms/signals/test/web/BUILD.bazel
+++ b/packages/forms/signals/test/web/BUILD.bazel
@@ -10,6 +10,7 @@ ng_project(
         "//packages/core/testing",
         "//packages/forms",
         "//packages/forms/signals",
+        "//packages/forms/signals/compat",
         "//packages/platform-browser",
         "//packages/platform-browser/testing",
         "//packages/private/testing",

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -15,13 +15,13 @@ import {
   input,
   inputBinding,
   model,
-  provideZonelessChangeDetection,
   signal,
   viewChild,
   viewChildren,
   ViewContainerRef,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NG_STATUS_CLASSES} from '../../compat/src/api/di';
 import {
   debounce,
   disabled,
@@ -32,7 +32,6 @@ import {
   maxLength,
   min,
   minLength,
-  NG_STATUS_CLASSES,
   pattern,
   provideSignalFormsConfig,
   readonly,
@@ -56,12 +55,6 @@ class TestStringControl {
 }
 
 describe('field directive', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   describe('field input', () => {
     it('should bind new field to control when changed', () => {
       @Component({
@@ -2368,7 +2361,6 @@ describe('field directive', () => {
     it('should apply classes based on config', () => {
       TestBed.configureTestingModule({
         providers: [
-          provideZonelessChangeDetection(),
           provideSignalFormsConfig({
             classes: {
               'my-invalid-class': (state) => state.invalid(),
@@ -2398,7 +2390,6 @@ describe('field directive', () => {
     it('should apply NG_STATUS_CLASSES', () => {
       TestBed.configureTestingModule({
         providers: [
-          provideZonelessChangeDetection(),
           provideSignalFormsConfig({
             classes: NG_STATUS_CLASSES,
           }),
@@ -2432,26 +2423,20 @@ describe('field directive', () => {
       expect(input.classList.contains('ng-valid')).toBe(true);
       expect(input.classList.contains('ng-invalid')).toBe(false);
 
-      // Touch it (simulating interaction)
-      act(() => {
-        input.dispatchEvent(new Event('blur'));
-      });
-      expect(input.classList.contains('ng-touched')).toBe(true);
-      expect(input.classList.contains('ng-untouched')).toBe(false);
-
-      // Make it dirty (simulating input)
-      act(() => {
-        input.value = 'new value';
-        input.dispatchEvent(new Event('input'));
-      });
+      // Make it dirty
+      act(() => input.dispatchEvent(new Event('input')));
       expect(input.classList.contains('ng-dirty')).toBe(true);
       expect(input.classList.contains('ng-pristine')).toBe(false);
+
+      // Touch it
+      act(() => input.dispatchEvent(new Event('blur')));
+      expect(input.classList.contains('ng-touched')).toBe(true);
+      expect(input.classList.contains('ng-untouched')).toBe(false);
     });
 
-    it('should not apply classes on a custom and native control, but not a component with a `field` input', () => {
+    it('should apply classes on a custom and native control, but not a component with a `field` input', () => {
       TestBed.configureTestingModule({
         providers: [
-          provideZonelessChangeDetection(),
           provideSignalFormsConfig({
             classes: {'always': () => true},
           }),

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -21,7 +21,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NG_STATUS_CLASSES} from '../../compat/src/api/di';
+import {NG_STATUS_CLASSES} from '../../compat/public_api';
 import {
   debounce,
   disabled,


### PR DESCRIPTION
Adds a DI configuration option for signal forms that allows the developer to specify CSS classes that should be automatically added by the `Field` directive based on the field's status.
