### PR TITLE
test: remove unnecessary test calls

### DIFF
--- a/adev/shared-docs/components/tab-group/tab-group.component.spec.ts
+++ b/adev/shared-docs/components/tab-group/tab-group.component.spec.ts
@@ -15,7 +15,6 @@ describe('TabGroup', () => {
   let fixture: ComponentFixture<TabGroup>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     fixture = TestBed.createComponent(TabGroup);
     fixture.detectChanges();
   });

--- a/adev/src/app/editor/code-editor/services/diagnostics-state.service.spec.ts
+++ b/adev/src/app/editor/code-editor/services/diagnostics-state.service.spec.ts
@@ -14,7 +14,6 @@ describe('DiagnosticsState', () => {
   let service: DiagnosticsState;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(DiagnosticsState);
   });
 

--- a/adev/src/app/editor/download-manager.service.spec.ts
+++ b/adev/src/app/editor/download-manager.service.spec.ts
@@ -14,7 +14,6 @@ describe('DownloadManager', () => {
   let service: DownloadManager;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(DownloadManager);
   });
 

--- a/adev/src/app/editor/stackblitz-opener.service.spec.ts
+++ b/adev/src/app/editor/stackblitz-opener.service.spec.ts
@@ -14,7 +14,6 @@ describe('StackBlitzOpener', () => {
   let service: StackBlitzOpener;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(StackBlitzOpener);
   });
 

--- a/adev/src/app/editor/terminal/command-validator.service.spec.ts
+++ b/adev/src/app/editor/terminal/command-validator.service.spec.ts
@@ -14,7 +14,6 @@ describe('CommandValidator', () => {
   let service: CommandValidator;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(CommandValidator);
   });
 

--- a/adev/src/app/editor/typings-loader.service.spec.ts
+++ b/adev/src/app/editor/typings-loader.service.spec.ts
@@ -48,7 +48,6 @@ describe('TypingsLoader', () => {
   } as unknown as WebContainer;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     service = TestBed.inject(TypingsLoader);
   });
 

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/src/lib/my-lib.service.spec.ts
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/src/lib/my-lib.service.spec.ts
@@ -3,8 +3,6 @@ import {TestBed} from '@angular/core/testing';
 import {MyLibService} from './my-lib.service';
 
 describe('MyLibService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
-
   it('should be created', () => {
     const service: MyLibService = TestBed.inject(MyLibService);
     expect(service).toBeTruthy();

--- a/devtools/projects/ng-devtools/src/lib/application-providers/supported_apis_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/supported_apis_spec.ts
@@ -13,7 +13,6 @@ describe('SUPPORTED_APIS', () => {
   let supportedApis: SupportedApisSignal;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
     supportedApis = TestBed.inject(SUPPORTED_APIS);
   });
 

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -2347,8 +2347,6 @@ describe('@defer', () => {
         isVisible = false;
       }
 
-      TestBed.configureTestingModule({});
-
       clearDirectiveDefs(RootCmp);
 
       const fixture = TestBed.createComponent(RootCmp);
@@ -2813,7 +2811,6 @@ describe('@defer', () => {
          `,
       })
       class MyCmp {}
-      TestBed.configureTestingModule({});
 
       const appRef = TestBed.inject(ApplicationRef);
       const zone = TestBed.inject(NgZone);
@@ -3458,8 +3455,6 @@ describe('@defer', () => {
       class RootCmp {
         isVisible = false;
       }
-
-      TestBed.configureTestingModule({});
 
       clearDirectiveDefs(RootCmp);
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -382,7 +382,6 @@ describe('EnvironmentProviders', () => {
   });
 
   it('should be accepted by createEnvironmentInjector', () => {
-    TestBed.configureTestingModule({});
     const inj = createEnvironmentInjector(
       [environmentProviders],
       TestBed.inject(EnvironmentInjector),
@@ -392,7 +391,6 @@ describe('EnvironmentProviders', () => {
 
   it('should be accepted as additional input to makeEnvironmentProviders', () => {
     const wrappedProviders = makeEnvironmentProviders([environmentProviders]);
-    TestBed.configureTestingModule({});
 
     const inj = createEnvironmentInjector([wrappedProviders], TestBed.inject(EnvironmentInjector));
     expect(inj.get(TOKEN)).toEqual('token!');

--- a/packages/core/test/acceptance/internal_spec.ts
+++ b/packages/core/test/acceptance/internal_spec.ts
@@ -134,7 +134,6 @@ describe('internal utilities', () => {
       })
       class Comp {}
 
-      TestBed.configureTestingModule({});
       const ref = createComponent(Comp, {environmentInjector: TestBed.inject(EnvironmentInjector)});
       ref.changeDetectorRef.detectChanges();
 

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -266,7 +266,6 @@ describe('reactivity', () => {
     });
 
     it('should create root effects when outside of a component, using injection context', () => {
-      TestBed.configureTestingModule({});
       const counter = signal(0);
       const log: number[] = [];
       TestBed.runInInjectionContext(() => effect(() => log.push(counter())));
@@ -280,7 +279,6 @@ describe('reactivity', () => {
     });
 
     it('should create root effects when outside of a component, using an injector', () => {
-      TestBed.configureTestingModule({});
       const counter = signal(0);
       const log: number[] = [];
       effect(() => log.push(counter()), {injector: TestBed.inject(Injector)});
@@ -294,7 +292,6 @@ describe('reactivity', () => {
     });
 
     it('should cleanup effect when manualCleanup is enabled and an injector is provided', () => {
-      TestBed.configureTestingModule({});
       const counter = signal(0);
       const log: number[] = [];
       // It needs the injector to be able to inject the other deps (and not just the DestroyRef).


### PR DESCRIPTION
Removes calls to `TestBed.configureTestingModule` since they aren't necessary.
