### PR TITLE
feat(forms): Adds `untouched` state signal to forms

### DIFF
--- a/adev/src/content/introduction/essentials/signal-forms.md
+++ b/adev/src/content/introduction/essentials/signal-forms.md
@@ -251,15 +251,16 @@ Here's a complete example:
 
 Every `field()` provides these state signals:
 
-| State        | Description                                                                |
-| ------------ | -------------------------------------------------------------------------- |
-| `valid()`    | Returns `true` if the field passes all validation rules                    |
-| `touched()`  | Returns `true` if the user has focused and blurred the field               |
-| `dirty()`    | Returns `true` if the user has changed the value                           |
-| `disabled()` | Returns `true` if the field is disabled                                    |
-| `readonly()` | Returns `true` if the field is readonly                                    |
-| `pending()`  | Returns `true` if async validation is in progress                          |
-| `errors()`   | Returns an array of validation errors with `kind` and `message` properties |
+| State         | Description                                                                |
+| ------------- | -------------------------------------------------------------------------- |
+| `valid()`     | Returns `true` if the field passes all validation rules                    |
+| `untouched()` | Returns `true` if the user hasn't focused and blurred the field            |
+| `touched()`   | Returns `true` if the user has focused and blurred the field               |
+| `dirty()`     | Returns `true` if the user has changed the value                           |
+| `disabled()`  | Returns `true` if the field is disabled                                    |
+| `readonly()`  | Returns `true` if the field is readonly                                    |
+| `pending()`   | Returns `true` if async validation is in progress                          |
+| `errors()`    | Returns an array of validation errors with `kind` and `message` properties |
 
 ## Next steps
 

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -188,6 +188,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     readonly pending: Signal<boolean>;
     reset(value?: TValue): void;
     readonly submitting: Signal<boolean>;
+    readonly untouched: Signal<boolean>;
     readonly valid: Signal<boolean>;
 }
 

--- a/packages/forms/signals/compat/src/compat_node_state.ts
+++ b/packages/forms/signals/compat/src/compat_node_state.ts
@@ -17,6 +17,7 @@ import {CompatFieldNodeOptions} from './compat_structure';
  */
 export class CompatNodeState extends FieldNodeState {
   override readonly touched: Signal<boolean>;
+  override readonly untouched: Signal<boolean>;
   override readonly dirty: Signal<boolean>;
   override readonly disabled: Signal<boolean>;
   private readonly control: Signal<AbstractControl>;
@@ -28,6 +29,7 @@ export class CompatNodeState extends FieldNodeState {
     super(compatNode);
     this.control = options.control;
     this.touched = getControlEventsSignal(options, (c) => c.touched);
+    this.untouched = getControlEventsSignal(options, (c) => c.untouched);
     this.dirty = getControlEventsSignal(options, (c) => c.dirty);
     const controlDisabled = getControlStatusSignal(options, (c) => c.disabled);
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -255,6 +255,16 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   readonly errorSummary: Signal<ValidationError.WithField[]>;
 
   /**
+   * A signal indicating whether the field has been touched by the user.
+   */
+  readonly touched: Signal<boolean>;
+
+  /**
+   * A signal indicating whether the field has not been touched by the user.
+   */
+  readonly untouched: Signal<boolean>;
+
+  /**
    * A signal indicating whether the field's value is currently valid.
    *
    * Note: `valid()` is not the same as `!invalid()`.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -138,6 +138,10 @@ export class FieldNode implements FieldState<unknown> {
     return this.nodeState.touched;
   }
 
+  get untouched(): Signal<boolean> {
+    return this.nodeState.untouched;
+  }
+
   get disabled(): Signal<boolean> {
     return this.nodeState.disabled;
   }

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -102,6 +102,14 @@ export class FieldNodeState {
   });
 
   /**
+   * Whether this field is considered untouched.
+   *
+   * A field is considered untouched if it has not been touched by the user.
+   * This is the logical opposite of {@link touched}.
+   */
+  readonly untouched: Signal<boolean> = computed(() => !this.touched());
+
+  /**
    * The reasons for this field's disablement. This includes disabled reasons for any parent field
    * that may have been disabled, indirectly causing this field to be disabled as well.
    * The `field` property of the `DisabledReason` can be used to determine which field ultimately

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -336,6 +336,44 @@ describe('Forms compat', () => {
       expect(f().touched()).withContext('form is touched when a child is touched').toBeTrue();
     });
 
+    it('propagates untouched state to parent', async () => {
+      const control = new FormControl(5, Validators.min(3));
+      const cat = signal({
+        name: 'pirojok-the-cat',
+        age: control,
+      });
+
+      const f = compatForm(cat, {
+        injector: TestBed.inject(Injector),
+      });
+
+      expect(f.name().untouched()).withContext('name is initially untouched').toBeTrue();
+      expect(f().untouched()).withContext('form is initially untouched').toBeTrue();
+
+      control.markAsTouched();
+
+      expect(f.age().untouched())
+        .withContext('age is not untouched, when control is touched')
+        .toBeFalse();
+      expect(f().untouched())
+        .withContext('form is not untouched when a child is touched')
+        .toBeFalse();
+
+      control.markAsUntouched();
+
+      expect(f.name().untouched()).withContext('name is untouched when not touched').toBeTrue();
+      expect(f().untouched()).withContext('form is initially untouched').toBeTrue();
+
+      f.age().markAsTouched();
+
+      expect(f.age().untouched())
+        .withContext('age is not untouched, when control is touched')
+        .toBeFalse();
+      expect(f().untouched())
+        .withContext('form is not untouched when a child is touched')
+        .toBeFalse();
+    });
+
     it('picks up submittedState from parent', async () => {
       const control = new FormControl(5, Validators.min(3));
       const cat = signal({
@@ -418,6 +456,7 @@ describe('Forms compat', () => {
       expect(f.age().touched()).toBeFalse();
       expect(f().dirty()).toBeFalse();
       expect(f().touched()).toBeFalse();
+      expect(f().untouched).toBeTrue();
     });
   });
 


### PR DESCRIPTION
Adds an untouched state signal to form fields. This aligns with the existing untouched property available in Reactive Forms.
Fixes #65820

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #65820


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
