### PR TITLE
docs: link `inject` function to its API reference

### DIFF
--- a/adev/src/content/best-practices/style-guide.md
+++ b/adev/src/content/best-practices/style-guide.md
@@ -110,11 +110,11 @@ When in doubt, go with the approach that leads to smaller files.
 
 ### Prefer the `inject` function over constructor parameter injection
 
-Prefer using the `inject` function over injecting constructor parameters. The `inject` function works the same way as constructor parameter injection, but offers several style advantages:
+Prefer using the [`inject`](/api/core/inject) function over injecting constructor parameters. The [`inject`](/api/core/inject) function works the same way as constructor parameter injection, but offers several style advantages:
 
-- `inject` is generally more readable, especially when a class injects many dependencies.
+- [`inject`](/api/core/inject) is generally more readable, especially when a class injects many dependencies.
 - It's more syntactically straightforward to add comments to injected dependencies
-- `inject` offers better type inference.
+- [`inject`](/api/core/inject) offers better type inference.
 - When targeting ES2022+ with [`useDefineForClassFields`](https://www.typescriptlang.org/tsconfig/#useDefineForClassFields), you can avoid separating field declaration and initialization when fields read on injected dependencies.
 
 [You can refactor existing code to `inject` with an automatic tool](reference/migrations/inject-function).

--- a/adev/src/content/guide/di/creating-injectable-service.md
+++ b/adev/src/content/guide/di/creating-injectable-service.md
@@ -101,7 +101,7 @@ For clarity and maintainability, it is recommended that you define components an
 
 ## Injecting services
 
-To inject a service as a dependency into a component, you can declare a class field representing the dependency and use Angular's `inject` function to initialize it.
+To inject a service as a dependency into a component, you can declare a class field representing the dependency and use Angular's [`inject`](/api/core/inject) function to initialize it.
 
 The following example specifies the `HeroService` in the `HeroListComponent`.
 The type of `heroService` is `HeroService`.
@@ -120,7 +120,7 @@ It is also possible to inject a service into a component using the component's c
   constructor(private heroService: HeroService)
 ```
 
-The `inject` method can be used in both classes and functions, while the constructor method can naturally only be used in a class constructor. However, in either case a dependency may only be injected in a valid [injection context](guide/di/dependency-injection-context), usually in the construction or initialization of a component.
+The [`inject`](/api/core/inject) method can be used in both classes and functions, while the constructor method can naturally only be used in a class constructor. However, in either case a dependency may only be injected in a valid [injection context](guide/di/dependency-injection-context), usually in the construction or initialization of a component.
 
 ## Injecting services in other services
 

--- a/adev/src/content/guide/di/dependency-injection-context.md
+++ b/adev/src/content/guide/di/dependency-injection-context.md
@@ -49,7 +49,7 @@ export class HeroService {
 }
 ```
 
-Note that `inject` will return an instance only if the injector can resolve the required token.
+Note that [`inject`](/api/core/inject) will return an instance only if the injector can resolve the required token.
 
 ## Asserts the context
 

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -171,7 +171,7 @@ HELPFUL: For `NgModule` based applications, Angular will search the `ModuleInjec
 ## Resolution modifiers
 
 Angular's resolution behavior can be modified with `optional`, `self`, `skipSelf` and `host`.
-Import each of them from `@angular/core` and use each in the `inject` configuration when you inject your service.
+Import each of them from `@angular/core` and use each in the [`inject`](/api/core/inject) configuration when you inject your service.
 
 ### Types of modifiers
 

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -93,7 +93,7 @@ export class NavbarComponent {
 
 ### Where can `inject()` be used?
 
-You can inject dependencies during construction of a component, directive, or service. The call to `inject` can appear in either the `constructor` or in a field initializer. Here are some common examples:
+You can inject dependencies during construction of a component, directive, or service. The call to [`inject`](/api/core/inject) can appear in either the `constructor` or in a field initializer. Here are some common examples:
 
 ```ts
 @Component({...})
@@ -137,7 +137,7 @@ export const authGuard = () => {
 }
 ```
 
-Angular uses the term "injection context" to describe any place in your code where you can call `inject`. While component, directive, and service construction is the most common, see [injection contexts](/guide/di/dependency-injection-context) for more details.
+Angular uses the term "injection context" to describe any place in your code where you can call [`inject`](/api/core/inject). While component, directive, and service construction is the most common, see [injection contexts](/guide/di/dependency-injection-context) for more details.
 
 For more information, see the [inject API docs](api/core/inject#usage-notes).
 

--- a/adev/src/content/guide/http/interceptors.md
+++ b/adev/src/content/guide/http/interceptors.md
@@ -85,7 +85,7 @@ CRITICAL: The body of a request or response is **not** protected from deep mutat
 
 ## Dependency injection in interceptors
 
-Interceptors are run in the _injection context_ of the injector which registered them, and can use Angular's `inject` API to retrieve dependencies.
+Interceptors are run in the _injection context_ of the injector which registered them, and can use Angular's [`inject`](/api/core/inject) API to retrieve dependencies.
 
 For example, suppose an application has a service called `AuthService`, which creates authentication tokens for outgoing requests. An interceptor can inject and use this service:
 

--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -231,7 +231,7 @@ Lazily loading routes can significantly improve the load speed of your Angular a
 
 ### Injection context lazy loading
 
-The Router executes `loadComponent` and `loadChildren` within the **injection context of the current route**, allowing you to call `inject` inside these loader functions to access providers declared on that route, inherited from parent routes through hierarchical dependency injection, or available globally. This enables context-aware lazy loading.
+The Router executes `loadComponent` and `loadChildren` within the **injection context of the current route**, allowing you to call [`inject`](/api/core/inject)inside these loader functions to access providers declared on that route, inherited from parent routes through hierarchical dependency injection, or available globally. This enables context-aware lazy loading.
 
 ```ts
 import { Routes } from '@angular/router';

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -124,7 +124,7 @@ Instead, use `computed` signals to model state that depends on other state.
 
 ### Injection context
 
-By default, you can only create an `effect()` within an [injection context](guide/di/dependency-injection-context) (where you have access to the `inject` function). The easiest way to satisfy this requirement is to call `effect` within a component, directive, or service `constructor`:
+By default, you can only create an `effect()` within an [injection context](guide/di/dependency-injection-context) (where you have access to the [`inject`](/api/core/inject) function). The easiest way to satisfy this requirement is to call `effect` within a component, directive, or service `constructor`:
 
 ```ts
 @Component({...})

--- a/adev/src/content/introduction/essentials/dependency-injection.md
+++ b/adev/src/content/introduction/essentials/dependency-injection.md
@@ -31,7 +31,7 @@ export class Calculator {
 When you want to use a service in a component, you need to:
 
 1. Import the service
-2. Declare a class field where the service is injected. Assign the class field to the result of the call of the built-in function `inject` which creates the service
+2. Declare a class field where the service is injected. Assign the class field to the result of the call of the built-in function [`inject`](/api/core/inject) which creates the service
 
 Here’s what it might look like in the `Receipt` component:
 
@@ -50,7 +50,7 @@ export class Receipt {
 }
 ```
 
-In this example, the `Calculator` is being used by calling the Angular function `inject` and passing in the service to it.
+In this example, the `Calculator` is being used by calling the Angular function [`inject`](/api/core/inject) and passing in the service to it.
 
 ## Next Step
 

--- a/adev/src/content/reference/migrations/inject-function.md
+++ b/adev/src/content/reference/migrations/inject-function.md
@@ -1,8 +1,8 @@
 # Migration to the `inject` function
 
-Angular's `inject` function offers more accurate types and better compatibility with standard decorators, compared to constructor-based injection.
+Angular's [`inject`](/api/core/inject) function offers more accurate types and better compatibility with standard decorators, compared to constructor-based injection.
 
-This schematic converts constructor-based injection in your classes to use the `inject` function instead.
+This schematic converts constructor-based injection in your classes to use the [`inject`](/api/core/inject) function instead.
 
 Run the schematic using the following command:
 
@@ -52,7 +52,7 @@ migrate the entire directory.
 ### `migrateAbstractClasses`
 
 Angular doesn't validate that parameters of abstract classes are injectable. This means that the
-migration can't reliably migrate them to `inject` without risking breakages which is why they're
+migration can't reliably migrate them to [`inject`](/api/core/inject) without risking breakages which is why they're
 disabled by default. Enable this option if you want abstract classes to be migrated, but note
 that you may have to **fix some breakages manually**.
 

--- a/adev/src/content/reference/migrations/overview.md
+++ b/adev/src/content/reference/migrations/overview.md
@@ -10,7 +10,7 @@ Learn about how you can migrate your existing angular project to the latest feat
     Built-in Control Flow Syntax allows you to use more ergonomic syntax which is close to JavaScript and has better type checking. It replaces the need to import `CommonModule` to use functionality like `*ngFor`, `*ngIf` and `*ngSwitch`.
   </docs-card>
   <docs-card title="inject() Function" link="Migrate now" href="reference/migrations/inject-function">
-    Angular's `inject` function offers more accurate types and better compatibility with standard decorators, compared to constructor-based injection.
+    Angular's [`inject`](/api/core/inject) function offers more accurate types and better compatibility with standard decorators, compared to constructor-based injection.
   </docs-card>
   <docs-card title="Lazy-loaded routes" link="Migrate now" href="reference/migrations/route-lazy-loading">
     Convert eagerly loaded component routes to lazy loaded ones. This allows the build process to split production bundles into smaller chunks, to load less JavaScript at initial page load.


### PR DESCRIPTION
Replaced plain code-form usage of `inject` with a link to the API docs (`/api/core/inject`) to improve navigation and help readers access detailed reference information more easily.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
