### PR TITLE
fix(devtools): hide profiler node details when the frame is changed

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
@@ -45,7 +45,11 @@ export class RecordingVisualizerComponent {
 
   private readonly selectedNodeCleanUpDeps = computed(
     // We don't care about the output format as long as
-    // the value is different when a dependency changes.
+    // the value is different when a dependency changes
+    // (i.e. it acts as a hash).
+    // NOTE: It's safe to stringify the frames since they
+    // are valid JSON objects that are also exported as part
+    // of the profiler results report.
     () => JSON.stringify(this.frame()) + this.visualizationMode(),
   );
   private readonly selectedNode = linkedSignal<string, SelectedEntry | null>({

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
@@ -42,8 +42,14 @@ export class RecordingVisualizerComponent {
   readonly changeDetection = input.required<boolean>();
 
   readonly cmpVisualizationModes = VisualizationMode;
-  private readonly selectedNode = linkedSignal<VisualizationMode, SelectedEntry | null>({
-    source: this.visualizationMode,
+
+  private readonly selectedNodeCleanUpDeps = computed(
+    // We don't care about the output format as long as
+    // the value is different when a dependency changes.
+    () => JSON.stringify(this.frame()) + this.visualizationMode(),
+  );
+  private readonly selectedNode = linkedSignal<string, SelectedEntry | null>({
+    source: this.selectedNodeCleanUpDeps,
     computation: () => null,
   });
 


### PR DESCRIPTION
Hide the details panel when the user selects a new frame.