### PR TITLE
docs: fix incorrect line highlighting in tutorials

### DIFF
--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -31,7 +31,7 @@ import { NgOptimizedImage } from '@angular/common';
 
 To enable the `NgOptimizedImage` directive, swap out the `src` attribute for `ngSrc`. This applies for both static image sources (i.e., `src`) and dynamic image sources (i.e., `[src]`).
 
-```angular-ts {highlight:[[9],[13]]}
+```angular-ts {highlight:[[7],[11]]}
 import { NgOptimizedImage } from '@angular/common';
 
 @Component({

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
@@ -31,7 +31,7 @@ For this form to use Angular features that enable data binding to forms, you'll 
 
 Import the `FormsModule` from `@angular/forms` and add it to the `imports` array of the `User`.
 
-```ts {highlight:[2,7]}
+```ts {highlight:[2,6]}
 import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 


### PR DESCRIPTION
Ensures highlighted lines in tutorial examples match the corresponding code shown to readers.

## What is the current behavior?

<img width="903" height="763" alt="image" src="https://github.com/user-attachments/assets/295afd24-28af-4247-b5cf-e561d79d1e59" />

<img width="898" height="721" alt="image" src="https://github.com/user-attachments/assets/9f49713d-f8c9-4db6-bf61-7f05a4629da3" />
