### PR TITLE
docs(docs-infra): Fix Drag handle SVG is not visible

### DIFF
--- a/adev/src/styles/_resets.scss
+++ b/adev/src/styles/_resets.scss
@@ -10,7 +10,6 @@
     // page don't affect them, however they can be somewhat aggressive. To prevent them from
     // affecting structural styles like the CDK overlay's positioning CSS, we include
     // them in the global stylesheet, as early as possible.
-    *,
     code::before,
     code,
     pre,


### PR DESCRIPTION
Fix Drag handle SVG is not visible. The css style overrides the default behavior

Fixes #65545

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #65545


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
