### PR TITLE
docs(docs-infra): sync heading colors between docs and API pages

### DIFF
--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -80,6 +80,10 @@
     h4,
     h5,
     h6 {
+      .docs-anchor {
+        color: inherit;
+      }
+
       // Show copy link button when hovering the heading
       &:hover docs-copy-link-button {
         opacity: 1;


### PR DESCRIPTION
Aligns documentation heading colors across docs and API pages to ensure visual consistency and a cohesive reading experience.

## What is the current behavior?
<img width="908" height="318" alt="image" src="https://github.com/user-attachments/assets/5ca4d74b-02fa-4a7e-8b81-a60c1d411723" />

## What is the new behavior?
<img width="690" height="224" alt="image" src="https://github.com/user-attachments/assets/b15a78d5-c0d3-4b08-b598-7c99ae69ebdf" />

