### PR TITLE
feat(devtools): add ability to hide internal signals on the graph

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {Events, MessageBus} from '../../../protocol';
-import {subscribeToClientEvents} from './client-event-subscribers';
+import {
+  isAngularInternalSignal,
+  RawSignalGraphNode,
+  subscribeToClientEvents,
+} from './client-event-subscribers';
 import {appIsAngular, appIsAngularIvy, appIsSupportedAngularVersion} from '../../../shared-utils';
 import {DirectiveForestHooks} from './hooks/hooks';
 import {of} from 'rxjs';
@@ -51,6 +55,106 @@ describe('ClientEventSubscriber', () => {
     expect(messageBusMock.on).toHaveBeenCalledWith('removeHighlightOverlay', jasmine.any(Function));
     expect(messageBusMock.on).toHaveBeenCalledWith('createHydrationOverlay', jasmine.any(Function));
     expect(messageBusMock.on).toHaveBeenCalledWith('removeHydrationOverlay', jasmine.any(Function));
+  });
+
+  describe('isAngularInternalSignal', () => {
+    const baseNode: RawSignalGraphNode = {
+      id: '1',
+      kind: 'signal',
+      epoch: 1,
+    };
+    const angularFn = Object.assign(() => {}, {
+      toString: () => 'function(){/* node_modules/@angular/forms */}',
+    });
+
+    it('returns true for unknown nodes and ɵ-prefixed labels', () => {
+      expect(isAngularInternalSignal({...baseNode, kind: 'unknown'})).toBeTrue();
+      expect(isAngularInternalSignal({...baseNode, label: 'ɵfoo'})).toBeTrue();
+    });
+
+    it('returns true for functions that look like Angular internals', () => {
+      const fn = function ɵɵinternalFn() {};
+      expect(isAngularInternalSignal({...baseNode, debuggableFn: fn})).toBeTrue();
+    });
+
+    it('returns true for common Angular-provided debug names when source is Angular', () => {
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: 'reactiveHref',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: 'pristine',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: 'touchedReactive',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: '_pristine',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: '_status',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+    });
+
+    it('returns true for functions with Angular paths in source', () => {
+      expect(
+        isAngularInternalSignal({...baseNode, debuggableFn: angularFn as () => void}),
+      ).toBeTrue();
+    });
+
+    it('returns false for user-defined signals', () => {
+      const userFn = function userEffect() {};
+      expect(
+        isAngularInternalSignal({...baseNode, label: 'user', debuggableFn: userFn}),
+      ).toBeFalse();
+      expect(
+        isAngularInternalSignal({...baseNode, label: 'reactiveTest', debuggableFn: userFn}),
+      ).toBeFalse();
+      expect(
+        isAngularInternalSignal({...baseNode, label: 'touched', debuggableFn: userFn}),
+      ).toBeFalse();
+      expect(
+        isAngularInternalSignal({...baseNode, label: 'pristine', debuggableFn: userFn}),
+      ).toBeFalse();
+    });
+
+    it('prefers source over label when available', () => {
+      const userFn = function pristine() {};
+
+      expect(
+        isAngularInternalSignal({
+          ...baseNode,
+          label: 'pristine',
+          debuggableFn: angularFn as () => void,
+        }),
+      ).toBeTrue();
+      expect(
+        isAngularInternalSignal({...baseNode, label: 'pristine', debuggableFn: userFn}),
+      ).toBeFalse();
+    });
+
+    it('returns true when debugName is explicitly marked internal', () => {
+      expect(isAngularInternalSignal({...baseNode, label: 'ɵanything'})).toBeTrue();
+    });
   });
 });
 

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.spec.ts
@@ -63,97 +63,18 @@ describe('ClientEventSubscriber', () => {
       kind: 'signal',
       epoch: 1,
     };
-    const angularFn = Object.assign(() => {}, {
-      toString: () => 'function(){/* node_modules/@angular/forms */}',
-    });
 
-    it('returns true for unknown nodes and ɵ-prefixed labels', () => {
-      expect(isAngularInternalSignal({...baseNode, kind: 'unknown'})).toBeTrue();
+    it('returns true for ɵ-prefixed labels', () => {
       expect(isAngularInternalSignal({...baseNode, label: 'ɵfoo'})).toBeTrue();
-    });
-
-    it('returns true for functions that look like Angular internals', () => {
-      const fn = function ɵɵinternalFn() {};
-      expect(isAngularInternalSignal({...baseNode, debuggableFn: fn})).toBeTrue();
-    });
-
-    it('returns true for common Angular-provided debug names when source is Angular', () => {
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: 'reactiveHref',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: 'pristine',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: 'touchedReactive',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: '_pristine',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: '_status',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-    });
-
-    it('returns true for functions with Angular paths in source', () => {
-      expect(
-        isAngularInternalSignal({...baseNode, debuggableFn: angularFn as () => void}),
-      ).toBeTrue();
-    });
-
-    it('returns false for user-defined signals', () => {
-      const userFn = function userEffect() {};
-      expect(
-        isAngularInternalSignal({...baseNode, label: 'user', debuggableFn: userFn}),
-      ).toBeFalse();
-      expect(
-        isAngularInternalSignal({...baseNode, label: 'reactiveTest', debuggableFn: userFn}),
-      ).toBeFalse();
-      expect(
-        isAngularInternalSignal({...baseNode, label: 'touched', debuggableFn: userFn}),
-      ).toBeFalse();
-      expect(
-        isAngularInternalSignal({...baseNode, label: 'pristine', debuggableFn: userFn}),
-      ).toBeFalse();
-    });
-
-    it('prefers source over label when available', () => {
-      const userFn = function pristine() {};
-
-      expect(
-        isAngularInternalSignal({
-          ...baseNode,
-          label: 'pristine',
-          debuggableFn: angularFn as () => void,
-        }),
-      ).toBeTrue();
-      expect(
-        isAngularInternalSignal({...baseNode, label: 'pristine', debuggableFn: userFn}),
-      ).toBeFalse();
-    });
-
-    it('returns true when debugName is explicitly marked internal', () => {
       expect(isAngularInternalSignal({...baseNode, label: 'ɵanything'})).toBeTrue();
+    });
+
+    it('returns false for non-prefixed labels', () => {
+      expect(isAngularInternalSignal({...baseNode, label: 'user'})).toBeFalse();
+      expect(isAngularInternalSignal({...baseNode, label: 'reactiveTest'})).toBeFalse();
+      expect(isAngularInternalSignal({...baseNode, label: 'touched'})).toBeFalse();
+      expect(isAngularInternalSignal({...baseNode, label: 'pristine'})).toBeFalse();
+      expect(isAngularInternalSignal({...baseNode, kind: 'unknown'})).toBeFalse();
     });
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
@@ -1,5 +1,14 @@
 <svg #component></svg>
 
+<label class="filter-toggle">
+  <input
+    type="checkbox"
+    [checked]="hideInternalSignals()"
+    (change)="hideInternalSignals.set($any($event.target)?.checked)"
+  />
+  Hide internal signals
+</label>
+
 @let node = selectedNode();
 @let dataSource = this.dataSource();
 @if (node && dataSource && detailsVisible()) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.scss
@@ -128,4 +128,22 @@
       font-size: 18px;
     }
   }
+
+  .filter-toggle {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.45rem;
+    border-radius: 6px;
+    background-color: rgba(0, 0, 0, 0.35);
+    color: var(--gray-100);
+    user-select: none;
+
+    input {
+      margin: 0;
+    }
+  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {NO_ERRORS_SCHEMA, signal} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DebugSignalGraph, Events, MessageBus, PropType} from '../../../../../../protocol';
+import {ApplicationOperations} from '../../../application-operations/index';
+import {FrameManager} from '../../../application-services/frame_manager';
+import {SignalGraphManager} from '../signal-graph/signal-graph-manager';
+import {SignalsTabComponent} from './signals-tab.component';
+import {SignalsGraphVisualizer} from './signals-visualizer';
+
+class MessageBusStub extends MessageBus<Events> {
+  override on<E extends keyof Events>(_topic: E, _cb: Events[E]): () => void {
+    return () => {};
+  }
+  override once<E extends keyof Events>(_topic: E, _cb: Events[E]): void {}
+  override emit<E extends keyof Events>(_topic: E, _args?: Parameters<Events[E]>): boolean {
+    return true;
+  }
+  override destroy(): void {}
+}
+
+class SignalGraphManagerStub {
+  readonly graphSignal = signal<DebugSignalGraph | null>(null);
+  readonly graph = this.graphSignal.asReadonly();
+  readonly element = signal(undefined);
+}
+
+class ApplicationOperationsStub extends ApplicationOperations {
+  viewSource(): void {}
+  selectDomElement(): void {}
+  inspect(): void {}
+  inspectSignal(): void {}
+  viewSourceFromRouter(): void {}
+  setStorageItems(): Promise<void> {
+    return Promise.resolve();
+  }
+  getStorageItems(): Promise<{[key: string]: unknown}> {
+    return Promise.resolve({});
+  }
+  removeStorageItems(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+class FrameManagerStub {
+  selectedFrame() {
+    return null;
+  }
+}
+
+describe('SignalsTabComponent', () => {
+  let fixture: ComponentFixture<SignalsTabComponent>;
+  let component: SignalsTabComponent;
+  let graphManager: SignalGraphManagerStub;
+  const setHideInternalSignals = (value: boolean) =>
+    (component as any).hideInternalSignals.set(value);
+  const readVisibleGraph = () => (component as any).visibleGraph() as DebugSignalGraph | null;
+
+  beforeAll(() => {
+    (globalThis as any).ResizeObserver =
+      (globalThis as any).ResizeObserver ||
+      class {
+        observe() {}
+        disconnect() {}
+      };
+  });
+
+  beforeEach(() => {
+    spyOn(SignalsTabComponent.prototype as any, 'setUpSignalsVisualizer').and.callFake(function (
+      component: SignalsTabComponent,
+    ) {
+      const visualizer = jasmine.createSpyObj<SignalsGraphVisualizer>('viz', [
+        'render',
+        'setSelected',
+        'reset',
+        'cleanup',
+        'resize',
+        'onNodeClick',
+      ]);
+      visualizer.onNodeClick.and.returnValue(() => {});
+      component.signalsVisualizer = visualizer;
+    });
+
+    TestBed.configureTestingModule({
+      imports: [SignalsTabComponent],
+      providers: [
+        {provide: MessageBus, useClass: MessageBusStub},
+        {provide: SignalGraphManager, useClass: SignalGraphManagerStub},
+        {provide: ApplicationOperations, useClass: ApplicationOperationsStub},
+        {provide: FrameManager, useClass: FrameManagerStub},
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).overrideComponent(SignalsTabComponent, {
+      set: {
+        template: '<svg #component></svg>',
+        imports: [],
+        styles: [],
+      },
+    });
+
+    fixture = TestBed.createComponent(SignalsTabComponent);
+    component = fixture.componentInstance;
+    graphManager = TestBed.inject(SignalGraphManager) as unknown as SignalGraphManagerStub;
+    fixture.detectChanges();
+  });
+
+  function buildDescriptor(): DebugSignalGraph['nodes'][number]['preview'] {
+    return {
+      expandable: false,
+      editable: false,
+      type: PropType.Number,
+      preview: '',
+      containerType: null,
+    };
+  }
+
+  it('filters Angular internal signals and reindexes edges', () => {
+    graphManager.graphSignal.set({
+      nodes: [
+        {id: 'userSignal', kind: 'signal', epoch: 1, preview: buildDescriptor(), debuggable: true},
+        {
+          id: 'ɵinternal',
+          kind: 'signal',
+          epoch: 1,
+          preview: buildDescriptor(),
+          debuggable: false,
+          isAngularInternal: true,
+        },
+        {id: 'userEffect', kind: 'effect', epoch: 1, preview: buildDescriptor(), debuggable: true},
+      ],
+      edges: [
+        {producer: 0, consumer: 1},
+        {producer: 0, consumer: 2},
+        {producer: 1, consumer: 2},
+      ],
+    });
+
+    setHideInternalSignals(true);
+
+    const graph = readVisibleGraph()!;
+    expect(graph.nodes.map((n) => n.id)).toEqual(['userSignal', 'userEffect']);
+    expect(graph.edges).toEqual([{producer: 0, consumer: 1}]);
+  });
+
+  it('returns the original graph when filtering is disabled', () => {
+    const graph: DebugSignalGraph = {
+      nodes: [{id: 'user', kind: 'signal', epoch: 1, preview: buildDescriptor(), debuggable: true}],
+      edges: [],
+    };
+
+    graphManager.graphSignal.set(graph);
+    setHideInternalSignals(false);
+
+    expect(readVisibleGraph()).toBe(graph);
+  });
+});

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -30,6 +30,8 @@ export interface DebugSignalGraphNode {
   label?: string;
   preview: Descriptor;
   debuggable: boolean;
+  /** True when the node is produced by Angular runtime infrastructure rather than app code. */
+  isAngularInternal?: boolean;
 }
 
 export interface DebugSignalGraphEdge {

--- a/packages/compiler-cli/src/ngtsc/transform/test/implicit_signal_debug_name_transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/implicit_signal_debug_name_transform_spec.ts
@@ -109,4 +109,68 @@ describe('implicit signal debug name transform', () => {
     );
     expect(output).toContain('debugName: "\\u0275mySignal"');
   });
+
+  it('prefixes private class properties', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        class Control {
+          private readonly _status = signal('VALID');
+        }
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275_status"');
+  });
+
+  it('prefixes fields marked with @internal', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        class Control {
+          /** @internal */
+          statusSignal = signal('VALID');
+        }
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275statusSignal"');
+  });
+
+  it('does not prefix public class fields', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        class Control {
+          statusSignal = signal('VALID');
+        }
+      `,
+    );
+    expect(output).toContain('debugName: "statusSignal"');
+    expect(output).not.toContain('\\u0275statusSignal');
+  });
+
+  it('prefixes non-exported module-level signals', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        const internalSignal = signal(true);
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275internalSignal"');
+  });
+
+  it('does not prefix exported module-level signals', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        export const READY = signal(true);
+      `,
+    );
+    expect(output).toContain('debugName: "READY"');
+    expect(output).not.toContain('\\u0275READY');
+  });
 });

--- a/packages/compiler-cli/src/ngtsc/transform/test/implicit_signal_debug_name_transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/implicit_signal_debug_name_transform_spec.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+
+import {signalMetadataTransform} from '../src/implicit_signal_debug_name_transform';
+
+describe('implicit signal debug name transform', () => {
+  const ANGULAR_CORE_DTS = `
+    export declare function signal<T>(value: T, config?: unknown): unknown;
+    export declare function computed<T>(fn: () => T, config?: unknown): unknown;
+  `;
+
+  function emitWithTransform(fileName: string, contents: string): string {
+    const files = new Map<string, string>();
+    files.set(fileName, contents);
+    files.set('/node_modules/@angular/core/index.d.ts', ANGULAR_CORE_DTS);
+
+    const compilerOptions: ts.CompilerOptions = {
+      target: ts.ScriptTarget.ES2015,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      skipLibCheck: true,
+      noEmitOnError: false,
+    };
+
+    const host = ts.createCompilerHost(compilerOptions);
+    const originalGetSourceFile = host.getSourceFile.bind(host);
+
+    host.getSourceFile = (fn, languageVersion, ...rest) => {
+      const content = files.get(fn);
+      if (content !== undefined) {
+        return ts.createSourceFile(fn, content, languageVersion, true);
+      }
+      return originalGetSourceFile(fn, languageVersion, ...rest);
+    };
+
+    host.readFile = (fn) => files.get(fn) ?? undefined;
+    host.fileExists = (fn) => files.has(fn) || ts.sys.fileExists(fn);
+
+    let output = '';
+    const program = ts.createProgram([fileName], compilerOptions, host);
+    program.emit(
+      undefined,
+      (fn, data) => {
+        if (fn.endsWith('.js')) {
+          output = data;
+        }
+      },
+      undefined,
+      undefined,
+      {before: [signalMetadataTransform(program)]},
+    );
+
+    return output;
+  }
+
+  it('does not prefix user code', () => {
+    const output = emitWithTransform(
+      '/workspace/packages/ui-lib/src/file.ts',
+      `
+        import {signal} from '@angular/core';
+        const mySignal = signal(0);
+      `,
+    );
+    expect(output).toContain('debugName: "mySignal"');
+    expect(output).not.toContain('debugName: "\\u0275mySignal"');
+  });
+
+  it('prefixes framework code without existing config', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        const mySignal = signal(0);
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275mySignal"');
+  });
+
+  it('adds a prefixed debugName when an options object is present', () => {
+    const output = emitWithTransform(
+      '/workspace/node_modules/@angular/forms/src/model.ts',
+      `
+        import {signal} from '@angular/core';
+        const mySignal = signal(0, { equal: (a, b) => true });
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275mySignal"');
+    expect(output).toContain('equal: (a, b) => true');
+  });
+
+  it('prefixes bazel-out framework outputs lacking package.json nearby', () => {
+    const output = emitWithTransform(
+      '/private/var/tmp/_bazel_user/hash/execroot/_main/bazel-out/fastbuild/bin/packages/forms/src/model/abstract_model.ts',
+      `
+        /**
+         * @license
+         * https://angular.dev/license
+         */
+        import {signal} from '@angular/core';
+        const mySignal = signal(0);
+      `,
+    );
+    expect(output).toContain('debugName: "\\u0275mySignal"');
+  });
+});


### PR DESCRIPTION
Marks Angular-authored signals with a ɵ debugName prefix and teaches DevTools to filter/sanitize those nodes, reducing noise in the signal graph.

Related to #65894

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Internal framework signals crowd the DevTools signal graph and are indistinguishable from user signals. Compiler-emitted debugNames for Angular sources were not consistently marked for filtering.

Issue Number: #65894 


## What is the new behavior?
Angular-authored signals get a `ɵ` debugName prefix from the compiler transform, and DevTools treats `ɵ`-prefixed nodes as internal. The signal graph hides prefixed/internal signals when the toggle is enabled,.
<img width="1247" height="589" alt="1" src="https://github.com/user-attachments/assets/406bde41-c330-4901-a359-8f68cbc12113" />

<img width="1247" height="591" alt="2" src="https://github.com/user-attachments/assets/da4b9644-d040-44d7-ab62-23c0c5a39836" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Tests updated for the compiler transform and DevTools backend to cover the new prefixing/filtering behavior.
