### PR TITLE
build: move NG_FORCE_TTY environment variable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Disable NG CLI TTY mode
+build --action_env=NG_FORCE_TTY=false
+
 # Enable debugging tests with --config=debug
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --strategy=TestRunner=standalone
 

--- a/adev/BUILD.bazel
+++ b/adev/BUILD.bazel
@@ -104,7 +104,6 @@ ng_application(
     ],
     env = {
         "NG_BUILD_PARTIAL_SSR": "1",
-        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",
@@ -131,7 +130,6 @@ ng_application(
     ],
     env = {
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
-        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",

--- a/dev-app/BUILD.bazel
+++ b/dev-app/BUILD.bazel
@@ -39,7 +39,6 @@ ng_application(
     ],
     env = {
         "NG_BUILD_PARTIAL_SSR": "1",
-        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",
@@ -59,7 +58,6 @@ ng_application(
     ],
     env = {
         "NG_BUILD_OPTIMIZE_CHUNKS": "1",
-        "NG_FORCE_TTY": "0",
     },
     ng_config = ":ng_config",
     node_modules = ":node_modules",


### PR DESCRIPTION
This moved the `NG_FORCE_TTY` from individual `ng_web_app` rules to a global Bazel build flag as this is also needed for integration tests that under the hood run `ng serve` .
