### PR TITLE
refactor(core): Use the provided Document value rather than global in FakeNavigation

### DIFF
--- a/packages/common/testing/src/mock_platform_location.ts
+++ b/packages/common/testing/src/mock_platform_location.ts
@@ -302,14 +302,15 @@ export class FakeNavigationPlatformLocation implements PlatformLocation {
     return this.config?.appBaseHref ?? '';
   }
 
+  // window, addEventListener, removeEventListener might be undefined due to test mocks
   onPopState(fn: LocationChangeListener): VoidFunction {
-    this._platformNavigation.window.addEventListener('popstate', fn);
-    return () => this._platformNavigation.window.removeEventListener('popstate', fn);
+    this._platformNavigation.window?.addEventListener?.('popstate', fn);
+    return () => this._platformNavigation.window?.removeEventListener?.('popstate', fn);
   }
 
   onHashChange(fn: LocationChangeListener): VoidFunction {
-    this._platformNavigation.window.addEventListener('hashchange', fn as any);
-    return () => this._platformNavigation.window.removeEventListener('hashchange', fn as any);
+    this._platformNavigation.window?.addEventListener?.('hashchange', fn as any);
+    return () => this._platformNavigation.window?.removeEventListener?.('hashchange', fn as any);
   }
 
   get href(): string {

--- a/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
+++ b/packages/core/primitives/dom-navigation/testing/fake_navigation.ts
@@ -125,7 +125,7 @@ export class FakeNavigation implements Navigation {
         return new EventTarget();
       }
     };
-    this._window = document.defaultView ?? this.createEventTarget();
+    this._window = doc.defaultView ?? this.createEventTarget();
     this.eventTarget = this.createEventTarget();
     // First entry.
     this.setInitialEntryForTesting(startURL);


### PR DESCRIPTION
This commit ensures the Document used by `FakeNavigation` is the one passed in the constructor rather than the global `document`, which may be different.
