### PR TITLE
docs: fix submit example

### DIFF
--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -610,7 +610,7 @@ export class Registration {
   })
 
   onSubmit() {
-    submit(this.registrationForm, () => {
+    submit(this.registrationForm, async () => {
       this.submitToServer()
     })
   }


### PR DESCRIPTION
`async` keyword is required for the `submit` callback
