### PR TITLE
refactor(core): formatter will only format function objects with the …

### DIFF
--- a/packages/core/primitives/signals/src/formatter.ts
+++ b/packages/core/primitives/signals/src/formatter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SIGNAL} from './graph';
+import {Reactive, SIGNAL} from './graph';
 
 // Only a subset of HTML tags are allowed in the custom formatter JsonML format.
 // See https://firefox-source-docs.mozilla.org/devtools-user/custom_formatters/index.html#html-template-format
@@ -36,7 +36,7 @@ declare global {
  * @see https://firefox-source-docs.mozilla.org/devtools-user/custom_formatters/index.html
  */
 
-const formatter = {
+export const formatter = {
   /**
    *  If the function returns `null`, the formatter is not used for this reference
    */
@@ -142,8 +142,8 @@ function prettifyPreview(
   }
 }
 
-function isSignal(value: any): boolean {
-  return value[SIGNAL] !== undefined;
+function isSignal(value: any): value is Reactive & (() => unknown) {
+  return typeof value === 'function' && value[SIGNAL] !== undefined;
 }
 
 /**

--- a/packages/core/primitives/signals/test/BUILD.bazel
+++ b/packages/core/primitives/signals/test/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(
+        [
+            "**/*.ts",
+        ],
+    ),
+    deps = [
+        "//packages/core/primitives/signals",
+    ],
+)
+
+angular_jasmine_test(
+    name = "test",
+    data = [
+        ":test_lib",
+    ],
+)

--- a/packages/core/primitives/signals/test/formattter.spec.ts
+++ b/packages/core/primitives/signals/test/formattter.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {createComputed} from '../src/computed';
+import {formatter} from '../src/formatter';
+import {createSignal} from '../src/signal';
+
+describe('Signal DevTools Formatter', () => {
+  it('should detect a Signal', () => {
+    const sigGetter = createSignal(42)[0];
+    expect(formatter.header(sigGetter, {}) as any).toBeInstanceOf(Array);
+  });
+
+  it('should not detect a Proxy as a Signal', () => {
+    // This proxyObj will not return undefined for the `SIGNAL` key.
+    const proxyObj = new Proxy({}, {get: () => 'pizza'});
+
+    expect(formatter.header(proxyObj, {})).toBeNull();
+  });
+
+  it('should format signal with error', () => {
+    const computed = createComputed(() => {
+      throw new Error('computation failed');
+    });
+
+    expect(formatter.header(computed, {}) as any).toEqual([
+      'span',
+      'Signal(⚠️ Error): computation failed',
+    ]);
+  });
+});


### PR DESCRIPTION
…`SIGNAL` key.

This will prevent objects like signal forms proxies to be recognized as signals (which they are not).