### PR TITLE
fix(devtools): router tree callables view source functionality

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -89,9 +89,6 @@ ts_test_library(
     ],
     deps = [
         ":router_tree",
-        "//:node_modules/@angular/core",
-        "//:node_modules/@angular/router",
-        "//devtools/projects/protocol",
     ],
 )
 

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -54,12 +54,7 @@ import {unHighlight} from './highlighter';
 import {disableTimingAPI, enableTimingAPI, initializeOrGetDirectiveForestHooks} from './hooks';
 import {start as startProfiling, stop as stopProfiling} from './hooks/capture';
 import {ComponentTreeNode} from './interfaces';
-import {
-  getElementRefByName,
-  getComponentRefByName,
-  parseRoutes,
-  RoutePropertyType,
-} from './router-tree';
+import {getRouterCallableConstructRef, parseRoutes, RoutePropertyType} from './router-tree';
 import {ngDebugClient, ngDebugDependencyInjectionApiIsSupported} from './ng-debug-api/ng-debug-api';
 import {setConsoleReference} from './set-console-reference';
 import {serializeDirectiveState, serializeValue} from './state-serializer/state-serializer';
@@ -203,24 +198,18 @@ const navigateRouteCallback = (messageBus: MessageBus<Events>) => (path: string)
 
 /**
  * Opens the source code of a component or a directive in the editor.
- * @param name - The name of the component, provider, or directive to view source for.
+ * @param constructName - The name of the class/function that represents a component, provider, guard
+ * or other callable to view source for.
  * @param type - The type of the element to view source for  component, provider, or directive.
  * @returns - The element instance of the component, provider, or directive.
  */
-export const viewSourceFromRouter = (name: string, type: RoutePropertyType) => {
+export const viewSourceFromRouter = (constructName: string, type: RoutePropertyType) => {
   const router: any = getRouterInstance();
 
-  if (router == null) {
+  if (router === null) {
     return;
   }
-
-  let element;
-  if (type === 'component') {
-    element = getComponentRefByName(router.config, name);
-  } else {
-    element = getElementRefByName(type, router.config, name);
-  }
-  return element;
+  return getRouterCallableConstructRef(router.config, type, constructName);
 };
 
 const startProfilingCallback = (messageBus: MessageBus<Events>) => () =>

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {parseRoutes} from './router-tree';
+import {getRouterCallableConstructRef, parseRoutes} from './router-tree';
 
 describe('parseRoutes', () => {
   it('should work without any routes', () => {
@@ -171,7 +171,7 @@ describe('parseRoutes', () => {
               'resolvers': [],
               'path': '/component-two/component-two-two',
               'pathMatch': undefined,
-              'title': 'titleResolver()',
+              'title': 'titleResolver',
               'data': [],
               'isAux': false,
               'isLazy': false,
@@ -240,7 +240,7 @@ describe('parseRoutes', () => {
           'isAux': false,
           'isLazy': false,
           'isActive': false,
-          'redirectTo': 'redirectResolver()',
+          'redirectTo': 'redirectResolver',
         },
       ],
       'isAux': false,
@@ -267,7 +267,7 @@ describe('parseRoutes', () => {
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
-    expect(parsedRoutes.children![0].canActivateGuards).toEqual(['canActivateGuard()']);
+    expect(parsedRoutes.children![0].canActivateGuards).toEqual(['canActivateGuard']);
   });
 
   it('should handle guards with arrow functions', () => {
@@ -285,7 +285,7 @@ describe('parseRoutes', () => {
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
-    expect(parsedRoutes.children![0].canActivateGuards).toEqual(['arrowGuard()']);
+    expect(parsedRoutes.children![0].canActivateGuards).toEqual(['arrowGuard']);
   });
 
   it('should handle guards with class instances', () => {
@@ -342,11 +342,11 @@ describe('parseRoutes', () => {
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
     expect(parsedRoutes.children![0].canActivateGuards).toEqual([
-      'canActivateGuard()',
+      'canActivateGuard',
       '[Function]',
       '[Function]',
     ]);
-    expect(parsedRoutes.children![0].canMatchGuards).toEqual(['canMatchGuard()']);
+    expect(parsedRoutes.children![0].canMatchGuards).toEqual(['canMatchGuard']);
     expect(parsedRoutes.children![0].canDeactivateGuards).toEqual(['CanDeactivateGuard']);
   });
 
@@ -365,7 +365,7 @@ describe('parseRoutes', () => {
     };
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
-    expect(parsedRoutes.children![0].matcher).toEqual('customMatcher()');
+    expect(parsedRoutes.children![0].matcher).toEqual('customMatcher');
     expect(parsedRoutes.children![0].path).toEqual('[Matcher]');
   });
 
@@ -406,7 +406,7 @@ describe('parseRoutes', () => {
     };
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
-    expect(parsedRoutes.children![0].runGuardsAndResolvers).toEqual('customRerunLogic()');
+    expect(parsedRoutes.children![0].runGuardsAndResolvers).toEqual('customRerunLogic');
   });
 
   it('should handle resolvers with named functions', () => {
@@ -428,7 +428,7 @@ describe('parseRoutes', () => {
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
-    expect(parsedRoutes.children![0].resolvers).toEqual([{key: 'user', value: 'userResolver()'}]);
+    expect(parsedRoutes.children![0].resolvers).toEqual([{key: 'user', value: 'userResolver'}]);
   });
 
   it('should handle resolvers with arrow functions', () => {
@@ -448,7 +448,7 @@ describe('parseRoutes', () => {
 
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
-    expect(parsedRoutes.children![0].resolvers).toEqual([{key: 'data', value: 'dataResolver()'}]);
+    expect(parsedRoutes.children![0].resolvers).toEqual([{key: 'data', value: 'dataResolver'}]);
   });
 
   it('should handle multiple resolvers on a single route', () => {
@@ -479,8 +479,8 @@ describe('parseRoutes', () => {
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
     expect(parsedRoutes.children![0].resolvers).toEqual([
-      {key: 'user', value: 'userResolver()'},
-      {key: 'settings', value: 'settingsResolver()'},
+      {key: 'user', value: 'userResolver'},
+      {key: 'settings', value: 'settingsResolver'},
       {key: 'permissions', value: 'PermissionsResolver'},
     ]);
   });
@@ -517,10 +517,144 @@ describe('parseRoutes', () => {
     const parsedRoutes = parseRoutes(nestedRouter as any);
 
     expect(parsedRoutes.children![0].resolvers).toEqual([
-      {key: 'parentData', value: 'parentResolver()'},
+      {key: 'parentData', value: 'parentResolver'},
     ]);
     expect(parsedRoutes.children![0].children![0].resolvers).toEqual([
-      {key: 'childData', value: 'childResolver()'},
+      {key: 'childData', value: 'childResolver'},
     ]);
+  });
+});
+
+describe('getRouterCallableConstructRef', () => {
+  class MockComponent {}
+  class MockService {}
+  function mockResolver() {}
+  function mockTitle() {}
+  function mockRedirectTo() {}
+  function mockMatcher() {}
+  function mockRunGuardsAndResolvers() {}
+  function mockCanActivate() {}
+  function mockCanDeactivate() {}
+  class MockCanActivateChild {}
+  class MockCanMatch {}
+
+  const MOCK_ROUTES = [
+    {
+      path: '',
+      providers: [MockService],
+      _loadedRoutes: [
+        {
+          path: 'foo',
+          component: MockComponent,
+          children: [
+            {
+              path: 'foo',
+              resolve: {
+                auth: mockResolver,
+              },
+            },
+            {
+              path: 'bar',
+              redirectTo: mockRedirectTo as any,
+              _loadedRoutes: [
+                {
+                  path: 'foo',
+                  title: mockTitle as any,
+                },
+                {
+                  path: 'bar',
+                  runGuardsAndResolvers: mockRunGuardsAndResolvers as any,
+                },
+                {
+                  path: 'baz',
+                  canActivate: [mockCanActivate],
+                  canActivateChild: [MockCanActivateChild],
+                  canDeactivate: [mockCanDeactivate],
+                },
+                {
+                  path: 'qux',
+                  canMatch: [MockCanMatch],
+                },
+              ],
+            },
+            {
+              path: 'baz',
+              matcher: mockMatcher as any,
+            },
+          ],
+        },
+        {
+          path: 'bar',
+        },
+      ],
+    },
+  ];
+
+  it(`should return null if the callable doesn't exist`, () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'component', 'NonExistent');
+    expect(ref).toEqual(null);
+  });
+
+  it('should return null if there is a callable with the provided name but wrongly typed', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'providers', 'MockComponent');
+    expect(ref).toEqual(null);
+  });
+
+  it('should find a component class', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'component', 'MockComponent');
+    expect(ref).toEqual(MockComponent);
+  });
+
+  it('should find a resolver function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'resolvers', 'mockResolver');
+    expect(ref).toEqual(mockResolver);
+  });
+
+  it('should find a title function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'title', 'mockTitle');
+    expect(ref).toEqual(mockTitle);
+  });
+
+  it('should find a redirectTo function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'redirectTo', 'mockRedirectTo');
+    expect(ref).toEqual(mockRedirectTo);
+  });
+
+  it('should find a matcher function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'matcher', 'mockMatcher');
+    expect(ref).toEqual(mockMatcher);
+  });
+
+  it('should find a runGuardsAndResolvers function', () => {
+    const ref = getRouterCallableConstructRef(
+      MOCK_ROUTES,
+      'runGuardsAndResolvers',
+      'mockRunGuardsAndResolvers',
+    );
+    expect(ref).toEqual(mockRunGuardsAndResolvers);
+  });
+
+  it('should find a canActivate function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'canActivate', 'mockCanActivate');
+    expect(ref).toEqual(mockCanActivate);
+  });
+
+  it('should find a canDeactivate function', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'canDeactivate', 'mockCanDeactivate');
+    expect(ref).toEqual(mockCanDeactivate);
+  });
+
+  it('should find a canActivateChild class', () => {
+    const ref = getRouterCallableConstructRef(
+      MOCK_ROUTES,
+      'canActivateChild',
+      'MockCanActivateChild',
+    );
+    expect(ref).toEqual(MockCanActivateChild);
+  });
+
+  it('should find a canMatch class', () => {
+    const ref = getRouterCallableConstructRef(MOCK_ROUTES, 'canMatch', 'MockCanMatch');
+    expect(ref).toEqual(MockCanMatch);
   });
 });


### PR DESCRIPTION
This PR fixes a set of issues with the router tree view source callable search algorithm:

- Depending on the function/class location in the router tree (should be inner leaf relative to tree level), the algorithm wasn't able to pin-point the ref every time because leaf routes that didn't hit a base case, would exit the recursion by an implicit `return undefined`. However, there was an explicit `!== null` check that was triggered, outputting an undefined ref. The algorithm explicitly returns `null` now.
- The function formatting that adds parentheses broke some of the base cases. In retrospect, my suggestion to add them wasn't a very good idea since they are misleading in cases where we have `const fn = () => ...` => `fn()`. Got rid of them.
- Added the missing `providers` case.
- Did some refactoring, including merging of `getElementRefByName` and `getComponentRefByName`.
- Tested the function
