### PR TITLE
fix(core): stop running further effects once one destroys the view mid-flush

### DIFF
--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -15,7 +15,7 @@ import {
   BASE_EFFECT_NODE,
   runEffect,
 } from '../../../primitives/signals';
-import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
+import {FLAGS, LViewFlags, type LView, EFFECTS} from '../interfaces/view';
 import {markAncestorsForTraversal} from '../util/view_utils';
 import {inject} from '../../di/injector_compatibility';
 import {Injector} from '../../di/injector';
@@ -200,6 +200,7 @@ export interface EffectNode extends BaseEffectNode, SchedulableEffect {
   cleanupFns: EffectCleanupFn[] | undefined;
   injector: Injector;
   notifier: ChangeDetectionScheduler;
+  destroyed: boolean;
 
   onDestroyFns: (() => void)[] | null;
 }
@@ -217,6 +218,7 @@ export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'noti
     ...BASE_EFFECT_NODE,
     cleanupFns: undefined,
     zone: null,
+    destroyed: false,
     onDestroyFns: null,
     run(this: EffectNode): void {
       if (ngDevMode && isInNotificationPhase()) {
@@ -245,7 +247,8 @@ export const EFFECT_NODE: Omit<EffectNode, 'fn' | 'destroy' | 'injector' | 'noti
           this.cleanupFns.pop()!();
         }
       } finally {
-        this.cleanupFns = [];
+        // Set to `undefined` instead of `[]` (no allocation required).
+        this.cleanupFns = undefined;
         setActiveConsumer(prevConsumer);
       }
     },
@@ -281,6 +284,9 @@ export const VIEW_EFFECT_NODE: Omit<ViewEffectNode, 'fn' | 'view' | 'injector' |
       this.notifier.notify(NotificationSource.ViewEffect);
     },
     destroy(this: ViewEffectNode): void {
+      // Set destroyed flag BEFORE `cleanup()` so `createEffectFn` can detect
+      // mid-execution destruction and run subsequently-registered cleanups immediately.
+      this.destroyed = true;
       consumerDestroy(this);
 
       if (this.onDestroyFns !== null) {
@@ -329,6 +335,18 @@ export function createRootEffect(
 
 function createEffectFn(node: EffectNode, fn: (onCleanup: EffectCleanupRegisterFn) => void) {
   return () => {
-    fn((cleanupFn) => (node.cleanupFns ??= []).push(cleanupFn));
+    fn((cleanupFn) => {
+      // Handle synchronous view destruction during effect execution.
+      // When an effect destroys its own view (e.g., `viewRef.destroy()`),
+      // `destroy()` sets `node.destroyed=true` and calls `cleanup()`. Any cleanup
+      // registered after that point would be lost since `cleanup()` already ran.
+      // Running it immediately ensures the cleanup contract is always honored,
+      // preventing memory leaks from event listeners, subscriptions, etc.
+      if (node.destroyed) {
+        cleanupFn();
+      } else {
+        (node.cleanupFns ??= []).push(cleanupFn);
+      }
+    });
   };
 }

--- a/packages/core/src/render3/reactivity/view_effect_runner.ts
+++ b/packages/core/src/render3/reactivity/view_effect_runner.ts
@@ -18,6 +18,10 @@ export function runEffectsInView(view: LView): void {
   let tryFlushEffects = true;
 
   while (tryFlushEffects) {
+    // If view was destroyed during effect execution, stop processing immediately.
+    if (view[EFFECTS] === null) {
+      break;
+    }
     let foundDirtyEffect = false;
     for (const effect of view[EFFECTS]) {
       if (!effect.dirty) {

--- a/packages/core/src/render3/reactivity/view_effect_runner.ts
+++ b/packages/core/src/render3/reactivity/view_effect_runner.ts
@@ -32,6 +32,11 @@ export function runEffectsInView(view: LView): void {
       } else {
         effect.zone.run(() => effect.run());
       }
+
+      // Stop immediately if the view was destroyed during effect execution.
+      if (view[EFFECTS] === null) {
+        return;
+      }
     }
 
     // Check if we need to continue flushing. If we didn't find any dirty effects, then there's

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -20,6 +20,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ComponentRef,
   computed,
   ContentChildren,
   createComponent,
@@ -36,6 +37,7 @@ import {
   OnChanges,
   provideZonelessChangeDetection,
   QueryList,
+  resource,
   signal,
   SimpleChanges,
   TemplateRef,
@@ -44,7 +46,7 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {EffectNode} from '../../src/render3/reactivity/effect';
-import {TestBed} from '../../testing';
+import {type ComponentFixture, TestBed} from '../../testing';
 
 describe('reactivity', () => {
   describe('effects', () => {
@@ -485,6 +487,118 @@ describe('reactivity', () => {
 
         fix.destroy();
         expect(destroyed).toBeTrue();
+      });
+
+      it('should execute effects cleanup functions when their view is destroyed', async () => {
+        const recorder: string[] = [];
+        let fixture: ComponentFixture<TestCmp>;
+
+        @Component({})
+        class TestCmp {
+          readonly counter = signal(0);
+
+          constructor() {
+            effect((onCleanup) => {
+              const value = this.counter();
+              recorder.push(`counter: ${value}`);
+              if (value === 2) {
+                fixture.destroy();
+              }
+              onCleanup(() => {
+                recorder.push(`counter onCleanup: ${value}`);
+              });
+            });
+
+            const doubled = computed(() => this.counter() * 2);
+            effect((onCleanup) => {
+              const value = doubled();
+              recorder.push(`doubled counter: ${value}`);
+              onCleanup(() => recorder.push(`doubled counter onCleanup: ${value}`));
+            });
+          }
+
+          increment() {
+            this.counter.update((c) => c + 1);
+          }
+        }
+
+        fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+
+        fixture.componentInstance.increment();
+        await fixture.whenStable();
+        fixture.componentInstance.increment();
+        await fixture.whenStable();
+
+        expect(recorder).toEqual([
+          'counter: 0',
+          'doubled counter: 0',
+          'counter onCleanup: 0',
+          'counter: 1',
+          'doubled counter onCleanup: 0',
+          'doubled counter: 2',
+          'counter onCleanup: 1',
+          'counter: 2',
+          'doubled counter onCleanup: 2', // During destroy()
+          'counter onCleanup: 2', // After destroy(), via a fix in `createEffectFn` (effect.ts)
+        ]);
+      });
+
+      it('should execute effect cleanup when component destroys itself via resource', async () => {
+        const recorder: string[] = [];
+        let compRef: ComponentRef<ExampleDialog>;
+
+        @Component({})
+        class TestCmp {
+          constructor() {
+            compRef = inject(ViewContainerRef).createComponent(ExampleDialog);
+          }
+        }
+
+        @Component({
+          template: 'foobar',
+        })
+        class ExampleDialog {
+          resource = resource({
+            loader: () => new Promise((res) => setTimeout(() => res('foobar'), 100)),
+          });
+
+          ref = effect((onCleanup) => {
+            const val = this.resource.value();
+            recorder.push(`effect: ${val}`);
+
+            if (val === 'foobar') {
+              compRef.destroy();
+            }
+
+            onCleanup(() => {
+              recorder.push(`cleanup: ${val}`);
+            });
+          });
+        }
+
+        const fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+
+        // Initial state: resource is loading, value is undefined
+        expect(recorder).toEqual(['effect: undefined']);
+
+        // Wait for the resource to resolves
+        await fixture.whenStable();
+
+        // Should have:
+        // 1. Cleanup from the undefined state
+        // 2. Effect run with 'foobar' value (which triggers destroy)
+        // 3. Cleanup from the 'foobar' state (this is the critical one - should run after destroy)
+        expect(recorder).toEqual([
+          'effect: undefined',
+          'cleanup: undefined',
+          'effect: foobar',
+          'cleanup: foobar', // This should run even though destroy() was called during the effect
+        ]);
+
+        // Verify component was actually destroyed
+        expect(compRef!.hostView.destroyed).toBe(true);
       });
 
       it('should destroy effects when their DestroyRef is separately destroyed', () => {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -44,7 +44,7 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {EffectNode} from '../../src/render3/reactivity/effect';
-import {TestBed} from '../../testing';
+import {type ComponentFixture, TestBed} from '../../testing';
 
 describe('reactivity', () => {
   describe('effects', () => {
@@ -485,6 +485,87 @@ describe('reactivity', () => {
 
         fix.destroy();
         expect(destroyed).toBeTrue();
+      });
+
+      it("should stop running a view's remaining effects once an earlier one destroys the view", async () => {
+        const recorder: string[] = [];
+        let fixture: ComponentFixture<TestCmp>;
+
+        @Component({})
+        class TestCmp {
+          readonly counter = signal(0);
+
+          constructor() {
+            // Added first, so it's visited first when the view's effects are flushed.
+            effect(() => {
+              recorder.push(`a: ${this.counter()}`);
+              if (this.counter() === 1) {
+                fixture.destroy();
+              }
+            });
+
+            // Added second. Also dirty in the same flush pass as "a" above, so it must not
+            // run once "a" has destroyed the view partway through that pass.
+            effect(() => {
+              recorder.push(`b: ${this.counter()}`);
+            });
+          }
+        }
+
+        fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(recorder).toEqual(['a: 0', 'b: 0']);
+
+        fixture.componentInstance.counter.set(1);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(recorder).toEqual(['a: 0', 'b: 0', 'a: 1']);
+      });
+
+      it('should not restart the flush loop once an effect dirties a sibling and destroys the view in the same run', async () => {
+        const recorder: string[] = [];
+        const trigger = signal(0);
+        let fixture: ComponentFixture<TestCmp>;
+
+        @Component({})
+        class TestCmp {
+          readonly counter = signal(0);
+
+          constructor() {
+            // Added first, so it's already had its turn (and was not dirty) earlier in the
+            // same flush pass by the time "a" below dirties it.
+            effect(() => {
+              trigger();
+              recorder.push('b');
+            });
+
+            // Added second. On its second run, dirties "b" above (which sets
+            // HasChildViewsToRefresh on this view) and destroys the view in the same call.
+            // That combination makes the outer while loop want to restart even though the
+            // view is already gone.
+            effect(() => {
+              const value = this.counter();
+              recorder.push(`a: ${value}`);
+              if (value === 1) {
+                trigger.update((v) => v + 1);
+                fixture.destroy();
+              }
+            });
+          }
+        }
+
+        fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(recorder).toEqual(['b', 'a: 0']);
+
+        fixture.componentInstance.counter.set(1);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(recorder).toEqual(['b', 'a: 0', 'a: 1']);
       });
 
       it('should destroy effects when their DestroyRef is separately destroyed', () => {


### PR DESCRIPTION
When a view has more than one effect scheduled to run, and one of them
destroys the view (e.g. by calling `componentRef.destroy()`), the
remaining effects in that same flush could still run afterward,
against a view that no longer exists. In some cases this crashed
outright with `TypeError: view[EFFECTS] is not iterable`.

Here's why: `runEffectsInView` walks a view's effects in a `for...of`
loop, wrapped in an outer `while` loop that re-checks for any effects
that became dirty as a side effect of ones that already ran. When an
effect destroys its view, `view[EFFECTS]` gets set to `null` as part
of tearing the view down.

First attempt checked for that inside the `for...of` loop, before each
effect runs. That covers a sibling effect later in the *same* pass,
but misses a second case: if the effect that destroys the view *also*
dirties another effect on that same view in the process (e.g. by
writing a signal the sibling depends on), the outer `while` loop sees
`HasChildViewsToRefresh` set and tries to restart — and immediately
crashes re-entering `for (const effect of view[EFFECTS])` on a
now-null value, before the in-loop check ever gets a chance to run.

Reproduced that exact crash with a test first: two effects on one
view, the second one writes a signal the first depends on and then
destroys the view in the same call — confirmed it throws before
touching the fix.

Fixed by checking right after `effect.run()` instead of before it,
covering both cases in one place: the remaining effects in the current
pass, and the loop trying to restart afterward. As soon as one effect
destroys the view, nothing else runs against it again.

This is intentionally narrow in scope. An earlier version of this fix
also tried to guarantee that `onCleanup()` callbacks still ran even
when registered after an effect destroyed its own view. That's been
dropped — destroying your own view and then continuing to register
more work for it isn't something the framework should have to paper
over. If you need to do both, register `onCleanup` first, then
destroy.