### PR TITLE
refactor(router): Adjust push/replace behavior to account for navigat…

### DIFF
--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -221,6 +221,13 @@ export class NavigationStateManager extends StateManager {
     };
 
     const info: NavigationInfo = {ɵrouterInfo: {intercept: true}};
+    // https://issues.chromium.org/issues/460137775 - Bug in all browsers where URL might actually not be updated
+    // by the time we get here. replaceUrl was set to true in the Router when navigating to sync with the browser
+    // because it assumes the URL is already committed. In this scenario, we need to go back to 'push' behavior
+    // because it was not yet been committed and we should not replace the current entry.
+    if (!this.navigation.transition && this.currentNavigation.navigationEvent) {
+      transition.extras.replaceUrl = false;
+    }
 
     // Determine if this should be a 'push' or 'replace' history operation.
     const history =


### PR DESCRIPTION
…ion API timing issues

There is a bug (?) in all browsers where the timing of the entry change is delayed when a navigation is initiated by a click on a link via user interaction. In this case, we need to ensure we do a 'push' navigation rather than a 'replace'.
Programatically doing element.click() does not reproduce this behavior, so adding a test for this is difficult (would require webdriver).
