### PR TITLE
docs(forms): add signal forms documentation for validating array items

### DIFF
--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -293,6 +293,30 @@ Common patterns:
 | Alphanumeric     | `/^[a-zA-Z0-9]+$/`      | abc123       |
 | URL-safe         | `/^[a-zA-Z0-9_-]+$/`    | my-url_123   |
 
+### Validating array items
+
+Forms can include arrays of nested objects (for example, a list of order items). To apply validation rules to each item in an array, use `applyEach()` inside your schema function. `applyEach()` iterates the array path and supplies a path for each item where you can apply validators just like top-level fields.
+
+```ts
+orderModel = signal({
+  title: '',
+  description: '',
+  items: [
+    { name: '', quantity: 0 },
+  ]
+})
+
+orderForm = form(this.orderModel, (schemaPath) => {
+  required(schemaPath.title);
+  required(schemaPath.description);
+
+  applyEach(schemaPath.items, (item) => {
+    required(item.name, { message: 'Item name is required' });
+    min(item.quantity, 1, { message: 'Quantity must be at least 1' });
+  });
+});
+```
+
 ## Validation errors
 
 When validation rules fail, they produce error objects that describe what went wrong. Understanding error structure helps you provide clear feedback to users.

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -293,28 +293,44 @@ Common patterns:
 | Alphanumeric     | `/^[a-zA-Z0-9]+$/`      | abc123       |
 | URL-safe         | `/^[a-zA-Z0-9_-]+$/`    | my-url_123   |
 
-### Validating array items
+## Validation of array items
 
 Forms can include arrays of nested objects (for example, a list of order items). To apply validation rules to each item in an array, use `applyEach()` inside your schema function. `applyEach()` iterates the array path and supplies a path for each item where you can apply validators just like top-level fields.
 
 ```ts
-orderModel = signal({
-  title: '',
-  description: '',
-  items: [
-    { name: '', quantity: 0 },
-  ]
-})
+import { Component, signal } from '@angular/core'
+import { applyEach, Field, form, min, required, SchemaPathTree } from '@angular/forms/signals';
 
-orderForm = form(this.orderModel, (schemaPath) => {
-  required(schemaPath.title);
-  required(schemaPath.description);
+type Item = { name: string; quantity: number }
 
-  applyEach(schemaPath.items, (item) => {
-    required(item.name, { message: 'Item name is required' });
-    min(item.quantity, 1, { message: 'Quantity must be at least 1' });
-  });
-});
+interface Order {
+  title: string;
+  description: string;
+  items: Item[];
+}
+
+function ItemSchema(item: SchemaPathTree<Item>) {
+  required(item.name, { message: 'Item name is required' })
+  min(item.quantity, 1, { message: 'Quantity must be at least 1' })
+}
+
+@Component(/* ... */)
+export class OrderComponent {
+  orderModel = signal<Order>({
+    title: '',
+    description: '',
+    items: [
+      { name: '', quantity: 0 },
+    ]
+  })
+
+  orderForm = form(this.orderModel, (schemaPath) => {
+    required(schemaPath.title)
+    required(schemaPath.description)
+
+    applyEach(schemaPath.items, ItemSchema)
+  })
+}
 ```
 
 ## Validation errors


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, the validation guide does not include examples for validating array items in Signal Forms.

Issue Number: #65901

## What is the new behavior?
Adds a new example demonstrating how to validate array items in Signal Forms using `applyEach()`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

