### PR TITLE
docs: fix up font in drag drop examples

### DIFF
--- a/adev/src/content/examples/drag-drop/src/axis-lock/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/axis-lock/app/app.component.css
@@ -13,6 +13,7 @@
   margin-right: 25px;
   position: relative;
   z-index: 1;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/boundary/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/boundary/app/app.component.css
@@ -15,6 +15,7 @@
   z-index: 1;
   box-sizing: border-box;
   padding: 10px;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/connected-sorting-group/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/connected-sorting-group/app/app.component.css
@@ -13,6 +13,7 @@
   border-radius: 4px;
   overflow: hidden;
   display: block;
+  font-family: sans-serif;
 }
 
 .example-box {
@@ -27,6 +28,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/connected-sorting/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/connected-sorting/app/app.component.css
@@ -13,6 +13,7 @@
   border-radius: 4px;
   overflow: hidden;
   display: block;
+  font-family: sans-serif;
 }
 
 .example-box {
@@ -27,6 +28,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/custom-handle/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/custom-handle/app/app.component.css
@@ -13,6 +13,7 @@
   border-radius: 4px;
   position: relative;
   z-index: 1;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/custom-placeholder/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/custom-placeholder/app/app.component.css
@@ -7,6 +7,7 @@
   background: white;
   border-radius: 4px;
   overflow: hidden;
+  font-family: sans-serif;
 }
 
 .example-box {
@@ -21,6 +22,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/custom-preview/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/custom-preview/app/app.component.css
@@ -7,6 +7,7 @@
   background: white;
   border-radius: 4px;
   overflow: hidden;
+  font-family: sans-serif;
 }
 
 .example-box {
@@ -21,6 +22,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/delay-drag/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/delay-drag/app/app.component.css
@@ -12,6 +12,7 @@
   border-radius: 4px;
   position: relative;
   z-index: 1;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/disable-drag/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/disable-drag/app/app.component.css
@@ -21,6 +21,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .example-box.cdk-drag-disabled {

--- a/adev/src/content/examples/drag-drop/src/disable-sorting/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/disable-sorting/app/app.component.css
@@ -1,7 +1,3 @@
-
-HTML
-TS
-CSS
 .example-container {
   width: 400px;
   max-width: 100%;
@@ -31,6 +27,7 @@ CSS
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/enter-predicate/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/enter-predicate/app/app.component.css
@@ -27,6 +27,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/free-drag-position/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/free-drag-position/app/app.component.css
@@ -12,6 +12,7 @@
   border-radius: 4px;
   position: relative;
   z-index: 1;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/horizontal-sorting/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/horizontal-sorting/app/app.component.css
@@ -24,6 +24,7 @@
   font-size: 14px;
   flex-grow: 1;
   flex-basis: 0;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/mixed-sorting/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/mixed-sorting/app/app.component.css
@@ -23,6 +23,7 @@
   text-align: center;
   font-size: 14px;
   min-width: 115px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/overview/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/overview/app/app.component.css
@@ -12,6 +12,7 @@
   border-radius: 4px;
   position: relative;
   z-index: 1;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/root-element/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/root-element/app/app.component.css
@@ -9,6 +9,7 @@
   align-items: center;
   background: #fff;
   border-radius: 4px;
+  font-family: sans-serif;
   transition: box-shadow 200ms cubic-bezier(0, 0, 0.2, 1);
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
               0 2px 2px 0 rgba(0, 0, 0, 0.14),

--- a/adev/src/content/examples/drag-drop/src/sort-predicate/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/sort-predicate/app/app.component.css
@@ -21,6 +21,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/sorting/app/app.component.css
+++ b/adev/src/content/examples/drag-drop/src/sorting/app/app.component.css
@@ -21,6 +21,7 @@
   cursor: move;
   background: white;
   font-size: 14px;
+  font-family: sans-serif;
 }
 
 .cdk-drag-preview {

--- a/adev/src/content/examples/drag-drop/src/sorting/app/app.component.ts
+++ b/adev/src/content/examples/drag-drop/src/sorting/app/app.component.ts
@@ -20,7 +20,7 @@ export class CdkDragDropSortingExample {
     'Episode VI - Return of the Jedi',
     'Episode VII - The Force Awakens',
     'Episode VIII - The Last Jedi',
-    'Episode IX – The Rise of Skywalker',
+    'Episode IX - The Rise of Skywalker',
   ];
 
   drop(event: CdkDragDrop<string[]>) {


### PR DESCRIPTION
Fixes that the CDK drag&drop examples were using a serif font.
