### PR TITLE
docs: add `'new'` to page `'Side effects for non-reactive APIs'`

### DIFF
--- a/adev/src/app/routing/sub-navigation-data.ts
+++ b/adev/src/app/routing/sub-navigation-data.ts
@@ -94,6 +94,7 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
     children: [
       {
         label: 'Signals',
+        status: 'updated',
         children: [
           {
             label: 'Overview',
@@ -114,6 +115,7 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             label: 'Side effects for non-reactives APIs',
             path: 'guide/signals/effect',
             contentPath: 'guide/signals/effect',
+            status: 'new',
           },
         ],
       },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

I noticed that ["docs: create a separate effect guide #64323"](https://github.com/angular/angular/pull/64323) did not add the `'new'` tag to the documentation.

Issue Number: N/A

## What is the new behavior?

Signals page now marked as updated and the new effects page marked as new

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
