### PR TITLE
refactor(forms): rename field to fieldTree in FieldContext and ValidationError

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -45,7 +45,7 @@ export class CompatValidationError<T = unknown> implements ValidationError {
     // (undocumented)
     readonly control: AbstractControl;
     // (undocumented)
-    readonly field: FieldTree<unknown>;
+    readonly fieldTree: FieldTree<unknown>;
     // (undocumented)
     readonly kind: string;
     // (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -99,7 +99,7 @@ export function customError<E extends Partial<ValidationError.WithField>>(obj?: 
 export class CustomValidationError implements ValidationError {
     constructor(options?: ValidationErrorOptions);
     [key: PropertyKey]: unknown;
-    readonly field: FieldTree<unknown>;
+    readonly fieldTree: FieldTree<unknown>;
     readonly kind: string;
     readonly message?: string;
 }
@@ -115,7 +115,7 @@ export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(pat
 
 // @public
 export interface DisabledReason {
-    readonly field: FieldTree<unknown>;
+    readonly fieldTree: FieldTree<unknown>;
     readonly message?: string;
 }
 
@@ -469,7 +469,7 @@ export class RequiredValidationError extends _NgValidationError {
 
 // @public
 export interface RootFieldContext<TValue> {
-    readonly field: FieldTree<TValue>;
+    readonly fieldTree: FieldTree<TValue>;
     fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): FieldTree<PModel>;
     readonly pathKeys: Signal<readonly string[]>;
     readonly state: FieldState<TValue>;
@@ -582,10 +582,10 @@ export interface ValidationError {
 // @public (undocumented)
 export namespace ValidationError {
     export interface WithField extends ValidationError {
-        readonly field: FieldTree<unknown>;
+        readonly fieldTree: FieldTree<unknown>;
     }
     export interface WithOptionalField extends ValidationError {
-        readonly field?: FieldTree<unknown>;
+        readonly fieldTree?: FieldTree<unknown>;
     }
     export interface WithoutField extends ValidationError {
         readonly field?: never;
@@ -603,17 +603,17 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
 
 // @public
 export type WithField<T> = T & {
-    field: FieldTree<unknown>;
+    fieldTree: FieldTree<unknown>;
 };
 
 // @public
-export type WithOptionalField<T> = Omit<T, 'field'> & {
-    field?: FieldTree<unknown>;
+export type WithOptionalField<T> = Omit<T, 'fieldTree'> & {
+    fieldTree?: FieldTree<unknown>;
 };
 
 // @public
 export type WithoutField<T> = T & {
-    field: never;
+    fieldTree: never;
 };
 
 // (No @packageDocumentation comment for this package)

--- a/packages/forms/signals/compat/src/api/compat_validation_error.ts
+++ b/packages/forms/signals/compat/src/api/compat_validation_error.ts
@@ -19,7 +19,7 @@ import {FieldTree} from '../../../src/api/types';
 export class CompatValidationError<T = unknown> implements ValidationError {
   readonly kind: string = 'compat';
   readonly control: AbstractControl;
-  readonly field!: FieldTree<unknown>;
+  readonly fieldTree!: FieldTree<unknown>;
   readonly context: T;
   readonly message?: string;
 

--- a/packages/forms/signals/src/api/rules/disabled.ts
+++ b/packages/forms/signals/src/api/rules/disabled.ts
@@ -38,8 +38,8 @@ export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(
       result = logic(ctx as FieldContext<TValue, TPathKind>);
     }
     if (typeof result === 'string') {
-      return {field: ctx.field, message: result};
+      return {fieldTree: ctx.fieldTree, message: result};
     }
-    return result ? {field: ctx.field} : undefined;
+    return result ? {fieldTree: ctx.fieldTree} : undefined;
   });
 }

--- a/packages/forms/signals/src/api/rules/validation/standard_schema.ts
+++ b/packages/forms/signals/src/api/rules/validation/standard_schema.ts
@@ -113,15 +113,15 @@ export function validateStandardSchema<TSchema, TModel extends IgnoreUnknownProp
 /**
  * Converts a `StandardSchemaV1.Issue` to a `FormTreeError`.
  *
- * @param field The root field to which the issue's path is relative.
+ * @param fieldTree The root field to which the issue's path is relative.
  * @param issue The `StandardSchemaV1.Issue` to convert.
  * @returns A `ValidationError` representing the issue.
  */
 function standardIssueToFormTreeError(
-  field: FieldTree<unknown>,
+  fieldTree: FieldTree<unknown>,
   issue: StandardSchemaV1.Issue,
 ): StandardSchemaValidationError {
-  let target = field as FieldTree<Record<PropertyKey, unknown>>;
+  let target = fieldTree as FieldTree<Record<PropertyKey, unknown>>;
   for (const pathPart of issue.path ?? []) {
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
     target = target[pathKey] as FieldTree<Record<PropertyKey, unknown>>;

--- a/packages/forms/signals/src/api/rules/validation/validate.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate.ts
@@ -38,7 +38,7 @@ export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.builder.addSyncErrorRule((ctx) => {
     return ensureCustomValidationResult(
-      addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.field),
+      addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.fieldTree),
     );
   });
 }

--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -143,10 +143,10 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
           return undefined;
         }
         errors = opts.onSuccess(res.value()!, ctx as FieldContext<TValue, TPathKind>);
-        return addDefaultField(errors, ctx.field);
+        return addDefaultField(errors, ctx.fieldTree);
       case 'error':
         errors = opts.onError(res.error(), ctx as FieldContext<TValue, TPathKind>);
-        return addDefaultField(errors, ctx.field);
+        return addDefaultField(errors, ctx.fieldTree);
     }
   });
 }

--- a/packages/forms/signals/src/api/rules/validation/validate_tree.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_tree.ts
@@ -31,6 +31,6 @@ export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>
 
   const pathNode = FieldPathNode.unwrapFieldPath(path);
   pathNode.builder.addSyncTreeErrorRule((ctx) =>
-    addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.field),
+    addDefaultField(logic(ctx as FieldContext<TValue, TPathKind>), ctx.fieldTree),
   );
 }

--- a/packages/forms/signals/src/api/rules/validation/validation_errors.ts
+++ b/packages/forms/signals/src/api/rules/validation/validation_errors.ts
@@ -23,7 +23,7 @@ interface ValidationErrorOptions {
  *
  * @experimental 21.0.0
  */
-export type WithField<T> = T & {field: FieldTree<unknown>};
+export type WithField<T> = T & {fieldTree: FieldTree<unknown>};
 
 /**
  * A type that allows the given type `T` to optionally have a `field` property.
@@ -31,7 +31,7 @@ export type WithField<T> = T & {field: FieldTree<unknown>};
  *
  * @experimental 21.0.0
  */
-export type WithOptionalField<T> = Omit<T, 'field'> & {field?: FieldTree<unknown>};
+export type WithOptionalField<T> = Omit<T, 'fieldTree'> & {fieldTree?: FieldTree<unknown>};
 
 /**
  * A type that ensures the given type `T` does not have a `field` property.
@@ -39,7 +39,7 @@ export type WithOptionalField<T> = Omit<T, 'field'> & {field?: FieldTree<unknown
  *
  * @experimental 21.0.0
  */
-export type WithoutField<T> = T & {field: never};
+export type WithoutField<T> = T & {fieldTree: never};
 
 /**
  * Create a required error associated with the target field
@@ -325,7 +325,7 @@ export declare namespace ValidationError {
    */
   export interface WithField extends ValidationError {
     /** The field associated with this error. */
-    readonly field: FieldTree<unknown>;
+    readonly fieldTree: FieldTree<unknown>;
   }
 
   /**
@@ -336,7 +336,7 @@ export declare namespace ValidationError {
    */
   export interface WithOptionalField extends ValidationError {
     /** The field associated with this error. */
-    readonly field?: FieldTree<unknown>;
+    readonly fieldTree?: FieldTree<unknown>;
   }
 
   /**
@@ -369,7 +369,7 @@ export class CustomValidationError implements ValidationError {
   readonly kind: string = '';
 
   /** The field associated with this error. */
-  readonly field!: FieldTree<unknown>;
+  readonly fieldTree!: FieldTree<unknown>;
 
   /** Human readable error message. */
   readonly message?: string;
@@ -395,7 +395,7 @@ abstract class _NgValidationError implements ValidationError {
   readonly kind: string = '';
 
   /** The field associated with this error. */
-  readonly field!: FieldTree<unknown>;
+  readonly fieldTree!: FieldTree<unknown>;
 
   /** Human readable error message. */
   readonly message?: string;

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -400,7 +400,7 @@ function setServerErrors(
   const errorsByField = new Map<FieldNode, ValidationError.WithField[]>();
   for (const error of errors) {
     const errorWithField = addDefaultField(error, submittedField.fieldProxy);
-    const field = errorWithField.field() as FieldNode;
+    const field = errorWithField.fieldTree() as FieldNode;
     let fieldErrors = errorsByField.get(field);
     if (!fieldErrors) {
       fieldErrors = [];

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -75,7 +75,7 @@ export type SubmittedStatus = 'unsubmitted' | 'submitted' | 'submitting';
  */
 export interface DisabledReason {
   /** The field that is disabled. */
-  readonly field: FieldTree<unknown>;
+  readonly fieldTree: FieldTree<unknown>;
   /** A user-facing message describing the reason for the disablement. */
   readonly message?: string;
 }
@@ -606,7 +606,7 @@ export interface RootFieldContext<TValue> {
   /** The state of the current field. */
   readonly state: FieldState<TValue>;
   /** The current field. */
-  readonly field: FieldTree<TValue>;
+  readonly fieldTree: FieldTree<TValue>;
 
   /** Gets the value of the field represented by the given path. */
   valueOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): PValue;

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -103,7 +103,7 @@ export class FieldNodeContext implements FieldContext<unknown> {
     return this.cache.get(target)!() as FieldTree<U>;
   }
 
-  get field(): FieldTree<unknown> {
+  get fieldTree(): FieldTree<unknown> {
     return this.node.fieldProxy;
   }
 

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -203,7 +203,7 @@ export class FieldValidationState implements ValidationState {
    * rather than a descendant.
    */
   readonly syncTreeErrors: Signal<ValidationError.WithField[]> = computed(() =>
-    this.rawSyncTreeErrors().filter((err) => err.field === this.node.fieldProxy),
+    this.rawSyncTreeErrors().filter((err) => err.fieldTree === this.node.fieldProxy),
   );
 
   /**
@@ -235,7 +235,7 @@ export class FieldValidationState implements ValidationState {
       return [];
     }
     return this.rawAsyncErrors().filter(
-      (err) => err === 'pending' || err.field === this.node.fieldProxy,
+      (err) => err === 'pending' || err.fieldTree === this.node.fieldProxy,
     );
   });
 
@@ -351,27 +351,27 @@ function normalizeErrors<T extends ValidationResult>(error: T | readonly T[]): r
 /**
  * Sets the given field on the given error(s) if it does not already have a field.
  * @param error The error(s) to add the field to
- * @param field The default field to add
+ * @param fieldTree The default field to add
  * @returns The passed in error(s), with its field set.
  */
 export function addDefaultField<E extends ValidationError.WithOptionalField>(
   error: E,
-  field: FieldTree<unknown>,
-): E & {field: FieldTree<unknown>};
+  fieldTree: FieldTree<unknown>,
+): E & {fieldTree: FieldTree<unknown>};
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  field: FieldTree<unknown>,
-): ValidationResult<E & {field: FieldTree<unknown>}>;
+  fieldTree: FieldTree<unknown>,
+): ValidationResult<E & {fieldTree: FieldTree<unknown>}>;
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  field: FieldTree<unknown>,
-): ValidationResult<E & {field: FieldTree<unknown>}> {
+  fieldTree: FieldTree<unknown>,
+): ValidationResult<E & {fieldTree: FieldTree<unknown>}> {
   if (isArray(errors)) {
     for (const error of errors) {
-      (error as ɵWritable<ValidationError.WithOptionalField>).field ??= field;
+      (error as ɵWritable<ValidationError.WithOptionalField>).fieldTree ??= fieldTree;
     }
   } else if (errors) {
-    (errors as ɵWritable<ValidationError.WithOptionalField>).field ??= field;
+    (errors as ɵWritable<ValidationError.WithOptionalField>).fieldTree ??= fieldTree;
   }
-  return errors as ValidationResult<E & {field: FieldTree<unknown>}>;
+  return errors as ValidationResult<E & {fieldTree: FieldTree<unknown>}>;
 }

--- a/packages/forms/signals/test/node/api/validators/email.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/email.spec.ts
@@ -26,7 +26,7 @@ describe('email validator', () => {
 
     expect(f.email().errors()).toEqual([]);
     f.email().value.set('not-real-email');
-    expect(f.email().errors()).toEqual([emailError({field: f.email})]);
+    expect(f.email().errors()).toEqual([emailError({fieldTree: f.email})]);
   });
 
   it('supports custom errors', () => {
@@ -46,7 +46,7 @@ describe('email validator', () => {
     expect(f.email().errors()).toEqual([
       customError({
         kind: 'special-email-pirojok-the-cat',
-        field: f.email,
+        fieldTree: f.email,
       }),
     ]);
   });
@@ -68,7 +68,7 @@ describe('email validator', () => {
     expect(f.email().errors()).toEqual([
       emailError({
         message: 'email error',
-        field: f.email,
+        fieldTree: f.email,
       }),
     ]);
   });

--- a/packages/forms/signals/test/node/api/validators/max.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max.spec.ts
@@ -21,7 +21,7 @@ describe('max validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+    expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -69,7 +69,7 @@ describe('max validator', () => {
         customError({
           kind: 'special-max',
           message: '6',
-          field: f.age,
+          fieldTree: f.age,
         }),
       ]);
     });
@@ -89,7 +89,7 @@ describe('max validator', () => {
       expect(f.age().errors()).toEqual([
         maxError(5, {
           message: 'max error',
-          field: f.age,
+          fieldTree: f.age,
         }),
       ]);
     });
@@ -111,7 +111,7 @@ describe('max validator', () => {
       );
 
       expect(f.age().errors()).toEqual([
-        customError({kind: 'special-max', message: '6', field: f.age}),
+        customError({kind: 'special-max', message: '6', fieldTree: f.age}),
       ]);
       f.name().value.set('disabled');
       expect(f.age().errors()).toEqual([]);
@@ -176,9 +176,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([maxError(10, {field: f.age}), maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([
+        maxError(10, {fieldTree: f.age}),
+        maxError(5, {fieldTree: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -198,9 +201,12 @@ describe('max validator', () => {
       );
 
       f.age().value.set(12);
-      expect(f.age().errors()).toEqual([maxError(10, {field: f.age}), maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([
+        maxError(10, {fieldTree: f.age}),
+        maxError(5, {fieldTree: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
       f.age().value.set(3);
       expect(f.age().errors()).toEqual([]);
 
@@ -208,7 +214,7 @@ describe('max validator', () => {
 
       maxSignal.set(2);
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([maxError(2, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(2, {fieldTree: f.age})]);
       expect(f.age().max?.()).toBe(2);
     });
 
@@ -227,14 +233,14 @@ describe('max validator', () => {
 
       // Initially, age 20 is greater than both 10 and 15
       expect(f.age().errors()).toEqual([
-        maxError(10, {field: f.age}),
-        maxError(15, {field: f.age}),
+        maxError(10, {fieldTree: f.age}),
+        maxError(15, {fieldTree: f.age}),
       ]);
 
       // Set the first max threshold to undefined
       maxSignal.set(undefined);
       // Now, age 20 is only greater than 15
-      expect(f.age().errors()).toEqual([maxError(15, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(15, {fieldTree: f.age})]);
 
       // Set the second max threshold to undefined
       maxSignal2.set(undefined);
@@ -255,7 +261,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
       maxValue.set(7);
       expect(f.age().errors()).toEqual([]);
     });
@@ -271,11 +277,11 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
       maxValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       maxValue.set(5);
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
     });
 
     it('handles dynamic value based on other field', () => {
@@ -291,7 +297,7 @@ describe('max validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([maxError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([maxError(5, {fieldTree: f.age})]);
 
       f.name().value.set('other cat');
 

--- a/packages/forms/signals/test/node/api/validators/max_length.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/max_length.spec.ts
@@ -21,7 +21,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([maxLengthError(3, {field: f.text})]);
+    expect(f.text().errors()).toEqual([maxLengthError(3, {fieldTree: f.text})]);
   });
 
   it('returns maxLength error when the length is larger for arrays', () => {
@@ -34,7 +34,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([maxLengthError(3, {field: f.list})]);
+    expect(f.list().errors()).toEqual([maxLengthError(3, {fieldTree: f.list})]);
   });
 
   it('is inclusive (no error if length equals maxLength)', () => {
@@ -84,7 +84,7 @@ describe('maxLength validator', () => {
       customError({
         kind: 'special-maxLength',
         message: 'Length is 6',
-        field: f.text,
+        fieldTree: f.text,
       }),
     ]);
   });
@@ -104,7 +104,7 @@ describe('maxLength validator', () => {
     expect(f.text().errors()).toEqual([
       maxLengthError(5, {
         message: 'abcdef is an error!',
-        field: f.text,
+        fieldTree: f.text,
       }),
     ]);
   });
@@ -119,7 +119,7 @@ describe('maxLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([maxLengthError(3, {field: f})]);
+    expect(f().errors()).toEqual([maxLengthError(3, {fieldTree: f})]);
   });
 
   it('should treat empty value as valid', () => {
@@ -171,12 +171,12 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        maxLengthError(10, {field: f.text}),
-        maxLengthError(5, {field: f.text}),
+        maxLengthError(10, {fieldTree: f.text}),
+        maxLengthError(5, {fieldTree: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {fieldTree: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
@@ -198,19 +198,19 @@ describe('maxLength validator', () => {
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([
-        maxLengthError(10, {field: f.text}),
-        maxLengthError(5, {field: f.text}),
+        maxLengthError(10, {fieldTree: f.text}),
+        maxLengthError(5, {fieldTree: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {fieldTree: f.text})]);
 
       f.text().value.set('abc');
       expect(f.text().errors()).toEqual([]);
 
       maxLengthSignal.set(2);
 
-      expect(f.text().errors()).toEqual([maxLengthError(2, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(2, {fieldTree: f.text})]);
       expect(f.text().maxLength?.()).toBe(2);
     });
   });
@@ -227,7 +227,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {fieldTree: f.text})]);
       dynamicMaxLength.set(7);
       expect(f.text().errors()).toEqual([]);
     });
@@ -242,7 +242,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([maxLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(5, {fieldTree: f.text})]);
       dynamicMaxLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -259,7 +259,7 @@ describe('maxLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([maxLengthError(8, {field: f.text})]);
+      expect(f.text().errors()).toEqual([maxLengthError(8, {fieldTree: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/signals/test/node/api/validators/min.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min.spec.ts
@@ -21,7 +21,7 @@ describe('min validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
+    expect(f.age().errors()).toEqual([minError(5, {fieldTree: f.age})]);
   });
 
   it('is inclusive', () => {
@@ -69,7 +69,7 @@ describe('min validator', () => {
         customError({
           kind: 'special-min',
           message: '3',
-          field: f.age,
+          fieldTree: f.age,
         }),
       ]);
     });
@@ -95,7 +95,7 @@ describe('min validator', () => {
         customError({
           kind: 'special-min',
           message: '3',
-          field: f.age,
+          fieldTree: f.age,
         }),
       ]);
     });
@@ -115,7 +115,7 @@ describe('min validator', () => {
       expect(f.age().errors()).toEqual([
         minError(5, {
           message: 'min error!!',
-          field: f.age,
+          fieldTree: f.age,
         }),
       ]);
     });
@@ -137,7 +137,7 @@ describe('min validator', () => {
       );
 
       expect(f.age().errors()).toEqual([
-        customError({kind: 'special-min', message: '3', field: f.age}),
+        customError({kind: 'special-min', message: '3', fieldTree: f.age}),
       ]);
       f.name().value.set('disabled');
       expect(f.age().errors()).toEqual([]);
@@ -198,9 +198,12 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age}), minError(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([
+        minError(5, {fieldTree: f.age}),
+        minError(10, {fieldTree: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {fieldTree: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
 
@@ -220,13 +223,16 @@ describe('min validator', () => {
       );
 
       f.age().value.set(3);
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age}), minError(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([
+        minError(5, {fieldTree: f.age}),
+        minError(10, {fieldTree: f.age}),
+      ]);
       f.age().value.set(7);
-      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {fieldTree: f.age})]);
       f.age().value.set(15);
       expect(f.age().errors()).toEqual([]);
       minSignal.set(30);
-      expect(f.age().errors()).toEqual([minError(30, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(30, {fieldTree: f.age})]);
       expect(f.age().min?.()).toBe(30);
     });
 
@@ -244,11 +250,11 @@ describe('min validator', () => {
       );
 
       expect(f.age().errors()).toEqual([
-        minError(15, {field: f.age}),
-        minError(10, {field: f.age}),
+        minError(15, {fieldTree: f.age}),
+        minError(10, {fieldTree: f.age}),
       ]);
       minSignal.set(undefined);
-      expect(f.age().errors()).toEqual([minError(10, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(10, {fieldTree: f.age})]);
       minSignal2.set(undefined);
       expect(f.age().errors()).toEqual([]);
     });
@@ -266,11 +272,11 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {fieldTree: f.age})]);
       minValue.set(undefined);
       expect(f.age().errors()).toEqual([]);
       minValue.set(5);
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {fieldTree: f.age})]);
     });
 
     it('handles dynamic value', () => {
@@ -284,7 +290,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {fieldTree: f.age})]);
       minValue.set(2);
       expect(f.age().errors()).toEqual([]);
     });
@@ -302,7 +308,7 @@ describe('min validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.age().errors()).toEqual([minError(5, {field: f.age})]);
+      expect(f.age().errors()).toEqual([minError(5, {fieldTree: f.age})]);
       f.name().value.set('other cat');
       expect(f.age().errors()).toEqual([]);
     });

--- a/packages/forms/signals/test/node/api/validators/min_length.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/min_length.spec.ts
@@ -21,7 +21,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
+    expect(f.text().errors()).toEqual([minLengthError(5, {fieldTree: f.text})]);
   });
 
   it('returns minLength error when the length is smaller for arrays', () => {
@@ -34,7 +34,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.list().errors()).toEqual([minLengthError(5, {field: f.list})]);
+    expect(f.list().errors()).toEqual([minLengthError(5, {fieldTree: f.list})]);
   });
 
   it('is inclusive (no error if length equals minLength)', () => {
@@ -84,7 +84,7 @@ describe('minLength validator', () => {
       customError({
         kind: 'special-minLength',
         message: 'Length is 2',
-        field: f.text,
+        fieldTree: f.text,
       }),
     ]);
   });
@@ -104,7 +104,7 @@ describe('minLength validator', () => {
     expect(f.text().errors()).toEqual([
       minLengthError(5, {
         message: 'ab is error!',
-        field: f.text,
+        fieldTree: f.text,
       }),
     ]);
   });
@@ -119,7 +119,7 @@ describe('minLength validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f().errors()).toEqual([minLengthError(5, {field: f})]);
+    expect(f().errors()).toEqual([minLengthError(5, {fieldTree: f})]);
   });
 
   it('should treat empty value as valid', () => {
@@ -171,12 +171,12 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        minLengthError(5, {field: f.text}),
-        minLengthError(10, {field: f.text}),
+        minLengthError(5, {fieldTree: f.text}),
+        minLengthError(10, {fieldTree: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([minLengthError(10, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(10, {fieldTree: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
@@ -198,19 +198,19 @@ describe('minLength validator', () => {
 
       f.text().value.set('ab');
       expect(f.text().errors()).toEqual([
-        minLengthError(5, {field: f.text}),
-        minLengthError(10, {field: f.text}),
+        minLengthError(5, {fieldTree: f.text}),
+        minLengthError(10, {fieldTree: f.text}),
       ]);
 
       f.text().value.set('abcdefg');
-      expect(f.text().errors()).toEqual([minLengthError(10, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(10, {fieldTree: f.text})]);
 
       f.text().value.set('abcdefghijklmno');
       expect(f.text().errors()).toEqual([]);
 
       minLengthSignal.set(20);
 
-      expect(f.text().errors()).toEqual([minLengthError(20, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(20, {fieldTree: f.text})]);
       expect(f.text().minLength?.()).toBe(20);
     });
   });
@@ -227,7 +227,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(5, {fieldTree: f.text})]);
       dynamicMinLength.set(3);
       expect(f.text().errors()).toEqual([]);
     });
@@ -243,7 +243,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([minLengthError(5, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(5, {fieldTree: f.text})]);
       dynamicMinLength.set(undefined);
       expect(f.text().errors()).toEqual([]);
     });
@@ -260,7 +260,7 @@ describe('minLength validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.text().errors()).toEqual([minLengthError(8, {field: f.text})]);
+      expect(f.text().errors()).toEqual([minLengthError(8, {fieldTree: f.text})]);
 
       f.category().value.set('B');
       expect(f.text().errors()).toEqual([]);

--- a/packages/forms/signals/test/node/api/validators/pattern.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/pattern.spec.ts
@@ -21,7 +21,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {field: f.name})]);
+    expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {fieldTree: f.name})]);
   });
 
   it('supports custom error', () => {
@@ -34,7 +34,7 @@ describe('pattern validator', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.name().errors()).toEqual([customError({field: f.name})]);
+    expect(f.name().errors()).toEqual([customError({fieldTree: f.name})]);
   });
 
   it('supports custom error message', () => {
@@ -48,7 +48,7 @@ describe('pattern validator', () => {
     );
 
     expect(f.name().errors()).toEqual([
-      patternError(/pir.*jok/, {message: 'pattern error', field: f.name}),
+      patternError(/pir.*jok/, {message: 'pattern error', fieldTree: f.name}),
     ]);
   });
 
@@ -120,12 +120,12 @@ describe('pattern validator', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {field: f.name})]);
+      expect(f.name().errors()).toEqual([patternError(/pir.*jok/, {fieldTree: f.name})]);
 
       patternSignal.set(/p.*/);
       expect(f.name().errors()).toEqual([]);
       patternSignal.set(/meow/);
-      expect(f.name().errors()).toEqual([patternError(/meow/, {field: f.name})]);
+      expect(f.name().errors()).toEqual([patternError(/meow/, {fieldTree: f.name})]);
 
       patternSignal.set(undefined);
 

--- a/packages/forms/signals/test/node/api/validators/required.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/required.spec.ts
@@ -24,7 +24,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([requiredError({field: f.name})]);
+    expect(f.name().errors()).toEqual([requiredError({fieldTree: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -43,7 +43,7 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([customError({kind: 'required-5', field: f.name})]);
+    expect(f.name().errors()).toEqual([customError({kind: 'required-5', fieldTree: f.name})]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -62,7 +62,9 @@ describe('required validator', () => {
       },
     );
 
-    expect(f.name().errors()).toEqual([requiredError({message: 'required error', field: f.name})]);
+    expect(f.name().errors()).toEqual([
+      requiredError({message: 'required error', fieldTree: f.name}),
+    ]);
     f.name().value.set('pirojok-the-cat');
     expect(f.name().errors()).toEqual([]);
   });
@@ -85,7 +87,7 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.age().value.set(15);
-    expect(f.name().errors()).toEqual([requiredError({field: f.name})]);
+    expect(f.name().errors()).toEqual([requiredError({fieldTree: f.name})]);
   });
 
   it('supports returning custom plain error, and wraps it as custom', () => {
@@ -106,6 +108,8 @@ describe('required validator', () => {
 
     expect(f.name().errors()).toEqual([]);
     f.name().value.set('');
-    expect(f.name().errors()).toEqual([customError({kind: 'pirojok-the-error', field: f.name})]);
+    expect(f.name().errors()).toEqual([
+      customError({kind: 'pirojok-the-error', fieldTree: f.name}),
+    ]);
   });
 });

--- a/packages/forms/signals/test/node/api/validators/util.spec.ts
+++ b/packages/forms/signals/test/node/api/validators/util.spec.ts
@@ -26,7 +26,7 @@ describe('validators utils', () => {
     });
 
     it('should wrap a plain error object with customError', () => {
-      const error: ValidationError.WithField = {kind: 'meow', field: {} as FieldTree<unknown>};
+      const error: ValidationError.WithField = {kind: 'meow', fieldTree: {} as FieldTree<unknown>};
       const result = ensureCustomValidationResult(error);
       expect(result).toEqual(customError(error));
     });
@@ -69,7 +69,7 @@ describe('validators utils', () => {
       it('should process a mixed array of validation errors', () => {
         const plainError: ValidationError.WithField = {
           kind: 'plain',
-          field: {} as FieldTree<unknown>,
+          fieldTree: {} as FieldTree<unknown>,
         };
         const custom = customError({kind: 'custom'});
 

--- a/packages/forms/signals/test/node/api/when.spec.ts
+++ b/packages/forms/signals/test/node/api/when.spec.ts
@@ -43,7 +43,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([requiredError({field: f.last})]);
+    expect(f.last().errors()).toEqual([requiredError({fieldTree: f.last})]);
   });
 
   it('Disallows using non-local paths', () => {
@@ -89,12 +89,12 @@ describe('when', () => {
     );
     f.needLastName().value.set(true);
     expect(f.items[0].last().errors()).toEqual([
-      customError({kind: 'required1', field: f.items[0].last}),
-      customError({kind: 'required2', field: f.items[0].last}),
+      customError({kind: 'required1', fieldTree: f.items[0].last}),
+      customError({kind: 'required2', fieldTree: f.items[0].last}),
     ]);
     f.needLastName().value.set(false);
     expect(f.items[0].last().errors()).toEqual([
-      customError({kind: 'required1', field: f.items[0].last}),
+      customError({kind: 'required1', fieldTree: f.items[0].last}),
     ]);
   });
 
@@ -115,7 +115,7 @@ describe('when', () => {
     f().value.set({first: 'meow', needLastName: false, last: ''});
     expect(f.last().errors()).toEqual([]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
-    expect(f.last().errors()).toEqual([requiredError({field: f.last})]);
+    expect(f.last().errors()).toEqual([requiredError({fieldTree: f.last})]);
   });
 
   it('supports mix of conditional and non conditional validators', () => {
@@ -135,11 +135,11 @@ describe('when', () => {
     );
 
     f().value.set({first: 'meow', needLastName: false, last: ''});
-    expect(f.last().errors()).toEqual([customError({kind: 'short', field: f.last})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'short', fieldTree: f.last})]);
     f().value.set({first: 'meow', needLastName: true, last: ''});
     expect(f.last().errors()).toEqual([
-      customError({kind: 'short', field: f.last}),
-      requiredError({field: f.last}),
+      customError({kind: 'short', fieldTree: f.last}),
+      requiredError({fieldTree: f.last}),
     ]);
   });
 
@@ -161,7 +161,7 @@ describe('when', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.items[0].last().errors()).toEqual([requiredError({field: f.items[0].last})]);
+    expect(f.items[0].last().errors()).toEqual([requiredError({fieldTree: f.items[0].last})]);
     f.needLastName().value.set(false);
     expect(f.items[0].last().errors()).toEqual([]);
   });
@@ -186,11 +186,17 @@ describe('applyWhenValue', () => {
       {injector: TestBed.inject(Injector)},
     );
 
-    expect(f.numOrNull().errors()).toEqual([customError({kind: 'too-small', field: f.numOrNull})]);
+    expect(f.numOrNull().errors()).toEqual([
+      customError({kind: 'too-small', fieldTree: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([customError({kind: 'too-small', field: f.numOrNull})]);
+    expect(f.numOrNull().errors()).toEqual([
+      customError({kind: 'too-small', fieldTree: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(null);
-    expect(f.numOrNull().errors()).toEqual([customError({kind: 'too-small', field: f.numOrNull})]);
+    expect(f.numOrNull().errors()).toEqual([
+      customError({kind: 'too-small', fieldTree: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(15);
     expect(f.numOrNull().errors()).toEqual([]);
   });
@@ -215,7 +221,9 @@ describe('applyWhenValue', () => {
 
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(5);
-    expect(f.numOrNull().errors()).toEqual([customError({kind: 'too-small', field: f.numOrNull})]);
+    expect(f.numOrNull().errors()).toEqual([
+      customError({kind: 'too-small', fieldTree: f.numOrNull}),
+    ]);
     f.numOrNull().value.set(null);
     expect(f.numOrNull().errors()).toEqual([]);
     f.numOrNull().value.set(15);

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -457,7 +457,7 @@ describe('Forms compat', () => {
         },
       );
 
-      expect(f().errors()).toEqual([customError({kind: 'too small', field: f})]);
+      expect(f().errors()).toEqual([customError({kind: 'too small', fieldTree: f})]);
     });
 
     it('supports getting control from fieldTreeOf', () => {
@@ -484,7 +484,7 @@ describe('Forms compat', () => {
         },
       );
 
-      expect(f().errors()).toEqual([customError({kind: 'too small', field: f})]);
+      expect(f().errors()).toEqual([customError({kind: 'too small', fieldTree: f})]);
     });
 
     it('fails for regular values', () => {
@@ -550,7 +550,7 @@ describe('Forms compat', () => {
     expect(f.name().errors()).toEqual([
       customError({
         kind: 'too small',
-        field: f.name,
+        fieldTree: f.name,
       }),
     ]);
 

--- a/packages/forms/signals/test/node/field_context.spec.ts
+++ b/packages/forms/signals/test/node/field_context.spec.ts
@@ -59,8 +59,8 @@ describe('Field Context', () => {
   it('field', () => {
     const cat = signal({name: 'pirojok-the-cat', age: 5});
     testContext(cat, (ctx) => {
-      expect(ctx.field.name().value()).toEqual('pirojok-the-cat');
-      expect(ctx.field.age().value()).toEqual(5);
+      expect(ctx.fieldTree.name().value()).toEqual('pirojok-the-cat');
+      expect(ctx.fieldTree.age().value()).toEqual(5);
     });
   });
 

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -751,7 +751,7 @@ describe('FieldNode', () => {
       const a = f.a;
       expect(f().disabled()).toBe(false);
       expect(a().disabled()).toBe(true);
-      expect(a().disabledReasons()).toEqual([{field: f.a}]);
+      expect(a().disabledReasons()).toEqual([{fieldTree: f.a}]);
 
       a().value.set(2);
       expect(f().disabled()).toBe(false);
@@ -770,7 +770,7 @@ describe('FieldNode', () => {
       expect(f.a().disabled()).toBe(true);
       expect(f.a().disabledReasons()).toEqual([
         {
-          field: f.a,
+          fieldTree: f.a,
           message: 'a cannot be changed',
         },
       ]);
@@ -793,7 +793,7 @@ describe('FieldNode', () => {
       expect(f.a().disabled()).toBe(true);
       expect(f.a().disabledReasons()).toEqual([
         {
-          field: f.a,
+          fieldTree: f.a,
           message: 'a cannot be changed',
         },
       ]);
@@ -811,14 +811,14 @@ describe('FieldNode', () => {
       expect(f().disabled()).toBe(true);
       expect(f().disabledReasons()).toEqual([
         {
-          field: f,
+          fieldTree: f,
           message: 'form unavailable',
         },
       ]);
       expect(f.a().disabled()).toBe(true);
       expect(f.a().disabledReasons()).toEqual([
         {
-          field: f,
+          fieldTree: f,
           message: 'form unavailable',
         },
       ]);
@@ -836,12 +836,12 @@ describe('FieldNode', () => {
 
       expect(f.a().disabledReasons()).toEqual([
         {
-          field: f.a,
+          fieldTree: f.a,
         },
       ]);
       expect(f.b().disabledReasons()).toEqual([
         {
-          field: f.b,
+          fieldTree: f.b,
           message: 'disabled!',
         },
       ]);
@@ -935,7 +935,7 @@ describe('FieldNode', () => {
       expect(f().valid()).toBe(true);
 
       f.a().value.set(11);
-      expect(f.a().errors()).toEqual([customError({kind: 'too-damn-high', field: f.a})]);
+      expect(f.a().errors()).toEqual([customError({kind: 'too-damn-high', fieldTree: f.a})]);
       expect(f.a().valid()).toBe(false);
       expect(f().errors()).toEqual([]);
       expect(f().valid()).toBe(false);
@@ -960,8 +960,8 @@ describe('FieldNode', () => {
 
       f.a().value.set(11);
       expect(f.a().errors()).toEqual([
-        customError({kind: 'too-damn-high', field: f.a}),
-        customError({kind: 'bad', field: f.a}),
+        customError({kind: 'too-damn-high', fieldTree: f.a}),
+        customError({kind: 'bad', fieldTree: f.a}),
       ]);
       expect(f.a().valid()).toBe(false);
     });
@@ -976,7 +976,7 @@ describe('FieldNode', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f.first().errors()).toEqual([requiredError({field: f.first})]);
+      expect(f.first().errors()).toEqual([requiredError({fieldTree: f.first})]);
       expect(f.first().valid()).toBe(false);
       expect(f.first().required()).toBe(true);
 
@@ -1004,7 +1004,7 @@ describe('FieldNode', () => {
 
       f.last().value.set('Loblaw');
 
-      expect(f.first().errors()).toEqual([requiredError({field: f.first})]);
+      expect(f.first().errors()).toEqual([requiredError({fieldTree: f.first})]);
       expect(f.first().valid()).toBe(false);
       expect(f.first().required()).toBe(true);
 
@@ -1040,7 +1040,7 @@ describe('FieldNode', () => {
       expect(f.name().errors()).toEqual([
         requiredError({
           message: 'Name is required in your country',
-          field: f.name,
+          fieldTree: f.name,
         }),
       ]);
 
@@ -1048,11 +1048,11 @@ describe('FieldNode', () => {
       expect(f.name().errors()).toEqual([
         requiredError({
           message: 'Name is required in your country',
-          field: f.name,
+          fieldTree: f.name,
         }),
         requiredError({
           message: 'Name is required for large transactions',
-          field: f.name,
+          fieldTree: f.name,
         }),
       ]);
 
@@ -1060,7 +1060,7 @@ describe('FieldNode', () => {
       expect(f.name().errors()).toEqual([
         requiredError({
           message: 'Name is required for large transactions',
-          field: f.name,
+          fieldTree: f.name,
         }),
       ]);
 
@@ -1081,7 +1081,7 @@ describe('FieldNode', () => {
       expect(f.a().valid()).toBe(true);
 
       f.a().value.set(2);
-      expect(f.a().errors()).toEqual([customError({field: f.a})]);
+      expect(f.a().errors()).toEqual([customError({fieldTree: f.a})]);
       expect(f.a().valid()).toBe(false);
     });
 
@@ -1094,10 +1094,10 @@ describe('FieldNode', () => {
             validateTree(p, ({value, fieldTreeOf}) => {
               const errors: ValidationError[] = [];
               if (value().name.length > 8) {
-                errors.push(customError({kind: 'long_name', field: fieldTreeOf(p.name)}));
+                errors.push(customError({kind: 'long_name', fieldTree: fieldTreeOf(p.name)}));
               }
               if (value().age < 0) {
-                errors.push(customError({kind: 'temporal_anomaly', field: fieldTreeOf(p.age)}));
+                errors.push(customError({kind: 'temporal_anomaly', fieldTree: fieldTreeOf(p.age)}));
               }
               return errors;
             });
@@ -1111,10 +1111,12 @@ describe('FieldNode', () => {
         f.age().value.set(-10);
 
         expect(f.name().errors()).toEqual([]);
-        expect(f.age().errors()).toEqual([customError({kind: 'temporal_anomaly', field: f.age})]);
+        expect(f.age().errors()).toEqual([
+          customError({kind: 'temporal_anomaly', fieldTree: f.age}),
+        ]);
 
         cat.set({name: 'Fluffy McFluffington', age: 10});
-        expect(f.name().errors()).toEqual([customError({kind: 'long_name', field: f.name})]);
+        expect(f.name().errors()).toEqual([customError({kind: 'long_name', fieldTree: f.name})]);
         expect(f.age().errors()).toEqual([]);
       });
 
@@ -1126,10 +1128,10 @@ describe('FieldNode', () => {
             validateTree(p, ({value, fieldTreeOf}) => {
               const errors: ValidationError[] = [];
               if (value().name.length > 8) {
-                errors.push(customError({kind: 'long_name', field: fieldTreeOf(p.name)}));
+                errors.push(customError({kind: 'long_name', fieldTree: fieldTreeOf(p.name)}));
               }
               if (value().age < 0) {
-                errors.push(customError({kind: 'temporal_anomaly', field: fieldTreeOf(p.age)}));
+                errors.push(customError({kind: 'temporal_anomaly', fieldTree: fieldTreeOf(p.age)}));
               }
               return errors;
             });
@@ -1143,10 +1145,12 @@ describe('FieldNode', () => {
         f.age().value.set(-10);
 
         expect(f.name().errors()).toEqual([]);
-        expect(f.age().errors()).toEqual([customError({kind: 'temporal_anomaly', field: f.age})]);
+        expect(f.age().errors()).toEqual([
+          customError({kind: 'temporal_anomaly', fieldTree: f.age}),
+        ]);
 
         cat.set({name: 'Fluffy McFluffington', age: 10});
-        expect(f.name().errors()).toEqual([customError({kind: 'long_name', field: f.name})]);
+        expect(f.name().errors()).toEqual([customError({kind: 'long_name', fieldTree: f.name})]);
         expect(f.age().errors()).toEqual([]);
       });
     });
@@ -1170,7 +1174,7 @@ describe('FieldNode', () => {
         {injector: TestBed.inject(Injector)},
       );
 
-      expect(f().errorSummary()).toEqual([requiredError({field: f})]);
+      expect(f().errorSummary()).toEqual([requiredError({fieldTree: f})]);
     });
 
     it('should contain errors from child fields', () => {
@@ -1185,8 +1189,8 @@ describe('FieldNode', () => {
       );
 
       expect(f().errorSummary()).toEqual([
-        requiredError({field: f.first}),
-        requiredError({field: f.last}),
+        requiredError({fieldTree: f.first}),
+        requiredError({fieldTree: f.last}),
       ]);
     });
 
@@ -1207,16 +1211,16 @@ describe('FieldNode', () => {
       );
 
       expect(f.child.child().errorSummary()).toEqual([
-        customError({kind: 'grandchild', field: f.child.child}),
+        customError({kind: 'grandchild', fieldTree: f.child.child}),
       ]);
       expect(f.child().errorSummary()).toEqual([
-        customError({kind: 'child', field: f.child}),
-        customError({kind: 'grandchild', field: f.child.child}),
+        customError({kind: 'child', fieldTree: f.child}),
+        customError({kind: 'grandchild', fieldTree: f.child.child}),
       ]);
       expect(f().errorSummary()).toEqual([
-        customError({kind: 'root', field: f}),
-        customError({kind: 'child', field: f.child}),
-        customError({kind: 'grandchild', field: f.child.child}),
+        customError({kind: 'root', fieldTree: f}),
+        customError({kind: 'child', fieldTree: f.child}),
+        customError({kind: 'grandchild', fieldTree: f.child.child}),
       ]);
     });
   });

--- a/packages/forms/signals/test/node/logic_node.spec.ts
+++ b/packages/forms/signals/test/node/logic_node.spec.ts
@@ -19,7 +19,7 @@ const fakeFieldContext: FieldContext<unknown> = {
       structure: {pathKeys: () => [], parent: undefined},
     }) as any,
   valueOf: () => undefined!,
-  field: undefined!,
+  fieldTree: undefined!,
   state: undefined!,
   value: undefined!,
   pathKeys: computed(() => []),

--- a/packages/forms/signals/test/node/recursive_logic.spec.ts
+++ b/packages/forms/signals/test/node/recursive_logic.spec.ts
@@ -19,11 +19,12 @@ interface TreeData {
 }
 
 function narrowed<TModel, TNarrowed extends TModel>(
-  field: FieldTree<TModel> | undefined,
+  fieldTree: FieldTree<TModel> | undefined,
   guard: (value: TModel) => value is TNarrowed,
 ): Signal<FieldTree<TNarrowed> | undefined> {
   return computed(
-    () => field && (guard(field().value()) ? (field as FieldTree<TNarrowed>) : undefined),
+    () =>
+      fieldTree && (guard(fieldTree().value()) ? (fieldTree as FieldTree<TNarrowed>) : undefined),
   );
 }
 

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -84,7 +84,7 @@ describe('resources', () => {
     expect(f.name().errors()).toEqual([
       customError({
         message: 'got: cat',
-        field: f.name,
+        fieldTree: f.name,
       }),
     ]);
 
@@ -93,7 +93,7 @@ describe('resources', () => {
     expect(f.name().errors()).toEqual([
       customError({
         message: 'got: dog',
-        field: f.name,
+        fieldTree: f.name,
       }),
     ]);
   });
@@ -128,13 +128,13 @@ describe('resources', () => {
     expect(f[0].name().errors()).toEqual([
       customError({
         message: 'got: cat',
-        field: f[0].name,
+        fieldTree: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
       customError({
         message: 'got: dog',
-        field: f[1].name,
+        fieldTree: f[1].name,
       }),
     ]);
 
@@ -143,13 +143,13 @@ describe('resources', () => {
     expect(f[0].name().errors()).toEqual([
       customError({
         message: 'got: bunny',
-        field: f[0].name,
+        fieldTree: f[0].name,
       }),
     ]);
     expect(f[1].name().errors()).toEqual([
       customError({
         message: 'got: dog',
-        field: f[1].name,
+        fieldTree: f[1].name,
       }),
     ]);
   });
@@ -170,7 +170,7 @@ describe('resources', () => {
             customError({
               kind: 'meows_too_much',
               name: cat.name,
-              field: fieldTreeOf(p)[index],
+              fieldTree: fieldTreeOf(p)[index],
             }),
           );
         },
@@ -183,10 +183,10 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      customError({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
+      customError({kind: 'meows_too_much', name: 'Fluffy', fieldTree: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([
-      customError({kind: 'meows_too_much', name: 'Ziggy', field: f[1]}),
+      customError({kind: 'meows_too_much', name: 'Ziggy', fieldTree: f[1]}),
     ]);
   });
 
@@ -205,7 +205,7 @@ describe('resources', () => {
           return customError({
             kind: 'meows_too_much',
             name: cats[0].name,
-            field: fieldTreeOf(p)[0],
+            fieldTree: fieldTreeOf(p)[0],
           });
         },
         onError: () => null,
@@ -217,7 +217,7 @@ describe('resources', () => {
 
     await appRef.whenStable();
     expect(f[0]().errors()).toEqual([
-      customError({kind: 'meows_too_much', name: 'Fluffy', field: f[0]}),
+      customError({kind: 'meows_too_much', name: 'Fluffy', fieldTree: f[0]}),
     ]);
     expect(f[1]().errors()).toEqual([]);
   });
@@ -274,7 +274,7 @@ describe('resources', () => {
       validateHttp(address, {
         request: ({value}) => ({url: '/checkaddress', params: {...value()}}),
         onSuccess: (message: string, {fieldTreeOf}) =>
-          customError({message, field: fieldTreeOf(address.street)}),
+          customError({message, fieldTree: fieldTreeOf(address.street)}),
         onError: () => null,
       });
     });
@@ -291,7 +291,7 @@ describe('resources', () => {
     await appRef.whenStable();
 
     expect(addressForm.street().errors()).toEqual([
-      customError({message: 'Invalid!', field: addressForm.street}),
+      customError({message: 'Invalid!', fieldTree: addressForm.street}),
     ]);
   });
 
@@ -303,7 +303,7 @@ describe('resources', () => {
         request: ({value}) => ({url: '/checkaddress', params: {...value()}}),
         onSuccess: () => undefined,
         onError: () => [
-          customError({kind: 'address-api-failed', message: 'API is down', field: addressForm}),
+          customError({kind: 'address-api-failed', message: 'API is down', fieldTree: addressForm}),
         ],
       });
     });
@@ -322,7 +322,7 @@ describe('resources', () => {
       customError({
         kind: 'address-api-failed',
         message: 'API is down',
-        field: addressForm,
+        fieldTree: addressForm,
       }),
     ]);
   });

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -33,7 +33,7 @@ describe('submit', () => {
       fail('Submit action should run not on invalid form');
     });
 
-    expect(f.first().errors()).toEqual([requiredError({field: f.first})]);
+    expect(f.first().errors()).toEqual([requiredError({fieldTree: f.first})]);
   });
 
   it('should not block on pending async validators', async () => {
@@ -80,12 +80,12 @@ describe('submit', () => {
       return Promise.resolve(
         customError({
           kind: 'lastName',
-          field: form.last,
+          fieldTree: form.last,
         }),
       );
     });
 
-    expect(f.last().errors()).toEqual([customError({kind: 'lastName', field: f.last})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'lastName', fieldTree: f.last})]);
   });
 
   it('maps errors to multiple fields', async () => {
@@ -96,23 +96,23 @@ describe('submit', () => {
       return Promise.resolve([
         customError({
           kind: 'firstName',
-          field: form.first,
+          fieldTree: form.first,
         }),
         customError({
           kind: 'lastName',
-          field: form.last,
+          fieldTree: form.last,
         }),
         customError({
           kind: 'lastName2',
-          field: form.last,
+          fieldTree: form.last,
         }),
       ]);
     });
 
-    expect(f.first().errors()).toEqual([customError({kind: 'firstName', field: f.first})]);
+    expect(f.first().errors()).toEqual([customError({kind: 'firstName', fieldTree: f.first})]);
     expect(f.last().errors()).toEqual([
-      customError({kind: 'lastName', field: f.last}),
-      customError({kind: 'lastName2', field: f.last}),
+      customError({kind: 'lastName', fieldTree: f.last}),
+      customError({kind: 'lastName2', fieldTree: f.last}),
     ]);
   });
 
@@ -153,7 +153,7 @@ describe('submit', () => {
       return Promise.resolve(customError());
     });
 
-    expect(f().errors()).toEqual([customError({field: f})]);
+    expect(f().errors()).toEqual([customError({fieldTree: f})]);
   });
 
   it('marks the form as submitting', async () => {
@@ -259,18 +259,18 @@ describe('submit', () => {
 
     await submit(f, async (form) => {
       return [
-        customError({kind: 'submit', field: f.first}),
-        customError({kind: 'submit', field: f.last}),
+        customError({kind: 'submit', fieldTree: f.first}),
+        customError({kind: 'submit', fieldTree: f.last}),
       ];
     });
 
-    expect(f.first().errors()).toEqual([customError({kind: 'submit', field: f.first})]);
-    expect(f.last().errors()).toEqual([customError({kind: 'submit', field: f.last})]);
+    expect(f.first().errors()).toEqual([customError({kind: 'submit', fieldTree: f.first})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'submit', fieldTree: f.last})]);
 
     f.first().value.set('Hello');
 
     expect(f.first().errors()).toEqual([]);
-    expect(f.last().errors()).toEqual([customError({kind: 'submit', field: f.last})]);
+    expect(f.last().errors()).toEqual([customError({kind: 'submit', fieldTree: f.last})]);
   });
 });
 

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -27,9 +27,9 @@ function validateValue(value: string): ValidationError[] {
 
 function validateValueForChild(
   value: string,
-  field: FieldTree<unknown> | undefined,
+  fieldTree: FieldTree<unknown> | undefined,
 ): ValidationError.WithField[] {
-  return value === 'INVALID' ? [customError({field})] : [];
+  return value === 'INVALID' ? [customError({fieldTree})] : [];
 }
 
 describe('validation status', () => {
@@ -236,7 +236,7 @@ describe('validation status', () => {
             onSuccess: (results, {fieldTreeOf}) =>
               results.map((e) => ({
                 ...e,
-                field: fieldTreeOf(p.child),
+                fieldTree: fieldTreeOf(p.child),
               })),
             onError: () => null,
           });

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -51,7 +51,7 @@ import {
 
 @Component({
   selector: 'string-control',
-  template: `<input [field]="field()"/>`,
+  template: `<input [field]="field()" />`,
   imports: [Field],
 })
 class TestStringControl {
@@ -64,7 +64,7 @@ describe('field directive', () => {
     it('should bind new field to control when changed', () => {
       @Component({
         imports: [Field],
-        template: `<input [field]="field()">`,
+        template: `<input [field]="field()" />`,
       })
       class TestCmp {
         readonly model = signal({x: 'a', y: 'b'});
@@ -84,7 +84,7 @@ describe('field directive', () => {
     it('should update new field when change value changes', () => {
       @Component({
         imports: [Field],
-        template: `<input [field]="field()">`,
+        template: `<input [field]="field()" />`,
       })
       class TestCmp {
         readonly model = signal({x: 'a', y: 'b'});
@@ -112,7 +112,7 @@ describe('field directive', () => {
       it('should bind to native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="f">`,
+          template: `<input [field]="f" />`,
         })
         class TestCmp {
           readonly disabled = signal(false);
@@ -186,7 +186,7 @@ describe('field directive', () => {
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="field()">`,
+          template: `<input [field]="field()" />`,
         })
         class TestCmp {
           readonly f = form(signal({x: 'a', y: 'b'}), (p) => {
@@ -238,8 +238,8 @@ describe('field directive', () => {
           imports: [Field],
           template: `
             @for (item of f; track item) {
-              <input #control [field]="item">
-              <span>{{item().value()}}</span>
+              <input #control [field]="item" />
+              <span>{{ item().value() }}</span>
             }
           `,
         })
@@ -257,7 +257,7 @@ describe('field directive', () => {
       });
 
       it('should bind to custom control', () => {
-        @Component({selector: 'custom-control', template: `{{value()}}`})
+        @Component({selector: 'custom-control', template: `{{ value() }}`})
         class CustomControl implements FormValueControl<string> {
           readonly value = model('');
           readonly name = input('');
@@ -314,7 +314,7 @@ describe('field directive', () => {
       it('should bind to native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="f">`,
+          template: `<input [field]="f" />`,
         })
         class TestCmp {
           readonly readonly = signal(true);
@@ -387,7 +387,7 @@ describe('field directive', () => {
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="field()">`,
+          template: `<input [field]="field()" />`,
         })
         class TestCmp {
           readonly f = form(signal({x: 'a', y: 'b'}), (p) => {
@@ -437,7 +437,7 @@ describe('field directive', () => {
       it('should bind to native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="f">`,
+          template: `<input [field]="f" />`,
         })
         class TestCmp {
           readonly required = signal(false);
@@ -510,7 +510,7 @@ describe('field directive', () => {
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
-          template: `<input [field]="field()">`,
+          template: `<input [field]="field()" />`,
         })
         class TestCmp {
           readonly f = form(signal({x: 'a', y: 'b'}), (p) => {
@@ -560,7 +560,7 @@ describe('field directive', () => {
       it('should bind to native control', () => {
         @Component({
           imports: [Field],
-          template: `<input type="number" [field]="f">`,
+          template: `<input type="number" [field]="f" />`,
         })
         class TestCmp {
           readonly max = signal(10);
@@ -633,7 +633,7 @@ describe('field directive', () => {
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
-          template: `<input type="number" [field]="field()">`,
+          template: `<input type="number" [field]="field()" />`,
         })
         class TestCmp {
           readonly f = form(signal({x: 1, y: 2}), (p) => {
@@ -683,7 +683,7 @@ describe('field directive', () => {
       it('should bind to native control', () => {
         @Component({
           imports: [Field],
-          template: `<input type="number" [field]="f">`,
+          template: `<input type="number" [field]="f" />`,
         })
         class TestCmp {
           readonly min = signal(10);
@@ -756,7 +756,7 @@ describe('field directive', () => {
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
-          template: `<input type="number" [field]="field()">`,
+          template: `<input type="number" [field]="field()" />`,
         })
         class TestCmp {
           readonly f = form(signal({x: 1, y: 2}), (p) => {
@@ -1277,9 +1277,7 @@ describe('field directive', () => {
   it('synchronizes with a value control', () => {
     @Component({
       imports: [Field],
-      template: `
-        <input [field]="f">
-      `,
+      template: ` <input [field]="f" /> `,
     })
     class TestCmp {
       f = form(signal('test'));
@@ -1307,7 +1305,7 @@ describe('field directive', () => {
   it('synchronizes with a checkbox control', () => {
     @Component({
       imports: [Field],
-      template: `<input type="checkbox" [field]="f">`,
+      template: `<input type="checkbox" [field]="f" />`,
     })
     class TestCmp {
       f = form(signal(false));
@@ -1583,8 +1581,8 @@ describe('field directive', () => {
       template: `
         @if (!f().hidden()) {
           <select #select [field]="f">
-            @for(opt of options; track opt) {
-              <option [value]="opt">{{opt}}</option>
+            @for (opt of options; track opt) {
+              <option [value]="opt">{{ opt }}</option>
             }
           </select>
         }
@@ -1614,8 +1612,8 @@ describe('field directive', () => {
       template: `
         @if (!f().hidden()) {
           <select #select [field]="f">
-            @for(opt of options; track opt) {
-              <option>{{opt}}</option>
+            @for (opt of options; track opt) {
+              <option>{{ opt }}</option>
             }
           </select>
         }
@@ -1644,8 +1642,8 @@ describe('field directive', () => {
       imports: [Field],
       template: `
         <select #select [field]="f">
-          @for(opt of options(); track opt) {
-            <option>{{opt}}</option>
+          @for (opt of options(); track opt) {
+            <option>{{ opt }}</option>
           }
         </select>
       `,
@@ -1838,9 +1836,7 @@ describe('field directive', () => {
     }
 
     @Component({
-      template: `
-        <my-input [field]="f" />
-      `,
+      template: ` <my-input [field]="f" /> `,
       imports: [CustomInput, Field],
     })
     class ReadonlyTestCmp {
@@ -1869,9 +1865,7 @@ describe('field directive', () => {
     }
 
     @Component({
-      template: `
-        <my-input [field]="f" />
-      `,
+      template: ` <my-input [field]="f" /> `,
       imports: [CustomInput, Field],
     })
     class ReadonlyTestCmp {
@@ -1899,9 +1893,7 @@ describe('field directive', () => {
     }
 
     @Component({
-      template: `
-        <my-input [field]="f" />
-      `,
+      template: ` <my-input [field]="f" /> `,
       imports: [CustomInput, Field],
     })
     class HiddenTestCmp {
@@ -1929,9 +1921,7 @@ describe('field directive', () => {
     }
 
     @Component({
-      template: `
-        <my-input [field]="f" />
-      `,
+      template: ` <my-input [field]="f" /> `,
       imports: [CustomInput, Field],
     })
     class DirtyTestCmp {
@@ -1959,9 +1949,7 @@ describe('field directive', () => {
     }
 
     @Component({
-      template: `
-        <my-input [field]="f" />
-      `,
+      template: ` <my-input [field]="f" /> `,
       imports: [CustomInput, Field],
     })
     class PendingTestCmp {
@@ -1994,7 +1982,7 @@ describe('field directive', () => {
   it(`should mark field as touched on native control 'blur' event`, () => {
     @Component({
       imports: [Field],
-      template: `<input [field]="f">`,
+      template: `<input [field]="f" />`,
     })
     class TestCmp {
       f = form(signal(''));
@@ -2060,10 +2048,10 @@ describe('field directive', () => {
       template: `
         <input #i [value]="value()" (input)="value.set(i.value)" />
         @for (reason of disabledReasons(); track $index) {
-          <p class="disabled-reason">{{reason.message}}</p>
+          <p class="disabled-reason">{{ reason.message }}</p>
         }
         @for (error of errors(); track $index) {
-          <p class="error">{{error.message}}</p>
+          <p class="error">{{ error.message }}</p>
         }
       `,
     })
@@ -2109,7 +2097,7 @@ describe('field directive', () => {
 
     @Component({
       imports: [Field, InputDirective],
-      template: `<input [field]="f">`,
+      template: `<input [field]="f" />`,
     })
     class TestCmp {
       f = form(signal('test'));
@@ -2138,7 +2126,7 @@ describe('field directive', () => {
     it('should sync string field with number type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="number" [field]="f">`,
+        template: `<input type="number" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal('123'));
@@ -2166,7 +2154,7 @@ describe('field directive', () => {
     it('should sync number field with number type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="number" [field]="f">`,
+        template: `<input type="number" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal(123));
@@ -2194,7 +2182,7 @@ describe('field directive', () => {
     it('should sync string field with date type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="date" [field]="f">`,
+        template: `<input type="date" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal('2024-01-01'));
@@ -2222,7 +2210,7 @@ describe('field directive', () => {
     it('should sync date field with date type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="date" [field]="f">`,
+        template: `<input type="date" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal(new Date('2024-01-01T12:00:00Z')));
@@ -2250,7 +2238,7 @@ describe('field directive', () => {
     it('should sync number field with date type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="date" [field]="f">`,
+        template: `<input type="date" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal(new Date('2024-01-01T12:00:00Z').valueOf()));
@@ -2278,7 +2266,7 @@ describe('field directive', () => {
     it('should sync number field with datetime-local type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="datetime-local" [field]="f">`,
+        template: `<input type="datetime-local" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal(new Date('2024-01-01T12:30:00Z').valueOf()));
@@ -2308,7 +2296,7 @@ describe('field directive', () => {
     it('should sync string field with color type input', () => {
       @Component({
         imports: [Field],
-        template: `<input type="color" [field]="f">`,
+        template: `<input type="color" [field]="f" />`,
       })
       class TestCmp {
         f = form(signal('#ff0000'));
@@ -2336,7 +2324,7 @@ describe('field directive', () => {
     it('should sync string field with dynamically typed input', () => {
       @Component({
         imports: [Field],
-        template: `<input [type]="type()" [field]="f">`,
+        template: `<input [type]="type()" [field]="f" />`,
       })
       class TestCmp {
         readonly passwordVisible = signal(false);
@@ -2383,7 +2371,7 @@ describe('field directive', () => {
     it('native control', () => {
       @Component({
         imports: [Field],
-        template: `<input [field]="f">`,
+        template: `<input [field]="f" />`,
       })
       class TestCmp {
         f = form(signal(''));
@@ -2454,10 +2442,10 @@ describe('field directive', () => {
       @Component({
         imports: [Field],
         template: `
-            @for (item of f; track item) {
-              <input #control [field]="item">
-            }
-          `,
+          @for (item of f; track item) {
+            <input #control [field]="item" />
+          }
+        `,
       })
       class TestCmp {
         readonly f = form(signal(['a', 'b']), {name: 'root'});
@@ -2499,10 +2487,10 @@ describe('field directive', () => {
       @Component({
         imports: [Field],
         template: `
-            @for (item of f; track item) {
-              <input #control [field]="item.x">
-            }
-          `,
+          @for (item of f; track item) {
+            <input #control [field]="item.x" />
+          }
+        `,
       })
       class TestCmp {
         readonly f = form(signal([{x: 'a'}, {x: 'b'}]), {name: 'root'});
@@ -2544,10 +2532,10 @@ describe('field directive', () => {
       @Component({
         imports: [Field],
         template: `
-            @for (item of f; track item) {
-              <input #control [field]="item[0]">
-            }
-          `,
+          @for (item of f; track item) {
+            <input #control [field]="item[0]" />
+          }
+        `,
       })
       class TestCmp {
         readonly f = form(signal([['a'], ['b']]), {name: 'root'});
@@ -2661,7 +2649,7 @@ describe('field directive', () => {
 
       @Component({
         imports: [Field],
-        template: `<input [field]="f">`,
+        template: `<input [field]="f" />`,
       })
       class TestCmp {
         readonly f = form(signal(''), (p) => {
@@ -2688,7 +2676,7 @@ describe('field directive', () => {
 
       @Component({
         imports: [Field],
-        template: `<input [field]="f">`,
+        template: `<input [field]="f" />`,
       })
       class TestCmp {
         readonly f = form(signal(''), (p) => {
@@ -2785,7 +2773,7 @@ describe('field directive', () => {
       @Component({
         imports: [Field],
         template: `
-          <input [field]="f">
+          <input [field]="f" />
           <textarea [field]="f"></textarea>
         `,
       })
@@ -2814,7 +2802,7 @@ describe('field directive', () => {
             <option value="ca">Canada</option>
           </select>
         </form>
-  `,
+      `,
     })
     class FormComponent {
       form = form(signal('us'));
@@ -2848,9 +2836,9 @@ function setupRadioGroup() {
     imports: [Field],
     template: `
       <form>
-        <input type="radio" value="a" [field]="f">
-        <input type="radio" value="b" [field]="f">
-        <input type="radio" value="c" [field]="f">
+        <input type="radio" value="a" [field]="f" />
+        <input type="radio" value="b" [field]="f" />
+        <input type="radio" value="c" [field]="f" />
       </form>
     `,
   })

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -1854,7 +1854,7 @@ describe('field directive', () => {
     const comp = act(() => TestBed.createComponent(ReadonlyTestCmp)).componentInstance;
 
     expect(comp.myInput().disabledReasons()).toEqual([
-      {message: 'Currently unavailable', field: comp.f},
+      {message: 'Currently unavailable', fieldTree: comp.f},
     ]);
   });
 


### PR DESCRIPTION
BREAKING CHANGE:

The `.field` property on `FieldContext` & `ValidationError` is now `.fieldTree`