### PR TITLE
Revert "fix(core): explicitly cast signal node value to String"

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -84,7 +84,7 @@ export function createComputed<T>(
   (computed as ComputedGetter<T>)[SIGNAL] = node;
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
-    computed.toString = () => `[Computed${debugName}: ${String(node.value)}]`;
+    computed.toString = () => `[Computed${debugName}: ${node.value}]`;
   }
 
   runPostProducerCreatedFn(node);

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -94,7 +94,7 @@ export function createLinkedSignal<S, D>(
   getter[SIGNAL] = node;
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
-    getter.toString = () => `[LinkedSignal${debugName}: ${String(node.value)}]`;
+    getter.toString = () => `[LinkedSignal${debugName}: ${node.value}]`;
   }
 
   runPostProducerCreatedFn(node);

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -63,7 +63,7 @@ export function createSignal<T>(
   (getter as any)[SIGNAL] = node;
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     const debugName = node.debugName ? ' (' + node.debugName + ')' : '';
-    getter.toString = () => `[Signal${debugName}: ${String(node.value)}]`;
+    getter.toString = () => `[Signal${debugName}: ${node.value}]`;
   }
 
   runPostProducerCreatedFn(node);


### PR DESCRIPTION
This reverts commit c501b25d041488b9da262be52baeee19e41100e1.

Revert reason: not fully "green" TGP.