### PR TITLE
docs: remove repeated description title and refference page

### DIFF
--- a/tools/manual_api_docs/blocks/defer.md
+++ b/tools/manual_api_docs/blocks/defer.md
@@ -19,8 +19,6 @@ directives and pipes used inside a component template.
 }
 ```
 
-## Description
-
 ### Blocks
 
 Supported sections of a defer block. Note: only the @defer block template fragment is deferred
@@ -33,7 +31,7 @@ loaded. The remaining optional blocks are eagerly loaded.
 | `@loading`     | Content shown during defer loading (Optional)            |
 | `@error`       | Content shown when defer loading errors occur (Optional) |
 
-<h3>Triggers</h3>
+### Triggers
 
 Triggers provide conditions for when defer loading occurs. Some allow a template reference variable
 as an optional parameter. Separate multiple triggers with a semicolon.
@@ -48,7 +46,7 @@ as an optional parameter. Separate multiple triggers with a semicolon.
 | `on timer(<duration>)`          | after a specific timeout                      |
 | `when <condition>`              | on a custom condition                         |
 
-<h2>Prefetch</h2>
+### Prefetch
 
 Configures prefetching of the defer block used in the `@defer` parameters, but does not affect
 rendering. Rendering is handled by the standard `on` and `when` conditions. Separate multiple
@@ -60,4 +58,4 @@ prefetch configurations with a semicolon.
 }
 ```
 
-Learn more in the [defer loading guide](guide/defer).
+Learn more in the [defer loading guide](guide/templates/defer).

--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -4,13 +4,11 @@ The `@for` block repeatedly renders content of a block for each item in a collec
 
 ```angular-html
 @for (item of items; track item.name) {
-<li>{{ item.name }}</li>
+  <li> {{ item.name }}</li>
 } @empty {
-<li>There are no items.</li>
+  <li> There are no items. </li>
 }
 ```
-
-## Description
 
 The `@for` block renders its content in response to changes in a collection. Collections can be any
 JavaScript [iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols),
@@ -54,9 +52,11 @@ These variables are always available with these names, but can be aliased via a 
 
 ```angular-html
 @for (item of items; track item.id; let idx = $index, e = $even) {
-Item #{{ idx }}: {{ item.name }}
+  <p>Item #{{ idx }}: {{ item.name }}</p>
 }
 ```
 
 The aliasing is especially useful in case of using nested `@for` blocks where contextual variable
 names could collide.
+
+Learn more in the [Repeat content with the @for block](guide/templates/control-flow#repeat-content-with-the-for-block).

--- a/tools/manual_api_docs/blocks/if.md
+++ b/tools/manual_api_docs/blocks/if.md
@@ -12,8 +12,6 @@ The `@if` block conditionally displays its content when its condition expression
 }
 ```
 
-## Description
-
 Content is added and removed from the DOM based on the evaluation of conditional expressions in
 the `@if` and `@else` blocks.
 
@@ -25,3 +23,5 @@ patterns:
   {{ users.length }}
 }
 ```
+
+Learn more in the [conditionally display content with `@if` and `@else` blocks](guide/templates/control-flow#conditionally-display-content-with-if-else-if-and-else).

--- a/tools/manual_api_docs/blocks/let.md
+++ b/tools/manual_api_docs/blocks/let.md
@@ -7,8 +7,6 @@
 @let data = data$ | async;
 ```
 
-## Description
-
 `@let` declarations are similar to [JavaScript's `let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) and
 their values can be any valid Angular expression. The expressions will be re-evaluated everytime the template is executed.
 

--- a/tools/manual_api_docs/blocks/switch.md
+++ b/tools/manual_api_docs/blocks/switch.md
@@ -16,8 +16,6 @@ The `@switch` block is inspired by the JavaScript `switch` statement:
 }
 ```
 
-## Description
-
 The `@switch` blocks displays content selected by one of the cases matching against the conditional
 expression. The value of the conditional expression is compared to the case expression using
 the `===` operator.
@@ -27,3 +25,5 @@ is no `@default` block, nothing is shown.
 
 **`@switch` does not have fallthrough**, so you do not need an equivalent to a `break` or `return`
 statement.
+
+Learn more in the [conditionally display content with the `@switch` block](guide/templates/control-flow#conditionally-display-content-with-the-switch-block).


### PR DESCRIPTION
Removes duplicate description title from the reference page and reformats example code blocks for better readability.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
