### PR TITLE
docs: use fenced code blocks and format examples

### DIFF
--- a/adev/src/content/guide/animations/overview.md
+++ b/adev/src/content/guide/animations/overview.md
@@ -32,13 +32,13 @@ To get started with adding Angular animations to your project, import the animat
 <docs-step title="Enabling the animations module">
 Import `provideAnimationsAsync` from `@angular/platform-browser/animations/async` and add it to the providers list in the `bootstrapApplication` function call.
 
-<docs-code header="Enabling Animations" language="ts" linenums>
+```ts {header: "Enabling Animations", linenums}
 bootstrapApplication(AppComponent, {
   providers: [
     provideAnimationsAsync(),
   ]
 });
-</docs-code>
+```
 
 <docs-callout important title="If you need immediate animations in your application">
   If you need to have an animation happen immediately when your application is loaded,
@@ -126,19 +126,15 @@ The `animate()` function \(second argument of the transition function\) accepts 
 
 The `timings` parameter takes either a number or a string defined in three parts.
 
-<docs-code language="typescript">
-
+```ts
 animate (duration)
-
-</docs-code>
+```
 
 or
 
-<docs-code language="typescript">
-
+```ts
 animate ('duration delay easing')
-
-</docs-code>
+```
 
 The first part, `duration`, is required.
 The duration can be expressed in milliseconds as a number without quotes, or in seconds with quotes and a time specifier.
@@ -194,11 +190,9 @@ HELPFUL: Some additional notes on using styles within [`state`](api/animations/s
 - When animations are disabled, `transition()` styles can be skipped, but [`state()`](api/animations/state) styles can't
 - Include multiple state pairs within the same `transition()` argument:
 
-    <docs-code language="typescript">
-
+  ```ts
   transition( 'on => off, off => void' )
-
-    </docs-code>
+  ```
 
 ### Triggering the animation
 
@@ -225,11 +219,9 @@ Put the code that defines your animations under the `animations:` property withi
 When you've defined an animation trigger for a component, attach it to an element in that component's template by wrapping the trigger name in brackets and preceding it with an `@` symbol.
 Then, you can bind the trigger to a template expression using standard Angular property binding syntax as shown below, where `triggerName` is the name of the trigger, and `expression` evaluates to a defined animation state.
 
-<docs-code language="typescript">
-
-<div [@triggerName]="expression">…</div>;
-
-</docs-code>
+```angular-html
+<div [@triggerName]="expression">…</div>
+```
 
 The animation is executed or triggered when the expression value changes to a new state.
 

--- a/adev/src/content/guide/i18n/prepare.md
+++ b/adev/src/content/guide/i18n/prepare.md
@@ -61,8 +61,6 @@ The attributes of HTML elements include text that should be translated along wit
 Use `i18n-{attribute_name}` with any attribute of any element and replace `{attribute_name}` with the name of the attribute.
 Use the following syntax to assign a meaning, description, and custom ID.
 
-<!--todo: replace with docs-code -->
-
 ```html
 i18n-{attribute_name}="{meaning}|{description}@@{id}"
 ```
@@ -88,45 +86,37 @@ In component code, the translation source text and the metadata are surrounded b
 
 Use the [`$localize`][ApiLocalizeInitLocalize] tagged message string to mark a string in your code for translation.
 
-<!--todo: replace with docs-code -->
-
-<docs-code language="typescript">
+```ts
 $localize`string_to_translate`;
-</docs-code>
+```
 
 The i18n metadata is surrounded by colon \(`:`\) characters and prepends the translation source text.
 
-<!--todo: replace with docs-code -->
-
-<docs-code language="typescript">
+```ts
 $localize`:{i18n_metadata}:string_to_translate`
-</docs-code>
+```
 
 ### Include interpolated text
 
 Include [interpolations](guide/templates/binding#render-dynamic-text-with-text-interpolation) in a [`$localize`][ApiLocalizeInitLocalize] tagged message string.
 
-<!--todo: replace with docs-code -->
-
-<docs-code language="typescript">
+```ts
 $localize`string_to_translate ${variable_name}`;
-</docs-code>
+```
 
 ### Name the interpolation placeholder
 
-<docs-code language="typescript">
+```ts
 $localize`string_to_translate ${variable_name}:placeholder_name:`;
-</docs-code>
+```
 
 ### Conditional syntax for translations
 
-<docs-code language="typescript">
+```ts
 return this.show ? $localize`Show Tabs` : $localize`Hide tabs`;
-</docs-code>
+```
 
 ## i18n metadata for translation
-
-<!--todo: replace with docs-code -->
 
 ```html
 {meaning}|{description}@@{custom_id}
@@ -154,13 +144,9 @@ The following example shows the value of the `i18n` attribute.
 
 The following example shows the value of the [`$localize`][ApiLocalizeInitLocalize] tagged message string with a description.
 
-<!--todo: replace with docs-code -->
-
-<docs-code language="typescript">
-
+```ts
 $localize`:An introduction header for this sample:Hello i18n!`;
-
-</docs-code>
+```
 
 The translator may also need to know the meaning or intent of the text message within this particular application context, in order to translate it the same way as other text with the same meaning.
 Start the `i18n` attribute value with the _meaning_ and separate it from the _description_ with the `|` character: `{meaning}|{description}`.
@@ -177,13 +163,9 @@ The result is any text marked with `site header`, as the _meaning_ is translated
 
 The following code example shows the value of the [`$localize`][ApiLocalizeInitLocalize] tagged message string with a meaning and a description.
 
-<!--todo: replace with docs-code -->
-
-<docs-code language="typescript">
-
+```ts
 $localize`:site header|An introduction header for this sample:Hello i18n!`;
-
-</docs-code>
+```
 
 <docs-callout title="How meanings control text extraction and merges">
 
@@ -211,8 +193,6 @@ That one translation entry is merged back into the application wherever the same
 
 ICU expressions help you mark alternate text in component templates to meet conditions.
 An ICU expression includes a component property, an ICU clause, and the case statements surrounded by open curly brace \(`{`\) and close curly brace \(`}`\) characters.
-
-<!--todo: replace with docs-code -->
 
 ```html
 

--- a/adev/src/content/guide/testing/using-component-harnesses.md
+++ b/adev/src/content/guide/testing/using-component-harnesses.md
@@ -29,7 +29,7 @@ For unit tests you can create a harness loader from [TestbedHarnessEnvironment](
 
 To create a harness loader rooted at the fixture's root element, use the `loader()` method:
 
-<docs-code language="typescript">
+```ts
 const fixture = TestBed.createComponent(MyComponent);
 
 // Create a harness loader from the fixture
@@ -38,7 +38,7 @@ const loader = TestbedHarnessEnvironment.loader(fixture);
 
 // Use the loader to get harness instances
 const myComponentHarness = await loader.getHarness(MyComponent);
-</docs-code>
+```
 
 To create a harness loader for harnesses for elements that fall outside the fixture, use the `documentRootLoader()` method. For example, code that displays a floating element or pop-up often attaches DOM elements directly to the document body, such as the `Overlay` service in Angular CDK.
 
@@ -50,12 +50,12 @@ For WebDriver-based end-to-end tests you can create a harness loader with `Selen
 
 Use the `loader()` method to get the harness loader instance for the current HTML document, rooted at the document's root element. This environment uses a WebDriver client.
 
-<docs-code language="typescript">
+```ts
 let wd: webdriver.WebDriver = getMyWebDriverClient();
 const loader = SeleniumWebDriverHarnessEnvironment.loader(wd);
 ...
 const myComponentHarness = await loader.getHarness(MyComponent);
-</docs-code>
+```
 
 ## Using a harness loader
 
@@ -63,13 +63,13 @@ Harness loader instances correspond to a specific DOM element and are used to cr
 
 To get `ComponentHarness` for the first instance of the element, use the `getHarness()` method. To get all `ComponentHarness` instances, use the `getAllHarnesses()` method.
 
-<docs-code language="typescript">
+```ts
 // Get harness for first instance of the element
 const myComponentHarness = await loader.getHarness(MyComponent);
 
 // Get harnesses for all instances of the element
 const myComponentHarnesses = await loader.getHarnesses(MyComponent);
-</docs-code>
+```
 
 In addition to `getHarness` and `getAllHarnesses`, `HarnessLoader` has several other useful methods for querying for harnesses:
 
@@ -85,7 +85,7 @@ As an example, consider a reusable dialog-button component that opens a dialog o
 
 The following test loads harnesses for each of these components:
 
-<docs-code language="typescript">
+```ts
 let fixture: ComponentFixture<MyDialogButton>;
 let loader: HarnessLoader;
 let rootLoader: HarnessLoader;
@@ -113,7 +113,7 @@ const dialogHarness = await rootLoader.getHarness(MyDialogHarness);
 
 // ... make some assertions
 });
-</docs-code>
+```
 
 ### Harness behavior in different environments
 
@@ -123,7 +123,7 @@ Harnesses may not behave exactly the same in all environments. Some differences 
 
 To interact with elements below the root element of this harness loader, use the `HarnessLoader` instance of a child element. For the first instance of the child element, use the `getChildLoader()` method. For all instances of the child element, use the `getAllChildLoaders()` method.
 
-<docs-code language="typescript">
+```ts
 const myComponentHarness = await loader.getHarness(MyComponent);
 
 // Get loader for first instance of child element with '.child' selector
@@ -131,7 +131,7 @@ const childLoader = await myComponentHarness.getLoader('.child');
 
 // Get loaders for all instances of child elements with '.child' selector
 const allChildLoaders = await myComponentHarness.getAllChildLoaders('.child');
-</docs-code>
+```
 
 ### Filtering harnesses
 
@@ -144,18 +144,18 @@ When you ask a `HarnessLoader` for a harness, you're actually providing a Harnes
 
 `HarnessPredicate` does support some base filters (selector, ancestor) that work on anything that extends `ComponentHarness`.
 
-<docs-code language="typescript">
+```ts
 // Example of loading a MyButtonComponentHarness with a harness predicate
 const disabledButtonPredicate = new HarnessPredicate(MyButtonComponentHarness, {selector: '[disabled]'});
 const disabledButton = await loader.getHarness(disabledButtonPredicate);
-</docs-code>
+```
 
 However it's common for harnesses to implement a static `with()` method that accepts component-specific filtering options and returns a `HarnessPredicate`.
 
-<docs-code language="typescript">
+```ts
 // Example of loading a MyButtonComponentHarness with a specific selector
 const button = await loader.getHarness(MyButtonComponentHarness.with({selector: 'btn'}))
-</docs-code>
+```
 
 For more details refer to the specific harness documentation since additional filtering options are specific to each harness implementation.
 
@@ -167,13 +167,13 @@ Beyond that, the API of any given harness is specific to its corresponding compo
 
 As an example, the following is a test for a component that uses the [Angular Material slider component harness](https://material.angular.dev/components/slider/api#MatSliderHarness):
 
-<docs-code language="typescript">
+```ts
 it('should get value of slider thumb', async () => {
   const slider = await loader.getHarness(MatSliderHarness);
   const thumb = await slider.getEndThumb();
   expect(await thumb.getValue()).toBe(50);
 });
-</docs-code>
+```
 
 ## Interop with Angular change detection
 
@@ -181,7 +181,7 @@ By default, test harnesses runs Angular's [change detection](https://angular.dev
 
 There may be times that you need finer-grained control over change detection in your tests. such as checking the state of a component while an async operation is pending. In these cases use the `manualChangeDetection` function to disable automatic handling of change detection for a block of code.
 
-<docs-code language="typescript">
+```ts
 it('checks state while async action is in progress', async () => {
   const buttonHarness = loader.getHarness(MyButtonHarness);
   await manualChangeDetection(async () => {
@@ -194,7 +194,7 @@ it('checks state while async action is in progress', async () => {
     expect(isProgressSpinnerVisible()).toBe(false);
   });
 });
-</docs-code>
+```
 
 Almost all harness methods are asynchronous and return a `Promise` to support the following:
 
@@ -206,7 +206,7 @@ The Angular team recommends using [await](https://developer.mozilla.org/en-US/do
 
 Occasionally, you may want to perform multiple actions simultaneously and wait until they're all done rather than performing each action sequentially. For example, read multiple properties of a single component. In these situations use the `parallel` function to parallelize the operations. The parallel function works similarly to `Promise.all`, while also optimizing change detection checks.
 
-<docs-code language="typescript">
+```ts
 it('reads properties in parallel', async () => {
   const checkboxHarness = loader.getHarness(MyCheckboxHarness);
   // Read the checked and intermediate properties simultaneously.
@@ -217,4 +217,4 @@ it('reads properties in parallel', async () => {
   expect(checked).toBe(false);
   expect(indeterminate).toBe(true);
 });
-</docs-code>
+```


### PR DESCRIPTION
Replaces custom docs-code blocks with fenced Markdown code blocks and reformats examples to improve readability, consistency, and copy-paste behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
