### PR TITLE
feat(forms): support non-string types for radio inputs and type-check [value] bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -2605,7 +2605,6 @@ describe('type check blocks', () => {
 
     [
       {inputType: 'text', expectedType: 'string'},
-      {inputType: 'radio', expectedType: 'string'},
       {inputType: 'checkbox', expectedType: 'boolean'},
       {inputType: 'number', expectedType: 'string | number'},
       {inputType: 'range', expectedType: 'string | number'},
@@ -2623,6 +2622,19 @@ describe('type check blocks', () => {
         expect(block).toContain('var _t2 = null! as i0.Field;');
         expect(block).toContain('_t2.field = (((this).f));');
       });
+    });
+
+    it('should allow any type for radio inputs and type-check [value] bindings', () => {
+      const block = tcb(
+        `<input type="radio" [field]="f" [value]="true"/>`,
+        [FieldMock],
+      );
+      // Radio inputs don't generate a type constraint check - they allow any type.
+      // Instead, [value] bindings are type-checked against the field's value type.
+      expect(block).toContain('var _t1 = ((this).f)().value();');
+      expect(block).toContain('_t1 = true;');
+      expect(block).toContain('var _t2 = null! as i0.Field;');
+      expect(block).toContain('_t2.field = (((this).f));');
     });
 
     it('should generate a string field for a textarea', () => {

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -1215,6 +1215,90 @@ describe('field directive', () => {
     expect(cmp.f().value()).toBe('b');
   });
 
+  it('synchronizes with a radio group using boolean values', () => {
+    @Component({
+      imports: [Field],
+      template: `
+        <form>
+          <input type="radio" [value]="true" [field]="f">
+          <input type="radio" [value]="false" [field]="f">
+        </form>
+      `,
+    })
+    class TestCmp {
+      f = form(signal(true), {
+        name: 'test',
+      });
+    }
+
+    const fix = act(() => TestBed.createComponent(TestCmp));
+    const formEl = (fix.nativeElement as HTMLElement).firstChild as HTMLFormElement;
+    const inputs = Array.from(formEl.children) as HTMLInputElement[];
+
+    const [inputTrue, inputFalse] = inputs;
+    const cmp = fix.componentInstance as TestCmp;
+
+    // Model -> View
+    expect(inputTrue.checked).toBe(true);
+    expect(inputFalse.checked).toBe(false);
+
+    act(() => cmp.f().value.set(false));
+    expect(inputTrue.checked).toBe(false);
+    expect(inputFalse.checked).toBe(true);
+
+    // View -> Model
+    act(() => {
+      inputTrue.click();
+    });
+    expect(inputTrue.checked).toBe(true);
+    expect(inputFalse.checked).toBe(false);
+    expect(cmp.f().value()).toBe(true);
+  });
+
+  it('synchronizes with a radio group using number values', () => {
+    @Component({
+      imports: [Field],
+      template: `
+        <form>
+          <input type="radio" [value]="1" [field]="f">
+          <input type="radio" [value]="2" [field]="f">
+          <input type="radio" [value]="3" [field]="f">
+        </form>
+      `,
+    })
+    class TestCmp {
+      f = form(signal(1), {
+        name: 'test',
+      });
+    }
+
+    const fix = act(() => TestBed.createComponent(TestCmp));
+    const formEl = (fix.nativeElement as HTMLElement).firstChild as HTMLFormElement;
+    const inputs = Array.from(formEl.children) as HTMLInputElement[];
+
+    const [input1, input2, input3] = inputs;
+    const cmp = fix.componentInstance as TestCmp;
+
+    // Model -> View
+    expect(input1.checked).toBe(true);
+    expect(input2.checked).toBe(false);
+    expect(input3.checked).toBe(false);
+
+    act(() => cmp.f().value.set(3));
+    expect(input1.checked).toBe(false);
+    expect(input2.checked).toBe(false);
+    expect(input3.checked).toBe(true);
+
+    // View -> Model
+    act(() => {
+      input2.click();
+    });
+    expect(input1.checked).toBe(false);
+    expect(input2.checked).toBe(true);
+    expect(input3.checked).toBe(false);
+    expect(cmp.f().value()).toBe(2);
+  });
+
   it('synchronizes with a textarea', () => {
     @Component({
       imports: [Field],


### PR DESCRIPTION
This PR addresses issue #65726 by:

## Changes

1. **Allow non-string types for radio inputs**: Radio inputs can now bind to `FieldTree<T>` where `T` is not necessarily `string`. This enables using boolean, number, or any other type with radio button groups.

2. **Type-check [value] bindings**: Added compile-time type-checking for `[value]` bindings on radio inputs. Invalid values that don't match the field type will now produce compilation errors.

## Implementation Details

- Modified `TcbNativeFieldDirectiveTypeOp` to skip type constraints for radio inputs
- Added type-checking logic that verifies `[value]` bindings are assignable to the field's value type
- Uses TypeScript's type inference to check compatibility

## Example Usage

```typescript
// Now works with boolean:
f = form(signal(true));
<input type="radio" [value]="true" [field]="f">
<input type="radio" [value]="false" [field]="f">

// Type-checking catches invalid values:
f = form(signal<'yes' | 'no'>('yes'));
<input type="radio" [value]="'invalid'" [field]="f"> // ❌ Compilation error
```

## Tests

- Added compile-time tests verifying non-string types work with radio inputs
- Added compile-time tests verifying [value] binding type-checking
- Added runtime tests verifying boolean and number values work correctly with radio groups

Fixes #65726