### PR TITLE
docs(forms): add migration guide for Signal Forms

### DIFF
--- a/adev/src/app/routing/sub-navigation-data.ts
+++ b/adev/src/app/routing/sub-navigation-data.ts
@@ -475,6 +475,11 @@ const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
                 path: 'guide/forms/signals/comparison',
                 contentPath: 'guide/forms/signals/comparison',
               },
+              {
+                label: 'Migrating from Legacy Forms',
+                path: 'guide/forms/signals/migration',
+                contentPath: 'guide/forms/signals/migration',
+              },
             ],
           },
           {

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.css
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.css
@@ -1,0 +1,70 @@
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  padding: 1rem;
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+
+div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 500;
+}
+
+input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+input:focus {
+  outline: none;
+  border-color: #4285f4;
+}
+
+button {
+  padding: 0.75rem 1.5rem;
+  background-color: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #357ae8;
+}
+
+button:active {
+  background-color: #2a65c8;
+}
+
+.error-list {
+  color: red;
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0 0;
+  padding-left: 0;
+  list-style-position: inside;
+}
+
+.error-list p {
+  margin: 0;
+}

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
@@ -2,7 +2,7 @@
   <div>
     <label>
       Email:
-      <input [field]="f.email">
+      <input [field]="f.email" />
     </label>
 
     @if (f.email().touched() && f.email().invalid()) {
@@ -15,7 +15,7 @@
   <div>
     <label>
       Password:
-      <input [field]="f.password" type="password">
+      <input [field]="f.password" type="password" />
     </label>
 
     @if (f.password().touched() && f.password().invalid(); as invalid) {

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
@@ -4,12 +4,6 @@
       Email:
       <input [field]="f.email" />
     </label>
-
-    @if (f.email().touched() && f.email().invalid()) {
-      <div class="error-list">
-        <p>Email is required.</p>
-      </div>
-    }
   </div>
 
   <div>
@@ -18,7 +12,7 @@
       <input [field]="f.password" type="password" />
     </label>
 
-    @if (f.password().touched() && f.password().invalid(); as invalid) {
+    @if (f.password().touched() && f.password().invalid()) {
       <div class="error-list">
         @for (error of f.password().errors(); track error) {
           <p>{{ error.message || error.kind }}</p>

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html
@@ -1,0 +1,31 @@
+<form>
+  <div>
+    <label>
+      Email:
+      <input [field]="f.email">
+    </label>
+
+    @if (f.email().touched() && f.email().invalid()) {
+      <div class="error-list">
+        <p>Email is required.</p>
+      </div>
+    }
+  </div>
+
+  <div>
+    <label>
+      Password:
+      <input [field]="f.password" type="password">
+    </label>
+
+    @if (f.password().touched() && f.password().invalid(); as invalid) {
+      <div class="error-list">
+        @for (error of f.password().errors(); track error) {
+          <p>{{ error.message || error.kind }}</p>
+        }
+      </div>
+    }
+  </div>
+  <h3>Value</h3>
+  <pre>{{ formValue() | json }}</pre>
+</form>

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
@@ -1,5 +1,5 @@
 import {signal, Injector, inject, Component, computed} from '@angular/core';
-import {FormControl, Validators, ReactiveFormsModule, AbstractControl} from '@angular/forms';
+import {FormControl, Validators, AbstractControl} from '@angular/forms';
 import {Field} from '@angular/forms/signals';
 import {compatForm} from '@angular/forms/signals/compat';
 import {JsonPipe} from '@angular/common';
@@ -16,12 +16,12 @@ function enterprisePasswordValidator() {
 
 @Component({
   selector: 'app',
-  standalone: true,
   imports: [Field, JsonPipe],
   templateUrl: './app.html',
   styleUrl: './app.css',
 })
 export class App {
+  // 1. Existing legacy control with a specialized validator
   readonly passwordControl = new FormControl('', {
     validators: [Validators.required, enterprisePasswordValidator()],
     nonNullable: true,
@@ -33,7 +33,7 @@ export class App {
     password: this.passwordControl, // Nest the legacy control directly
   });
 
-  // 3. Initialize the bridge
+  // 3. Create the form
   readonly f = compatForm(this.user, {
     injector: inject(Injector),
   });

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
@@ -1,4 +1,4 @@
-import {signal, Injector, inject, Component, computed} from '@angular/core';
+import {signal, Component, computed} from '@angular/core';
 import {FormControl, Validators, AbstractControl} from '@angular/forms';
 import {Field} from '@angular/forms/signals';
 import {compatForm} from '@angular/forms/signals/compat';
@@ -34,9 +34,7 @@ export class App {
   });
 
   // 3. Create the form
-  readonly f = compatForm(this.user, {
-    injector: inject(Injector),
-  });
+  readonly f = compatForm(this.user);
 
   // We have to manually extract values, because JSON pipe can't serialize FormControl
   readonly formValue = computed(() => ({

--- a/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts
@@ -1,0 +1,51 @@
+import {signal, Injector, inject, Component, computed} from '@angular/core';
+import {FormControl, Validators, ReactiveFormsModule, AbstractControl} from '@angular/forms';
+import {Field} from '@angular/forms/signals';
+import {compatForm} from '@angular/forms/signals/compat';
+import {JsonPipe} from '@angular/common';
+
+// Dummy enterprisePasswordValidator for the example
+function enterprisePasswordValidator() {
+  return (control: AbstractControl) => {
+    if (control.value && control.value.length < 8) {
+      return {enterprisePassword: {message: 'Password must be at least 8 characters.'}};
+    }
+    return null;
+  };
+}
+
+@Component({
+  selector: 'app',
+  standalone: true,
+  imports: [Field, JsonPipe],
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+})
+export class App {
+  readonly passwordControl = new FormControl('', {
+    validators: [Validators.required, enterprisePasswordValidator()],
+    nonNullable: true,
+  });
+
+  // 2. Wrap it inside your form state signal
+  readonly user = signal({
+    email: '',
+    password: this.passwordControl, // Nest the legacy control directly
+  });
+
+  // 3. Initialize the bridge
+  readonly f = compatForm(this.user, {
+    injector: inject(Injector),
+  });
+
+  // We have to manually extract values, because JSON pipe can't serialize FormControl
+  readonly formValue = computed(() => ({
+    email: this.f.email().value(),
+    password: this.f.password().value(),
+  }));
+
+  constructor() {
+    console.log(this.f.email().value()); // "angular_user"
+    console.log(this.f.password().value()); // Current value of passwordControl
+  }
+}

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.css
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.css
@@ -1,0 +1,82 @@
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  padding: 1rem;
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+
+div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-weight: 500;
+}
+
+input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+input:focus {
+  outline: none;
+  border-color: #4285f4;
+}
+
+button {
+  padding: 0.75rem 1.5rem;
+  background-color: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover {
+  background-color: #357ae8;
+}
+
+button:active {
+  background-color: #2a65c8;
+}
+
+.error-list {
+  color: red;
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0 0;
+  padding-left: 0;
+  list-style-position: inside;
+}
+
+.error-list p {
+  margin: 0;
+}
+
+fieldset {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-top: 15px;
+  border-radius: 4px;
+}
+
+legend {
+  font-weight: bold;
+  padding: 0 5px;
+}

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html
@@ -1,0 +1,61 @@
+<form>
+  <h3>Shipping Details</h3>
+
+  <div>
+    <label>
+      Customer Name:
+      <input [field]="f.customerName">
+    </label>
+
+    @if (f.customerName().touched() && f.customerName().invalid()) {
+      <div class="error-list">
+        <p>Customer name is required.</p>
+      </div>
+    }
+  </div>
+
+  <fieldset>
+    <legend>Address</legend>
+
+    @let street = f.shippingAddress().control().controls.street;
+    <div>
+      <label>
+        Street:
+        <input [formControl]="street">
+      </label>
+      @if (street.touched && street.invalid) {
+        <div class="error-list">
+          <p>Street is required</p>
+        </div>
+      }
+    </div>
+
+    @let city = f.shippingAddress().control().controls.city;
+    <div>
+      <label>
+        City:
+        <input [formControl]="city">
+      </label>
+      @if (city.touched && city.invalid) {
+         <div class="error-list">
+           <p>City is required</p>
+         </div>
+      }
+    </div>
+
+    @let zip = f.shippingAddress().control().controls.zip;
+    <div>
+      <label>
+        Zip Code:
+        <input [formControl]="zip">
+      </label>
+      @if (zip.touched && zip.invalid) {
+         <div class="error-list">
+           <p>Zip Code is required</p>
+         </div>
+      }
+    </div>
+  </fieldset>
+  <h3>Value</h3>
+  <pre>{{ formValue() | json }}</pre>
+</form>

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html
@@ -4,7 +4,7 @@
   <div>
     <label>
       Customer Name:
-      <input [field]="f.customerName">
+      <input [field]="f.customerName" />
     </label>
 
     @if (f.customerName().touched() && f.customerName().invalid()) {
@@ -21,7 +21,7 @@
     <div>
       <label>
         Street:
-        <input [formControl]="street">
+        <input [formControl]="street" />
       </label>
       @if (street.touched && street.invalid) {
         <div class="error-list">
@@ -34,12 +34,12 @@
     <div>
       <label>
         City:
-        <input [formControl]="city">
+        <input [formControl]="city" />
       </label>
       @if (city.touched && city.invalid) {
-         <div class="error-list">
-           <p>City is required</p>
-         </div>
+        <div class="error-list">
+          <p>City is required</p>
+        </div>
       }
     </div>
 
@@ -47,12 +47,12 @@
     <div>
       <label>
         Zip Code:
-        <input [formControl]="zip">
+        <input [formControl]="zip" />
       </label>
       @if (zip.touched && zip.invalid) {
-         <div class="error-list">
-           <p>Zip Code is required</p>
-         </div>
+        <div class="error-list">
+          <p>Zip Code is required</p>
+        </div>
       }
     </div>
   </fieldset>

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
@@ -6,7 +6,6 @@ import {JsonPipe} from '@angular/common';
 
 @Component({
   selector: 'app',
-  standalone: true,
   imports: [ReactiveFormsModule, Field, JsonPipe],
   templateUrl: './app.html',
   styleUrl: './app.css',
@@ -15,8 +14,8 @@ export class App {
   // 1. A legacy address group with its own validation logic
   readonly addressGroup = new FormGroup({
     street: new FormControl('123 Angular Way', Validators.required),
-    city: new FormControl('Mountain View'),
-    zip: new FormControl('94043'),
+    city: new FormControl('Mountain View', Validators.required),
+    zip: new FormControl('94043', Validators.required),
   });
 
   // 2. Wrap it inside a new Signal Form state

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
@@ -1,0 +1,41 @@
+import {signal, Injector, inject, Component, computed} from '@angular/core';
+import {FormControl, FormGroup, Validators, ReactiveFormsModule} from '@angular/forms';
+import {Field} from '@angular/forms/signals';
+import {compatForm} from '@angular/forms/signals/compat';
+import {JsonPipe} from '@angular/common';
+
+@Component({
+  selector: 'app',
+  standalone: true,
+  imports: [ReactiveFormsModule, Field, JsonPipe],
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+})
+export class App {
+  // 1. A legacy address group with its own validation logic
+  readonly addressGroup = new FormGroup({
+    street: new FormControl('123 Angular Way', Validators.required),
+    city: new FormControl('Mountain View'),
+    zip: new FormControl('94043'),
+  });
+
+  // 2. Wrap it inside a new Signal Form state
+  readonly checkoutModel = signal({
+    customerName: '',
+    shippingAddress: this.addressGroup, // The bridge handles the nesting
+  });
+
+  // 3. Create the form
+  readonly f = compatForm(this.checkoutModel);
+
+  // We have to manually extract values, because JSON pipe can't serialize FormControl
+  readonly formValue = computed(() => ({
+    customerName: this.f.customerName().value(),
+    shippingAddress: this.f.shippingAddress().value(),
+  }));
+
+  constructor() {
+    console.log('Customer Name:', this.f.customerName().value());
+    console.log('Street:', this.f.shippingAddress().value().street);
+  }
+}

--- a/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
+++ b/adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts
@@ -1,4 +1,4 @@
-import {signal, Injector, inject, Component, computed} from '@angular/core';
+import {signal, Component, computed} from '@angular/core';
 import {FormControl, FormGroup, Validators, ReactiveFormsModule} from '@angular/forms';
 import {Field} from '@angular/forms/signals';
 import {compatForm} from '@angular/forms/signals/compat';
@@ -18,10 +18,10 @@ export class App {
     zip: new FormControl('94043', Validators.required),
   });
 
-  // 2. Wrap it inside a new Signal Form state
+  // 2. Include it in the state like it's a value
   readonly checkoutModel = signal({
     customerName: '',
-    shippingAddress: this.addressGroup, // The bridge handles the nesting
+    shippingAddress: this.addressGroup,
   });
 
   // 3. Create the form

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -17,7 +17,7 @@ controls that involve:
 Consider an existing `passwordControl` that uses a specialized `enterprisePasswordValidator`. Instead of rewriting the
 validator, you can bridge the control into your signal state.
 
-We can do it using `compatForm`
+We can do it using `compatForm`:
 
 ```typescript
 import {signal} from '@angular/core';
@@ -44,7 +44,7 @@ console.log(f.email().value()); // Current email value
 console.log(f.password().value()); // Current value of passwordControl
 
 // Reactive state is proxied automatically
-const isInvalid = f.password().valid();
+const isPasswordValid = f.password().valid();
 const passwordErrors = f.password().errors(); // Returns CompatValidationError if the legacy validator fails
 ```
 
@@ -57,12 +57,6 @@ In the template, use standard reactive syntax by binding the underlying control:
       Email:
       <input [field]="f.email">
     </label>
-
-    @if (f.email().touched() && f.email().invalid()) {
-    <div class="error-list">
-      <p>Email is required.</p>
-    </div>
-    }
   </div>
 
   <div>
@@ -72,11 +66,11 @@ In the template, use standard reactive syntax by binding the underlying control:
     </label>
 
     @if (f.password().touched() && f.password().invalid()) {
-    <div class="error-list">
-      @for (error of f.password().errors(); track error) {
-      <p>{{ error.message || error.kind }}</p>
-      }
-    </div>
+      <div class="error-list">
+        @for (error of f.password().errors(); track error) {
+          <p>{{ error.message || error.kind }}</p>
+        }
+      </div>
     }
   </div>
 </form>
@@ -89,8 +83,7 @@ In the template, use standard reactive syntax by binding the underlying control:
 
 ### Integrating a `FormGroup` into a signal form
 
-You can also wrap an entire `FormGroup`. This is common when a reusable sub-section of a form—such as an **Address Block
-**—is still managed by legacy Reactive Forms.
+You can also wrap an entire `FormGroup`. This is common when a reusable sub-section of a form—such as an **Address Block**—is still managed by legacy Reactive Forms.
 
 ```typescript
 import {signal} from '@angular/core';
@@ -156,9 +149,9 @@ template by accessing the underlying legacy controls via `.control()`:
         <input [formControl]="city">
       </label>
       @if (city.touched && city.invalid) {
-         <div class="error-list">
-           <p>City is required</p>
-         </div>
+        <div class="error-list">
+          <p>City is required</p>
+        </div>
       }
     </div>
 
@@ -169,9 +162,9 @@ template by accessing the underlying legacy controls via `.control()`:
         <input [formControl]="zip">
       </label>
       @if (zip.touched && zip.invalid) {
-         <div class="error-list">
-           <p>Zip Code is required</p>
-         </div>
+        <div class="error-list">
+          <p>Zip Code is required</p>
+        </div>
       }
     </div>
   </fieldset>
@@ -185,7 +178,7 @@ template by accessing the underlying legacy controls via `.control()`:
 
 ### Accessing values
 
-While `compatForm` proxies value access on the `FormControl` level, full form value would preserve the control:
+While `compatForm` proxies value access on the `FormControl` level, the full form value preserves the control:
 
 ```typescript
 const passwordControl = new FormControl('password' /** ... */);
@@ -215,7 +208,7 @@ This is coming soon.
 
 ## Automatic status classes
 
-To avoid manually adding classes like `.ng-valid`, `.ng-dirty` etc to every field, you can provide a global configuration using `provideSignalFormsConfig`.
+To avoid manually adding classes like `.ng-valid`, `.ng-dirty` etc to every field, you can provide a global configuration using `provideSignalFormsConfig`. Signal Forms provides a built-in `NG_STATUS_CLASSES` preset that matches legacy Reactive Forms behavior.
 
 ```typescript
 import {provideSignalFormsConfig} from '@angular/forms/signals';

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -210,7 +210,7 @@ This is coming soon.
 
 ## Automatic status classes
 
-Reactive/Template Forms automatically adds [class attributes](https://angular.dev/guide/forms/template-driven-forms#track-control-states) (such as `.ng-valid` or `.ng-dirty`) to facilitate styling control states. Signal Forms does not do that.
+Reactive/Template Forms automatically adds [class attributes](/guide/forms/template-driven-forms#track-control-states) (such as `.ng-valid` or `.ng-dirty`) to facilitate styling control states. Signal Forms does not do that.
 
 If you want to preserve this behavior, you can provide the `NG_STATUS_CLASSES` preset:
 

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -212,3 +212,24 @@ const formValue = computed(() => ({
 ## Bottom-up migration
 
 This is coming soon.
+
+## Automatic status classes
+
+To avoid manually adding classes like `.ng-valid`, `.ng-dirty` etc to every field, you can provide a global configuration using `provideSignalFormsConfig`.
+
+```typescript
+import {provideSignalFormsConfig} from '@angular/forms/signals';
+
+bootstrapApplication(App, {
+  providers: [
+    provideSignalFormsConfig({
+      classes: {
+        'ng-valid': ({state}) => state().valid(),
+        'ng-invalid': ({state}) => state().invalid(),
+        'ng-touched': ({state}) => state().touched(),
+        'ng-dirty': ({state}) => state().dirty(),
+      },
+    }),
+  ],
+});
+```

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -1,0 +1,192 @@
+# Migrating existing forms to Signal Forms
+
+This guide provides strategies for migrating existing codebases to Signal Forms, focusing on interoperability with
+legacy Reactive Forms.
+
+## Top-down migration using `compatForm`
+
+Sometimes you may want to use existing reactive `FormControl` instances within a Signal Form. This is useful for
+controls that involve:
+
+* Complex asynchronous logic.
+* Intricate RxJS operators that are not yet ported.
+* Integration with legacy third-party libraries.
+
+### Integrating a `FormControl` into a signal form
+
+Consider an existing `passwordControl` that uses a specialized `enterprisePasswordValidator`. Instead of rewriting the
+validator, you can bridge the control into your signal state.
+
+First, define your legacy control:
+
+```typescript
+import {signal, Injector, inject} from '@angular/core';
+import {FormControl, Validators} from '@angular/forms';
+import {compatForm} from '@angular/forms/signals';
+
+// 1. Existing legacy control with a specialized validator
+const passwordControl = new FormControl('', {
+  validators: [Validators.required, enterprisePasswordValidator()],
+  nonNullable: true,
+});
+
+// 2. Wrap it inside your form state signal
+const user = signal({
+  email: '',
+  password: passwordControl, // Nest the legacy control directly
+});
+
+// 3. Create the form
+const f = compatForm(user, {
+  injector: inject(Injector),
+});
+
+
+// Access values via the signal tree
+console.log(f.email().value()); // Current email value
+console.log(f.password().value()); // Current value of passwordControl
+
+// Reactive state is proxied automatically
+const isInvalid = f.password().valid();
+const passwordErrors = f.password().errors(); // Returns CompatValidationError if the legacy validator fails
+```
+
+In the template, use standard reactive syntax by binding the underlying control:
+
+```html
+
+<form>
+  <div>
+    <label>
+      Email:
+      <input [field]="f.email">
+    </label>
+
+    @if (f.email().touched() && f.email().invalid()) {
+    <div class="error-list">
+      <p>Email is required.</p>
+    </div>
+    }
+  </div>
+
+  <div>
+    <label>
+      Password:
+      <input [field]="f.password" type="password">
+    </label>
+
+    @if (f.password().touched() && f.password().invalid()) {
+    <div class="error-list">
+      @for (error of f.password().errors(); track error) {
+      <p>{{ error.message || error.kind }}</p>
+      }
+    </div>
+    }
+  </div>
+</form>
+```
+
+<docs-code-multifile preview path="adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts">
+  <docs-code header="app.ts" path="adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.ts"/>
+  <docs-code header="app.html" path="adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html"/>
+</docs-code-multifile>
+
+## Integrating a `FormGroup` into a signal form
+
+You can also wrap an entire `FormGroup`. This is common when a reusable sub-section of a form—such as an **Address Block
+**—is still managed by legacy Reactive Forms.
+
+```typescript
+import {signal, Injector, inject} from '@angular/core';
+import {FormGroup, FormControl, Validators} from '@angular/forms';
+import {compatForm} from '@angular/forms/signals';
+
+// 1. A legacy address group with its own validation logic
+const addressGroup = new FormGroup({
+  street: new FormControl('123 Angular Way', Validators.required),
+  city: new FormControl('Mountain View'),
+  zip: new FormControl('94043')
+});
+
+// 2. Wrap it inside a new Signal Form state
+const checkoutModel = signal({
+  customerName: 'Pirojok the Cat',
+  shippingAddress: addressGroup // The bridge handles the nesting
+});
+
+const f = compatForm(checkoutModel, {
+  injector: inject(Injector)
+});
+```
+
+The `shippingAddress` field acts as a branch in your Signal Form tree. You can bind these nested controls in your
+template by accessing the underlying legacy controls via `.control()`:
+
+```html
+<form>
+  <h3>Shipping Details</h3>
+
+  <div>
+    <label>
+      Customer Name:
+      <input [field]="f.customerName">
+    </label>
+
+    @if (f.customerName().touched() && f.customerName().invalid()) {
+      <div class="error-list">
+        <p>Customer name is required.</p>
+      </div>
+    }
+  </div>
+
+  <fieldset>
+    <legend>Address</legend>
+
+    @let street = f.shippingAddress().control().controls.street;
+    <div>
+      <label>
+        Street:
+        <input [formControl]="street">
+      </label>
+      @if (street.touched && street.invalid) {
+        <div class="error-list">
+          <p>Street is required</p>
+        </div>
+      }
+    </div>
+
+    @let city = f.shippingAddress().control().controls.city;
+    <div>
+      <label>
+        City:
+        <input [formControl]="city">
+      </label>
+      @if (city.touched && city.invalid) {
+         <div class="error-list">
+           <p>City is required</p>
+         </div>
+      }
+    </div>
+
+    @let zip = f.shippingAddress().control().controls.zip;
+    <div>
+      <label>
+        Zip Code:
+        <input [formControl]="zip">
+      </label>
+      @if (zip.touched && zip.invalid) {
+         <div class="error-list">
+           <p>Zip Code is required</p>
+         </div>
+      }
+    </div>
+  </fieldset>
+</form>
+```
+<docs-code-multifile preview path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts">
+  <docs-code header="app.ts" path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts"/>
+  <docs-code header="app.html" path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html"/>
+</docs-code-multifile>
+
+## Bottom-up migration
+This is coming soon.

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -103,7 +103,9 @@ const checkoutModel = signal({
   shippingAddress: addressGroup,
 });
 
-const f = compatForm(checkoutModel);
+const f = compatForm(checkoutModel, (p) => {
+  required(p.customerName);
+});
 ```
 
 The `shippingAddress` field acts as a branch in your Signal Form tree. You can bind these nested controls in your
@@ -208,7 +210,24 @@ This is coming soon.
 
 ## Automatic status classes
 
-To avoid manually adding classes like `.ng-valid`, `.ng-dirty` etc to every field, you can provide a global configuration using `provideSignalFormsConfig`. Signal Forms provides a built-in `NG_STATUS_CLASSES` preset that matches legacy Reactive Forms behavior.
+Reactive forms used to bind classes like `.ng-valid` or `.ng-dirty` to every field. Signal forms do not do that anymore.
+
+If you want this behavior you can provide an NG_STATUS_CLASSES preset that can be provided to match the Reactive Forms
+behavior:
+
+```typescript
+import {provideSignalFormsConfig} from '@angular/forms/signals';
+
+bootstrapApplication(App, {
+  providers: [
+    provideSignalFormsConfig({
+      classes: NG_STATUS_CLASSES,
+    }),
+  ],
+});
+```
+
+You can also provide your own custom configuration to apply whatever classes you wish based on you custom logic:
 
 ```typescript
 import {provideSignalFormsConfig} from '@angular/forms/signals';

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -8,19 +8,19 @@ legacy Reactive Forms.
 Sometimes you may want to use existing reactive `FormControl` instances within a Signal Form. This is useful for
 controls that involve:
 
-* Complex asynchronous logic.
-* Intricate RxJS operators that are not yet ported.
-* Integration with legacy third-party libraries.
+- Complex asynchronous logic.
+- Intricate RxJS operators that are not yet ported.
+- Integration with legacy third-party libraries.
 
 ### Integrating a `FormControl` into a signal form
 
 Consider an existing `passwordControl` that uses a specialized `enterprisePasswordValidator`. Instead of rewriting the
 validator, you can bridge the control into your signal state.
 
-First, define your legacy control:
+We can do it using `compatForm`
 
 ```typescript
-import {signal, Injector, inject} from '@angular/core';
+import {signal} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
 import {compatForm} from '@angular/forms/signals/compat';
 
@@ -37,10 +37,7 @@ const user = signal({
 });
 
 // 3. Create the form
-const f = compatForm(user, {
-  injector: inject(Injector),
-});
-
+const f = compatForm(user);
 
 // Access values via the signal tree
 console.log(f.email().value()); // Current email value
@@ -96,7 +93,7 @@ You can also wrap an entire `FormGroup`. This is common when a reusable sub-sect
 **—is still managed by legacy Reactive Forms.
 
 ```typescript
-import {signal, Injector, inject} from '@angular/core';
+import {signal} from '@angular/core';
 import {FormGroup, FormControl, Validators} from '@angular/forms';
 import {compatForm} from '@angular/forms/signals/compat';
 
@@ -104,18 +101,16 @@ import {compatForm} from '@angular/forms/signals/compat';
 const addressGroup = new FormGroup({
   street: new FormControl('123 Angular Way', Validators.required),
   city: new FormControl('Mountain View', Validators.required),
-  zip: new FormControl('94043', Validators.required)
+  zip: new FormControl('94043', Validators.required),
 });
 
-// 2. Wrap it inside a new Signal Form state
+// 2. Include it in the state like it's a value
 const checkoutModel = signal({
   customerName: 'Pirojok the Cat',
-  shippingAddress: addressGroup // The bridge handles the nesting
+  shippingAddress: addressGroup,
 });
 
-const f = compatForm(checkoutModel, {
-  injector: inject(Injector)
-});
+const f = compatForm(checkoutModel);
 ```
 
 The `shippingAddress` field acts as a branch in your Signal Form tree. You can bind these nested controls in your
@@ -191,6 +186,7 @@ template by accessing the underlying legacy controls via `.control()`:
 ### Accessing values
 
 While `compatForm` proxies value access on the `FormControl` level, full form value would preserve the control:
+
 ```typescript
 const passwordControl = new FormControl('password' /** ... */);
 
@@ -199,17 +195,17 @@ const user = signal({
   password: passwordControl, // Nest the legacy control directly
 });
 
-user.password().value() // 'password'
-user().value() // { email: '', password: FormControl}
-
+const form = compatForm(user);
+form.password().value(); // 'password'
+form().value(); // { email: '', password: FormControl}
 ```
 
 If you need the whole form value, you'd have to build it manually:
 
 ```typescript
 const formValue = computed(() => ({
-  email: f.email().value(),
-  password: f.password().value,
+  email: form.email().value(),
+  password: form.password().value(),
 })); // {email: '', password: ''}
 ```
 

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -22,7 +22,7 @@ First, define your legacy control:
 ```typescript
 import {signal, Injector, inject} from '@angular/core';
 import {FormControl, Validators} from '@angular/forms';
-import {compatForm} from '@angular/forms/signals';
+import {compatForm} from '@angular/forms/signals/compat';
 
 // 1. Existing legacy control with a specialized validator
 const passwordControl = new FormControl('', {
@@ -53,8 +53,7 @@ const passwordErrors = f.password().errors(); // Returns CompatValidationError i
 
 In the template, use standard reactive syntax by binding the underlying control:
 
-```html
-
+```angular-html
 <form>
   <div>
     <label>
@@ -99,13 +98,13 @@ You can also wrap an entire `FormGroup`. This is common when a reusable sub-sect
 ```typescript
 import {signal, Injector, inject} from '@angular/core';
 import {FormGroup, FormControl, Validators} from '@angular/forms';
-import {compatForm} from '@angular/forms/signals';
+import {compatForm} from '@angular/forms/signals/compat';
 
 // 1. A legacy address group with its own validation logic
 const addressGroup = new FormGroup({
   street: new FormControl('123 Angular Way', Validators.required),
-  city: new FormControl('Mountain View'),
-  zip: new FormControl('94043')
+  city: new FormControl('Mountain View', Validators.required),
+  zip: new FormControl('94043', Validators.required)
 });
 
 // 2. Wrap it inside a new Signal Form state
@@ -122,7 +121,7 @@ const f = compatForm(checkoutModel, {
 The `shippingAddress` field acts as a branch in your Signal Form tree. You can bind these nested controls in your
 template by accessing the underlying legacy controls via `.control()`:
 
-```html
+```angular-html
 <form>
   <h3>Shipping Details</h3>
 

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -90,7 +90,7 @@ In the template, use standard reactive syntax by binding the underlying control:
   <docs-code header="app.html" path="adev/src/content/examples/signal-forms/src/compat-form-control-integration/app/app.html"/>
 </docs-code-multifile>
 
-## Integrating a `FormGroup` into a signal form
+### Integrating a `FormGroup` into a signal form
 
 You can also wrap an entire `FormGroup`. This is common when a reusable sub-section of a form—such as an **Address Block
 **—is still managed by legacy Reactive Forms.
@@ -182,10 +182,37 @@ template by accessing the underlying legacy controls via `.control()`:
   </fieldset>
 </form>
 ```
+
 <docs-code-multifile preview path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts">
   <docs-code header="app.ts" path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.ts"/>
   <docs-code header="app.html" path="adev/src/content/examples/signal-forms/src/compat-form-group-integration/app/app.html"/>
 </docs-code-multifile>
 
+### Accessing values
+
+While `compatForm` proxies value access on the `FormControl` level, full form value would preserve the control:
+```typescript
+const passwordControl = new FormControl('password' /** ... */);
+
+const user = signal({
+  email: '',
+  password: passwordControl, // Nest the legacy control directly
+});
+
+user.password().value() // 'password'
+user().value() // { email: '', password: FormControl}
+
+```
+
+If you need the whole form value, you'd have to build it manually:
+
+```typescript
+const formValue = computed(() => ({
+  email: f.email().value(),
+  password: f.password().value,
+})); // {email: '', password: ''}
+```
+
 ## Bottom-up migration
+
 This is coming soon.

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -210,13 +210,12 @@ This is coming soon.
 
 ## Automatic status classes
 
-Reactive forms used to bind classes like `.ng-valid` or `.ng-dirty` to every field. Signal forms do not do that anymore.
+Reactive/Template Forms automatically adds [class attributes](https://angular.dev/guide/forms/template-driven-forms#track-control-states) (such as `.ng-valid` or `.ng-dirty`) to facilitate styling control states. Signal Forms does not do that.
 
-If you want this behavior you can provide an NG_STATUS_CLASSES preset that can be provided to match the Reactive Forms
-behavior:
+If you want to preserve this behavior, you can provide the `NG_STATUS_CLASSES` preset:
 
 ```typescript
-import {provideSignalFormsConfig} from '@angular/forms/signals';
+import {NG_STATUS_CLASSES, provideSignalFormsConfig} from '@angular/forms/signals';
 
 bootstrapApplication(App, {
   providers: [


### PR DESCRIPTION
A new guide for migrating from legacy forms (Reactive and Template-driven) to the new Signal Forms.
