### PR TITLE
refactor(devtools): don't query defer nodes

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -676,6 +676,9 @@ export const queryDirectiveForest = (
     }
     forest = node.children;
   }
+  if (node?.defer) {
+    return null;
+  }
   return node;
 };
 


### PR DESCRIPTION
This prevents from throwing errors when selecting defer nodes
