### PR TITLE
fix(compiler-cli): allow null values for native controls

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -140,7 +140,10 @@ export class TcbNativeFieldDirectiveTypeOp extends TcbOp {
   private getExpectedTypeFromDomNode(node: TmplAstElement): ts.TypeNode {
     if (node.name === 'textarea' || node.name === 'select') {
       // `<textarea>` and `<select>` are always strings.
-      return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+      return ts.factory.createUnionTypeNode([
+        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ts.factory.createLiteralTypeNode(ts.factory.createNull()),
+      ]);
     }
 
     if (node.name !== 'input') {
@@ -157,6 +160,7 @@ export class TcbNativeFieldDirectiveTypeOp extends TcbOp {
         return ts.factory.createUnionTypeNode([
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
           ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+          ts.factory.createLiteralTypeNode(ts.factory.createNull()),
         ]);
 
       case 'date':
@@ -172,7 +176,10 @@ export class TcbNativeFieldDirectiveTypeOp extends TcbOp {
     }
 
     // Fall back to string if we couldn't map the type.
-    return ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+    return ts.factory.createUnionTypeNode([
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ts.factory.createLiteralTypeNode(ts.factory.createNull()),
+    ]);
   }
 
   private getUnsupportedType(): ts.TypeNode {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -2595,26 +2595,26 @@ describe('type check blocks', () => {
       };
     });
 
-    it('should generate a string field for an input without a type', () => {
+    it('should generate a string field for input without a type', () => {
       const block = tcb('<input [field]="f"/>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('var _t1 = null! as string | null;');
       expect(block).toContain('_t1 = ((this).f)().value();');
       expect(block).toContain('var _t2 = null! as i0.Field;');
       expect(block).toContain('_t2.field = (((this).f));');
     });
 
     [
-      {inputType: 'text', expectedType: 'string'},
-      {inputType: 'radio', expectedType: 'string'},
+      {inputType: 'text', expectedType: 'string | null'},
+      {inputType: 'radio', expectedType: 'string | null'},
       {inputType: 'checkbox', expectedType: 'boolean'},
-      {inputType: 'number', expectedType: 'string | number'},
-      {inputType: 'range', expectedType: 'string | number'},
-      {inputType: 'datetime-local', expectedType: 'string | number'},
+      {inputType: 'number', expectedType: 'string | number | null'},
+      {inputType: 'range', expectedType: 'string | number | null'},
+      {inputType: 'datetime-local', expectedType: 'string | number | null'},
       {inputType: 'date', expectedType: 'string | number | Date | null'},
       {inputType: 'month', expectedType: 'string | number | Date | null'},
       {inputType: 'time', expectedType: 'string | number | Date | null'},
       {inputType: 'week', expectedType: 'string | number | Date | null'},
-      {inputType: 'unknown', expectedType: 'string'},
+      {inputType: 'unknown', expectedType: 'string | null'},
     ].forEach(({inputType, expectedType}) => {
       it(`should generate a '${expectedType}' field for an input with a '${inputType}' type`, () => {
         const block = tcb(`<input type="${inputType}" [field]="f"/>`, [FieldMock]);
@@ -2627,7 +2627,7 @@ describe('type check blocks', () => {
 
     it('should generate a string field for a textarea', () => {
       const block = tcb('<textarea [field]="f"></textarea>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('var _t1 = null! as string | null;');
       expect(block).toContain('_t1 = ((this).f)().value();');
       expect(block).toContain('var _t2 = null! as i0.Field;');
       expect(block).toContain('_t2.field = (((this).f));');
@@ -2635,7 +2635,7 @@ describe('type check blocks', () => {
 
     it('should generate a string field for a select', () => {
       const block = tcb('<select [field]="f"></select>', [FieldMock]);
-      expect(block).toContain('var _t1 = null! as string;');
+      expect(block).toContain('var _t1 = null! as string | null;');
       expect(block).toContain('_t1 = ((this).f)().value();');
       expect(block).toContain('var _t2 = null! as i0.Field;');
       expect(block).toContain('_t2.field = (((this).f));');

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -2568,6 +2568,110 @@ describe('field directive', () => {
     const select = fixture.debugElement.parent!.nativeElement.querySelector('select');
     expect(select.value).toBe('us');
   });
+
+  describe('null value handling', () => {
+    it('handles null values for plain inputs', () => {
+      @Component({
+        imports: [Field],
+        template: `<input [field]="f">`,
+      })
+      class TestCmp {
+        f = form(signal('test' as string | null));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('test');
+
+      // Nullable value
+      act(() => cmp.f().value.set(null));
+      expect(input.value).toBe('');
+
+      act(() => cmp.f().value.set('test again'));
+      expect(input.value).toBe('test again');
+    });
+
+    it('handles null values for number inputs', () => {
+      @Component({
+        imports: [Field],
+        template: `<input type="number" [field]="f">`,
+      })
+      class TestCmp {
+        f = form(signal(123 as number | null));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('123');
+
+      // Nullable value
+      act(() => cmp.f().value.set(null));
+      expect(input.value).toBe('');
+
+      act(() => cmp.f().value.set(456));
+      expect(input.value).toBe('456');
+    });
+
+    it('handles null values for textarea', () => {
+      @Component({
+        imports: [Field],
+        template: `<textarea [field]="f"></textarea>`,
+      })
+      class TestCmp {
+        f = form(signal('test' as string | null));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const textarea = fix.nativeElement.firstChild as HTMLTextAreaElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(textarea.value).toBe('test');
+
+      // Nullable value
+      act(() => cmp.f().value.set(null));
+      expect(textarea.value).toBe('');
+
+      act(() => cmp.f().value.set('test again'));
+      expect(textarea.value).toBe('test again');
+    });
+
+    it('handles null values for a select', () => {
+      @Component({
+        imports: [Field],
+        template: `
+          <select #select [field]="f">
+            <option value="one">One</option>
+            <option value="two">Two</option>
+            <option value="three">Three</option>
+          </select>
+        `,
+      })
+      class TestCmp {
+        f = form(signal('two' as string | null));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const select = fix.nativeElement.firstChild as HTMLSelectElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(select.value).toBe('two');
+
+      // Nullable value
+      act(() => cmp.f().value.set(null));
+      expect(select.value).toBe('');
+
+      act(() => cmp.f().value.set('three'));
+      expect(select.value).toBe('three');
+    });
+  });
 });
 
 function setupRadioGroup() {


### PR DESCRIPTION
Updates the generated type checking code to allow null values for native signal form controls.

Fixes #65839.
