### PR TITLE
DevTools tree visualizer improvements

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -296,3 +296,51 @@ export function d3InjectorTreeNodeModifier(d3Node: SvgD3Node<InjectorTreeNode>) 
       return -1;
     });
 }
+
+/** Returns whether InjectorTreeNodes are equal (excl. children comparison). */
+export function areInjectorTreeNodesEqual(a: InjectorTreeNode, b: InjectorTreeNode): boolean {
+  const isSameInjector = equalInjector(a?.injector, b?.injector);
+  const isSameLabel = a?.label === b?.label;
+  const isSameSubLabel = a?.subLabel === b?.subLabel;
+
+  return isSameInjector && isSameLabel && isSameSubLabel;
+}
+
+/** Returns whether injector trees (InjectorTreeNodes with children) are equal. */
+export function areInjectorTreesEqual(
+  a: InjectorTreeNode | null,
+  b: InjectorTreeNode | null,
+): boolean {
+  if (!a && !b) {
+    return true;
+  }
+  if ((a && !b) || (!a && b)) {
+    return false;
+  }
+
+  const stackA: InjectorTreeNode[] = [a!];
+  const stackB: InjectorTreeNode[] = [b!];
+
+  while (stackA.length && stackB.length) {
+    const aNode = stackA.pop()!;
+    const bNode = stackB.pop()!;
+
+    const isDiffChildrenLength = aNode?.children.length !== bNode?.children.length;
+
+    if (!areInjectorTreeNodesEqual(aNode, bNode) || isDiffChildrenLength) {
+      return false;
+    }
+
+    if (aNode?.children && bNode?.children) {
+      for (let i = 0; i < aNode.children.length; i++) {
+        const aChild = aNode.children[i];
+        const bChild = bNode.children[i];
+
+        stackA.push(aChild);
+        stackB.push(bChild);
+      }
+    }
+  }
+
+  return true;
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.html
@@ -37,6 +37,7 @@
                   #environmentTree
                   a11yTitle="Environment hierarchy visualization"
                   [root]="environmentInjectorTree()!"
+                  [nodeEqualityFn]="treeNodesEqualityFn"
                   [config]="environmentTreeConfig"
                   (nodeClick)="selectInjectorByNode($event)"
                   (render)="onTreeRender(environmentTree, $event)"
@@ -55,6 +56,7 @@
                   #elementTree
                   a11yTitle="Element hierarchy visualization"
                   [root]="elementInjectorTree()!"
+                  [nodeEqualityFn]="treeNodesEqualityFn"
                   [config]="elementTreeConfig"
                   (nodeClick)="selectInjectorByNode($event)"
                   (render)="onTreeRender(elementTree, $event)"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -30,6 +30,7 @@ import {TreeD3Node, TreeVisualizerConfig} from '../../shared/tree-visualizer/tre
 import {TreeVisualizerComponent} from '../../shared/tree-visualizer/tree-visualizer.component';
 import {InjectorProvidersComponent} from './injector-providers/injector-providers.component';
 import {
+  areInjectorTreesEqual,
   d3InjectorTreeLinkModifier,
   d3InjectorTreeNodeModifier,
   filterOutAngularInjectors,
@@ -103,8 +104,12 @@ export class InjectorTreeComponent {
   private hideInjectorsWithNoProviders = false;
   private hideFrameworkInjectors = false;
 
-  protected readonly elementInjectorTree = signal<InjectorTreeNode | null>(null);
-  protected readonly environmentInjectorTree = signal<InjectorTreeNode | null>(null);
+  protected readonly elementInjectorTree = signal<InjectorTreeNode | null>(null, {
+    equal: areInjectorTreesEqual,
+  });
+  protected readonly environmentInjectorTree = signal<InjectorTreeNode | null>(null, {
+    equal: areInjectorTreesEqual,
+  });
 
   protected readonly responsiveSplitConfig: ResponsiveSplitConfig = {
     defaultDirection: 'vertical',

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -30,6 +30,7 @@ import {TreeD3Node, TreeVisualizerConfig} from '../../shared/tree-visualizer/tre
 import {TreeVisualizerComponent} from '../../shared/tree-visualizer/tree-visualizer.component';
 import {InjectorProvidersComponent} from './injector-providers/injector-providers.component';
 import {
+  areInjectorTreeNodesEqual,
   areInjectorTreesEqual,
   d3InjectorTreeLinkModifier,
   d3InjectorTreeNodeModifier,
@@ -92,6 +93,8 @@ export class InjectorTreeComponent {
   protected readonly providers = input.required<SerializedProviderRecord[]>();
   protected readonly componentExplorerView = input.required<ComponentExplorerView | null>();
   protected readonly hidden = input(false);
+
+  protected readonly treeNodesEqualityFn = areInjectorTreeNodesEqual;
 
   protected readonly diDebugAPIsAvailable = computed<boolean>(() => {
     const view = this.componentExplorerView();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -163,7 +163,12 @@ export class InjectorTreeComponent {
 
   onTreeRender(tree: InjectorTreeVisualizer, {initial}: {initial: boolean}) {
     if (initial) {
-      this.snapToRoot(tree);
+      // Slightly defer the node snapping since the production app
+      // needs a bit more time for registering the tree container size.
+      // INFO: Container size is not bound/related to tree rendering.
+      setTimeout(() => {
+        this.snapToRoot(tree);
+      }, 100);
     }
   }
 

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
@@ -19,7 +19,13 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import {TreeD3Node, TreeNode, TreeVisualizer, TreeVisualizerConfig} from './tree-visualizer';
+import {
+  TreeD3Node,
+  TreeNode,
+  TreeNodeEqualityFn,
+  TreeVisualizer,
+  TreeVisualizerConfig,
+} from './tree-visualizer';
 
 let instanceIdx = 0;
 
@@ -45,6 +51,7 @@ export class TreeVisualizerComponent<T extends TreeNode = TreeNode> {
   protected readonly group = viewChild.required<ElementRef>('group');
 
   readonly root = input.required<T>();
+  protected readonly nodeEqualityFn = input<TreeNodeEqualityFn<T> | null>(null);
   protected readonly config = input<Partial<TreeVisualizerConfig<T>>>();
   protected readonly a11yTitle = input.required<string>();
   protected readonly a11yTitleId = `tree-vis-host-${++instanceIdx}`;
@@ -68,6 +75,7 @@ export class TreeVisualizerComponent<T extends TreeNode = TreeNode> {
           new TreeVisualizer<T>(
             this.container().nativeElement,
             this.group().nativeElement,
+            this.nodeEqualityFn(),
             this.config(),
           ),
         );


### PR DESCRIPTION
The PR includes 3 changes:

### perf(devtools): improve injector tree rendering performance

Introduce an equality function for transformed injector trees in order to omit redundant D3 tree visualization render cycles when the underlying tree data structure hasn't been changed. 

In the specific case of the demo app, the render calls are reduced by 57%.

### fix(devtools): retain tree-viz snapped node on pre-render cleanup

Each tree-visualizer render cycle resets the snapped node in an effort to not end up with a non-existent snapped node. However, each render cycle doesn't constitute a completely different tree. This change retains the snapped node as long as it exists in the tree.

This also fixes a concrete issue where the initially snapped root node in the Injector Tree tab doesn't work after container resize.

### fix(devtools): injector tree initial root node snapping on prod

Fix initial broken root node snapping/focusing when the Injector Tree tab is opened in the production app.