### PR TITLE
refactor(compiler): Generate the `controlCreate` after the native ele…

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
@@ -10,9 +10,8 @@ MyComponent.ɵcmp = /* @__PURE__ */i0.ɵɵdefineComponent({
       i0.ɵɵelementStart(1, "div");
       i0.ɵɵtext(2, "Not a form control either.");
       i0.ɵɵelementEnd();
-      i0.ɵɵelementStart(3, "input", 1);
+      i0.ɵɵelement(3, "input", 1);
       i0.ɵɵcontrolCreate();
-      i0.ɵɵelementEnd();
     }
     if (rf & 2) {
       i0.ɵɵadvance();

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -2527,6 +2527,47 @@ describe('field directive', () => {
       expect(customSubform.classList.contains('always')).toBe(false);
     });
   });
+
+  it('should create & bind input when a macro task is running', async () => {
+    const {promise, resolve} = promiseWithResolvers<void>();
+
+    @Component({
+      selector: 'app-form',
+      imports: [Field],
+      template: `
+        <form>
+          <select [field]="form">
+            <option value="us">United States</option>
+            <option value="ca">Canada</option>
+          </select>
+        </form>
+  `,
+    })
+    class FormComponent {
+      form = form(signal('us'));
+    }
+
+    @Component({
+      selector: 'app-root',
+      template: ``,
+    })
+    class App {
+      vcr = inject(ViewContainerRef);
+      constructor() {
+        promise.then(() => {
+          this.vcr.createComponent(FormComponent);
+        });
+      }
+    }
+
+    const fixture = act(() => TestBed.createComponent(App));
+
+    resolve();
+    await fixture.whenStable();
+
+    const select = fixture.debugElement.parent!.nativeElement.querySelector('select');
+    expect(select.value).toBe('us');
+  });
 });
 
 function setupRadioGroup() {


### PR DESCRIPTION
…ment has been created

This is necessary to exclude a race condition where the MutationObserver initialized by the instruction fired before the inputs are binded.

fixes #65678
