### PR TITLE
build: add the ignore all rc files flag when running bazel info

### DIFF
--- a/packages/language-service/build.sh
+++ b/packages/language-service/build.sh
@@ -5,7 +5,9 @@ set -ex
 # so that it can be consumed by the Angular extension for local development.
 # Usage: ./build.sh /path/to/vscode-ng-language-service
 
-readonly bazel_bin=$(pnpm --silent bazel info bazel-bin)
+# TODO: Remove --ignore_all_rc_files flag once a repository can be loaded in bazelrc during info
+# commands again. See https://github.com/bazelbuild/bazel/issues/25145 for more context.
+readonly bazel_bin=$(pnpm --silent bazel --ignore_all_rc_files info bazel-bin)
 readonly extension_repo="$1"
 
 if [[ -z "${extension_repo}" ]]; then

--- a/scripts/build/angular-in-memory-web-api.mts
+++ b/scripts/build/angular-in-memory-web-api.mts
@@ -31,7 +31,9 @@ export function buildAngularInMemoryWebApiPackage(destDir: string): void {
   // Ensure the output directory is available.
   exec(`mkdir -p ${destDir}`);
 
-  const bazelBinPath = exec(`${bazelCmd} info bazel-bin`, true);
+  // TODO: Remove --ignore_all_rc_files flag once a repository can be loaded in bazelrc during info
+  // commands again. See https://github.com/bazelbuild/bazel/issues/25145 for more context.
+  const bazelBinPath = exec(`${bazelCmd} --ignore_all_rc_files info bazel-bin`, true);
 
   // Copy artifacts to `destDir`, so they can be easier persisted on CI and used by non-bazel
   // scripts/tests.

--- a/scripts/build/package-builder.mts
+++ b/scripts/build/package-builder.mts
@@ -58,7 +58,9 @@ function buildReleasePackages(
   // List of targets to build. e.g. "packages/core:npm_package", or "packages/forms:npm_package".
   const targets = exec(queryPackagesCmd, true).split(/\r?\n/).concat(additionalTargets);
   const packageNames = getPackageNamesOfTargets(targets);
-  const bazelBinPath = exec(`${bazelCmd} info bazel-bin`, true);
+  // TODO: Remove --ignore_all_rc_files flag once a repository can be loaded in bazelrc during info
+  // commands again. See https://github.com/bazelbuild/bazel/issues/25145 for more context.
+  const bazelBinPath = exec(`${bazelCmd} --ignore_all_rc_files info bazel-bin`, true);
   const getBazelOutputPath = (pkgName: string) => {
     return pkgName === 'language-server'
       ? join(bazelBinPath, 'vscode-ng-language-service/server/npm_package')

--- a/scripts/build/zone-js-builder.mts
+++ b/scripts/build/zone-js-builder.mts
@@ -31,7 +31,9 @@ export function buildZoneJsPackage(destDir: string): void {
   // Ensure the output directory is available.
   exec(`mkdir -p ${destDir}`);
 
-  const bazelBinPath = exec(`${bazelCmd} info bazel-bin`, true);
+  // TODO: Remove --ignore_all_rc_files flag once a repository can be loaded in bazelrc during info
+  // commands again. See https://github.com/bazelbuild/bazel/issues/25145 for more context.
+  const bazelBinPath = exec(`${bazelCmd} --ignore_all_rc_files info bazel-bin`, true);
 
   // Copy artifacts to `destDir`, so they can be easier persisted on CI and used by non-bazel
   // scripts/tests.

--- a/scripts/diff-release-package.mts
+++ b/scripts/diff-release-package.mts
@@ -67,8 +67,10 @@ async function main(packageName: string) {
     git.run(['clone', '--depth=1', `https://github.com/${snapshotRepoName}.git`, tmpDir]);
     console.info(`--> Cloned snapshot repo.`);
 
+    // TODO: Remove --ignore_all_rc_files flag once a repository can be loaded in bazelrc during info
+    // commands again. See https://github.com/bazelbuild/bazel/issues/25145 for more context.
     const bazelBinDir = childProcess
-      .spawnSync(bazel, ['info', 'bazel-bin'], {
+      .spawnSync(bazel, ['--ignore_all_rc_files', 'info', 'bazel-bin'], {
         shell: true,
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'inherit'],


### PR DESCRIPTION
Due to a bug in bazel we need to ignore all of the rc files when running bazel info commands
