### PR TITLE
refactor(docs-infra): extract normalizeModuleName helper to replace d…

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/index.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/index.mts
@@ -28,17 +28,27 @@ interface EntryCollection {
   symbols: Record<string, string>;
 }
 
+/**
+ * Normalizes a module name by removing the '@angular/' prefix if present.
+ */
+function normalizeModuleName(moduleName: string): string {
+  // Remove @angular/ prefix if present
+  if (moduleName.startsWith('@angular/')) {
+    return moduleName.slice(9); // Remove '@angular/' (9 chars)
+  }
+  return moduleName;
+}
+
 /** Parse all JSON data source files into an array of collections. */
 function parseEntryData(srcs: string[]): EntryCollection[] {
   return srcs.flatMap((jsonDataFilePath): EntryCollection | EntryCollection[] => {
     const fileContent = readFileSync(jsonDataFilePath, {encoding: 'utf8'});
     const fileContentJson = JSON.parse(fileContent) as unknown;
     if ((fileContentJson as EntryCollection).entries) {
+      // Normalize module names in symbols
       const symbols = Object.fromEntries(
-        // TODO: refactor that, it's dirty and we can probably do better than this.
-        // We're removing the leading `@angular/` from module names.
         (((fileContentJson as any).symbols ?? []) as [string, string][]).map(
-          ([symbol, moduleName]) => [symbol, moduleName.slice(9)],
+          ([symbol, moduleName]) => [symbol, normalizeModuleName(moduleName)],
         ),
       );
 


### PR DESCRIPTION
…irty slice approach

Replace the hardcoded slice(9) operation with a dedicated normalizeModuleName function for removing @angular/ prefix from module names.

The previous implementation used a magic number (9) to slice off the @angular/ prefix, which was brittle and unclear. This change introduces a proper helper function that checks for the prefix before removing it, making the code more maintainable and self-documenting.

Fixes TODO in parseEntryData about dirty module name normalization.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
