### PR TITLE
refactor(core): use proper type for stringifyTypeFromDebugify parameter

### DIFF
--- a/packages/core/src/render3/util/stringify_utils.ts
+++ b/packages/core/src/render3/util/stringify_utils.ts
@@ -8,6 +8,7 @@
 
 import {Type} from '../../interface/type';
 import {getComponentDef} from '../def_getters';
+import type {ClassDebugInfo} from '../interfaces/definition';
 
 /**
  * Used for stringify render output in Ivy.
@@ -54,9 +55,7 @@ export function debugStringifyTypeForError(type: Type<any>): string {
   return stringifyForError(type);
 }
 
-// TODO(pmvald): Do some refactoring so that we can use the type ClassDebugInfo for the param
-// debugInfo here without creating circular deps.
-function stringifyTypeFromDebugInfo(debugInfo: any): string {
+function stringifyTypeFromDebugInfo(debugInfo: ClassDebugInfo): string {
   if (!debugInfo.filePath || !debugInfo.lineNumber) {
     return debugInfo.className;
   } else {


### PR DESCRIPTION
Replace the 'any' type with ClassDebugInfo for the debugInfo parameter in stringifyTypeFromDebugInfo function. This removes the TODO comment that was tracking the need for proper typing without creating circular dependencies.

The change improves type safety while avoiding circular imports since stringify_utils.ts doesn't export anything that definition.ts imports.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
