### PR TITLE
docs(docs-infra): Fixed missing rendering backticks in Error encyclop…

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -17,10 +17,10 @@
               <a
                 [href]="item.path"
                 target="_blank"
-                [matTooltip]="item.label"
+                [matTooltip]="item.label | removeHtmlTags"
                 [matTooltipDisabled]="itemLabel.length < 27"
                 matTooltipPosition="after"
-                [attr.aria-label]="item.label"
+                [attr.aria-label]="item.label | removeHtmlTags"
                 [matTooltipClass]="'API-tooltip'"
               >
                 <span
@@ -46,14 +46,14 @@
                   fragment: 'ignored',
                 }"
                 (click)="emitClickOnLink()"
-                [matTooltip]="item.label"
+                [matTooltip]="item.label | removeHtmlTags"
                 [matTooltipDisabled]="itemLabel.length < 27"
                 matTooltipPosition="after"
-                [attr.aria-label]="item.label"
+                [attr.aria-label]="item.label | removeHtmlTags"
                 [matTooltipClass]="'API-tooltip'"
               >
                 <span class="docs-faceted-list-item-text">
-                  {{ item.label }}
+                  <span [innerHTML]="item.label"></span>
                   <ng-container *ngTemplateOutlet="itemStatus; context: {$implicit: item}" />
                 </span>
 
@@ -67,14 +67,14 @@
             @if (item.level !== collapsableLevel() && item.level !== expandableLevel()) {
               <div
                 class="docs-secondary-nav-header"
-                [matTooltip]="item.label"
+                [matTooltip]="item.label | removeHtmlTags"
                 [matTooltipDisabled]="itemLabel.length < 27"
                 matTooltipPosition="after"
-                [attr.aria-label]="item.label"
+                [attr.aria-label]="item.label | removeHtmlTags"
                 [matTooltipClass]="'API-tooltip'"
               >
                 <span class="docs-faceted-list-item-text">
-                  {{ item.label }}
+                  <span [innerHTML]="item.label"></span>
                   <ng-container *ngTemplateOutlet="itemStatus; context: {$implicit: item}" />
                 </span>
               </div>
@@ -88,7 +88,9 @@
               <button
                 type="button"
                 (click)="toggle(item)"
-                [attr.aria-label]="(item.isExpanded ? 'Collapse' : 'Expand') + ' ' + item.label"
+                [attr.aria-label]="
+                  (item.isExpanded ? 'Collapse' : 'Expand') + ' ' + (item.label | removeHtmlTags)
+                "
                 [attr.aria-expanded]="item.isExpanded"
                 class="docs-secondary-nav-button"
                 [class.docs-faceted-list-item-active]="item | isActiveNavigationItem: activeItem()"
@@ -97,17 +99,16 @@
                 [class.docs-nav-item-has-icon]="
                   item.children && item.level === expandableLevel() && !item.isExpanded
                 "
-                [matTooltip]="item.label"
+                [matTooltip]="item.label | removeHtmlTags"
                 [matTooltipDisabled]="itemLabel.length < 27"
                 matTooltipPosition="after"
-                [attr.aria-label]="item.label"
                 [matTooltipClass]="'API-tooltip'"
               >
                 @if (item.children && item.level === collapsableLevel()) {
                   <docs-icon>arrow_back</docs-icon>
                 }
                 <span class="docs-faceted-list-item-text">
-                  {{ item.label }}
+                  <span [innerHTML]="item.label"></span>
                   <ng-container *ngTemplateOutlet="itemStatus; context: {$implicit: item}" />
                 </span>
               </button>

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -11,7 +11,7 @@ import {NavigationItem} from '../../interfaces/index';
 import {NavigationState} from '../../services/index';
 import {RouterLink, RouterLinkActive} from '@angular/router';
 import {IconComponent} from '../icon/icon.component';
-import {IsActiveNavigationItem} from '../../pipes';
+import {IsActiveNavigationItem, RemoveHtmlTags} from '../../pipes';
 import {NgTemplateOutlet, TitleCasePipe} from '@angular/common';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {ReactiveFormsModule} from '@angular/forms';
@@ -27,6 +27,7 @@ import {ReactiveFormsModule} from '@angular/forms';
     MatTooltipModule,
     ReactiveFormsModule,
     TitleCasePipe,
+    RemoveHtmlTags,
   ],
   templateUrl: './navigation-list.component.html',
   styleUrls: ['./navigation-list.component.scss'],

--- a/adev/shared-docs/pipeline/navigation/strategies.mts
+++ b/adev/shared-docs/pipeline/navigation/strategies.mts
@@ -40,7 +40,7 @@ function errorsStrategy(packageDir: string): NavigationItemGenerationStrategy {
   return {
     pathPrefix: 'errors',
     contentPath: packageDir.replace(CONTENT_FOLDER_PATH, ''),
-    labelGeneratorFn: (fileName, firstLine) => fileName + ': ' + firstLine,
+    labelGeneratorFn: (fileName, firstLine) => fileName + ': ' + convertBackticksToCode(firstLine),
   };
 }
 
@@ -49,6 +49,10 @@ function extendedDiagnosticsStrategy(packageDir: string): NavigationItemGenerati
   return {
     pathPrefix: 'extended-diagnostics',
     contentPath: packageDir.replace(CONTENT_FOLDER_PATH, ''),
-    labelGeneratorFn: (fileName, firstLine) => fileName + ': ' + firstLine,
+    labelGeneratorFn: (fileName, firstLine) => fileName + ': ' + convertBackticksToCode(firstLine),
   };
+}
+
+function convertBackticksToCode(text: string): string {
+  return text.replace(/`([^`]+)`/g, '<code>$1</code>');
 }

--- a/adev/shared-docs/pipes/index.ts
+++ b/adev/shared-docs/pipes/index.ts
@@ -8,3 +8,4 @@
 
 export * from './is-active-navigation-item.pipe';
 export * from './relative-link.pipe';
+export * from './remove-html-tags.pipe';

--- a/adev/shared-docs/pipes/remove-html-tags.pipe.spec.ts
+++ b/adev/shared-docs/pipes/remove-html-tags.pipe.spec.ts
@@ -1,0 +1,44 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {RemoveHtmlTags} from './remove-html-tags.pipe';
+
+describe('RemoveHtmlTags', () => {
+  let pipe: RemoveHtmlTags;
+
+  beforeEach(() => {
+    pipe = new RemoveHtmlTags();
+  });
+
+  it('should remove code tags from text', () => {
+    const input = 'NG0203: <code>inject()</code> must be called from an injection context';
+    expect(pipe.transform(input)).toBe('NG0203: inject() must be called from an injection context');
+  });
+
+  it('should remove multiple HTML tags', () => {
+    const input = '<strong>Bold</strong> and <em>italic</em>';
+    expect(pipe.transform(input)).toBe('Bold and italic');
+  });
+
+  it('should handle text without HTML tags', () => {
+    const input = 'Plain text without tags';
+    expect(pipe.transform(input)).toBe('Plain text without tags');
+  });
+
+  it('should return empty string for null', () => {
+    expect(pipe.transform(null)).toBe('');
+  });
+
+  it('should return empty string for undefined', () => {
+    expect(pipe.transform(undefined)).toBe('');
+  });
+
+  it('should return empty string for empty string', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+});

--- a/adev/shared-docs/pipes/remove-html-tags.pipe.ts
+++ b/adev/shared-docs/pipes/remove-html-tags.pipe.ts
@@ -1,0 +1,21 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({
+  name: 'removeHtmlTags',
+})
+export class RemoveHtmlTags implements PipeTransform {
+  transform(value: string | undefined | null): string {
+    if (!value) {
+      return '';
+    }
+    return value.replace(/<[^>]*>/g, '');
+  }
+}


### PR DESCRIPTION
…edia and reference to render code tag

Ensures that backticks in error encyclopedia and extended diagnostics messages are rendered as `<code>` tags. Also, it introduces a pipe to remove HTML tags from navigation labels to prevent rendering issues and improve accessibility for tooltips and aria labels.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<img width="396" height="1035" alt="image" src="https://github.com/user-attachments/assets/0e258110-a32d-4824-bd3c-614416f89fd9" />


## What is the new behavior?

<img width="373" height="1015" alt="image" src="https://github.com/user-attachments/assets/e2e6763f-b5f5-4041-96c7-1e676610bee8" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
