### PR TITLE
refactor(upgrade): deprecate `VERSION` export

### DIFF
--- a/packages/upgrade/public_api.ts
+++ b/packages/upgrade/public_api.ts
@@ -9,6 +9,8 @@
 /**
  * @module
  * @description
+ *
+ * @deprecated Use the entry from `@angular/upgrade/static` instead.
  * Entry point for all public APIs of this package. allowing
  * Angular 1 and Angular 2+ to run side by side in the same application.
  */


### PR DESCRIPTION
This is the last remaining entry from `@angular/upgrade`. 

users should use the entry from `upgrade/static`.

DEPRECATED: `VERSION` from `@angular/upgrade` is deprecated. Please use the entry from `@angular/upgrade/static` instead.
