### PR TITLE
refactor(forms): rename server errors to submission errors

### DIFF
--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -330,10 +330,10 @@ export function applyWhenValue(
 }
 
 /**
- * Submits a given `FieldTree` using the given action function and applies any server errors
- * resulting from the action to the field. Server errors returned by the `action` will be integrated
+ * Submits a given `FieldTree` using the given action function and applies any submission errors
+ * resulting from the action to the field. Submission errors returned by the `action` will be integrated
  * into the field as a `ValidationError` on the sub-field indicated by the `field` property of the
- * server error.
+ * submission error.
  *
  * @example
  * ```ts
@@ -356,7 +356,7 @@ export function applyWhenValue(
  * ```
  *
  * @param form The field to submit.
- * @param action An asynchronous action used to submit the field. The action may return server
+ * @param action An asynchronous action used to submit the field. The action may return submission
  * errors.
  * @template TModel The data type of the field being submitted.
  *
@@ -378,19 +378,19 @@ export async function submit<TModel>(
   node.submitState.selfSubmitting.set(true);
   try {
     const errors = await action(form);
-    errors && setServerErrors(node, errors);
+    errors && setSubmissionErrors(node, errors);
   } finally {
     node.submitState.selfSubmitting.set(false);
   }
 }
 
 /**
- * Sets a list of server errors to their individual fields.
+ * Sets a list of submission errors to their individual fields.
  *
  * @param submittedField The field that was submitted, resulting in the errors.
  * @param errors The errors to set.
  */
-function setServerErrors(
+function setSubmissionErrors(
   submittedField: FieldNode,
   errors: OneOrMany<ValidationError.WithOptionalField>,
 ) {
@@ -409,7 +409,7 @@ function setServerErrors(
     fieldErrors.push(errorWithField);
   }
   for (const [field, fieldErrors] of errorsByField) {
-    field.submitState.serverErrors.set(fieldErrors);
+    field.submitState.submissionErrors.set(fieldErrors);
   }
 }
 

--- a/packages/forms/signals/src/field/submit.ts
+++ b/packages/forms/signals/src/field/submit.ts
@@ -20,11 +20,11 @@ export class FieldSubmitState {
    */
   readonly selfSubmitting = signal<boolean>(false);
 
-  /** Server errors that are associated with this field. */
-  readonly serverErrors: WritableSignal<readonly ValidationError.WithField[]>;
+  /** Submission errors that are associated with this field. */
+  readonly submissionErrors: WritableSignal<readonly ValidationError.WithField[]>;
 
   constructor(private readonly node: FieldNode) {
-    this.serverErrors = linkedSignal({
+    this.submissionErrors = linkedSignal({
       source: this.node.structure.value,
       computation: () => [] as readonly ValidationError.WithField[],
     });

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -38,8 +38,8 @@ export interface ValidationState {
   rawSyncTreeErrors: Signal<ValidationError.WithField[]>;
 
   /**
-   * The full set of synchronous errors for this field, including synchronous tree errors and server
-   * errors. Server errors are considered "synchronous" because they are imperatively added. From
+   * The full set of synchronous errors for this field, including synchronous tree errors and submission
+   * errors. Submission errors are considered "synchronous" because they are imperatively added. From
    * the perspective of the field state they are either there or not, they are never in a pending
    * state.
    */
@@ -163,10 +163,10 @@ export class FieldValidationState implements ValidationState {
   });
 
   /**
-   * The full set of synchronous errors for this field, including synchronous tree errors and server
-   * errors. Server errors are considered "synchronous" because they are imperatively added. From
-   * the perspective of the field state they are either there or not, they are never in a pending
-   * state.
+   * The full set of synchronous errors for this field, including synchronous tree errors and
+   * submission errors. Submission errors are considered "synchronous" because they are imperatively
+   * added. From the perspective of the field state they are either there or not, they are never in a
+   * pending state.
    */
   readonly syncErrors: Signal<ValidationError.WithField[]> = computed(() => {
     // Short-circuit running validators if validation doesn't apply to this field.
@@ -177,7 +177,7 @@ export class FieldValidationState implements ValidationState {
     return [
       ...this.node.logicNode.logic.syncErrors.compute(this.node.context),
       ...this.syncTreeErrors(),
-      ...normalizeErrors(this.node.submitState.serverErrors()),
+      ...normalizeErrors(this.node.submitState.submissionErrors()),
     ];
   });
 


### PR DESCRIPTION
This better reflects the intent to indicate an error during submission, regardless of whether the error came from the server or not.
