### PR TITLE
feat(router): add configurable parameter equality depth

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -628,11 +628,11 @@ export class Router {
       options = matchOptions;
     }
     if (isUrlTree(url)) {
-      return containsTree(this.currentUrlTree, url, options);
+      return containsTree(this.currentUrlTree, url, options, this.options);
     }
 
     const urlTree = this.parseUrl(url);
-    return containsTree(this.currentUrlTree, urlTree, options);
+    return containsTree(this.currentUrlTree, urlTree, options, this.options);
   }
 
   private removeEmptyProps(params: Params): Params {

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -136,6 +136,17 @@ export interface RouterConfigOptions {
    * if an error occurs.
    */
   resolveNavigationPromiseOnError?: boolean;
+
+  /**
+   * Configures the depth of equality checks for router parameters.
+   *
+   * - 'shallow': Compare parameters by reference (default, current behavior)
+   * - 'deep': Compare parameters by content, including arrays
+   *
+   * When set to 'deep', array-valued query parameters with identical content
+   * will be treated as equal even if they are different array instances.
+   */
+  paramsEqualityDepth?: 'shallow' | 'deep';
 }
 
 /**

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -91,3 +91,37 @@ export function wrapIntoPromise<T>(value: T | Promise<T> | Observable<T>): Promi
   }
   return Promise.resolve(value);
 }
+
+export function deepEqual(
+  a: {[key: string | symbol]: any},
+  b: {[key: string | symbol]: any},
+): boolean {
+  const k1 = a ? getDataKeys(a) : undefined;
+  const k2 = b ? getDataKeys(b) : undefined;
+  if (!k1 || !k2 || k1.length != k2.length) {
+    return false;
+  }
+
+  for (const key of k1) {
+    const valA = a[key];
+    const valB = b[key];
+
+    if (Array.isArray(valA) && Array.isArray(valB)) {
+      if (!shallowEqualArrays(valA, valB)) {
+        return false;
+      }
+    } else if (
+      typeof valA === 'object' &&
+      typeof valB === 'object' &&
+      valA !== null &&
+      valB !== null
+    ) {
+      if (!deepEqual(valA, valB)) {
+        return false;
+      }
+    } else if (valA !== valB) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/router/test/integration/router_link_active.spec.ts
+++ b/packages/router/test/integration/router_link_active.spec.ts
@@ -5,10 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import {Component, NgZone} from '@angular/core';
+import {Component, NgZone, ViewChild} from '@angular/core';
 import {Location} from '@angular/common';
 import {TestBed} from '@angular/core/testing';
-import {Router, provideRouter} from '../../src';
+import {Router, RouterLinkActive, RouterModule, provideRouter, withRouterConfig} from '../../src';
 import {By} from '@angular/platform-browser';
 import {
   RootCmp,
@@ -304,6 +304,42 @@ export function routerLinkActiveIntegrationSuite() {
       expect(location.path()).toEqual('/team/22/link/simple');
       expect(nativeLink.hasAttribute('aria-current')).toEqual(false);
       expect(nativeButton.hasAttribute('aria-current')).toEqual(false);
+    });
+
+    it('should work with array params when deep equality is configured', async () => {
+      @Component({
+        template: `  
+      <a routerLink="/test" routerLinkActive="active" #rla="routerLinkActive">  
+        Test Link  
+      </a>  
+    `,
+        standalone: false,
+      })
+      class TestComponent {
+        @ViewChild('rla') routerLinkActive!: RouterLinkActive;
+      }
+
+      TestBed.configureTestingModule({
+        declarations: [TestComponent, SimpleCmp],
+        imports: [RouterModule],
+        providers: [
+          provideRouter(
+            [{path: 'test', component: SimpleCmp}],
+            withRouterConfig({paramsEqualityDepth: 'deep'}),
+          ),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      // Navigate to the route
+      await router.navigateByUrl('/test?tags=a&tags=b');
+      fixture.detectChanges();
+
+      // Check if the link is active
+      expect(fixture.componentInstance.routerLinkActive.isActive).toBe(true);
     });
   });
 }

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {EnvironmentInjector, inject, ɵConsole as Console} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {RouterModule} from '../index';
+import {provideRouter, RouterModule, withRouterConfig} from '../index';
 import {of} from 'rxjs';
 
 import {ChildActivationStart} from '../src/events';
@@ -17,7 +17,7 @@ import {GuardResult, Routes} from '../src/models';
 import {NavigationTransition} from '../src/navigation_transition';
 import {checkGuards as checkGuardsOperator} from '../src/operators/check_guards';
 import {resolveData as resolveDataOperator} from '../src/operators/resolve_data';
-import {Router} from '../src/router';
+import {exactMatchOptions, Router} from '../src/router';
 import {ChildrenOutletContexts} from '../src/router_outlet_context';
 import {createEmptyStateSnapshot, RouterStateSnapshot} from '../src/router_state';
 import {DefaultUrlSerializer, UrlSerializer, UrlTree} from '../src/url_tree';
@@ -881,6 +881,31 @@ describe('Router', () => {
           expect(s2.root.firstChild!.firstChild!.data).toEqual({data: 'resolver2_value'});
         });
       });
+    });
+  });
+
+  describe('Router.isActive with deep equality', () => {
+    it('should treat array params as equal when deep equality is configured', async () => {
+      TestBed.configureTestingModule({
+        providers: [provideRouter([], withRouterConfig({paramsEqualityDepth: 'deep'}))],
+      });
+
+      const router = TestBed.inject(Router);
+      const tree1 = router.createUrlTree(['/test'], {queryParams: {tags: ['a', 'b']}});
+      const tree2 = router.createUrlTree(['/test'], {queryParams: {tags: ['a', 'b']}});
+
+      // Fixed: Use exactMatchOptions constant or provide all properties
+      expect(router.isActive(tree2, exactMatchOptions)).toBe(true);
+
+      // Alternative: Provide all required properties explicitly
+      expect(
+        router.isActive(tree2, {
+          paths: 'exact',
+          queryParams: 'exact',
+          matrixParams: 'ignored',
+          fragment: 'ignored',
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -8,7 +8,7 @@
 
 import {TestBed} from '@angular/core/testing';
 import {exactMatchOptions, Router, subsetMatchOptions} from '../src/router';
-import {containsTree, DefaultUrlSerializer} from '../src/url_tree';
+import {containsTree, DefaultUrlSerializer, equalParams} from '../src/url_tree';
 
 describe('UrlTree', () => {
   const serializer = new DefaultUrlSerializer();
@@ -327,6 +327,20 @@ describe('UrlTree', () => {
             expect(containsTree(t1, t2, {...subsetMatchOptions, matrixParams})).toBe(true);
           },
         );
+      });
+    });
+
+    describe('equalParams with deep equality', () => {
+      it('should use shallow equality by default', () => {
+        const a = {tags: ['angular', 'typescript']};
+        const b = {tags: ['angular', 'typescript']};
+        expect(equalParams(a, b)).toBe(false);
+      });
+
+      it('should use deep equality when configured', () => {
+        const a = {tags: ['angular', 'typescript']};
+        const b = {tags: ['angular', 'typescript']};
+        expect(equalParams(a, b, {paramsEqualityDepth: 'deep'})).toBe(true);
       });
     });
   });


### PR DESCRIPTION
Add a new paramsEqualityDepth option to withRouterConfig that allows configuring how router parameters are compared for equality. This addresses the issue where array-valued query parameters are compared by reference rather than content, causing logically identical parameters to be treated as unequal.

The new option supports:

'shallow' (default): Compare parameters by reference, maintaining current behavior 'deep': Compare parameters by content, including arrays and nested objects This is particularly useful for router reuse strategies and navigation checks that depend on parameter equality when using array query parameters.

Closes #65824

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
