### PR TITLE
Docs: hide trailing empty line in code examples

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -373,6 +373,11 @@ $code-font-size: 0.875rem;
       display: none;
     }
 
+    // Hide the last line if it's empty
+    &:last-child:empty {
+      display: none;
+    }
+
     span:last-child {
       margin-inline-end: 4rem;
     }


### PR DESCRIPTION
Add CSS rule to hide the last empty line in code blocks to prevent displaying unnecessary empty lines when source files end with a newline character. The empty line remains in the DOM for proper copy-paste functionality.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<img width="791" height="361" alt="image" src="https://github.com/user-attachments/assets/88db2b4f-cf38-462c-876d-f0d21492623e" />

Issue Number: N/A


## What is the new behavior?
<img width="791" height="361" alt="image" src="https://github.com/user-attachments/assets/46dd77f7-d742-4f77-9cd0-3dd229195a0f" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
