### PR TITLE
fix(migrations): inject migration not work in multi-project workspace…

### DIFF
--- a/packages/core/schematics/ng-generate/inject-migration/index.ts
+++ b/packages/core/schematics/ng-generate/inject-migration/index.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {join, relative} from 'path';
+import ts from 'typescript';
 
 import {normalizePath} from '../../utils/change_tracker';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
@@ -21,49 +22,54 @@ interface Options extends MigrationOptions {
 }
 
 export function migrate(options: Options): Rule {
-  return async (tree: Tree) => {
-    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+  return async (tree: Tree, context: SchematicContext) => {
     const basePath = process.cwd();
-    const allPaths = [...buildPaths, ...testPaths];
-    const pathToMigrate = normalizePath(join(basePath, options.path));
-
-    if (!allPaths.length) {
-      throw new SchematicsException(
-        'Could not find any tsconfig file. Cannot run the inject migration.',
-      );
+    let pathToMigrate: string | undefined;
+    if (options.path) {
+      if (options.path.startsWith('..')) {
+        throw new SchematicsException(
+          'Cannot run inject migration outside of the current project.',
+        );
+      }
+      pathToMigrate = normalizePath(join(basePath, options.path));
     }
 
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      context.logger.warn('Could not find any tsconfig file. Cannot run the inject migration.');
+      return;
+    }
+
+    let sourceFilesCount = 0;
+
     for (const tsconfigPath of allPaths) {
-      runInjectMigration(tree, tsconfigPath, basePath, pathToMigrate, options);
+      const program = createMigrationProgram(tree, tsconfigPath, basePath);
+      const sourceFiles = program
+        .getSourceFiles()
+        .filter(
+          (sourceFile) =>
+            (pathToMigrate ? sourceFile.fileName.startsWith(pathToMigrate) : true) &&
+            canMigrateFile(basePath, sourceFile, program),
+        );
+
+      sourceFilesCount += runInjectMigration(tree, sourceFiles, basePath, options);
+    }
+
+    if (sourceFilesCount === 0) {
+      context.logger.warn('Inject migration did not find any files to migrate');
     }
   };
 }
 
 function runInjectMigration(
   tree: Tree,
-  tsconfigPath: string,
+  sourceFiles: ts.SourceFile[],
   basePath: string,
-  pathToMigrate: string,
   schematicOptions: Options,
-): void {
-  if (schematicOptions.path.startsWith('..')) {
-    throw new SchematicsException('Cannot run inject migration outside of the current project.');
-  }
-
-  const program = createMigrationProgram(tree, tsconfigPath, basePath);
-  const sourceFiles = program
-    .getSourceFiles()
-    .filter(
-      (sourceFile) =>
-        sourceFile.fileName.startsWith(pathToMigrate) &&
-        canMigrateFile(basePath, sourceFile, program),
-    );
-
-  if (sourceFiles.length === 0) {
-    throw new SchematicsException(
-      `Could not find any files to migrate under the path ${pathToMigrate}. Cannot run the inject migration.`,
-    );
-  }
+): number {
+  let migratedFiles = 0;
 
   for (const sourceFile of sourceFiles) {
     const changes = migrateFile(sourceFile, schematicOptions);
@@ -79,6 +85,8 @@ function runInjectMigration(
       }
 
       tree.commitUpdate(update);
+      migratedFiles++;
     }
   }
+  return migratedFiles;
 }

--- a/packages/core/schematics/test/inject_migration_spec.ts
+++ b/packages/core/schematics/test/inject_migration_spec.ts
@@ -411,6 +411,76 @@ describe('inject migration', () => {
     ]);
   });
 
+  it('should migrate files present in other workspace projects', async () => {
+    writeFile('/tsconfig.json', '{}');
+
+    // Multiple projects...
+    writeFile(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}},
+          lib: {root: 'lib', architect: {build: {options: {tsConfig: './lib/tsconfig.json'}}}},
+        },
+      }),
+    );
+
+    // The lib tsconfig includes only its own folder so the second program does see the file.
+    writeFile('/lib/tsconfig.json', JSON.stringify({include: ['**/*.ts']}));
+
+    // File that should be migrated exists only under the second project's folder.
+    writeFile(
+      '/lib/should-migrate/dir.ts',
+      [
+        `import { Directive } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class MyDir {`,
+        `  constructor(private foo: Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    // Unrelated file outside the specified path should remain unchanged.
+    writeFile(
+      '/other.ts',
+      [
+        `import { Directive } from '@angular/core';`,
+        `import { Foo } from 'foo';`,
+        ``,
+        `@Directive()`,
+        `class Other {`,
+        `  constructor(private foo: Foo) {}`,
+        `}`,
+      ].join('\n'),
+    );
+
+    // Files should be migrated under the path
+    await runMigration({path: 'lib/should-migrate'});
+
+    expect(tree.readContent('/lib/should-migrate/dir.ts').split('\n')).toEqual([
+      `import { Directive, inject } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class MyDir {`,
+      `  private foo = inject(Foo);`,
+      `}`,
+    ]);
+
+    expect(tree.readContent('/other.ts').split('\n')).toEqual([
+      `import { Directive } from '@angular/core';`,
+      `import { Foo } from 'foo';`,
+      ``,
+      `@Directive()`,
+      `class Other {`,
+      `  constructor(private foo: Foo) {}`,
+      `}`,
+    ]);
+  });
+
   it('should only migrate the specified file', async () => {
     writeFile(
       '/dir.ts',


### PR DESCRIPTION
Fix inject migration in multi-project workspace. The inject migration doesn't work when targeting one of the projects due to either not finding any files in other projects or considering them external thus it throws a SchematicsException

Fixes: #66074

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

Issue Number: #66074

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
