### PR TITLE
docs(docs-infra): simplify tab selection

### DIFF
--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -1,7 +1,12 @@
 <div class="docs-example-viewer" role="group">
   <header class="docs-example-viewer-actions">
     @if (showCode()) {
-      <mat-tab-group #codeTabs animationDuration="0ms" mat-stretch-tabs="false">
+      <mat-tab-group
+        #codeTabs
+        animationDuration="0ms"
+        mat-stretch-tabs="false"
+        (selectedTabChange)="onTabIndexChange($event.index)"
+      >
         @for (tab of tabs(); track tab) {
           <mat-tab [label]="tab.name" />
         }
@@ -94,10 +99,7 @@
   </header>
 
   @if (showCode()) {
-    <div
-      class="docs-example-viewer-code-wrapper"
-      [class.shell]="snippetCode()?.shell"
-    >
+    <div class="docs-example-viewer-code-wrapper" [class.shell]="snippetCode()?.shell">
       <button docs-copy-source-code></button>
       @if (snippetCode()?.sanitizedContent; as content) {
         <div class="docs-example-code-block" [innerHTML]="content"></div>


### PR DESCRIPTION
Tab selection relied on the tabs being visible whe nthe example is loaded. That didn't work when `hideCode` was used.

fixes #65550
