### PR TITLE
fix(core): avoid false-positive deprecation when using `InjectionToke…

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -922,7 +922,7 @@ export interface InjectDecorator {
 export class InjectionToken<T> {
     // @deprecated
     constructor(_desc: string, options: {
-        providedIn?: Type<any> | 'any';
+        providedIn: Type<any> | 'any';
         factory: () => T;
     });
     constructor(_desc: string, options?: {

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -74,7 +74,7 @@ export class InjectionToken<T> {
   constructor(
     _desc: string,
     options: {
-      providedIn?: Type<any> | 'any';
+      providedIn: Type<any> | 'any';
       factory: () => T;
     },
   );


### PR DESCRIPTION
…n` with factory only

Prevents the deprecation warning that was incorrectly triggered when defining an InjectionToken with only a `factory`, which correctly defaults to the `root` scope.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<img width="978" height="309" alt="image" src="https://github.com/user-attachments/assets/7172addf-6b7f-4971-bca5-5e586d496e98" />



## What is the new behavior?

Prevents the deprecation warning that was incorrectly triggered when defining an InjectionToken with only a `factory`, which correctly defaults to the `root` scope.

<img width="630" height="70" alt="image" src="https://github.com/user-attachments/assets/3ba32f66-caa1-4e39-b27a-de12b89d690f" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
