### PR TITLE
refactor(devtools): slightly optimize extension initialization messaging

### DIFF
--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -447,6 +447,7 @@ export interface Events {
   enableFrameConnection: (frameId: number, tabId: number) => void;
   frameConnected: (frameId: number) => void;
   detectAngular: (detectionResult: AngularDetection) => void;
+  backendInstalled: () => void;
   backendReady: () => void;
 
   log: (logEvent: {message: string; level: 'log' | 'warn' | 'debug' | 'error'}) => void;

--- a/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
+++ b/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
@@ -22,6 +22,8 @@ const detectAngularMessageBus = new SamePageMessageBus(
   CONTENT_SCRIPT_URI,
 );
 
+let detectAngularTimeout: ReturnType<typeof setTimeout>;
+
 function detectAngular(win: Window): void {
   const isAngular = appIsAngular();
   const isSupportedAngularVersion = appIsSupportedAngularVersion();
@@ -50,7 +52,11 @@ function detectAngular(win: Window): void {
     },
   ]);
 
-  setTimeout(() => detectAngular(win), 1000);
+  detectAngularTimeout = setTimeout(() => detectAngular(win), 1000);
 }
+
+detectAngularMessageBus.on('backendInstalled', () => {
+  clearTimeout(detectAngularTimeout);
+});
 
 detectAngular(window);


### PR DESCRIPTION
- Stop infinite `detectAngular` messages after the backend is installed. Currently, they continue to be emitted even after the process has completed. @AleksanderBodurri, tagging you in case there is a reason to keep things as before.
- Do not attempt handshake with the BE (from content scripts) until it's installed. Prior to that moment, the attempt will fail.
