### PR TITLE
fix(core): return `StaticProvider` for `providePlatformInitializer`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1485,7 +1485,7 @@ export function provideEnvironmentInitializer(initializerFn: () => void): Enviro
 export function provideNgReflectAttributes(): EnvironmentProviders;
 
 // @public
-export function providePlatformInitializer(initializerFn: () => void): EnvironmentProviders;
+export function providePlatformInitializer(initializerFn: () => void): StaticProvider;
 
 // @public
 export type Provider = TypeProvider | ValueProvider | ClassProvider | ConstructorProvider | ExistingProvider | FactoryProvider | any[];

--- a/packages/core/src/platform/platform.ts
+++ b/packages/core/src/platform/platform.ts
@@ -187,20 +187,23 @@ export function createOrReusePlatformInjector(providers: StaticProvider[] = []):
  *
  * Note that the provided initializer is run in the injection context.
  *
- * Previously, this was achieved using the `PLATFORM_INITIALIZER` token which is now deprecated.
+ * @usageNotes
+ * The platform initializer should be provided during platform creation:
  *
- * @see {@link PLATFORM_INITIALIZER}
+ * ```ts
+ * const platformRef = platformBrowser([ providePlatformInitializer(() =>  ...) ]);
+ *
+ * bootstrapApplication(App, appConfig, { platformRef })
+ * ```
  *
  * @publicApi
  */
-export function providePlatformInitializer(initializerFn: () => void): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    {
-      provide: PLATFORM_INITIALIZER,
-      useValue: initializerFn,
-      multi: true,
-    },
-  ]);
+export function providePlatformInitializer(initializerFn: () => void): StaticProvider {
+  return {
+    provide: PLATFORM_INITIALIZER,
+    useValue: initializerFn,
+    multi: true,
+  };
 }
 
 function runPlatformInitializers(injector: Injector): void {


### PR DESCRIPTION
Prior to this change, `providePlatformInitializer` could not be used correctly because `EnvironmentProviders` were not compatible with  platform providers. 

fixes #64277
