### PR TITLE
fix(docs-infra): truncate long TOC items and add title tooltips

### DIFF
--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.html
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.html
@@ -9,7 +9,7 @@
       <li class="docs-faceted-list-item" [class.docs-toc-item-h2]="item.level === TableOfContentsLevel.H2"
         [class.docs-toc-item-h3]="item.level === TableOfContentsLevel.H3">
         <!-- Not using routerLink + fragment because of: https://github.com/angular/angular/issues/30139 -->
-        <a [href]="location.path() + '#' + item.id" [class.docs-faceted-list-item-active]="item.id === activeItemId()">
+        <a [href]="location.path() + '#' + item.id" [class.docs-faceted-list-item-active]="item.id === activeItemId()" [title]="item.title">
           {{ item.title }}
         </a>
       </li>

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
@@ -61,6 +61,9 @@
       display: block; // to prevent overflow from the li parent
       padding: 0.5rem 0.5rem 0.5rem 1rem;
       font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &.docs-toc-item-h3 a {


### PR DESCRIPTION
Long TOC entries now truncate with …, and a title attribute is added to display the full label on hover.

Fixes: #65727

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65727


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
