### PR TITLE
refactor(docs-infra): remove deprecated h.JSX.HTMLAttributes usage

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/header-api.tsx
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Fragment, h} from 'preact';
+import {Fragment, h, HTMLAttributes} from 'preact';
 import {EntryType, isDocEntryWithSourceInfo, PipeEntry} from '../entities.mjs';
 import {DocEntryRenderable, PipeEntryRenderable} from '../entities/renderables.mjs';
 import {
@@ -73,7 +73,7 @@ export function HeaderApi(props: {
 }
 
 function statusTag(entry: DocEntryRenderable) {
-  let tag: h.JSX.HTMLAttributes<HTMLDivElement> | null = null;
+  let tag: HTMLAttributes<HTMLDivElement> | null = null;
 
   // Cascading Deprecated > Stable > Developer Preview > Experimental
 


### PR DESCRIPTION
Import HTMLAttributes directly from preact to address deprecation warning in header-api.tsx

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
