### PR TITLE
docs: remove unnecessary `standalone: true` from examples

### DIFF
--- a/adev/src/content/examples/aria/menubar/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/basic/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/disabled/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/disabled/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.ts
@@ -7,7 +7,6 @@ import {OverlayModule} from '@angular/cdk/overlay';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/rtl/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/rtl/app/app.ts
@@ -8,7 +8,6 @@ import {Dir} from '@angular/cdk/bidi';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [Dir, MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.ts
@@ -8,7 +8,6 @@ import {Dir} from '@angular/cdk/bidi';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [Dir, MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.ts
+++ b/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.ts
@@ -8,7 +8,6 @@ import {Dir} from '@angular/cdk/bidi';
   templateUrl: 'app.html',
   styleUrl: 'app.css',
   imports: [Dir, MenuBar, Menu, MenuContent, MenuItem, OverlayModule],
-  standalone: true,
 })
 export class App {
   fileMenu = viewChild<Menu<string>>('fileMenu');

--- a/adev/src/content/reference/migrations/common-to-standalone.md
+++ b/adev/src/content/reference/migrations/common-to-standalone.md
@@ -24,7 +24,6 @@ import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [CommonModule],
   template: `
     <div *ngIf="show">
@@ -46,7 +45,6 @@ import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [AsyncPipe, JsonPipe, NgIf],
   template: `
     <div *ngIf="show">


### PR DESCRIPTION
Standalone components are now the default, so explicitly specifying `standalone: true` is no longer required. Updated relevant documentation examples to avoid redundant configuration and keep the guides concise.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
