### PR TITLE
docs(docs-infra): add primary color vars so button is visible (#54838)

### DIFF
--- a/adev/shared-docs/pipeline/tutorials/common/src/styles.css
+++ b/adev/shared-docs/pipeline/tutorials/common/src/styles.css
@@ -1,4 +1,18 @@
 /* You can add global styles to this file, and also import other style files */
+:root {
+  --primary-color: #605DC8;
+  --secondary-color: #8B89E6;
+  --accent-color: #e8e7fa;
+  --shadow-color: #E8E8E8;
+}
+
+button.primary {
+  padding: 10px;
+  border: solid 1px var(--primary-color);
+  background: var(--primary-color);
+  color: white;
+  border-radius: 8px;
+}
 body {
   font-family: 'Be Vietnam Pro', sans-serif;
 }

--- a/adev/src/content/tutorials/first-app/steps/02-Home/README.md
+++ b/adev/src/content/tutorials/first-app/steps/02-Home/README.md
@@ -95,6 +95,26 @@ In this step, you add a search filter and button that is used in a later lesson.
 For now, that's all that `Home` has.
 Note that, this step just adds the search elements to the layout without any functionality, yet.
 
+If you started from a fresh Angular project instead of downloading the starter
+(ng new): add these globals to `src/styles.css` so the search button and input border are visible:
+
+```
+:root {
+  --primary-color: #605DC8;
+  --secondary-color: #8B89E6;
+  --accent-color: #e8e7fa;
+  --shadow-color: #E8E8E8;
+}
+
+button.primary {
+  padding: 10px;
+  border: solid 1px var(--primary-color);
+  background: var(--primary-color);
+  color: white;
+  border-radius: 8px;
+}
+```
+
 In the **Edit** pane of your IDE:
 
 1. In the `first-app` directory, open `home.ts` in the editor.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The housing tutorial relies on `var(--primary-color)` for the Home search button/input. The shared styles don’t define that variable, so the button appears white-on-white and the input border is invisible for users who start from a fresh `ng new` or use the download without added globals.

Issue Number: #54838


## What is the new behavior?
Defined the primary color variables in the shared tutorial styles so the download includes them, and added a short note in step 2 for users starting from a fresh project. The button and input border now render visibly by default when project is created from 'ng new'.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
