### PR TITLE
docs: clarify Vite proxy glob behavior for nested API paths

### DIFF
--- a/adev/src/content/tools/cli/serve.md
+++ b/adev/src/content/tools/cli/serve.md
@@ -70,6 +70,32 @@ For example, to divert all calls for `http://localhost:4200/api` to a server run
 
 1. To run the development server with this proxy configuration, call `ng serve`.
 
+> **Note:** When using the modern builder (Vite + esbuild), proxy patterns use
+> strict globbing rules.
+>
+> The pattern `"/api/*"` will only match a single path segment:
+>
+> - `/api/user`
+>
+> but **will not match nested routes**, such as:
+>
+> - `/api/user/settings`
+> - `/api/user/settings/admin/profile`
+>
+> To match nested routes, you must use the recursive glob:
+>
+> ```json
+> {
+>   "/api/**": {
+>     "target": "http://localhost:3000",
+>     "secure": false
+>   }
+> }
+> ```
+>
+> Older Webpack-based dev servers automatically expanded `*` to include nested
+> paths. Vite does not, so using `**` is required to avoid silent proxy misses.
+
 Edit the proxy configuration file to add configuration options; following are some examples.
 For a detailed description of all options, refer to the [webpack DevServer documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy) when using `@angular-devkit/build-angular:browser`, or the [Vite DevServer documentation](https://vite.dev/config/server-options#server-proxy) when using `@angular-devkit/build-angular:browser-esbuild` or `@angular-devkit/build-angular:application`.
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Documentation content changes

## What is the current behavior?
The documentation for the dev-server proxy does not mention that the modern
Angular builder (Vite + esbuild) uses strict globbing rules. The pattern
`/api/*` only matches a single path segment such as `/api/user` and does not
match nested routes like `/api/user/settings` or deeper paths.

This differs from Webpack-based dev servers, which previously expanded `*`
to recursively match nested paths. Because of this difference, users migrating
from Webpack may experience silent proxy misses with Vite when using `/api/*`.

## What is the new behavior?
This PR updates the `ng serve` proxy documentation to explain the difference
between `/api/*` and `/api/**` when using the modern builder. A note and
updated example are added to clarify that nested API routes require the
recursive glob pattern `/api/**` to match paths such as `/api/user/settings`
and avoid silent proxy misses.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This update aligns the Angular documentation with Vite’s strict glob
behavior and addresses community confusion reported in Angular CLI issues,
where nested API proxy routes worked in Webpack but not in Vite.
