### PR TITLE
docs(docs-infra): Not handling with reloading from resource.status()

### DIFF
--- a/adev/src/content/tutorials/signals/steps/4-managing-async-data-with-signals/README.md
+++ b/adev/src/content/tutorials/signals/steps/4-managing-async-data-with-signals/README.md
@@ -54,7 +54,7 @@ Changing the params signal automatically triggers a reload, or you can manually 
 Add computed signals to access different states of the resource.
 
 ```ts
-isLoading = computed(() => this.userResource.status() === 'loading');
+isLoading = computed(() => this.userResource.status() === 'loading' && this.userResource.status() === 'reloading');
 hasError = computed(() => this.userResource.status() === 'error');
 ```
 


### PR DESCRIPTION
Fix documentation and explicit reloading status after reload function

Fixes: #66033

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #66033


## What is the new behavior?
Add explicit reloading status after reload function

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
