### PR TITLE
refactor(core): wrap operationsCounter calls with ngDevMode checks

### DIFF
--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -440,13 +440,13 @@ class LiveCollectionLContainerImpl extends LiveCollection<
       new RepeaterContext(this.lContainer, value, index),
       {dehydratedView},
     );
-    this.operationsCounter?.recordCreate();
+    ngDevMode && this.operationsCounter?.recordCreate();
 
     return embeddedLView;
   }
   override destroy(lView: LView<RepeaterContext<unknown>>): void {
     destroyLView(lView[TVIEW], lView);
-    this.operationsCounter?.recordDestroy();
+    ngDevMode && this.operationsCounter?.recordDestroy();
   }
   override updateValue(index: number, value: unknown): void {
     this.getLView(index)[CONTEXT].$implicit = value;
@@ -454,7 +454,7 @@ class LiveCollectionLContainerImpl extends LiveCollection<
 
   reset(): void {
     this.needsIndexUpdate = false;
-    this.operationsCounter?.reset();
+    ngDevMode && this.operationsCounter?.reset();
   }
 
   updateIndexes(): void {


### PR DESCRIPTION
Wrap operationsCounter method calls (recordCreate, recordDestroy, reset) with ngDevMode guards to ensure they are tree-shaken in production builds.

This aligns with the existing pattern where operationsCounter is only initialized in development mode, and eliminates unnecessary method call overhead in production.

The optional chaining (?.) is retained as TypeScript doesn't narrow types based on ngDevMode checks, but the entire expression will be removed during production builds.