### PR TITLE
[Documentation] Expand the recommended use of ::ng-deep

### DIFF
--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -72,8 +72,6 @@ as `::shadow` or `::part`.
 #### `::ng-deep`
 
 Angular's emulated encapsulation mode supports a custom pseudo class, `::ng-deep`.
-**The Angular team strongly discourages new use of `::ng-deep`**. These APIs remain
-exclusively for backwards compatibility.
 
 When a selector contains `::ng-deep`, Angular stops applying view-encapsulation boundaries after that point in the selector. Any part of the selector that follows `::ng-deep` can match elements outside the component’s template.
 
@@ -93,6 +91,9 @@ For example:
 - With `:host ::ng-deep p a`, both the `<a>` and `<p>` elements must be decendants of the component's host element.
 
   They can come from the component's template or the views of its child components, but not elsewhere in the app.
+
+The only recommended use of `::ng-deep` is when preceded with a component-bound selector as in the last examples above, in order to style elements that are in the component's template or in its projected or child content.
+**The Angular team strongly discourages other uses of `::ng-deep`** applying to the outside of the component. That use case remains exclusively for backwards compatibility.
 
 ### ViewEncapsulation.ShadowDom
 


### PR DESCRIPTION
Among the possible uses of `::ng-deep`, this change specifies two different cases, and declares that the "Angular team's discouragement" on the use of `::ng-deep` now only applies to one of these cases.

Follows #65718

The two cases are as follows :
- using `::ng-deep` at the start of a selector is still discouraged, as it applies style outside of the component, but inconsistently as it only triggers when the component is loaded.
- using `::ng-deep` in the **middle** of a selector is now okayed (whether the left part is `:host` or something else), as its effects are constrained to the HTML element of the component (and its descendents, whether written in the component's template, in child content, in non-recommended innerHTML bindings...).

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:
