### PR TITLE
feat(forms): expose element on signal forms `Field` directive

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -16,8 +16,11 @@ import { Signal } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
+import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
+import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
+import { ɵɵcontrolCreate } from '@angular/core';
 
 // @public
 export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;

--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -16,12 +16,8 @@ import { Signal } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
-import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
-import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
-import { ɵInteropControl } from '@angular/core';
-import { ɵɵcontrolCreate } from '@angular/core';
 
 // @public
 export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -154,6 +154,8 @@ export class Field<T> implements ɵControl<T> {
     // (undocumented)
     readonly classes: (readonly [string, i0.Signal<boolean>])[];
     // (undocumented)
+    readonly element: HTMLElement;
+    // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
     protected getOrCreateNgControl(): InteropNgControl;
     // (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -26,8 +26,11 @@ import { StandardSchemaV1 } from '@standard-schema/spec';
 import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
+import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
+import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
+import { ɵɵcontrolCreate } from '@angular/core';
 
 // @public
 export function aggregateMetadata<TValue, TMetadataItem, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, key: AggregateMetadataKey<any, TMetadataItem>, logic: NoInfer<LogicFn<TValue, TMetadataItem, TPathKind>>): void;
@@ -142,6 +145,11 @@ export const FIELD: InjectionToken<Field<unknown>>;
 
 // @public
 export class Field<T> implements ɵControl<T> {
+    // (undocumented)
+    readonly [ɵCONTROL]: {
+        readonly create: typeof ɵɵcontrolCreate;
+        readonly update: typeof ɵcontrolUpdate;
+    };
     // (undocumented)
     readonly element: HTMLElement;
     // (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -26,12 +26,8 @@ import { StandardSchemaV1 } from '@standard-schema/spec';
 import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
-import { ɵCONTROL } from '@angular/core';
 import { ɵControl } from '@angular/core';
-import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
-import { ɵInteropControl } from '@angular/core';
-import { ɵɵcontrolCreate } from '@angular/core';
 
 // @public
 export function aggregateMetadata<TValue, TMetadataItem, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, key: AggregateMetadataKey<any, TMetadataItem>, logic: NoInfer<LogicFn<TValue, TMetadataItem, TPathKind>>): void;
@@ -147,26 +143,18 @@ export const FIELD: InjectionToken<Field<unknown>>;
 // @public
 export class Field<T> implements ɵControl<T> {
     // (undocumented)
-    readonly [ɵCONTROL]: {
-        readonly create: typeof ɵɵcontrolCreate;
-        readonly update: typeof ɵcontrolUpdate;
-    };
-    // (undocumented)
-    readonly classes: (readonly [string, i0.Signal<boolean>])[];
-    // (undocumented)
     readonly element: HTMLElement;
     // (undocumented)
     readonly field: i0.InputSignal<FieldTree<T>>;
     protected getOrCreateNgControl(): InteropNgControl;
+    // (undocumented)
+    readonly injector: Injector;
     // (undocumented)
     readonly state: i0.Signal<[T] extends [_angular_forms.AbstractControl<any, any, any>] ? CompatFieldState<T, string | number> : FieldState<T, string | number>>;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<Field<any>, "[field]", never, { "field": { "alias": "field"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Field<any>, never>;
-    get ɵinteropControl(): ɵInteropControl | undefined;
-    // (undocumented)
-    ɵregister(): void;
 }
 
 // @public

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -73,13 +73,15 @@ const controlInstructions = {
 })
 export class Field<T> implements ɵControl<T> {
   readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
-  private readonly injector = inject(Injector);
+  readonly injector = inject(Injector);
   private config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
+  /** @internal */
   readonly classes = Object.entries(this.config?.classes ?? {}).map(
     ([className, computation]) => [className, computed(() => computation(this.state()))] as const,
   );
   readonly field = input.required<FieldTree<T>>();
   readonly state = computed(() => this.field()());
+  /** @internal */
   readonly [ɵCONTROL] = controlInstructions;
 
   /** Any `ControlValueAccessor` instances provided on the host element. */
@@ -88,7 +90,11 @@ export class Field<T> implements ɵControl<T> {
   /** A lazily instantiated fake `NgControl`. */
   private interopNgControl: InteropNgControl | undefined;
 
-  /** A `ControlValueAccessor`, if configured, for the host component. */
+  /**
+   * A `ControlValueAccessor`, if configured, for the host component.
+   *
+   * @internal
+   */
   get ɵinteropControl(): ɵInteropControl | undefined {
     return this.controlValueAccessors?.[0] ?? this.interopNgControl?.valueAccessor ?? undefined;
   }
@@ -98,7 +104,8 @@ export class Field<T> implements ɵControl<T> {
     return (this.interopNgControl ??= new InteropNgControl(this.state));
   }
 
-  // TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131861631
+  //TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131861631
+  /** @internal */
   ɵregister() {
     // Register this control on the field it is currently bound to. We do this at the end of
     // initialization so that it only runs if we are actually syncing with this control

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -104,7 +104,6 @@ export class Field<T> implements ɵControl<T> {
     return (this.interopNgControl ??= new InteropNgControl(this.state));
   }
 
-  //TODO: https://github.com/orgs/angular/projects/60/views/1?pane=issue&itemId=131861631
   /** @internal */
   ɵregister() {
     // Register this control on the field it is currently bound to. We do this at the end of

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -8,17 +8,18 @@
 
 import {
   computed,
+  ɵɵcontrolCreate as createControlBinding,
   Directive,
   effect,
+  ElementRef,
   inject,
   InjectionToken,
   Injector,
   input,
+  ɵcontrolUpdate as updateControlBinding,
   ɵCONTROL,
   ɵControl,
-  ɵcontrolUpdate as updateControlBinding,
   ɵInteropControl,
-  ɵɵcontrolCreate as createControlBinding,
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
 import {InteropNgControl} from '../controls/interop_ng_control';
@@ -71,6 +72,7 @@ const controlInstructions = {
   ],
 })
 export class Field<T> implements ɵControl<T> {
+  readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   private readonly injector = inject(Injector);
   private config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
   readonly classes = Object.entries(this.config?.classes ?? {}).map(

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -74,15 +74,16 @@ const controlInstructions = {
 export class Field<T> implements ɵControl<T> {
   readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   readonly injector = inject(Injector);
+  readonly field = input.required<FieldTree<T>>();
+  readonly state = computed(() => this.field()());
+
+  readonly [ɵCONTROL] = controlInstructions;
+
   private config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
   /** @internal */
   readonly classes = Object.entries(this.config?.classes ?? {}).map(
     ([className, computation]) => [className, computed(() => computation(this.state()))] as const,
   );
-  readonly field = input.required<FieldTree<T>>();
-  readonly state = computed(() => this.field()());
-  /** @internal */
-  readonly [ɵCONTROL] = controlInstructions;
 
   /** Any `ControlValueAccessor` instances provided on the host element. */
   private readonly controlValueAccessors = inject(NG_VALUE_ACCESSOR, {optional: true, self: true});


### PR DESCRIPTION
This allows for easier focusing of the relevant element based on the `field` property of a `ValidationError`.

Converted to draft for now so we can discuss if its better to expose the element or just a `focus()` method
