### PR TITLE
fix(core): Rendering web element inside a component with @for

### DIFF
--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -17,7 +17,7 @@ import {
 } from '../../hydration/views';
 import {assertDefined, assertFunction} from '../../util/assert';
 import {performanceMarkFeature} from '../../util/performance';
-import {assertLContainer, assertLView, assertTNode} from '../assert';
+import {assertLContainer, assertLViewOrUndefined, assertTNode} from '../assert';
 import {bindingUpdated} from '../bindings';
 import {CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
 import {ComponentTemplate} from '../interfaces/definition';
@@ -612,14 +612,14 @@ function maybeInitDetachAnimationList(lContainer: LContainer, index: number): vo
 
 function detachExistingView<T>(lContainer: LContainer, index: number): LView<T> {
   const existingLView = detachView(lContainer, index);
-  ngDevMode && assertLView(existingLView);
+  ngDevMode && assertLViewOrUndefined(existingLView);
 
   return existingLView as LView<T>;
 }
 
 function getExistingLViewFromLContainer<T>(lContainer: LContainer, index: number): LView<T> {
   const existingLView = getLViewFromLContainer<T>(lContainer, index);
-  ngDevMode && assertLView(existingLView);
+  ngDevMode && assertLViewOrUndefined(existingLView);
 
   return existingLView!;
 }

--- a/packages/core/src/render3/view/container.ts
+++ b/packages/core/src/render3/view/container.ts
@@ -8,7 +8,7 @@
 
 import {addToArray, removeFromArray} from '../../util/array_utils';
 import {assertDefined, assertEqual} from '../../util/assert';
-import {assertLContainer, assertLView} from '../assert';
+import {assertLContainer, assertLViewOrUndefined, assertLView} from '../assert';
 import {
   CONTAINER_HEADER_OFFSET,
   LContainer,
@@ -89,7 +89,7 @@ export function getLViewFromLContainer<T>(
   // avoid reading past the array boundaries
   if (adjustedIndex < lContainer.length) {
     const lView = lContainer[adjustedIndex];
-    ngDevMode && assertLView(lView);
+    ngDevMode && assertLViewOrUndefined(lView);
     return lView as LView<T>;
   }
   return undefined;


### PR DESCRIPTION
Fix Error: ASSERTION ERROR: LView must be defined [Expected=> null != undefined <=Actual] When Rendering web element inside a component with @for gives a runtime error.
Assertions have been made more forgiving by replacing **assertLView** with **assertLViewOrUndefined** at critical points.

Fix #65666

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Runtime error: ASSERTION ERROR: LView must be defined [Expected=> null != undefined <=Actual] When Rendering web 

Issue Number: #65666

## What is the new behavior?

Fix runtime error

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
