### PR TITLE
dev-infra: enable markdown formatting in ng-dev

### DIFF
--- a/.ng-dev/format.mjs
+++ b/.ng-dev/format.mjs
@@ -4,6 +4,14 @@
  * @type { import("@angular/ng-dev").FormatConfig }
  */
 export const format = {
-  'prettier': true,
+  'prettier': {
+    'matchers': [
+      '**/*.{js,cjs,mjs}',
+      '**/*.{ts,cts,mts}',
+      '**/*.{json,json5}',
+      '**/*.{yml,yaml}',
+      '**/*.md',
+    ],
+  },
   'buildifier': true,
 };


### PR DESCRIPTION
Lint on a PR was complaining that formatting was broken for my .md file, but when I ran suggested command, I got a `No files matched for formatting.`.

```
  pnpm ng-dev format files adev/src/content/guide/forms/signals/migration.md


> angular-srcs@21.1.0-next.3 ng-dev /Users/kirjs/code/angular
> tsx --tsconfig .ng-dev/tsconfig.json node_modules/@angular/ng-dev/bundles/cli.mjs format files adev/src/content/guide/forms/signals/migration.md

(node:93480) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
No files matched for formatting.

```

Gemini suggested this PR to fix it (it worked for my case)