### PR TITLE
docs(docs-infra): fix content projection documentation

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -95,7 +95,7 @@ export class CardBody {}
 
 ```angular-ts
 <!-- Component template -->
-Component({
+@Component({
   selector: 'custom-card',
   template: `
   <div class="card-shadow">
@@ -218,7 +218,7 @@ placeholder, Angular compares against the `ngProjectAs` value instead of the ele
 <div class="card-shadow">
   <ng-content select="card-title"></ng-content>
   <div class="card-divider"></div>
-  <ng-content></ng-content>
+  <ng-content />
 </div>
 ```
 


### PR DESCRIPTION
Fixed documentation issues in content projection examples.
- Component decorator without '@'
- Self-closing tag for ng-content

Fix #65675

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #65675


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
