### PR TITLE
docs: add FormArrayDirective documentation to reactive forms guide

### DIFF
--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -381,6 +381,36 @@ Each time a new alias instance is added, the new form array instance is provided
 
 </docs-step>
 
+### Using `FormArrayDirective` for top-level form arrays
+
+You can bind a `FormArray` directly to a `<form>` element by using the `FormArrayDirective`.  
+This is useful when the form does not use a top-level `FormGroup`, and the array itself represents the full form model.
+
+```angular-ts
+import { Component } from '@angular/core';
+import { FormArray, FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'form-array-example',
+  template: `
+    <form [formArray]="form">
+      @for (control of form.controls; track $index) {
+        <input [formControlName]="$index">
+      }
+    </form>
+  `,
+})
+export class FormArrayExampleComponent {
+  controls = [
+    new FormControl('fish'),
+    new FormControl('cat'),
+    new FormControl('dog'),
+  ];
+
+  form = new FormArray(this.controls);
+}
+```
+
 <docs-step title="Add an alias">
 
 Initially, the form contains one `Alias` field. To add another field, click the **Add Alias** button. You can also validate the array of aliases reported by the form model displayed by `Form Value` at the bottom of the template. Instead of a form control instance for each alias, you can compose another form group instance with additional fields. The process of defining a control for each item is the same.
@@ -542,3 +572,4 @@ For complete syntax details, see the API reference documentation for the [Forms 
 | `FormGroupDirective`   | Syncs an existing `FormGroup` instance to a DOM element.                                   |
 | `FormGroupName`        | Syncs a nested `FormGroup` instance to a DOM element.                                      |
 | `FormArrayName`        | Syncs a nested `FormArray` instance to a DOM element.                                      |
+| `FormArrayDirective`   | Syncs a standalone `FormArray` instance to a DOM element.                                  |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The reactive forms guide did not include documentation for the new `FormArrayDirective`, added in v21 to allow binding a top-level `FormArray` directly to a `<form>` element.

Issue Number: #65136


## What is the new behavior?
This PR adds a new section to the reactive forms guide explaining how to use `FormArrayDirective` with a top-level `FormArray`, including a usage example in both HTML and TypeScript.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Adds missing documentation for `FormArrayDirective` introduced in PR #55880.