### PR TITLE
fix(compiler-cli): do not type check native controls with ControlValueAccessor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -116,6 +116,9 @@ export interface DirectiveTypeCheckMeta {
    */
   undeclaredInputFields: Set<ClassPropertyName>;
 
+  /** Names of the public methods of the class. */
+  publicMethods: Set<string>;
+
   /**
    * Whether the Directive's class is generic, i.e. `class MyDir<T> {...}`.
    */

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -36,6 +36,7 @@ export function flattenInheritedDirectiveMetadata(
   const undeclaredInputFields = new Set<ClassPropertyName>();
   const restrictedInputFields = new Set<ClassPropertyName>();
   const stringLiteralInputFields = new Set<ClassPropertyName>();
+  const publicMethods = new Set<string>();
   let hostDirectives: HostDirectiveMeta[] | null = null;
   let isDynamic = false;
   let inputs = ClassPropertyMapping.empty<InputMapping>();
@@ -72,6 +73,9 @@ export function flattenInheritedDirectiveMetadata(
     for (const field of meta.stringLiteralInputFields) {
       stringLiteralInputFields.add(field);
     }
+    for (const name of meta.publicMethods) {
+      publicMethods.add(name);
+    }
     if (meta.hostDirectives !== null && meta.hostDirectives.length > 0) {
       hostDirectives ??= [];
       hostDirectives.push(...meta.hostDirectives);
@@ -88,6 +92,7 @@ export function flattenInheritedDirectiveMetadata(
     undeclaredInputFields,
     restrictedInputFields,
     stringLiteralInputFields,
+    publicMethods,
     baseClass: isDynamic ? 'dynamic' : null,
     isStructural,
     hostDirectives,

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -352,6 +352,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     restrictedInputFields: new Set<string>(),
     stringLiteralInputFields: new Set<string>(),
     undeclaredInputFields: new Set<string>(),
+    publicMethods: new Set<string>(),
     isGeneric: false,
     baseClass: null,
     isPoisoned: false,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
@@ -55,6 +55,7 @@ import {
   CustomFieldType,
   getCustomFieldDirectiveType,
   isFieldDirective,
+  isNativeField,
   TcbNativeFieldDirectiveTypeOp,
 } from './signal_forms';
 import {Reference} from '../../../imports';
@@ -772,13 +773,8 @@ export class Scope {
     const dirIndex = this.opQueue.push(directiveOp) - 1;
     dirMap.set(dir, dirIndex);
 
-    if (
-      isFieldDirective(dir) &&
-      node instanceof TmplAstElement &&
-      (node.name === 'input' || node.name === 'select' || node.name === 'textarea') &&
-      !allDirectiveMatches.some(getCustomFieldDirectiveType)
-    ) {
-      this.opQueue.push(new TcbNativeFieldDirectiveTypeOp(this.tcb, this, node));
+    if (isNativeField(dir, node, allDirectiveMatches)) {
+      this.opQueue.push(new TcbNativeFieldDirectiveTypeOp(this.tcb, this, node as TmplAstElement));
     }
 
     this.opQueue.push(new TcbDirectiveInputsOp(this.tcb, this, node, dir, customFieldType));

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -308,6 +308,7 @@ export interface TestDirective
         | 'restrictedInputFields'
         | 'stringLiteralInputFields'
         | 'undeclaredInputFields'
+        | 'publicMethods'
         | 'inputs'
         | 'outputs'
         | 'hostDirectives'
@@ -334,6 +335,7 @@ export interface TestDirective
   restrictedInputFields?: string[];
   stringLiteralInputFields?: string[];
   undeclaredInputFields?: string[];
+  publicMethods?: string[];
   isGeneric?: boolean;
   code?: string;
   ngContentSelectors?: string[] | null;
@@ -879,6 +881,7 @@ function getDirectiveMetaFromDeclaration(
     restrictedInputFields: new Set<string>(decl.restrictedInputFields || []),
     stringLiteralInputFields: new Set<string>(decl.stringLiteralInputFields || []),
     undeclaredInputFields: new Set<string>(decl.undeclaredInputFields || []),
+    publicMethods: new Set<string>(decl.publicMethods || []),
     isGeneric: decl.isGeneric ?? false,
     outputs: ClassPropertyMapping.fromMappedObject(decl.outputs || {}),
     queries: decl.queries || [],
@@ -938,6 +941,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         restrictedInputFields: new Set<string>(decl.restrictedInputFields ?? []),
         stringLiteralInputFields: new Set<string>(decl.stringLiteralInputFields ?? []),
         undeclaredInputFields: new Set<string>(decl.undeclaredInputFields ?? []),
+        publicMethods: new Set<string>(decl.publicMethods ?? []),
         isGeneric: decl.isGeneric ?? false,
         isPoisoned: false,
         isStructural: false,

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -510,5 +510,69 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(0);
     });
+
+    it('should not check field on native control that has a ControlValueAccessor directive', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, signal} from '@angular/core';
+          import {ControlValueAccessor} from '@angular/forms';
+          import {Field, form} from '@angular/forms/signals';
+
+          @Directive({selector: '[customCva]'})
+          export class CustomCva implements ControlValueAccessor {
+            writeValue() {}
+            registerOnChange() {}
+            registerOnTouched() {}
+          }
+
+          @Component({
+            template: '<input customCva [field]="f"/>',
+            imports: [Field, CustomCva]
+          })
+          export class Comp {
+            f = form(signal(0));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not check field on native control that has a directive inheriting from a ControlValueAccessor', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, Directive, signal} from '@angular/core';
+          import {ControlValueAccessor} from '@angular/forms';
+          import {Field, form} from '@angular/forms/signals';
+
+          @Directive()
+          export class Grandparent implements ControlValueAccessor {
+            writeValue() {}
+            registerOnChange() {}
+            registerOnTouched() {}
+          }
+
+          @Directive()
+          export class Parent extends Grandparent {}
+
+          @Directive({selector: '[customCva]'})
+          export class CustomCva extends Parent {}
+
+          @Component({
+            template: '<input customCva [field]="f"/>',
+            imports: [Field, CustomCva]
+          })
+          export class Comp {
+            f = form(signal(0));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Currently when we detect a `field` binding on a native element, we treat it as a built-in native control. This might not be the case if it's a pre-existing `ControlValueAccessor` relying on the CVA interop.

These changes try to detect any CVA-like directive on the element and disable the additional type checking if there are any.

Fixes #65468.