### PR TITLE
Feature/performance panel

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -105,7 +105,7 @@ export {createComponent, reflectComponentType, ComponentMirror} from './render3/
 export {isStandalone} from './render3/def_getters';
 export {AfterRenderRef} from './render3/after_render/api';
 export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
-export {enableProfiling} from './render3/debug/chrome_dev_tools_performance';
+export {enableProfiling as ɵenableDevToolsProfiling} from './render3/debug/chrome_dev_tools_performance';
 export {
   AfterRenderOptions,
   afterEveryRender,

--- a/scripts/build/package-builder.mts
+++ b/scripts/build/package-builder.mts
@@ -78,8 +78,8 @@ function buildReleasePackages(
   packageNames.forEach((pkgName) => {
     const outputPath = getBazelOutputPath(pkgName);
     if (existsSync(outputPath) && lstatSync(outputPath).isDirectory()) {
-      exec(`chmod -R u+w ${outputPath}`);
-      exec(`rm -rf ${outputPath}`);
+      exec(`chmod -R u+w "${outputPath}"`);
+      exec(`rm -rf "${outputPath}"`);
     }
   });
 
@@ -87,16 +87,16 @@ function buildReleasePackages(
 
   // Delete the distribution directory so that the output is guaranteed to be clean. Re-create
   // the empty directory so that we can copy the release packages into it later.
-  exec(`rm -rf ${distPath}`);
-  exec(`mkdir -p ${distPath}`);
+  exec(`rm -rf "${distPath}"`);
+  exec(`mkdir -p "${distPath}"`);
 
   // Copy the package output into the specified distribution folder.
   packageNames.forEach((pkgName) => {
     const outputPath = getBazelOutputPath(pkgName);
     const targetFolder = getDistPath(pkgName);
     console.info(`> Copying package output to "${targetFolder}"`);
-    exec(`cp -R ${outputPath} ${targetFolder}`);
-    exec(`chmod -R u+w ${targetFolder}`);
+    exec(`cp -R "${outputPath}" "${targetFolder}"`);
+    exec(`chmod -R u+w "${targetFolder}"`);
   });
 
   return packageNames.map((pkg) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, when developers use enableProfiling() and record a performance profile in Chrome DevTools, Angular lifecycle hooks and other framework events appear in the Performance panel timeline under the "🅰️ Angular" custom track. However, when clicking on these events (e.g., AppComponent:ngOnInit, "Change detection", "Bootstrap application"), the details panel only shows basic information, such as timestamp and duration, without any contextual documentation or explanation of what these events represent.
This makes it difficult for developers to:

Understand what each Angular-specific performance mark means
Learn about lifecycle hooks that they're unfamiliar with
Get guidance on performance optimization directly in DevTools

Developers must manually search for Angular documentation to understand the events they're seeing in their performance profiles.

Issue Number: #63959


## What is the new behavior?

What is the new behavior?
After this change, when developers record a performance profile and click on Angular events in the Chrome DevTools Performance panel, they'll see clickable documentation links in the details panel that navigate directly to relevant Angular documentation.
For example:

Clicking on AppComponent:ngOnInit now shows a link to https://angular.dev/api/core/OnInit
Clicking on "Change detection" shows a link to the zone pollution best practices guide
Clicking on "Bootstrap application" shows a link to the bootstrapApplication API docs

The links appear in the details panel as:
json{
  "links": [
    {
      "url": "https://angular.dev/api/core/OnInit",
      "title": "View documentation"
    }
  ]
}
This provides immediate, contextual access to Angular documentation directly from the performance profiling workflow, helping developers understand what they're seeing and how to optimize their applications without leaving DevTools.
Note: This feature requires Chrome v141+ (currently available in Chrome Canary/Dev channels) and only works when profiling is enabled in development mode.




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
