### PR TITLE
fix(router): Remove debug toString overrides in prod mode bundles

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1029,7 +1029,6 @@
       "searchTokensOnInjector",
       "selectIndexInternal",
       "serializeMatrixParams",
-      "serializeNode",
       "serializePath",
       "serializePaths",
       "serializeQueryParams",

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -30,6 +30,8 @@ export const IMPERATIVE_NAVIGATION = 'imperative';
  *
  * @publicApi
  */
+// TODO(atscott): This enum provides no value other than allowing a switch over the type on Event
+// That is not worth the ~200 bytes we pay in bundle size cost. Consider deprecating and removing.
 export enum EventType {
   NavigationStart,
   NavigationEnd,
@@ -126,7 +128,7 @@ export class NavigationStart extends RouterEvent {
     /** @docsNotRequired */
     url: string,
     /** @docsNotRequired */
-    navigationTrigger: NavigationTrigger = 'imperative',
+    navigationTrigger: NavigationTrigger = IMPERATIVE_NAVIGATION,
     /** @docsNotRequired */
     restoredState: {[k: string]: any; navigationId: number} | null = null,
   ) {
@@ -137,7 +139,10 @@ export class NavigationStart extends RouterEvent {
 
   /** @docsNotRequired */
   override toString(): string {
-    return `NavigationStart(id: ${this.id}, url: '${this.url}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -166,7 +171,10 @@ export class NavigationEnd extends RouterEvent {
 
   /** @docsNotRequired */
   override toString(): string {
-    return `NavigationEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -257,7 +265,10 @@ export class NavigationCancel extends RouterEvent {
 
   /** @docsNotRequired */
   override toString(): string {
-    return `NavigationCancel(id: ${this.id}, url: '${this.url}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -333,7 +344,10 @@ export class NavigationError extends RouterEvent {
 
   /** @docsNotRequired */
   override toString(): string {
-    return `NavigationError(id: ${this.id}, url: '${this.url}', error: ${this.error})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -360,7 +374,10 @@ export class RoutesRecognized extends RouterEvent {
 
   /** @docsNotRequired */
   override toString(): string {
-    return `RoutesRecognized(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -388,7 +405,10 @@ export class GuardsCheckStart extends RouterEvent {
   }
 
   override toString(): string {
-    return `GuardsCheckStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -418,7 +438,10 @@ export class GuardsCheckEnd extends RouterEvent {
   }
 
   override toString(): string {
-    return `GuardsCheckEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state}, shouldActivate: ${this.shouldActivate})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -449,7 +472,10 @@ export class ResolveStart extends RouterEvent {
   }
 
   override toString(): string {
-    return `ResolveStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -476,7 +502,10 @@ export class ResolveEnd extends RouterEvent {
   }
 
   override toString(): string {
-    return `ResolveEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -495,7 +524,10 @@ export class RouteConfigLoadStart {
     public route: Route,
   ) {}
   toString(): string {
-    return `RouteConfigLoadStart(path: ${this.route.path})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -514,7 +546,10 @@ export class RouteConfigLoadEnd {
     public route: Route,
   ) {}
   toString(): string {
-    return `RouteConfigLoadEnd(path: ${this.route.path})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -534,8 +569,10 @@ export class ChildActivationStart {
     public snapshot: ActivatedRouteSnapshot,
   ) {}
   toString(): string {
-    const path = (this.snapshot.routeConfig && this.snapshot.routeConfig.path) || '';
-    return `ChildActivationStart(path: '${path}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -554,8 +591,10 @@ export class ChildActivationEnd {
     public snapshot: ActivatedRouteSnapshot,
   ) {}
   toString(): string {
-    const path = (this.snapshot.routeConfig && this.snapshot.routeConfig.path) || '';
-    return `ChildActivationEnd(path: '${path}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -575,8 +614,10 @@ export class ActivationStart {
     public snapshot: ActivatedRouteSnapshot,
   ) {}
   toString(): string {
-    const path = (this.snapshot.routeConfig && this.snapshot.routeConfig.path) || '';
-    return `ActivationStart(path: '${path}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -596,8 +637,10 @@ export class ActivationEnd {
     public snapshot: ActivatedRouteSnapshot,
   ) {}
   toString(): string {
-    const path = (this.snapshot.routeConfig && this.snapshot.routeConfig.path) || '';
-    return `ActivationEnd(path: '${path}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 
@@ -624,8 +667,10 @@ export class Scroll {
   ) {}
 
   toString(): string {
-    const pos = this.position ? `${this.position[0]}, ${this.position[1]}` : null;
-    return `Scroll(anchor: '${this.anchor}', position: '${pos}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return stringifyEvent(this);
+    }
+    return '';
   }
 }
 

--- a/packages/router/src/navigation_canceling_error.ts
+++ b/packages/router/src/navigation_canceling_error.ts
@@ -42,7 +42,12 @@ export function navigationCancelingError(
   message: string | null | false,
   code: NavigationCancellationCode,
 ) {
-  const error = new Error(`NavigationCancelingError: ${message || ''}`) as NavigationCancelingError;
+  message = message || '';
+  const error = new Error(
+    typeof ngDevMode === 'undefined' || ngDevMode
+      ? `NavigationCancelingError: ${message}`
+      : message,
+  ) as NavigationCancelingError;
   error[NAVIGATION_CANCELING_ERROR] = true;
   error.cancellationCode = code;
   return error;

--- a/packages/router/src/operators/prioritized_guard_value.ts
+++ b/packages/router/src/operators/prioritized_guard_value.ts
@@ -12,7 +12,9 @@ import {filter, map, startWith, switchMap, take} from 'rxjs/operators';
 import {GuardResult, RedirectCommand} from '../models';
 import {isUrlTree, UrlTree} from '../url_tree';
 
-const INITIAL_VALUE = /* @__PURE__ */ Symbol('INITIAL_VALUE');
+const INITIAL_VALUE = /* @__PURE__ */ Symbol(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'INITIAL_VALUE' : '',
+);
 declare type INTERIM_VALUES = typeof INITIAL_VALUE | GuardResult;
 
 export function prioritizedGuardValue(): OperatorFunction<Observable<GuardResult>[], GuardResult> {

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -23,7 +23,7 @@ import {NavigationTransitions} from './navigation_transition';
 import {UrlSerializer} from './url_tree';
 
 export const ROUTER_SCROLLER = new InjectionToken<RouterScroller>(
-  typeof ngDevMode !== 'undefined' && ngDevMode ? 'Router Scroller' : '',
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'Router Scroller' : '',
 );
 
 @Injectable()

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -234,7 +234,10 @@ export class ActivatedRoute {
   }
 
   toString(): string {
-    return this.snapshot ? this.snapshot.toString() : `Future(${this._futureSnapshot})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return this.snapshot ? this.snapshot.toString() : `Future(${this._futureSnapshot})`;
+    }
+    return '';
   }
 }
 
@@ -428,9 +431,12 @@ export class ActivatedRouteSnapshot {
   }
 
   toString(): string {
-    const url = this.url.map((segment) => segment.toString()).join('/');
-    const matched = this.routeConfig ? this.routeConfig.path : '';
-    return `Route(url:'${url}', path:'${matched}')`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      const url = this.url.map((segment) => segment.toString()).join('/');
+      const matched = this.routeConfig ? this.routeConfig.path : '';
+      return `Route(url:'${url}', path:'${matched}')`;
+    }
+    return '';
   }
 }
 
@@ -473,18 +479,22 @@ export class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
   }
 
   override toString(): string {
-    return serializeNode(this._root);
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      const serializeNode = (node: TreeNode<ActivatedRouteSnapshot>): string => {
+        const c =
+          node.children.length > 0 ? ` { ${node.children.map(serializeNode).join(', ')} } ` : '';
+        return `${node.value}${c}`;
+      };
+
+      return serializeNode(this._root);
+    }
+    return '';
   }
 }
 
 function setRouterState<U, T extends {_routerState: U}>(state: U, node: TreeNode<T>): void {
   node.value._routerState = state;
   node.children.forEach((c) => setRouterState(state, c));
-}
-
-function serializeNode(node: TreeNode<ActivatedRouteSnapshot>): string {
-  const c = node.children.length > 0 ? ` { ${node.children.map(serializeNode).join(', ')} } ` : '';
-  return `${node.value}${c}`;
 }
 
 /**

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -21,7 +21,9 @@ export const PRIMARY_OUTLET = 'primary';
  * static string or `Route.resolve` if anything else. This allows us to reuse the existing route
  * data/resolvers to support the title feature without new instrumentation in the `Router` pipeline.
  */
-export const RouteTitleKey: unique symbol = /* @__PURE__ */ Symbol('RouteTitle');
+export const RouteTitleKey: unique symbol = /* @__PURE__ */ Symbol(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'RouteTitle' : '',
+);
 
 /**
  * A collection of matrix and query URL parameters.

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -36,7 +36,7 @@ export function getOrCreateRouteInjectorIfNeeded(
     route._injector = createEnvironmentInjector(
       route.providers,
       currentInjector,
-      `Route: ${route.path}`,
+      typeof ngDevMode === 'undefined' || ngDevMode ? `Route: ${route.path}` : '',
     );
   }
   return route._injector ?? currentInjector;

--- a/packages/router/src/utils/tree.ts
+++ b/packages/router/src/utils/tree.ts
@@ -95,7 +95,10 @@ export class TreeNode<T> {
   ) {}
 
   toString(): string {
-    return `TreeNode(${this.value})`;
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return `TreeNode(${this.value})`;
+    }
+    return '';
   }
 }
 


### PR DESCRIPTION
The strings for events and other router classes contribute far too much to the bundle size and should not be present in production.

BREAKING CHANGE: The toString overrides of the following have been removed from production bundles:

* Router events (NavigationStart, NavigationEnd, etc),
* Router state (ActivatedRoute, RouterStateSnapshot, etc)
