### PR TITLE
fix(migrations): prevent duplicate imports in common-to-standalone migration

### DIFF
--- a/packages/core/schematics/migrations/common-to-standalone-migration/util.ts
+++ b/packages/core/schematics/migrations/common-to-standalone-migration/util.ts
@@ -136,10 +136,18 @@ function createCommonModuleImportsArrayRemoval(
     return !isCommonModuleFromAngularCommon(typeChecker, el);
   });
 
-  const newElements = [
-    ...filteredElements,
-    ...neededImports.sort().map((imp) => ts.factory.createIdentifier(imp)),
-  ];
+  // Get existing import names to avoid duplicates
+  const existingImportNames = new Set(
+    filteredElements.filter((el) => ts.isIdentifier(el)).map((el) => el.getText()),
+  );
+
+  // Only add imports that don't already exist
+  const importsToAdd = neededImports
+    .filter((imp) => !existingImportNames.has(imp))
+    .sort()
+    .map((imp) => ts.factory.createIdentifier(imp));
+
+  const newElements = [...filteredElements, ...importsToAdd];
 
   if (newElements.length === originalElements.length && neededImports.length === 0) {
     return null;


### PR DESCRIPTION

### Description:

The `common-to-standalone` migration did not check for existing imports when adding needed imports after removing CommonModule. This caused duplicate imports when a component already had individual imports (e.g., `AsyncPipe`) alongside `CommonModule`. This change adds deduplication logic to filter out imports that already exist in the imports array before adding them, ensuring each import appears only once.

**Minimal Repro:**

```ts
@Component({
  imports: [CommonModule, AsyncPipe],
  template: `<div>{{ data$ | async }}</div>`
})
export class TestCmp { 
  data$ = of('test'); 
}
```

## What is the current behavior?

Components with both `CommonModule` and individual imports end up with duplicate imports after migration.

```ts
@Component({
  imports: [AsyncPipe, AsyncPipe],  // ❌ DUPLICATE!
  template: `<div>{{ data$ | async }}</div>`
})
export class TestCmp { 
  data$ = of('test'); 
}
```

## Expected behavior

```ts
@Component({
  imports: [AsyncPipe],  // ✅ No duplicate
  template: `<div>{{ data$ | async }}</div>`
})
export class TestCmp { 
  data$ = of('test'); 
}
```

## What is the new behavior?

The migration now checks for existing imports before adding new ones:

1. Extracts all existing import names from the filtered imports array (after removing `CommonModule`)
2. Filters the needed imports to exclude any that already exist
3. Only adds imports that aren't already present in the array

This ensures the migration produces valid standalone components without duplicate imports.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

