### PR TITLE
fix(docs-infra): allow searching API reference by Group title

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
@@ -16,7 +16,7 @@ import {RouterTestingHarness} from '@angular/router/testing';
 import {provideRouter} from '@angular/router';
 import {Location} from '@angular/common';
 import {By} from '@angular/platform-browser';
-import {NavigationItem, TextField} from '@angular/docs';
+import {TextField} from '@angular/docs';
 import {ApiItem} from '../interfaces/api-item';
 
 describe('ApiReferenceList', () => {
@@ -115,6 +115,15 @@ describe('ApiReferenceList', () => {
     fixture.detectChanges();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeItem1]);
+  });
+
+  it('should display items which match the query by group title', () => {
+    fixture.componentRef.setInput('query', 'Fake Group');
+    fixture.detectChanges();
+
+    // Should find all items whose group title contains the query
+    expect(component.filteredGroups()![0].items.length).toBeGreaterThan(0);
+    expect(component.filteredGroups()![0].items).toContain(fakeItem1);
   });
 
   it('should display only class items when user selects Class in the Type select', () => {

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -97,7 +97,10 @@ export default class ApiReferenceList {
         id: group.id,
         items: group.items.filter((apiItem) => {
           return (
-            (query == '' ? true : apiItem.title.toLocaleLowerCase().includes(query)) &&
+            (query == ''
+              ? true
+              : apiItem.title.toLocaleLowerCase().includes(query) ||
+                group.title.toLocaleLowerCase().includes(query)) &&
             (type === ALL_TYPES_KEY || apiItem.itemType === type) &&
             ((status & STATUSES.stable &&
               !apiItem.developerPreview &&


### PR DESCRIPTION
The API reference search filter now also searches by the item's URL path in addition to its title. This allows users to search using queries containing slashes (e.g., 'core/' or 'forms/signal') to find matching API items.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
