### PR TITLE
docs: update testing examples to use Vitest instead of Jasmine

### DIFF
--- a/adev/src/content/examples/testing/src/app/demo/demo.spec.ts
+++ b/adev/src/content/examples/testing/src/app/demo/demo.spec.ts
@@ -1,6 +1,6 @@
 // #docplaster
-import {LightswitchComponent, MasterService, ValueService, ReversePipe} from './demo';
 import {firstValueFrom} from 'rxjs';
+import {LightswitchComponent, MasterService, ValueService, ReversePipe} from './demo';
 
 ///////// Fakes /////////
 export class FakeValueService extends ValueService {

--- a/adev/src/content/guide/testing/services.md
+++ b/adev/src/content/guide/testing/services.md
@@ -1,7 +1,5 @@
 # Testing services
 
-NOTE: While this guide is being updated for Vitest, some code examples currently use Karma/Jasmine syntax and APIs. We are actively working to provide Vitest equivalents where applicable.
-
 To check that your services are working as you intend, you can write tests specifically for them.
 
 Services are often the smoothest files to unit test.


### PR DESCRIPTION
Replace Jasmine-specific APIs with Vitest equivalents in service testing examples

Fixes #65987

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #65987
The testing documentation examples use Jasmine-specific APIs (DoneFn, jasmine.createSpyObj, .withContext()) which don't work with Vitest. This causes confusion for developers trying to follow the Angular 21 testing guide, as Angular has migrated to Vitest.


## What is the new behavior?
The testing examples now use proper Vitest syntax:
  - Async tests use `async/await` instead of `done` callbacks
  - Mock creation uses `vi.fn().mockReturnValue()` instead of `jasmine.createSpyObj`
  - Custom error messages use Vitest's second parameter: `expect(value, 'message')` instead of `.withContext()`
  - Added proper `import {vi} from 'vitest'` statement


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change helps complete the Vitest migration mentioned in the documentation. The examples now match the official Vitest documentation and will work correctly when developers copy them.