### PR TITLE
feat(forms): provide host native element to class predicate callbacks

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -518,7 +518,7 @@ export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
 // @public
 export interface SignalFormsConfig {
     classes?: {
-        [className: string]: (state: FieldState<unknown>) => boolean;
+        [className: string]: (state: FieldState<unknown>, el?: Element) => boolean;
     };
 }
 

--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -16,8 +16,11 @@ import type {FieldState} from './types';
  * @experimental 21.0.1
  */
 export interface SignalFormsConfig {
-  /** A map of CSS class names to predicate functions that determine when to apply them. */
-  classes?: {[className: string]: (state: FieldState<unknown>) => boolean};
+  /** A map of CSS class names to predicate functions that determine when to apply them.
+   *
+   * The predicate receives the field `state` and optionally the host element.
+   */
+  classes?: {[className: string]: (state: FieldState<unknown>, el?: Element) => boolean};
 }
 
 /**

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -10,6 +10,7 @@ import {
   computed,
   Directive,
   effect,
+  ElementRef,
   inject,
   InjectionToken,
   Injector,
@@ -62,9 +63,11 @@ export const FIELD = new InjectionToken<Field<unknown>>(
 })
 export class Field<T> implements ɵControl<T> {
   private readonly injector = inject(Injector);
+  private readonly host = inject(ElementRef<HTMLElement>);
   private config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
   readonly classes = Object.entries(this.config?.classes ?? {}).map(
-    ([className, computation]) => [className, computed(() => computation(this.state()))] as const,
+    ([className, computation]) =>
+      [className, computed(() => computation(this.state(), this.host.nativeElement))] as const,
   );
   readonly field = input.required<FieldTree<T>>();
   readonly state = computed(() => this.field()());


### PR DESCRIPTION
Allows class predicate callbacks in `SignalFormsConfig` to receive the host native element.

Fixes: #65762

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Class predicate callbacks defined in SignalFormsConfig only receive the field state.
They do not receive the host native element, which limits scenarios where classes need to be applied based on DOM attributes or element characteristics.

Issue Number: #65762

## What is the new behavior?
Class predicate callbacks now receive an additional argument with the host native element.
This enables predicates to apply classes based on DOM attributes, tag name, or any other element-specific information.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No