### PR TITLE
docs(docs-infra): expose VERSION from `@angular/upgrade`

### DIFF
--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -60,6 +60,7 @@ generate_api_docs(
     srcs = [
         ":files_for_docgen",
         "//packages:common_files_and_deps_for_docs",
+        "//packages/upgrade/src/common:files_for_docgen",
     ],
     entry_point = ":index.ts",
     module_name = "@angular/upgrade",


### PR DESCRIPTION
The missing src was responsible for not exposing the symbols during the doc extraction.

fixes #65916
