### PR TITLE
ci: update google sync configuration to not include package.json

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -32,6 +32,7 @@
     "**/rollup.config.js",
     "**/BUILD.bazel",
     "**/*.md",
+    "**/package.json",
     "packages/**/integrationtest/**",
     "packages/**/test/**",
     "packages/zone.js/*",


### PR DESCRIPTION
We don't use the package.json files within google3 and they don't need to be marked for sync
