### PR TITLE
refactor(core): add dedicated deprecated signatures for providedIn: any / NgModule.

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
@@ -174,8 +174,9 @@ function getTag<T extends HasJsDocTags | FunctionEntry>(entry: T, tag: string, e
 export function getTagSinceVersion<T extends HasJsDocTags>(
   entry: T,
   tagName: string,
+  every = false,
 ): {version: string | undefined} | undefined {
-  const tag = getTag(entry, tagName);
+  const tag = getTag(entry, tagName, every);
   if (!tag) {
     return undefined;
   }

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
@@ -9,7 +9,11 @@
 import {initHighlighter} from '../../../../shared/shiki.mjs';
 import {setHighlighterInstance} from '../../shiki/shiki.mjs';
 import {setCurrentSymbol, setSymbols} from '../../symbol-context.mjs';
-import {addHtmlAdditionalLinks, addHtmlDescription} from '../../transforms/jsdoc-transforms.mjs';
+import {
+  addHtmlAdditionalLinks,
+  addHtmlDescription,
+  setEntryFlags,
+} from '../../transforms/jsdoc-transforms.mjs';
 
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
 describe('jsdoc transforms', () => {
@@ -229,5 +233,63 @@ function setupRouter() {
     expect(entry.htmlDescription).toContain('class="docs-code"');
 
     expect(entry.htmlDescription).toContain('/api/angular/router/Router');
+  });
+
+  it('should only mark as deprecated if all overloads are deprecated', () => {
+    const entry = setEntryFlags({
+      name: 'Injectable',
+      jsdocTags: [
+        {'name': 'see', 'comment': '[Introduction to Services and DI](guide/di)'},
+        {
+          'name': 'see',
+          'comment': '[Creating and using services](guide/di/creating-and-using-services)',
+        },
+      ],
+      signatures: [
+        {
+          'parameters': [],
+          'jsdocTags': [{'name': 'see', 'comment': '[Introduction to Services and DI](guide/di)'}],
+        },
+        {
+          'parameters': [],
+          'jsdocTags': [
+            {
+              'name': 'deprecated',
+              'comment':
+                "The `providedIn: NgModule` or `providedIn:'any'` options are deprecated. Please use the other signatures.",
+            },
+          ],
+        },
+      ],
+    } as any);
+
+    expect(entry.deprecated).toEqual(undefined);
+
+    const deprecatedEntry = setEntryFlags({
+      name: 'Injectable',
+      jsdocTags: [
+        {'name': 'see', 'comment': '[Introduction to Services and DI](guide/di)'},
+        {
+          'name': 'see',
+          'comment': '[Creating and using services](guide/di/creating-and-using-services)',
+        },
+      ],
+      signatures: [
+        {
+          'parameters': [],
+          'jsdocTags': [
+            {'name': 'see', 'comment': '[Introduction to Services and DI](guide/di)'},
+            {'name': 'deprecated', 'comment': '19.0 something something'},
+          ],
+        },
+        {
+          'parameters': [],
+          'jsdocTags': [{'name': 'deprecated', 'comment': '19.0 something something'}],
+        },
+      ],
+    } as any);
+
+    // It's deprecated by
+    expect(deprecatedEntry.deprecated).toEqual({version: '19.0'});
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
@@ -119,7 +119,7 @@ export function setEntryFlags<T extends HasJsDocTags & HasModuleName>(
   const deprecationMessage = getDeprecatedEntry(entry);
   return {
     ...entry,
-    deprecated: getTagSinceVersion(entry, 'deprecated'),
+    deprecated: getTagSinceVersion(entry, 'deprecated', true),
     deprecationMessage: deprecationMessage
       ? getHtmlForJsDocText(deprecationMessage)
       : deprecationMessage,

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -884,9 +884,13 @@ export const Injectable: InjectableDecorator;
 // @public
 export interface InjectableDecorator {
     (): TypeDecorator;
+    // @deprecated (undocumented)
+    (options?: {
+        providedIn: Type<any> | 'any';
+    } & InjectableProvider): TypeDecorator;
     // (undocumented)
     (options?: {
-        providedIn: Type<any> | 'root' | 'platform' | 'any' | null;
+        providedIn: 'root' | 'platform' | null;
     } & InjectableProvider): TypeDecorator;
     // (undocumented)
     new (): Injectable;
@@ -916,6 +920,11 @@ export interface InjectDecorator {
 
 // @public
 export class InjectionToken<T> {
+    // @deprecated
+    constructor(_desc: string, options: {
+        providedIn?: Type<any> | 'any';
+        factory: () => T;
+    });
     constructor(_desc: string, options?: {
         providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
         factory: () => T;

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -61,9 +61,12 @@ export interface InjectableDecorator {
    *
    */
   (): TypeDecorator;
-  (
-    options?: {providedIn: Type<any> | 'root' | 'platform' | 'any' | null} & InjectableProvider,
-  ): TypeDecorator;
+
+  /**
+   * @deprecated The `providedIn: NgModule` or `providedIn:'any'` options are deprecated. Please use the other signatures.
+   */
+  (options?: {providedIn: Type<any> | 'any'} & InjectableProvider): TypeDecorator;
+  (options?: {providedIn: 'root' | 'platform' | null} & InjectableProvider): TypeDecorator;
   new (): Injectable;
   new (
     options?: {providedIn: Type<any> | 'root' | 'platform' | 'any' | null} & InjectableProvider,

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -69,11 +69,30 @@ export class InjectionToken<T> {
   readonly ɵprov: unknown;
 
   /**
+   * @deprecated The `providedIn: NgModule` or `providedIn:'any'` options are deprecated. Please use the other signature.
+   */
+  constructor(
+    _desc: string,
+    options: {
+      providedIn?: Type<any> | 'any';
+      factory: () => T;
+    },
+  );
+
+  /**
    * @param _desc   Description for the token,
    *                used only for debugging purposes,
    *                it should but does not need to be unique
    * @param options Options for the token's usage, as described above
    */
+  constructor(
+    _desc: string,
+    options?: {
+      providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+      factory: () => T;
+    },
+  );
+
   constructor(
     protected _desc: string,
     options?: {


### PR DESCRIPTION
Those were deprecated by #47616 back in v15.

fixes #65923
