### PR TITLE
fix(forms): handle space-separated class names in control class bindings

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -466,17 +466,25 @@ function updateControlClasses(lView: LView, tNode: TNode, control: ɵControl<unk
   if (control.classes) {
     const bindings = getControlBindings(lView);
     bindings.classes ??= {};
-    const state = control.state();
+
     const renderer = lView[RENDERER];
     const element = getNativeByTNode(tNode, lView) as HTMLElement;
 
     for (const [className, enabled] of control.classes) {
       const isEnabled = enabled();
+
       if (controlClassBindingUpdated(bindings.classes, className, isEnabled)) {
+        // Handle multiple classes: split on whitespace
+        const classTokens = className.split(/\s+/).filter(Boolean);
+
         if (isEnabled) {
-          renderer.addClass(element, className);
+          for (const token of classTokens) {
+            renderer.addClass(element, token);
+          }
         } else {
-          renderer.removeClass(element, className);
+          for (const token of classTokens) {
+            renderer.removeClass(element, token);
+          }
         }
       }
     }

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -2409,7 +2409,7 @@ describe('field directive', () => {
         providers: [
           provideSignalFormsConfig({
             classes: {
-              'my-invalid-class': (state) => state.invalid(),
+              'my-invalid-class text-red': (state) => state.invalid(),
             },
           }),
         ],


### PR DESCRIPTION
Prevents InvalidCharacterError when a class rule contains space-separated classes. Renderer now adds/removes each class token individually.

Fixes: #65761

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65761


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
