### PR TITLE
feat(forms): Allows any type of pre-transform value on FormUiControl signals

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -222,22 +222,22 @@ export interface FormOptions {
 
 // @public
 export interface FormUiControl {
-    readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly disabledReasons?: InputSignal<readonly WithOptionalField<DisabledReason>[]> | InputSignalWithTransform<readonly WithOptionalField<DisabledReason>[], unknown>;
-    readonly errors?: InputSignal<readonly WithOptionalField<ValidationError>[]> | InputSignalWithTransform<readonly WithOptionalField<ValidationError>[], unknown>;
-    readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly max?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly maxLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly min?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
-    readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], unknown>;
-    readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly touched?: ModelSignal<boolean> | InputSignal<boolean> | InputSignalWithTransform<boolean, unknown> | OutputRef<boolean>;
+    readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly disabledReasons?: InputSignal<readonly WithOptionalField<DisabledReason>[]> | InputSignalWithTransform<readonly WithOptionalField<DisabledReason>[], any>;
+    readonly errors?: InputSignal<readonly WithOptionalField<ValidationError>[]> | InputSignalWithTransform<readonly WithOptionalField<ValidationError>[], any>;
+    readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly max?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, any>;
+    readonly maxLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, any>;
+    readonly min?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, any>;
+    readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, any>;
+    readonly name?: InputSignal<string> | InputSignalWithTransform<string, any>;
+    readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], any>;
+    readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
+    readonly touched?: ModelSignal<boolean> | InputSignal<boolean> | InputSignalWithTransform<boolean, any> | OutputRef<boolean>;
 }
 
 // @public

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InputSignal, InputSignalWithTransform, ModelSignal, OutputRef} from '@angular/core';
-import type {DisabledReason} from './types';
-import {ValidationError, type WithOptionalField} from './rules/validation/validation_errors';
+import { InputSignal, InputSignalWithTransform, ModelSignal, OutputRef } from '@angular/core';
+import { ValidationError, type WithOptionalField } from './rules/validation/validation_errors';
+import type { DisabledReason } from './types';
 
 /**
  * The base set of properties shared by all form control contracts.
@@ -27,39 +27,39 @@ export interface FormUiControl {
    */
   readonly errors?:
     | InputSignal<readonly WithOptionalField<ValidationError>[]>
-    | InputSignalWithTransform<readonly WithOptionalField<ValidationError>[], unknown>;
+    | InputSignalWithTransform<readonly WithOptionalField<ValidationError>[], any>;
   /**
    * An input to receive the disabled status for the field. If implemented, the `Field` directive
    * will automatically bind the disabled status from the bound field to this input.
    */
-  readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the reasons for the disablement of the field. If implemented, the `Field`
    * directive will automatically bind the disabled reason from the bound field to this input.
    */
   readonly disabledReasons?:
     | InputSignal<readonly WithOptionalField<DisabledReason>[]>
-    | InputSignalWithTransform<readonly WithOptionalField<DisabledReason>[], unknown>;
+    | InputSignalWithTransform<readonly WithOptionalField<DisabledReason>[], any>;
   /**
    * An input to receive the readonly status for the field. If implemented, the `Field` directive
    * will automatically bind the readonly status from the bound field to this input.
    */
-  readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the hidden status for the field. If implemented, the `Field` directive
    * will automatically bind the hidden status from the bound field to this input.
    */
-  readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the invalid status for the field. If implemented, the `Field` directive
    * will automatically bind the invalid status from the bound field to this input.
    */
-  readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the pending status for the field. If implemented, the `Field` directive
    * will automatically bind the pending status from the bound field to this input.
    */
-  readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the touched status for the field. If implemented, the `Field` directive
    * will automatically bind the touched status from the bound field to this input.
@@ -67,58 +67,58 @@ export interface FormUiControl {
   readonly touched?:
     | ModelSignal<boolean>
     | InputSignal<boolean>
-    | InputSignalWithTransform<boolean, unknown>
+    | InputSignalWithTransform<boolean, any>
     | OutputRef<boolean>;
   /**
    * An input to receive the dirty status for the field. If implemented, the `Field` directive
    * will automatically bind the dirty status from the bound field to this input.
    */
-  readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the name for the field. If implemented, the `Field` directive will
    * automatically bind the name from the bound field to this input.
    */
-  readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
+  readonly name?: InputSignal<string> | InputSignalWithTransform<string, any>;
   /**
    * An input to receive the required status for the field. If implemented, the `Field` directive
    * will automatically bind the required status from the bound field to this input.
    */
-  readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, any>;
   /**
    * An input to receive the min value for the field. If implemented, the `Field` directive will
    * automatically bind the min value from the bound field to this input.
    */
   readonly min?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<number | undefined, any>;
   /**
    * An input to receive the min length for the field. If implemented, the `Field` directive will
    * automatically bind the min length from the bound field to this input.
    */
   readonly minLength?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<number | undefined, any>;
   /**
    * An input to receive the max value for the field. If implemented, the `Field` directive will
    * automatically bind the max value from the bound field to this input.
    */
   readonly max?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<number | undefined, any>;
   /**
    * An input to receive the max length for the field. If implemented, the `Field` directive will
    * automatically bind the max length from the bound field to this input.
    */
   readonly maxLength?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<number | undefined, any>;
   /**
    * An input to receive the value patterns for the field. If implemented, the `Field` directive
    * will automatically bind the value patterns from the bound field to this input.
    */
   readonly pattern?:
     | InputSignal<readonly RegExp[]>
-    | InputSignalWithTransform<readonly RegExp[], unknown>;
+    | InputSignalWithTransform<readonly RegExp[], any>;
 }
 
 /**

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -1192,6 +1192,32 @@ describe('field directive', () => {
       expect(fixture.componentInstance).toBeDefined();
     });
 
+    it('should accept InputSignalWithTransform for boolean properties with stricter pre-transform types', () => {
+      @Component({selector: 'custom-control', template: ``})
+      class CustomControl implements FormValueControl<string> {
+        readonly value = model('');
+        readonly disabled = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly readonly = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly required = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly hidden = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly invalid = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly pending = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly dirty = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly touched = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+      }
+
+      @Component({
+        imports: [Field, CustomControl],
+        template: `<custom-control [field]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(''));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      expect(fixture.componentInstance).toBeDefined();
+    });
+
     it('should accept InputSignalWithTransform for number properties', () => {
       @Component({selector: 'custom-control', template: ``})
       class CustomControl implements FormValueControl<number> {
@@ -1202,6 +1228,32 @@ describe('field directive', () => {
           transform: numberAttribute,
         });
         readonly maxLength = input<number | undefined, unknown>(undefined, {
+          transform: numberAttribute,
+        });
+      }
+
+      @Component({
+        imports: [Field, CustomControl],
+        template: `<custom-control [field]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(0));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      expect(fixture.componentInstance).toBeDefined();
+    });
+
+    it('should accept InputSignalWithTransform for number properties with stricter pre-transform types', () => {
+      @Component({selector: 'custom-control', template: ``})
+      class CustomControl implements FormValueControl<number> {
+        readonly value = model(0);
+        readonly min = input<number | undefined, number | string | undefined>(undefined, {transform: numberAttribute});
+        readonly max = input<number | undefined, number | string | undefined>(undefined, {transform: numberAttribute});
+        readonly minLength = input<number | undefined, number | string | undefined>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly maxLength = input<number | undefined, number | string | undefined>(undefined, {
           transform: numberAttribute,
         });
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65889


## What is the new behavior?
Inputs in `FormUiControl` now allow for any type of pre-transform value, instead of limiting the type to only `unknown`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
