### PR TITLE
fix(http): prevent XSRF token leakage to protocol-relative URLs

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -82,11 +82,15 @@ export class HttpXsrfCookieExtractor implements HttpXsrfTokenExtractor {
   }
 }
 
+/**
+ * Regex to match absolute URLs, including protocol-relative URLs.
+ */
+const ABSOLUTE_URL_REGEX = /^(?:https?:)?\/\//i;
+
 export function xsrfInterceptorFn(
   req: HttpRequest<unknown>,
   next: HttpHandlerFn,
 ): Observable<HttpEvent<unknown>> {
-  const lcUrl = req.url.toLowerCase();
   // Skip both non-mutating requests and absolute URLs.
   // Non-mutating requests don't require a token, and absolute URLs require special handling
   // anyway as the cookie set
@@ -95,8 +99,7 @@ export function xsrfInterceptorFn(
     !inject(XSRF_ENABLED) ||
     req.method === 'GET' ||
     req.method === 'HEAD' ||
-    lcUrl.startsWith('http://') ||
-    lcUrl.startsWith('https://')
+    ABSOLUTE_URL_REGEX.test(req.url)
   ) {
     return next(req);
   }

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -70,6 +70,23 @@ describe('HttpXsrfInterceptor', () => {
     expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
     req.flush({});
   });
+
+  it('does not apply XSRF protection when request is absolute', () => {
+    interceptor
+      .intercept(new HttpRequest('POST', 'https://example.com/test', {}), backend)
+      .subscribe();
+    const req = backend.expectOne('https://example.com/test');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+    req.flush({});
+  });
+
+  it('does not apply XSRF protection when request is protocol relative', () => {
+    interceptor.intercept(new HttpRequest('POST', '//example.com/test', {}), backend).subscribe();
+    const req = backend.expectOne('//example.com/test');
+    expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+    req.flush({});
+  });
+
   it('does not overwrite existing header', () => {
     interceptor
       .intercept(


### PR DESCRIPTION
The XSRF interceptor previously failed to detect protocol-relative URLs (starting with `//`) as absolute URLs. This allowed requests to such URLs to include the XSRF token, potentially leaking it to external domains.

This change updates the interceptor to correctly identify protocol-relative URLs as absolute and exclude them from receiving the XSRF token.
