### PR TITLE
fix(compiler): provide location information for literal map keys

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -218,11 +218,13 @@ export class LiteralArray extends AST {
   }
 }
 
-export type LiteralMapKey = {
+export interface LiteralMapKey {
   key: string;
   quoted: boolean;
+  span: ParseSpan;
+  sourceSpan: AbsoluteSourceSpan;
   isShorthandInitialized?: boolean;
-};
+}
 
 export class LiteralMap extends AST {
   constructor(

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1197,7 +1197,14 @@ class _ParseAST {
         const keyStart = this.inputIndex;
         const quoted = this.next.isString();
         const key = this.expectIdentifierOrKeywordOrString();
-        const literalMapKey: LiteralMapKey = {key, quoted};
+        const keySpan = this.span(keyStart);
+        const keySourceSpan = this.sourceSpan(keyStart);
+        const literalMapKey: LiteralMapKey = {
+          key,
+          quoted,
+          span: keySpan,
+          sourceSpan: keySourceSpan,
+        };
         keys.push(literalMapKey);
 
         // Properties with quoted keys can't use the shorthand syntax.
@@ -1209,14 +1216,12 @@ class _ParseAST {
         } else {
           literalMapKey.isShorthandInitialized = true;
 
-          const span = this.span(keyStart);
-          const sourceSpan = this.sourceSpan(keyStart);
           values.push(
             new PropertyRead(
-              span,
-              sourceSpan,
-              sourceSpan,
-              new ImplicitReceiver(span, sourceSpan),
+              keySpan,
+              keySourceSpan,
+              keySourceSpan,
+              new ImplicitReceiver(keySpan, keySourceSpan),
               key,
             ),
           );

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -18,6 +18,7 @@ import {
   TemplateBinding,
   VariableBinding,
   BindingPipeType,
+  ParseSpan,
 } from '../../src/expression_parser/ast';
 import {ParseError} from '../../src/parse_util';
 import {Lexer} from '../../src/expression_parser/lexer';
@@ -732,6 +733,17 @@ describe('parser', () => {
         '/^http:\\/\\/foo\\.bar/gim',
         '/^http:\\/\\/foo\\.bar/gim',
       ]);
+    });
+
+    it('should record span for literal map keys', () => {
+      const ast = parseBinding('{one: 1, two: "the number two", three, "four": 4}');
+      const literal = ast.ast as LiteralMap;
+      const getSource = (span: ParseSpan) => ast.source?.substring(span.start, span.end);
+
+      expect(getSource(literal.keys[0].span)).toBe('one');
+      expect(getSource(literal.keys[1].span)).toBe('two');
+      expect(getSource(literal.keys[2].span)).toBe('three');
+      expect(getSource(literal.keys[3].span)).toBe('"four"');
     });
   });
 


### PR DESCRIPTION
Adds spans for the keys of a `LiteralMap`.

Fixes #66175.
