### PR TITLE
docs: release notes for the v21.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+<a name="21.0.1"></a>
+
+# 21.0.1 (2025-11-25)
+
+### compiler-cli
+
+| Commit                                                                                           | Type | Description                                                 |
+| ------------------------------------------------------------------------------------------------ | ---- | ----------------------------------------------------------- |
+| [39c577bc36](https://github.com/angular/angular/commit/39c577bc362b263896b38c9486131d4342b8f1a8) | fix  | do not type check native controls with ControlValueAccessor |
+| [8d3a89a477](https://github.com/angular/angular/commit/8d3a89a477e273b9b2223b6db775955e35105963) | fix  | escape angular control flow in jsdoc                        |
+| [bc34083d34](https://github.com/angular/angular/commit/bc34083d349a7d30efb43df97de0509fd85a1996) | fix  | ignore non-existent files                                   |
+
+### core
+
+| Commit                                                                                           | Type | Description                                                   |
+| ------------------------------------------------------------------------------------------------ | ---- | ------------------------------------------------------------- |
+| [0ea1e07174](https://github.com/angular/angular/commit/0ea1e071742a031d9afb7a39f8e23082cd88ca2e) | fix  | apply bootstrap-options migration to `platformBrowserDynamic` |
+| [70507b8c1c](https://github.com/angular/angular/commit/70507b8c1ce733b8232a12fa45037ee219b5b102) | fix  | debug data causing memory leak for root effects               |
+| [a55482fca3](https://github.com/angular/angular/commit/a55482fca3b7e4f39d95f8ff236b6619e59b8190) | fix  | notify profiler events in case of errors                      |
+| [49ad7c6508](https://github.com/angular/angular/commit/49ad7c650818ee7db321a24c89282dbf9bb250f3) | fix  | use injected `DOCUMENT` for `CSP_NONCE`                       |
+| [cc1ec09931](https://github.com/angular/angular/commit/cc1ec099315b0f429d0b0f07c9b1bf686668db6b) | perf | avoid repeat searches for field directive                     |
+
+### forms
+
+| Commit                                                                                           | Type | Description                                           |
+| ------------------------------------------------------------------------------------------------ | ---- | ----------------------------------------------------- |
+| [7d5c7cf99a](https://github.com/angular/angular/commit/7d5c7cf99aa5c6490f8bea950b04bd56073582a1) | feat | add DI option for classes on `Field` directive        |
+| [8acf5d2756](https://github.com/angular/angular/commit/8acf5d27563ec51cc76971732d50e1f4142a3fe3) | fix  | allow dynamic `type` bindings on signal form controls |
+| [de5fca94c5](https://github.com/angular/angular/commit/de5fca94c5cfafa9098d9ee270f448b90d4ac06f) | fix  | run reset as untracked                                |
+
+### http
+
+| Commit                                                                                           | Type | Description                                          |
+| ------------------------------------------------------------------------------------------------ | ---- | ---------------------------------------------------- |
+| [3240d856d9](https://github.com/angular/angular/commit/3240d856d942727372a705252f7c8c115394a41e) | fix  | prevent XSRF token leakage to protocol-relative URLs |
+
+### migrations
+
+| Commit                                                                                           | Type | Description                                              |
+| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------------------- |
+| [f394215b14](https://github.com/angular/angular/commit/f394215b14d59c49e1433472ecdd2fd5547cc769) | fix  | detect structural ngTemplateOutlet and ngComponentOutlet |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.0"></a>
 
 # 21.0.0 (2025-11-19)


### PR DESCRIPTION
Cherry-picks the changelog from the "21.0.x" branch to the next branch (main).