### PR TITLE
fix(compiler): ensure all href and src attributes are sanitized as URLs

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/namespace_attr.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/namespace_attr.js
@@ -4,6 +4,6 @@ template: function MyComponent_Template(rf, ctx) {
 		i0.ɵɵnamespaceSVG();
 		i0.ɵɵelement(0, "use")(1, "use", 0);
 	} if (rf & 2) {
-		i0.ɵɵattribute("href", ctx.value, null, "xlink");
+		i0.ɵɵattribute("href", ctx.value, i0.ɵɵsanitizeUrl, "xlink");
 	}
 }

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -15,7 +15,6 @@ import {SecurityContext} from '../core';
 // =================================================================================================
 //
 //        DO NOT EDIT THIS LIST OF SECURITY SENSITIVE PROPERTIES WITHOUT A SECURITY REVIEW!
-//                               Reach out to mprobst for details.
 //
 // =================================================================================================
 
@@ -32,21 +31,49 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
     // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
     registerContext(SecurityContext.URL, [
       '*|formAction',
-      'area|href',
-      'area|ping',
-      'audio|src',
       'a|href',
       'a|ping',
+      'a|xlink:href',
+      'animate|href',
+      'animate|xlink:href',
+      'animateMotion|href',
+      'animateMotion|xlink:href',
+      'animateTransform|href',
+      'animateTransform|xlink:href',
+      'area|href',
+      'area|ping',
+      'area|xlink:href',
+      'audio|src',
       'blockquote|cite',
       'body|background',
       'del|cite',
+      'feImage|href',
+      'feImage|xlink:href',
+      'filter|href',
+      'filter|xlink:href',
       'form|action',
+      'image|href',
+      'image|xlink:href',
       'img|src',
       'input|src',
       'ins|cite',
+      'linearGradient|href',
+      'linearGradient|xlink:href',
+      'mpath|href',
+      'mpath|xlink:href',
+      'pattern|href',
+      'pattern|xlink:href',
       'q|cite',
+      'radialGradient|href',
+      'radialGradient|xlink:href',
+      'set|href',
+      'set|xlink:href',
       'source|src',
+      'textPath|href',
+      'textPath|xlink:href',
       'track|src',
+      'use|href',
+      'use|xlink:href',
       'video|poster',
       'video|src',
     ]);

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -149,6 +149,21 @@ describe('sanitization', () => {
     ).toEqual('javascript:true');
   });
 
+  it('should sanitize SVG xlink:href', () => {
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'a', 'xlink:href')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'a', 'href')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'image', 'xlink:href')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'use', 'xlink:href')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+  });
+
   it('should sanitize urls via sanitizeUrlOrResourceUrl', () => {
     expect(ɵɵsanitizeUrlOrResourceUrl('http://server', 'a', 'href')).toEqual('http://server');
     expect(ɵɵsanitizeUrlOrResourceUrl(new Wrap('http://server'), 'a', 'href')).toEqual(


### PR DESCRIPTION
Previously, the security schema listed specific elements for `href`, `xlink:href`, and `src` attributes to be sanitized as URLs. This list was incomplete and missing several SVG elements (e.g. `image`, `use`, `feImage`), which could potentially lead to XSS vulnerabilities if malicious URLs were bound to these attributes.

This commit updates the schema to include a comprehensive list of all SVG and HTML elements that accept `href`, `xlink:href`, or `src` attributes, ensuring they are correctly treated as `SecurityContext.URL`. This provides robust protection against XSS vectors across all relevant elements.


Cherry-pick of https://github.com/angular/angular/pull/65663