### PR TITLE
docs: standardize component decorator placeholders in markdown

### DIFF
--- a/adev/src/content/best-practices/style-guide.md
+++ b/adev/src/content/best-practices/style-guide.md
@@ -197,7 +197,7 @@ ensures that the value set by Angular is not overwritten.
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class UserProfile {
   readonly userId = input();
@@ -211,7 +211,7 @@ advice applies to output properties and queries, but not input properties.
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class UserProfile {
   @Output() readonly userSaved = new EventEmitter<void>();
@@ -276,7 +276,7 @@ then delegate to more specific behaviors based on the event details:
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 class RichText {
   handleKeydown(event: KeyboardEvent) {
@@ -323,7 +323,7 @@ your class, import and `implement` these interfaces to ensure that the methods a
 import {Component, OnInit} from '@angular/core';
 
 @Component({
-  /* ... */
+  /*...*/
 })
 export class UserProfile implements OnInit {
   // The `OnInit` interface ensures this method is named correctly.

--- a/adev/src/content/guide/components/anatomy-of-components.md
+++ b/adev/src/content/guide/components/anatomy-of-components.md
@@ -97,8 +97,8 @@ You show a component by creating a matching HTML element in the template of _oth
 export class ProfilePhoto { }
 
 @Component({
-imports: [ProfilePhoto],
-template: `<profile-photo />`
+  imports: [ProfilePhoto],
+  template: `<profile-photo />`
 })
 export class UserProfile { }
 ```

--- a/adev/src/content/guide/components/dom-apis.md
+++ b/adev/src/content/guide/components/dom-apis.md
@@ -7,7 +7,9 @@ directly interact with a component's DOM. Components can inject ElementRef to ge
 component's host element:
 
 ```ts
-@Component({...})
+@Component({
+  /*...*/
+})
 export class ProfilePhoto {
   constructor() {
     const elementRef = inject(ElementRef);
@@ -23,7 +25,9 @@ You can use Angular's `afterEveryRender` and `afterNextRender` functions to regi
 callback** that runs when Angular has finished rendering the page.
 
 ```ts
-@Component({...})
+@Component({
+  /*...*/
+})
 export class ProfilePhoto {
   constructor() {
     const elementRef = inject(ElementRef);

--- a/adev/src/content/guide/components/inheritance.md
+++ b/adev/src/content/guide/components/inheritance.md
@@ -12,7 +12,9 @@ export class ListboxBase {
   value: string;
 }
 
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class CustomListbox extends ListboxBase {
   // CustomListbox inherits the `value` property.
 }
@@ -70,12 +72,16 @@ and their own.
 If a base class injects dependencies as constructor parameters, the child class must explicitly class these dependencies to `super`.
 
 ```ts
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class ListboxBase {
-  constructor(private element: ElementRef) { }
+  constructor(private element: ElementRef) {}
 }
 
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class CustomListbox extends ListboxBase {
   constructor(element: ElementRef) {
     super(element);
@@ -90,7 +96,9 @@ implements `ngOnInit` _overrides_ the base class's implementation. If you want t
 class's lifecycle method, explicitly call the method with `super`:
 
 ```ts
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class ListboxBase {
   protected isInitialized = false;
   ngOnInit() {
@@ -98,7 +106,9 @@ export class ListboxBase {
   }
 }
 
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class CustomListbox extends ListboxBase {
   override ngOnInit() {
     super.ngOnInit();

--- a/adev/src/content/guide/components/inputs.md
+++ b/adev/src/content/guide/components/inputs.md
@@ -294,7 +294,9 @@ TIP: While the Angular team recommends using the signal-based `input` function f
 You can alternatively declare component inputs by adding the `@Input` decorator to a property:
 
 ```ts {highlight:[3]}
-@Component({...})
+@Component({
+  /*...*/
+})
 export class CustomSlider {
   @Input() value = 0;
 }
@@ -315,7 +317,9 @@ The `@Input` decorator accepts a config object that lets you change the way that
 You can specify the `required` option to enforce that a given input must always have a value.
 
 ```ts {highlight:[3]}
-@Component({...})
+@Component({
+  /*...*/
+})
 export class CustomSlider {
   @Input({required: true}) value = 0;
 }
@@ -346,7 +350,9 @@ function trimString(value: string | undefined) {
 You can specify the `alias` option to change the name of an input in templates.
 
 ```ts {highlight:[3]}
-@Component({...})
+@Component({
+  /*...*/
+})
 export class CustomSlider {
   @Input({alias: 'sliderValue'}) value = 0;
 }

--- a/adev/src/content/guide/components/lifecycle.md
+++ b/adev/src/content/guide/components/lifecycle.md
@@ -256,7 +256,9 @@ next phase.
 ```ts
 import {Component, ElementRef, afterNextRender} from '@angular/core';
 
-@Component({...})
+@Component({
+  /*...*/
+})
 export class UserProfile {
   private prevPadding = 0;
   private elementHeight = 0;
@@ -281,7 +283,7 @@ export class UserProfile {
         if (didWrite) {
           this.elementHeight = nativeElement.getBoundingClientRect().height;
         }
-      }
+      },
     });
   }
 }

--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -20,10 +20,10 @@ chunks automatically and loaded only when necessary, based on the configured tri
 template.
 
 ```angular-ts
-@Component({ ... })
+@Component({/*...*/})
 export class AdminBio { /* ... */ }
 
-@Component({ ... })
+@Component({/*...*/})
 export class StandardBio { /* ... */ }
 
 @Component({

--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -150,7 +150,7 @@ In some cases, especially with `viewChild`, you know with certainty that a speci
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class CustomCard {
   header = viewChild.required(CustomCardHeader);

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -96,7 +96,9 @@ export class NavbarComponent {
 You can inject dependencies during construction of a component, directive, or service. The call to [`inject`](/api/core/inject) can appear in either the `constructor` or in a field initializer. Here are some common examples:
 
 ```ts
-@Component({...})
+@Component({
+  /*...*/
+})
 export class MyComponent {
   // ✅ In class field initializer
   private service = inject(MyService);

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -451,7 +451,7 @@ import {
 } from '@angular/forms';
 
 @Component({
-  /* ... */
+  /*...*/
 })
 export class UnifiedEventsBasicComponent {
   form = new FormGroup({
@@ -601,7 +601,9 @@ When updating form controls programmatically, you have precise control over how 
 By default `emitEvent: true`, any change to a control emits events through the `valueChanges` and `statusChanges` observables. Setting `emitEvent: false` suppresses these emissions, which is useful when setting values programmatically without triggering reactive behavior like auto-save, avoiding circular updates between controls, or performing bulk updates where events should emit only once at the end.
 
 ```ts
-@Component({/* ... */})
+@Component({
+  /* ... */
+})
 export class BlogPostEditor {
   postForm = new FormGroup({
     title: new FormControl(''),
@@ -610,16 +612,15 @@ export class BlogPostEditor {
 
   constructor() {
     // Auto-save draft every time user types
-    this.postForm.valueChanges.subscribe(formValue => {
+    this.postForm.valueChanges.subscribe((formValue) => {
       this.autosaveDraft(formValue);
     });
   }
 
   loadExistingDraft(savedDraft: {title: string; content: string}) {
     // Restore draft without triggering auto-save
-    this.postForm.setValue(savedDraft, { emitEvent: false });
+    this.postForm.setValue(savedDraft, {emitEvent: false});
   }
-
 }
 ```
 

--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -32,10 +32,12 @@ When you want to run code during specific navigation lifecycle events, you can d
 
 ```ts
 // Example of subscribing to router events
-import { Component, inject, signal, effect } from '@angular/core';
-import { Event, Router, NavigationStart, NavigationEnd } from '@angular/router';
+import {Component, inject, signal, effect} from '@angular/core';
+import {Event, Router, NavigationStart, NavigationEnd} from '@angular/router';
 
-@Component({ ... })
+@Component({
+  /*...*/
+})
 export class RouterEventsComponent {
   private readonly router = inject(Router);
 

--- a/adev/src/content/guide/routing/read-route-state.md
+++ b/adev/src/content/guide/routing/read-route-state.md
@@ -44,7 +44,7 @@ Here’s an example of how you’d access a route snapshot:
 ```angular-ts
 import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
 
-@Component({ ... })
+@Component({/*...*/})
 export class UserProfileComponent {
   readonly userId: string;
   private route = inject(ActivatedRoute);

--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -35,7 +35,7 @@ By default, you can only create an `effect()` within an [injection context](guid
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class EffectiveCounter {
   readonly count = signal(0);
@@ -52,15 +52,20 @@ export class EffectiveCounter {
 To create an effect outside the constructor, you can pass an `Injector` to `effect` via its options:
 
 ```ts
-@Component({...})
+@Component({
+  /*...*/
+})
 export class EffectiveCounterComponent {
   readonly count = signal(0);
   private injector = inject(Injector);
 
   initializeLogging(): void {
-    effect(() => {
-      console.log(`The count is: ${this.count()}`);
-    }, {injector: this.injector});
+    effect(
+      () => {
+        console.log(`The count is: ${this.count()}`);
+      },
+      {injector: this.injector},
+    );
   }
 }
 ```
@@ -117,7 +122,7 @@ For these situations, you can use `afterRenderEffect`. It functions like `effect
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class MyFancyChart {
   chartData = input.required<ChartData>();

--- a/adev/src/content/guide/signals/linked-signal.md
+++ b/adev/src/content/guide/signals/linked-signal.md
@@ -22,7 +22,7 @@ In this example, the `selectedOption` defaults to the first option, but changes 
 
 **The `linkedSignal` function lets you create a signal to hold some state that is intrinsically _linked_ to some other state.** Revisiting the example above, `linkedSignal` can replace `signal`:
 
-```typescript
+```ts
 @Component({
   /* ... */
 })
@@ -42,7 +42,7 @@ export class ShippingMethodPicker {
 
 The following example shows how the value of a `linkedSignal` can change based on its linked state:
 
-```typescript
+```ts
 const shippingOptions = signal(['Ground', 'Air', 'Sea']);
 const selectedOption = linkedSignal(() => shippingOptions()[0]);
 console.log(selectedOption()); // 'Ground'
@@ -60,7 +60,7 @@ In some cases, the computation for a `linkedSignal` needs to account for the pre
 
 In the example above, `selectedOption` always updates back to the first option when `shippingOptions` changes. You may, however, want to preserve the user's selection if their selected option is still somewhere in the list. To accomplish this, you can create a `linkedSignal` with a separate _source_ and _computation_:
 
-```typescript
+```ts
 interface ShippingMethod {
   id: number;
   name: string;

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -329,7 +329,7 @@ Inject and use the service in your components:
 
 ```ts
 @Component({
-  /* ... */
+  /*...*/
 })
 export class Checkout {
   private analytics = inject(AnalyticsService);

--- a/adev/src/content/introduction/essentials/signals.md
+++ b/adev/src/content/introduction/essentials/signals.md
@@ -55,7 +55,7 @@ console.log(firstNameCapitalized()); // JAIME
 
 Use `signal` and `computed` inside your components to create and manage state:
 
-```typescript
+```ts
 @Component({
   /* ... */
 })


### PR DESCRIPTION
Updates `@Component({ ... })` to `@Component({/*...*/})` across documentation examples for consistency and clearer formatting.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
