### PR TITLE
perf(compiler): chain query creation instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_directive.js
@@ -3,11 +3,10 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 5);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4);
+    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 5)(dirIndex, SomeDirective, 4);
     }
     if (rf & 2) {
-    let $tmp$;
+      let $tmp$;
       $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
       $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDirList = $tmp$);
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_local_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_for_local_ref.js
@@ -5,8 +5,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-    $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5);
-    $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4);
+    $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5)(dirIndex, $e1_attrs$, 4);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
@@ -3,8 +3,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__)(dirIndex, SomeDirective, __QueryFlags.emitDistinctChangesOnly__);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_read_token.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_read_token.js
@@ -5,13 +5,10 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5, TemplateRef);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 5, ElementRef);
-    $r3$.ɵɵcontentQuery(dirIndex, $e1_attrs$, 4, ElementRef);
-    $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, 4, TemplateRef);
+      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, 5, TemplateRef)(dirIndex, SomeDirective, 5, ElementRef)(dirIndex, $e1_attrs$, 4, ElementRef)(dirIndex, SomeDirective, 4, TemplateRef);
     }
     if (rf & 2) {
-    let $tmp$;
+      let $tmp$;
       $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRef = $tmp$.first);
       $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
       $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.myRefs = $tmp$);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/query_with_emit_distinct_changes_only.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/query_with_emit_distinct_changes_only.js
@@ -4,8 +4,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, __QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, __QueryFlags.none__);
+      $r3$.ɵɵcontentQuery(dirIndex, $e0_attrs$, __QueryFlags.emitDistinctChangesOnly__)(dirIndex, $e0_attrs$, __QueryFlags.none__);
     }
     if (rf & 2) {
       let $tmp$;
@@ -16,8 +15,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   viewQuery: function ContentQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.emitDistinctChangesOnly__|__QueryFlags.descendants__);
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.emitDistinctChangesOnly__|__QueryFlags.descendants__)(SomeDirective, __QueryFlags.descendants__);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_content_query.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_content_query.js
@@ -3,9 +3,7 @@ ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["content-query-component"]],
   contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
     if (rf & 1) {
-      $r3$.ɵɵcontentQuery(
-          dirIndex, SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵcontentQuery(dirIndex, $ref0$, 5);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__)(dirIndex, $ref0$, 5);
     }
     if (rf & 2) {
     let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_view_query.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/static_view_query.js
@@ -5,8 +5,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵviewQuery($refs$, 5);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.isStatic__|__QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__)($refs$, 5);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_directive.js
@@ -3,8 +3,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, 5);
-      $r3$.ɵɵviewQuery(SomeDirective, 5);
+      $r3$.ɵɵviewQuery(SomeDirective, 5)(SomeDirective, 5);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_local_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_for_local_ref.js
@@ -5,8 +5,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery($e0_attrs$, 5);
-      $r3$.ɵɵviewQuery($e1_attrs$, 5);
+      $r3$.ɵɵviewQuery($e0_attrs$, 5)($e1_attrs$, 5);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
@@ -3,8 +3,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   selectors: [["view-query-component"]],
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
-      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__)(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_read_token.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_read_token.js
@@ -5,10 +5,7 @@ ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   // ...
   viewQuery: function ViewQueryComponent_Query(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵviewQuery($e0_attrs$, 5, TemplateRef);
-      $r3$.ɵɵviewQuery(SomeDirective, 5, ElementRef);
-      $r3$.ɵɵviewQuery($e1_attrs$, 5, ElementRef);
-      $r3$.ɵɵviewQuery(SomeDirective, 5, TemplateRef);
+      $r3$.ɵɵviewQuery($e0_attrs$, 5, TemplateRef)(SomeDirective, 5, ElementRef)($e1_attrs$, 5, ElementRef)(SomeDirective, 5, TemplateRef);
     }
     if (rf & 2) {
       let $tmp$;

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_component.js
@@ -2,18 +2,16 @@ TestComp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
     …
     contentQueries: function TestComp_ContentQueries(rf, ctx, dirIndex) {
         if (rf & 1) {
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
+            $r3$.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5)(dirIndex, ctx.query4, _c1, 4);
         } if (rf & 2) {
-            i0.ɵɵqueryAdvance(2);
+            $r3$.ɵɵqueryAdvance(2);
         }
     },
     viewQuery: function TestComp_Query(rf, ctx) {
         if (rf & 1) {
-            i0.ɵɵviewQuerySignal(ctx.query1, _c2, 5);
-            i0.ɵɵviewQuerySignal(ctx.query2, _c3, 5);
+            $r3$.ɵɵviewQuerySignal(ctx.query1, _c2, 5)(ctx.query2, _c3, 5);
         } if (rf & 2) {
-            i0.ɵɵqueryAdvance(2);
+            $r3$.ɵɵqueryAdvance(2);
         }
     },
     …

--- a/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_directive.js
+++ b/packages/compiler-cli/test/compliance/test_cases/signal_queries/query_in_directive.js
@@ -11,23 +11,16 @@ TestDir.ɵdir = /*@__PURE__*/ $r3$.ɵɵdefineDirective({
     …
     contentQueries: function TestDir_ContentQueries(rf, ctx, dirIndex) {
         if (rf & 1) {
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query4, _c1, 4);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query8, _c2, 5);
-            i0.ɵɵcontentQuerySignal(dirIndex, ctx.query9, nonAnalyzableRefersToString, 5);
+            $r3$.ɵɵcontentQuerySignal(dirIndex, ctx.query3, _c0, 5)(dirIndex, ctx.query4, _c1, 4)(dirIndex, ctx.query8, _c2, 5)(dirIndex, ctx.query9, nonAnalyzableRefersToString, 5);
         } if (rf & 2) {
-            i0.ɵɵqueryAdvance(4);
+            $r3$.ɵɵqueryAdvance(4);
         }
     },
     viewQuery: function TestDir_Query(rf, ctx) {
         if (rf & 1) {
-            i0.ɵɵviewQuerySignal(ctx.query1, _c3, 5);
-            i0.ɵɵviewQuerySignal(ctx.query2, _c4, 5);
-            i0.ɵɵviewQuerySignal(ctx.query5, SomeToken, 5);
-            i0.ɵɵviewQuerySignal(ctx.query6, SomeToken, 5);
-            i0.ɵɵviewQuerySignal(ctx.query7, _c5, 5, SomeToken);
+            $r3$.ɵɵviewQuerySignal(ctx.query1, _c3, 5)(ctx.query2, _c4, 5)(ctx.query5, SomeToken, 5)(ctx.query6, SomeToken, 5)(ctx.query7, _c5, 5, SomeToken);
         } if (rf & 2) {
-            i0.ɵɵqueryAdvance(5);
+            $r3$.ɵɵqueryAdvance(5);
         }
     }
     …

--- a/packages/compiler-cli/test/ngtsc/authoring_queries_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_queries_spec.ts
@@ -63,8 +63,9 @@ runInEachFileSystem(() => {
       env.driveMain();
 
       const js = env.getContents('test.js');
-      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el, _c0, 5, X);`);
-      expect(js).toContain(`i0.ɵɵviewQuerySignal(ctx.el2, _c0, 5, fromOtherFile.X);`);
+      expect(js).toContain(
+        `i0.ɵɵviewQuerySignal(ctx.el, _c0, 5, X)(ctx.el2, _c0, 5, fromOtherFile.X);`,
+      );
       expect(js).toContain(`i0.ɵɵqueryAdvance(2);`);
     });
 

--- a/packages/core/src/render3/instructions/queries.ts
+++ b/packages/core/src/render3/instructions/queries.ts
@@ -37,8 +37,9 @@ export function ɵɵcontentQuery<T>(
   predicate: ProviderToken<unknown> | string | string[],
   flags: QueryFlags,
   read?: any,
-): void {
+): typeof ɵɵcontentQuery {
   createContentQuery<T>(directiveIndex, predicate, flags, read);
+  return ɵɵcontentQuery;
 }
 
 /**
@@ -54,8 +55,9 @@ export function ɵɵviewQuery<T>(
   predicate: ProviderToken<unknown> | string | string[],
   flags: QueryFlags,
   read?: any,
-): void {
+): typeof ɵɵviewQuery {
   createViewQuery(predicate, flags, read);
+  return ɵɵviewQuery;
 }
 
 /**

--- a/packages/core/src/render3/instructions/queries_signals.ts
+++ b/packages/core/src/render3/instructions/queries_signals.ts
@@ -30,8 +30,9 @@ export function ɵɵcontentQuerySignal<T>(
   predicate: ProviderToken<unknown> | string[],
   flags: QueryFlags,
   read?: any,
-): void {
+): typeof ɵɵcontentQuerySignal {
   bindQueryToSignal(target, createContentQuery(directiveIndex, predicate, flags, read));
+  return ɵɵcontentQuerySignal;
 }
 
 /**
@@ -50,8 +51,9 @@ export function ɵɵviewQuerySignal(
   predicate: ProviderToken<unknown> | string[],
   flags: QueryFlags,
   read?: ProviderToken<unknown>,
-): void {
+): typeof ɵɵviewQuerySignal {
   bindQueryToSignal(target, createViewQuery(predicate, flags, read));
+  return ɵɵviewQuerySignal;
 }
 
 /**

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -175,13 +175,11 @@ describe('component declaration jit compilation', () => {
       contentQueries: functionContaining([
         // "byRef" should use `contentQuery` with `0` (`QueryFlags.none`) for query flag
         // without a read token, and bind to the full query result.
-        /contentQuery[^(]*\(dirIndex,_c0,4\)/,
-        '(ctx.byRef = _t)',
-
         // "byToken" should use `staticContentQuery` with `3`
         // (`QueryFlags.descendants|QueryFlags.isStatic`) for query flag and `ElementRef` as
         // read token, and bind to the first result in the query result.
-        /contentQuery[^(]*\(dirIndex,[^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        /contentQuery[^(]*\(dirIndex,_c0,4\)[^(]*\(dirIndex,[^,]*String[^,]*,\s*3,[^)]*ElementRef[^)]*\)/,
+        '(ctx.byRef = _t)',
         '(ctx.byToken = _t.first)',
       ]),
     });
@@ -213,13 +211,11 @@ describe('component declaration jit compilation', () => {
       viewQuery: functionContaining([
         // "byRef" should use `viewQuery` with `0` (`QueryFlags.none`) for query flag without a read
         // token, and bind to the full query result.
-        /viewQuery[^(]*\(_c0,4\)/,
-        '(ctx.byRef = _t)',
-
         // "byToken" should use `viewQuery` with `3`
         // (`QueryFlags.descendants|QueryFlags.isStatic`) for query flag and `ElementRef` as
         // read token, and bind to the first result in the query result.
-        /viewQuery[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        /viewQuery[^(]*\(_c0,4\)[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        '(ctx.byRef = _t)',
         '(ctx.byToken = _t.first)',
       ]),
     });

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -118,13 +118,11 @@ describe('directive declaration jit compilation', () => {
       contentQueries: functionContaining([
         // "byRef" should use `contentQuery` with `0` (`QueryFlags.descendants|QueryFlags.isStatic`)
         // for query flag without a read token, and bind to the full query result.
-        /contentQuery[^(]*\(dirIndex,_c0,4\)/,
-        '(ctx.byRef = _t)',
-
         // "byToken" should use `viewQuery` with `3` (`QueryFlags.static|QueryFlags.descendants`)
         // for query flag and `ElementRef` as read token, and bind to the first result in the
         // query result.
-        /contentQuery[^(]*\([^,]*dirIndex,[^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        /contentQuery[^(]*\(dirIndex,_c0,4\)\(dirIndex,[^,]*String[^,]*,\s*3,[^)]*ElementRef[^)]*\)/,
+        '(ctx.byRef = _t)',
         '(ctx.byToken = _t.first)',
       ]),
     });
@@ -177,13 +175,11 @@ describe('directive declaration jit compilation', () => {
       viewQuery: functionContaining([
         // "byRef" should use `viewQuery` with`0` (`QueryFlags.none`) for query flag without a read
         // token, and bind to the full query result.
-        /viewQuery[^(]*\(_c0,4\)/,
-        '(ctx.byRef = _t)',
-
         // "byToken" should use `viewQuery` with `3` (`QueryFlags.static|QueryFlags.descendants`)
         // for query flag and `ElementRef` as read token, and bind to the first result in the
         // query result.
-        /viewQuery[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        /viewQuery[^(]*\(_c0,4\)[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
+        '(ctx.byRef = _t)',
         '(ctx.byToken = _t.first)',
       ]),
     });


### PR DESCRIPTION
We always emit the query creation instructions in a group which makes them good candidates for chaining.
