### PR TITLE
docs(docs-infra): Fixes the visibility of the copy link button in API…

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/section-heading.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/section-heading.tsx
@@ -17,7 +17,7 @@ export function SectionHeading(props: {name: string}) {
 
   return (
     <h2 id={id} class={SECTION_HEADING}>
-      <a href={'#' + id} aria-label={label} tabIndex={-1}>
+      <a class="docs-anchor" href={'#' + id} aria-label={label} tabIndex={-1}>
         {props.name}
       </a>
     </h2>

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -73,6 +73,20 @@
     }
   }
 
+  .docs-api {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      // Show copy link button when hovering the heading
+      &:hover docs-copy-link-button {
+        opacity: 1;
+      }
+    }
+  }
+
   .docs-reference-members {
     box-sizing: border-box;
     width: 100%;


### PR DESCRIPTION
… documentation headings

Fixes the visibility of the copy link button in API documentation headings. The button now appears on hover, improving the user experience.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
 https://angular.dev/api/forms/MinLengthValidator

https://github.com/user-attachments/assets/e5447185-3bf1-49fb-a667-15393acd43e9



## What is the new behavior?

https://github.com/user-attachments/assets/f6656a3f-d836-49c9-abe4-e4122f6144f6



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
