### PR TITLE
docs: update Signal Forms link to point to new overview page

### DIFF
--- a/adev/src/content/tutorials/signal-forms/steps/6-next-steps/README.md
+++ b/adev/src/content/tutorials/signal-forms/steps/6-next-steps/README.md
@@ -18,7 +18,7 @@ Ready to learn more? Here are recommended next steps:
 
 ### Explore the documentation
 
-- **[Signal Forms Overview](guide/forms/signal-forms)** - Introduction to Signal Forms and when to use them
+- **[Signal Forms Overview](guide/forms/signals/overview)** - Introduction to Signal Forms and when to use them
 - **[Form Models Guide](guide/forms/signal-forms/models)** - Deep dive into form models and data management
   <!-- TODO: Uncomment when the guides are available -->
   <!-- - **[Validation Guide](guide/forms/signal-forms/validation)** - Comprehensive validation reference


### PR DESCRIPTION
Replaces outdated `guide/forms/signal-forms` link with the current `guide/forms/signals/overview` path to ensure readers are directed to the correct Signal Forms documentation.

fixes: #65461