### PR TITLE
refactor(core): Include decorator name in `assertTypeDefined` only wh…

### DIFF
--- a/packages/core/src/render3/def_getters.ts
+++ b/packages/core/src/render3/def_getters.ts
@@ -14,7 +14,7 @@ import {NG_COMP_DEF, NG_DIR_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
 import type {ComponentDef, DirectiveDef, PipeDef} from './interfaces/definition';
 
 export function getNgModuleDef<T>(type: any): NgModuleDef<T> | null {
-  assertTypeDefined(type, '@NgModule');
+  assertTypeDefined(type, typeof ngDevMode !== 'undefined' && ngDevMode ? '@NgModule' : '');
   return type[NG_MOD_DEF] || null;
 }
 
@@ -37,7 +37,7 @@ export function getNgModuleDefOrThrow<T>(type: any): NgModuleDef<T> | never {
  */
 
 export function getComponentDef<T>(type: any): ComponentDef<T> | null {
-  assertTypeDefined(type, '@Component');
+  assertTypeDefined(type, typeof ngDevMode !== 'undefined' && ngDevMode ? '@Component' : '');
   return type[NG_COMP_DEF] || null;
 }
 
@@ -54,12 +54,12 @@ export function getDirectiveDefOrThrow<T>(type: any): DirectiveDef<T> | never {
 }
 
 export function getDirectiveDef<T>(type: any): DirectiveDef<T> | null {
-  assertTypeDefined(type, '@Directive');
+  assertTypeDefined(type, typeof ngDevMode !== 'undefined' && ngDevMode ? '@Directive' : '');
   return type[NG_DIR_DEF] || null;
 }
 
 export function getPipeDef<T>(type: any): PipeDef<T> | null {
-  assertTypeDefined(type, '@Pipe');
+  assertTypeDefined(type, typeof ngDevMode !== 'undefined' && ngDevMode ? '@Pipe' : '');
   return type[NG_PIPE_DEF] || null;
 }
 


### PR DESCRIPTION
…en `ngDevMode` is enabled.

Avoids including decorator names in production
`assertTypeDefined` calls, improving tree-shaking by preventing debug-only metadata from being included in production builds.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
