### PR TITLE
fix(forms): fix signal forms type error

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -17,7 +17,6 @@ import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
-import { ɵControl } from '@angular/core';
 import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
 import { ɵɵcontrolCreate } from '@angular/core';

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -27,7 +27,6 @@ import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';
 import { WritableSignal } from '@angular/core';
 import { ɵCONTROL } from '@angular/core';
-import { ɵControl } from '@angular/core';
 import { ɵcontrolUpdate } from '@angular/core';
 import { ɵFieldState } from '@angular/core';
 import { ɵɵcontrolCreate } from '@angular/core';
@@ -139,7 +138,7 @@ export class EmailValidationError extends _NgValidationError {
 export const FIELD: InjectionToken<Field<unknown>>;
 
 // @public
-export class Field<T> implements ɵControl<T> {
+export class Field<T> {
     // (undocumented)
     readonly [ɵCONTROL]: {
         readonly create: typeof ɵɵcontrolCreate;

--- a/packages/forms/signals/src/api/field_directive.ts
+++ b/packages/forms/signals/src/api/field_directive.ts
@@ -18,8 +18,8 @@ import {
   input,
   ɵcontrolUpdate as updateControlBinding,
   ɵCONTROL,
-  ɵControl,
   ɵInteropControl,
+  type ɵControl,
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
 import {InteropNgControl} from '../controls/interop_ng_control';
@@ -71,7 +71,10 @@ const controlInstructions = {
     {provide: NgControl, useFactory: () => inject(Field).getOrCreateNgControl()},
   ],
 })
-export class Field<T> implements ɵControl<T> {
+// This directive should `implements ɵControl<T>`, but actually adding that breaks people's
+// builds because part of the public API is marked `@internal` and stripped.
+// Instead we have an type check below that enforces this in a non-breaking way.
+export class Field<T> {
   readonly element = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;
   readonly injector = inject(Injector);
   readonly field = input.required<FieldTree<T>>();
@@ -127,3 +130,8 @@ export class Field<T> implements ɵControl<T> {
     );
   }
 }
+
+// We can't add `implements ɵControl<T>` to `Field` even though it should conform to the interface.
+// Instead we enforce it here through some utility types.
+type Check<T extends true> = T;
+type FieldImplementsɵControl = Check<Field<any> extends ɵControl<any> ? true : false>;


### PR DESCRIPTION
Loosens the `implements` clause on the `Field` directive since it is causing type errors for people.
