### PR TITLE
fix(migrations): apply bootstrap-options migration to `platformBrowserDynamic`

### DIFF
--- a/packages/core/schematics/migrations/bootstrap-options-migration/migration.spec.ts
+++ b/packages/core/schematics/migrations/bootstrap-options-migration/migration.spec.ts
@@ -753,7 +753,7 @@ describe('bootstrap options migration', () => {
 
   describe('bootstrapModule', () => {
     [
-      // {packageName: 'platform-browser-dynamic', platformBrowserFn: 'platformBrowserDynamic'},
+      {packageName: 'platform-browser-dynamic', platformBrowserFn: 'platformBrowserDynamic'},
       {packageName: 'platform-browser', platformBrowserFn: 'platformBrowser'},
     ].forEach(({packageName, platformBrowserFn}) => {
       describe(`${platformBrowserFn}().bootstrapModule`, () => {

--- a/packages/core/schematics/migrations/bootstrap-options-migration/migration.ts
+++ b/packages/core/schematics/migrations/bootstrap-options-migration/migration.ts
@@ -816,6 +816,7 @@ function getSpecifiers(sourceFile: ts.SourceFile) {
     !createApplicationSpecifier &&
     !bootstrapAppSpecifier &&
     !platformBrowserSpecifier &&
+    !platformBrowserDynamicSpecifier &&
     !testBedSpecifier &&
     !ngModuleSpecifier &&
     !getTestBedSpecifier


### PR DESCRIPTION
The migration wasn't applied to projects relying on `platformBrowserDynamic()` prior to this fix.
