### PR TITLE
docs(router): fix example imports and missing event URL reference

### DIFF
--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -117,7 +117,8 @@ export class AppComponent {
 Track page views for analytics:
 
 ```ts
-import { Component, inject, signal, effect } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { inject, Injectable, DestroyRef } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
@@ -131,7 +132,7 @@ export class AnalyticsService {
         // Track page views when URL changes
         if (event instanceof NavigationEnd) {
            // Send page view to analytics
-          this.analytics.trackPageView(url);
+          this.analytics.trackPageView(event.url);
         }
       });
   }


### PR DESCRIPTION
The [analytics tracking example](https://angular.dev/guide/routing/lifecycle-and-events#analytics-tracking) contained unused and missing imports, and it incorrectly referenced the page's URL.
This update fixes the imports and ensures the handler uses `event.url`, allowing the example to work correctly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The [analytics tracking example](https://angular.dev/guide/routing/lifecycle-and-events#analytics-tracking) contains unused and missing imports, and it incorrectly references the page's URL, causing the example to not behave as intended when used.

Issue Number: N/A


## What is the new behavior?
The example now includes only the necessary imports and references `event.url` so that the page-view tracking code functions correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
