### PR TITLE
fix(core): use mutable ResponseInit type for RESPONSE_INIT token

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1679,7 +1679,13 @@ export type ResourceStreamItem<T> = {
 };
 
 // @public
-export const RESPONSE_INIT: InjectionToken<ResponseInit | null>;
+export const RESPONSE_INIT: InjectionToken<ResponseInit_2 | null>;
+
+// @public
+type ResponseInit_2 = {
+    -readonly [P in keyof globalThis.ResponseInit]: globalThis.ResponseInit[P];
+};
+export { ResponseInit_2 as ResponseInit }
 
 // @public
 export function runInInjectionContext<ReturnT>(injector: Injector, fn: () => ReturnT): ReturnT;

--- a/packages/core/src/application/platform_tokens.ts
+++ b/packages/core/src/application/platform_tokens.ts
@@ -37,6 +37,16 @@ export const REQUEST = new InjectionToken<Request | null>(
 );
 
 /**
+ * Type that represents the initialization options for a response.
+ *
+ * @publicApi
+ */
+export type ResponseInit = {
+  // This is needed as `@types/node` and Undici marks all these properties as readonly. This is not the case in lib.dom.d.ts
+  -readonly [P in keyof globalThis.ResponseInit]: globalThis.ResponseInit[P];
+};
+
+/**
  * Injection token for response initialization options.
  *
  * Use this token to provide response options for configuring or initializing

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -116,7 +116,7 @@ export {Binding, inputBinding, outputBinding, twoWayBinding} from './render3/dyn
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';
-export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT} from './application/platform_tokens';
+export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT, ResponseInit} from './application/platform_tokens';
 export {DOCUMENT} from './document';
 export {provideNgReflectAttributes} from './ng_reflect';
 export {


### PR DESCRIPTION
The `RESPONSE_INIT` token previously used `ResponseInit`. However, `@types/node` (and `undici`) definitions for `ResponseInit` mark properties as `readonly`, which differs from the standard DOM `ResponseInit`.

This commit introduces a `ResponseInit` type that explicitly removes `readonly` modifiers to ensure compatibility and allow for mutable options. This type is now used by the `RESPONSE_INIT` token and is exported from `@angular/core`.


Example: https://github.com/angular/angular-cli/pull/32147/