### PR TITLE
docs: standardize class naming across tutorial steps to match Angular style guide

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/README.md
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/README.md
@@ -1,23 +1,23 @@
-# Create the application’s HousingLocation component
+# Create the application's HousingLocationCard component
 
-This tutorial lesson demonstrates how to add the `HousingLocation` component to your Angular app.
+This tutorial lesson demonstrates how to add the `HousingLocationCard` component to your Angular app.
 
 <docs-video src="https://www.youtube.com/embed/R0nRX8jD2D0?si=U4ONEbPvtptdUHTt&amp;start=440"/>
 
 ## What you'll learn
 
-- Your app has a new component: `HousingLocation` and it displays a message confirming that the component was added to your application.
+- Your app has a new component: `HousingLocationCard` and it displays a message confirming that the component was added to your application.
 
 <docs-workflow>
 
-<docs-step title="Create the `HousingLocation`">
+<docs-step title="Create the `HousingLocationCard`">
 In this step, you create a new component for your app.
 
 In the **Terminal** pane of your IDE:
 
 1. In your project directory, navigate to the `first-app` directory.
 
-1. Run this command to create a new `HousingLocation`
+1. Run this command to create a new `HousingLocationCard`
 
    ```shell
    ng generate component housingLocation
@@ -40,27 +40,27 @@ In the **Terminal** pane of your IDE:
    </docs-step>
 
 <docs-step title="Add the new component to your app's layout">
-In this step, you add the new component, `HousingLocation` to your app's `Home`, so that it displays in your app's layout.
+In this step, you add the new component, `HousingLocationCard` to your app's `Home`, so that it displays in your app's layout.
 
 In the **Edit** pane of your IDE:
 
 1. Open `home.ts` in the editor.
-1. In `home.ts`, import `HousingLocation` by adding this line to the file level imports.
+1. In `home.ts`, import `HousingLocationCard` by adding this line to the file level imports.
 
-<docs-code header="Import HousingLocation in src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts" visibleLines="[2]"/>
+<docs-code header="Import HousingLocationCard in src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts" visibleLines="[2]"/>
 
-1. Next update the `imports` property of the `@Component` metadata by adding `HousingLocation` to the array.
+1. Next update the `imports` property of the `@Component` metadata by adding `HousingLocationCard` to the array.
 
-<docs-code  header="Add HousingLocation to imports array in src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts" visibleLines="[6]"/>
+<docs-code  header="Add HousingLocationCard to imports array in src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts" visibleLines="[6]"/>
 
-1. Now the component is ready for use in the template for the `Home`. Update the `template` property of the `@Component` metadata to include a reference to the `<app-housing-location>` tag.
+1. Now the component is ready for use in the template for the `Home`. Update the `template` property of the `@Component` metadata to include a reference to the `<app-housing-location-card>` tag.
 
 <docs-code language="angular-ts" header="Add housing location to the component template in src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts" visibleLines="[7,17]"/>
 
 </docs-step>
 
 <docs-step title="Add the styles for the component">
-In this step, you will copy over the pre-written styles for the `HousingLocation` to your app so that the app renders properly.
+In this step, you will copy over the pre-written styles for the `HousingLocationCard` to your app so that the app renders properly.
 
 1. Open `src/app/housing-location/housing-location.css`, and paste the styles below into the file:
 

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.ts
@@ -1,9 +1,9 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
+import {HousingLocationCard} from '../housing-location/housing-location';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -12,7 +12,7 @@ import {HousingLocation} from '../housing-location/housing-location';
       </form>
     </section>
     <section class="results">
-      <app-housing-location />
+      <app-housing-location-card />
     </section>
   `,
   styleUrls: ['./home.css'],

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/housing-location/housing-location.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   template: `
     <p>housing-location works!</p>
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {}
+export class HousingLocationCard {}

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/README.md
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/README.md
@@ -8,27 +8,27 @@ NOTE: This video reflects an older syntax, but the main concepts remain valid.
 
 ## What you'll learn
 
-Your app's `HousingLocation` template has a `HousingLocation` property to receive input.
+Your app's `HousingLocationCard` template has a `HousingLocation` property to receive input.
 
 ## Conceptual preview of Inputs
 
 [Inputs](api/core/input) allow components to specify data that can be passed to it from a parent component.
 
-In this lesson, you'll define an `input` property in the `HousingLocation` component that enables you to customize the data displayed in the component.
+In this lesson, you'll define an `input` property in the `HousingLocationCard` component that enables you to customize the data displayed in the component.
 
 Learn more in the [Accepting data with input properties](guide/components/inputs) and [Custom events with outputs](guide/components/outputs) guides.
 
 <docs-workflow>
 
 <docs-step title="Import the input() function">
-In the code editor, import the `input` helper method from `@angular/core` into the `HousingLocation` component.
+In the code editor, import the `input` helper method from `@angular/core` into the `HousingLocationCard` component.
 
 <docs-code header="Import input in housing-location.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.ts" visibleLines="[1]"/>
 
 </docs-step>
 
 <docs-step title="Add the Input property">
-Add a required property called `housingLocation` and initialize it using `input.required()` with the type `HousingLocationInfo`.
+Add a required property called `housingLocation` and initialize it using `input.required()` with the type `HousingLocation`.
 
   <docs-code header="Declare the input property in housing-location.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.ts" visibleLines="[12]"/>
 
@@ -37,9 +37,9 @@ You have to invoke the `required` method on `input` to indicate that the parent 
 </docs-step>
 
 <docs-step title="Pass data to the input">
-Send the `housingLocation` value from the `Home` component to the `housingLocation` property of the HousingLocation component.
+Send the `housingLocation` value from the `Home` component to the `housingLocation` property of the HousingLocationCard component.
 
-<docs-code language="angular-ts" header="Declare the input property for HousingLocation in home.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.ts" visibleLines="[16]"/>
+<docs-code language="angular-ts" header="Declare the input property for HousingLocationCard in home.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.ts" visibleLines="[16]"/>
 
 </docs-step>
 

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -13,7 +13,7 @@ import {HousingLocationInfo} from '../housinglocation';
       </form>
     </section>
     <section class="results">
-      <app-housing-location />
+      <app-housing-location-card />
     </section>
   `,
   styleUrls: ['./home.css'],
@@ -21,7 +21,7 @@ import {HousingLocationInfo} from '../housinglocation';
 export class Home {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  housingLocation: HousingLocationInfo = {
+  housingLocation: HousingLocation = {
     id: 9999,
     name: 'Test Home',
     city: 'Test city',

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housing-location/housing-location.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   template: `
     <p>housing-location works!</p>
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {}
+export class HousingLocationCard {}

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/README.md
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/README.md
@@ -7,7 +7,7 @@ This tutorial lesson demonstrates how to add property binding to a template and 
 ## What you'll learn
 
 - Your app has data bindings in the `Home` template.
-- Your app sends data from the `Home` to the `HousingLocation`.
+- Your app sends data from the `Home` to the `HousingLocationCard`.
 
 ## Conceptual preview of Inputs
 
@@ -20,7 +20,7 @@ For a more in depth explanation, please refer to the [Property binding](guide/te
 <docs-workflow>
 
 <docs-step title="Update the `Home` template">
-This step adds property binding to the `<app-housing-location>` tag.
+This step adds property binding to the `<app-housing-location-card>` tag.
 
 In the code editor:
 
@@ -41,7 +41,7 @@ In the code editor:
 
 </docs-workflow>
 
-SUMMARY: In this lesson, you added a new property binding and passed in a reference to a class property. Now, the `HousingLocation` has access to data that it can use to customize the component's display.
+SUMMARY: In this lesson, you added a new property binding and passed in a reference to a class property. Now, the `HousingLocationCard` has access to data that it can use to customize the component's display.
 
 For more information about the topics covered in this lesson, visit:
 

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -13,7 +13,7 @@ import {HousingLocationInfo} from '../housinglocation';
       </form>
     </section>
     <section class="results">
-      <app-housing-location [housingLocation]="housingLocation"/>
+      <app-housing-location-card [housingLocation]="housingLocation"/>
     </section>
   `,
   styleUrls: ['./home.css'],
@@ -21,7 +21,7 @@ import {HousingLocationInfo} from '../housinglocation';
 export class Home {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  housingLocation: HousingLocationInfo = {
+  housingLocation: HousingLocation = {
     id: 9999,
     name: 'Test Home',
     city: 'Test city',

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.ts
@@ -1,13 +1,13 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   template: `
     <p>housing-location works!</p>
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/README.md
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/README.md
@@ -6,7 +6,7 @@ This tutorial lesson demonstrates how to add interpolation to Angular templates 
 
 ## What you'll learn
 
-- Your app will display interpolated values in the `HousingLocation` template.
+- Your app will display interpolated values in the `HousingLocationCard` template.
 - Your app will render a housing location data to the browser.
 
 ## Conceptual preview of interpolation
@@ -19,15 +19,15 @@ For a more in depth explanation, please refer to the [Displaying values with int
 
 <docs-workflow>
 
-<docs-step title="Update `HousingLocation` template to include interpolated values">
-This step adds new HTML structure and interpolated values in the `HousingLocation` template.
+<docs-step title="Update `HousingLocationCard` template to include interpolated values">
+This step adds new HTML structure and interpolated values in the `HousingLocationCard` template.
 
 In the code editor:
 
 1.  Navigate to `src/app/housing-location/housing-location.ts`
 1.  In the template property of the `@Component` decorator, replace the existing HTML markup with the following code:
 
-<docs-code language="angular-ts"  header="Update HousingLocation template in housing-location.ts" path="adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.ts" visibleLines="[6,17]"/>
+<docs-code language="angular-ts"  header="Update HousingLocationCard template in housing-location.ts" path="adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.ts" visibleLines="[6,17]"/>
 
 In this updated template code you have used property binding to bind the `housingLocation.photo` to the `src` attribute. The `alt` attribute uses interpolation to give more context to the alt text of the image.
 
@@ -43,7 +43,7 @@ You use interpolation to include the values for `name`, `city` and `state` of th
 
 </docs-workflow>
 
-SUMMARY: In this lesson, you added a new HTML structure and used Angular template syntax to render values in the `HousingLocation` template.
+SUMMARY: In this lesson, you added a new HTML structure and used Angular template syntax to render values in the `HousingLocationCard` template.
 
 Now, you have two important skills:
 

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -13,7 +13,7 @@ import {HousingLocationInfo} from '../housinglocation';
       </form>
     </section>
     <section class="results">
-      <app-housing-location [housingLocation]="housingLocation" />
+      <app-housing-location-card [housingLocation]="housingLocation" />
     </section>
   `,
   styleUrls: ['./home.css'],
@@ -21,7 +21,7 @@ import {HousingLocationInfo} from '../housinglocation';
 export class Home {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  housingLocation: HousingLocationInfo = {
+  housingLocation: HousingLocation = {
     id: 9999,
     name: 'Test Home',
     city: 'Test city',

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housing-location/housing-location.ts
@@ -1,13 +1,13 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   template: `
     <p>housing-location works!</p>
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
@@ -27,7 +27,7 @@ In the `Home` there is only a single housing location. In this step, you will ad
 
 1. In `src/app/home/home.ts`, remove the `housingLocation` property from the `Home` class.
 1. Update the `Home` class to have a property called `housingLocationList`. Update your code to match the following code:
-   <docs-code language="angular-ts"  header="Add housingLocationList property in home.ts" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts" visibleLines="26-131"/>
+   <docs-code language="angular-ts"  header="Add housingLocationList property in home.ts" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts" visibleLines="[26,124]"/>
 
    IMPORTANT: Do not remove the `@Component` decorator, you will update that code in an upcoming step.
 
@@ -36,7 +36,7 @@ In the `Home` there is only a single housing location. In this step, you will ad
 <docs-step title="Update the `Home` template to use `@for`">
 Now the app has a dataset that you can use to display the entries in the browser using the `@for` block.
 
-1. Update the `<app-housing-location>` tag in the template code to this:
+1. Update the `<app-housing-location-card>` tag in the template code to this:
    <docs-code language="angular-ts"  header="Add @for to Home template in home.ts" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts" visibleLines="[15,19]"/>
 
    Note, in the code `[housingLocation] = "housingLocation"` the `housingLocation` value now refers to the variable used in the `@for` block. Before this change, it referred to the property on the `Home` class.

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -13,7 +13,7 @@ import {HousingLocationInfo} from '../housinglocation';
       </form>
     </section>
     <section class="results">
-      <app-housing-location [housingLocation]="housingLocation" />
+      <app-housing-location-card [housingLocation]="housingLocation" />
     </section>
   `,
   styleUrls: ['./home.css'],
@@ -21,7 +21,7 @@ import {HousingLocationInfo} from '../housinglocation';
 export class Home {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  housingLocation: HousingLocationInfo = {
+  housingLocation: HousingLocation = {
     id: 9999,
     name: 'Test Home',
     city: 'Test city',

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.ts
@@ -1,8 +1,8 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   template: `
     <section class="listing">
       <img
@@ -17,6 +17,6 @@ import {HousingLocationInfo} from '../housinglocation';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/09-services/README.md
+++ b/adev/src/content/tutorials/first-app/steps/09-services/README.md
@@ -53,8 +53,8 @@ In the **Edit** pane of your IDE:
 
 1. In `src/app/home/home.ts`, from `Home`, copy the `housingLocationList` variable and its array value.
 1. In `src/app/housing.service.ts`:
-   1. Inside the `HousingService` class, paste the variable that you copied from `Home` in the previous step.
-   1. Inside the `HousingService` class, paste these functions after the data you just copied.
+   1. Inside the `HousingAPI` class, paste the variable that you copied from `Home` in the previous step.
+   1. Inside the `HousingAPI` class, paste these functions after the data you just copied.
       These functions allow dependencies to access the service's data.
 
       <docs-code header="Service functions in src/app/housing.service.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts" visibleLines="[112,118]"/>
@@ -79,11 +79,11 @@ In the **Edit** pane of your IDE, in `src/app/home/home.ts`:
 
 <docs-code language="angular-ts" header="Update to src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts" visibleLines="[1]"/>
 
-1. Add a new file level import for the `HousingService`:
+1. Add a new file level import for the `HousingAPI`:
 
 <docs-code language="angular-ts" header="Add import to src/app/home/home.ts" path="adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts" visibleLines="[4]"/>
 
-1. From `Home`, delete the `housingLocationList` array entries and assign `housingLocationList` the value of empty array (`[]`). In a few steps you will update the code to pull the data from the `HousingService`.
+1. From `Home`, delete the `housingLocationList` array entries and assign `housingLocationList` the value of empty array (`[]`). In a few steps you will update the code to pull the data from the `HousingAPI`.
 
 1. In `Home`, add the following code to inject the new service and initialize the data for the app. The `constructor` is the first function that runs when this component is created. The code in the `constructor` will assign the `housingLocationList` the value returned from the call to `getAllHousingLocations`.
 

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -14,7 +14,7 @@ import {HousingLocationInfo} from '../housinglocation';
     </section>
     <section class="results">
       @for(housingLocation of housingLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
@@ -23,7 +23,7 @@ import {HousingLocationInfo} from '../housinglocation';
 export class Home {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  housingLocationList: HousingLocationInfo[] = [
+  housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/housing-location/housing-location.ts
@@ -1,8 +1,8 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [],
   template: `
     <section class="listing">
@@ -18,6 +18,6 @@ import {HousingLocationInfo} from '../housinglocation';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/09-services/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/09-services/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/10-routing/README.md
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/README.md
@@ -20,8 +20,8 @@ In this lesson, you will enable routing in your application to navigate to the d
 
 <docs-workflow>
 
-<docs-step title="Create a default details component ">
-1. From the terminal, enter the following command to create the `Details`:
+<docs-step title="Create a default HousingLocationDetails component ">
+1. From the terminal, enter the following command to create the `HousingLocationDetails`:
 
     ```shell
     ng generate component details
@@ -59,7 +59,7 @@ In this lesson, you will enable routing in your application to navigate to the d
 In the previous step you removed the reference to the `<app-home>` component in the template. In this step, you will add a new route to that component.
 
 1. In `routes.ts`, perform the following updates to create a route.
-   1. Add a file level imports for the `Home`, `Details` and the `Routes` type that you'll use in the route definitions.
+   1. Add a file level imports for the `Home`, `HousingLocationDetails` and the `Routes` type that you'll use in the route definitions.
 
    <docs-code header="Import components and Routes" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/routes.ts" visibleLines="[1,3]"/>
    1. Define a variable called `routeConfig` of type `Routes` and define two routes for the app:

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/home/home.ts
@@ -1,10 +1,10 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -14,15 +14,15 @@ import {HousingService} from '../housing.service';
     </section>
     <section class="results">
       @for(housingLocation of housingLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
 
   constructor() {
     this.housingLocationList = this.housingService.getAllHousingLocations();

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing-location/housing-location.ts
@@ -1,8 +1,8 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [],
   template: `
     <section class="listing">
@@ -18,6 +18,6 @@ import {HousingLocationInfo} from '../housinglocation';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housing.service.ts
@@ -1,12 +1,12 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  protected housingLocationList: HousingLocationInfo[] = [
+  protected housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',
@@ -109,11 +109,11 @@ export class HousingService {
     },
   ];
 
-  getAllHousingLocations(): HousingLocationInfo[] {
+  getAllHousingLocations(): HousingLocation[] {
     return this.housingLocationList;
   }
 
-  getHousingLocationById(id: number): HousingLocationInfo | undefined {
+  getHousingLocationById(id: number): HousingLocation | undefined {
     return this.housingLocationList.find((housingLocation) => housingLocation.id === id);
   }
 }

--- a/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
@@ -42,9 +42,9 @@ In this case, `:id` is dynamic and will change based on how the route is request
 </docs-step>
 
 <docs-step title="Get route parameters">
-In this step, you will get the route parameter in the `Details`. Currently, the app displays `details works!`. Next you'll update the code to display the `id` value passed using the route parameters.
+In this step, you will get the route parameter in the `HousingLocationDetails`. Currently, the app displays `details works!`. Next you'll update the code to display the `id` value passed using the route parameters.
 
-1. In `src/app/details/details.ts` update the template to import the functions, classes and services that you'll need to use in the `Details`:
+1. In `src/app/details/details.ts` update the template to import the functions, classes and services that you'll need to use in the `HousingLocationDetails`:
 
 <docs-code header="Update file level imports" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[1,4]"/>
 
@@ -54,10 +54,10 @@ In this step, you will get the route parameter in the `Details`. Currently, the 
      template: `<p>details works! {{ housingLocationId }}</p>`,
    ```
 
-1. Update the body of the `Details` class with the following code:
+1. Update the body of the `HousingLocationDetails` class with the following code:
 
    ```ts
-   export class Details {
+   export class HousingLocationDetails {
      route: ActivatedRoute = inject(ActivatedRoute);
      housingLocationId = -1;
      constructor() {
@@ -66,37 +66,37 @@ In this step, you will get the route parameter in the `Details`. Currently, the 
    }
    ```
 
-   This code gives the `Details` access to the `ActivatedRoute` router feature that enables you to have access to the data about the current route. In the `constructor`, the code converts the `id` parameter acquired from the route from a string to a number.
+   This code gives the `HousingLocationDetails` access to the `ActivatedRoute` router feature that enables you to have access to the data about the current route. In the `constructor`, the code converts the `id` parameter acquired from the route from a string to a number.
 
 1. Save all changes.
 
 1. In the browser, click on one of the housing location's "Learn More" links and confirm that the numeric value displayed on the page matches the `id` property for that location in the data.
    </docs-step>
 
-<docs-step title="Customize the `Details`">
-Now that routing is working properly in the application this is a great time to update the template of the `Details` to display the specific data represented by the housing location for the route parameter.
+<docs-step title="Customize the `HousingLocationDetails`">
+Now that routing is working properly in the application this is a great time to update the template of the `HousingLocationDetails` to display the specific data represented by the housing location for the route parameter.
 
-To access the data you will add a call to the `HousingService`.
+To access the data you will add a call to the `HousingAPI`.
 
 1. Update the template code to match the following code:
 
-   <docs-code language="angular-ts" header="Update the Details template in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[8,29]"/>
+   <docs-code language="angular-ts" header="Update the HousingLocationDetails template in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[8,29]"/>
 
    Notice that the `housingLocation` properties are being accessed with the optional chaining operator `?`. This ensures that if the `housingLocation` value is null or undefined the application doesn't crash.
 
-1. Update the body of the `Details` class to match the following code:
+1. Update the body of the `HousingLocationDetails` class to match the following code:
 
-   <docs-code language="angular-ts" header="Update the Details class in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[32,41]"/>
+   <docs-code language="angular-ts" header="Update the HousingLocationDetails class in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[32,41]"/>
 
-   Now the component has the code to display the correct information based on the selected housing location. The `constructor` now includes a call to the `HousingService` to pass the route parameter as an argument to the `getHousingLocationById` service function.
+   Now the component has the code to display the correct information based on the selected housing location. The `constructor` now includes a call to the `HousingAPI` to pass the route parameter as an argument to the `getHousingLocationById` service function.
 
 1. Copy the following styles into the `src/app/details/details.css` file:
 
-   <docs-code header="Add styles for the Details" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.css" visibleLines="[1,71]"/>
+   <docs-code header="Add styles for the HousingLocationDetails" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.css" visibleLines="[1,71]"/>
 
    and save your changes
 
-1. In `Details` use the just created `details.css` file as the source for the styles:
+1. In `HousingLocationDetails` use the just created `details.css` file as the source for the styles:
    <docs-code language="angular-ts" header="Update details.ts to use the created css file" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts" visibleLines="[30]"/>
 
 1. In the browser refresh the page and confirm that when you click on the "Learn More" link for a given housing location the details page displays the correct information based on the data for that selected item.
@@ -124,7 +124,7 @@ You now know how to:
 
 - use route parameters to pass data to a route
 - use the `routerLink` directive to use dynamic data to create a route
-- use route parameter to retrieve data from the `HousingService` to display specific housing location information.
+- use route parameter to retrieve data from the `HousingAPI` to display specific housing location information.
 
 Really great work so far.
 

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/details/details.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/details/details.ts
@@ -1,10 +1,10 @@
 import {Component} from '@angular/core';
 
 @Component({
-  selector: 'app-details',
+  selector: 'app-housing-location-details',
   template: `
     <p>details works!</p>
   `,
   styleUrls: ['./details.css'],
 })
-export class Details {}
+export class HousingLocationDetails {}

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/home/home.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -15,15 +15,15 @@ import {HousingService} from '../housing.service';
     </section>
     <section class="results">
       @for(housingLocation of housingLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
 
   constructor() {
     this.housingLocationList = this.housingService.getAllHousingLocations();

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing-location/housing-location.ts
@@ -1,9 +1,9 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [RouterLink],
   template: `
     <section class="listing">
@@ -19,6 +19,6 @@ import {RouterLink} from '@angular/router';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housing.service.ts
@@ -1,13 +1,13 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  protected housingLocationList: HousingLocationInfo[] = [
+  protected housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',
@@ -110,11 +110,11 @@ export class HousingService {
     },
   ];
 
-  getAllHousingLocations(): HousingLocationInfo[] {
+  getAllHousingLocations(): HousingLocation[] {
     return this.housingLocationList;
   }
 
-  getHousingLocationById(id: number): HousingLocationInfo | undefined {
+  getHousingLocationById(id: number): HousingLocation | undefined {
     return this.housingLocationList.find((housingLocation) => housingLocation.id === id);
   }
 }

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/routes.ts
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/src/app/routes.ts
@@ -1,6 +1,6 @@
 import {Routes} from '@angular/router';
 import {Home} from './home/home';
-import {Details} from './details/details';
+import {HousingLocationDetails} from './details/details';
 
 const routeConfig: Routes = [
   {
@@ -10,7 +10,7 @@ const routeConfig: Routes = [
   },
   {
     path: 'details/:id',
-    component: Details,
+    component: HousingLocationDetails,
     title: 'Home details',
   },
 ];

--- a/adev/src/content/tutorials/first-app/steps/12-forms/README.md
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/README.md
@@ -23,7 +23,7 @@ In this example, the method writes the data from the form to the browser's conso
 
 In the **Edit** pane of your IDE:
 
-1. In `src/app/housing.service.ts`, inside the `HousingService` class, paste this method at the bottom of the class definition.
+1. In `src/app/housing.service.ts`, inside the `HousingAPI` class, paste this method at the bottom of the class definition.
 
 <docs-code header="Submit method in src/app/housing.service.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts" visibleLines="[120,124]"/>
 
@@ -40,17 +40,17 @@ In the **Edit** pane of your IDE, in `src/app/details/details.ts`:
 
 <docs-code header="Forms imports in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts" visibleLines="[5]"/>
 
-1. In the `Details` decorator metadata, update the `imports` property with the following code:
+1. In the `HousingLocationDetails` decorator metadata, update the `imports` property with the following code:
 
 <docs-code header="imports directive in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts" visibleLines="[9]"/>
 
-1. In the `Details` class, before the `constructor()` method, add the following code to create the form object.
+1. In the `HousingLocationDetails` class, before the `constructor()` method, add the following code to create the form object.
 
    <docs-code header="template directive in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts" visibleLines="[52,56]"/>
 
    In Angular, `FormGroup` and `FormControl` are types that enable you to build forms. The `FormControl` type can provide a default value and shape the form data. In this example `firstName` is a `string` and the default value is empty string.
 
-1. In the `Details` class, after the `constructor()` method, add the following code to handle the **Apply now** click.
+1. In the `HousingLocationDetails` class, after the `constructor()` method, add the following code to handle the **Apply now** click.
 
    <docs-code header="template directive in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts" visibleLines="[62,68]"/>
 
@@ -65,7 +65,7 @@ This step adds the markup to the details page that displays the form.
 
 In the **Edit** pane of your IDE, in `src/app/details/details.ts`:
 
-1. In the `Details` decorator metadata, update the `template` HTML to match the following code to add the form's markup.
+1. In the `HousingLocationDetails` decorator metadata, update the `template` HTML to match the following code to add the form's markup.
 
    <docs-code language="angular-ts" header="template directive in src/app/details/details.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts" visibleLines="[10,45]"/>
 

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.ts
@@ -1,10 +1,10 @@
 import {Component, inject} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {HousingService} from '../housing.service';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
+import {HousingLocation} from '../housinglocation';
 
 @Component({
-  selector: 'app-details',
+  selector: 'app-housing-location-details',
   template: `
     <article>
       <img
@@ -29,10 +29,10 @@ import {HousingLocationInfo} from '../housinglocation';
   `,
   styleUrls: ['./details.css'],
 })
-export class Details {
+export class HousingLocationDetails {
   route: ActivatedRoute = inject(ActivatedRoute);
-  housingService = inject(HousingService);
-  housingLocation: HousingLocationInfo | undefined;
+  housingService = inject(HousingAPI);
+  housingLocation: HousingLocation | undefined;
 
   constructor() {
     const housingLocationId = Number(this.route.snapshot.params['id']);

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/home/home.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -15,15 +15,15 @@ import {HousingService} from '../housing.service';
     </section>
     <section class="results">
       @for(housingLocation of housingLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
 
   constructor() {
     this.housingLocationList = this.housingService.getAllHousingLocations();

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.ts
@@ -1,9 +1,9 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [RouterLink],
   template: `
     <section class="listing">
@@ -20,6 +20,6 @@ import {RouterLink} from '@angular/router';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing.service.ts
@@ -1,13 +1,13 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  protected housingLocationList: HousingLocationInfo[] = [
+  protected housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',
@@ -110,11 +110,11 @@ export class HousingService {
     },
   ];
 
-  getAllHousingLocations(): HousingLocationInfo[] {
+  getAllHousingLocations(): HousingLocation[] {
     return this.housingLocationList;
   }
 
-  getHousingLocationById(id: number): HousingLocationInfo | undefined {
+  getHousingLocationById(id: number): HousingLocation | undefined {
     return this.housingLocationList.find((housingLocation) => housingLocation.id === id);
   }
 }

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/12-forms/src/app/routes.ts
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/src/app/routes.ts
@@ -1,6 +1,6 @@
 import {Routes} from '@angular/router';
 import {Home} from './home/home';
-import {Details} from './details/details';
+import {HousingLocationDetails} from './details/details';
 
 const routeConfig: Routes = [
   {
@@ -10,7 +10,7 @@ const routeConfig: Routes = [
   },
   {
     path: 'details/:id',
-    component: Details,
+    component: HousingLocationDetails,
     title: 'Home details',
   },
 ];

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {HousingService} from '../housing.service';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
+import {HousingLocation} from '../housinglocation';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
-  selector: 'app-details',
+  selector: 'app-housing-location-details',
   imports: [ReactiveFormsModule],
   template: `
     <article>
@@ -45,10 +45,10 @@ import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
   `,
   styleUrls: ['./details.css'],
 })
-export class Details {
+export class HousingLocationDetails {
   route: ActivatedRoute = inject(ActivatedRoute);
-  housingService = inject(HousingService);
-  housingLocation: HousingLocationInfo | undefined;
+  housingService = inject(HousingAPI);
+  housingLocation: HousingLocation | undefined;
   applyForm = new FormGroup({
     firstName: new FormControl(''),
     lastName: new FormControl(''),

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/home/home.ts
@@ -1,31 +1,44 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
-        <input type="text" placeholder="Filter by city" />
-        <button class="primary" type="button">Search</button>
+        <input type="text" placeholder="Filter by city" #filter />
+        <button class="primary" type="button" (click)="filterResults(filter.value)">Search</button>
       </form>
     </section>
     <section class="results">
-      @for(housingLocation of housingLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+      @for(housingLocation of filteredLocationList; track $index) {
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
+  filteredLocationList: HousingLocation[] = [];
 
   constructor() {
     this.housingLocationList = this.housingService.getAllHousingLocations();
+    this.filteredLocationList = this.housingLocationList;
+  }
+
+  filterResults(text: string) {
+    if (!text) {
+      this.filteredLocationList = this.housingLocationList;
+      return;
+    }
+
+    this.filteredLocationList = this.housingLocationList.filter((housingLocation) =>
+      housingLocation?.city.toLowerCase().includes(text.toLowerCase()),
+    );
   }
 }

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing-location/housing-location.ts
@@ -1,9 +1,9 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [RouterLink],
   template: `
     <section class="listing">
@@ -20,6 +20,6 @@ import {RouterLink} from '@angular/router';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts
@@ -1,13 +1,13 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  protected housingLocationList: HousingLocationInfo[] = [
+  protected housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',
@@ -110,11 +110,11 @@ export class HousingService {
     },
   ];
 
-  getAllHousingLocations(): HousingLocationInfo[] {
+  getAllHousingLocations(): HousingLocation[] {
     return this.housingLocationList;
   }
 
-  getHousingLocationById(id: number): HousingLocationInfo | undefined {
+  getHousingLocationById(id: number): HousingLocation | undefined {
     return this.housingLocationList.find((housingLocation) => housingLocation.id === id);
   }
   submitApplication(firstName: string, lastName: string, email: string) {

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/13-search/src/app/routes.ts
+++ b/adev/src/content/tutorials/first-app/steps/13-search/src/app/routes.ts
@@ -1,6 +1,6 @@
 import {Routes} from '@angular/router';
 import {Home} from './home/home';
-import {Details} from './details/details';
+import {HousingLocationDetails} from './details/details';
 
 const routeConfig: Routes = [
   {
@@ -10,7 +10,7 @@ const routeConfig: Routes = [
   },
   {
     path: 'details/:id',
-    component: Details,
+    component: HousingLocationDetails,
     title: 'Home details',
   },
 ];

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {HousingService} from '../housing.service';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
+import {HousingLocation} from '../housinglocation';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
-  selector: 'app-details',
+  selector: 'app-housing-location-details',
   imports: [ReactiveFormsModule],
   template: `
     <article>
@@ -45,10 +45,10 @@ import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
   `,
   styleUrls: ['./details.css'],
 })
-export class Details {
+export class HousingLocationDetails {
   route: ActivatedRoute = inject(ActivatedRoute);
-  housingService = inject(HousingService);
-  housingLocation: HousingLocationInfo | undefined;
+  housingService = inject(HousingAPI);
+  housingLocation: HousingLocation | undefined;
 
   applyForm = new FormGroup({
     firstName: new FormControl(''),

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -15,24 +15,22 @@ import {HousingService} from '../housing.service';
     </section>
     <section class="results">
       @for(housingLocation of filteredLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
-  filteredLocationList: HousingLocationInfo[] = [];
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
+  filteredLocationList: HousingLocation[] = [];
 
   constructor() {
-    this.housingService
-      .getAllHousingLocations()
-      .then((housingLocationList: HousingLocationInfo[]) => {
-        this.housingLocationList = housingLocationList;
-        this.filteredLocationList = housingLocationList;
-      });
+    this.housingService.getAllHousingLocations().then((housingLocationList: HousingLocation[]) => {
+      this.housingLocationList = housingLocationList;
+      this.filteredLocationList = housingLocationList;
+    });
   }
 
   filterResults(text: string) {

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing-location/housing-location.ts
@@ -1,9 +1,9 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [RouterLink],
   template: `
     <section class="listing">
@@ -20,6 +20,6 @@ import {RouterLink} from '@angular/router';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts
@@ -1,18 +1,18 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   url = 'http://localhost:3000/locations';
 
-  async getAllHousingLocations(): Promise<HousingLocationInfo[]> {
+  async getAllHousingLocations(): Promise<HousingLocation[]> {
     const data = await fetch(this.url);
     return (await data.json()) ?? [];
   }
 
-  async getHousingLocationById(id: number): Promise<HousingLocationInfo | undefined> {
+  async getHousingLocationById(id: number): Promise<HousingLocation | undefined> {
     const data = await fetch(`${this.url}?id=${id}`);
     const locationJson = await data.json();
     return locationJson[0] ?? {};

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/routes.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src-final/app/routes.ts
@@ -1,6 +1,6 @@
 import {Routes} from '@angular/router';
 import {Home} from './home/home';
-import {Details} from './details/details';
+import {HousingLocationDetails} from './details/details';
 
 const routeConfig: Routes = [
   {
@@ -10,7 +10,7 @@ const routeConfig: Routes = [
   },
   {
     path: 'details/:id',
-    component: Details,
+    component: HousingLocationDetails,
     title: 'Home details',
   },
 ];

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/details/details.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/details/details.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {HousingService} from '../housing.service';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
+import {HousingLocation} from '../housinglocation';
 import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 
 @Component({
-  selector: 'app-details',
+  selector: 'app-housing-location-details',
   imports: [ReactiveFormsModule],
   template: `
     <article>
@@ -45,10 +45,10 @@ import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
   `,
   styleUrls: ['./details.css'],
 })
-export class Details {
+export class HousingLocationDetails {
   route: ActivatedRoute = inject(ActivatedRoute);
-  housingService = inject(HousingService);
-  housingLocation: HousingLocationInfo | undefined;
+  housingService = inject(HousingAPI);
+  housingLocation: HousingLocation | undefined;
 
   applyForm = new FormGroup({
     firstName: new FormControl(''),

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.ts
@@ -1,11 +1,11 @@
 import {Component, inject} from '@angular/core';
-import {HousingLocation} from '../housing-location/housing-location';
-import {HousingLocationInfo} from '../housinglocation';
-import {HousingService} from '../housing.service';
+import {HousingLocationCard} from '../housing-location/housing-location';
+import {HousingLocation} from '../housinglocation';
+import {HousingAPI} from '../housing.service';
 
 @Component({
   selector: 'app-home',
-  imports: [HousingLocation],
+  imports: [HousingLocationCard],
   template: `
     <section>
       <form>
@@ -15,16 +15,16 @@ import {HousingService} from '../housing.service';
     </section>
     <section class="results">
       @for(housingLocation of filteredLocationList; track $index) {
-        <app-housing-location [housingLocation]="housingLocation" />
+        <app-housing-location-card [housingLocation]="housingLocation" />
       }
     </section>
   `,
   styleUrls: ['./home.css'],
 })
 export class Home {
-  housingLocationList: HousingLocationInfo[] = [];
-  housingService: HousingService = inject(HousingService);
-  filteredLocationList: HousingLocationInfo[] = [];
+  housingLocationList: HousingLocation[] = [];
+  housingService: HousingAPI = inject(HousingAPI);
+  filteredLocationList: HousingLocation[] = [];
 
   constructor() {
     this.housingLocationList = this.housingService.getAllHousingLocations();

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing-location/housing-location.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing-location/housing-location.ts
@@ -1,9 +1,9 @@
 import {Component, input} from '@angular/core';
-import {HousingLocationInfo} from '../housinglocation';
+import {HousingLocation} from '../housinglocation';
 import {RouterLink} from '@angular/router';
 
 @Component({
-  selector: 'app-housing-location',
+  selector: 'app-housing-location-card',
   imports: [RouterLink],
   template: `
     <section class="listing">
@@ -20,6 +20,6 @@ import {RouterLink} from '@angular/router';
   `,
   styleUrls: ['./housing-location.css'],
 })
-export class HousingLocation {
-  housingLocation = input.required<HousingLocationInfo>();
+export class HousingLocationCard {
+  housingLocation = input.required<HousingLocation>();
 }

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing.service.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/housing.service.ts
@@ -1,13 +1,13 @@
 import {Injectable} from '@angular/core';
-import {HousingLocationInfo} from './housinglocation';
+import {HousingLocation} from './housinglocation';
 
 @Injectable({
   providedIn: 'root',
 })
-export class HousingService {
+export class HousingAPI {
   readonly baseUrl = 'https://angular.dev/assets/images/tutorials/common';
 
-  protected housingLocationList: HousingLocationInfo[] = [
+  protected housingLocationList: HousingLocation[] = [
     {
       id: 0,
       name: 'Acme Fresh Start Housing',
@@ -110,11 +110,11 @@ export class HousingService {
     },
   ];
 
-  getAllHousingLocations(): HousingLocationInfo[] {
+  getAllHousingLocations(): HousingLocation[] {
     return this.housingLocationList;
   }
 
-  getHousingLocationById(id: number): HousingLocationInfo | undefined {
+  getHousingLocationById(id: number): HousingLocation | undefined {
     return this.housingLocationList.find((housingLocation) => housingLocation.id === id);
   }
 

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/housinglocation.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/housinglocation.ts
@@ -1,4 +1,4 @@
-export interface HousingLocationInfo {
+export interface HousingLocation {
   id: number;
   name: string;
   city: string;

--- a/adev/src/content/tutorials/first-app/steps/14-http/src/app/routes.ts
+++ b/adev/src/content/tutorials/first-app/steps/14-http/src/app/routes.ts
@@ -1,6 +1,6 @@
 import {Routes} from '@angular/router';
 import {Home} from './home/home';
-import {Details} from './details/details';
+import {HousingLocationDetails} from './details/details';
 
 const routeConfig: Routes = [
   {
@@ -10,7 +10,7 @@ const routeConfig: Routes = [
   },
   {
     path: 'details/:id',
-    component: Details,
+    component: HousingLocationDetails,
     title: 'Home details',
   },
 ];


### PR DESCRIPTION
This global refactor updates different files across the entire tutorial progression to ensure strict adherence to Angular naming conventions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Class names in the tutorial are inconsistent or generic.
Specifically:
- `Details` is too generic for a component class.
- `HousingLocationInfo` is unnecessarily verbose for the main data interface.
- `HousingLocation` is used for a component, occupying the ideal name for the interface.
- `HousingService` is generic.

Issue Number: #65618


## What is the new behavior?
Class names are specific, descriptive, and follow a clear hierarchy. The core interface takes the primary domain name (`HousingLocation`), and components use descriptive suffixes (`Card`, `Details`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Relates to #65618
This PR addresses only the naming convention requirements. Logic refactoring related to this issue will be handled in a subsequent PR.