### PR TITLE
docs: clarify linkedSignal update behavior

### DIFF
--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -104,7 +104,7 @@ export class ShippingMethodPicker {
 
 When you create a `linkedSignal`, you can pass an object with separate `source` and `computation` properties instead of providing just a computation.
 
-The `source` can be any signal, such as a `computed` or component `input`. When the value of `source` changes, `linkedSignal` updates its value to the result of the provided `computation`.
+The `source` can be any signal, such as a `computed` or component `input`. The `linkedSignal` updates its value when the `source` changes or when any signal referenced in the `computation` changes, updating its value with the result of the provided `computation`.
 
 The `computation` is a function that receives the new value of `source` and a `previous` object. The `previous` object has two properties— `previous.source` is the previous value of `source`, and `previous.value` is the previous value of the `linkedSignal`. You can use these previous values to decide the new result of the computation.
 


### PR DESCRIPTION
Updates the linkedSignal documentation to specify that it updates its value when the source changes or when any signal referenced in the computation changes, ensuring the description accurately reflects its behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The current documentation states that linkedSignal updates when the value of its source changes. While this is correct, the wording can lead readers to assume that it only updates when the source changes, omitting that it also updates when other signals referenced inside the computation change.


Issue Number: #65787


## What is the new behavior?
The documentation now correctly explains that `linkedSignal` updates its value when the `source` changes or when any signal referenced in the `computation` changes, providing a clearer and more accurate description of its behavior.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

