### PR TITLE
refactor(core): tree-shake symbol descriptions

### DIFF
--- a/packages/core/primitives/di/src/not_found.ts
+++ b/packages/core/primitives/di/src/not_found.ts
@@ -6,11 +6,17 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+// Required as the signals library is in a separate package, so we need to explicitly ensure the
+// global `ngDevMode` type is defined.
+declare const ngDevMode: boolean | undefined;
+
 /**
  * Value returned if the key-value pair couldn't be found in the context
  * hierarchy.
  */
-export const NOT_FOUND: unique symbol = Symbol('NotFound');
+export const NOT_FOUND: unique symbol = Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'NotFound' : '',
+);
 
 /**
  * Error thrown when the key-value pair couldn't be found in the context

--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -96,21 +96,27 @@ export function createComputed<T>(
  * A dedicated symbol used before a computed value has been calculated for the first time.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-export const UNSET: any = /* @__PURE__ */ Symbol('UNSET');
+export const UNSET: any = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'UNSET' : '',
+);
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * is in progress. Used to detect cycles in computation chains.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-export const COMPUTING: any = /* @__PURE__ */ Symbol('COMPUTING');
+export const COMPUTING: any = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'COMPUTING' : '',
+);
 
 /**
  * A dedicated symbol used in place of a computed signal value to indicate that a given computation
  * failed. The thrown error is cached until the computation gets dirty again.
  * Explicitly typed as `any` so we can use it as signal's value.
  */
-export const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
+export const ERRORED: any = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'ERRORED' : '',
+);
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -37,7 +37,9 @@ let postProducerCreatedFn: ReactiveHookFn | null = null;
  *
  * This can be used to auto-unwrap signals in various cases, or to auto-wrap non-signal values.
  */
-export const SIGNAL: unique symbol = /* @__PURE__ */ Symbol('SIGNAL');
+export const SIGNAL: unique symbol = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'SIGNAL' : '',
+);
 
 export function setActiveConsumer(consumer: ReactiveNode | null): ReactiveNode | null {
   const prev = activeConsumer;

--- a/packages/core/src/authoring/input/input_signal_node.ts
+++ b/packages/core/src/authoring/input/input_signal_node.ts
@@ -8,7 +8,9 @@
 
 import {SIGNAL_NODE, SignalNode, signalSetFn} from '../../../primitives/signals';
 
-export const REQUIRED_UNSET_VALUE: unique symbol = /* @__PURE__ */ Symbol('InputSignalNode#UNSET');
+export const REQUIRED_UNSET_VALUE: unique symbol = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'InputSignalNode#UNSET' : '',
+);
 
 /**
  * Reactive node type for an input signal. An input signal extends a signal.

--- a/packages/core/src/render3/dynamic_bindings.ts
+++ b/packages/core/src/render3/dynamic_bindings.ts
@@ -23,7 +23,9 @@ import {getComponentLViewByIndex} from './util/view_utils';
 import {NotificationSource} from '../change_detection/scheduling/zoneless_scheduling';
 
 /** Symbol used to store and retrieve metadata about a binding. */
-export const BINDING: unique symbol = /* @__PURE__ */ Symbol('BINDING');
+export const BINDING: unique symbol = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'BINDING' : '',
+);
 
 /**
  * A dynamically-defined binding targeting.

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -9,7 +9,9 @@ import {Signal} from '../reactivity/api';
 import {WritableSignal} from '../reactivity/signal';
 
 /** A unique symbol used to identify {@link ɵControl} implementations. */
-export const ɵCONTROL: unique symbol = Symbol('CONTROL');
+export const ɵCONTROL: unique symbol = Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'CONTROL' : '',
+);
 
 /**
  * Instructions for dynamically binding a {@link ɵControl} to a form control.

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -43,7 +43,10 @@ import {
   setInjectorProfilerContext,
 } from '../debug/injector_profiler';
 
-const NOT_SET = /* @__PURE__ */ Symbol('NOT_SET');
+const NOT_SET = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'NOT_SET' : '',
+);
+
 const EMPTY_CLEANUP_SET = /* @__PURE__ */ new Set<() => void>();
 
 /** Callback type for an `afterRenderEffect` phase effect */

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -11,7 +11,9 @@ import {createSignal, SIGNAL, SignalGetter, SignalNode} from '../../../primitive
 import {Signal, ValueEqualityFn} from './api';
 
 /** Symbol used distinguish `WritableSignal` from other non-writable signals and functions. */
-export const ɵWRITABLE_SIGNAL: unique symbol = /* @__PURE__ */ Symbol('WRITABLE_SIGNAL');
+export const ɵWRITABLE_SIGNAL: unique symbol = /* @__PURE__ */ Symbol(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'WRITABLE_SIGNAL' : '',
+);
 
 /**
  * A `Signal` with a value that can be mutated via a setter interface.


### PR DESCRIPTION
Moves symbol descriptions behind ngDevMode to enable tree-shaking of only metadata in production builds.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
