### PR TITLE
fix(core): Microtask scheduling should be used after any application synchronization

### DIFF
--- a/packages/core/src/application/application_ref.ts
+++ b/packages/core/src/application/application_ref.ts
@@ -293,7 +293,8 @@ export class ApplicationRef {
   // Eventually the hostView of the fixture should just attach to ApplicationRef.
   private allTestViews: Set<InternalViewRef<unknown>> = new Set();
   private autoDetectTestViews: Set<InternalViewRef<unknown>> = new Set();
-  private includeAllTestViews = false;
+  /** @internal */
+  includeAllTestViews = false;
   /** @internal */
   afterTick = new Subject<void>();
   /** @internal */

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -78,6 +78,9 @@ describe('public PendingTasks', () => {
     // stability is delayed until a tick happens
     await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(false);
     TestBed.inject(ApplicationRef).tick();
+    // Stability is not synchronous after a tick. We wait for a microtask
+    // in case there is a Promise inside tick that requires tick again
+    await Promise.resolve();
     await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(true);
   });
 

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -91,6 +91,7 @@ describe('reactivity', () => {
       expect(isStable).toEqual([true, false]);
 
       appRef.tick();
+      await appRef.whenStable();
 
       expect(isStable).toEqual([true, false, true]);
     });

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -880,6 +880,8 @@ export class TestBedImpl implements TestBed {
       // The behavior should be that TestBed.tick, ComponentFixture.detectChanges, and ApplicationRef.tick all result in the test fixtures
       // getting synchronized, regardless of whether they are autoDetect: true.
       // Automatic scheduling (zone or zoneless) will call _tick which will _not_ include fixtures with autoDetect: false
+      // If this does get changed, we will need a new flag for the scheduler to use to omit the microtask scheduling
+      // from a tick initiated by tests.
       (appRef as any).includeAllTestViews = true;
       appRef.tick();
     } finally {


### PR DESCRIPTION
Previously, Angular would switch from the macrotask to a microtask scheduler _only_ when the scheduler was the trigger for the synchronization. This microtask scheduling is to ensure patterns such as `Promise.resolve().then(() => updateAppStateAgain())` _during_ synchronization are caught and synchronized again within the same event loop (guaranteeing that they aren't split across multiple browser paints).

The microtask scheduler should be used after any tick, not just from those than run within the scheduler to always account for the promises within synchronization. This is encountered most frequently during bootstrap, which triggers the tick directly.

In this change we exempt `TestBed.tick` and
`ComponentFixture.detectChanges` from this behavior. Doing so would affect the timing of stability and tests are quite sensitive to this (e.g. `fixture.whenStable`). It is somewhat unfortunate that we have "special" test-only behavior. However, it is important to acknowledge that this only affects the test-only APIs as well. Any code in the application under test that triggers `ApplicationRef.tick` directly would still use the microtask scheduling behavior.

fixes #65444
