### PR TITLE
refactor: add mark for signal forms

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import {performanceMarkFeature} from '../../util/performance';
 import {getClosureSafeProperty} from '../../util/property';
 import {assertFirstCreatePass} from '../assert';
 import {bindingUpdated} from '../bindings';
@@ -54,9 +55,12 @@ export function ɵɵcontrolCreate(): void {
   }
 
   const control = getControlDirective(tNode, lView);
+
   if (!control) {
     return;
   }
+
+  performanceMarkFeature('NgSignalForms');
 
   if (tNode.flags & TNodeFlags.isFormValueControl) {
     listenToCustomControl(lView, tNode, control, 'value');

--- a/packages/core/src/render3/instructions/let_declaration.ts
+++ b/packages/core/src/render3/instructions/let_declaration.ts
@@ -25,6 +25,7 @@ const UNINITIALIZED_LET = {};
  * @codeGenApi
  */
 export function ɵɵdeclareLet(index: number): typeof ɵɵdeclareLet {
+  performanceMarkFeature('NgLet');
   const tView = getTView();
   const lView = getLView();
   const adjustedIndex = index + HEADER_OFFSET;
@@ -41,7 +42,6 @@ export function ɵɵdeclareLet(index: number): typeof ɵɵdeclareLet {
  * @codeGenApi
  */
 export function ɵɵstoreLet<T>(value: T): T {
-  performanceMarkFeature('NgLet');
   const tView = getTView();
   const lView = getLView();
   const index = getSelectedIndex();


### PR DESCRIPTION
Adds a mark for signal forms so we can track adoption. Also moves the call for `@let` into `declareLet` since we don't need it to fire as often as in `storeLet`.
