### PR TITLE
docs: release notes for the v20.3.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="20.3.14"></a>
+
+# 20.3.14 (2025-11-25)
+
+### http
+
+| Commit                                                                                           | Type | Description                                          |
+| ------------------------------------------------------------------------------------------------ | ---- | ---------------------------------------------------- |
+| [0276479e7d](https://github.com/angular/angular/commit/0276479e7d0e280e0f8d26fa567d3b7aa97a516f) | fix  | prevent XSRF token leakage to protocol-relative URLs |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.1"></a>
 
 # 21.0.1 (2025-11-25)


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).