### PR TITLE
docs(docs-infra): adjust z-index to prevent adev tutorial nav overlap…

### DIFF
--- a/adev/shared-docs/styles/_z-index.scss
+++ b/adev/shared-docs/styles/_z-index.scss
@@ -3,6 +3,7 @@
   --z-index-top-level-banner: 150;
   --z-index-nav: 100;
   --z-index-cookie-consent: 200;
+  --z-index-nav-tutorial: 75;
   --z-index-content: 50;
   --z-index-icon: 10;
 }

--- a/adev/src/app/features/tutorial/tutorial-navigation.scss
+++ b/adev/src/app/features/tutorial/tutorial-navigation.scss
@@ -58,7 +58,7 @@
   padding-block-end: calc(1.5rem + 50px);
   margin-block-end: 1rem;
   border-block-end: 1px solid var(--septenary-contrast);
-  z-index: var(--z-index-nav);
+  z-index: var(--z-index-nav-tutorial);
   transition: background-color 0.3s ease;
   container: nav-container / inline-size;
 


### PR DESCRIPTION
…ping sidebar

Updated the z-index hierarchy to avoid the adev tutorial navigation bar overlapping the main sidebar.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
https://angular.dev/tutorials/learn-angular
<img width="434" height="804" alt="image" src="https://github.com/user-attachments/assets/d35f7341-1e9d-4368-8dd8-5b6ec406e53e" />

 

## What is the new behavior?
<img width="571" height="857" alt="image" src="https://github.com/user-attachments/assets/197e89d2-6722-4390-9e2d-290efd3adb47" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
