### PR TITLE
docs: fix router event subscription in error handler example

### DIFF
--- a/adev/src/content/guide/routing/data-resolvers.md
+++ b/adev/src/content/guide/routing/data-resolvers.md
@@ -182,7 +182,7 @@ You can also handle resolver errors by subscribing to router events and listenin
 import { Component, inject, signal } from '@angular/core';
 import { Router, NavigationError } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { filter, map } from 'rxjs';
+import { map } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -202,15 +202,17 @@ export class App {
 
   private navigationErrors = toSignal(
     this.router.events.pipe(
-      filter((event): event is NavigationError => event instanceof NavigationError),
       map(event => {
-        this.lastFailedUrl.set(event.url);
-
-        if (event.error) {
-          console.error('Navigation error', event.error)
+        if (event instanceof NavigationError) {
+          this.lastFailedUrl.set(event.url);
+  
+          if (event.error) {
+            console.error('Navigation error', event.error)
+          }
+  
+          return 'Navigation failed. Please try again.';
         }
-
-        return 'Navigation failed. Please try again.';
+        return '';
       })
     ),
     { initialValue: '' }


### PR DESCRIPTION
The example incorrectly persisted the error message after a successful navigation retry because the stream only emitted NavigationError events. This update removes the filter and returns an empty string for non-error events, allowing the signal to clear the message on normal navigation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
