### PR TITLE
refactor(devtools): move route parsing logic to debug apis

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -94,7 +94,10 @@ ts_test_library(
 
 ts_project(
     name = "router_tree",
-    srcs = ["router-tree.ts"],
+    srcs = [
+        "legacy-parse-routes.ts",
+        "router-tree.ts",
+    ],
     deps = [
         "//:node_modules/@angular/router",
         "//devtools/projects/protocol",

--- a/devtools/projects/ng-devtools-backend/src/lib/legacy-parse-routes.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/legacy-parse-routes.ts
@@ -1,0 +1,224 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Route} from '../../../protocol';
+import type {ActivatedRoute, Route as AngularRoute} from '@angular/router';
+
+type Routes = any;
+type Router = any;
+
+type RouteGuard = 'canActivate' | 'canActivateChild' | 'canDeactivate' | 'canMatch';
+
+/**
+ * Legacy implementation of parseRoutes for older Angular versions that don't have
+ * the ɵparseRoutes debug API. This uses the old URL-based active route detection approach.
+ *
+ * @param router - The Angular Router instance
+ * @returns A Route tree representing the router configuration with active route information
+ */
+export function legacyParseRoutes(router: Router): Route {
+  const rootName = 'App Root';
+  const rootChildren = router.config;
+
+  // Get the set of active Route configuration objects from the router state
+  const activeRouteConfigs = getActiveRouteConfigs(router);
+
+  const root: Route = {
+    component: rootName,
+    path: rootName,
+    children: rootChildren ? assignChildrenToParent(null, rootChildren, activeRouteConfigs) : [],
+    isAux: false,
+    isLazy: false,
+    isActive: true, // Root is always active.
+  };
+
+  return root;
+}
+
+/**
+ * Gets the set of currently active Route configuration objects from the router state.
+ * This function synchronously reads the current router state without waiting for navigation events.
+ *
+ * @param router - The Angular Router instance
+ * @returns A Set containing all Route configuration objects that are currently active
+ *
+ * @example
+ * ```ts
+ * const activeRoutes = getActiveRouteConfigs(router);
+ * // activeRoutes is a Set<Route> containing all currently active route configurations
+ * ```
+ */
+export function getActiveRouteConfigs(router: Router): Set<AngularRoute> {
+  const rootActivatedRoute = router.routerState?.root;
+  if (!rootActivatedRoute) {
+    return new Set();
+  }
+
+  return collectActiveRouteConfigs(rootActivatedRoute);
+}
+
+/**
+ * Recursively traverses the ActivatedRoute tree and collects all routeConfig objects.
+ * @param activatedRoute - The ActivatedRoute to start traversal from
+ * @param activeRoutes - Set to collect active Route configuration objects
+ * @returns Set of active Route configuration objects
+ */
+function collectActiveRouteConfigs(
+  activatedRoute: ActivatedRoute,
+  activeRoutes: Set<AngularRoute> = new Set(),
+): Set<AngularRoute> {
+  // Get the routeConfig for this ActivatedRoute
+  const routeConfig = activatedRoute.routeConfig;
+  if (routeConfig) {
+    activeRoutes.add(routeConfig);
+  }
+
+  // Recursively process all children
+  const children = activatedRoute.children || [];
+  for (const child of children) {
+    collectActiveRouteConfigs(child, activeRoutes);
+  }
+
+  return activeRoutes;
+}
+
+function assignChildrenToParent(
+  parentPath: string | null,
+  children: Routes,
+  activeRouteConfigs: Set<AngularRoute>,
+): Route[] {
+  return children.map((child: AngularRoute) => {
+    const childName = childRouteName(child);
+    const loadedRoutes = (window as any).ng?.ɵgetLoadedRoutes?.(child as any);
+    const childDescendents: [AngularRoute] = loadedRoutes || child.children;
+
+    const pathFragment = child.outlet ? `(${child.outlet}:${child.path})` : child.path;
+    const routePath = `${parentPath ?? ''}/${pathFragment}`.split('//').join('/');
+
+    // only found in aux routes, otherwise property will be undefined
+    const isAux = Boolean(child.outlet);
+    const isLazy = Boolean(child.loadChildren || child.loadComponent);
+
+    // Check if this route configuration object is in the active routes set
+    // This is the direct reference to the Route object from router.config
+    const isActive = activeRouteConfigs.has(child);
+
+    const routeConfig: Route = {
+      pathMatch: child.pathMatch,
+      component: childName,
+      canActivateGuards: getGuardNames(child, 'canActivate'),
+      canActivateChildGuards: getGuardNames(child, 'canActivateChild'),
+      canMatchGuards: getGuardNames(child, 'canMatch'),
+      canDeactivateGuards: getGuardNames(child, 'canDeactivate'),
+      providers: getProviderName(child),
+      path: routePath,
+      isAux,
+      isLazy,
+      isActive,
+    };
+
+    if (child.title) {
+      routeConfig.title = getPropertyName(child, 'title');
+    }
+
+    if (child.redirectTo) {
+      routeConfig.redirectTo = getPropertyName(child, 'redirectTo');
+    }
+
+    if (child.matcher) {
+      routeConfig.matcher = getPropertyName(child, 'matcher');
+      // For custom matchers, override the path to indicate it's a matcher
+      // Since the path be undefined when using a matcher, because the matcher defines the path matching
+      routeConfig.path = '[Matcher]';
+    }
+
+    if (child.runGuardsAndResolvers) {
+      routeConfig.runGuardsAndResolvers = getPropertyName(child, 'runGuardsAndResolvers');
+    }
+
+    if (childDescendents) {
+      routeConfig.children = assignChildrenToParent(
+        routeConfig.path,
+        childDescendents,
+        activeRouteConfigs,
+      );
+    }
+
+    if (child.resolve) {
+      routeConfig.resolvers = {};
+
+      for (const [name, resolver] of Object.entries(child.resolve)) {
+        routeConfig.resolvers[name] = getClassOrFunctionName(resolver);
+      }
+    }
+
+    if (child.data) {
+      routeConfig.data = child.data;
+    }
+
+    return routeConfig;
+  });
+}
+
+/**
+ * Get the display name for a function or class.
+ * @param fn - The function or class to get the name from
+ * @param defaultName - Optional name to check against. If the function name matches this value,
+ * '[Function]' is returned instead
+ * @returns The formatted name: class name, function name with '()', or '[Function]' for anonymous/arrow functions
+ */
+function getClassOrFunctionName(fn: Function, defaultName?: string) {
+  const isArrow = !fn.hasOwnProperty('prototype');
+
+  const isEmptyName = fn.name === '';
+
+  if ((isArrow && isEmptyName) || isEmptyName) {
+    return '[Function]';
+  }
+
+  const hasDefaultName = fn.name === defaultName;
+  if (hasDefaultName) {
+    return '[Function]';
+  }
+
+  return fn.name;
+}
+
+function getPropertyName(
+  child: AngularRoute,
+  property: 'title' | 'redirectTo' | 'matcher' | 'runGuardsAndResolvers',
+) {
+  if (child[property] instanceof Function) {
+    return getClassOrFunctionName(child[property], property);
+  }
+
+  return child[property];
+}
+
+function childRouteName(child: AngularRoute): string {
+  if (child.component) {
+    return child.component.name;
+  } else if (child.loadChildren || child.loadComponent) {
+    return `${child.path} [Lazy]`;
+  } else {
+    return 'no-name-route';
+  }
+}
+
+function getGuardNames(child: AngularRoute, type: RouteGuard): string[] {
+  const guards = child?.[type] || [];
+
+  const names = guards.map((g: any) => getClassOrFunctionName(g));
+  return names || [];
+}
+
+function getProviderName(child: any): string[] {
+  const providers = child?.providers || [];
+  const names = providers.map((p: any) => p.name);
+  return names || [];
+}

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.spec.ts
@@ -9,6 +9,14 @@
 import {getRouterCallableConstructRef, parseRoutes} from './router-tree';
 
 describe('parseRoutes', () => {
+  beforeEach(() => {
+    if ((window as any).ng) {
+      // test the legacy parseRoutes implementation, the
+      // modern one is tested in framework tests
+      delete (window as any).ng.ɵparseRoutes;
+    }
+  });
+
   it('should work without any routes', () => {
     const routes: any[] = [];
     const parsedRoutes = parseRoutes(routes as any);

--- a/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/router-tree.ts
@@ -7,7 +7,8 @@
  */
 
 import {Route} from '../../../protocol';
-import type {Route as AngularRoute, ActivatedRoute} from '@angular/router';
+import type {Route as AngularRoute} from '@angular/router';
+import {legacyParseRoutes} from './legacy-parse-routes';
 
 export type RoutePropertyType =
   | RouteGuard
@@ -21,164 +22,23 @@ export type RoutePropertyType =
 
 export type RouteGuard = 'canActivate' | 'canActivateChild' | 'canDeactivate' | 'canMatch';
 
-type Routes = any;
 type Router = any;
 
 /**
- * Recursively traverses the ActivatedRoute tree and collects all routeConfig objects.
- * @param activatedRoute - The ActivatedRoute to start traversal from
- * @param activeRoutes - Set to collect active Route configuration objects
- * @returns Set of active Route configuration objects
- */
-function collectActiveRouteConfigs(
-  activatedRoute: ActivatedRoute,
-  activeRoutes: Set<AngularRoute> = new Set(),
-): Set<AngularRoute> {
-  // Get the routeConfig for this ActivatedRoute
-  const routeConfig = activatedRoute.routeConfig;
-  if (routeConfig) {
-    activeRoutes.add(routeConfig);
-  }
-
-  // Recursively process all children
-  const children = activatedRoute.children || [];
-  for (const child of children) {
-    collectActiveRouteConfigs(child, activeRoutes);
-  }
-
-  return activeRoutes;
-}
-
-/**
- * Gets the set of currently active Route configuration objects from the router state.
- * This function synchronously reads the current router state without waiting for navigation events.
+ * Parses the router configuration and returns a tree structure suitable for devtools visualization.
+ * This function uses the debug API published by the Angular Router when available,
+ * otherwise falls back to the legacy implementation for older Angular versions.
  *
  * @param router - The Angular Router instance
- * @returns A Set containing all Route configuration objects that are currently active
- *
- * @example
- * ```ts
- * const activeRoutes = getActiveRouteConfigs(router);
- * // activeRoutes is a Set<Route> containing all currently active route configurations
- * ```
+ * @returns A Route tree representing the router configuration with active route information
  */
-export function getActiveRouteConfigs(router: Router): Set<AngularRoute> {
-  const rootActivatedRoute = router.routerState?.root;
-  if (!rootActivatedRoute) {
-    return new Set();
-  }
-
-  return collectActiveRouteConfigs(rootActivatedRoute);
-}
-
 export function parseRoutes(router: Router): Route {
-  const rootName = 'App Root';
-  const rootChildren = router.config;
-
-  // Get the set of active Route configuration objects from the router state
-  const activeRouteConfigs = getActiveRouteConfigs(router);
-
-  const root: Route = {
-    component: rootName,
-    path: rootName,
-    children: rootChildren ? assignChildrenToParent(null, rootChildren, activeRouteConfigs) : [],
-    isAux: false,
-    isLazy: false,
-    isActive: true, // Root is always active.
-  };
-
-  return root;
-}
-
-function getGuardNames(child: AngularRoute, type: RouteGuard): string[] {
-  const guards = child?.[type] || [];
-
-  const names = guards.map((g: any) => getClassOrFunctionName(g));
-  return names || [];
-}
-
-function getProviderName(child: any): string[] {
-  const providers = child?.providers || [];
-  const names = providers.map((p: any) => p.name);
-  return names || [];
-}
-
-function assignChildrenToParent(
-  parentPath: string | null,
-  children: Routes,
-  activeRouteConfigs: Set<AngularRoute>,
-): Route[] {
-  return children.map((child: AngularRoute) => {
-    const childName = childRouteName(child);
-    const loadedRoutes = (window as any).ng?.ɵgetLoadedRoutes?.(child as any);
-    const childDescendents: [AngularRoute] = loadedRoutes || child.children;
-
-    const pathFragment = child.outlet ? `(${child.outlet}:${child.path})` : child.path;
-    const routePath = `${parentPath ?? ''}/${pathFragment}`.split('//').join('/');
-
-    // only found in aux routes, otherwise property will be undefined
-    const isAux = Boolean(child.outlet);
-    const isLazy = Boolean(child.loadChildren || child.loadComponent);
-
-    // Check if this route configuration object is in the active routes set
-    // This is the direct reference to the Route object from router.config
-    const isActive = activeRouteConfigs.has(child);
-
-    const routeConfig: Route = {
-      pathMatch: child.pathMatch,
-      component: childName,
-      canActivateGuards: getGuardNames(child, 'canActivate'),
-      canActivateChildGuards: getGuardNames(child, 'canActivateChild'),
-      canMatchGuards: getGuardNames(child, 'canMatch'),
-      canDeactivateGuards: getGuardNames(child, 'canDeactivate'),
-      providers: getProviderName(child),
-      path: routePath,
-      isAux,
-      isLazy,
-      isActive,
-    };
-
-    if (child.title) {
-      routeConfig.title = getPropertyName(child, 'title');
-    }
-
-    if (child.redirectTo) {
-      routeConfig.redirectTo = getPropertyName(child, 'redirectTo');
-    }
-
-    if (child.matcher) {
-      routeConfig.matcher = getPropertyName(child, 'matcher');
-      // For custom matchers, override the path to indicate it's a matcher
-      // Since the path be undefined when using a matcher, because the matcher defines the path matching
-      routeConfig.path = '[Matcher]';
-    }
-
-    if (child.runGuardsAndResolvers) {
-      routeConfig.runGuardsAndResolvers = getPropertyName(child, 'runGuardsAndResolvers');
-    }
-
-    if (childDescendents) {
-      routeConfig.children = assignChildrenToParent(
-        routeConfig.path,
-        childDescendents,
-        activeRouteConfigs,
-      );
-    }
-
-    if (child.resolve) {
-      routeConfig.resolvers = {};
-
-      for (const [name, resolver] of Object.entries(child.resolve)) {
-        routeConfig.resolvers[name] = getClassOrFunctionName(resolver);
-      }
-    }
-
-    if (child.data) {
-      routeConfig.data = child.data;
-    }
-
-    return routeConfig;
-  });
+  const parseRoutesFn = (window as any).ng?.ɵparseRoutes;
+  if (!parseRoutesFn) {
+    // Fallback to legacy implementation for older Angular versions
+    return legacyParseRoutes(router);
+  }
+  return parseRoutesFn(router);
 }
 
 /**
@@ -188,9 +48,8 @@ function assignChildrenToParent(
  * '[Function]' is returned instead
  * @returns The formatted name: class name, function name with '()', or '[Function]' for anonymous/arrow functions
  */
-function getClassOrFunctionName(fn: Function, defaultName?: string) {
+function getClassOrFunctionName(fn: Function, defaultName?: string): string {
   const isArrow = !fn.hasOwnProperty('prototype');
-
   const isEmptyName = fn.name === '';
 
   if ((isArrow && isEmptyName) || isEmptyName) {
@@ -203,27 +62,6 @@ function getClassOrFunctionName(fn: Function, defaultName?: string) {
   }
 
   return fn.name;
-}
-
-function getPropertyName(
-  child: AngularRoute,
-  property: 'title' | 'redirectTo' | 'matcher' | 'runGuardsAndResolvers',
-) {
-  if (child[property] instanceof Function) {
-    return getClassOrFunctionName(child[property], property);
-  }
-
-  return child[property];
-}
-
-function childRouteName(child: AngularRoute): string {
-  if (child.component) {
-    return child.component.name;
-  } else if (child.loadChildren || child.loadComponent) {
-    return `${child.path} [Lazy]`;
-  } else {
-    return 'no-name-route';
-  }
 }
 
 /**

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -63,6 +63,7 @@ export interface ExternalGlobalUtils {
   ɵgetLoadedRoutes(route: any): any;
   ɵnavigateByUrl(router: any, url: string): any;
   ɵgetRouterInstance(injector: any): any;
+  ɵparseRoutes(router: any): any;
 }
 
 const globalUtilsFunctions = {

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -52,7 +52,12 @@ import {
   VIEW_TRANSITION_OPTIONS,
   ViewTransitionsFeatureOptions,
 } from './utils/view_transition';
-import {getLoadedRoutes, getRouterInstance, navigateByUrl} from './router_devtools';
+import {
+  getLoadedRoutes,
+  getRouterInstance,
+  navigateByUrl,
+  parseRoutes,
+} from './router_devtools';
 import {StateManager} from './statemanager/state_manager';
 import {NavigationStateManager} from './statemanager/navigation_state_manager';
 
@@ -99,6 +104,7 @@ export function provideRouter(routes: Routes, ...features: RouterFeatures[]): En
     ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);
     ɵpublishExternalGlobalUtil('ɵgetRouterInstance', getRouterInstance);
     ɵpublishExternalGlobalUtil('ɵnavigateByUrl', navigateByUrl);
+    ɵpublishExternalGlobalUtil('ɵparseRoutes', parseRoutes);
   }
 
   return makeEnvironmentProviders([

--- a/packages/router/src/router_devtools.ts
+++ b/packages/router/src/router_devtools.ts
@@ -8,12 +8,50 @@
 
 import {Injector} from '@angular/core';
 import {Router} from './router';
-import {Route} from './models';
+import {Route as AngularRoute, Routes} from './models';
+import {ActivatedRoute} from './router_state';
+
+/**
+ * Route representation for devtools.
+ * This matches the protocol Route interface used by Angular DevTools.
+ */
+export interface DebugRoute {
+  name?: string;
+  hash?: string;
+  specificity?: string;
+  handler?: string;
+  pathMatch?: 'prefix' | 'full';
+  canActivateGuards?: string[];
+  canActivateChildGuards?: string[];
+  canMatchGuards?: string[];
+  canDeactivateGuards?: string[];
+  providers?: string[];
+  title?: string;
+  children?: Array<DebugRoute>;
+  data?: {[key: string | symbol]: any};
+  resolvers?: {[key: string]: string};
+  path: string;
+  component: string;
+  redirectTo?: string;
+  isActive: boolean;
+  isAux: boolean;
+  isLazy: boolean;
+  matcher?: string;
+  runGuardsAndResolvers?:
+    | 'pathParamsChange'
+    | 'pathParamsOrQueryParamsChange'
+    | 'paramsChange'
+    | 'paramsOrQueryParamsChange'
+    | 'always'
+    | (string & {});
+}
+
+type RouteGuard = 'canActivate' | 'canActivateChild' | 'canDeactivate' | 'canMatch';
 
 /**
  * Returns the loaded routes for a given route.
  */
-export function getLoadedRoutes(route: Route): Route[] | undefined {
+export function getLoadedRoutes(route: AngularRoute): Routes | undefined {
   return route._loadedRoutes;
 }
 
@@ -33,4 +71,224 @@ export function navigateByUrl(router: Router, url: string): Promise<boolean> {
     throw new Error('The provided router is not an Angular Router.');
   }
   return router.navigateByUrl(url);
+}
+
+/**
+ * Recursively traverses the ActivatedRoute tree and collects all routeConfig objects.
+ * @param activatedRoute - The ActivatedRoute to start traversal from
+ * @param activeRoutes - Set to collect active Route configuration objects
+ * @returns Set of active Route configuration objects
+ */
+function collectActiveRouteConfigs(
+  activatedRoute: ActivatedRoute,
+  activeRoutes: Set<AngularRoute> = new Set(),
+): Set<AngularRoute> {
+  // Get the routeConfig for this ActivatedRoute
+  const routeConfig = activatedRoute.routeConfig;
+  if (routeConfig) {
+    activeRoutes.add(routeConfig);
+  }
+
+  // Recursively process all children
+  const children = activatedRoute.children || [];
+  for (const child of children) {
+    collectActiveRouteConfigs(child, activeRoutes);
+  }
+
+  return activeRoutes;
+}
+
+/**
+ * Gets the set of currently active Route configuration objects from the router state.
+ * This function synchronously reads the current router state without waiting for navigation events.
+ *
+ * @param router - The Angular Router instance
+ * @returns A Set containing all Route configuration objects that are currently active
+ *
+ * @example
+ * ```ts
+ * const activeRoutes = getActiveRouteConfigs(router);
+ * // activeRoutes is a Set<Route> containing all currently active route configurations
+ * ```
+ */
+export function getActiveRouteConfigs(router: Router): Set<AngularRoute> {
+  const rootActivatedRoute = router.routerState?.root;
+  if (!rootActivatedRoute) {
+    return new Set();
+  }
+
+  return collectActiveRouteConfigs(rootActivatedRoute);
+}
+
+/**
+ * Returns the router configuration (routes) for the given router instance.
+ * Throws if the provided router is not an Angular Router.
+ *
+ * @param router - The Angular Router instance
+ * @returns The array of Route configuration objects
+ */
+export function getRouterConfig(router: Router): Routes {
+  if (!(router instanceof Router)) {
+    throw new Error('The provided router is not an Angular Router.');
+  }
+  return router.config;
+}
+
+/**
+ * Get the display name for a function or class.
+ * @param fn - The function or class to get the name from
+ * @param defaultName - Optional name to check against. If the function name matches this value,
+ * '[Function]' is returned instead
+ * @returns The formatted name: class name, function name with '()', or '[Function]' for anonymous/arrow functions
+ */
+function getClassOrFunctionName(fn: Function, defaultName?: string) {
+  const isArrow = !fn.hasOwnProperty('prototype');
+  const isEmptyName = fn.name === '';
+
+  if ((isArrow && isEmptyName) || isEmptyName) {
+    return '[Function]';
+  }
+
+  const hasDefaultName = fn.name === defaultName;
+  if (hasDefaultName) {
+    return '[Function]';
+  }
+
+  return fn.name;
+}
+
+function getGuardNames(child: AngularRoute, type: RouteGuard): string[] {
+  const guards = child?.[type] || [];
+  const names = guards.map((g: any) => getClassOrFunctionName(g));
+  return names || [];
+}
+
+function getProviderName(child: any): string[] {
+  const providers = child?.providers || [];
+  const names = providers.map((p: any) => p.name);
+  return names || [];
+}
+
+function getPropertyName(
+  child: AngularRoute,
+  property: 'title' | 'redirectTo' | 'matcher' | 'runGuardsAndResolvers',
+) {
+  if (child[property] instanceof Function) {
+    return getClassOrFunctionName(child[property], property);
+  }
+  return child[property];
+}
+
+function childRouteName(child: AngularRoute): string {
+  if (child.component) {
+    return child.component.name;
+  } else if (child.loadChildren || child.loadComponent) {
+    return `${child.path} [Lazy]`;
+  } else {
+    return 'no-name-route';
+  }
+}
+
+function assignChildrenToParent(
+  parentPath: string | null,
+  children: Routes,
+  activeRouteConfigs: Set<AngularRoute>,
+): DebugRoute[] {
+  return children.map((child: AngularRoute) => {
+    const childName = childRouteName(child);
+    const loadedRoutes = (window as any).ng?.ɵgetLoadedRoutes?.(child as any);
+    const childDescendents: Routes = loadedRoutes || child.children;
+
+    const pathFragment = child.outlet ? `(${child.outlet}:${child.path})` : child.path;
+    const routePath = `${parentPath ?? ''}/${pathFragment}`.split('//').join('/');
+
+    // only found in aux routes, otherwise property will be undefined
+    const isAux = Boolean(child.outlet);
+    const isLazy = Boolean(child.loadChildren || child.loadComponent);
+
+    // Check if this route configuration object is in the active routes set
+    // This is the direct reference to the Route object from router.config
+    const isActive = activeRouteConfigs.has(child);
+
+    const routeConfig: DebugRoute = {
+      pathMatch: child.pathMatch,
+      component: childName,
+      canActivateGuards: getGuardNames(child, 'canActivate'),
+      canActivateChildGuards: getGuardNames(child, 'canActivateChild'),
+      canMatchGuards: getGuardNames(child, 'canMatch'),
+      canDeactivateGuards: getGuardNames(child, 'canDeactivate'),
+      providers: getProviderName(child),
+      path: routePath,
+      isAux,
+      isLazy,
+      isActive,
+    };
+
+    if (child.title) {
+      routeConfig.title = getPropertyName(child, 'title');
+    }
+
+    if (child.redirectTo) {
+      routeConfig.redirectTo = getPropertyName(child, 'redirectTo');
+    }
+
+    if (child.matcher) {
+      routeConfig.matcher = getPropertyName(child, 'matcher');
+      // For custom matchers, override the path to indicate it's a matcher
+      // Since the path be undefined when using a matcher, because the matcher defines the path matching
+      routeConfig.path = '[Matcher]';
+    }
+
+    if (child.runGuardsAndResolvers) {
+      routeConfig.runGuardsAndResolvers = getPropertyName(child, 'runGuardsAndResolvers');
+    }
+
+    if (childDescendents) {
+      routeConfig.children = assignChildrenToParent(
+        routeConfig.path,
+        childDescendents,
+        activeRouteConfigs,
+      );
+    }
+
+    if (child.resolve) {
+      routeConfig.resolvers = {};
+
+      for (const [name, resolver] of Object.entries(child.resolve)) {
+        routeConfig.resolvers[name] = getClassOrFunctionName(resolver);
+      }
+    }
+
+    if (child.data) {
+      routeConfig.data = child.data;
+    }
+
+    return routeConfig;
+  });
+}
+
+/**
+ * Parses the router configuration and returns a tree structure suitable for devtools visualization.
+ * This function analyzes the router's configuration and current state to determine which routes are active.
+ *
+ * @param router - The Angular Router instance
+ * @returns A DebugRoute tree representing the router configuration with active route information
+ */
+export function parseRoutes(router: Router): DebugRoute {
+  const rootName = 'App Root';
+  const rootChildren = router.config;
+
+  // Get the set of active Route configuration objects from the router state
+  const activeRouteConfigs = getActiveRouteConfigs(router);
+
+  const root: DebugRoute = {
+    component: rootName,
+    path: rootName,
+    children: rootChildren ? assignChildrenToParent(null, rootChildren, activeRouteConfigs) : [],
+    isAux: false,
+    isLazy: false,
+    isActive: true, // Root is always active.
+  };
+
+  return root;
 }

--- a/packages/router/test/router_devtools.spec.ts
+++ b/packages/router/test/router_devtools.spec.ts
@@ -8,8 +8,13 @@
 
 import {Component, Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {Router, RouterModule} from '../index';
-import {getLoadedRoutes, getRouterInstance, navigateByUrl} from '../src/router_devtools';
+import {Router, RouterModule, CanActivateFn} from '../index';
+import {
+  getLoadedRoutes,
+  getRouterInstance,
+  navigateByUrl,
+  parseRoutes,
+} from '../src/router_devtools';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}
@@ -103,6 +108,220 @@ describe('router_devtools', () => {
       expect(() => navigateByUrl({} as unknown as Router, '/foo')).toThrowError(
         'The provided router is not an Angular Router.',
       );
+    });
+  });
+
+  describe('parseRoutes', () => {
+    it('should parse basic routes', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {path: 'foo', component: SimpleStandaloneComponent},
+            {path: 'bar', component: RootCmp},
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.component).toBe('App Root');
+      expect(result.path).toBe('App Root');
+      expect(result.isActive).toBe(true);
+      expect(result.children).toBeDefined();
+      expect(result.children!.length).toBe(2);
+      expect(result.children![0].path).toBe('/foo');
+      expect(result.children![0].component).toBe('SimpleStandaloneComponent');
+      expect(result.children![1].path).toBe('/bar');
+      expect(result.children![1].component).toBe('RootCmp');
+    });
+
+    it('should mark active routes correctly', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {path: 'foo', component: SimpleStandaloneComponent},
+            {path: 'bar', component: RootCmp},
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      await router.navigateByUrl('/foo');
+
+      const result = parseRoutes(router);
+
+      expect(result.children![0].isActive).toBe(true);
+      expect(result.children![1].isActive).toBe(false);
+    });
+
+    it('should handle nested routes', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'parent',
+              component: RootCmp,
+              children: [
+                {path: 'child1', component: SimpleStandaloneComponent},
+                {path: 'child2', component: SimpleStandaloneComponent},
+              ],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      await router.navigateByUrl('/parent/child1');
+
+      const result = parseRoutes(router);
+
+      expect(result.children![0].path).toBe('/parent');
+      expect(result.children![0].children).toBeDefined();
+      expect(result.children![0].children!.length).toBe(2);
+      expect(result.children![0].children![0].path).toBe('/parent/child1');
+      expect(result.children![0].children![0].isActive).toBe(true);
+    });
+
+    it('should detect lazy loaded routes', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'lazy',
+              loadChildren: () => [{path: 'simple', component: SimpleStandaloneComponent}],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      await router.navigateByUrl('/lazy/simple');
+
+      const result = parseRoutes(router);
+
+      expect(result.children![0].path).toBe('/lazy');
+      expect(result.children![0].isLazy).toBe(true);
+      expect(result.children![0].component).toBe('lazy [Lazy]');
+    });
+
+    it('should include guard information', async () => {
+      const testGuard: CanActivateFn = () => true;
+
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'guarded',
+              component: SimpleStandaloneComponent,
+              canActivate: [testGuard],
+              canMatch: [testGuard],
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].canActivateGuards).toContain('testGuard');
+      expect(result.children![0].canMatchGuards).toContain('testGuard');
+    });
+
+    it('should handle routes with title', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'titled',
+              component: SimpleStandaloneComponent,
+              title: 'Test Title',
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].title).toBe('Test Title');
+    });
+
+    it('should handle redirect routes', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'redirect',
+              redirectTo: '/foo',
+            },
+            {path: 'foo', component: SimpleStandaloneComponent},
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].redirectTo).toBe('/foo');
+      expect(result.children![0].component).toBe('no-name-route');
+    });
+
+    it('should handle auxiliary routes', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {path: 'aux', component: SimpleStandaloneComponent, outlet: 'sidebar'},
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].isAux).toBe(true);
+      expect(result.children![0].path).toContain('sidebar');
+    });
+
+    it('should handle routes with data', async () => {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'data',
+              component: SimpleStandaloneComponent,
+              data: {key: 'value', number: 42},
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].data).toEqual({key: 'value', number: 42});
+    });
+
+    it('should handle routes with resolvers', async () => {
+      const testResolver = () => 'resolved';
+
+      TestBed.configureTestingModule({
+        imports: [
+          RouterModule.forRoot([
+            {
+              path: 'resolve',
+              component: SimpleStandaloneComponent,
+              resolve: {data: testResolver},
+            },
+          ]),
+        ],
+      });
+
+      const router = TestBed.inject(Router);
+      const result = parseRoutes(router);
+
+      expect(result.children![0].resolvers).toBeDefined();
+      expect(result.children![0].resolvers!['data']).toBe('testResolver');
     });
   });
 });


### PR DESCRIPTION
Previously we depended on Angular DevTools specific logic to parse the underlying router tree from a router instance.

Now, Angular DevTools defers this logic to the framework, so that we can change implementation on the across framework versions as needed, and make way for similar debug APIs in Wiz.

There are test cases for the legacy implementation on the DevTools side and test cases for the framework implementation on the framework side.
