### PR TITLE
ci: update pullapprove reviewers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -262,7 +262,7 @@ groups:
         - devversion
         - josephperrott
         - ~pkozlowski-opensource
-        - mgechev
+        - ~mgechev
         - MarkTechson
         - mmalerba
         - ~hawkgs


### PR DESCRIPTION
Removing Minko from the pool of automatically picked reviewers
