### PR TITLE
fix(core): Fix unkwown type for coercion.ts methods

### DIFF
--- a/packages/core/src/util/coercion.ts
+++ b/packages/core/src/util/coercion.ts
@@ -20,7 +20,9 @@
  *
  * @publicApi
  */
-export function booleanAttribute(value: unknown): boolean {
+export function booleanAttribute(
+  value: boolean | '' | null | undefined | 'true' | 'false',
+): boolean {
   return typeof value === 'boolean' ? value : value != null && value !== 'false';
 }
 
@@ -38,7 +40,10 @@ export function booleanAttribute(value: unknown): boolean {
  * @publicApi
  * @see [Built-in transformations](guide/components/inputs#built-in-transformations)
  */
-export function numberAttribute(value: unknown, fallbackValue = NaN): number {
+export function numberAttribute(
+  value: number | '' | null | undefined | 'true' | 'false',
+  fallbackValue = NaN,
+): number {
   // parseFloat(value) handles most of the cases we're interested in (it treats null, empty string,
   // and other non-number values as NaN, where Number just uses 0) but it considers the string
   // '123hello' to be a valid number. Therefore we also check if Number(value) is NaN.


### PR DESCRIPTION
Create specific type for coercion.ts methods:

- booleanAttribute
- numberAttribute

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

A component with this input property:
```typescript
readonly readOnly = input(undefined, { transform: booleanAttribute });
```

Accepts this type of format:
```typescript
@Component({
  template: `
    <app-component-one [readOnly]="toolbarReadOnly" />
  `
})
export class App {
  toolbarReadOnly = signal(false);
}
```

Where **toolbarReadOnly** is a signal. Since the previous type was **unknown**, the **booleanAttribute** function would accept any value as input, leading to inconsistencies.

## What is the new behavior?

Created specific types for the methods indicated in the PR. This way, the error will be flagged at compile time.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
