### PR TITLE
feat(forms): introduce `ReadonlyFieldState` type for immutable field …

### DIFF
--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -9,6 +9,17 @@
 import {type Provider} from '@angular/core';
 import {SIGNAL_FORMS_CONFIG} from '../field/di';
 import type {FormField} from '../directive/form_field_directive';
+import type {FieldStateSnapshot} from './types';
+
+/**
+ * A readonly snapshot of a form field.
+ *
+ * @category control
+ * @experimental 21.0.0
+ */
+export type FormFieldSnapshot = Pick<FormField<unknown>, 'element' | 'errors' | 'parseErrors'> & {
+  readonly state: FieldStateSnapshot<unknown>;
+};
 
 /**
  * Configuration options for signal forms.
@@ -17,7 +28,7 @@ import type {FormField} from '../directive/form_field_directive';
  */
 export interface SignalFormsConfig {
   /** A map of CSS class names to predicate functions that determine when to apply them. */
-  classes?: {[className: string]: (state: FormField<unknown>) => boolean};
+  classes?: {[className: string]: (state: FormFieldSnapshot) => boolean};
 }
 
 /**

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -398,6 +398,28 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 }
 
 /**
+ * A readonly snapshot of a field's state.
+ *
+ * This type removes all mutable operations from {@link FieldState}, providing only readonly access
+ * to the field's current state values. This is useful for scenarios where code needs to read the
+ * state without being able to modify it, such as in CSS class predicates.
+ *
+ * @category structure
+ * @experimental 21.0.0
+ */
+export type FieldStateSnapshot<TValue, TKey extends string | number = string | number> = Omit<
+  FieldState<TValue, TKey>,
+  | 'markAsDirty'
+  | 'markAsTouched'
+  | 'metadata'
+  | 'reset'
+  | 'focusBoundControl'
+  | 'formFieldBindings'
+  | 'value'
+  | 'controlValue'
+>;
+
+/**
  * This is FieldState also providing access to the wrapped FormControl.
  *
  * @category interop

--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -30,6 +30,7 @@ import {RuntimeErrorCode} from '../errors';
 import {SIGNAL_FORMS_CONFIG} from '../field/di';
 import type {FieldNode} from '../field/node';
 import type {FieldTree} from '../api/types';
+import type {FormFieldSnapshot} from '../api/di';
 import {
   isNativeFormElement,
   isNumericFormElement,
@@ -193,7 +194,7 @@ export class FormField<T> {
   private installClassBindingEffect(): void {
     const classes = Object.entries(this.config?.classes ?? {}).map(
       ([className, computation]) =>
-        [className, computed(() => computation(this as FormField<unknown>))] as const,
+        [className, computed(() => computation(this as FormFieldSnapshot))] as const,
     );
     if (classes.length === 0) {
       return;

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -6,8 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {signal, WritableSignal} from '@angular/core';
-import {FieldTree, form, required, schema, SchemaFn} from '../../public_api';
+import {signal, WritableSignal, Signal} from '@angular/core';
+import {
+  FieldTree,
+  form,
+  required,
+  schema,
+  SchemaFn,
+  FieldStateSnapshot,
+  FormFieldSnapshot,
+  SignalFormsConfig,
+} from '../../public_api';
 
 interface Order {
   id: string;
@@ -111,6 +120,136 @@ function typeVerificationOnlyDoNotRunMe() {
         const p: FieldTree<string> = product;
         p().value();
       }
+    });
+
+    describe('FieldStateSnapshot', () => {
+      it('should not expose mutation methods', () => {
+        const state: FieldStateSnapshot<string> = null!;
+        // @ts-expect-error
+        state.markAsDirty;
+        // @ts-expect-error
+        state.markAsTouched;
+        // @ts-expect-error
+        state.reset;
+        // @ts-expect-error
+        state.metadata;
+        // @ts-expect-error
+        state.focusBoundControl;
+        // @ts-expect-error
+        state.formFieldBindings;
+        // @ts-expect-error
+        state.value;
+        // @ts-expect-error
+        state.controlValue;
+      });
+
+      it('should expose read-only signal properties', () => {
+        const state: FieldStateSnapshot<string> = null!;
+        state.dirty;
+        state.touched;
+        state.valid;
+        state.invalid;
+        state.pending;
+        state.disabled;
+        state.errors;
+        state.errorSummary;
+        state.hidden;
+        state.readonly;
+        state.required;
+        state.name;
+        state.pattern;
+        state.disabledReasons;
+        state.submitting;
+        state.keyInParent;
+        state.max;
+        state.min;
+        state.maxLength;
+        state.minLength;
+      });
+    });
+
+    describe('FormFieldSnapshot', () => {
+      it('should not expose mutation methods', () => {
+        const snapshot: FormFieldSnapshot = null!;
+        // @ts-expect-error
+        snapshot.focus;
+        // @ts-expect-error
+        snapshot.registerAsBinding;
+        // @ts-expect-error
+        snapshot.fieldTree;
+        // @ts-expect-error
+        snapshot.state.markAsDirty;
+        // @ts-expect-error
+        snapshot.state.markAsTouched;
+        // @ts-expect-error
+        snapshot.state.reset;
+        // @ts-expect-error
+        snapshot.state.value;
+        // @ts-expect-error
+        snapshot.state.controlValue;
+      });
+
+      it('should expose read-only properties', () => {
+        const snapshot: FormFieldSnapshot = null!;
+        snapshot.element;
+        snapshot.errors;
+        snapshot.parseErrors;
+        snapshot.state;
+        snapshot.state.dirty;
+        snapshot.state.touched;
+        snapshot.state.valid;
+        snapshot.state.invalid;
+        snapshot.state.disabled;
+        snapshot.state.errors;
+        snapshot.state.hidden;
+      });
+    });
+
+    describe('SignalFormsConfig', () => {
+      it('should accept FormFieldSnapshot in classes predicate', () => {
+        const config: SignalFormsConfig = {
+          classes: {
+            'my-class': (state: FormFieldSnapshot) => {
+              // Can access readonly properties
+              state.element;
+              state.errors;
+              state.parseErrors;
+              state.state.valid;
+              state.state.invalid;
+              state.state.dirty;
+              state.state.touched;
+              state.state.disabled;
+              return state.state.valid();
+            },
+          },
+        };
+      });
+
+      it('should not allow mutation methods in classes predicate', () => {
+        const config: SignalFormsConfig = {
+          classes: {
+            'invalid-class': (state: FormFieldSnapshot) => {
+              // @ts-expect-error
+              state.focus;
+              // @ts-expect-error
+              state.registerAsBinding;
+              // @ts-expect-error
+              state.fieldTree;
+              // @ts-expect-error
+              state.state.markAsDirty;
+              // @ts-expect-error
+              state.state.markAsTouched;
+              // @ts-expect-error
+              state.state.reset;
+              // @ts-expect-error
+              state.state.value;
+              // @ts-expect-error
+              state.state.controlValue;
+              return false;
+            },
+          },
+        };
+      });
     });
   });
 }


### PR DESCRIPTION
…state representation

Adds a `FormFieldSnapshot` type that provides a read-only view of the FormField, excluding methods that would mutate it.

Fixes #65779

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
