### PR TITLE
docs(docs-infra): Show examples on function overloads

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -37,7 +37,7 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
     const signature = method.signatures.length ? method.signatures : [method.implementation];
     return signature.map((sig) => {
       const renderableMember = getFunctionMetadataRenderable(sig, method.moduleName, method.repo);
-      return <ClassMethodInfo entry={renderableMember} options={{showUsageNotes: true}} />;
+      return <ClassMethodInfo entry={renderableMember} />;
     });
   };
 

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-method-info.tsx
@@ -7,7 +7,10 @@
  */
 
 import {Fragment, h} from 'preact';
-import {FunctionSignatureMetadataRenderable, ParameterEntryRenderable} from '../entities/renderables.mjs';
+import {
+  FunctionSignatureMetadataRenderable,
+  ParameterEntryRenderable,
+} from '../entities/renderables.mjs';
 import {PARAM_KEYWORD_CLASS_NAME, REFERENCE_MEMBER_CARD_ITEM} from '../styling/css-classes.mjs';
 import {DeprecatedLabel} from './deprecated-label';
 import {Parameter} from './parameter';
@@ -17,12 +20,7 @@ import {CodeSymbol} from './code-symbols';
 /**
  * Component to render the method-specific parts of a class's API reference.
  */
-export function ClassMethodInfo(props: {
-  entry: FunctionSignatureMetadataRenderable;
-  options?: {
-    showUsageNotes?: boolean;
-  };
-}) {
+export function ClassMethodInfo(props: {entry: FunctionSignatureMetadataRenderable}) {
   const entry = props.entry;
 
   return (
@@ -45,9 +43,9 @@ export function ClassMethodInfo(props: {
         <span className={PARAM_KEYWORD_CLASS_NAME}>@returns</span>
         <CodeSymbol code={entry.returnType} />
       </div>
-      {entry.htmlUsageNotes && props.options?.showUsageNotes ? (
+      {entry.htmlUsageNotes ? (
         <div className={'docs-usage-notes'}>
-          <span className={PARAM_KEYWORD_CLASS_NAME}>Usage notes</span>
+          <span className={'docs-usage-notes-heading'}>Usage notes</span>
           <RawHtml value={entry.htmlUsageNotes} />
         </div>
       ) : (

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -336,6 +336,16 @@
           border-block-start: 1px solid var(--senary-contrast);
         }
       }
+
+      .docs-usage-notes {
+        border-block-start: 1px solid var(--senary-contrast);
+
+        .docs-usage-notes-heading {
+          color: var(--primary-contrast);
+          margin: 0.5rem 0;
+          font-size: 1.2rem;
+        }
+      }
     }
   }
 }

--- a/packages/forms/signals/compat/src/api/compat_form.ts
+++ b/packages/forms/signals/compat/src/api/compat_form.ts
@@ -27,7 +27,7 @@ export type CompatFormOptions = Omit<FormOptions, 'adapter'>;
  * compatibility with Reactive forms by accepting Reactive controls as a part of the data.
  *
  * @example
- * ```
+ * ```ts
  * const lastName = new FormControl('lastName');
  *
  * const nameModel = signal({
@@ -40,7 +40,8 @@ export type CompatFormOptions = Omit<FormOptions, 'adapter'>;
  * });
  *
  * nameForm.last().value(); // lastName, not FormControl
- *
+ * ```
+ * 
  * @param model A writable signal that contains the model data for the form. The resulting field
  * structure will match the shape of the model and any changes to the form data will be written to
  * the model.
@@ -57,7 +58,7 @@ export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TMo
  * compatibility with Reactive forms by accepting Reactive controls as a part of the data.
  *
  * @example
- * ```
+ * ```ts
  * const lastName = new FormControl('lastName');
  *
  * const nameModel = signal({
@@ -94,7 +95,7 @@ export function compatForm<TModel>(
  * compatibility with Reactive forms by accepting Reactive controls as a part of the data.
  *
  * @example
- * ```
+ * ```ts
  * const lastName = new FormControl('lastName');
  *
  * const nameModel = signal({

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -61,7 +61,7 @@ export interface FormOptions {
  * as well.
  *
  * @example
- * ```
+ * ```ts
  * const nameModel = signal({first: '', last: ''});
  * const nameForm = form(nameModel);
  * nameForm.first().value.set('John');
@@ -89,7 +89,7 @@ export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
  * as well.
  *
  * @example
- * ```
+ * ```ts
  * const nameModel = signal({first: '', last: ''});
  * const nameForm = form(nameModel);
  * nameForm.first().value.set('John');
@@ -102,7 +102,7 @@ export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
  * function that builds the schema by binding logic to a parts of the field structure.
  *
  * @example
- * ```
+ * ```ts
  * const nameForm = form(signal({first: '', last: ''}), (name) => {
  *   required(name.first);
  *   pattern(name.last, /^[a-z]+$/i, {message: 'Alphabet characters only'});
@@ -139,7 +139,7 @@ export function form<TModel>(
  * as well.
  *
  * @example
- * ```
+ * ```ts
  * const nameModel = signal({first: '', last: ''});
  * const nameForm = form(nameModel);
  * nameForm.first().value.set('John');
@@ -152,7 +152,7 @@ export function form<TModel>(
  * function that builds the schema by binding logic to a parts of the field structure.
  *
  * @example
- * ```
+ * ```ts
  * const nameForm = form(signal({first: '', last: ''}), (name) => {
  *   required(name.first);
  *   validate(name.last, ({value}) => !/^[a-z]+$/i.test(value()) ? customError({kind: 'alphabet-only'}) : undefined);
@@ -195,7 +195,7 @@ export function form<TModel>(...args: any[]): FieldTree<TModel> {
  * Applies a schema to each item of an array.
  *
  * @example
- * ```
+ * ```ts
  * const nameSchema = schema<{first: string, last: string}>((name) => {
  *   required(name.first);
  *   required(name.last);
@@ -235,7 +235,7 @@ export function applyEach<TValue extends Object>(
  * Applies a predefined schema to a given `FieldPath`.
  *
  * @example
- * ```
+ * ```ts
  * const nameSchema = schema<{first: string, last: string}>((name) => {
  *   required(name.first);
  *   required(name.last);
@@ -336,7 +336,7 @@ export function applyWhenValue(
  * server error.
  *
  * @example
- * ```
+ * ```ts
  * async function registerNewUser(registrationForm: FieldTree<{username: string, password: string}>) {
  *   const result = await myClient.registerNewUser(registrationForm().value());
  *   if (result.errorCode === myClient.ErrorCode.USERNAME_TAKEN) {

--- a/packages/forms/signals/src/api/validation_errors.ts
+++ b/packages/forms/signals/src/api/validation_errors.ts
@@ -534,7 +534,7 @@ export class StandardSchemaValidationError extends _NgValidationError {
  * is one of the standard kinds, allowing you to switch on the kind to further narrow the type.
  *
  * @example
- * ```
+ * ```ts
  * const f = form(...);
  * for (const e of form().errors()) {
  *   if (e instanceof NgValidationError) {


### PR DESCRIPTION
Prior to this change, @example jsdoc tags funtion overloads weren't displayed in the API docs. 