### PR TITLE
refactor(compiler-cli):  add warning for matching viewport `@defer` t…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
@@ -16,6 +16,8 @@ import {
   TmplAstInteractionDeferredTrigger,
   TmplAstTimerDeferredTrigger,
   TmplAstViewportDeferredTrigger,
+  LiteralMap,
+  LiteralPrimitive,
 } from '@angular/compiler';
 
 import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../../../diagnostics';
@@ -26,6 +28,37 @@ import {
   TemplateCheckWithVisitor,
   TemplateContext,
 } from '../../api';
+
+function areLiteralMapsEqual(a: LiteralMap | null, b: LiteralMap | null): boolean {
+  // Treat null and empty LiteralMaps as equivalent
+  const aIsEmpty = a === null || a.keys.length === 0;
+  const bIsEmpty = b === null || b.keys.length === 0;
+
+  if (aIsEmpty && bIsEmpty) return true;
+  if (aIsEmpty || bIsEmpty) return false;
+  if (a.keys.length !== b.keys.length) return false;
+
+  const bMap = new Map<string, unknown>();
+
+  for (let i = 0; i < b.keys.length; i++) {
+    const bKey = b.keys[i];
+    if (bKey.kind !== 'property') continue;
+    const bVal = b.values[i];
+    bMap.set(bKey.key, bVal instanceof LiteralPrimitive ? bVal.value : null);
+  }
+
+  for (let i = 0; i < a.keys.length; i++) {
+    const aKey = a.keys[i];
+    if (aKey.kind !== 'property') continue;
+    const aVal = a.values[i];
+    const aValue = aVal instanceof LiteralPrimitive ? aVal.value : null;
+
+    if (!bMap.has(aKey.key)) return false;
+    if (bMap.get(aKey.key) !== aValue) return false;
+  }
+
+  return true;
+}
 
 /**
  * This check implements warnings for unreachable or redundant @defer triggers.
@@ -103,10 +136,9 @@ class DeferTriggerMisconfiguration extends TemplateCheckWithVisitor<ErrorCode.DE
           }
         }
 
-        // Reference-based triggers (hover/interaction/viewport): only warn if both
-        // have a reference and the references are identical. If references differ
-        // (or one is missing), the prefetch targets a different element and
-        // provides potential value.
+        // Reference-based triggers (hover/interaction/viewport): warn if both
+        // have identical configurations - same reference (or both null) and
+        // same options (for viewport triggers).
 
         const isHoverTrigger =
           main instanceof TmplAstHoverDeferredTrigger && pre instanceof TmplAstHoverDeferredTrigger;
@@ -120,9 +152,12 @@ class DeferTriggerMisconfiguration extends TemplateCheckWithVisitor<ErrorCode.DE
           pre instanceof TmplAstViewportDeferredTrigger;
 
         if (isHoverTrigger || isInteractionTrigger || isViewportTrigger) {
-          const mainRef = main.reference;
-          const preRef = pre.reference;
-          if (mainRef && preRef && mainRef === preRef) {
+          const referencesMatch = main.reference === pre.reference;
+          const optionsMatch = isViewportTrigger
+            ? areLiteralMapsEqual(main.options, pre.options)
+            : true;
+
+          if (referencesMatch && optionsMatch) {
             const kindName = main.constructor.name.replace('DeferredTrigger', '').toLowerCase();
             const msg = `Prefetch '${kindName}' matches the main trigger and provides no benefit. Remove the prefetch modifier.`;
             diags.push(

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
@@ -16,6 +16,25 @@ import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checke
 
 runInEachFileSystem(() => {
   describe('DeferTriggerMisconfiguration', () => {
+    function getDiags(template: string) {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {'TestCmp': template},
+          source: 'export class TestCmp { }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [deferTriggerMisconfigurationFactory],
+        {} /* options */,
+      );
+      return extendedTemplateChecker.getDiagnosticsForComponent(component);
+    }
     it('binds the error code to its extended template diagnostic name', () => {
       expect(deferTriggerMisconfigurationFactory.code).toBe(
         ErrorCode.DEFER_TRIGGER_MISCONFIGURATION,
@@ -26,172 +45,111 @@ runInEachFileSystem(() => {
     });
 
     it('should emit when on immediate coexists with other mains', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on immediate; on timer(100ms) ; on viewport(ref) ) { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
+      const diags = getDiags(
+        `@defer (on immediate; on timer(100ms) ; on viewport(ref) ) { <div></div> }`,
       );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
 
     it('should emit when on immediate coexists with prefetch', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on immediate;  prefetch on viewport ) { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
-      );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      const diags = getDiags(`@defer (on immediate;  prefetch on viewport ) { <div></div> }`);
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
 
     it('should emit when prefetch timer >= main timer', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on timer(1s); prefetch on timer(2000ms)) { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
-      );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      const diags = getDiags(`@defer (on timer(1s); prefetch on timer(2000ms)) { <div></div> }`);
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
 
     it('should emit when prefetch identical to main viewport/interaction/hover', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on viewport(ref); prefetch on viewport(ref)) { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
+      const diags = getDiags(
+        `@defer (on viewport(ref); prefetch on viewport(ref)) { <div></div> }`,
       );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
 
     it('should not emit for valid prefetch earlier than main', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on timer(1s); prefetch on timer(500ms)) { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
-      );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      const diags = getDiags(`@defer (on timer(1s); prefetch on timer(500ms)) { <div></div> }`);
       expect(diags.length).toBe(0);
     });
 
     it('should not emit when main is viewport(ref) and prefetch is viewport without reference', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on viewport(ref); prefetch on viewport) { <div></div> } @placeholder { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
+      const diags = getDiags(
+        `@defer (on viewport(ref); prefetch on viewport) { <div></div> } @placeholder { <div></div> }`,
       );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
       expect(diags.length).toBe(0);
     });
 
     it('should not emit when main is interaction(refA) and prefetch is interaction(refB)', () => {
-      const fileName = absoluteFrom('/main.ts');
-      const {program, templateTypeChecker} = setup([
-        {
-          fileName,
-          templates: {
-            'TestCmp': `@defer (on interaction(refA); prefetch on interaction(refB)) { <div></div> } @placeholder { <div></div> }`,
-          },
-          source: 'export class TestCmp { }',
-        },
-      ]);
-      const sf = getSourceFileOrError(program, fileName);
-      const component = getClass(sf, 'TestCmp');
-      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
-        templateTypeChecker,
-        program.getTypeChecker(),
-        [deferTriggerMisconfigurationFactory],
-        {} /* options */,
+      const diags = getDiags(
+        `@defer (on interaction(refA); prefetch on interaction(refB)) { <div></div> } @placeholder { <div></div> }`,
       );
-      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
       expect(diags.length).toBe(0);
+    });
+
+    it('should not emit when viewport triggers share the same rootMargin but use different trigger references', () => {
+      const diags = getDiags(
+        `@defer (on viewport({trigger: refA , rootMargin: '100px'}); prefetch on viewport({trigger: refB , rootMargin: '100px'})) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(0);
+    });
+
+    it('should emit when viewport triggers have identical rootMargin options', () => {
+      const diags = getDiags(
+        `@defer (on viewport({rootMargin: '100px'}); prefetch on viewport({rootMargin: '100px'})) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should emit when viewport triggers have identical empty options', () => {
+      const diags = getDiags(
+        `@defer (on viewport({}); prefetch on viewport({})) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should emit when viewport triggers have identical no parameters', () => {
+      const diags = getDiags(
+        `@defer (on viewport; prefetch on viewport) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should not emit when viewport triggers have different rootMargin options', () => {
+      const diags = getDiags(
+        `@defer (on viewport({rootMargin: '100px'}); prefetch on viewport({rootMargin: '200px'})) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not emit when one viewport has options and the other does not', () => {
+      const diags = getDiags(
+        `@defer (on viewport({rootMargin: '100px'}); prefetch on viewport) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(0);
+    });
+
+    it('should emit when main viewport has no options and prefetch has empty options', () => {
+      const diags = getDiags(
+        `@defer (on viewport; prefetch on viewport({})) { <div></div> } @placeholder { <div></div> }`,
+      );
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
   });
 });


### PR DESCRIPTION
…rigger options

Ensures that viewport `@defer` trigger prefetch warnings occur when the viewport options are identical, including cases with empty or no parameters.
 
 Currently, when using cases like don’t show warning, this PR adds proper support and fixes the missing viewport warning.

With viewport options
 ```
     @defer (
      on viewport({   rootMargin: '100px' , threshold: 0.1});
      prefetch on viewport({    threshold: 0.1  rootMargin: '100px'})
    ) {
      <p>Defer Content</p>
    }  @placeholder {
      <p>Placeholder</p>
    }
 ```
 
Using default viewport
  ```
     @defer (
      on viewport;
      prefetch on viewport // also viewport({})
    ) {
      <p>Defer Content</p>
    }  @placeholder {
      <p>Placeholder</p>
    }
 ```