### PR TITLE
docs(docs-infra): fix form custom control example uses syntax

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -25,7 +25,7 @@ import { FormValueControl } from '@angular/forms/signals';
       <input
         type="text"
         [value]="value()"
-        (input)="value.set(($event.target as HTMLInputElement).value)"
+        (input)="value.set($event.target.value)"
         placeholder="Enter text..."
       />
     </div>
@@ -269,7 +269,7 @@ import type { ValidationError, DisabledReason } from '@angular/forms/signals';
         <input
           type="text"
           [value]="value()"
-          (input)="value.set(($event.target as HTMLInputElement).value)"
+          (input)="value.set($event.target.value)"
           [disabled]="disabled()"
           [readonly]="readonly()"
           [class.invalid]="invalid()"
@@ -365,7 +365,7 @@ import { FormValueControl } from '@angular/forms/signals';
     <input
       type="text"
       [value]="displayValue()"
-      (input)="handleInput(($event.target as HTMLInputElement).value)"
+      (input)="handleInput($event.target.value)"
     />
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Fixed form custom control example uses non-working syntax in template

Fix #65647

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #65647

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
