### PR TITLE
refactor(devtools): Internal signals prototype

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -666,6 +666,7 @@ const getSignalGraphCallback = (messageBus: MessageBus<Events>) => (element: Ele
         epoch: node.epoch,
         preview: serializeValue(node.value),
         debuggable: !!node.debuggableFn,
+        isInternal: node.isInternal ?? false,
       };
     });
     messageBus.emit('latestSignalGraph', [{nodes, edges: graph.edges}]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
@@ -54,12 +54,39 @@ export class SignalsTabComponent implements OnDestroy {
   private svgComponent = viewChild.required<ElementRef>('component');
 
   signalsVisualizer?: SignalsGraphVisualizer;
+  protected readonly showInternalSignals = signal(false);
+  protected readonly visibleGraph = computed(() => {
+    const graph = this.signalGraph.graph();
+    if (!graph) {
+      return null;
+    }
+    if (this.showInternalSignals()) {
+      return graph;
+    }
+    const nodesWithIndexes = graph.nodes.map((node, index) => ({node, index}));
+    const filteredNodes = nodesWithIndexes.filter(({node}) => !node.isInternal);
+    if (filteredNodes.length === graph.nodes.length) {
+      return graph;
+    }
+    const indexMap = new Map<number, number>();
+    const nodes = filteredNodes.map(({node, index}, mappedIndex) => {
+      indexMap.set(index, mappedIndex);
+      return node;
+    });
+    const edges = graph.edges
+      .filter((edge) => indexMap.has(edge.consumer) && indexMap.has(edge.producer))
+      .map((edge) => ({
+        consumer: indexMap.get(edge.consumer)!,
+        producer: indexMap.get(edge.producer)!,
+      }));
+    return {nodes, edges};
+  });
 
   protected readonly preselectedNodeId = input<string | null>(null);
 
   // selected is automatically reset to null whenever `graph` changes
   private selected = linkedSignal<DebugSignalGraph | null, string | null>({
-    source: this.signalGraph.graph,
+    source: this.visibleGraph,
     computation: () => this.preselectedNodeId(),
   });
 
@@ -73,7 +100,7 @@ export class SignalsTabComponent implements OnDestroy {
   readonly close = output<void>();
 
   protected selectedNode = computed(() => {
-    const signalGraph = this.signalGraph.graph();
+    const signalGraph = this.visibleGraph();
     if (!signalGraph) {
       return undefined;
     }
@@ -123,11 +150,13 @@ export class SignalsTabComponent implements OnDestroy {
     );
   });
 
-  protected empty = computed(() => !(this.signalGraph.graph()?.nodes.length! > 0));
-
+  protected empty = computed(() => {
+    const graph = this.visibleGraph();
+    return !(graph && graph.nodes.length > 0);
+  });
   constructor() {
     const renderGraph = () => {
-      const graph = this.signalGraph.graph();
+      const graph = this.visibleGraph();
       if (graph) {
         this.signalsVisualizer?.render(graph);
       }

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -30,6 +30,7 @@ export interface DebugSignalGraphNode {
   label?: string;
   preview: Descriptor;
   debuggable: boolean;
+  isInternal: boolean;
 }
 
 export interface DebugSignalGraphEdge {

--- a/devtools/projects/shell-browser/src/app/content-script.ts
+++ b/devtools/projects/shell-browser/src/app/content-script.ts
@@ -28,8 +28,7 @@ const handleDisconnect = (): void => {
 
 function attemptBackendHandshake() {
   if (!backendInitialized) {
-    // tslint:disable-next-line:no-console
-    console.log('Attempting handshake with backend', new Date());
+    console.debug('Attempting handshake with backend', new Date());
 
     const retry = () => {
       if (backendInitialized || backgroundDisconnected) {

--- a/devtools/src/app/demo-app/todo/BUILD.bazel
+++ b/devtools/src/app/demo-app/todo/BUILD.bazel
@@ -26,6 +26,7 @@ ng_project(
         "//:node_modules/@angular/material",
         "//:node_modules/@angular/router",
         "//devtools/src/app/demo-app/todo/about",
+        "//devtools/src/app/demo-app/todo/forms",
         "//devtools/src/app/demo-app/todo/home",
         "//devtools/src/app/demo-app/todo/routes",
     ],

--- a/devtools/src/app/demo-app/todo/app-todo.component.html
+++ b/devtools/src/app/demo-app/todo/app-todo.component.html
@@ -2,6 +2,7 @@
   <a routerLink="/demo-app/todos/app">Todos</a>
   <a routerLink="/demo-app/todos/about">About</a>
   <a routerLink="/demo-app/todos/routes">Routes</a>
+  <a routerLink="/demo-app/todos/forms">Forms</a>
 </nav>
 
 <div class="guard-toggle-container">

--- a/devtools/src/app/demo-app/todo/app.module.ts
+++ b/devtools/src/app/demo-app/todo/app.module.ts
@@ -65,6 +65,10 @@ export const canMatchGuard: CanActivateFn = () => {
             loadChildren: () => import('./routes/routes.module').then((m) => m.RoutesModule),
           },
           {
+            path: 'forms',
+            loadComponent: () => import('./forms/forms.component').then((m) => m.FormsComponent),
+          },
+          {
             path: '**',
             redirectTo: 'app',
           },

--- a/devtools/src/app/demo-app/todo/forms/BUILD.bazel
+++ b/devtools/src/app/demo-app/todo/forms/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//devtools/tools:defaults.bzl", "ng_project")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_project(
+    name = "forms",
+    srcs = [
+        "forms.component.ts",
+    ],
+    deps = [
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/forms",
+    ],
+)

--- a/devtools/src/app/demo-app/todo/forms/forms.component.ts
+++ b/devtools/src/app/demo-app/todo/forms/forms.component.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+import {FormControl, FormGroup, ReactiveFormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'app-forms',
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="profileForm">
+      <label>
+        First Name:
+        <input formControlName="firstName" />
+      </label>
+
+      <label>
+        Last Name:
+        <input formControlName="lastName" />
+      </label>
+
+      <button type="submit">Submit</button>
+    </form>
+  `,
+})
+export class FormsComponent {
+  profileForm = new FormGroup({
+    firstName: new FormControl(''),
+    lastName: new FormControl(''),
+  });
+}

--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -196,6 +196,13 @@ export interface ReactiveNode {
    * Used in Angular DevTools to identify the kind of signal.
    */
   kind: ReactiveNodeKind;
+
+  /**
+   * @internal
+   * A debug information, only present in dev mode.
+   * Internal reactive nodes should not be visible by default when debugging the signal graph
+   */
+  isInternal?: boolean;
 }
 
 /**

--- a/packages/core/src/render3/reactivity/computed.ts
+++ b/packages/core/src/render3/reactivity/computed.ts
@@ -23,6 +23,11 @@ export interface CreateComputedOptions<T> {
    * A debug name for the computed signal. Used in Angular DevTools to identify the signal.
    */
   debugName?: string;
+
+  /**
+   * @internal
+   */
+  isInternal?: boolean;
 }
 
 /**
@@ -35,6 +40,7 @@ export function computed<T>(computation: () => T, options?: CreateComputedOption
   if (ngDevMode) {
     getter.toString = () => `[Computed: ${getter()}]`;
     getter[SIGNAL].debugName = options?.debugName;
+    (getter[SIGNAL] as any).isInternal = options?.isInternal ?? false;
   }
 
   return getter;

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -63,6 +63,11 @@ export interface CreateSignalOptions<T> {
    * A debug name for the signal. Used in Angular DevTools to identify the signal.
    */
   debugName?: string;
+
+  /**
+   * @internal
+   */
+  isInternal?: boolean;
 }
 
 /**
@@ -82,6 +87,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   if (ngDevMode) {
     signalFn.toString = () => `[Signal: ${signalFn()}]`;
     node.debugName = options?.debugName;
+    (node as any).isInternal = options?.isInternal ?? false;
   }
 
   return signalFn as WritableSignal<T>;

--- a/packages/core/src/render3/util/signal_debug.ts
+++ b/packages/core/src/render3/util/signal_debug.ts
@@ -30,6 +30,8 @@ export interface DebugSignalGraphNode {
   label?: string;
   value?: unknown;
   debuggableFn?: () => unknown;
+
+  isInternal?: boolean;
 }
 
 export interface DebugSignalGraphEdge {
@@ -115,6 +117,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         epoch: consumer.version,
         debuggableFn: consumer.computation,
         id,
+        isInternal: (consumer as any).isInternal ?? false,
       });
     } else if (isSignalNode(consumer)) {
       debugSignalGraphNodes.push({
@@ -123,6 +126,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         kind: consumer.kind,
         epoch: consumer.version,
         id,
+        isInternal: (consumer as any).isInternal ?? false,
       });
     } else if (isTemplateEffectNode(consumer)) {
       debugSignalGraphNodes.push({
@@ -133,6 +137,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         // We get the constructor so that `inspect(.constructor)` shows the component class.
         debuggableFn: consumer.lView?.[CONTEXT]?.constructor as (() => unknown) | undefined,
         id,
+        isInternal: (consumer as any).isInternal ?? false,
       });
     } else {
       debugSignalGraphNodes.push({
@@ -140,6 +145,7 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
         kind: consumer.kind,
         epoch: consumer.version,
         id,
+        isInternal: (consumer as any).isInternal ?? false,
       });
     }
 
@@ -148,7 +154,6 @@ function getNodesAndEdgesFromSignalMap(signalMap: ReadonlyMap<ReactiveNode, Reac
       edges.push({consumer: consumerIndex, producer: nodes.indexOf(producer)});
     }
   }
-
   return {nodes: debugSignalGraphNodes, edges};
 }
 

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -70,8 +70,14 @@ export abstract class AbstractFormDirective
     this._submittedReactive.set(value);
   }
   /** @internal */
-  readonly _submitted = computed(() => this._submittedReactive());
-  private readonly _submittedReactive = signal(false);
+  readonly _submitted = computed(
+    () => this._submittedReactive(),
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
+  private readonly _submittedReactive = signal(
+    false,
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
 
   /**
    * Reference to an old form group input value, which is needed to cleanup

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -617,8 +617,14 @@ export abstract class AbstractControl<
     untracked(() => this.statusReactive.set(v));
   }
   /** @internal */
-  readonly _status = computed(() => this.statusReactive());
-  private readonly statusReactive = signal<FormControlStatus | undefined>(undefined);
+  readonly _status = computed(
+    () => this.statusReactive(),
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
+  private readonly statusReactive = signal<FormControlStatus | undefined>(
+    undefined,
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
 
   /**
    * A control is `valid` when its `status` is `VALID`.
@@ -704,8 +710,14 @@ export abstract class AbstractControl<
     untracked(() => this.pristineReactive.set(v));
   }
   /** @internal */
-  readonly _pristine = computed(() => this.pristineReactive());
-  private readonly pristineReactive = signal(true);
+  readonly _pristine = computed(
+    () => this.pristineReactive(),
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
+  private readonly pristineReactive = signal(
+    true,
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
 
   /**
    * A control is `dirty` if the user has changed the value
@@ -731,8 +743,14 @@ export abstract class AbstractControl<
     untracked(() => this.touchedReactive.set(v));
   }
   /** @internal */
-  readonly _touched = computed(() => this.touchedReactive());
-  private readonly touchedReactive = signal(false);
+  readonly _touched = computed(
+    () => this.touchedReactive(),
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
+  private readonly touchedReactive = signal(
+    false,
+    ...(ngDevMode ? [{isInternal: true} as any] : []),
+  );
 
   /**
    * True if the control has not been marked as touched


### PR DESCRIPTION
This uses an internal property for prototyping purposes so we don't commit to an API at the moment.

fixes #65894
