### PR TITLE
docs: fix incorrect Signal Forms link

### DIFF
--- a/adev/src/content/guide/forms/signals/comparison.md
+++ b/adev/src/content/guide/forms/signals/comparison.md
@@ -158,6 +158,6 @@ TypeScript understands your component properties but has no knowledge of form st
 
 To learn more about each approach:
 
-- **Signal Forms**: See the [Overview guide](guide/forms/signal-forms/overview) to get started, or dive into [Form Models](guide/forms/signal-forms/models), [Validation](guide/forms/signal-forms/validation), and [Field State Management](guide/forms/signal-forms/field-state-management)
+- **Signal Forms**: See the [Overview guide](guide/forms/signals/overview) to get started, or dive into [Form Models](guide/forms/signals/models), [Validation](guide/forms/signals/validation), and [Field State Management](guide/forms/signals/field-state-management)
 - **Reactive Forms**: See the [Reactive Forms guide](guide/forms/reactive-forms) in Angular documentation
 - **Template-driven Forms**: See the [Template-driven Forms guide](guide/forms/template-driven-forms) in Angular documentation

--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -241,7 +241,7 @@ export class MyForm {
 }
 ```
 
-TIP: For complete coverage of creating and managing form models, see the [Form Models guide](guide/forms/signal-forms/models).
+TIP: For complete coverage of creating and managing form models, see the [Form Models guide](guide/forms/signals/models).
 
 When you bind `[field]="userForm.username"`, the Field directive:
 
@@ -424,5 +424,5 @@ This guide covered building custom controls that integrate with Signal Forms. Re
 
 - [Form Models guide](guide/forms/signal-forms/models) - Creating and updating form models
   <!-- TODO: Uncomment when guides are available -->
-  <!-- - [Field State Management guide](guide/forms/signal-forms/field-state-management) - Using form state signals -->
-  <!-- - [Validation guide](guide/forms/signal-forms/validation) - Adding validation to your forms -->
+  <!-- - [Field State Management guide](guide/forms/signals/field-state-management) - Using form state signals -->
+  <!-- - [Validation guide](guide/forms/signals/validation) - Adding validation to your forms -->

--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -47,7 +47,7 @@ In this example, the template checks `registrationForm.email().invalid()` to det
 
 ### Field state signals
 
-The most commonly used signal is `value()`, a [writable signal](guide/forms/signal-forms/models#updating-models) that provides access to the field's current value:
+The most commonly used signal is `value()`, a [writable signal](guide/forms/signals/models#updating-models) that provides access to the field's current value:
 
 ```ts
 const emailValue = registrationForm.email().value()

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -172,7 +172,7 @@ Field state provides reactive signals for each field's value, making it suitable
 TIP: Field state includes many more signals beyond `value()`, such as validation state (e.g., valid, invalid, errors), interaction tracking (e.g., touched, dirty), and visibility (e.g., hidden, disabled).
 
 <!-- TODO: UNCOMMENT BELOW WHEN GUIDE IS AVAILABLE -->
-<!-- See the [Field State Management guide](guide/forms/signal-forms/field-state-management) for complete coverage. -->
+<!-- See the [Field State Management guide](guide/forms/signals/field-state-management) for complete coverage. -->
 
 ## Updating form models programmatically
 
@@ -419,7 +419,7 @@ orderForm.items[0].quantity // FieldTree<number>
 
 Array items containing objects automatically receive tracking identities, which helps maintain field state even when items change position in the array. This ensures validation state and user interactions persist correctly when arrays are reordered.
 
-<!-- TBD: For dynamic arrays and complex array operations, see the [Working with arrays guide](guide/forms/signal-forms/arrays). -->
+<!-- TBD: For dynamic arrays and complex array operations, see the [Working with arrays guide](guide/forms/signals/arrays). -->
 
 ## Model design best practices
 
@@ -530,7 +530,7 @@ For forms that always start with existing data, you might wait to render the for
 <!-- ## Next steps
 
 <docs-pill-row>
-  <docs-pill href="guide/forms/signal-forms/field-state-management" title="Field State Management" />
-  <docs-pill href="guide/forms/signal-forms/validation" title="Validation" />
-  <docs-pill href="guide/forms/signal-forms/arrays" title="Working with Arrays" />
+  <docs-pill href="guide/forms/signals/field-state-management" title="Field State Management" />
+  <docs-pill href="guide/forms/signals/validation" title="Validation" />
+  <docs-pill href="guide/forms/signals/arrays" title="Working with Arrays" />
 </docs-pill-row> -->

--- a/adev/src/content/guide/forms/signals/overview.md
+++ b/adev/src/content/guide/forms/signals/overview.md
@@ -20,7 +20,7 @@ Signal Forms address these challenges by:
 Signal Forms work best in new applications built with signals. If you're working with an existing application that uses reactive forms, or if you need production stability guarantees, reactive forms remain a solid choice.
 
 <!-- TODO: UNCOMMENT SECTION BELOW WHEN AVAILABLE -->
-<!-- NOTE: If you're coming from template or reactive forms, you may be interested in our [comparison guide](guide/forms/signal-forms/comparison). -->
+<!-- NOTE: If you're coming from template or reactive forms, you may be interested in our [comparison guide](guide/forms/signals/comparison). -->
 
 ## Prerequisites
 
@@ -52,8 +52,8 @@ To learn more about how Signal Forms work, check out the following guides:
 
 <docs-pill-row>
   <docs-pill href="essentials/signal-forms" title="Signal forms essentials" />
-  <docs-pill href="guide/forms/signal-forms/models" title="Form models" />
-  <docs-pill href="guide/forms/signal-forms/field-state-management" title="Field state management" />
-  <docs-pill href="guide/forms/signal-forms/validation" title="Validation" />
-  <docs-pill href="guide/forms/signal-forms/custom-controls" title="Custom controls" />
+  <docs-pill href="guide/forms/signals/models" title="Form models" />
+  <docs-pill href="guide/forms/signals/field-state-management" title="Field state management" />
+  <docs-pill href="guide/forms/signals/validation" title="Validation" />
+  <docs-pill href="guide/forms/signals/custom-controls" title="Custom controls" />
 </docs-pill-row> -->

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -299,7 +299,7 @@ When validation rules fail, they produce error objects that describe what went w
 
 <!-- TODO: Uncomment when field state management guide is published
 
-NOTE: This section covers the errors that validation rules produce. For displaying and using validation errors in your UI, see the [Field State Management guide](guide/forms/signal-forms/field-state-management). -->
+NOTE: This section covers the errors that validation rules produce. For displaying and using validation errors in your UI, see the [Field State Management guide](guide/forms/signals/field-state-management). -->
 
 ### Error structure
 
@@ -374,7 +374,7 @@ signupForm = form(this.signupModel, (schemaPath) => {
 
 If the email field is empty, only the `required()` error appears. If the user types "a@b", both `email()` and `minLength()` errors appear. All validation rules run - validation doesn't stop after the first failure.
 
-TIP: Use the `touched() && invalid()` pattern in your templates to prevent errors from appearing before users have interacted with a field. For comprehensive guidance on displaying validation errors, see the [Field State Management guide](guide/forms/signal-forms/field-state-management#conditional-error-display).
+TIP: Use the `touched() && invalid()` pattern in your templates to prevent errors from appearing before users have interacted with a field. For comprehensive guidance on displaying validation errors, see the [Field State Management guide](guide/forms/signals/field-state-management#conditional-error-display).
 
 ## Custom validation rules
 
@@ -626,4 +626,4 @@ This guide covered creating and applying validation rules. Related guides explor
 
 - [Form Models guide](guide/forms/signal-forms/models) - Creating and updating form models
   <!-- TODO: Uncomment when Field State Management guide is published -->
-  <!-- - [Field State Management guide](guide/forms/signal-forms/field-state-management) - Using validation state in templates and displaying errors -->
+  <!-- - [Field State Management guide](guide/forms/signals/field-state-management) - Using validation state in templates and displaying errors -->


### PR DESCRIPTION
Updated outdated link `guide/forms/signal-forms/` to the correct path `guide/forms/signals/` to ensure proper navigation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
