### PR TITLE
build(forms): setup infrastructure for code examples

### DIFF
--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_package", "ng_project")
+load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "generate_api_docs", "ng_examples_db", "ng_package", "ng_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,8 +17,23 @@ ng_project(
     ],
 )
 
+ng_examples_db(
+    name = "forms_example_database",
+    srcs = glob(
+        include = [
+            "examples/**/*.md",
+        ],
+        allow_empty = True,
+    ),
+    out = "resources/code-examples.db",
+    path = "packages/forms/examples",
+)
+
 ng_package(
-    srcs = ["package.json"],
+    srcs = [
+        "package.json",
+        "resources/code-examples.db",
+    ],
     package = "@angular/forms",
     tags = [
         "release-with-framework",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,6 +22,12 @@
     "url": "https://github.com/angular/angular.git",
     "directory": "packages/forms"
   },
+  "angular": {
+    "examples": {
+      "format": "sqlite",
+      "path": "./resources/code-examples.db"
+    }
+  },
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -5,6 +5,7 @@ load("@devinfra//bazel:extract_types.bzl", _extract_types = "extract_types")
 load("@devinfra//bazel/api-golden:index.bzl", _api_golden_test = "api_golden_test", _api_golden_test_npm_package = "api_golden_test_npm_package")
 load("@devinfra//bazel/http-server:index.bzl", _http_server = "http_server")
 load("@devinfra//bazel/ts_project:index.bzl", "strict_deps_test")
+load("@rules_angular//src/ng_examples_db:index.bzl", _ng_examples_db = "ng_examples_db")
 load("@rules_angular//src/ng_project:index.bzl", _ng_project = "ng_project")
 load("@rules_angular//src/ts_project:index.bzl", _ts_project = "ts_project")
 load("@rules_sass//src:index.bzl", _npm_sass_library = "npm_sass_library", _sass_binary = "sass_binary", _sass_library = "sass_library")
@@ -43,6 +44,7 @@ api_golden_test_npm_package = _api_golden_test_npm_package
 copy_to_bin = _copy_to_bin
 tsec_test = _tsec_test
 js_library = _js_library
+ng_examples_db = _ng_examples_db
 
 def _determine_tsconfig(testonly):
     if native.package_name().startswith("packages/compiler-cli"):


### PR DESCRIPTION
This commit introduces the infrastructure for embedding code examples within Angular packages, enabling them to be consumed by the Angular CLI's MCP server.

The `@angular/forms` package is the first to adopt this new feature. A new `ng_examples_db` Bazel rule is used to build a SQLite database from markdown files containing code examples. This database is then included in the published npm package.

The `package.json` for `@angular/forms` has been updated with an `angular.examples` field to allow tooling to discover and use the code examples.