### PR TITLE
refactor: replace `getDocument()` with `inject(DOCUMENT)`

### DIFF
--- a/packages/core/src/render3/util/transfer_state_utils.ts
+++ b/packages/core/src/render3/util/transfer_state_utils.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getDocument} from '../interfaces/document';
 import {Injector} from '../../di';
 import {isInternalHydrationTransferStateKey} from '../../hydration/utils';
 import {APP_ID} from '../../application/application_tokens';
 import {retrieveTransferredState} from '../../transfer_state';
+import {DOCUMENT} from '../../document';
 
 /**
  * Retrieves transfer state data from the DOM using the provided injector to get APP_ID.
@@ -22,7 +22,7 @@ import {retrieveTransferredState} from '../../transfer_state';
  * @returns The transfer state data as an object, or empty object if not available
  */
 export function getTransferState(injector: Injector): Record<string, unknown> {
-  const doc = getDocument();
+  const doc = injector.get(DOCUMENT);
   const appId = injector.get(APP_ID);
 
   const transferState = retrieveTransferredState(doc, appId);

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -9,7 +9,7 @@
 import {APP_ID} from './application/application_tokens';
 import {inject} from './di/injector_compatibility';
 import {ɵɵdefineInjectable} from './di/interface/defs';
-import {getDocument} from './render3/interfaces/document';
+import {DOCUMENT} from './document';
 
 /**
  * A type-safe key to use with `TransferState`.
@@ -48,15 +48,6 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
   return key as StateKey<T>;
 }
 
-function initTransferState(): TransferState {
-  const transferState = new TransferState();
-  if (typeof ngServerMode === 'undefined' || !ngServerMode) {
-    transferState.store = retrieveTransferredState(getDocument(), inject(APP_ID));
-  }
-
-  return transferState;
-}
-
 /**
  * A key value store that is transferred from the application on the server side to the application
  * on the client side.
@@ -77,7 +68,14 @@ export class TransferState {
   static ɵprov = /** @pureOrBreakMyCode */ /* @__PURE__ */ ɵɵdefineInjectable({
     token: TransferState,
     providedIn: 'root',
-    factory: initTransferState,
+    factory: () => {
+      const transferState = new TransferState();
+      if (typeof ngServerMode === 'undefined' || !ngServerMode) {
+        transferState.store = retrieveTransferredState(inject(DOCUMENT), inject(APP_ID));
+      }
+
+      return transferState;
+    },
   });
 
   /** @internal */

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -537,7 +537,6 @@
       "initDomAdapter",
       "initFeatures",
       "initTNodeFlags",
-      "initTransferState",
       "initializeDirectives",
       "initializeInputAndOutputAliases",
       "inject2",


### PR DESCRIPTION
This replaces `getDocument()` with `inject(DOCUMENT)` across hydration and transfer state logic.
