### PR TITLE
fix(docs-infra): exclude SVG elements from CSS reset to preserve path rendering

### DIFF
--- a/adev/src/styles/_resets.scss
+++ b/adev/src/styles/_resets.scss
@@ -29,7 +29,8 @@
     hr,
     input,
     select,
-    table {
+    table, 
+    :not(svg|*) {
       all: revert;
     }
   }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?
SVG icons in docs examples (like the drag handle icon) are not visible because the `all: revert` CSS rule resets the `d` CSS property on path elements, overriding the `d` attribute and causing paths to render with 0x0 dimensions.

Issue Number: #65545

## What is the new behavior?
SVG elements are excluded from the CSS reset using `:not(svg|*)` selector, preserving path data and fill inheritance.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No