### PR TITLE
refactor(core): Add transition.to property to FakeNavigation

### DIFF
--- a/packages/core/primitives/dom-navigation/src/navigation_types.ts
+++ b/packages/core/primitives/dom-navigation/src/navigation_types.ts
@@ -66,6 +66,7 @@ export declare class Navigation extends EventTarget {
 export declare class NavigationTransition {
   readonly navigationType: NavigationTypeString;
   readonly from: NavigationHistoryEntry;
+  readonly to: NavigationDestination;
   readonly finished: Promise<void>;
   readonly committed: Promise<void>;
 }

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -1022,7 +1022,11 @@ function dispatchNavigateEvent({
         );
         return;
       }
-      const transition = new InternalNavigationTransition(navigation.currentEntry, navigationType);
+      const transition = new InternalNavigationTransition(
+        navigation.currentEntry,
+        event.destination,
+        navigationType,
+      );
       navigation.transition = transition;
       // Mark transition.finished as handled (Spec Step 33.4)
       transition.finished.catch(() => {});
@@ -1229,6 +1233,7 @@ class InternalNavigationTransition implements NavigationTransition {
   committedReject!: (reason: Error) => void;
   constructor(
     readonly from: NavigationHistoryEntry,
+    readonly to: NavigationDestination,
     readonly navigationType: NavigationTypeString,
   ) {
     this.finished = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
This matches the upstream changes in https://github.com/whatwg/html/commit/f19930f98afeb7565cfc1cbc6a1d4a2086535bca
