### PR TITLE
feat(forms): add markAllAsTouched and markAllAsDirty methods to signal-based forms

### DIFF
--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -648,6 +648,16 @@ export class Contact {
 
 This two-step reset ensures the form is ready for new input without showing stale error messages or dirty state indicators.
 
+### Marking all fields as touched
+
+Fields and forms can be marked as touched using the `markAllAsTouched()` method.
+This method sets the touched state on the field where it is called and on all of its descendants.
+
+```ts
+//  Mark the entire form and all nested fields as touched
+this.registrationForm().markAllAsTouched()
+```
+
 ## Styling based on validation state
 
 You can apply custom styles to your form by binding CSS classes based on the validation state:

--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -658,6 +658,16 @@ This method sets the touched state on the field where it is called and on all of
 this.registrationForm().markAllAsTouched()
 ```
 
+### Marking all fields as dirty
+
+Fields and forms can be marked as dirty using the `markAllAsDirty()` method.
+This method sets the dirty state on the field where it is called and on all of its descendants.
+
+```ts
+//  Mark the entire form and all nested fields as dirty
+this.registrationForm().markAllAsDirty()
+```
+
 ## Styling based on validation state
 
 You can apply custom styles to your form by binding CSS classes based on the validation state:

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -315,6 +315,11 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   hasMetadata(key: MetadataKey<any> | AggregateMetadataKey<any, any>): boolean;
 
   /**
+   * Marks this field and its descendants as touched.
+   */
+  markAllAsTouched(): void;
+
+  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -320,6 +320,11 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   markAllAsTouched(): void;
 
   /**
+   * Marks this field and its descendants as dirty.
+   */
+  markAllAsDirty(): void;
+
+  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -230,6 +230,16 @@ export class FieldNode implements FieldState<unknown> {
   }
 
   /**
+   * Marks this field and all descendant fields as dirty.
+   */
+  markAllAsDirty(): void {
+    this.markAsDirty();
+    for (const child of this.structure.children()) {
+      child.markAllAsDirty();
+    }
+  }
+
+  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -213,6 +213,16 @@ export class FieldNode implements FieldState<unknown> {
   }
 
   /**
+   * Marks this field and all descendant fields as touched.
+   */
+  markAllAsTouched(): void {
+    this.markAsTouched();
+    for (const child of this.structure.children()) {
+      child.markAllAsTouched();
+    }
+  }
+
+  /**
    * Marks this specific field as dirty.
    */
   markAsDirty(): void {

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -332,6 +332,33 @@ describe('FieldNode', () => {
       expect(f().readonly()).toBe(false);
       expect(f().dirty()).toBe(true);
     });
+
+    it('should mark the field and all descendants as dirty', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: {
+            c: 2,
+            d: 3,
+          },
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f().dirty()).toBeFalse();
+      expect(f.a().dirty()).toBeFalse();
+      expect(f.b().dirty()).toBeFalse();
+      expect(f.b.c().dirty()).toBeFalse();
+      expect(f.b.d().dirty()).toBeFalse();
+
+      f().markAllAsDirty();
+
+      expect(f().dirty()).toBeTrue();
+      expect(f.a().dirty()).toBeTrue();
+      expect(f.b().dirty()).toBeTrue();
+      expect(f.b.c().dirty()).toBeTrue();
+      expect(f.b.d().dirty()).toBeTrue();
+    });
   });
 
   describe('touched', () => {

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -561,6 +561,33 @@ describe('FieldNode', () => {
       expect(f().hidden()).toBe(false);
       expect(f().touched()).toBe(true);
     });
+
+    it('should mark the field and all descendants as touched', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: {
+            c: 2,
+            d: 3,
+          },
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f().touched()).toBeFalse();
+      expect(f.a().touched()).toBeFalse();
+      expect(f.b().touched()).toBeFalse();
+      expect(f.b.c().touched()).toBeFalse();
+      expect(f.b.d().touched()).toBeFalse();
+
+      f().markAllAsTouched();
+
+      expect(f().touched()).toBeTrue();
+      expect(f.a().touched()).toBeTrue();
+      expect(f.b().touched()).toBeTrue();
+      expect(f.b.c().touched()).toBeTrue();
+      expect(f.b.d().touched()).toBeTrue();
+    });
   });
 
   describe('arrays', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, signal-based forms do not expose a public API to manually mark a form and all its descendants as touched or dirty.

Issue Number: N/A

## What is the new behavior?
Two new methods are added to signal-based forms, providing a public and explicit API to mark the form and all its nested fields as touched or dirty:

- `markAllAsTouched()`: marks the form and all nested fields as touched.
- `markAllAsDirty()`: marks the form and all nested fields as dirty.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
