### PR TITLE
fix(forms): allow dynamic `type` bindings on signal form controls

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -80,7 +80,6 @@ export class TcbNativeFieldDirectiveTypeOp extends TcbOp {
     ...formControlInputFields,
     'value',
     'checked',
-    'type',
     'maxlength',
     'minlength',
   ]);
@@ -373,10 +372,7 @@ export function checkUnsupportedFieldBindings(
 
   if (!(node instanceof TmplAstHostElement)) {
     for (const attr of node.attributes) {
-      const name = attr.name.toLowerCase();
-
-      // `type` is allowed to be a static attribute.
-      if (name !== 'type' && unsupportedBindingFields.has(name)) {
+      if (unsupportedBindingFields.has(attr.name.toLowerCase())) {
         tcb.oobRecorder.formFieldUnsupportedBinding(tcb.id, attr);
       }
     }

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -305,12 +305,12 @@ runInEachFileSystem(() => {
           import {Field, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input [attr.type]="type" [field]="f"/>',
+            template: '<input [field]="f" [attr.maxlength]="maxLength"/>',
             imports: [Field]
           })
           export class Comp {
             f = form(signal(''));
-            type = 'number';
+            maxLength = 10;
           }
         `,
       );
@@ -318,7 +318,7 @@ runInEachFileSystem(() => {
       const diags = env.driveDiagnostics();
       expect(diags.length).toBe(1);
       expect(extractMessage(diags[0])).toBe(
-        `Binding to '[attr.type]' is not allowed on nodes using the '[field]' directive`,
+        `Binding to '[attr.maxlength]' is not allowed on nodes using the '[field]' directive`,
       );
     });
 


### PR DESCRIPTION
The type checker will no longer prohibit binding the Signal Forms `[field]` directive to an input with a dynamic `[attr.type]` or `[type]` binding.