### PR TITLE
fix(forms): support custom controls with non signal-based models

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -440,10 +440,9 @@ function extractFieldValue(expression: AST, tcb: Context, scope: Scope): ts.Expr
   );
 }
 
-/** Checks whether a directive has a model input with a specific name. */
+/** Checks whether a directive has a model-like input with a specific name. */
 function hasModelInput(name: string, meta: TypeCheckableDirectiveMeta): boolean {
   return (
-    !!meta.inputs.getByBindingPropertyName(name)?.some((v) => v.isSignal) &&
-    meta.outputs.hasBindingPropertyName(name + 'Change')
+    meta.inputs.hasBindingPropertyName(name) && meta.outputs.hasBindingPropertyName(name + 'Change')
   );
 }

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -12,7 +12,6 @@ import {assertFirstCreatePass} from '../assert';
 import {bindingUpdated} from '../bindings';
 import {ɵCONTROL, ɵControl, ɵFieldState} from '../interfaces/control';
 import {DirectiveDef} from '../interfaces/definition';
-import {InputFlags} from '../interfaces/input_flags';
 import {TElementNode, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {Renderer} from '../interfaces/renderer';
 import {SanitizerFn} from '../interfaces/sanitization';
@@ -296,15 +295,19 @@ function getControlDirective<T>(tNode: TNode, lView: LView): ɵControl<T> | null
   return index === -1 ? null : lView[index];
 }
 
-/** Returns whether the specified `directiveDef` has a model input named `name`. */
+/**
+ * Returns whether the specified `directiveDef` has a model-like input named `name`.
+ *
+ * A model-like input is an input-output pair where the input is named `name` and the output is
+ * named `name + 'Change'`.
+ */
 function hasModelInput(directiveDef: DirectiveDef<unknown>, name: string): boolean {
-  return hasSignalInput(directiveDef, name) && hasOutput(directiveDef, name + 'Change');
+  return hasInput(directiveDef, name) && hasOutput(directiveDef, name + 'Change');
 }
 
-/** Returns whether the specified `directiveDef` has a signal-based input named `name`.*/
-function hasSignalInput(directiveDef: DirectiveDef<unknown>, name: string): boolean {
-  const input = directiveDef.inputs[name];
-  return input && (input[1] & InputFlags.SignalBased) !== 0;
+/** Returns whether the specified `directiveDef` has an input named `name`.*/
+function hasInput(directiveDef: DirectiveDef<unknown>, name: string): boolean {
+  return name in directiveDef.inputs;
 }
 
 /** Returns whether the specified `directiveDef` has an output named `name`. */


### PR DESCRIPTION
* Recognize directives with non signal-based models as valid custom controls
* Relax type checker to allow non signal-based models

The `FormValueControl` and `FormCheckboxControl` interfaces still
require a `model()`-input, however, a custom control need not implement
either interface to be bound by the `Field` directive.

All of the following examples can be used to define a custom control:

```ts
// Preferred: model()
class MyFormControl implements FormValueControl<string> {
  readonly value: model.required<string>();
}

// Supported: input() + output()
class MyFormControl {
  readonly value: input.required<string>();
  readonly valueChange: output<string>();
}

// Supported: @Input() + @Output()
class MyFormControl {
  @Input({required: true}) value!: string;
  @Output() valueChange: new EventEmitter<string>();
}
```

The latter two may still choose to implement `FormUiControl` for other
properties, but again it is not required.