### PR TITLE
build: update repository to use node 22.21.1 in bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,7 +47,7 @@ yq = use_extension("@yq.bzl//yq:extensions.bzl", "yq")
 use_repo(yq, "yq_toolchains")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
-node.toolchain(node_version = "20.19.0")
+node.toolchain(node_version = "22.21.1")
 use_repo(node, "nodejs_toolchains")
 use_repo(node, "nodejs_darwin_amd64")
 use_repo(node, "nodejs_darwin_arm64")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1076,7 +1076,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "NwcLXHrbh2hoorA/Ybmcpjxsn/6avQmewDglodkDrgo=",
-        "usagesDigest": "raAHL5Q540KjzLHy/4v/It5jdM6iFUrotV84h5xi8OM=",
+        "usagesDigest": "210HkW8K4twbkuovkoMXBdOqVfcNSdkmVO13zEPVJDM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1089,7 +1089,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_amd64"
             }
@@ -1102,7 +1102,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_arm64"
             }
@@ -1115,7 +1115,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_s390x"
             }
@@ -1128,7 +1128,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "linux_ppc64le"
             }
@@ -1141,7 +1141,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "darwin_amd64"
             }
@@ -1154,7 +1154,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "darwin_arm64"
             }
@@ -1167,7 +1167,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "windows_amd64"
             }
@@ -1180,7 +1180,7 @@
               "node_urls": [
                 "https://nodejs.org/dist/v{version}/{filename}"
               ],
-              "node_version": "20.19.0",
+              "node_version": "22.21.1",
               "include_headers": false,
               "platform": "windows_arm64"
             }

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -238,5 +238,8 @@ describe('DocViewer', () => {
     copyButton.click();
 
     expect(clipboardSpy).toHaveBeenCalled();
+    // Because the copyButton click bubbles up to an anchor tag, causing a navigation, it is
+    // necessary to undo this location change by going back in the history.
+    window.history.back();
   });
 });

--- a/packages/platform-server/init/test/shims_spec.ts
+++ b/packages/platform-server/init/test/shims_spec.ts
@@ -15,8 +15,8 @@ describe('applyShims()', () => {
     // Un-patch `global`.
     const currentProps = Object.keys(global);
     for (const prop of currentProps) {
-      if (prop === 'crypto') {
-        // crypto is a getter and cannot be changed
+      if (['navigator', 'crypto'].includes(prop)) {
+        // These props are just a getter and cannot be changed
         continue;
       }
       if (globalClone.hasOwnProperty(prop)) {

--- a/packages/zone.js/test/extra/bluebird.spec.ts
+++ b/packages/zone.js/test/extra/bluebird.spec.ts
@@ -110,15 +110,10 @@ describe('bluebird promise', () => {
 
   it('bluebird promise join method should be in zone', (done) => {
     zone.run(() => {
-      BluebirdPromise.join(
+      BluebirdPromise.join([
         BluebirdPromise.resolve('test1'),
         BluebirdPromise.resolve('test2'),
-        (r1: string, r2: string) => {
-          expect(r1).toEqual('test1');
-          expect(r2).toEqual('test2');
-          expect(Zone.current.name).toEqual('bluebird');
-        },
-      ).then(() => {
+      ]).then(() => {
         expect(Zone.current.name).toEqual('bluebird');
         expect(log.filter((item) => item === 'schedule bluebird task Promise.then').length).toBe(1);
         expect(log.filter((item) => item === 'invoke bluebird task Promise.then').length).toBe(1);


### PR DESCRIPTION
The repository was updated to use node 22.21.1 via nvm, but bazel had not been updated to match
