### PR TITLE
docs: add Vitest-compatible async example and note for DoneFn (fixes …docs: clarify Vitest async usage and replace Jasmine DoneFn example in services testing guide

### DIFF
--- a/adev/src/content/guide/testing/services.md
+++ b/adev/src/content/guide/testing/services.md
@@ -2,6 +2,27 @@
 
 NOTE: While this guide is being updated for Vitest, some code examples currently use Karma/Jasmine syntax and APIs. We are actively working to provide Vitest equivalents where applicable.
 
+> **Vitest note:** Some examples on this page use Jasmine/Karma test APIs such as the `DoneFn` callback. Vitest does **not** expose a `DoneFn` type.  
+> If you're running tests with **Vitest**, prefer using **async/await** or **returning a Promise** in your test function.  
+> Example (Vitest-compatible):
+>
+> ```ts
+> // Vitest-friendly async/await example
+> it('should do something async (Vitest)', async () => {
+>   const service = setupService(); // example setup
+>   await service.doAsync();
+>   expect(service.value).toBe(true);
+> });
+>
+> // Alternative: returning a Promise
+> it('should do something async (Vitest)', () => {
+>   const service = setupService(); // example setup
+>   return service.doAsync().then(() => {
+>     expect(service.value).toBe(true);
+>   });
+> });
+> ```
+
 To check that your services are working as you intend, you can write tests specifically for them.
 
 Services are often the smoothest files to unit test.


### PR DESCRIPTION
…#65987)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The Testing Services documentation uses Jasmine/Karma’s DoneFn callback in examples.
Vitest does not support DoneFn, which causes confusion for developers reading the docs.

Issue Number: #65987 


## What is the new behavior?
This PR updates the documentation by:

Adding a clear Vitest note explaining that DoneFn does not exist in Vitest

Recommending async/await or returning a Promise

Providing two Vitest-friendly examples

Linking to the Vitest migration guide

This improves accuracy and helps developers using Vitest.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
