### PR TITLE
docs: update `ng serve` builder to `@angular/build:dev-server` and detail proxy path matching behavior.

### DIFF
--- a/adev/src/content/tools/cli/serve.md
+++ b/adev/src/content/tools/cli/serve.md
@@ -4,8 +4,7 @@ You can serve your Angular CLI application with the `ng serve` command.
 This will compile your application, skip unnecessary optimizations, start a devserver, and automatically rebuild and live reload any subsequent changes.
 You can stop the server by pressing `Ctrl+C`.
 
-`ng serve` only executes the builder for the `serve` target in the default project as specified in `angular.json`.
-While any builder can be used here, the most common (and default) builder is `@angular-devkit/build-angular:dev-server`.
+`ng serve` only executes the builder for the `serve` target in the default project as specified in `angular.json`. While any builder can be used here, the most common (and default) builder is `@angular/build:dev-server`.
 
 You can determine which builder is being used for a particular project by looking up the `serve` target for that project.
 
@@ -17,10 +16,10 @@ You can determine which builder is being used for a particular project by lookin
       "architect": {
         // `ng serve` invokes the Architect target named `serve`.
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           // ...
         },
-        "build": { /* ... */ }
+        "build": { /* ... */ },
         "test": { /* ... */ }
       }
     }
@@ -29,11 +28,9 @@ You can determine which builder is being used for a particular project by lookin
 
 ```
 
-This page discusses usage and options of `@angular-devkit/build-angular:dev-server`.
-
 ## Proxying to a backend server
 
-Use [proxying support](https://webpack.js.org/configuration/dev-server/#devserverproxy) to divert certain URLs to a backend server, by passing a file to the `--proxy-config` build option.
+Use [proxying support](https://vite.dev/config/server-options#server-proxy) to divert certain URLs to a backend server, by passing a file to the `--proxy-config` build option.
 For example, to divert all calls for `http://localhost:4200/api` to a server running on `http://localhost:3000/api`, take the following steps.
 
 1. Create a file `proxy.conf.json` in your project's `src/` folder.
@@ -41,9 +38,9 @@ For example, to divert all calls for `http://localhost:4200/api` to a server run
 
 ```json
 {
-  "/api": {
-  "target": "http://localhost:3000",
-  "secure": false
+  "/api/**": {
+    "target": "http://localhost:3000",
+    "secure": false
   }
 }
 ```
@@ -56,10 +53,10 @@ For example, to divert all calls for `http://localhost:4200/api` to a server run
     "my-app": {
       "architect": {
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "options": {
-          "proxyConfig": "src/proxy.conf.json"
-            }
+            "proxyConfig": "src/proxy.conf.json"
+          }
         }
       }
     }
@@ -70,7 +67,16 @@ For example, to divert all calls for `http://localhost:4200/api` to a server run
 
 1. To run the development server with this proxy configuration, call `ng serve`.
 
-Edit the proxy configuration file to add configuration options; following are some examples.
-For a detailed description of all options, refer to the [webpack DevServer documentation](https://webpack.js.org/configuration/dev-server/#devserverproxy) when using `@angular-devkit/build-angular:browser`, or the [Vite DevServer documentation](https://vite.dev/config/server-options#server-proxy) when using `@angular-devkit/build-angular:browser-esbuild` or `@angular-devkit/build-angular:application`.
+NOTE: To apply changes made to your proxy configuration file, you must restart the `ng serve` process.
 
-NOTE: If you edit the proxy configuration file, you must relaunch the `ng serve` process to make your changes effective.
+### Path matching behavior depends on the builder
+
+**`@angular/build:dev-server`** (based on [Vite](https://vite.dev/config/server-options#server-proxy))
+
+- `/api` matches only `/api`.
+- `/api/*` matches `/api/users` but not `/api/users/123`.
+- `/api/**` matches `/api/users` and `/api/users/123`.
+
+**`@angular-devkit/build-angular:dev-server`** (based on [Webpack DevServer](https://webpack.js.org/configuration/dev-server/#devserverproxy))
+
+- `/api` matches `/api` and any sub-paths (equivalent to `/api/**`).


### PR DESCRIPTION

Closes #53652
