### PR TITLE
docs: document deprecation of `providedIn: 'any'`

### DIFF
--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -44,6 +44,8 @@ When you use `@Injectable({ providedIn: 'root' })` in your service, Angular:
 
 This is the recommended approach for most services.
 
+IMPORTANT: `providedIn: 'any'` is deprecated and will be removed in a future version of Angular. Use `providedIn: 'root'` for application-wide singleton services or `providedIn: 'platform'` for platform-level services.
+
 ## Injecting a service
 
 Once you've created a service with `providedIn: 'root'`, you can inject it anywhere in your application using the `inject()` function from `@angular/core`.


### PR DESCRIPTION
Adds missing note explaining that `providedIn: 'any'` is deprecated and will be removed in a future Angular version.
Also clarifies recommended alternatives: `providedIn: 'root'` for app-wide singletons and `providedIn: 'platform'` for platform-scoped services.

Fixes: #65923

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65923


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
