### PR TITLE
Adds `pristine` state signal to forms

### DIFF
--- a/adev/src/content/introduction/essentials/signal-forms.md
+++ b/adev/src/content/introduction/essentials/signal-forms.md
@@ -256,6 +256,7 @@ Every `field()` provides these state signals:
 | `valid()`    | Returns `true` if the field passes all validation rules                    |
 | `touched()`  | Returns `true` if the user has focused and blurred the field               |
 | `dirty()`    | Returns `true` if the user has changed the value                           |
+| `pristine()` | Returns `true` if the user has not changed the value                       |
 | `disabled()` | Returns `true` if the field is disabled                                    |
 | `readonly()` | Returns `true` if the field is readonly                                    |
 | `pending()`  | Returns `true` if async validation is in progress                          |

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -180,6 +180,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     metadata<M>(key: AggregateMetadataKey<M, any>): Signal<M>;
     metadata<M>(key: MetadataKey<M>): M | undefined;
     readonly pending: Signal<boolean>;
+    readonly pristine: Signal<boolean>;
     reset(value?: TValue): void;
     readonly submitting: Signal<boolean>;
     readonly valid: Signal<boolean>;

--- a/packages/forms/signals/compat/src/compat_node_state.ts
+++ b/packages/forms/signals/compat/src/compat_node_state.ts
@@ -18,6 +18,7 @@ import {CompatFieldNodeOptions} from './compat_structure';
 export class CompatNodeState extends FieldNodeState {
   override readonly touched: Signal<boolean>;
   override readonly dirty: Signal<boolean>;
+  override readonly pristine: Signal<boolean>;
   override readonly disabled: Signal<boolean>;
   private readonly control: Signal<AbstractControl>;
 
@@ -29,6 +30,7 @@ export class CompatNodeState extends FieldNodeState {
     this.control = options.control;
     this.touched = getControlEventsSignal(options, (c) => c.touched);
     this.dirty = getControlEventsSignal(options, (c) => c.dirty);
+    this.pristine = getControlEventsSignal(options, (c) => c.pristine);
     const controlDisabled = getControlStatusSignal(options, (c) => c.disabled);
 
     this.disabled = computed(() => {

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -234,6 +234,11 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   readonly dirty: Signal<boolean>;
 
   /**
+   * A signal indicating whether the field value has not been changed by user.
+   */
+  readonly pristine: Signal<boolean>;
+
+  /**
    * A signal indicating whether a field is hidden.
    *
    * When a field is hidden it is ignored when determining the valid, touched, and dirty states.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -134,6 +134,10 @@ export class FieldNode implements FieldState<unknown> {
     return this.nodeState.dirty;
   }
 
+  get pristine(): Signal<boolean> {
+    return this.nodeState.pristine;
+  }
+
   get touched(): Signal<boolean> {
     return this.nodeState.touched;
   }

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -85,6 +85,14 @@ export class FieldNodeState {
   });
 
   /**
+   * Whether this field is considered pristine.
+   *
+   * A field is considered pristine if it has not been dirtied by the user.
+   * This is the logical opposite of {@link dirty}.
+   */
+  readonly pristine: Signal<boolean> = computed(() => !this.dirty());
+
+  /**
    * Whether this field is considered touched.
    *
    * A field is considered touched if one of the following is true:

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -395,6 +395,37 @@ describe('Forms compat', () => {
       expect(f().dirty()).withContext('form is dirty when the child is dirty').toBeTrue();
     });
 
+    it('propagates pristine state to parent', () => {
+      const control = new FormControl(5, Validators.min(3));
+      const cat = signal({
+        name: 'pirojok-the-cat',
+        age: control,
+      });
+
+      const f = compatForm(cat, {
+        injector: TestBed.inject(Injector),
+      });
+
+      expect(f.age().pristine()).withContext('age is initially pristine').toBeTrue();
+      expect(f().pristine()).withContext('form is initially pristine').toBeTrue();
+
+      control.markAsDirty();
+
+      expect(f.age().pristine()).withContext('age is not pristine, when control is dirty').toBeFalse();
+      expect(f().pristine()).withContext('form is not pristine when the child is dirty').toBeFalse();
+
+      control.markAsPristine();
+
+      expect(f.age().pristine()).withContext('age is pristine when marked as pristine').toBeTrue();
+      expect(f().pristine())
+        .withContext('form is pristine when age is marked as pristine')
+        .toBeTrue();
+
+      f.age().markAsDirty();
+      expect(f.age().pristine()).withContext('age is not pristine, when control is dirty').toBeFalse();
+      expect(f().pristine()).withContext('form is not pristine when the child is dirty').toBeFalse();
+    });
+
     it('allows resetting state', () => {
       const control = new FormControl(5, Validators.min(3));
       const cat = signal({
@@ -411,6 +442,7 @@ describe('Forms compat', () => {
 
       expect(f.age().dirty()).toBeTrue();
       expect(f.age().touched()).toBeTrue();
+      expect(f.age().pristine()).toBeFalse();
 
       f.age().reset();
 
@@ -418,6 +450,7 @@ describe('Forms compat', () => {
       expect(f.age().touched()).toBeFalse();
       expect(f().dirty()).toBeFalse();
       expect(f().touched()).toBeFalse();
+      expect(f().pristine()).toBeTrue();
     });
   });
 

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -334,6 +334,58 @@ describe('FieldNode', () => {
     });
   });
 
+  describe('pristine', () => {
+    it('is pristine initially', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+      expect(f().pristine()).toBe(true);
+      expect(f.a().pristine()).toBe(true);
+    });
+
+    it('is not pristine when dirty', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+      expect(f().pristine()).toBe(true);
+
+      f().markAsDirty();
+      expect(f().pristine()).toBe(false);
+    });
+
+    it('becomes pristine after reset', () => {
+      const model = signal({a: 1, b: 2});
+      const f = form(model, {injector: TestBed.inject(Injector)});
+      f().markAsDirty();
+      expect(f().pristine()).toBe(false);
+
+      f().reset();
+      expect(f().pristine()).toBe(true);
+    });
+
+    it('is not pristine when child is dirty', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+      expect(f().pristine()).toBe(true);
+
+      f.a().markAsDirty();
+      expect(f().pristine()).toBe(false);
+    });
+  });
+
   describe('touched', () => {
     it('is untouched initially', () => {
       const f = form(


### PR DESCRIPTION
Adds a `pristine` state signal to form fields, indicating whether the user has modified the field's value. This aligns with the existing `pristine` property available in Angular Reactive Forms.

Fixes #65797

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
