### PR TITLE
refactor(core): extract shared reference utility to avoid duplication

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output_helpers.ts
+++ b/packages/core/schematics/migrations/output-migration/output_helpers.ts
@@ -25,7 +25,8 @@ import {
   HostBindingReference,
   TemplateReference,
 } from '../signal-migration/src/passes/reference_resolution/reference_kinds';
-import {AST, PropertyRead} from '@angular/compiler';
+import {PropertyRead} from '@angular/compiler';
+import {checkNonTsReferenceAccessesField} from '../../utils/reference_utils';
 
 /** Type describing an extracted output query that can be migrated. */
 export interface ExtractedOutput {
@@ -149,31 +150,6 @@ export function isTestRunnerImport(node: ts.Node) {
     return moduleSpecifier.includes('jasmine') || moduleSpecifier.includes('catalyst');
   }
   return false;
-}
-
-// TODO: code duplication with signals migration - sort it out
-
-/**
- * Gets whether the given read is used to access
- * the specified field.
- *
- * E.g. whether `<my-read>.toArray` is detected.
- */
-export function checkNonTsReferenceAccessesField(
-  ref: HostBindingReference<ClassFieldDescriptor> | TemplateReference<ClassFieldDescriptor>,
-  fieldName: string,
-): PropertyRead | null {
-  const readFromPath = ref.from.readAstPath.at(-1) as PropertyRead | AST | undefined;
-  const parentRead = ref.from.readAstPath.at(-2) as PropertyRead | AST | undefined;
-
-  if (ref.from.read !== readFromPath) {
-    return null;
-  }
-  if (!(parentRead instanceof PropertyRead) || parentRead.name !== fieldName) {
-    return null;
-  }
-
-  return parentRead;
 }
 
 /**

--- a/packages/core/schematics/migrations/signal-queries-migration/fn_first_last_replacement.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/fn_first_last_replacement.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {checkNonTsReferenceAccessesField} from '../../utils/reference_utils';
 import {ProgramInfo, projectFile, Replacement, TextUpdate} from '../../utils/tsurge';
 import {ClassFieldDescriptor} from '../signal-migration/src';
 import {
@@ -16,7 +17,7 @@ import {
 } from '../signal-migration/src/passes/reference_resolution/reference_kinds';
 import {KnownQueries} from './known_queries';
 import type {GlobalUnitData} from './migration';
-import {checkNonTsReferenceAccessesField, checkTsReferenceAccessesField} from './property_accesses';
+import {checkTsReferenceAccessesField} from './property_accesses';
 
 const mapping = new Map([
   ['first', 'at(0)!'],

--- a/packages/core/schematics/migrations/signal-queries-migration/incompatible_query_list_fns.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/incompatible_query_list_fns.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {checkNonTsReferenceAccessesField} from '../../utils/reference_utils';
 import {ClassFieldDescriptor} from '../signal-migration/src';
 import {
   isHostBindingReference,
@@ -14,7 +15,7 @@ import {
   Reference,
 } from '../signal-migration/src/passes/reference_resolution/reference_kinds';
 import type {CompilationUnitData} from './migration';
-import {checkNonTsReferenceAccessesField, checkTsReferenceAccessesField} from './property_accesses';
+import {checkTsReferenceAccessesField} from './property_accesses';
 
 const problematicQueryListMethods = [
   'dirty',

--- a/packages/core/schematics/migrations/signal-queries-migration/property_accesses.ts
+++ b/packages/core/schematics/migrations/signal-queries-migration/property_accesses.ts
@@ -14,7 +14,8 @@ import {
   TsReference,
 } from '../signal-migration/src/passes/reference_resolution/reference_kinds';
 import {ClassFieldDescriptor} from '../signal-migration/src';
-import {AST, Call, PropertyRead} from '@angular/compiler';
+import {Call, PropertyRead} from '@angular/compiler';
+import {checkNonTsReferenceAccessesField} from '../../utils/reference_utils';
 
 /**
  * Gets whether the given field is accessed via the
@@ -42,29 +43,6 @@ export function checkTsReferenceAccessesField(
   }
 
   return accessNode.parent as ReturnType<typeof checkTsReferenceAccessesField>;
-}
-
-/**
- * Gets whether the given read is used to access
- * the specified field.
- *
- * E.g. whether `<my-read>.toArray` is detected.
- */
-export function checkNonTsReferenceAccessesField(
-  ref: HostBindingReference<ClassFieldDescriptor> | TemplateReference<ClassFieldDescriptor>,
-  fieldName: string,
-): PropertyRead | null {
-  const readFromPath = ref.from.readAstPath.at(-1) as PropertyRead | AST | undefined;
-  const parentRead = ref.from.readAstPath.at(-2) as PropertyRead | AST | undefined;
-
-  if (ref.from.read !== readFromPath) {
-    return null;
-  }
-  if (!(parentRead instanceof PropertyRead) || parentRead.name !== fieldName) {
-    return null;
-  }
-
-  return parentRead;
 }
 
 export interface FnCallExpression extends ts.CallExpression {

--- a/packages/core/schematics/utils/reference_utils.ts
+++ b/packages/core/schematics/utils/reference_utils.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {PropertyRead, AST} from '@angular/compiler';
+import {ClassFieldDescriptor} from '../migrations/signal-migration/src';
+import {
+  HostBindingReference,
+  TemplateReference,
+} from '../migrations/signal-migration/src/passes/reference_resolution/reference_kinds';
+
+/**
+ * Gets whether the given read is used to access
+ * the specified field.
+ *
+ * E.g. whether `<my-read>.toArray` is detected.
+ */
+export function checkNonTsReferenceAccessesField(
+  ref: HostBindingReference<ClassFieldDescriptor> | TemplateReference<ClassFieldDescriptor>,
+  fieldName: string,
+): PropertyRead | null {
+  const readFromPath = ref.from.readAstPath.at(-1) as PropertyRead | AST | undefined;
+  const parentRead = ref.from.readAstPath.at(-2) as PropertyRead | AST | undefined;
+
+  if (ref.from.read !== readFromPath) {
+    return null;
+  }
+  if (!(parentRead instanceof PropertyRead) || parentRead.name !== fieldName) {
+    return null;
+  }
+
+  return parentRead;
+}


### PR DESCRIPTION
Move checkNonTsReferenceAccessesField from output-migration to a shared location to eliminate code duplication with signal-queries-migration.

Both migrations were using identical logic for checking non-TypeScript reference field access. This change centralizes the utility in reference_utils.ts and updates imports accordingly.

Fixes #TODO in output_helpers.ts about code duplication.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
