### PR TITLE
refactor(forms): Break up interop ng control and interop abstract control

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -14,7 +14,6 @@ import { Injector } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { Signal } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
-import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -23,7 +23,6 @@ import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { StandardSchemaV1 } from '@standard-schema/spec';
 import { ValidationErrors } from '@angular/forms';
-import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';

--- a/packages/forms/signals/src/controls/interop_abstract_control.ts
+++ b/packages/forms/signals/src/controls/interop_abstract_control.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {FieldTree} from '../api/types';
+import {InteropBase} from './interop_base';
+import {REQUIRED} from '../api/metadata';
+import {type AbstractControl, type ValidatorFn, Validators} from '@angular/forms';
+
+// TODO: Also consider supporting (if possible):
+// - hasError
+// - getError
+// - reset
+// - name
+// - path
+// - markAs[Touched,Dirty,etc.]
+
+export type InteropAbstractControlKeys = 'hasValidator' | 'setValue' | 'updateValueAndValidity';
+
+/**
+ * A functional wrapper for InteropAbstractControl, which handles the type casting.
+ *
+ * @param f Field tree
+ */
+export function createInteropControl<T>(f: FieldTree<T>) {
+  return new InteropAbstractControl(f) as unknown as AbstractControl<T>;
+}
+
+/**
+ * Implementation for an AbstractControl that takes a FieldTree, and proxies relevant properties.
+ *
+ * This can be used to include a signal form in a reactive form, and also when binding signal
+ * forms to components that take AbstractControls.
+ *
+ * It doesn't extend or implements AbstractControl, because it has 70+ props, some of which are private.
+ */
+export class InteropAbstractControl<T>
+  extends InteropBase<T>
+  implements Pick<AbstractControl<unknown>, InteropAbstractControlKeys>
+{
+  constructor(field: FieldTree<T>) {
+    super(field);
+  }
+
+  setValue(v: T): void {
+    (this.field().value as any).set(v);
+  }
+
+  hasValidator(validator: ValidatorFn): boolean {
+    // This addresses a common case where users look for the presence of `Validators.required` to
+    // determine whether to show a required "*" indicator in the UI.
+    if (validator === Validators.required) {
+      return this.field().metadata(REQUIRED)();
+    }
+    return false;
+  }
+
+  updateValueAndValidity() {
+    // No-op since value and validity are always up to date in signal forms.
+    // We offer this method so that reactive forms code attempting to call it doesn't error.
+  }
+}

--- a/packages/forms/signals/src/controls/interop_base.ts
+++ b/packages/forms/signals/src/controls/interop_base.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type {FormControlStatus, NgControl, ValidationErrors} from '@angular/forms';
+import {FieldState} from '../api/types';
+
+/**
+ * Properties of both NgControl & AbstractControl that are supported by the InteropNgControl.
+ */
+export type InteropSharedKeys =
+  | 'value'
+  | 'valid'
+  | 'invalid'
+  | 'touched'
+  | 'untouched'
+  | 'disabled'
+  | 'enabled'
+  | 'errors'
+  | 'pristine'
+  | 'dirty'
+  | 'status';
+
+/**
+ * Base class for Interop controls.
+ */
+export abstract class InteropBase<T> implements Pick<NgControl, InteropSharedKeys> {
+  constructor(protected field: () => FieldState<T>) {}
+
+  get value(): T {
+    return this.field().value();
+  }
+
+  get valid(): boolean {
+    return this.field().valid();
+  }
+
+  get invalid(): boolean {
+    return this.field().invalid();
+  }
+
+  get pending(): boolean | null {
+    return this.field().pending();
+  }
+
+  get disabled(): boolean {
+    return this.field().disabled();
+  }
+
+  get enabled(): boolean {
+    return !this.field().disabled();
+  }
+
+  get errors(): ValidationErrors | null {
+    const errors = this.field().errors();
+    if (errors.length === 0) {
+      return null;
+    }
+    const errObj: ValidationErrors = {};
+    for (const error of errors) {
+      errObj[error.kind] = error;
+    }
+    return errObj;
+  }
+
+  get pristine(): boolean {
+    return !this.field().dirty();
+  }
+
+  get dirty(): boolean {
+    return this.field().dirty();
+  }
+
+  get touched(): boolean {
+    return this.field().touched();
+  }
+
+  get untouched(): boolean {
+    return !this.field().touched();
+  }
+
+  get status(): FormControlStatus {
+    if (this.field().disabled()) {
+      return 'DISABLED';
+    }
+    if (this.field().valid()) {
+      return 'VALID';
+    }
+    if (this.field().invalid()) {
+      return 'INVALID';
+    }
+    if (this.field().pending()) {
+      return 'PENDING';
+    }
+    throw Error('AssertionError: unknown form control status');
+  }
+}

--- a/packages/forms/signals/src/controls/interop_ng_control.ts
+++ b/packages/forms/signals/src/controls/interop_ng_control.ts
@@ -6,41 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ControlValueAccessor,
-  Validators,
-  type AbstractControl,
-  type FormControlStatus,
-  type NgControl,
-  type ValidationErrors,
-  type ValidatorFn,
-} from '@angular/forms';
-import {REQUIRED} from '../api/metadata';
+import {ControlValueAccessor, type AbstractControl, type NgControl} from '@angular/forms';
 import type {FieldState} from '../api/types';
-
-// TODO: Also consider supporting (if possible):
-// - hasError
-// - getError
-// - reset
-// - name
-// - path
-// - markAs[Touched,Dirty,etc.]
-
-/**
- * Properties of both NgControl & AbstractControl that are supported by the InteropNgControl.
- */
-export type InteropSharedKeys =
-  | 'value'
-  | 'valid'
-  | 'invalid'
-  | 'touched'
-  | 'untouched'
-  | 'disabled'
-  | 'enabled'
-  | 'errors'
-  | 'pristine'
-  | 'dirty'
-  | 'status';
+import {InteropBase, InteropSharedKeys} from './interop_base';
+import {createInteropControl} from './interop_abstract_control';
 
 /**
  * A fake version of `NgControl` provided by the `Field` directive. This allows interoperability
@@ -50,95 +19,14 @@ export type InteropSharedKeys =
  * equivalent in signal forms.
  */
 export class InteropNgControl
-  implements
-    Pick<NgControl, InteropSharedKeys | 'control' | 'valueAccessor'>,
-    Pick<AbstractControl<unknown>, InteropSharedKeys | 'hasValidator'>
+  extends InteropBase<unknown>
+  implements Pick<NgControl, 'control' | 'valueAccessor'>
 {
-  constructor(protected field: () => FieldState<unknown>) {}
-
-  readonly control: AbstractControl<any, any> = this as unknown as AbstractControl<any, any>;
-
-  get value(): any {
-    return this.field().value();
+  constructor(field: () => FieldState<unknown>) {
+    super(field);
   }
 
-  get valid(): boolean {
-    return this.field().valid();
-  }
-
-  get invalid(): boolean {
-    return this.field().invalid();
-  }
-
-  get pending(): boolean | null {
-    return this.field().pending();
-  }
-
-  get disabled(): boolean {
-    return this.field().disabled();
-  }
-
-  get enabled(): boolean {
-    return !this.field().disabled();
-  }
-
-  get errors(): ValidationErrors | null {
-    const errors = this.field().errors();
-    if (errors.length === 0) {
-      return null;
-    }
-    const errObj: ValidationErrors = {};
-    for (const error of errors) {
-      errObj[error.kind] = error;
-    }
-    return errObj;
-  }
-
-  get pristine(): boolean {
-    return !this.field().dirty();
-  }
-
-  get dirty(): boolean {
-    return this.field().dirty();
-  }
-
-  get touched(): boolean {
-    return this.field().touched();
-  }
-
-  get untouched(): boolean {
-    return !this.field().touched();
-  }
-
-  get status(): FormControlStatus {
-    if (this.field().disabled()) {
-      return 'DISABLED';
-    }
-    if (this.field().valid()) {
-      return 'VALID';
-    }
-    if (this.field().invalid()) {
-      return 'INVALID';
-    }
-    if (this.field().pending()) {
-      return 'PENDING';
-    }
-    throw Error('AssertionError: unknown form control status');
-  }
+  readonly control = createInteropControl(this.field);
 
   valueAccessor: ControlValueAccessor | null = null;
-
-  hasValidator(validator: ValidatorFn): boolean {
-    // This addresses a common case where users look for the presence of `Validators.required` to
-    // determine whether or not to show a required "*" indicator in the UI.
-    if (validator === Validators.required) {
-      return this.field().metadata(REQUIRED)();
-    }
-    return false;
-  }
-
-  updateValueAndValidity() {
-    // No-op since value and validity are always up to date in signal forms.
-    // We offer this method so that reactive forms code attempting to call it doesn't error.
-  }
 }

--- a/packages/forms/signals/test/node/controls/interop_abstract_control.spec.ts
+++ b/packages/forms/signals/test/node/controls/interop_abstract_control.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {Validators} from '@angular/forms';
+import {disabled, form, required} from '../../../public_api';
+import {
+  createInteropControl,
+  InteropAbstractControl,
+} from '../../../src/controls/interop_abstract_control';
+
+describe('InteropAbstractControl', () => {
+  describe('createInteropControl', () => {
+    it('creates an interop control from a field tree', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control).toBeInstanceOf(InteropAbstractControl);
+      expect(control.value).toBe('pirojok');
+    });
+
+    it('maintains type information', () => {
+      const f = form(signal({name: 'test', age: 25}), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control.value).toEqual({name: 'test', age: 25});
+    });
+  });
+
+  describe('setValue', () => {
+    it('updates the underlying field value', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      control.setValue('pirojok');
+
+      expect(f().value()).toBe('pirojok');
+      expect(control.value).toBe('pirojok');
+    });
+  });
+
+  describe('hasValidator', () => {
+    it('returns true for Validators.required when field has REQUIRED metadata', () => {
+      const f = form(
+        signal('pirojok'),
+        (p) => {
+          required(p);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      expect(control.hasValidator(Validators.required)).toBe(true);
+    });
+
+    it('returns false for Validators.required when field does not have REQUIRED metadata', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control.hasValidator(Validators.required)).toBe(false);
+    });
+  });
+
+  describe('updateValueAndValidity', () => {
+    it('is a no-op and does not change any state', () => {
+      const f = form(
+        signal('pirojok'),
+        (p) => {
+          required(p);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      const valueBefore = control.value;
+      const validBefore = control.valid;
+      const errorsBefore = control.errors;
+
+      control.updateValueAndValidity();
+
+      expect(control.value).toBe(valueBefore);
+      expect(control.valid).toBe(validBefore);
+      expect(control.errors).toEqual(errorsBefore);
+    });
+  });
+
+  describe('inherited properties from InteropBase', () => {
+    it('exposes value property', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control.value).toBe('pirojok');
+
+      f().value.set('pirojok');
+      expect(control.value).toBe('pirojok');
+    });
+
+    it('exposes valid and invalid properties', () => {
+      const f = form(
+        signal(''),
+        (p) => {
+          required(p);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      expect(control.valid).toBe(false);
+      expect(control.invalid).toBe(true);
+
+      f().value.set('pirojok');
+      expect(control.valid).toBe(true);
+      expect(control.invalid).toBe(false);
+    });
+
+    it('exposes disabled and enabled properties', () => {
+      const isDisabled = signal(false);
+      const f = form(
+        signal('pirojok'),
+        (p) => {
+          disabled(p, () => isDisabled());
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      expect(control.disabled).toBe(false);
+      expect(control.enabled).toBe(true);
+
+      isDisabled.set(true);
+      expect(control.disabled).toBe(true);
+      expect(control.enabled).toBe(false);
+    });
+
+    it('exposes errors property', () => {
+      const f = form(
+        signal(''),
+        (p) => {
+          required(p);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      expect(control.errors).not.toBeNull();
+      expect(control.errors?.['required']).toBeDefined();
+
+      f().value.set('pirojok');
+      expect(control.errors).toBeNull();
+    });
+
+    it('exposes pristine and dirty properties', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control.pristine).toBe(true);
+      expect(control.dirty).toBe(false);
+
+      f().value.set('pirojok');
+      f().markAsDirty();
+      expect(control.pristine).toBe(false);
+      expect(control.dirty).toBe(true);
+    });
+
+    it('exposes touched and untouched properties', () => {
+      const f = form(signal('pirojok'), {injector: TestBed.inject(Injector)});
+      const control = createInteropControl(f);
+
+      expect(control.touched).toBe(false);
+      expect(control.untouched).toBe(true);
+
+      f().markAsTouched();
+      expect(control.touched).toBe(true);
+      expect(control.untouched).toBe(false);
+    });
+
+    it('exposes status property', () => {
+      const isDisabled = signal(false);
+      const f = form(
+        signal(''),
+        (p) => {
+          required(p);
+          disabled(p, () => isDisabled());
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+      const control = createInteropControl(f);
+
+      expect(control.status).toBe('INVALID');
+
+      f().value.set('pirojok');
+      expect(control.status).toBe('VALID');
+
+      isDisabled.set(true);
+      expect(control.status).toBe('DISABLED');
+    });
+  });
+});


### PR DESCRIPTION
Later they can be exposed for improving interop capabilities.

This PR:
- Extracts the shared base class  from 
- Creates a new  class that implements AbstractControl-like interface
- Adds comprehensive unit tests for 
- Keeps  focused on NgControl-specific functionality