### PR TITLE
ci: adding myself as optional to the compiler scope

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -110,6 +110,7 @@ groups:
         - ~amishne
         - ~leonsenft
         - ~mattrbeck
+        - ~JeanMeche
 
   # =========================================================
   #  Framework: General (most code in our packages)


### PR DESCRIPTION
For whenever I feel confortable approving compiler PRs like diagnostics
