### PR TITLE
docs: Since NgModule is deprecated in Angular 21 it could make sense to remove to not cause confusion among new devs

### DIFF
--- a/adev/src/content/guide/zoneless.md
+++ b/adev/src/content/guide/zoneless.md
@@ -17,11 +17,6 @@ bootstrapApplication(MyApp, {providers: [
   provideZonelessChangeDetection(),
 ]});
 
-// NgModule bootstrap
-platformBrowser().bootstrapModule(AppModule);
-@NgModule({
-  providers: [provideZonelessChangeDetection()]
-})
 export class AppModule {}
 ```
 


### PR DESCRIPTION
docs: Since NgModule is deprecated in Angular 21 it could make sense to remove to not cause confusion among new devs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
