### PR TITLE
docs(docs-infra): renders inline code snippets in docs pills

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/docs-pill-row.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/docs-pill-row.tsx
@@ -16,9 +16,12 @@ export function DocsPillRow(props: {links: LinkEntryRenderable[]}) {
   return (
     <nav class="docs-pill-row">
       {props.links.map((link) => (
-        <a class="docs-pill" href={link.url} title={link.title}>
-          {link.label}
-        </a>
+        <a
+          class="docs-pill"
+          href={link.url}
+          title={link.title}
+          dangerouslySetInnerHTML={{__html: link.label}}
+        ></a>
       ))}
     </nav>
   );

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
@@ -139,6 +139,47 @@ describe('jsdoc transforms', () => {
     });
   });
 
+  it('should convert backticks to code tags in markdown links', () => {
+    const entry = addHtmlAdditionalLinks({
+      jsdocTags: [
+        {
+          name: 'see',
+          comment:
+            '[Host view using `ViewContainerRef.createComponent`](guide/components/programmatic-rendering#host-view-using-viewcontainerrefcreatecomponent)',
+        },
+        {
+          name: 'see',
+          comment:
+            '[Popup attached to `document.body` with `createComponent` + `hostElement`](guide/components/programmatic-rendering#popup-attached-to-documentbody-with-createcomponent--hostelement)',
+        },
+        {
+          name: 'see',
+          comment: '[Method with `backticks` in title](https://example.com "Title with `code`")',
+        },
+      ],
+      moduleName: 'test',
+    });
+
+    expect(entry.additionalLinks[0]).toEqual({
+      label: 'Host view using <code>ViewContainerRef.createComponent</code>',
+      url: 'guide/components/programmatic-rendering#host-view-using-viewcontainerrefcreatecomponent',
+      title: undefined,
+    });
+
+    expect(entry.additionalLinks[1]).toEqual({
+      label:
+        'Popup attached to <code>document.body</code> with <code>createComponent</code> + <code>hostElement</code>',
+      url: 'guide/components/programmatic-rendering#popup-attached-to-documentbody-with-createcomponent--hostelement',
+      title: undefined,
+    });
+
+    expect(entry.additionalLinks[2]).toEqual({
+      label: 'Method with <code>backticks</code> in title',
+      url: 'https://example.com',
+      title: 'Title with `code`',
+    });
+  });
+
   it('should throw on invalid relatie @link', () => {
     const entryFn = () =>
       addHtmlAdditionalLinks({

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
@@ -140,7 +140,7 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags>(entry: T): LinkEntryRend
 
       if (markdownLinkMatch) {
         return {
-          label: markdownLinkMatch[1],
+          label: convertBackticksToCodeTags(markdownLinkMatch[1]),
           url: markdownLinkMatch[2],
           title: markdownLinkMatch[3],
         };
@@ -163,6 +163,15 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags>(entry: T): LinkEntryRend
     .filter((link): link is LinkEntryRenderable => !!link);
 
   return seeAlsoLinks;
+}
+
+/**
+ * Converts backticks to HTML code tags.
+ * This handles code blocks within link text, e.g., `ViewContainerRef.createComponent`
+ */
+function convertBackticksToCodeTags(text: string): string {
+  // Convert backticks to <code> tags
+  return text.replace(/`([^`]+)`/g, '<code>$1</code>');
 }
 
 /**

--- a/adev/shared-docs/styles/docs/_pill.scss
+++ b/adev/shared-docs/styles/docs/_pill.scss
@@ -4,6 +4,8 @@
   .docs-pill {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     // Default blue
     --pill-accent: var(--bright-blue);
     background: color-mix(in srgb, var(--pill-accent) 5%, transparent);


### PR DESCRIPTION
Improves the rendering of `DocsPillRow` to correctly display inline code snippets (using backticks) within the pill labels.


## What is the current behavior?
 https://angular.dev/api/core/createComponent
 
<img width="380" height="493" alt="image" src="https://github.com/user-attachments/assets/fa0c873b-a336-402b-817c-f6c4e986522e" />

## What is the new behavior?
<img width="392" height="364" alt="image" src="https://github.com/user-attachments/assets/2f5746fc-ac66-486d-a04e-5fe60c58e157" />


## Other information

I'm not sure this is the best approach, but it is more testable since it doesn't require parsing the `<code>` tag in `docs-pill-row.tsx`. I believe it wouldn't be insecure, considering that the API is generated at build time.

