### PR TITLE
refactor(forms): add signal forms to the type tests

### DIFF
--- a/integration/typings_test_ts59/include-all.ts
+++ b/integration/typings_test_ts59/include-all.ts
@@ -18,6 +18,7 @@ import * as core from '@angular/core';
 import * as coreTesting from '@angular/core/testing';
 import * as elements from '@angular/elements';
 import * as forms from '@angular/forms';
+import * as formsSignals from '@angular/forms/signals';
 import * as localize from '@angular/localize';
 import * as platformBrowser from '@angular/platform-browser';
 import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
@@ -48,6 +49,7 @@ export default {
   coreTesting,
   elements,
   forms,
+  formsSignals,
   localize,
   platformBrowser,
   platformBrowserTesting,

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -8,13 +8,13 @@
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "dependencies": {
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "@standard-schema/spec": "^1.0.0"
   },
   "peerDependencies": {
     "@angular/core": "0.0.0-PLACEHOLDER",
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "@standard-schema/spec": "^1.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,6 +1092,9 @@ importers:
       '@angular/platform-browser':
         specifier: 'workspace: *'
         version: link:../platform-browser
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       rxjs:
         specifier: ^6.5.3 || ^7.4.0
         version: 7.8.2


### PR DESCRIPTION
On top of #66012. 

This will ensure that signal forms emit valid typings.
