### PR TITLE
docs: hide menu icons from screen readers in aria example

### DIFF
--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="auto-select">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox filterMode="highlight">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="material-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
@@ -1,6 +1,8 @@
 <div ngCombobox focusMode="manual">
   <div #origin class="retro-autocomplete">
-    <span class="search-icon material-symbols-outlined" translate="no">search</span>
+    <span class="search-icon material-symbols-outlined" translate="no" aria-hidden="true"
+      >search</span
+    >
     <input
       aria-label="Label dropdown"
       placeholder="Select a country"
@@ -23,7 +25,9 @@
           @for (country of countries(); track country) {
             <div ngOption [value]="country" [label]="country">
               <span class="option-label">{{country}}</span>
-              <span class="check-icon material-symbols-outlined" translate="no">check</span>
+              <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >check</span
+              >
             </div>
           }
         </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/app/app.html
@@ -1,14 +1,18 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no" aria-hidden="true"
+            >search</span
+          >
           <input
             ngComboboxInput
             class="combobox-input"
@@ -26,7 +30,12 @@
             @for (option of options(); track option) {
               <div ngOption [value]="option" [label]="option">
                 <span class="option-label">{{option}}</span>
-                <span class="material-symbols-outlined icon check-icon" translate="no">check</span>
+                <span
+                  class="material-symbols-outlined icon check-icon"
+                  translate="no"
+                  aria-hidden="true"
+                  >check</span
+                >
               </div>
             }
           </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.html
@@ -1,14 +1,18 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true" class="material-combobox">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no" aria-hidden="true"
+            >search</span
+          >
           <input
             ngComboboxInput
             class="combobox-input"
@@ -26,7 +30,12 @@
             @for (option of options(); track option) {
               <div ngOption [value]="option" [label]="option">
                 <span class="option-label">{{option}}</span>
-                <span class="material-symbols-outlined icon check-icon" translate="no">check</span>
+                <span
+                  class="material-symbols-outlined icon check-icon"
+                  translate="no"
+                  aria-hidden="true"
+                  >check</span
+                >
               </div>
             }
           </div>

--- a/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.html
+++ b/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.html
@@ -1,14 +1,18 @@
 <div ngCombobox #combobox="ngCombobox" [readonly]="true" class="retro-combobox">
   <div class="combobox-input-container">
     <input ngComboboxInput placeholder="Select a country..." [value]="value()" />
-    <span class="material-symbols-outlined icon arrow-icon" translate="no">arrow_drop_down</span>
+    <span class="material-symbols-outlined icon arrow-icon" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
     <dialog ngComboboxDialog class="dialog">
       <div ngCombobox #combobox="ngCombobox" filterMode="manual" [alwaysExpanded]="true">
         <div class="combobox-input-container">
-          <span class="material-symbols-outlined icon search-icon" translate="no">search</span>
+          <span class="material-symbols-outlined icon search-icon" translate="no" aria-hidden="true"
+            >search</span
+          >
           <input
             ngComboboxInput
             class="combobox-input"
@@ -22,7 +26,10 @@
             @for (option of options(); track option) {
               <div ngOption [value]="option" [label]="option">
                 <span>{{option}}</span>
-                <span class="material-symbols-outlined icon selected-icon" translate="no"
+                <span
+                  class="material-symbols-outlined icon selected-icon"
+                  translate="no"
+                  aria-hidden="true"
                   >check</span
                 >
               </div>

--- a/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/basic/app/app.html
@@ -1,11 +1,15 @@
 <div class="calendar basic-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_left</span
+      >
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_right</span
+      >
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/material/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/material/app/app.html
@@ -1,11 +1,15 @@
 <div class="calendar material-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_left</span
+      >
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_right</span
+      >
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.html
@@ -1,11 +1,15 @@
 <div class="calendar retro-calendar">
   <div class="calendar-header">
     <button class="month-control" aria-label="previous month" (click)="prevMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_left</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_left</span
+      >
     </button>
     <h3>{{monthYearLabel()}}</h3>
     <button class="month-control" aria-label="next month" (click)="nextMonth()">
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">chevron_right</span>
+      <span aria-hidden="true" class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >chevron_right</span
+      >
     </button>
   </div>
 

--- a/adev/src/content/examples/aria/grid/src/table/basic/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/table/basic/app/app.html
@@ -19,7 +19,12 @@
           (click)="sortTaskById()"
         >
           ID
-          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
+          <span
+            aria-hidden="true"
+            class="material-symbols-outlined"
+            translate="no"
+            aria-hidden="true"
+          >
             {{sortAscending ? 'arrow_upward' : 'arrow_downward'}}
           </span>
         </button>

--- a/adev/src/content/examples/aria/grid/src/table/retro/app/app.html
+++ b/adev/src/content/examples/aria/grid/src/table/retro/app/app.html
@@ -19,7 +19,12 @@
           (click)="sortTaskById()"
         >
           Reward
-          <span aria-hidden="true" class="material-symbols-outlined" translate="no">
+          <span
+            aria-hidden="true"
+            class="material-symbols-outlined"
+            translate="no"
+            aria-hidden="true"
+          >
             {{sortAscending ? 'arrow_upward' : 'arrow_downward'}}
           </span>
         </button>

--- a/adev/src/content/examples/aria/listbox/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/app/app.html
@@ -3,7 +3,12 @@
     @for (option of options; track option) {
       <div ngOption [value]="option">
         <span class="example-option-text">{{ option }}</span>
-        <span class="example-option-check material-symbols-outlined" translate="no">check</span>
+        <span
+          class="example-option-check material-symbols-outlined"
+          translate="no"
+          aria-hidden="true"
+          >check</span
+        >
       </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/material/app/app.html
@@ -3,7 +3,12 @@
     @for (option of options; track option) {
       <div ngOption [value]="option">
         <span class="example-option-text">{{ option }}</span>
-        <span class="example-option-check material-symbols-outlined" translate="no">check</span>
+        <span
+          class="example-option-check material-symbols-outlined"
+          translate="no"
+          aria-hidden="true"
+          >check</span
+        >
       </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.html
@@ -3,7 +3,12 @@
     @for (option of options; track option) {
       <div ngOption [value]="option">
         <span class="example-option-text">{{ option }}</span>
-        <span class="example-option-check material-symbols-outlined" translate="no">check</span>
+        <span
+          class="example-option-check material-symbols-outlined"
+          translate="no"
+          aria-hidden="true"
+          >check</span
+        >
       </div>
     }
   </div>

--- a/adev/src/content/examples/aria/listbox/src/horizontal/material/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/horizontal/material/app/app.html
@@ -8,7 +8,9 @@
 >
   @for (amenity of amenities; track amenity) {
     <div ngOption [value]="amenity" [label]="amenity">
-      <span class="check-icon material-symbols-outlined" translate="no">check</span>
+      <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >check</span
+      >
       <span class="option-label">{{ amenity }}</span>
     </div>
   }

--- a/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.html
+++ b/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.html
@@ -8,7 +8,9 @@
 >
   @for (amenity of amenities; track amenity) {
     <div ngOption [value]="amenity" [label]="amenity">
-      <span class="check-icon material-symbols-outlined" translate="no">check</span>
+      <span class="check-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >check</span
+      >
       <span class="option-label">{{ amenity }}</span>
     </div>
   }

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/app/app.html
@@ -4,19 +4,27 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >lock_open</span
+        >
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined" translate="no">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >security_key</span
+        >
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined" translate="no">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >refresh</span
+        >
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -28,17 +36,23 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined" translate="no">email</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >email</span
+              >
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined" translate="no">phone</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >phone</span
+              >
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >vpn_key</span
+              >
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -52,12 +66,14 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined" translate="no">help</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined" translate="no">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >feedback</span
+        >
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -65,7 +81,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined" translate="no">logout</span>
+      <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.html
@@ -9,19 +9,27 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >lock_open</span
+        >
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined" translate="no">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >security_key</span
+        >
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined" translate="no">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >refresh</span
+        >
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -33,17 +41,23 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined" translate="no">email</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >email</span
+              >
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined" translate="no">phone</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >phone</span
+              >
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >vpn_key</span
+              >
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -57,12 +71,14 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined" translate="no">help</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined" translate="no">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >feedback</span
+        >
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -70,7 +86,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined" translate="no">logout</span>
+      <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.html
@@ -9,19 +9,27 @@
 
     <div role="group" aria-labelledby="security-label">
       <div ngMenuItem value="Change password">
-        <span class="icon material-symbols-outlined" translate="no">lock_open</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >lock_open</span
+        >
         <span class="label">Change password</span>
       </div>
 
       <div ngMenuItem value="Two-factor authentication">
-        <span class="icon material-symbols-outlined" translate="no">security_key</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >security_key</span
+        >
         <span class="label">Two-factor authentication</span>
       </div>
 
       <div ngMenuItem value="Reset" #resetItem [submenu]="updateMenu()">
-        <span class="icon material-symbols-outlined" translate="no">refresh</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >refresh</span
+        >
         <span class="label">Reset</span>
-        <span class="icon material-symbols-outlined" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -33,17 +41,23 @@
         <div ngMenu #updateMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Email address">
-              <span class="icon material-symbols-outlined" translate="no">email</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >email</span
+              >
               <span class="label">Email address</span>
             </div>
 
             <div ngMenuItem value="Phone number">
-              <span class="icon material-symbols-outlined" translate="no">phone</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >phone</span
+              >
               <span class="label">Phone number</span>
             </div>
 
             <div ngMenuItem value="Password">
-              <span class="icon material-symbols-outlined" translate="no">vpn_key</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >vpn_key</span
+              >
               <span class="label">Password</span>
             </div>
           </ng-template>
@@ -57,12 +71,14 @@
 
     <div role="group" aria-labelledby="help-label">
       <div ngMenuItem value="Support">
-        <span class="icon material-symbols-outlined" translate="no">help</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">help</span>
         <span class="label">Support</span>
       </div>
 
       <div ngMenuItem value="Feedback">
-        <span class="icon material-symbols-outlined" translate="no">feedback</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >feedback</span
+        >
         <span class="label">Feedback</span>
       </div>
     </div>
@@ -70,7 +86,7 @@
     <div role="separator" class="separator"></div>
 
     <div ngMenuItem value="Logout">
-      <span class="icon material-symbols-outlined" translate="no">logout</span>
+      <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">logout</span>
       <span class="label">Logout</span>
     </div>
   </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/app/app.html
@@ -9,12 +9,14 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >mark_email_read</span
+        >
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze" [disabled]="true">
-        <span class="icon material-symbols-outlined" translate="no">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -28,9 +30,13 @@
         [submenu]="categorizeMenu()"
         [disabled]="true"
       >
-        <span class="icon material-symbols-outlined" translate="no">category</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >category</span
+        >
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -42,17 +48,23 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined" translate="no">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label_important</span
+              >
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined" translate="no">star</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >star</span
+              >
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined" translate="no">label</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label</span
+              >
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -62,17 +74,19 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined" translate="no">archive</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >archive</span
+        >
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined" translate="no">report</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined" translate="no">delete</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.html
@@ -10,17 +10,23 @@
     <ng-template ngMenuContent>
       <div class="group">
         <div ngMenuItem value="Mark as read">
-          <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >mark_email_read</span
+          >
           <span class="label">Mark as read</span>
         </div>
 
         <div ngMenuItem value="Snooze">
-          <span class="icon material-symbols-outlined" translate="no">snooze</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >snooze</span
+          >
           <span class="label">Snooze</span>
         </div>
 
         <div ngMenuItem value="Delete" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Delete</span>
         </div>
       </div>
@@ -33,9 +39,13 @@
           #categorizeItem
           [submenu]="categorizeMenu()"
         >
-          <span class="icon material-symbols-outlined" translate="no">category</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >category</span
+          >
           <span class="label">Categorize</span>
-          <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+          <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
       </div>
 
@@ -49,17 +59,23 @@
           <ng-template ngMenuContent>
             <div class="group">
               <div ngMenuItem value="Mark as important">
-                <span class="icon material-symbols-outlined" translate="no">label_important</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >label_important</span
+                >
                 <span class="label">Mark as important</span>
               </div>
 
               <div ngMenuItem value="Star">
-                <span class="icon material-symbols-outlined" translate="no">star</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >star</span
+                >
                 <span class="label">Star</span>
               </div>
 
               <div ngMenuItem value="Label" [disabled]="true">
-                <span class="icon material-symbols-outlined" translate="no">label</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >label</span
+                >
                 <span class="label">Label</span>
               </div>
             </div>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.html
@@ -11,12 +11,14 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read" [disabled]="true">
-        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >mark_email_read</span
+        >
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined" translate="no">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -29,9 +31,13 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined" translate="no">category</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >category</span
+        >
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -43,17 +49,23 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined" translate="no">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label_important</span
+              >
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined" translate="no">star</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >star</span
+              >
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined" translate="no">label</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label</span
+              >
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -63,17 +75,19 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined" translate="no">archive</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >archive</span
+        >
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined" translate="no">report</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined" translate="no">delete</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/app/app.html
@@ -9,12 +9,14 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >mark_email_read</span
+        >
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined" translate="no">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -27,9 +29,13 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined" translate="no">category</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >category</span
+        >
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -41,17 +47,23 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined" translate="no">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label_important</span
+              >
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined" translate="no">star</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >star</span
+              >
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined" translate="no">label</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label</span
+              >
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -61,17 +73,19 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined" translate="no">archive</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >archive</span
+        >
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined" translate="no">report</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined" translate="no">delete</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.html
@@ -10,17 +10,23 @@
     <ng-template ngMenuContent>
       <div class="group">
         <div ngMenuItem value="Mark as read">
-          <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >mark_email_read</span
+          >
           <span class="label">Mark as read</span>
         </div>
 
         <div ngMenuItem value="Snooze">
-          <span class="icon material-symbols-outlined" translate="no">snooze</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >snooze</span
+          >
           <span class="label">Snooze</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Delete</span>
         </div>
       </div>
@@ -33,9 +39,13 @@
           #categorizeItem
           [submenu]="categorizeMenu()"
         >
-          <span class="icon material-symbols-outlined" translate="no">category</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >category</span
+          >
           <span class="label">Categorize</span>
-          <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+          <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
       </div>
 
@@ -49,17 +59,23 @@
           <ng-template ngMenuContent>
             <div class="group">
               <div ngMenuItem value="Mark as important">
-                <span class="icon material-symbols-outlined" translate="no">label_important</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >label_important</span
+                >
                 <span class="label">Mark as important</span>
               </div>
 
               <div ngMenuItem value="Star">
-                <span class="icon material-symbols-outlined" translate="no">star</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >star</span
+                >
                 <span class="label">Star</span>
               </div>
 
               <div ngMenuItem value="Label">
-                <span class="icon material-symbols-outlined" translate="no">label</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >label</span
+                >
                 <span class="label">Label</span>
               </div>
             </div>

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.html
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.html
@@ -11,12 +11,14 @@
   <div ngMenu class="menu" #formatMenu="ngMenu">
     <ng-template ngMenuContent>
       <div ngMenuItem value="Mark as read">
-        <span class="icon material-symbols-outlined" translate="no">mark_email_read</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >mark_email_read</span
+        >
         <span class="label">Mark as read</span>
       </div>
 
       <div ngMenuItem value="Snooze">
-        <span class="icon material-symbols-outlined" translate="no">snooze</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">snooze</span>
         <span class="label">Snooze</span>
       </div>
 
@@ -29,9 +31,13 @@
         #categorizeItem
         [submenu]="categorizeMenu()"
       >
-        <span class="icon material-symbols-outlined" translate="no">category</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >category</span
+        >
         <span class="label">Categorize</span>
-        <span class="icon material-symbols-outlined arrow" translate="no">arrow_right</span>
+        <span class="icon material-symbols-outlined arrow" translate="no" aria-hidden="true"
+          >arrow_right</span
+        >
       </div>
 
       <ng-template
@@ -43,17 +49,23 @@
         <div ngMenu class="menu" #categorizeMenu="ngMenu">
           <ng-template ngMenuContent>
             <div ngMenuItem value="Mark as important">
-              <span class="icon material-symbols-outlined" translate="no">label_important</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label_important</span
+              >
               <span class="label">Mark as important</span>
             </div>
 
             <div ngMenuItem value="Star">
-              <span class="icon material-symbols-outlined" translate="no">star</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >star</span
+              >
               <span class="label">Star</span>
             </div>
 
             <div ngMenuItem value="Label">
-              <span class="icon material-symbols-outlined" translate="no">label</span>
+              <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                >label</span
+              >
               <span class="label">Label</span>
             </div>
           </ng-template>
@@ -63,17 +75,19 @@
       <div role="separator" aria-orientation="horizontal" class="separator"></div>
 
       <div ngMenuItem value="Archive">
-        <span class="icon material-symbols-outlined" translate="no">archive</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+          >archive</span
+        >
         <span class="label">Archive</span>
       </div>
 
       <div ngMenuItem value="Report spam">
-        <span class="icon material-symbols-outlined" translate="no">report</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">report</span>
         <span class="label">Report spam</span>
       </div>
 
       <div ngMenuItem value="Delete">
-        <span class="icon material-symbols-outlined" translate="no">delete</span>
+        <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">delete</span>
         <span class="label">Delete</span>
       </div>
     </ng-template>

--- a/adev/src/content/examples/aria/menubar/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_right</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_right</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_right</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_left</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_left</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
@@ -19,28 +19,38 @@
     <div ngMenu #fileMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="New">
-          <span class="icon material-symbols-outlined" translate="no">article</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >article</span
+          >
           <span class="label">New</span>
           <span class="shortcut">⌘N</span>
         </div>
 
         <div ngMenuItem value="Open">
-          <span class="icon material-symbols-outlined" translate="no">folder</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >folder</span
+          >
           <span class="label">Open</span>
           <span class="shortcut">⌘O</span>
         </div>
 
         <div ngMenuItem value="Make a copy">
-          <span class="icon material-symbols-outlined" translate="no">file_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >file_copy</span
+          >
           <span class="label">Make a copy</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem #shareEl value="Share" [submenu]="shareMenu()">
-          <span class="icon material-symbols-outlined" translate="no">person_add</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >person_add</span
+          >
           <span class="label">Share</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -52,12 +62,16 @@
           <div ngMenu #shareMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Share with others">
-                <span class="icon material-symbols-outlined" translate="no">person_add</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >person_add</span
+                >
                 <span class="label">Share with others</span>
               </div>
 
               <div ngMenuItem value="Publish to web">
-                <span class="icon material-symbols-outlined" translate="no">public</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >public</span
+                >
                 <span class="label">Publish to web</span>
               </div>
             </ng-template>
@@ -65,24 +79,30 @@
         </ng-template>
 
         <div ngMenuItem value="Download">
-          <span class="icon material-symbols-outlined" translate="no">download</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >download</span
+          >
           <span class="label">Download</span>
         </div>
 
         <div ngMenuItem value="Print">
-          <span class="icon material-symbols-outlined" translate="no">print</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >print</span
+          >
           <span class="label">Print</span>
         </div>
 
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Rename">
-          <span class="icon material-symbols-outlined" translate="no">edit</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">edit</span>
           <span class="label">Rename</span>
         </div>
 
         <div ngMenuItem value="Delete">
-          <span class="icon material-symbols-outlined" translate="no">delete</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >delete</span
+          >
           <span class="label">Move to trash</span>
         </div>
       </ng-template>
@@ -109,13 +129,13 @@
     <div ngMenu #editMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Undo">
-          <span class="icon material-symbols-outlined" translate="no">undo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">undo</span>
           <span class="label">Undo</span>
           <span class="shortcut">⌘Z</span>
         </div>
 
         <div ngMenuItem value="Redo">
-          <span class="icon material-symbols-outlined" translate="no">redo</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true">redo</span>
           <span class="label">Redo</span>
           <span class="shortcut">⌘Y</span>
         </div>
@@ -123,19 +143,25 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Cut">
-          <span class="icon material-symbols-outlined" translate="no">content_cut</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_cut</span
+          >
           <span class="label">Cut</span>
           <span class="shortcut">⌘X</span>
         </div>
 
         <div ngMenuItem value="Copy">
-          <span class="icon material-symbols-outlined" translate="no">content_copy</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_copy</span
+          >
           <span class="label">Copy</span>
           <span class="shortcut">⌘C</span>
         </div>
 
         <div ngMenuItem value="Paste">
-          <span class="icon material-symbols-outlined" translate="no">content_paste</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >content_paste</span
+          >
           <span class="label">Paste</span>
           <span class="shortcut">⌘V</span>
         </div>
@@ -143,7 +169,9 @@
         <div role="separator" class="example-menu-item-separator"></div>
 
         <div ngMenuItem value="Find and replace">
-          <span class="icon material-symbols-outlined" translate="no">find_replace</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >find_replace</span
+          >
           <span class="label">Find and replace</span>
           <span class="shortcut">⇧⌘H</span>
         </div>
@@ -171,12 +199,16 @@
     <div ngMenu #viewMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem value="Show print layout" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show print layout</span>
         </div>
 
         <div ngMenuItem value="Show ruler" [disabled]="true">
-          <span class="icon material-symbols-outlined" translate="no">check</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >check</span
+          >
           <span class="label">Show ruler</span>
         </div>
 
@@ -221,9 +253,13 @@
     <div ngMenu #insertMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #imageEl value="Image" [submenu]="imageMenu()">
-          <span class="icon material-symbols-outlined" translate="no">image</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >image</span
+          >
           <span class="label">Image</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -235,17 +271,23 @@
           <div ngMenu #imageMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Upload from computer">
-                <span class="icon material-symbols-outlined" translate="no">upload</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >upload</span
+                >
                 <span class="label">Upload from computer</span>
               </div>
 
               <div ngMenuItem value="Search the web">
-                <span class="icon material-symbols-outlined" translate="no">search</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >search</span
+                >
                 <span class="label">Search the web</span>
               </div>
 
               <div ngMenuItem value="By URL">
-                <span class="icon material-symbols-outlined" translate="no">link</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >link</span
+                >
                 <span class="label">By URL</span>
               </div>
             </ng-template>
@@ -253,14 +295,20 @@
         </ng-template>
 
         <div ngMenuItem value="Table">
-          <span class="icon material-symbols-outlined" translate="no">table_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >table_chart</span
+          >
           <span class="label">Table</span>
         </div>
 
         <div ngMenuItem #chartEl value="Chart" [submenu]="chartMenu()">
-          <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >insert_chart</span
+          >
           <span class="label">Chart</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -272,22 +320,30 @@
           <div ngMenu #chartMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bar">
-                <span class="icon material-symbols-outlined" translate="no">bar_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >bar_chart</span
+                >
                 <span class="label">Bar</span>
               </div>
 
               <div ngMenuItem value="Column">
-                <span class="icon material-symbols-outlined" translate="no">insert_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >insert_chart</span
+                >
                 <span class="label">Column</span>
               </div>
 
               <div ngMenuItem value="Line">
-                <span class="icon material-symbols-outlined" translate="no">show_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >show_chart</span
+                >
                 <span class="label">Line</span>
               </div>
 
               <div ngMenuItem value="Pie">
-                <span class="icon material-symbols-outlined" translate="no">pie_chart</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >pie_chart</span
+                >
                 <span class="label">Pie</span>
               </div>
             </ng-template>
@@ -295,7 +351,9 @@
         </ng-template>
 
         <div ngMenuItem value="Horizontal line">
-          <span class="icon material-symbols-outlined" translate="no">horizontal_rule</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >horizontal_rule</span
+          >
           <span class="label">Horizontal line</span>
         </div>
       </ng-template>
@@ -322,9 +380,13 @@
     <div ngMenu #formatMenu="ngMenu">
       <ng-template ngMenuContent>
         <div ngMenuItem #textEl #textItem="ngMenuItem" value="Text" [submenu]="textMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_bold</span
+          >
           <span class="label">Text</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -336,25 +398,33 @@
           <div ngMenu #textMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Bold">
-                <span class="icon material-symbols-outlined" translate="no">format_bold</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_bold</span
+                >
                 <span class="label">Bold</span>
                 <span class="shortcut">⌘B</span>
               </div>
 
               <div ngMenuItem value="Italic">
-                <span class="icon material-symbols-outlined" translate="no">format_italic</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_italic</span
+                >
                 <span class="label">Italic</span>
                 <span class="shortcut">⌘I</span>
               </div>
 
               <div ngMenuItem value="Underline">
-                <span class="icon material-symbols-outlined" translate="no">format_underlined</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_underlined</span
+                >
                 <span class="label">Underline</span>
                 <span class="shortcut">⌘U</span>
               </div>
 
               <div ngMenuItem value="Strikethrough">
-                <span class="icon material-symbols-outlined" translate="no">strikethrough_s</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >strikethrough_s</span
+                >
                 <span class="label">Strikethrough</span>
                 <span class="shortcut">⇧⌘X</span>
               </div>
@@ -363,7 +433,9 @@
 
               <div ngMenuItem #sizeEl value="Size" [submenu]="sizeMenu()">
                 <span class="label">Size</span>
-                <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+                <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+                  >arrow_left</span
+                >
               </div>
 
               <ng-template
@@ -391,9 +463,13 @@
         </ng-template>
 
         <div ngMenuItem #paragraphEl value="Paragraph styles" [submenu]="paragraphMenu()">
-          <span class="icon material-symbols-outlined" translate="no">format_align_justify</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_align_justify</span
+          >
           <span class="label">Paragraph styles</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -412,9 +488,13 @@
         </ng-template>
 
         <div ngMenuItem #alignEl [submenu]="alignMenu()" value="Align & indent">
-          <span class="icon material-symbols-outlined" translate="no">format_indent_increase</span>
+          <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+            >format_indent_increase</span
+          >
           <span class="label">Align & indent</span>
-          <span class="icon arrow material-symbols-outlined" translate="no">arrow_left</span>
+          <span class="icon arrow material-symbols-outlined" translate="no" aria-hidden="true"
+            >arrow_left</span
+          >
         </div>
 
         <ng-template
@@ -426,26 +506,28 @@
           <div ngMenu #alignMenu="ngMenu">
             <ng-template ngMenuContent>
               <div ngMenuItem value="Align left">
-                <span class="icon material-symbols-outlined" translate="no">format_align_left</span>
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
+                  >format_align_left</span
+                >
                 <span class="label">Align left</span>
               </div>
 
               <div ngMenuItem value="Align center">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_center</span
                 >
                 <span class="label">Align center</span>
               </div>
 
               <div ngMenuItem value="Align right">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_right</span
                 >
                 <span class="label">Align right</span>
               </div>
 
               <div ngMenuItem value="Justify">
-                <span class="icon material-symbols-outlined" translate="no"
+                <span class="icon material-symbols-outlined" translate="no" aria-hidden="true"
                   >format_align_justify</span
                 >
                 <span class="label">Justify</span>

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label.value) {
             <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label.value) {
             <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label.value) {
             <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/material/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/basic/retro/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/material/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/disabled/retro/app/app.html
@@ -4,7 +4,9 @@
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -17,7 +19,10 @@
           @for (label of labels; track label) {
             <div ngOption [value]="label" [label]="label">
               <span class="example-option-text">{{label}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/material/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/select/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/select/src/icons/retro/app/app.html
@@ -4,12 +4,15 @@
       <span
         class="selected-label-icon material-symbols-outlined"
         translate="no"
+        aria-hidden="true"
         >{{ displayIcon() }}</span
       >
       <span class="selected-label-text">{{ displayValue() }}</span>
     </span>
     <input aria-label="Label dropdown" placeholder="Select a label" ngComboboxInput />
-    <span class="example-arrow material-symbols-outlined" translate="no">arrow_drop_down</span>
+    <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+      >arrow_drop_down</span
+    >
   </div>
 
   <ng-template ngComboboxPopupContainer>
@@ -24,10 +27,14 @@
               <span
                 class="example-option-icon material-symbols-outlined"
                 translate="no"
+                aria-hidden="true"
                 >{{label.icon}}</span
               >
               <span class="example-option-text">{{label.value}}</span>
-              <span class="example-option-check material-symbols-outlined" translate="no"
+              <span
+                class="example-option-check material-symbols-outlined"
+                translate="no"
+                aria-hidden="true"
                 >check</span
               >
             </div>

--- a/adev/src/content/examples/aria/tabs/src/vertical/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/app/app.html
@@ -1,13 +1,15 @@
 <div ngTabs>
   <div ngTabList orientation="vertical" selectedTab="movie">
     <div ngTab value="movie">
-      <span class="material-symbols-outlined" translate="no">videocam</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">videocam</span>
     </div>
     <div ngTab value="theatres">
-      <span class="material-symbols-outlined" translate="no">theater_comedy</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >theater_comedy</span
+      >
     </div>
     <div ngTab value="showtimes">
-      <span class="material-symbols-outlined" translate="no">reviews</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">reviews</span>
     </div>
   </div>
 

--- a/adev/src/content/examples/aria/tabs/src/vertical/material/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/material/app/app.html
@@ -1,13 +1,15 @@
 <div ngTabs>
   <div ngTabList class="material-tabs" orientation="vertical" selectedTab="movie">
     <div ngTab value="movie">
-      <span class="material-symbols-outlined" translate="no">videocam</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">videocam</span>
     </div>
     <div ngTab value="theatres">
-      <span class="material-symbols-outlined" translate="no">theater_comedy</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >theater_comedy</span
+      >
     </div>
     <div ngTab value="showtimes">
-      <span class="material-symbols-outlined" translate="no">reviews</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">reviews</span>
     </div>
     <div class="bottom-border"></div>
   </div>

--- a/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.html
+++ b/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.html
@@ -1,13 +1,15 @@
 <div ngTabs class="retro-tabs">
   <div ngTabList orientation="vertical" selectedTab="movie">
     <div ngTab value="movie">
-      <span class="material-symbols-outlined" translate="no">videocam</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">videocam</span>
     </div>
     <div ngTab value="theatres">
-      <span class="material-symbols-outlined" translate="no">theater_comedy</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true"
+        >theater_comedy</span
+      >
     </div>
     <div ngTab value="showtimes">
-      <span class="material-symbols-outlined" translate="no">reviews</span>
+      <span class="material-symbols-outlined" translate="no" aria-hidden="true">reviews</span>
     </div>
   </div>
 

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/basic/app/app.html
@@ -29,7 +29,11 @@
         >{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/disabled-focusable/retro/app/app.html
@@ -56,7 +56,11 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/basic/app/app.html
@@ -29,7 +29,11 @@
         >{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/multi-select/retro/app/app.html
@@ -56,7 +56,11 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/nav/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/nav/basic/app/app.html
@@ -19,7 +19,13 @@
       href="#{{ node.name }}"
       (click)="$event.preventDefault()"
     >
-      <span aria-hidden="true" class="material-symbols-outlined" translate="no">{{node.icon}}</span>
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined"
+        translate="no"
+        aria-hidden="true"
+        >{{node.icon}}</span
+      >
       {{ node.name }}
       <span
         aria-hidden="true"

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/basic/app/app.html
@@ -29,7 +29,11 @@
         >{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select-follow-focus/retro/app/app.html
@@ -56,7 +56,11 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.html
@@ -29,7 +29,11 @@
         >{{node.children ? 'folder' : 'docs'}}</span
       >
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>

--- a/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/retro/app/app.html
@@ -56,7 +56,11 @@
         }
       </span>
       {{ node.name }}
-      <span aria-hidden="true" class="material-symbols-outlined selected-icon" translate="no"
+      <span
+        aria-hidden="true"
+        class="material-symbols-outlined selected-icon"
+        translate="no"
+        aria-hidden="true"
         >check</span
       >
     </li>


### PR DESCRIPTION
Add aria-hidden="true" to decorative icon elements in the ARIA menu documentation example to prevent screen readers from announcing both icon names and labels. This improves the accessibility experience by ensuring only meaningful text is announced to screen reader users.

Fixes: #65768

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65768


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
