### PR TITLE
fix(docs-infra): parse linenums attribute from triple ba…

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
@@ -42,6 +42,7 @@ export const docsCodeBlockExtension = {
       const highlightRule = /highlight\s*:\s*(.*)([^,])/;
       const hideCopyRule = /hideCopy/;
       const preferRule = /(prefer|avoid)/;
+      const linenumsRule = /linenums/;
 
       const token: DocsCodeBlock = {
         raw: match[0],
@@ -52,6 +53,7 @@ export const docsCodeBlockExtension = {
         highlight: highlightRule.exec(metadataStr)?.[1],
         hideCopy: hideCopyRule.test(metadataStr),
         style: preferRule.exec(metadataStr)?.[1] as 'prefer' | 'avoid' | undefined,
+        linenums: linenumsRule.test(metadataStr),
       };
       return token;
     }

--- a/adev/src/content/guide/animations/overview.md
+++ b/adev/src/content/guide/animations/overview.md
@@ -32,13 +32,13 @@ To get started with adding Angular animations to your project, import the animat
 <docs-step title="Enabling the animations module">
 Import `provideAnimationsAsync` from `@angular/platform-browser/animations/async` and add it to the providers list in the `bootstrapApplication` function call.
 
-<docs-code header="Enabling Animations" language="ts" linenums>
+```ts {header: "Enabling Animations", linenums}
 bootstrapApplication(AppComponent, {
   providers: [
     provideAnimationsAsync(),
   ]
 });
-</docs-code>
+```
 
 <docs-callout important title="If you need immediate animations in your application">
   If you need to have an animation happen immediately when your application is loaded,


### PR DESCRIPTION
…cktick metadata

The triple backtick code block parser now extracts the linenums attribute from metadata and applies it to enable line number display in code examples

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
