### PR TITLE
docs: format JSON examples and replace <docs-code> with fenced code b…

### DIFF
--- a/adev/src/content/reference/extended-diagnostics/NG8101.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8101.md
@@ -34,7 +34,8 @@ In this case:
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -44,6 +45,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8102.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8102.md
@@ -73,7 +73,8 @@ username: string = 'Angelino';
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {

--- a/adev/src/content/reference/extended-diagnostics/NG8103.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8103.md
@@ -58,7 +58,8 @@ class MyComponent {}
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -68,6 +69,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8104.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8104.md
@@ -36,18 +36,17 @@ When binding to `attr.`, `class.`, or `style.`, ensure you use the Angular templ
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
 
 {
-"angularCompilerOptions": {
-"extendedDiagnostics": {
-"checks": {
-"textAttributeNotBinding": "suppress"
+  "angularCompilerOptions": {
+    "extendedDiagnostics": {
+      "checks": {
+        "textAttributeNotBinding": "suppress"
+      }
+    }
+  }
 }
-}
-}
-}
-
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8105.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8105.md
@@ -44,7 +44,8 @@ class MyComponent {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -54,6 +55,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8106.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8106.md
@@ -33,7 +33,8 @@ move this to the value assignment of the binding.
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -43,6 +44,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8107.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8107.md
@@ -65,7 +65,8 @@ class MyComponent {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -75,6 +76,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8108.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8108.md
@@ -66,7 +66,8 @@ class MyComponent {}
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -76,6 +77,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8109.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8109.md
@@ -42,7 +42,8 @@ class MyComponent {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -52,6 +53,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8111.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8111.md
@@ -46,7 +46,8 @@ class MyComponent {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -56,6 +57,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8113.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8113.md
@@ -30,7 +30,8 @@ class AwesomeCheckbox {}
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -40,6 +41,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8115.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8115.md
@@ -46,7 +46,8 @@ class Items {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
+
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -56,6 +57,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8116.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8116.md
@@ -43,7 +43,7 @@ class MyComponent {}
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -53,6 +53,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.

--- a/adev/src/content/reference/extended-diagnostics/NG8117.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8117.md
@@ -46,7 +46,7 @@ class MyComponent {
 
 This diagnostic can be disabled by editing the project's `tsconfig.json` file:
 
-<docs-code language="json">
+```json
 {
   "angularCompilerOptions": {
     "extendedDiagnostics": {
@@ -56,6 +56,6 @@ This diagnostic can be disabled by editing the project's `tsconfig.json` file:
     }
   }
 }
-</docs-code>
+```
 
 See [extended diagnostic configuration](/extended-diagnostics#configuration) for more info.


### PR DESCRIPTION
…locks

Replaced <docs-code language="json" header=".postcssrc.json"> with fenced JSON code blocks using ```json {header: '.postcssrc.json'} for improved readability and consistency across documentation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
