### PR TITLE
[Documentation] Explain how ::ng-deep works

### DIFF
--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -71,10 +71,28 @@ as `::shadow` or `::part`.
 
 #### `::ng-deep`
 
-Angular's emulated encapsulation mode supports a custom pseudo class, `::ng-deep`. Applying this
-pseudo class to a CSS rule disables encapsulation for that rule, effectively turning it into a
-global style. **The Angular team strongly discourages new use of `::ng-deep`**. These APIs remain
+Angular's emulated encapsulation mode supports a custom pseudo class, `::ng-deep`.
+**The Angular team strongly discourages new use of `::ng-deep`**. These APIs remain
 exclusively for backwards compatibility.
+
+When a selector contains `::ng-deep`, Angular stops applying view-encapsulation boundaries after that point in the selector. Any part of the selector that follows `::ng-deep` can match elements outside the component’s template.
+
+For example:
+
+- a CSS rule selector like `p a`, using the emulated encapsulation, will match `<a>` elements that are descendants of a `<p>` element,
+  both being within the component's own template.
+
+- A selector like `::ng-deep p a` will match `<a>` elements anywhere in the application, descendants of a `<p>` element anywhere in the application.
+
+  That effectively makes it behave like a global style.
+
+- In `p ::ng-deep a`, Angular requires the `<p>` element to come from the component's own template, but the `<a>` element may be anywhere in the application.
+
+  So, in effect, the `<a>` element may be in the component's template, or in any of its projected or child content.
+
+- With `:host ::ng-deep p a`, both the `<a>` and `<p>` elements must be decendants of the component's host element.
+
+  They can come from the component's template or the views of its child components, but not elsewhere in the app.
 
 ### ViewEncapsulation.ShadowDom
 


### PR DESCRIPTION
Clarify usage of Angular's ::ng-deep pseudo class and its implications for global styles.

This is a documentation-only change, that explains how `::ng-deep` actually works, explaining in effect what was mentioned in #25160.

I will also be proposing a change to the discouragement line - though I expect it will require more discussion since it explicitly engages "the Angular team" - to only discourage CSS rules where `::ng-deep` appears at the start of the rule / applies to the whole selector.
In my view, it is perfectly useful and legitimate to want a component to have style authority on both its template _and_ the children that it's provided with. It's even less drastic than the other ViewEncapsulation modes.