### PR TITLE
fix(language-service): avoid interpolation highlighting inside `@let`

### DIFF
--- a/vscode-ng-language-service/syntaxes/src/template.ts
+++ b/vscode-ng-language-service/syntaxes/src/template.ts
@@ -10,7 +10,7 @@ import {GrammarDefinition} from './types';
 
 export const Template: GrammarDefinition = {
   scopeName: 'template.ng',
-  injectionSelector: 'L:text.html -comment -control.block.ng',
+  injectionSelector: 'L:text.html -comment -control.block.ng -meta.definition.variable.ng',
   patterns: [{include: '#interpolation'}],
   repository: {
     interpolation: {

--- a/vscode-ng-language-service/syntaxes/template.json
+++ b/vscode-ng-language-service/syntaxes/template.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "template.ng",
-  "injectionSelector": "L:text.html -comment -control.block.ng",
+  "injectionSelector": "L:text.html -comment -control.block.ng -meta.definition.variable.ng",
   "patterns": [
     {
       "include": "#interpolation"


### PR DESCRIPTION
This change omits treating `{{ }}` interpolation syntax as valid inside `@let` binding strings, preventing the interpolation curly braces from superseding the match of the surrounding binding expression and ensuring the highlighter reflects the correct semantics of `@let` bindings.

fixes https://github.com/angular/angular/issues/61643

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<img width="492" height="98" alt="image" src="https://github.com/user-attachments/assets/f3730816-295c-4541-bf4a-172f86248008" />
 
 


## What is the new behavior?
<img width="553" height="92" alt="image" src="https://github.com/user-attachments/assets/46346a0b-29ae-49b9-a13c-1c55b27767e0" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
