### PR TITLE
docs: fix lazy loading documentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Join the conversation and help the community.
 [angularelements]: https://angular.dev/guide/elements
 [ssr]: https://angular.dev/guide/ssr
 [schematics]: https://angular.dev/tools/cli/schematics
-[lazyloading]: https://angular.dev/guide/ngmodules/lazy-loading
+[lazyloading]: https://angular.dev/guide/routing/define-routes#lazily-loaded-components
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/get-npm
 [codeofconduct]: CODE_OF_CONDUCT.md


### PR DESCRIPTION
Updates broken or outdated references in the lazy loading guide.

Fixes: #65906
