### PR TITLE
fix(http): enable XSRF protection for same-origin absolute URLs

### DIFF
--- a/adev/src/content/guide/http/security.md
+++ b/adev/src/content/guide/http/security.md
@@ -18,10 +18,10 @@ A common technique to prevent XSSI is to serve JSON responses with a "non-execut
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on GET/HEAD requests or on requests with an absolute URL.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET`/`HEAD` requests.
 
 <docs-callout helpful title="Why not protect GET requests?">
-CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated GET requests.
+CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated `GET` requests.
 </docs-callout>
 
 To take advantage of this, your server needs to set a token in a JavaScript readable session cookie called `XSRF-TOKEN` on either the page load or the first GET request. On subsequent requests the server can verify that the cookie matches the `X-XSRF-TOKEN` HTTP header, and therefore be sure that only code running on your domain could have sent the request. The token must be unique for each user and must be verifiable by the server; this prevents the client from making up its own tokens. Set the token to a digest of your site's authentication cookie with a salt for added security.

--- a/adev/src/content/guide/http/security.md
+++ b/adev/src/content/guide/http/security.md
@@ -18,7 +18,7 @@ A common technique to prevent XSSI is to serve JSON responses with a "non-execut
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative URLs, but not on GET/HEAD requests or on requests with an absolute URL.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on GET/HEAD requests or on requests with an absolute URL.
 
 <docs-callout helpful title="Why not protect GET requests?">
 CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated GET requests.

--- a/adev/src/content/guide/http/security.md
+++ b/adev/src/content/guide/http/security.md
@@ -18,7 +18,7 @@ A common technique to prevent XSSI is to serve JSON responses with a "non-execut
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET`/`HEAD` requests.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET` or `HEAD` requests.
 
 <docs-callout helpful title="Why not protect GET requests?">
 CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated `GET` requests.

--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -299,7 +299,7 @@ The malicious code on `evil.com` can't.
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative URLs, but not on GET/HEAD requests or on requests with an absolute URL.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on GET/HEAD requests or on requests with an absolute URL.
 
 <docs-callout helpful title="Why not protect GET requests?">
 CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated GET requests.

--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -299,10 +299,10 @@ The malicious code on `evil.com` can't.
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on GET/HEAD requests or on requests with an absolute URL.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET`/`HEAD` requests.
 
 <docs-callout helpful title="Why not protect GET requests?">
-CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated GET requests.
+CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated `GET` requests.
 </docs-callout>
 
 To take advantage of this, your server needs to set a token in a JavaScript readable session cookie called `XSRF-TOKEN` on either the page load or the first GET request. On subsequent requests the server can verify that the cookie matches the `X-XSRF-TOKEN` HTTP header, and therefore be sure that only code running on your domain could have sent the request. The token must be unique for each user and must be verifiable by the server; this prevents the client from making up its own tokens. Set the token to a digest of your site's authentication cookie with a salt for added security.

--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -299,7 +299,7 @@ The malicious code on `evil.com` can't.
 
 `HttpClient` supports a [common mechanism](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Cookie-to-header_token) used to prevent XSRF attacks. When performing HTTP requests, an interceptor reads a token from a cookie, by default `XSRF-TOKEN`, and sets it as an HTTP header, `X-XSRF-TOKEN`. Because only code that runs on your domain could read the cookie, the backend can be certain that the HTTP request came from your client application and not an attacker.
 
-By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET`/`HEAD` requests.
+By default, an interceptor sends this header on all mutating requests (such as `POST`) to relative and same origin URLs, but not on `GET` or `HEAD` requests.
 
 <docs-callout helpful title="Why not protect GET requests?">
 CSRF protection is only needed for requests that can change state on the backend. By their nature, CSRF attacks cross domain boundaries, and the web's [same-origin policy](https://developer.mozilla.org/docs/Web/Security/Same-origin_policy) will prevent an attacking page from retrieving the results of authenticated `GET` requests.

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -101,14 +101,18 @@ export function xsrfInterceptorFn(
     return next(req);
   }
 
-  // Skip requests to different origins
-  const locationHref = inject(PlatformLocation).href;
-  const {origin: locationOrigin} = new URL(locationHref);
+  try {
+    const locationHref = inject(PlatformLocation).href;
+    const {origin: locationOrigin} = new URL(locationHref);
+    // new URL('//something.com', 'https://example.com') ->
+    // 'https://something.com'
+    const {origin: requestOrigin} = new URL(req.url, locationOrigin);
 
-  // new URL('//something.com', 'https://example.com') -> 'https://something.com'
-  const {origin: requestOrigin} = new URL(req.url, locationOrigin);
-
-  if (locationOrigin !== requestOrigin) {
+    if (locationOrigin !== requestOrigin) {
+      return next(req);
+    }
+  } catch {
+    // Handle invalid URLs gracefully.
     return next(req);
   }
 

--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -104,8 +104,8 @@ export function xsrfInterceptorFn(
   try {
     const locationHref = inject(PlatformLocation).href;
     const {origin: locationOrigin} = new URL(locationHref);
-    // new URL('//something.com', 'https://example.com') ->
-    // 'https://something.com'
+    // We can use `new URL` to normalize a relative URL like '//something.com' to
+    // 'https://something.com' in order to make consistent same-origin comparisons.
     const {origin: requestOrigin} = new URL(req.url, locationOrigin);
 
     if (locationOrigin !== requestOrigin) {

--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -14,6 +14,7 @@ ts_project(
         "//packages/common",
         "//packages/common/http",
         "//packages/common/http/testing",
+        "//packages/common/testing",
         "//packages/core",
         "//packages/core/testing",
         "//packages/private/testing",


### PR DESCRIPTION
Previously, the XSRF interceptor only added the XSRF token to requests with relative URLs. This commit updates the interceptor to also add the token to requests with absolute URLs, provided they match the current origin.

Closes #20511