### PR TITLE
 feat(forms) : allow flexible min/max types in FormValueControl fixes #65676

### DIFF
--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -80,7 +80,7 @@ export interface FormUiControl {
    * An input to receive the min value for the field. If implemented, the `Field` directive will
    * automatically bind the min value from the bound field to this input.
    */
-  readonly min?: InputSignal<number | undefined>;
+  readonly min?: InputSignal<unknown>;
   /**
    * An input to receive the min length for the field. If implemented, the `Field` directive will
    * automatically bind the min length from the bound field to this input.
@@ -90,7 +90,7 @@ export interface FormUiControl {
    * An input to receive the max value for the field. If implemented, the `Field` directive will
    * automatically bind the max value from the bound field to this input.
    */
-  readonly max?: InputSignal<number | undefined>;
+  readonly max?: InputSignal<unknown>;
   /**
    * An input to receive the max length for the field. If implemented, the `Field` directive will
    * automatically bind the max length from the bound field to this input.


### PR DESCRIPTION
feat(forms): allow flexible min and max types in FormUiControl

expand the min and max input types from number-only to string or number
to match native HTML behavior for date and time fields. this change
removes type assignment errors when building custom signal-based form
controls and aligns form inputs with the HTML specification. the update
improves compatibility for developers implementing ControlValueAccessor
or Field bindings that require non numeric min and max values.

issue - #65676 
