### PR TITLE
fix(compiler-cli): avoid allocating an object for signals in production mode

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/model_inputs/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/model_inputs/GOLDEN_PARTIAL.js
@@ -5,8 +5,8 @@ import { Directive, model } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestDir {
     constructor() {
-        this.counter = model(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
-        this.name = model.required(Object.assign({}, (ngDevMode ? { debugName: "name" } : {})));
+        this.counter = model(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
+        this.name = model.required(...(ngDevMode ? [{ debugName: "name" }] : []));
     }
 }
 TestDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
@@ -34,8 +34,8 @@ import { Component, model } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestComp {
     constructor() {
-        this.counter = model(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
-        this.name = model.required(Object.assign({}, (ngDevMode ? { debugName: "name" } : {})));
+        this.counter = model(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
+        this.name = model.required(...(ngDevMode ? [{ debugName: "name" }] : []));
     }
 }
 TestComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
@@ -65,7 +65,7 @@ import { Directive, EventEmitter, Input, model, Output } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestDir {
     constructor() {
-        this.counter = model(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
+        this.counter = model(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
         this.modelWithAlias = model(false, Object.assign(Object.assign({}, (ngDevMode ? { debugName: "modelWithAlias" } : {})), { alias: 'alias' }));
         this.decoratorInput = true;
         this.decoratorInputWithAlias = true;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/GOLDEN_PARTIAL.js
@@ -188,7 +188,7 @@ import { Component, signal } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyComponent {
     constructor() {
-        this.enterClass = signal('slide', Object.assign({}, (ngDevMode ? { debugName: "enterClass" } : {})));
+        this.enterClass = signal('slide', ...(ngDevMode ? [{ debugName: "enterClass" }] : []));
     }
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
@@ -299,7 +299,7 @@ import { Component, signal } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyComponent {
     constructor() {
-        this.leaveClass = signal('fade', Object.assign({}, (ngDevMode ? { debugName: "leaveClass" } : {})));
+        this.leaveClass = signal('fade', ...(ngDevMode ? [{ debugName: "leaveClass" }] : []));
     }
 }
 MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/GOLDEN_PARTIAL.js
@@ -5,7 +5,7 @@ import { Component, Directive, input } from '@angular/core';
 import * as i0 from "@angular/core";
 export class Field {
     constructor() {
-        this.field = input(undefined, Object.assign({}, (ngDevMode ? { debugName: "field" } : {})));
+        this.field = input(...(ngDevMode ? [undefined, { debugName: "field" }] : []));
     }
 }
 Field.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Field, deps: [], target: i0.ɵɵFactoryTarget.Directive });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
@@ -967,7 +967,7 @@ import { Component, Directive, model, signal } from '@angular/core';
 import * as i0 from "@angular/core";
 export class NgModelDirective {
     constructor() {
-        this.ngModel = model.required(Object.assign({}, (ngDevMode ? { debugName: "ngModel" } : {})));
+        this.ngModel = model.required(...(ngDevMode ? [{ debugName: "ngModel" }] : []));
     }
 }
 NgModelDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
@@ -1023,7 +1023,7 @@ import { Component, Directive, model } from '@angular/core';
 import * as i0 from "@angular/core";
 export class NgModelDirective {
     constructor() {
-        this.ngModel = model('', Object.assign({}, (ngDevMode ? { debugName: "ngModel" } : {})));
+        this.ngModel = model('', ...(ngDevMode ? [{ debugName: "ngModel" }] : []));
     }
 }
 NgModelDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });

--- a/packages/compiler-cli/test/compliance/test_cases/signal_inputs/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_inputs/GOLDEN_PARTIAL.js
@@ -5,8 +5,8 @@ import { Directive, input } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestDir {
     constructor() {
-        this.counter = input(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
-        this.name = input.required(Object.assign({}, (ngDevMode ? { debugName: "name" } : {})));
+        this.counter = input(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
+        this.name = input.required(...(ngDevMode ? [{ debugName: "name" }] : []));
     }
 }
 TestDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
@@ -34,8 +34,8 @@ import { Component, input } from '@angular/core';
 import * as i0 from "@angular/core";
 export class TestComp {
     constructor() {
-        this.counter = input(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
-        this.name = input.required(Object.assign({}, (ngDevMode ? { debugName: "name" } : {})));
+        this.counter = input(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
+        this.name = input.required(...(ngDevMode ? [{ debugName: "name" }] : []));
     }
 }
 TestComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
@@ -68,7 +68,7 @@ function convertToBoolean(value) {
 }
 export class TestDir {
     constructor() {
-        this.counter = input(0, Object.assign({}, (ngDevMode ? { debugName: "counter" } : {})));
+        this.counter = input(0, ...(ngDevMode ? [{ debugName: "counter" }] : []));
         this.signalWithTransform = input(false, Object.assign(Object.assign({}, (ngDevMode ? { debugName: "signalWithTransform" } : {})), { transform: convertToBoolean }));
         this.signalWithTransformAndAlias = input(false, Object.assign(Object.assign({}, (ngDevMode ? { debugName: "signalWithTransformAndAlias" } : {})), { alias: 'publicNameSignal', transform: convertToBoolean }));
         this.decoratorInput = true;

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/GOLDEN_PARTIAL.js
@@ -8,12 +8,12 @@ export class SomeToken {
 const nonAnalyzableRefersToString = 'a, b, c';
 export class TestDir {
     constructor() {
-        this.query1 = viewChild('locatorA', Object.assign({}, (ngDevMode ? { debugName: "query1" } : {})));
-        this.query2 = viewChildren('locatorB', Object.assign({}, (ngDevMode ? { debugName: "query2" } : {})));
-        this.query3 = contentChild('locatorC', Object.assign({}, (ngDevMode ? { debugName: "query3" } : {})));
-        this.query4 = contentChildren('locatorD', Object.assign({}, (ngDevMode ? { debugName: "query4" } : {})));
-        this.query5 = viewChild(forwardRef(() => SomeToken), Object.assign({}, (ngDevMode ? { debugName: "query5" } : {})));
-        this.query6 = viewChildren(SomeToken, Object.assign({}, (ngDevMode ? { debugName: "query6" } : {})));
+        this.query1 = viewChild('locatorA', ...(ngDevMode ? [{ debugName: "query1" }] : []));
+        this.query2 = viewChildren('locatorB', ...(ngDevMode ? [{ debugName: "query2" }] : []));
+        this.query3 = contentChild('locatorC', ...(ngDevMode ? [{ debugName: "query3" }] : []));
+        this.query4 = contentChildren('locatorD', ...(ngDevMode ? [{ debugName: "query4" }] : []));
+        this.query5 = viewChild(forwardRef(() => SomeToken), ...(ngDevMode ? [{ debugName: "query5" }] : []));
+        this.query6 = viewChildren(SomeToken, ...(ngDevMode ? [{ debugName: "query6" }] : []));
         this.query7 = viewChild('locatorE', Object.assign(Object.assign({}, (ngDevMode ? { debugName: "query7" } : {})), { read: SomeToken }));
         this.query8 = contentChildren('locatorF, locatorG', Object.assign(Object.assign({}, (ngDevMode ? { debugName: "query8" } : {})), { descendants: true }));
         this.query9 = contentChildren(nonAnalyzableRefersToString, Object.assign(Object.assign({}, (ngDevMode ? { debugName: "query9" } : {})), { descendants: true }));
@@ -53,10 +53,10 @@ import { Component, contentChild, contentChildren, viewChild, viewChildren } fro
 import * as i0 from "@angular/core";
 export class TestComp {
     constructor() {
-        this.query1 = viewChild('locatorA', Object.assign({}, (ngDevMode ? { debugName: "query1" } : {})));
-        this.query2 = viewChildren('locatorB', Object.assign({}, (ngDevMode ? { debugName: "query2" } : {})));
-        this.query3 = contentChild('locatorC', Object.assign({}, (ngDevMode ? { debugName: "query3" } : {})));
-        this.query4 = contentChildren('locatorD', Object.assign({}, (ngDevMode ? { debugName: "query4" } : {})));
+        this.query1 = viewChild('locatorA', ...(ngDevMode ? [{ debugName: "query1" }] : []));
+        this.query2 = viewChildren('locatorB', ...(ngDevMode ? [{ debugName: "query2" }] : []));
+        this.query3 = contentChild('locatorC', ...(ngDevMode ? [{ debugName: "query3" }] : []));
+        this.query4 = contentChildren('locatorD', ...(ngDevMode ? [{ debugName: "query4" }] : []));
     }
 }
 TestComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
@@ -88,8 +88,8 @@ import { ContentChild, contentChild, Directive, ViewChild, viewChild } from '@an
 import * as i0 from "@angular/core";
 export class TestDir {
     constructor() {
-        this.signalViewChild = viewChild('locator1', Object.assign({}, (ngDevMode ? { debugName: "signalViewChild" } : {})));
-        this.signalContentChild = contentChild('locator2', Object.assign({}, (ngDevMode ? { debugName: "signalContentChild" } : {})));
+        this.signalViewChild = viewChild('locator1', ...(ngDevMode ? [{ debugName: "signalViewChild" }] : []));
+        this.signalContentChild = contentChild('locator2', ...(ngDevMode ? [{ debugName: "signalContentChild" }] : []));
     }
 }
 TestDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });

--- a/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/debug_transform_spec.ts
@@ -70,7 +70,7 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `signal('Hello World', { ...(ngDevMode ? { debugName: "testSignal" } : {}) })`,
+          `signal('Hello World', ...(ngDevMode ? [{ debugName: "testSignal" }] : []))`,
         );
       });
 
@@ -88,7 +88,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('signal("Hello World", {})');
+          expect(builtContent).toContain('signal("Hello World")');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -160,7 +160,7 @@ runInEachFileSystem(() => {
 
           const jsContents = env.getContents('test.js');
           expect(jsContents).toContain(
-            `signal('Hello World', { ...(ngDevMode ? { debugName: "testSignal" } : {}) })`,
+            `signal('Hello World', ...(ngDevMode ? [{ debugName: "testSignal" }] : [])`,
           );
         });
 
@@ -183,7 +183,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('signal("Hello World", {})');
+          expect(builtContent).toContain('signal("Hello World")');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -277,7 +277,7 @@ runInEachFileSystem(() => {
 
           const jsContents = env.getContents('test.js');
           expect(jsContents).toContain(
-            `signal('Hello World', { ...(ngDevMode ? { debugName: "testSignal" } : {}) })`,
+            `signal('Hello World', ...(ngDevMode ? [{ debugName: "testSignal" }] : [])`,
           );
         });
 
@@ -303,7 +303,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('signal("Hello World", {})');
+          expect(builtContent).toContain('signal("Hello World")');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -411,7 +411,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `computed(() => testSignal(), { ...(ngDevMode ? { debugName: "testComputed" } : {}) })`,
+          `computed(() => testSignal(), ...(ngDevMode ? [{ debugName: "testComputed" }] : []))`,
         );
       });
 
@@ -429,7 +429,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('computed(() => testSignal(), {})');
+          expect(builtContent).toContain('computed(() => testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -526,7 +526,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('computed(() => this.testSignal(), {})');
+          expect(builtContent).toContain('computed(() => this.testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -648,7 +648,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('computed(() => this.testSignal(), {})');
+          expect(builtContent).toContain('computed(() => this.testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -800,10 +800,10 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `model('Hello World', { ...(ngDevMode ? { debugName: "testModel" } : {}) })`,
+          `model('Hello World', ...(ngDevMode ? [{ debugName: "testModel" }] : [])`,
         );
         expect(jsContents).toContain(
-          `model(undefined, { ...(ngDevMode ? { debugName: "testModel2" } : {}) })`,
+          `model(...(ngDevMode ? [undefined, { debugName: "testModel2" }] : [])`,
         );
       });
 
@@ -824,7 +824,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('model("Hello World", {})');
+        expect(builtContent).toContain('model("Hello World")');
       });
 
       describe('.required', () => {
@@ -845,7 +845,7 @@ runInEachFileSystem(() => {
 
           const jsContents = env.getContents('test.js');
           expect(jsContents).toContain(
-            `model.required({ ...(ngDevMode ? { debugName: "testModel" } : {}) })`,
+            `model.required(...(ngDevMode ? [{ debugName: "testModel" }] : [])`,
           );
         });
 
@@ -887,7 +887,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('model.required({});');
+          expect(builtContent).toContain('model.required();');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -990,7 +990,7 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `input(undefined, { ...(ngDevMode ? { debugName: "testInput" } : {}) })`,
+          `input(...(ngDevMode ? [undefined, { debugName: "testInput" }] : [])`,
         );
       });
 
@@ -1012,7 +1012,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('input(void 0, {});');
+        expect(builtContent).toContain('input();');
       });
 
       describe('.required', () => {
@@ -1033,7 +1033,7 @@ runInEachFileSystem(() => {
 
           const jsContents = env.getContents('test.js');
           expect(jsContents).toContain(
-            `input.required({ ...(ngDevMode ? { debugName: "testInput" } : {}) })`,
+            `input.required(...(ngDevMode ? [{ debugName: "testInput" }] : []))`,
           );
         });
 
@@ -1076,7 +1076,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('input.required({});');
+          expect(builtContent).toContain('input.required();');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1191,10 +1191,10 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `viewChild('foo', { ...(ngDevMode ? { debugName: "testViewChild" } : {}) })`,
+          `viewChild('foo', ...(ngDevMode ? [{ debugName: "testViewChild" }] : [])`,
         );
         expect(jsContents).toContain(
-          `viewChild(ChildComponent, { ...(ngDevMode ? { debugName: "testViewChildComponent" } : {}) })`,
+          `viewChild(ChildComponent, ...(ngDevMode ? [{ debugName: "testViewChildComponent" }] : [])`,
         );
       });
 
@@ -1224,8 +1224,8 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain(`viewChild("foo", {})`);
-        expect(builtContent).toContain(`viewChild(ChildComponent, {})`);
+        expect(builtContent).toContain(`viewChild("foo")`);
+        expect(builtContent).toContain(`viewChild(ChildComponent)`);
       });
 
       it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1340,7 +1340,7 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `viewChildren('foo', { ...(ngDevMode ? { debugName: "testViewChildren" } : {}) })`,
+          `viewChildren('foo', ...(ngDevMode ? [{ debugName: "testViewChildren" }] : [])`,
         );
       });
 
@@ -1362,7 +1362,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('viewChildren("foo", {})');
+        expect(builtContent).toContain('viewChildren("foo")');
       });
 
       it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1466,7 +1466,7 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `contentChild('foo', { ...(ngDevMode ? { debugName: "testContentChild" } : {}) })`,
+          `contentChild('foo', ...(ngDevMode ? [{ debugName: "testContentChild" }] : [])`,
         );
       });
 
@@ -1488,7 +1488,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('contentChild("foo", {})');
+        expect(builtContent).toContain('contentChild("foo")');
       });
 
       it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1594,7 +1594,7 @@ runInEachFileSystem(() => {
 
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `contentChildren('foo', { ...(ngDevMode ? { debugName: "testContentChildren" } : {}) })`,
+          `contentChildren('foo', ...(ngDevMode ? [{ debugName: "testContentChildren" }] : [])`,
         );
       });
 
@@ -1616,7 +1616,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('contentChildren("foo", {})');
+        expect(builtContent).toContain('contentChildren("foo")');
       });
 
       it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1724,7 +1724,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `effect(() => this.testSignal(), { ...(ngDevMode ? { debugName: "testEffect" } : {}) })`,
+          `effect(() => this.testSignal(), ...(ngDevMode ? [{ debugName: "testEffect" }] : [])`,
         );
       });
 
@@ -1745,7 +1745,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
         const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
         expect(builtContent).not.toContain('debugName');
-        expect(builtContent).toContain('effect(() => this.testSignal(), {})');
+        expect(builtContent).toContain('effect(() => this.testSignal())');
       });
 
       it('should not tree-shake away debug info if in dev mode', async () => {
@@ -1845,7 +1845,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
         expect(jsContents).toContain(
-          `linkedSignal(() => testSignal(), { ...(ngDevMode ? { debugName: "testLinkedSignal" } : {}) })`,
+          `linkedSignal(() => testSignal(), ...(ngDevMode ? [{ debugName: "testLinkedSignal" }] : [])`,
         );
       });
 
@@ -1863,7 +1863,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('linkedSignal(() => testSignal(), {})');
+          expect(builtContent).toContain('linkedSignal(() => testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -2039,7 +2039,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('linkedSignal(() => this.testSignal(), {})');
+          expect(builtContent).toContain('linkedSignal(() => this.testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -2251,7 +2251,7 @@ runInEachFileSystem(() => {
           const jsContents = env.getContents('test.js');
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           expect(builtContent).not.toContain('debugName');
-          expect(builtContent).toContain('linkedSignal(() => this.testSignal(), {})');
+          expect(builtContent).toContain('linkedSignal(() => this.testSignal())');
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -2777,9 +2777,7 @@ runInEachFileSystem(() => {
         env.driveMain();
         const jsContents = cleanNewLines(env.getContents('test.js'));
         expect(jsContents).toContain(
-          `httpResource(() => '/api', { ` +
-            '...(ngDevMode ? { debugName: "testHttpResource" } : {}) ' +
-            '})',
+          `httpResource(() => '/api', ...(ngDevMode ? [{ debugName: "testHttpResource" }] : []))`,
         );
       });
 
@@ -2798,7 +2796,7 @@ runInEachFileSystem(() => {
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           const contentWoNewLines = cleanNewLines(builtContent);
           expect(contentWoNewLines).not.toContain('debugName');
-          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api", {})`);
+          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api")`);
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -2839,9 +2837,7 @@ runInEachFileSystem(() => {
           env.driveMain();
           const jsContents = cleanNewLines(env.getContents('test.js'));
           expect(jsContents).toContain(
-            `httpResource(() => '/api', { ` +
-              '...(ngDevMode ? { debugName: "testHttpResource" } : {}) ' +
-              '})',
+            `httpResource(() => '/api', ...(ngDevMode ? [{ debugName: "testHttpResource" }] : []))`,
           );
         });
 
@@ -2864,7 +2860,7 @@ runInEachFileSystem(() => {
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           const contentWoNewLines = cleanNewLines(builtContent);
           expect(contentWoNewLines).not.toContain('debugName');
-          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api", {})`);
+          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api")`);
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {
@@ -2913,9 +2909,7 @@ runInEachFileSystem(() => {
           env.driveMain();
           const jsContents = cleanNewLines(env.getContents('test.js'));
           expect(jsContents).toContain(
-            `httpResource(() => '/api', { ` +
-              '...(ngDevMode ? { debugName: "testHttpResource" } : {}) ' +
-              '})',
+            `httpResource(() => '/api', ...(ngDevMode ? [{ debugName: "testHttpResource" }] : []))`,
           );
         });
 
@@ -2941,7 +2935,7 @@ runInEachFileSystem(() => {
           const builtContent = (await esbuild.transform(jsContents, minifiedProdBuildOptions)).code;
           const contentWoNewLines = cleanNewLines(builtContent);
           expect(contentWoNewLines).not.toContain('debugName');
-          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api", {})`);
+          expect(contentWoNewLines).toContain(`testHttpResource = httpResource(() => "/api")`);
         });
 
         it('should not tree-shake away debug info if in dev mode', async () => {


### PR DESCRIPTION
Currently when the signal debug name transform sees something like `const foo = signal(0);`, it transforms the signal into `signal(0, {...(ngDevMode ? { debugName: 'foo' } : {})})`. After minification this becomes `signal(0, {})` which will allocate memory for the empty object literal.

These changes rework the logic to produce `signal(0, ...(ngDevMode ? [{ debugName: 'foo' }] : []))` which will be fully tree shaken away to `signal(0)`.
