### PR TITLE
fix(forms): add signals for dirty, hidden, and pending states in custom controls

### DIFF
--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -930,7 +930,9 @@ type ControlBindings = {
 const CONTROL_BINDING_NAMES = {
   disabled: 'disabled',
   disabledReasons: 'disabledReasons',
+  dirty: 'dirty',
   errors: 'errors',
+  hidden: 'hidden',
   invalid: 'invalid',
   max: 'max',
   maxLength: 'maxLength',
@@ -938,6 +940,7 @@ const CONTROL_BINDING_NAMES = {
   minLength: 'minLength',
   name: 'name',
   pattern: 'pattern',
+  pending: 'pending',
   readonly: 'readonly',
   required: 'required',
   touched: 'touched',

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -144,6 +144,21 @@ export interface ɵFieldState<T> {
   readonly touched: Signal<boolean>;
 
   /**
+   * A signal indicating whether the field value has been changed by user.
+   */
+  readonly dirty: Signal<boolean>;
+
+  /**
+   * A signal indicating whether the field is hidden.
+   */
+  readonly hidden: Signal<boolean>;
+
+  /**
+   * A signal indicating whether there are any validators still pending for this field.
+   */
+  readonly pending: Signal<boolean>;
+
+  /**
    * A writable signal containing the value for this field.
    *
    * Updating this signal will update the data model that the field is bound to.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

FormUiControl states that hidden, pending and dirty will be bind in custom controls, but this is currently not the case.

Issue Number: #65575


## What is the new behavior?

These states are now bound

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
