### PR TITLE
feat(router): add controls for route cleanup

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -147,7 +147,7 @@ Angular's `RouteReuseStrategy` class allows you to customize navigation behavior
 
 "Detached route handles" are Angular's way of storing component instances and their entire view hierarchy. When a route is detached, Angular preserves the component instance, its child components, and all associated state in memory. This preserved state can later be reattached when navigating back to the route.
 
-The `RouteReuseStrategy` class provides five methods that control the lifecycle of route components:
+The `RouteReuseStrategy` class provides the following methods that control the lifecycle of route components:
 
 | Method                                                                         | Description                                                                                                         |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -243,7 +243,9 @@ export const appConfig: ApplicationConfig = {
 
 If you do not provide a custom `RouteReuseStrategy` or your custom strategy extends `BaseRouteReuseStrategy`, injectors will now be destroyed when the route is inactive.
 
-Otherwise, your strategy should implement `shouldDestroyInjector` to tell the router which routes should have their injectors destroyed:
+#### Cleanup with a custom `RouteReuseStrategy`
+
+If your application uses a custom `RouteReuseStrategy` _and_ the strategy does not extend `BaseRouteReuseStrategy`, you must implement `shouldDestroyInjector` to tell the router which routes should have their injectors destroyed:
 
 ```ts
 @Injectable()

--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -149,13 +149,14 @@ Angular's `RouteReuseStrategy` class allows you to customize navigation behavior
 
 The `RouteReuseStrategy` class provides five methods that control the lifecycle of route components:
 
-| Method                                                               | Description                                                                                                 |
-| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| [`shouldDetach`](api/router/RouteReuseStrategy#shouldDetach)         | Determines if a route should be stored for later reuse when navigating away                                 |
-| [`store`](api/router/RouteReuseStrategy#store)                       | Stores the detached route handle when `shouldDetach` returns true                                           |
-| [`shouldAttach`](api/router/RouteReuseStrategy#shouldAttach)         | Determines if a stored route should be reattached when navigating to it                                     |
-| [`retrieve`](api/router/RouteReuseStrategy#retrieve)                 | Returns the previously stored route handle for reattachment                                                 |
-| [`shouldReuseRoute`](api/router/RouteReuseStrategy#shouldReuseRoute) | Determines if the router should reuse the current route instance instead of destroying it during navigation |
+| Method                                                                         | Description                                                                                                         |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| [`shouldDetach`](api/router/RouteReuseStrategy#shouldDetach)                   | Determines if a route should be stored for later reuse when navigating away                                         |
+| [`store`](api/router/RouteReuseStrategy#store)                                 | Stores the detached route handle when `shouldDetach` returns true                                                   |
+| [`shouldAttach`](api/router/RouteReuseStrategy#shouldAttach)                   | Determines if a stored route should be reattached when navigating to it                                             |
+| [`retrieve`](api/router/RouteReuseStrategy#retrieve)                           | Returns the previously stored route handle for reattachment                                                         |
+| [`shouldReuseRoute`](api/router/RouteReuseStrategy#shouldReuseRoute)           | Determines if the router should reuse the current route instance instead of destroying it during navigation         |
+| [`shouldDestroyInjector`](api/router/RouteReuseStrategy#shouldDestroyInjector) | (Experimental) Determines if the router should destroy the injector of a detached route when it is no longer stored |
 
 The following example demonstrates a custom route reuse strategy that selectively preserves component state based on route metadata:
 
@@ -203,7 +204,76 @@ export class CustomRouteReuseStrategy implements RouteReuseStrategy {
 }
 ```
 
+### Manually destroying detached route handles
+
+When implementing a custom `RouteReuseStrategy`, you may need to manually destroy a `DetachedRouteHandle` if you decide to discard it without reattaching it. For example, if your strategy has a cache size limit or expires handles after a certain time, you must ensure the component and its state are properly destroyed to avoid memory leaks.
+
+Since `DetachedRouteHandle` is an opaque type, you cannot call a destroy method directly on it. Instead, use the `destroyDetachedRouteHandle` function provided by the Router.
+
+```ts
+import { destroyDetachedRouteHandle } from '@angular/router';
+
+// ... inside your strategy
+if (this.handles.size > MAX_CACHE_SIZE) {
+  const handle = this.handles.get(oldestKey);
+  if (handle) {
+    destroyDetachedRouteHandle(handle);
+    this.handles.delete(oldestKey);
+  }
+}
+```
+
 NOTE: Avoid using the route path as the key when `canMatch` guards are involved, as it may lead to duplicate entries.
+
+### (Experimental) Automatic cleanup of unused route injectors
+
+By default, Angular does not destroy the injectors of detached routes, even if they are no longer stored by the `RouteReuseStrategy`. This is primarily because this level of memory management is not commonly needed for most applications.
+
+To enable automatic cleanup of unused route injectors, you can use the `withExperimentalAutoCleanupInjectors` feature in your router configuration. This feature checks which routes are currently stored by the strategy after navigations and destroys the injectors of any detached routes that are not currently stored by the reuse strategy.
+
+```ts
+import { provideRouter, withExperimentalAutoCleanupInjectors } from '@angular/router';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withExperimentalAutoCleanupInjectors())
+  ]
+};
+```
+
+If you do not provide a custom `RouteReuseStrategy` or your custom strategy extends `BaseRouteReuseStrategy`, injectors will now be destroyed when the route is inactive.
+
+Otherwise, your strategy should implement `shouldDestroyInjector` to tell the router which routes should have their injectors destroyed:
+
+```ts
+@Injectable()
+export class CustomRouteReuseStrategy implements RouteReuseStrategy {
+  // ... other methods
+
+  shouldDestroyInjector(route: Route): boolean {
+    return !route.data['retainInjector'];
+  }
+}
+```
+
+If your strategy ever stores a `DetachedRouteHandle`, you will also need to tell the Router about these so it does not destroy any injectors needed by that detached handle:
+
+```ts
+@Injectable()
+export class CustomRouteReuseStrategy implements RouteReuseStrategy {
+  private readonly handles = new Map<Route, DetachedRouteHandle>();
+
+  store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null) {
+    this.handles.set(route.routeConfig!, handle);
+  }
+
+  retrieveStoredRouteHandles(): DetachedRouteHandle {
+    return Array.from(this.handles.values());
+  }
+
+  // ... other methods
+}
+```
 
 ### Configuring a route to use a custom route reuse strategy
 

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -106,6 +106,7 @@ export class ActivationStart {
 export abstract class BaseRouteReuseStrategy implements RouteReuseStrategy {
     retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null;
     shouldAttach(route: ActivatedRouteSnapshot): boolean;
+    shouldDestroyInjector(route: Route): boolean;
     shouldDetach(route: ActivatedRouteSnapshot): boolean;
     shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean;
     store(route: ActivatedRouteSnapshot, detachedTree: DetachedRouteHandle): void;
@@ -246,6 +247,9 @@ export type DeprecatedGuard = ProviderToken<any> | string;
 
 // @public @deprecated
 export type DeprecatedResolve = DeprecatedGuard | any;
+
+// @public
+export function destroyDetachedRouteHandle(handle: DetachedRouteHandle): void;
 
 // @public
 export type DetachedRouteHandle = {};
@@ -793,7 +797,7 @@ export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
 }
 
 // @public
-export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature | RouterHashLocationFeature;
+export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature | ViewTransitionsFeature | ExperimentalAutoCleanupInjectorsFeature | RouterHashLocationFeature;
 
 // @public
 export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHashLocationFeature>;
@@ -1132,6 +1136,9 @@ export function withDisabledInitialNavigation(): DisabledInitialNavigationFeatur
 
 // @public
 export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNavigationFeature;
+
+// @public
+export function withExperimentalAutoCleanupInjectors(): ExperimentalAutoCleanupInjectorsFeature;
 
 // @public
 export function withHashLocation(): RouterHashLocationFeature;

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -238,6 +238,7 @@
       "ROUTER_SCROLLER",
       "ROUTES",
       "ROUTES2",
+      "ROUTE_INJECTOR_CLEANUP",
       "Recognizer",
       "RedirectCommand",
       "RedirectRequest",

--- a/packages/router/docs/injector_cleanup.md
+++ b/packages/router/docs/injector_cleanup.md
@@ -1,0 +1,178 @@
+# Design Doc: Router Injector and Detached Route Cleanup
+
+**Author**: Atscott
+**Date**: November 21, 2025
+**Status**: In Review
+
+## 1. Introduction & Motivation
+
+This document outlines the solution to two distinct but related issues concerning memory retention in the Router.
+
+1.  **Undisposed Route Injectors**: When `providers` are defined on a `Route`, Angular creates a dedicated `EnvironmentInjector` for that route. This also happens when lazy loading routes through an `NgModule` and `RouterModule.forChild`. Prior to this proposed change, these injectors were never destroyed, even after the user navigated away from the route permanently. This meant that these injectors and their provided services would remain in memory for the application's lifetime, even when the routes were no longer active. This is tracked in [issue #37095](https://github.com/angular/angular/issues/37095).
+    - Additionally, because these injectors were never destroyed, developers could not reliably use APIs that depend on injector destruction, such as `takeUntilDestroyed`, `toSignal`, or `toObservable`, within guards and resolvers ([#51290](https://github.com/angular/angular/issues/51290)). By ensuring injectors are destroyed when the route is deactivated, this change enables streaming observables in resolvers that remain subscribed for the lifetime of the activated route.
+
+2.  **Undisposed DetachedRouteHandles**: A custom `RouteReuseStrategy` can store `DetachedRouteHandle` objects for later reuse. These handles contain the component instance and its DOM subtree. When a custom `RouteReuseStrategy` discards a `DetachedRouteHandle` from its internal store (e.g., due to cache limits or specific reuse logic), there was no public API to explicitly destroy the associated component. This could lead to retained component instances and subscriptions. This is tracked in [issue #27290](https://github.com/angular/angular/issues/27290).
+
+This document details a solution that provides both an automatic, opt-in mechanism for cleaning up route injectors and a manual utility function for destroying detached route components.
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- Provide an automatic mechanism to clean up `EnvironmentInjector`s for routes that are no longer active or stored for reuse.
+- Ensure the cleanup mechanism is opt-in to prevent breaking changes for applications with existing custom `RouteReuseStrategy` implementations.
+- Provide a public, manual API for developers to destroy the components associated with a `DetachedRouteHandle` when it's no longer needed.
+- The solution must handle lazy loaded routes correctly.
+
+### Non-Goals
+
+- The Router will not automatically manage the cache of `DetachedRouteHandle`s. The responsibility for when to `store` and when to discard a handle remains with the custom `RouteReuseStrategy`.
+
+## 3. Proposed Solution
+
+The solution is divided into two main parts: an automatic cleanup system for route injectors and a manual cleanup function for detached routes.
+
+### 3.1. Automatic Route Injector Cleanup
+
+This is an opt-in feature that automatically finds and destroys injectors associated with routes that are no longer in use.
+
+#### Enabling the Feature
+
+The feature is enabled by calling `withAutoCleanupInjectors()` in the `provideRouter` function:
+
+```ts
+provideRouter(routes, withAutoCleanupInjectors());
+```
+
+#### Cleanup Trigger and Process
+
+When enabled, a cleanup process runs after every successful navigation completes (i.e., after the `NavigationEnd` event). This ensures that the router is in a stable and predictable state before any injectors are destroyed.
+
+Cleanup was also considered for `NavigationCancel` and `NavigationError` events, but this approach was determined to be unsafe for the following reasons:
+
+- **`NavigationCancel`**: When a navigation is canceled, the router attempts to roll back its state to the previously successful one. Running a cleanup process during this transitional phase is risky, as it could accidentally destroy injectors from the very state the router is trying to restore.
+- **`NavigationError`**: An error can occur at any point during the activation process. This means that if an error is thrown midway through, the router's internal state can be left partially modified. Attempting to determine which routes are "active" versus "inactive" in this indeterminate state is unreliable and could lead to the erroneous destruction of injectors that are still in use.
+
+By restricting the cleanup to `NavigationEnd`, we guarantee that we are only ever operating on a stable, consistent, and fully resolved router state.
+
+The process is as follows:
+
+1.  **Identify Active Routes**: The router first identifies all "active" `Route` configurations. A route is considered active if:
+    - It is part of the current router state (i.e., it's in the current activated route tree). The router collects these by traversing the descendant tree from the root of the current `RouterState` snapshot.
+    - It is part of a `DetachedRouteHandle` currently stored in the `RouteReuseStrategy`. For these, the router collects all routes in their `pathFromRoot` array, ensuring all ancestors of stored routes are also marked as active.
+
+2.  **Consult the RouteReuseStrategy**: To get the list of stored routes, the router calls a new optional method on `RouteReuseStrategy`:
+    - `retrieveStoredRouteHandles?(): DetachedRouteHandle[]`
+      This method should return an array of all handles the strategy is currently storing.
+
+3.  **Traverse and Destroy**: The router then traverses the entire static route configuration tree. For each `Route`, it checks if it was marked as "active" in step 1.
+    - If a route is **not** active, the router consults another new optional method on `RouteReuseStrategy`:
+      - `shouldDestroyInjector?(route: Route): boolean`
+    - If this method returns `true`, the router will destroy the route's injector (`_injector` for providers and `_loadedInjector` for lazy-loaded module/component providers).
+    - **Note**: The default `BaseRouteReuseStrategy` (and thus the default router behavior) implements `shouldDestroyInjector` to always return `true`. This means that by default, when the feature is enabled, all inactive injectors will be destroyed unless a custom strategy overrides this behavior.
+    - **Crucially, if a parent route's injector is destroyed, the injectors of all its descendant routes will also be destroyed, regardless of the value returned by `shouldDestroyInjector?` for those descendants. This ensures the integrity of the injector hierarchy.**
+
+This design gives the `RouteReuseStrategy` full control over which injectors get destroyed, allowing for complex caching or pooling strategies while preventing common memory leaks.
+
+## 4. Alternatives Considered
+
+### Child-First (Post-Order) Traversal
+
+An alternative design was considered where the cleanup traversal would happen in a post-order (child-first) manner. In this model, the cleanup logic would first check if any of a route's children were being preserved. A parent route would be automatically kept alive if any of its children were preserved, regardless of the `shouldDestroyInjector` return value for the parent itself.
+
+- **Pros**: This approach offers a superior developer experience. To preserve a deeply nested inactive route, a developer would only need to return `false` from `shouldDestroyInjector` for that specific route, and the framework would automatically infer that all of its ancestors must also be preserved.
+- **Cons**: This implementation is more complex. It requires the recursive traversal function to return a boolean (`wasAnythingPreserved`) back up the call stack. This complicates the logic and can be less performant than a simple one-way traversal. It also makes the `shouldDestroyInjector` method's role less clear, as its return value for one route would implicitly affect the behavior of its parents.
+
+The current parent-first (pre-order) traversal was chosen for its implementation simplicity, single-pass performance, and explicitness. It enforces the injector hierarchy robustly: if a developer wishes to preserve a child route, they must also explicitly ensure all of its parents are preserved. While more verbose for the developer, this is an acceptable trade-off for a clearer and safer implementation within the framework.
+
+### Destruction During Activation Traversal
+
+Another alternative considered was performing the destruction of injectors during the activation traversal itself. For instance, if a route is being deactivated and not stored for reuse, its injector could be destroyed immediately.
+
+- **Pros**: This approach would not require any additional traversal logic, as the router is already traversing the route tree during activation.
+- **Cons**:
+  - This approach is not viable because of how the router handles route reuse. A child route can be stored for reuse even if its parent is not. Since the activation traversal is top-down, the router might encounter a parent route that is not being reused and destroy its injector, only to later discover that one of its children _is_ being reused and requires the parent's injector to remain alive. By deferring cleanup until after navigation completes, we can accurately identify all necessary injectors by looking at the final state of both the active route tree and the stored handles.
+  - We could handle the problem of descendants detaching after the parent injector was destroyed by _not_ querying `shouldDetach` in the first place on any descendants if the a parent injector was destroyed. However, this couples the detach logic with the injector destroy. You now need to be careful about destroying parents if you're going to detach a child. Our current approach handles this for you so the concerns are kept separate and the Router handles the question of what even can be destroyed safely.
+  - Additionally, there would be no good, safe way to destroy the injector for a previously stored handle that is being disposed of. For example, if a developer decides to drop a stored handle, they would need to manually destroy its injector, which could easily be done at the wrong time or forgotten entirely.
+
+### 3.2. Manual DetachedRouteHandle Cleanup
+
+To address the issue of undisposed components in discarded `DetachedRouteHandle`s, a new standalone utility function is introduced:
+
+- `destroyDetachedRouteHandle(handle: DetachedRouteHandle): void`
+
+A custom `RouteReuseStrategy` can call this function when it evicts a handle from its storage. The function accesses the internal `ComponentRef` on the handle and calls its `destroy()` method, properly cleaning up the component and its associated DOM elements.
+
+This function is also designed to support future features like route-level "resources". Such resources would have their own injector tied to the `ActivatedRoute` instance. While the injector for a resource on a non-stored route would be destroyed automatically upon deactivation, if the route is stored in a `DetachedRouteHandle`, the developer would be responsible for calling `destroyDetachedRouteHandle` to also clean up the resource's injector.
+
+Example usage in a custom strategy:
+
+```ts
+class MyStrategy extends BaseRouteReuseStrategy {
+  private cache = new Map<Route, DetachedRouteHandle>();
+
+  store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle): void {
+    if (this.cache.size > 10) {
+      // Evict oldest handle and destroy it
+      const oldestRoute = this.cache.keys().next().value;
+      const handleToDestroy = this.cache.get(oldestRoute);
+      if (handleToDestroy) {
+        destroyDetachedRouteHandle(handleToDestroy); // Clean up the component
+        this.cache.delete(oldestRoute);
+      }
+    }
+    this.cache.set(route.routeConfig, handle);
+  }
+
+  // ... other methods
+}
+```
+
+#### Potential Risks of a Standalone Function
+
+One potential limitation of `destroyDetachedRouteHandle` being a standalone function is its isolation from the Dependency Injection (DI) system. It cannot have services injected into it, which could be a constraint if future cleanup logic requires access to other parts of the framework.
+
+However, this risk is mitigated because the internal structure of the `DetachedRouteHandle` contains a reference to the `ActivatedRoute`. The `ActivatedRoute`, in turn, holds a reference to its injector. This provides an indirect but effective way for the function to access the DI system if more complex destruction logic is ever needed, without requiring the function itself to be an injectable service.
+
+## 4. Design Considerations
+
+### The Lazy Loading Sticking Point
+
+A notable complexity in this design relates to lazy-loaded modules. When a lazy module is loaded, its routes are provided from within its own `EnvironmentInjector`. The Router then attaches these routes (as `_loadedRoutes`) to the parent `Route` config object.
+
+This creates a dilemma when the injector for the lazy-loaded configuration (`_loadedInjector`) is destroyed. What should happen to the `_loadedRoutes` that were attached to the parent `Route`?
+
+1.  **Option A: Remove `_loadedRoutes`**. When the injector is destroyed, we could also remove the `_loadedRoutes` from the parent `Route` object. This would keep the runtime configuration perfectly in sync with the live injectors. However, this approach mutates the static route configuration object, which can be very surprising and lead to subtle bugs. It breaks the developer's mental model that the route configuration is static after being defined.
+
+2.  **Option B: Keep `_loadedRoutes`**. Alternatively, we can destroy the injector but leave the `_loadedRoutes` array on the parent `Route`. This means the configuration object remains structurally intact, even though the injector that provided those routes is gone and when the injector is recreated, its provided routes will be effectively ignored.
+
+The chosen solution is **Option B**. While it creates a temporary state where `_loadedRoutes` exist without a corresponding `_loadedInjector`. When a future navigation targets these routes again, the router will see that the `_loadedInjector` is missing (or destroyed) and will recreate it with the stored module factory.
+
+### Handling Destroyed Injectors During Preloading
+
+A related consideration is how the `RouterPreloader` interacts with injector destruction. The preloader optimistically loads route configurations and their associated injectors. However, it's possible for an injector that was created for a preloading operation (e.g., for a lazy-loaded route or its providers) to be destroyed before the preloading callback fully completes.
+
+In such cases, the `RouterPreloader` accounts for this by making the affected preloading operation a no-op if the injector is already destroyed. The `preloadConfig` method in `RouterPreloader` explicitly checks `if (injector.destroyed)` and returns `of(null)` if true.
+
+This design ensures robustness: if an injector is destroyed due to a navigation event or cleanup, the ongoing preloading task for that specific injector will gracefully terminate without errors. The next time a navigation occurs, the router will re-traverse the configuration, establish a new `EnvironmentInjector` if needed, and hand out new callbacks with fresh injectors, allowing the preloading to proceed correctly with the updated state.
+
+## 5. API Changes
+
+### New Provider Function
+
+- `withAutoCleanupInjectors()`: A `RouterFeature` to be used with `provideRouter` to enable automatic injector cleanup.
+
+### New Standalone Function
+
+- `destroyDetachedRouteHandle(handle: DetachedRouteHandle): void`: Destroys the component associated with a `DetachedRouteHandle`. This is a standalone function rather than a method on the handle itself to avoid breaking changes for developers who mock `DetachedRouteHandle` in tests.
+
+### `RouteReuseStrategy` Interface Changes
+
+The `RouteReuseStrategy` abstract class is extended with two new optional methods:
+
+- `retrieveStoredRouteHandles?(): DetachedRouteHandle[]`: Called by the router to get a list of all currently stored `DetachedRouteHandle`s.
+- `shouldDestroyInjector?(route: Route): boolean`: Called by the router for each inactive route to determine if its injector should be destroyed.
+
+## 6. Developer Experience
+
+- **Opt-In**: The injector cleanup is opt-in via `withAutoCleanupInjectors()` to maintain backward compatibility. Existing applications will not be affected.

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -96,10 +96,13 @@ export {
   withNavigationErrorHandler,
   withPreloading,
   withRouterConfig,
+  withExperimentalAutoCleanupInjectors,
 } from './provide_router';
+
 export {
   BaseRouteReuseStrategy,
   DetachedRouteHandle,
+  destroyDetachedRouteHandle,
   RouteReuseStrategy,
 } from './route_reuse_strategy';
 export {Router} from './router';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -792,11 +792,17 @@ export interface Route {
    * @internal
    */
   _loadedInjector?: EnvironmentInjector;
+  /**
+   * Filled if loadChildren retruns a module factory
+   * @internal
+   */
+  _loadedNgModuleFactory?: NgModuleFactory<any>;
 }
 
 export interface LoadedRouterConfig {
   routes: Route[];
   injector: EnvironmentInjector | undefined;
+  factory?: NgModuleFactory<unknown>;
 }
 
 /**

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -23,6 +23,7 @@ import {BehaviorSubject, EMPTY, from, Observable, of, Subject} from 'rxjs';
 import {catchError, filter, finalize, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 import {createRouterState} from './create_router_state';
+
 import {INPUT_BINDER} from './directives/router_outlet';
 import {
   BeforeActivateRoutes,
@@ -82,6 +83,7 @@ import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {CREATE_VIEW_TRANSITION} from './utils/view_transition';
 import {getClosestRouteInjector} from './utils/config';
 import {abortSignalToObservable} from './utils/abort_signal_to_observable';
+import type {Router} from './router';
 
 /**
  * @description
@@ -320,19 +322,6 @@ export interface NavigationTransition {
   guardsResult: GuardResult | null;
 }
 
-/**
- * The interface from the Router needed by the transitions. Used to avoid a circular dependency on
- * Router. This interface should be whittled down with future refactors. For example, we do not need
- * to get `UrlSerializer` from the Router. We can instead inject it in `NavigationTransitions`
- * directly.
- */
-interface InternalRouterInterface {
-  config: Routes;
-  navigated: boolean;
-  routeReuseStrategy: RouteReuseStrategy;
-  onSameUrlNavigation: 'reload' | 'ignore';
-}
-
 export const NAVIGATION_ERROR_HANDLER = new InjectionToken<
   (error: NavigationError) => unknown | RedirectCommand
 >(typeof ngDevMode === 'undefined' || ngDevMode ? 'navigation error handler' : '');
@@ -434,7 +423,7 @@ export class NavigationTransitions {
     });
   }
 
-  setupNavigations(router: InternalRouterInterface): Observable<NavigationTransition> {
+  setupNavigations(router: Router): Observable<NavigationTransition> {
     this.transitions = new BehaviorSubject<NavigationTransition | null>(null);
     return this.transitions.pipe(
       filter((t): t is NavigationTransition => t !== null),

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -43,7 +43,10 @@ import {Router} from './router';
 import {InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';
 import {ROUTES} from './router_config_loader';
 import {PreloadingStrategy, RouterPreloader} from './router_preloader';
+import {routeInjectorCleanup, ROUTE_INJECTOR_CLEANUP} from './route_injector_cleanup';
+
 import {ROUTER_SCROLLER, RouterScroller} from './router_scroller';
+
 import {ActivatedRoute} from './router_state';
 import {afterNextNavigation} from './utils/navigations';
 import {
@@ -747,6 +750,38 @@ export function withNavigationErrorHandler(
 }
 
 /**
+ * A type alias for providers returned by `withExperimentalAutoCleanupInjectors` for use with `provideRouter`.
+ *
+ * @see {@link withExperimentalAutoCleanupInjectors}
+ * @see {@link provideRouter}
+ *
+ * @publicApi
+ */
+export type ExperimentalAutoCleanupInjectorsFeature =
+  RouterFeature<RouterFeatureKind.ExperimentalAutoCleanupInjectorsFeature>;
+
+/**
+ * Enables automatic destruction of unused route injectors.
+ *
+ * @description
+ *
+ * When enabled, the router will automatically destroy `EnvironmentInjector`s associated with `Route`s
+ * that are no longer active or stored by the `RouteReuseStrategy`.
+ *
+ * This feature is opt-in and requires `RouteReuseStrategy.shouldDestroyInjector` to return `true`
+ * for the routes that should be destroyed. If the `RouteReuseStrategy` uses stored handles, it
+ * should also implement `retrieveStoredHandle` to ensure we don't destroy injectors for handles that will be reattached.
+ *
+ * @publicApi
+ * @experimental 21.1
+ */
+export function withExperimentalAutoCleanupInjectors(): ExperimentalAutoCleanupInjectorsFeature {
+  return routerFeature(RouterFeatureKind.ExperimentalAutoCleanupInjectorsFeature, [
+    {provide: ROUTE_INJECTOR_CLEANUP, useValue: routeInjectorCleanup},
+  ]);
+}
+
+/**
  * A type alias for providers returned by `withComponentInputBinding` for use with `provideRouter`.
  *
  * @see {@link withComponentInputBinding}
@@ -875,6 +910,7 @@ export type RouterFeatures =
   | NavigationErrorHandlerFeature
   | ComponentInputBindingFeature
   | ViewTransitionsFeature
+  | ExperimentalAutoCleanupInjectorsFeature
   | RouterHashLocationFeature;
 
 /**
@@ -891,4 +927,5 @@ export const enum RouterFeatureKind {
   NavigationErrorHandlerFeature,
   ComponentInputBindingFeature,
   ViewTransitionsFeature,
+  ExperimentalAutoCleanupInjectorsFeature,
 }

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -755,7 +755,7 @@ export function withNavigationErrorHandler(
  * @see {@link withExperimentalAutoCleanupInjectors}
  * @see {@link provideRouter}
  *
- * @publicApi
+ * @experimental 21.1
  */
 export type ExperimentalAutoCleanupInjectorsFeature =
   RouterFeature<RouterFeatureKind.ExperimentalAutoCleanupInjectorsFeature>;
@@ -772,7 +772,6 @@ export type ExperimentalAutoCleanupInjectorsFeature =
  * for the routes that should be destroyed. If the `RouteReuseStrategy` uses stored handles, it
  * should also implement `retrieveStoredHandle` to ensure we don't destroy injectors for handles that will be reattached.
  *
- * @publicApi
  * @experimental 21.1
  */
 export function withExperimentalAutoCleanupInjectors(): ExperimentalAutoCleanupInjectorsFeature {

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -484,8 +484,9 @@ export class Recognizer {
     if (route.loadChildren) {
       // lazy children belong to the loaded module
       if (route._loadedRoutes !== undefined) {
-        if (route._loadedNgModuleFactory && !route._loadedInjector) {
-          route._loadedInjector = route._loadedNgModuleFactory.create(injector).injector;
+        const ngModuleFactory = route._loadedNgModuleFactory;
+        if (ngModuleFactory && !route._loadedInjector) {
+          route._loadedInjector = ngModuleFactory.create(injector).injector;
         }
         return {routes: route._loadedRoutes, injector: route._loadedInjector};
       }

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -484,7 +484,10 @@ export class Recognizer {
     if (route.loadChildren) {
       // lazy children belong to the loaded module
       if (route._loadedRoutes !== undefined) {
-        return {routes: route._loadedRoutes, injector: route._loadedInjector!};
+        if (route._loadedNgModuleFactory && !route._loadedInjector) {
+          route._loadedInjector = route._loadedNgModuleFactory.create(injector).injector;
+        }
+        return {routes: route._loadedRoutes, injector: route._loadedInjector};
       }
 
       if (this.abortSignal.aborted) {
@@ -497,6 +500,7 @@ export class Recognizer {
         const cfg = await this.configLoader.loadChildren(injector, route);
         route._loadedRoutes = cfg.routes;
         route._loadedInjector = cfg.injector;
+        route._loadedNgModuleFactory = cfg.factory;
         return cfg;
       }
       throw canLoadFails(route);

--- a/packages/router/src/route_injector_cleanup.ts
+++ b/packages/router/src/route_injector_cleanup.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+import {Route, Routes} from './models';
+import {
+  DetachedRouteHandleInternal,
+  ExperimentalRouteReuseStrategy,
+  RouteReuseStrategy,
+} from './route_reuse_strategy';
+import {ActivatedRouteSnapshot, RouterState} from './router_state';
+
+/**
+ * @description
+ *
+ * Cleans up `EnvironmentInjector`s assigned to `Route`s that are no longer in use.
+ */
+export const ROUTE_INJECTOR_CLEANUP = new InjectionToken<typeof routeInjectorCleanup>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'RouteInjectorCleanup' : '',
+);
+
+export function routeInjectorCleanup(
+  routeReuseStrategy: RouteReuseStrategy,
+  routerState: RouterState,
+  config: Routes,
+) {
+  const activeRoutes = new Set<Route>();
+  // Collect all active routes from the current state tree
+  if (routerState.snapshot.root) {
+    collectDescendants(routerState.snapshot.root, activeRoutes);
+  }
+
+  // For stored routes, collect them and all their parents by iterating pathFromRoot.
+  const storedHandles =
+    (routeReuseStrategy as ExperimentalRouteReuseStrategy).retrieveStoredRouteHandles?.() || [];
+  for (const handle of storedHandles) {
+    const internalHandle = handle as DetachedRouteHandleInternal;
+    if (internalHandle?.route?.value?.snapshot) {
+      for (const snapshot of internalHandle.route.value.snapshot.pathFromRoot) {
+        if (snapshot.routeConfig) {
+          activeRoutes.add(snapshot.routeConfig);
+        }
+      }
+    }
+  }
+
+  // 2. Traverse the config tree and destroy unused injectors
+  destroyUnusedInjectors(config, activeRoutes, routeReuseStrategy, false);
+}
+
+function collectDescendants(snapshot: ActivatedRouteSnapshot, activeRoutes: Set<Route>) {
+  if (snapshot.routeConfig) {
+    activeRoutes.add(snapshot.routeConfig);
+  }
+
+  for (const child of snapshot.children) {
+    collectDescendants(child, activeRoutes);
+  }
+}
+
+function destroyUnusedInjectors(
+  routes: Routes,
+  activeRoutes: Set<Route>,
+  strategy: RouteReuseStrategy,
+  inheritedForceDestroy: boolean,
+) {
+  for (const route of routes) {
+    const shouldDestroyCurrentRoute =
+      inheritedForceDestroy ||
+      !!(
+        (route._injector || route._loadedInjector) &&
+        !activeRoutes.has(route) &&
+        ((strategy as ExperimentalRouteReuseStrategy).shouldDestroyInjector?.(route) ?? false)
+      );
+
+    if (route.children) {
+      destroyUnusedInjectors(route.children, activeRoutes, strategy, shouldDestroyCurrentRoute);
+    }
+    if (route.loadChildren && route._loadedRoutes) {
+      destroyUnusedInjectors(
+        route._loadedRoutes,
+        activeRoutes,
+        strategy,
+        shouldDestroyCurrentRoute,
+      );
+    }
+
+    if (shouldDestroyCurrentRoute) {
+      if (route._injector) {
+        route._injector.destroy();
+        route._injector = undefined;
+      }
+      if (route._loadedInjector) {
+        route._loadedInjector.destroy();
+        route._loadedInjector = undefined;
+      }
+    }
+  }
+}

--- a/packages/router/src/route_injector_cleanup.ts
+++ b/packages/router/src/route_injector_cleanup.ts
@@ -50,7 +50,6 @@ export function routeInjectorCleanup(
     }
   }
 
-  // 2. Traverse the config tree and destroy unused injectors
   destroyUnusedInjectors(config, activeRoutes, routeReuseStrategy, false);
 }
 

--- a/packages/router/src/route_reuse_strategy.ts
+++ b/packages/router/src/route_reuse_strategy.ts
@@ -10,6 +10,7 @@ import {ComponentRef, inject, Injectable} from '@angular/core';
 
 import {OutletContext} from './router_outlet_context';
 import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
+import {Route} from './models';
 import {TreeNode} from './utils/tree';
 
 /**
@@ -30,6 +31,31 @@ export type DetachedRouteHandleInternal = {
   componentRef: ComponentRef<any>;
   route: TreeNode<ActivatedRoute>;
 };
+
+/**
+ * @description
+ *
+ * Destroys the component associated with a `DetachedRouteHandle`.
+ *
+ * This function should be used when a `RouteReuseStrategy` decides to drop a stored handle
+ * and wants to ensure that the component is destroyed.
+ *
+ * @param handle The detached route handle to destroy.
+ *
+ * @publicApi
+ * @see [Manually destroying detached route handles](guide/routing/customizing-route-behavior#manually-destroying-detached-route-handles)
+ */
+export function destroyDetachedRouteHandle(handle: DetachedRouteHandle): void {
+  const internalHandle = handle as DetachedRouteHandleInternal;
+  if (internalHandle && internalHandle.componentRef) {
+    internalHandle.componentRef.destroy();
+  }
+}
+
+export interface ExperimentalRouteReuseStrategy {
+  shouldDestroyInjector?(route: Route): boolean;
+  retrieveStoredRouteHandles?(): Array<DetachedRouteHandleInternal>;
+}
 
 /**
  * @description
@@ -108,6 +134,19 @@ export abstract class BaseRouteReuseStrategy implements RouteReuseStrategy {
    */
   shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
     return future.routeConfig === curr.routeConfig;
+  }
+
+  /**
+   * Determines if the injector for the given route should be destroyed.
+   *
+   * This method is called by the router when the `RouteReuseStrategy` is destroyed.
+   * If this method returns `true`, the router will destroy the injector for the given route.
+   *
+   * @see withExperimentalAutoCleanupInjectors
+   * @xperimental 21.1
+   */
+  shouldDestroyInjector(route: Route): boolean {
+    return true;
   }
 }
 

--- a/packages/router/src/route_reuse_strategy.ts
+++ b/packages/router/src/route_reuse_strategy.ts
@@ -142,7 +142,7 @@ export abstract class BaseRouteReuseStrategy implements RouteReuseStrategy {
    * This method is called by the router when the `RouteReuseStrategy` is destroyed.
    * If this method returns `true`, the router will destroy the injector for the given route.
    *
-   * @see withExperimentalAutoCleanupInjectors
+   * @see {@link withExperimentalAutoCleanupInjectors}
    * @xperimental 21.1
    */
   shouldDestroyInjector(route: Route): boolean {

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -98,6 +98,7 @@ export class RouterConfigLoader {
         );
         route._loadedRoutes = result.routes;
         route._loadedInjector = result.injector;
+        route._loadedNgModuleFactory = result.factory;
         return result;
       } finally {
         this.childrenLoaders.delete(route);
@@ -142,11 +143,13 @@ export async function loadChildren(
   let injector: EnvironmentInjector | undefined;
   let rawRoutes: Route[];
   let requireStandaloneComponents = false;
+  let factory: NgModuleFactory<unknown> | undefined = undefined;
   if (Array.isArray(factoryOrRoutes)) {
     rawRoutes = factoryOrRoutes;
     requireStandaloneComponents = true;
   } else {
     injector = factoryOrRoutes.create(parentInjector).injector;
+    factory = factoryOrRoutes;
     // When loading a module that doesn't provide `RouterModule.forChild()` preloader
     // will get stuck in an infinite loop. The child module's Injector will look to
     // its parent `Injector` when it doesn't find any ROUTES so it will return routes
@@ -156,7 +159,7 @@ export async function loadChildren(
   const routes = rawRoutes.map(standardizeConfig);
   (typeof ngDevMode === 'undefined' || ngDevMode) &&
     validateConfig(routes, route.path, requireStandaloneComponents);
-  return {routes, injector};
+  return {routes, injector, factory};
 }
 
 function isWrappedDefaultExport<T>(value: T | DefaultExport<T>): value is DefaultExport<T> {

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -115,6 +115,10 @@ export class RouterPreloader implements OnDestroy {
       }
 
       const injectorForCurrentRoute = route._injector ?? injector;
+      if (route._loadedNgModuleFactory && !route._loadedInjector) {
+        route._loadedInjector =
+          route._loadedNgModuleFactory.create(injectorForCurrentRoute).injector;
+      }
       const injectorForChildren = route._loadedInjector ?? injectorForCurrentRoute;
 
       // Note that `canLoad` is only checked as a condition that prevents `loadChildren` and not
@@ -140,6 +144,9 @@ export class RouterPreloader implements OnDestroy {
 
   private preloadConfig(injector: EnvironmentInjector, route: Route): Observable<void> {
     return this.preloadingStrategy.preload(route, () => {
+      if (injector.destroyed) {
+        return of(null);
+      }
       let loadedChildren$: Observable<LoadedRouterConfig | null>;
       if (route.loadChildren && route.canLoad === undefined) {
         loadedChildren$ = from(this.loader.loadChildren(injector, route));
@@ -154,6 +161,7 @@ export class RouterPreloader implements OnDestroy {
           }
           route._loadedRoutes = config.routes;
           route._loadedInjector = config.injector;
+          route._loadedNgModuleFactory = config.factory;
           // If the loaded config was a module, use that as the module/module injector going
           // forward. Otherwise, continue using the current module/module injector.
           return this.processRoutes(config.injector ?? injector, config.routes);

--- a/packages/router/test/route_injector_cleanup.spec.ts
+++ b/packages/router/test/route_injector_cleanup.spec.ts
@@ -1,0 +1,417 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ApplicationRef, NgModule, Component, DestroyRef, inject, Injectable} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {
+  ActivatedRouteSnapshot,
+  BaseRouteReuseStrategy,
+  DetachedRouteHandle,
+  Route,
+  RouteReuseStrategy,
+  Router,
+  RouterOutlet,
+  provideRouter,
+  withExperimentalAutoCleanupInjectors,
+  RouterModule,
+  destroyDetachedRouteHandle,
+} from '@angular/router';
+
+describe('Route Injector Destruction', () => {
+  @Component({
+    template: '<router-outlet></router-outlet>',
+    standalone: true,
+    imports: [RouterOutlet],
+  })
+  class AppComponent {}
+
+  @Component({template: 'home', standalone: true})
+  class HomeComponent {}
+
+  @Component({template: 'away', standalone: true})
+  class AwayComponent {}
+
+  @Component({template: 'child', standalone: true})
+  class ChildComponent {}
+
+  @Component({template: 'lazy', standalone: true})
+  class LazyComponent {}
+
+  @NgModule({
+    imports: [RouterModule.forChild([{path: '', component: LazyComponent}])],
+  })
+  class LazyModule {}
+
+  @Component({template: 'check', standalone: true})
+  class DestroyCheckComponent {
+    destroyRefCalled = false;
+    destroyRef = inject(DestroyRef);
+
+    constructor() {
+      this.destroyRef.onDestroy(() => {
+        this.destroyRefCalled = true;
+      });
+    }
+  }
+
+  @Injectable({providedIn: 'root'})
+  class CustomReuseStrategy extends BaseRouteReuseStrategy {
+    storedHandles = new Map<Route, DetachedRouteHandle>();
+    shouldDestroyMap = new Map<Route, boolean>();
+
+    override shouldDetach(route: ActivatedRouteSnapshot): boolean {
+      return (
+        route.routeConfig?.path === 'home' ||
+        route.routeConfig?.path === 'check' ||
+        route.routeConfig?.path === 'child'
+      );
+    }
+
+    override store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void {
+      if (route.routeConfig?.path && handle) {
+        this.storedHandles.set(route.routeConfig, handle);
+      }
+    }
+
+    override shouldAttach(route: ActivatedRouteSnapshot): boolean {
+      return !!route.routeConfig?.path && !!this.storedHandles.has(route.routeConfig);
+    }
+
+    override retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null {
+      return this.storedHandles.get(route.routeConfig!) || null;
+    }
+
+    retrieveStoredRouteHandles(): DetachedRouteHandle[] {
+      return Array.from(this.storedHandles.values());
+    }
+
+    override shouldDestroyInjector(route: Route): boolean {
+      // Default to true if not specified, so we don't block destruction by default
+      return this.shouldDestroyMap.has(route) ? this.shouldDestroyMap.get(route)! : true;
+    }
+  }
+
+  let router: Router;
+  let strategy: CustomReuseStrategy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {
+              path: 'home',
+              component: HomeComponent,
+              providers: [],
+            },
+            {
+              path: 'away',
+              component: AwayComponent,
+              providers: [],
+            },
+            {path: 'check', component: DestroyCheckComponent},
+            {
+              path: 'parent',
+              component: AppComponent,
+              providers: [],
+              children: [
+                {
+                  path: 'child',
+                  component: ChildComponent,
+                  providers: [],
+                },
+              ],
+            },
+            {
+              path: 'lazy',
+              loadChildren: () => Promise.resolve(LazyModule),
+            },
+          ],
+          withExperimentalAutoCleanupInjectors(),
+        ),
+        {provide: RouteReuseStrategy, useClass: CustomReuseStrategy},
+      ],
+    });
+
+    router = TestBed.inject(Router);
+    strategy = TestBed.inject(RouteReuseStrategy) as CustomReuseStrategy;
+    const fixture = TestBed.createComponent(AppComponent);
+  });
+
+  it('should NOT destroy injectors by default (when shouldDestroyInjector returns false)', async () => {
+    const homeRoute = router.config.find((r) => r.path === 'home')!;
+    strategy.shouldDestroyMap.set(homeRoute, false);
+
+    await router.navigateByUrl('/home');
+    await whenStable();
+    const homeInjector = (homeRoute as any)._injector;
+    expect(homeInjector).toBeDefined();
+
+    await router.navigateByUrl('/away');
+    await whenStable();
+
+    expect((homeRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(homeInjector?.destroyed).toBe(false);
+  });
+
+  it('should destroy injectors when shouldDestroyInjector returns true and route is unused', async () => {
+    await router.navigateByUrl('/home');
+    await whenStable();
+    const homeRoute = router.config.find((r) => r.path === 'home')!;
+    const homeInjector = (homeRoute as any)._injector;
+    expect(homeInjector).toBeDefined();
+
+    await router.navigateByUrl('/away');
+    await whenStable();
+
+    // Home is detached (stored), so it should NOT be destroyed yet because it is stored
+    // Wait, my strategy stores 'home'.
+    // Let's verify it is stored.
+    expect(strategy.storedHandles.get(homeRoute)).toBeDefined();
+    expect((homeRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(homeInjector?.destroyed).toBe(false);
+
+    // Now clear the storage to simulate it being unused
+    strategy.storedHandles.clear();
+    // Navigate again to trigger cleanup
+    // Actually navigate to somewhere else to trigger cleanup
+    await router.navigateByUrl('/away?t=2');
+    await whenStable();
+
+    expect((homeRoute as any)._injector).toBeUndefined();
+    // @ts-ignore
+    expect(homeInjector?.destroyed).toBe(true);
+  });
+
+  it('should NOT destroy injectors for active routes', async () => {
+    await router.navigateByUrl('/home');
+    await whenStable();
+    const homeRoute = router.config.find((r) => r.path === 'home')!;
+    const homeInjector = (homeRoute as any)._injector;
+    expect(homeInjector).toBeDefined();
+
+    // Stay on home, maybe change params
+    await router.navigateByUrl('/home?t=1');
+    await whenStable();
+
+    expect((homeRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(homeInjector?.destroyed).toBe(false);
+  });
+
+  it('should NOT destroy injectors for parent of active routes', async () => {
+    await router.navigateByUrl('/parent/child');
+    await whenStable();
+    const parentRoute = router.config.find((r) => r.path === 'parent')!;
+    const childRoute = parentRoute.children![0];
+    const parentInjector = (parentRoute as any)._injector;
+
+    const childInjector = (childRoute as any)._injector;
+
+    expect(parentInjector).toBeDefined();
+    expect(childInjector).toBeDefined();
+
+    await router.navigateByUrl('/parent/child?t=1');
+    await whenStable();
+
+    expect((parentRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(parentInjector?.destroyed).toBe(false);
+  });
+
+  it('should NOT destroy injectors for parent of stored routes', async () => {
+    router.navigateByUrl('/parent/child');
+    await whenStable();
+    const parentRoute = router.config.find((r) => r.path === 'parent')!;
+    const childRoute = parentRoute.children![0];
+    const parentInjector = (parentRoute as any)._injector;
+    const childInjector = (childRoute as any)._injector;
+
+    expect(parentInjector).toBeDefined();
+    expect(childInjector).toBeDefined();
+
+    // This navigation will cause the `child` route to be stored
+    router.navigateByUrl('/away');
+    await whenStable();
+
+    // The parent injector should NOT be destroyed because its child is in the reuse store
+    expect((parentRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(parentInjector?.destroyed).toBe(false);
+
+    // The child injector should also not be destroyed because it is stored.
+    expect((childRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(childInjector?.destroyed).toBe(false);
+  });
+
+  it('should destroy child injectors when parent is destroyed when no child is stored', async () => {
+    await router.navigateByUrl('/parent/child');
+    await whenStable();
+    const parentRoute = router.config.find((r) => r.path === 'parent')!;
+    const childRoute = parentRoute.children![0];
+    const parentInjector = (parentRoute as any)._injector;
+    const childInjector = (childRoute as any)._injector;
+
+    strategy.shouldDetach = () => false;
+    await router.navigateByUrl('/away');
+    await whenStable();
+
+    // Parent and child should be destroyed
+    expect((parentRoute as any)._injector).toBeUndefined();
+    expect((childRoute as any)._injector).toBeUndefined();
+
+    // @ts-ignore
+    expect(parentInjector?.destroyed).toBe(true);
+    // @ts-ignore
+    expect(childInjector?.destroyed).toBe(true);
+  });
+
+  it('should destroy child injectors when parent is destroyed, even if child strategy would false', async () => {
+    await router.navigateByUrl('/parent/child');
+    await whenStable();
+    const parentRoute = router.config.find((r) => r.path === 'parent')!;
+    const childRoute = parentRoute.children![0];
+    const parentInjector = (parentRoute as any)._injector;
+    const childInjector = (childRoute as any)._injector;
+
+    expect(parentInjector).toBeDefined();
+    expect(childInjector).toBeDefined();
+
+    strategy.shouldDetach = () => false;
+    // Set strategy to destroy parent but NOT child
+    strategy.shouldDestroyMap.set(parentRoute, true);
+    strategy.shouldDestroyMap.set(childRoute, false);
+
+    await router.navigateByUrl('/away');
+    await whenStable();
+
+    // Both parent and child should be destroyed due to inheritedForceDestroy
+    expect((parentRoute as any)._injector).toBeUndefined();
+    expect((childRoute as any)._injector).toBeUndefined();
+
+    // @ts-ignore
+    expect(parentInjector?.destroyed).toBe(true);
+    // @ts-ignore
+    expect(childInjector?.destroyed).toBe(true);
+  });
+
+  it('should destroy component when destroyDetachedRouteHandle is called', async () => {
+    const checkRoute = router.config.find((r) => r.path === 'check')!;
+    strategy.shouldDestroyMap.set(checkRoute, false);
+    await router.navigateByUrl('/check');
+
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const component = fixture.debugElement.query(
+      By.directive(DestroyCheckComponent),
+    ).componentInstance;
+
+    // 1. Navigate away to detach 'check' route
+    await router.navigateByUrl('/away');
+    fixture.detectChanges();
+
+    // 2. Verify 'check' route is detached and stored
+    expect(strategy.storedHandles.get(checkRoute)).toBeDefined();
+    expect(component.destroyRefCalled).toBe(false);
+
+    // 3. Manually destroy the handle
+    destroyDetachedRouteHandle(strategy.storedHandles.get(checkRoute)!);
+
+    // 4. Verify component is destroyed
+    expect(component.destroyRefCalled).toBe(true);
+  });
+
+  it('should NOT destroy injectors when withAutoCleanupInjectors is NOT provided', async () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [
+        provideRouter(
+          [
+            {
+              path: 'home',
+              component: AppComponent,
+              providers: [],
+            },
+            {
+              path: 'away',
+              component: AppComponent,
+              providers: [],
+            },
+          ],
+          // withAutoCleanupInjectors() is OMITTED
+        ),
+        {provide: RouteReuseStrategy, useClass: CustomReuseStrategy},
+      ],
+    });
+
+    router = TestBed.inject(Router);
+    strategy = TestBed.inject(RouteReuseStrategy) as CustomReuseStrategy;
+    const fixture = TestBed.createComponent(AppComponent);
+
+    await router.navigateByUrl('/home');
+    await whenStable();
+    const homeRoute = router.config.find((r) => r.path === 'home')!;
+    const homeInjector = (homeRoute as any)._injector;
+    expect(homeInjector).toBeDefined();
+
+    await router.navigateByUrl('/away');
+    await whenStable();
+
+    // Should NOT be destroyed because the feature is not enabled
+    expect((homeRoute as any)._injector).toBeDefined();
+    // @ts-ignore
+    expect(homeInjector?.destroyed).toBe(false);
+  });
+
+  it('should destroy and recreate lazy loaded injectors while keeping routes', async () => {
+    await router.navigateByUrl('/lazy');
+    await whenStable();
+    const lazyRoute = router.config.find((r) => r.path === 'lazy')!;
+    const loadedInjector = (lazyRoute as any)._loadedInjector;
+    const loadedRoutes = (lazyRoute as any)._loadedRoutes;
+
+    expect(loadedInjector).toBeDefined();
+    expect(loadedRoutes).toBeDefined();
+    expect((lazyRoute as any)._loadedNgModuleFactory).toBeDefined();
+
+    // Navigate away
+    await router.navigateByUrl('/home');
+    await whenStable();
+
+    // _loadedInjector should be destroyed and undefined
+    expect((lazyRoute as any)._loadedInjector).toBeUndefined();
+    // @ts-ignore
+    expect(loadedInjector.destroyed).toBe(true);
+
+    // _loadedRoutes should STILL be defined
+    expect((lazyRoute as any)._loadedRoutes).toBe(loadedRoutes);
+
+    // Navigate back
+    await router.navigateByUrl('/lazy');
+    await whenStable();
+
+    // _loadedInjector should be recreated (new instance)
+    const newLoadedInjector = (lazyRoute as any)._loadedInjector;
+    expect(newLoadedInjector).toBeDefined();
+    expect(newLoadedInjector).not.toBe(loadedInjector);
+    // @ts-ignore
+    expect(newLoadedInjector.destroyed).toBe(false);
+
+    // _loadedRoutes should be the same
+    expect((lazyRoute as any)._loadedRoutes).toBe(loadedRoutes);
+  });
+});
+
+function whenStable() {
+  return TestBed.inject(ApplicationRef).whenStable();
+}


### PR DESCRIPTION
This commit introduces a new feature to automatically destroy `EnvironmentInjector`s associated with routes that are no longer active or stored. This helps in managing memory by releasing resources held by unused injectors.

Key changes:
- Added `shouldDestroyInjector` and `retrieveStoredRouteHandles` to `RouteReuseStrategy`.
- Introduced `withExperimentalAutoCleanupInjectors` provider function to opt-in to this feature.
- Implemented a "mark and sweep" algorithm to identify and destroy unused injectors.
- Added a dev mode warning if the strategy implements destruction methods but the feature is not enabled.
- Added integration tests to verify the behavior.

This commit also `destroyDetachedRouteHandle`, a standalone function that allows developers to explicitly destroy the component associated with a `DetachedRouteHandle`.

We chose to implement this as a standalone function rather than adding a `destroy()` method to the `DetachedRouteHandle` type to avoid breaking changes. Currently, `DetachedRouteHandle` is defined as `{}`, and many applications mock it as such. Adding a required method to the interface would break these existing tests and usages.

By using a standalone function, we can safely cast the handle to its internal type and invoke destruction without altering the public contract of the handle itself.

This feature is particularly useful for `RouteReuseStrategy` implementations that need to drop stored handles and ensure the associated components are properly cleaned up to prevent memory leaks.

resolves #27290
resolves #37095
resolves #15873
