### PR TITLE
fix(core): use injected `DOCUMENT` for `CSP_NONCE`

### DIFF
--- a/packages/core/src/application/application_tokens.ts
+++ b/packages/core/src/application/application_tokens.ts
@@ -8,8 +8,8 @@
 
 import {ENVIRONMENT_INITIALIZER, inject, StaticProvider} from '../di';
 import {InjectionToken} from '../di/injection_token';
+import {DOCUMENT} from '../document';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {getDocument} from '../render3/interfaces/document';
 
 /**
  * A DI token representing a string ID, used
@@ -136,7 +136,9 @@ export const CSP_NONCE = new InjectionToken<string | null>(
       // 4. Have the `ComponentFactory` read the attribute and provide it to the injector under the
       // hood - has the same problem as #1 and #2 in that the renderer is used to query for the root
       // node and the nonce value needs to be available when the renderer is created.
-      return getDocument().body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null;
+      return (
+        inject(DOCUMENT).body?.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce') || null
+      );
     },
   },
 );

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -494,7 +494,6 @@
       "getDOM",
       "getDeclarationTNode",
       "getDirectiveDef",
-      "getDocument",
       "getElementDepthCount",
       "getFactoryDef",
       "getFirstLContainer",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -440,7 +440,6 @@
       "getDeclarationTNode",
       "getDeferBlockDataIndex",
       "getDirectiveDef",
-      "getDocument",
       "getElementDepthCount",
       "getFactoryDef",
       "getFirstLContainer",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -558,7 +558,6 @@
       "getDOM",
       "getDeclarationTNode",
       "getDirectiveDef",
-      "getDocument",
       "getElementDepthCount",
       "getFactoryDef",
       "getFactoryOf",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -559,7 +559,6 @@
       "getDOM",
       "getDeclarationTNode",
       "getDirectiveDef",
-      "getDocument",
       "getElementDepthCount",
       "getFactoryDef",
       "getFactoryOf",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -647,7 +647,6 @@
       "getDataKeys",
       "getDeclarationTNode",
       "getDirectiveDef",
-      "getDocument",
       "getElementDepthCount",
       "getFactoryDef",
       "getFactoryOf",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -365,7 +365,6 @@
       "getDOM",
       "getDeclarationTNode",
       "getDirectiveDef",
-      "getDocument",
       "getFactoryDef",
       "getFirstLContainer",
       "getGlobalLocale",


### PR DESCRIPTION
This ensures that the right document is used and that `CSP_NONCE` can be used in `provideAppInitializer` and `provideEnvironmentInitializer`.

Closes #65624