### PR TITLE
fixed the 'router: equalParams incorrectly compares array query param…

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -92,8 +92,10 @@ export function containsTree(
 }
 
 function equalParams(container: Params, containee: Params): boolean {
-  // TODO: This does not handle array params correctly.
-  return shallowEqual(container, containee);
+  return (
+    Object.keys(container).length === Object.keys(containee).length &&
+    Object.keys(containee).every((key) => equalArraysOrString(container[key], containee[key]))
+  );
 }
 
 function equalSegmentGroups(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: Fixes #65817

`equalParams` in `@angular/router` uses `shallowEqual` to compare query parameters.
```ts
// TODO: This does not handle array params correctly.
return shallowEqual(container, containee);
```
This does not handle array-valued parameters correctly because arrays are compared by reference.  
Even when two arrays contain the same values in the same order, they are treated as unequal.

Example:

```ts
equalParams({ tags: ['a', 'b'] }, { tags: ['a', 'b'] }) // false (incorrect)
```

## What is the new behavior?
`equalParams` now performs a key-by-key comparison using the existing `equalArraysOrString` utility (already used in `containsParams`).

This ensures array query parameters are compared by content rather than reference.

### New implementation:
```ts
function equalParams(container: Params, containee: Params): boolean {
  return (
    Object.keys(container).length === Object.keys(containee).length &&
    Object.keys(containee).every((key) =>
      equalArraysOrString(container[key], containee[key])
    )
  );
}
```
### Updated behavior:
```ts
equalParams({ tags: ['a', 'b'] }, { tags: ['a', 'b'] }) // true
```
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
*   Resolves incorrect equality behavior for array-valued query parameters.
    
*   Aligns behavior with `containsParams`.
    
*   Removes the need for the TODO in the router source.
    
