### PR TITLE
fix(http): prevent XSRF token leakage to protocol-relative URLs for angular 12

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -19,6 +19,10 @@ export const XSRF_COOKIE_NAME = new InjectionToken<string>('XSRF_COOKIE_NAME');
 export const XSRF_HEADER_NAME = new InjectionToken<string>('XSRF_HEADER_NAME');
 
 /**
+ * Regex to match absolute URLs, including protocol-relative URLs.
+ */
+const ABSOLUTE_URL_REGEX = /^(?:https?:)?\/\//i;
+/**
  * Retrieves the current XSRF token to use with the next outgoing request.
  *
  * @publicApi
@@ -78,8 +82,7 @@ export class HttpXsrfInterceptor implements HttpInterceptor {
     // Non-mutating requests don't require a token, and absolute URLs require special handling
     // anyway as the cookie set
     // on our origin is not the same as the token expected by another origin.
-    if (req.method === 'GET' || req.method === 'HEAD' || lcUrl.startsWith('http://') ||
-        lcUrl.startsWith('https://')) {
+    if (req.method === 'GET' || req.method === 'HEAD' || ABSOLUTE_URL_REGEX.test(req.url)) {
       return next.handle(req);
     }
     const token = this.tokenService.getToken();

--- a/packages/common/http/test/xsrf_spec.ts
+++ b/packages/common/http/test/xsrf_spec.ts
@@ -47,6 +47,21 @@ class SampleTokenExtractor extends HttpXsrfTokenExtractor {
       expect(req.request.headers.has('X-XSRF-TOKEN')).toEqual(false);
       req.flush({});
     });
+    it('does not apply XSRF protection when request is absolute', () => {
+      interceptor
+        .intercept(new HttpRequest('POST', 'https://example.com/test', {}), backend)
+        .subscribe();
+      const req = backend.expectOne('https://example.com/test');
+      expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+      req.flush({});
+    });
+
+    it('does not apply XSRF protection when request is protocol relative', () => {
+      interceptor.intercept(new HttpRequest('POST', '//example.com/test', {}), backend).subscribe();
+      const req = backend.expectOne('//example.com/test');
+      expect(req.request.headers.has('X-XSRF-TOKEN')).toBeFalse();
+      req.flush({});
+    });
     it('does not overwrite existing header', () => {
       interceptor
           .intercept(


### PR DESCRIPTION
The XSRF interceptor previously failed to detect protocol-relative URLs (starting with `//`) as absolute URLs. This allowed requests to such URLs to include the XSRF token, potentially leaking it to external domains.

This change updates the interceptor to correctly identify protocol-relative URLs as absolute and exclude them from receiving the XSRF token.

based on:
https://github.com/angular/angular/pull/65619

for angular 12. we still use it in one of the production apps and this fix is crucial for us.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

