### PR TITLE
fix(forms): Reuse key in parent in compat structure

### DIFF
--- a/packages/forms/signals/compat/src/compat_structure.ts
+++ b/packages/forms/signals/compat/src/compat_structure.ts
@@ -101,9 +101,7 @@ function getControlValueSignal<T>(options: CompatFieldNodeOptions) {
  */
 export class CompatStructure extends FieldNodeStructure {
   override value: WritableSignal<unknown>;
-  override keyInParent: Signal<string> = (() => {
-    throw new Error('Compat nodes do not use keyInParent.');
-  }) as unknown as Signal<string>;
+  override keyInParent: Signal<string>;
   override root: FieldNode;
   override pathKeys: Signal<readonly string[]>;
   override readonly children = signal([]);
@@ -119,6 +117,11 @@ export class CompatStructure extends FieldNodeStructure {
     this.parent = getParentFromOptions(options);
     this.root = this.parent?.structure.root ?? node;
     this.fieldManager = getFieldManagerFromOptions(options);
+
+    const identityInParent = options.kind === 'child' ? options.identityInParent : undefined;
+    const initialKeyInParent = options.kind === 'child' ? options.initialKeyInParent : undefined;
+    this.keyInParent = this.createKeyInParent(options, identityInParent, initialKeyInParent);
+
     this.pathKeys = computed(() =>
       this.parent ? [...this.parent.structure.pathKeys(), this.keyInParent()] : [],
     );

--- a/packages/forms/signals/test/web/compat_form.spec.ts
+++ b/packages/forms/signals/test/web/compat_form.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {TestBed} from '@angular/core/testing';
+import {Field} from '../../public_api';
+import {compatForm} from '../../compat';
+
+describe('compatForm with [field] directive', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+  });
+
+  it('should bind compat form to input with [field] directive', () => {
+    @Component({
+      imports: [Field],
+      template: `
+        <input [field]="f.name" />
+        <input type="number" [field]="f.age" />
+      `,
+    })
+    class TestCmp {
+      readonly cat = signal({
+        name: new FormControl('pirojok-the-cat', {nonNullable: true}),
+        age: new FormControl(5, {nonNullable: true}),
+      });
+      readonly f = compatForm(this.cat);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const inputs = fixture.nativeElement.querySelectorAll('input');
+    const nameInput = inputs[0] as HTMLInputElement;
+    const ageInput = inputs[1] as HTMLInputElement;
+
+    expect(nameInput.value).toBe('pirojok-the-cat');
+    expect(ageInput.value).toBe('5');
+  });
+
+  it('should bind root-level FormControl to input with [field] directive', () => {
+    @Component({
+      imports: [Field],
+      template: `<input [field]="f" />`,
+    })
+    class TestCmp {
+      readonly cat = signal(new FormControl('pirojok-the-cat', {nonNullable: true}));
+      readonly f = compatForm(this.cat);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    expect(input.value).toBe('pirojok-the-cat');
+  });
+
+  it('should bind fields when FormControls are mixed with regular values', () => {
+    @Component({
+      imports: [Field],
+      template: `
+        <input [field]="f.name" />
+        <input type="number" [field]="f.age" />
+      `,
+    })
+    class TestCmp {
+      readonly cat = signal({
+        name: new FormControl('fluffy', {nonNullable: true}),
+        age: 3,
+        species: 'cat',
+      });
+      readonly f = compatForm(this.cat);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const inputs = fixture.nativeElement.querySelectorAll('input');
+    const nameInput = inputs[0] as HTMLInputElement;
+    const ageInput = inputs[1] as HTMLInputElement;
+
+    expect(nameInput.value).toBe('fluffy');
+    expect(ageInput.value).toBe('3');
+    expect(fixture.componentInstance.f().value().species).toBe('cat');
+  });
+});
+
+function act<T>(fn: () => T): T {
+  try {
+    return fn();
+  } finally {
+    TestBed.tick();
+  }
+}


### PR DESCRIPTION
This fixes the "Compat nodes do not use keyInParent." error when trying to bind compatField.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
