### PR TITLE
fix(compiler-cli): escape angular control flow in jsdoc

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/jsdoc_extractor.ts
@@ -11,11 +11,11 @@ import ts from 'typescript';
 import {JsDocTagEntry} from './entities';
 
 /**
- * RegExp to match the `@` character follow by any Angular decorator, used to escape Angular
- * decorators in JsDoc blocks so that they're not parsed as JsDoc tags.
+ * RegExp to match the `@` character follow by any Angular decorator and control flow syntax, used to escape Angular
+ * decorators and control flow syntax in JsDoc blocks so that they're not parsed as JsDoc tags.
  */
-const decoratorExpression =
-  /@(?=(Injectable|Component|Directive|Pipe|NgModule|Input|Output|HostBinding|HostListener|Inject|Optional|Self|Host|SkipSelf|ViewChild|ViewChildren|ContentChild|ContentChildren))/g;
+const angularAtExpression =
+  /@(?=(Injectable|Component|Directive|Pipe|NgModule|Input|Output|HostBinding|HostListener|Inject|Optional|Self|Host|SkipSelf|ViewChild|ViewChildren|ContentChild|ContentChildren|if|else|for|switch|case|default|empty|defer|placeholder|loading|error|let)\b)/g;
 
 /** Gets the set of JsDoc tags applied to a node. */
 export function extractJsDocTags(node: ts.HasJSDoc): JsDocTagEntry[] {
@@ -79,12 +79,12 @@ function getEscapedNode(node: ts.HasJSDoc): ts.HasJSDoc {
   return file.statements.find((s) => ts.isClassDeclaration(s)) as ts.ClassDeclaration;
 }
 
-/** Escape the `@` character for Angular decorators. */
+/** Escape the `@` character for Angular decorators and template control flow syntax. */
 function escapeAngularDecorators(comment: string): string {
-  return comment.replace(decoratorExpression, '_NG_AT_');
+  return comment.replace(angularAtExpression, '_NG_AT_');
 }
 
-/** Unescapes the `@` character for Angular decorators. */
+/** Unescapes the `@` character for Angular decorators and template control flow syntax. */
 function unescapeAngularDecorators(comment: string): string {
   return comment.replace(/_NG_AT_/g, '@');
 }

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/jsdoc_extraction_spec.ts
@@ -350,5 +350,45 @@ runInEachFileSystem(() => {
       expect(entry.jsdocTags.length).toBe(1);
       expect(entry.jsdocTags[0].name).toBe('deprecated');
     });
+
+    it('should escape Angular control flow syntax', () => {
+      env.write(
+        'index.ts',
+        `
+        /**
+         * Renders a list using Angular control flow.
+         *
+         * \`\`\`html
+         * @for (item of items; track item) {
+         *   @if (item.visible) {
+         *     <div>{{item.label}}</div>
+         *   } @else {
+         *     <span>Hidden</span>
+         *   }
+         *   @empty {
+         *     <div>No items</div>
+         *   }
+         * }
+         * \`\`\`
+         *
+         * @deprecated Use something else.
+         */
+        export class Example {}
+      `,
+      );
+
+      const docs: DocEntry[] = env.driveDocsExtraction('index.ts');
+      expect(docs.length).toBe(1);
+
+      const entry = docs[0] as ClassEntry;
+      expect(entry.description).toContain('@for (item of items; track item)');
+      expect(entry.description).toContain('@if (item.visible)');
+      expect(entry.description).toContain('@empty {');
+      expect(entry.jsdocTags.length).toBe(1);
+      expect(entry.jsdocTags[0]).toEqual({
+        name: 'deprecated',
+        comment: 'Use something else.',
+      });
+    });
   });
 });


### PR DESCRIPTION
Escape @-prefixed template control flow constructs during doc extraction so JSDoc parsing keeps description text intact. Add regression coverage for @for snippets.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
JSDoc extraction treats @for/@if template control-flow markers as JSDoc tags, stripping them out of descriptions in generated API docs (e.g., Aria components). https://angular.dev/api/aria/grid/Grid#description

Issue Number: N/A


## What is the new behavior?
Escape Angular control-flow markers before parsing JSDoc so their text remains in descriptions; add regression tests to cover @for snippets.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Some examples of broken pages:
- https://angular.dev/api/aria/grid/Grid#description
- https://angular.dev/api/aria/listbox/Listbox#description