### PR TITLE
refactor(forms): Test more use cases for compat forms

### DIFF
--- a/packages/forms/signals/test/web/compat_form.spec.ts
+++ b/packages/forms/signals/test/web/compat_form.spec.ts
@@ -7,9 +7,9 @@
  */
 
 import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
-import {FormControl} from '@angular/forms';
+import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
 import {TestBed} from '@angular/core/testing';
-import {Field} from '../../public_api';
+import {Field, form} from '../../public_api';
 import {compatForm} from '../../compat';
 
 describe('compatForm with [field] directive', () => {
@@ -60,6 +60,22 @@ describe('compatForm with [field] directive', () => {
     expect(input.value).toBe('pirojok-the-cat');
   });
 
+  it('allows to bind formGroup', () => {
+    @Component({
+      imports: [Field],
+      template: `
+        <input [field]="f" />
+      `,
+    })
+    class TestCmp {
+      readonly f = form(signal(new FormControl('meow', {nonNullable: true})));
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+
+    expect(fixture.componentInstance.f().value()).toBe('2');
+  });
+
   it('should bind fields when FormControls are mixed with regular values', () => {
     @Component({
       imports: [Field],
@@ -85,6 +101,68 @@ describe('compatForm with [field] directive', () => {
     expect(nameInput.value).toBe('fluffy');
     expect(ageInput.value).toBe('3');
     expect(fixture.componentInstance.f().value().species).toBe('cat');
+  });
+
+  describe('control', () => {
+    it('should bind control to input with [formControl] directive', () => {
+      @Component({
+        imports: [ReactiveFormsModule, Field],
+        template: `
+          <input [formControl]="f.name().control()" />
+          <input type="number" [field]="f.age" />
+        `,
+      })
+      class TestCmp {
+        readonly cat = signal({
+          name: new FormControl('pirojok-the-cat', {nonNullable: true}),
+          age: 3,
+          species: 'cat',
+        });
+        readonly f = compatForm(this.cat);
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const inputs = fixture.nativeElement.querySelectorAll('input');
+      const nameInput = inputs[0] as HTMLInputElement;
+      const ageInput = inputs[1] as HTMLInputElement;
+
+      expect(nameInput.value).toBe('pirojok-the-cat');
+      expect(ageInput.value).toBe('3');
+      act(() => {
+        nameInput.value = 'pelmen-the-cat';
+        nameInput.dispatchEvent(new Event('input', {bubbles: true}));
+      });
+      expect(fixture.componentInstance.f.name().value()).toBe('pelmen-the-cat');
+    });
+  });
+
+  it('should bind group to input with [formGroup] directive', () => {
+    @Component({
+      imports: [ReactiveFormsModule],
+      template: `
+        <div [formGroup]="f.name().control()">
+          <input formControlName="name" />
+        </div>
+      `,
+    })
+    class TestCmp {
+      readonly cat = signal({
+        name: new FormGroup({
+          name: new FormControl('pirojok-the-cat', {nonNullable: true}),
+        }),
+      });
+      readonly f = compatForm(this.cat);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    expect(input.value).toBe('pirojok-the-cat');
+    act(() => {
+      input.value = 'pelmen-the-cat';
+      input.dispatchEvent(new Event('input', {bubbles: true}));
+    });
+    expect(fixture.componentInstance.f.name().value()).toEqual({name: 'pelmen-the-cat'});
   });
 });
 


### PR DESCRIPTION
Make sure f().control can be bound with [formControl] and [formGroup]

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
