### PR TITLE
refactor(router): Retain original navigateEvent across redirects

### DIFF
--- a/packages/common/src/navigation/platform_navigation.ts
+++ b/packages/common/src/navigation/platform_navigation.ts
@@ -8,6 +8,7 @@
 
 import {
   Injectable,
+  InjectionToken,
   ɵNavigateEvent as NavigateEvent,
   ɵNavigation as Navigation,
   ɵNavigationCurrentEntryChangeEvent as NavigationCurrentEntryChangeEvent,
@@ -19,6 +20,19 @@ import {
   ɵNavigationTransition as NavigationTransition,
   ɵNavigationUpdateCurrentEntryOptions as NavigationUpdateCurrentEntryOptions,
 } from '@angular/core';
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NavigationPrecommitController
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent/intercept#precommithandler
+ */
+export const PRECOMMIT_HANDLER_SUPPORTED = new InjectionToken<boolean>('', {
+  factory: () => {
+    return (
+      typeof window !== 'undefined' &&
+      typeof (window as any).NavigationPrecommitController !== 'undefined'
+    );
+  },
+});
 
 /**
  * This class wraps the platform Navigation API which allows server-specific and test

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -12,3 +12,4 @@ export {
   setRootDomAdapter as ɵsetRootDomAdapter,
 } from './dom_adapter';
 export {NavigationAdapterForLocation as ɵNavigationAdapterForLocation} from './location/navigation_adapter_for_location';
+export {PRECOMMIT_HANDLER_SUPPORTED as ɵPRECOMMIT_HANDLER_SUPPORTED} from './navigation/platform_navigation';

--- a/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
+++ b/packages/common/testing/src/navigation/provide_fake_platform_navigation.ts
@@ -8,6 +8,7 @@
 
 import {DOCUMENT, PlatformLocation, PlatformNavigation} from '../../../index';
 import {inject, InjectionToken, Provider} from '@angular/core';
+import {PRECOMMIT_HANDLER_SUPPORTED} from '../../../src/navigation/platform_navigation';
 
 import {
   FakeNavigationPlatformLocation,
@@ -38,5 +39,6 @@ export function provideFakePlatformNavigation(): Provider[] {
       useFactory: () => inject(FAKE_NAVIGATION),
     },
     {provide: PlatformLocation, useClass: FakeNavigationPlatformLocation},
+    {provide: PRECOMMIT_HANDLER_SUPPORTED, useValue: true},
   ];
 }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -29,6 +29,7 @@
       "BROWSER_MODULE_PROVIDERS",
       "BaseRouteReuseStrategy",
       "BeforeActivateRoutes",
+      "BeforeRoutesRecognized",
       "BehaviorSubject",
       "BrowserDomAdapter",
       "BrowserPlatformLocation",

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -630,15 +630,20 @@ export class Scroll {
 }
 
 export class BeforeActivateRoutes {}
+export class BeforeRoutesRecognized {}
 export class RedirectRequest {
   constructor(
     readonly url: UrlTree,
     readonly navigationBehaviorOptions: NavigationBehaviorOptions | undefined,
   ) {}
 }
-export type PrivateRouterEvents = BeforeActivateRoutes | RedirectRequest;
+export type PrivateRouterEvents = BeforeActivateRoutes | RedirectRequest | BeforeRoutesRecognized;
 export function isPublicRouterEvent(e: Event | PrivateRouterEvents): e is Event {
-  return !(e instanceof BeforeActivateRoutes) && !(e instanceof RedirectRequest);
+  return (
+    !(e instanceof BeforeActivateRoutes) &&
+    !(e instanceof RedirectRequest) &&
+    !(e instanceof BeforeRoutesRecognized)
+  );
 }
 
 /**

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -278,6 +278,7 @@ export class Router {
         this.location.path(true),
         IMPERATIVE_NAVIGATION,
         this.stateManager.restoredState(),
+        {replaceUrl: true},
       );
     }
   }
@@ -292,9 +293,11 @@ export class Router {
     // already patch onPopState, so location change callback will
     // run into ngZone
     this.nonRouterCurrentEntryChangeSubscription ??=
-      this.stateManager.registerNonRouterCurrentEntryChangeListener((url, state, source) => {
-        this.navigateToSyncWithBrowser(url, source, state);
-      });
+      this.stateManager.registerNonRouterCurrentEntryChangeListener(
+        (url, state, source, extras) => {
+          this.navigateToSyncWithBrowser(url, source, state, extras);
+        },
+      );
   }
 
   /**
@@ -308,9 +311,8 @@ export class Router {
     url: string,
     source: NavigationTrigger,
     state: RestoredState | null | undefined,
+    extras: NavigationExtras,
   ) {
-    const extras: NavigationExtras = {replaceUrl: true};
-
     // TODO: restoredState should always include the entire state, regardless
     // of navigationId. This requires a breaking change to update the type on
     // NavigationStart’s restoredState, which currently requires navigationId

--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -20,9 +20,14 @@ import {
   ɵPRECOMMIT_HANDLER_SUPPORTED as PRECOMMIT_HANDLER_SUPPORTED,
 } from '@angular/common';
 import {StateManager} from './state_manager';
-import {RestoredState, Navigation as RouterNavigation} from '../navigation_transition';
+import {
+  NavigationExtras,
+  RestoredState,
+  Navigation as RouterNavigation,
+} from '../navigation_transition';
 import {
   BeforeActivateRoutes,
+  BeforeRoutesRecognized,
   isRedirectingEvent,
   NavigationCancel,
   NavigationCancellationCode,
@@ -32,7 +37,6 @@ import {
   NavigationStart,
   NavigationTrigger,
   PrivateRouterEvents,
-  RoutesRecognized,
 } from '../events';
 import {Subject, SubscriptionLike} from 'rxjs';
 import {UrlTree} from '../url_tree';
@@ -85,6 +89,7 @@ export class NavigationStateManager extends StateManager {
     /** Function to resolve the intercepted navigation event. */
     resolveHandler?: (v: void) => void;
     navigationEvent?: NavigateEvent;
+    commitUrl?: () => Promise<void>;
   } = {};
 
   /**
@@ -124,12 +129,18 @@ export class NavigationStateManager extends StateManager {
       url: string,
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
+      extras: NavigationExtras,
     ) => void,
   ): SubscriptionLike {
     this.activeHistoryEntry = this.navigation.currentEntry!;
     this.nonRouterEntryChangeListener = this.nonRouterCurrentEntryChangeSubject.subscribe(
       ({path, state}) => {
-        listener(path, state, 'popstate');
+        listener(
+          path,
+          state,
+          'popstate',
+          !this.precommitHandlerSupported ? {replaceUrl: true} : {},
+        );
       },
     );
     return this.nonRouterEntryChangeListener;
@@ -150,20 +161,46 @@ export class NavigationStateManager extends StateManager {
     this.currentNavigation = {...this.currentNavigation, routerTransition: transition};
     if (e instanceof NavigationStart) {
       this.updateStateMemento();
+      // If we have precommit handler support, we can create a navigation
+      // immediately and redirect it later.
+      if (this.precommitHandlerSupported) {
+        this.maybeCreateNavigationForTransition(transition);
+      }
     } else if (e instanceof NavigationSkipped) {
       this.finishNavigation();
       this.commitTransition(transition);
-    } else if (e instanceof RoutesRecognized) {
-      if (this.urlUpdateStrategy === 'eager' && !transition.extras.skipLocationChange) {
-        this.createNavigationForTransition(transition);
-      }
+    } else if (e instanceof BeforeRoutesRecognized) {
+      transition.routesRecognizeHandler.deferredHandle = new Promise<void>(async (resolve) => {
+        if (this.urlUpdateStrategy === 'eager') {
+          try {
+            this.maybeCreateNavigationForTransition(transition);
+            await this.currentNavigation.commitUrl?.();
+          } catch {
+            // If commit fails (e.g., precommitHandler rejects), abort.
+            // The AbortSignal will notify
+            return;
+          }
+        }
+        resolve();
+      });
     } else if (e instanceof BeforeActivateRoutes) {
-      // Commit the internal router state.
-      this.commitTransition(transition);
-      if (this.urlUpdateStrategy === 'deferred' && !transition.extras.skipLocationChange) {
-        this.createNavigationForTransition(transition);
-      }
+      transition.beforeActivateHandler.deferredHandle = new Promise<void>(async (resolve) => {
+        // If URL update strategy is 'deferred', commit the URL now (before activation).
+        if (this.urlUpdateStrategy === 'deferred') {
+          try {
+            this.maybeCreateNavigationForTransition(transition);
+            await this.currentNavigation.commitUrl?.();
+          } catch {
+            return;
+          }
+        }
+        // Commit the internal router state.
+        this.commitTransition(transition);
+        resolve();
+      });
     } else if (e instanceof NavigationCancel || e instanceof NavigationError) {
+      // TODO(atscott): We want to keep the navigation event on redirects if
+      // the URL wasn't committed yet rather than cancelling it.
       void this.cancel(transition, e);
     } else if (e instanceof NavigationEnd) {
       const {resolveHandler, removeAbortListener} = this.currentNavigation;
@@ -183,17 +220,19 @@ export class NavigationStateManager extends StateManager {
     }
   }
 
-  private createNavigationForTransition(transition: RouterNavigation) {
-    const {navigationEvent} = this.currentNavigation;
-    // If we are currently handling a traversal navigation, we do not need a new navigation for it
-    // because we are strictly restoring a previous state. If we are instead handling a navigation
-    // initiated outside the router, we do need to replace it with a router-triggered navigation
-    // to add the router-specific state.
+  private maybeCreateNavigationForTransition(transition: RouterNavigation) {
+    const {navigationEvent, commitUrl} = this.currentNavigation;
     if (
-      navigationEvent &&
-      (navigationEvent.navigationType === 'traverse' ||
-        navigationEvent.navigationType === 'reload') &&
-      this.eventAndRouterDestinationsMatch(navigationEvent, transition)
+      // Presence of commitUrl function indicates the navigateEvent supports redirect
+      commitUrl ||
+      // If we are currently handling a traversal navigation, we do not need a new navigation for it
+      // because we are strictly restoring a previous state. If we are instead handling a navigation
+      // initiated outside the router, we do need to replace it with a router-triggered navigation
+      // to add the router-specific state.
+      (navigationEvent &&
+        (navigationEvent.navigationType === 'traverse' ||
+          navigationEvent.navigationType === 'reload') &&
+        this.eventAndRouterDestinationsMatch(navigationEvent, transition))
     ) {
       return;
     }
@@ -258,6 +297,7 @@ export class NavigationStateManager extends StateManager {
    * and resolving the post-commit handler promise. Clears the `currentNavigation` state.
    */
   private finishNavigation() {
+    this.currentNavigation.commitUrl?.();
     this.currentNavigation?.resolveHandler?.();
     this.currentNavigation = {};
   }
@@ -386,17 +426,65 @@ export class NavigationStateManager extends StateManager {
       resolve: resolveHandler,
       reject: rejectHandler,
     } = promiseWithResolvers<void>();
+
+    const {
+      promise: precommitHandlerPromise,
+      resolve: resolvePrecommitHandler,
+      reject: rejectPrecommitHandler,
+    } = promiseWithResolvers<void>();
+    this.currentNavigation.rejectNavigateEvent = () => {
+      event.signal.removeEventListener('abort', abortHandler);
+      rejectPrecommitHandler();
+      rejectHandler();
+    };
     this.currentNavigation.resolveHandler = () => {
       this.currentNavigation.removeAbortListener?.();
       resolveHandler();
     };
-    this.currentNavigation.rejectNavigateEvent = () => {
-      this.currentNavigation.removeAbortListener?.();
-      rejectHandler();
-    };
     // Prevent unhandled promise rejections from internal promises.
     handlerPromise.catch(() => {});
+    precommitHandlerPromise.catch(() => {});
     interceptOptions.handler = () => handlerPromise;
+
+    if (this.deferredCommitSupported(event)) {
+      const redirect = new Promise<
+        (url: string, options: {state: unknown; history?: 'push' | 'replace'}) => void
+      >((resolve) => {
+        // The `precommitHandler` option is not in the standard DOM types yet
+        (interceptOptions as any).precommitHandler = (controller: any) => {
+          resolve(controller.redirect.bind(controller));
+          return precommitHandlerPromise;
+        };
+      });
+      // `commitUrl` is a function that will be called by the router's lifecycle
+      // (e.g., in `BeforeRoutesRecognized` or `BeforeActivateRoutes` depending on `urlUpdateStrategy`)
+      // to actually perform the URL change via the Navigation API.
+      this.currentNavigation.commitUrl = async () => {
+        this.currentNavigation.commitUrl = undefined; // Ensure it's only called once.
+        const transition = this.currentNavigation.routerTransition;
+
+        // If not skipping location change, use the `redirect` function (from `precommitHandler`'s
+        // controller) to perform the URL update with the correct state and history action.
+        if (transition && !transition.extras.skipLocationChange) {
+          const internalPath = this.createBrowserPath(transition);
+          const history =
+            this.location.isCurrentPathEqualTo(internalPath) || !!transition.extras.replaceUrl
+              ? 'replace'
+              : 'push';
+          const state = {
+            ...transition.extras.state,
+            navigationId: transition.id,
+          };
+          // this might be a path or an actual URL depending on the baseHref
+          const pathOrUrl = this.location.prepareExternalUrl(internalPath);
+          (await redirect)(pathOrUrl, {state, history});
+        }
+        resolvePrecommitHandler();
+        // Wait for the Navigation API's own `committed` promise if available (part of transition object)
+        // This ensures we respect the browser's timing for when the commit actually happens.
+        return await this.navigation.transition?.committed;
+      };
+    }
 
     // Intercept the navigation event with the configured options.
     event.intercept(interceptOptions);
@@ -438,6 +526,16 @@ export class NavigationStateManager extends StateManager {
     // this might be a path or an actual URL depending on the baseHref
     const routerDestination = this.location.prepareExternalUrl(internalPath);
     return new URL(routerDestination, eventDestination.origin).href === eventDestination.href;
+  }
+
+  private deferredCommitSupported(event: NavigateEvent): boolean {
+    return (
+      this.precommitHandlerSupported &&
+      // Cannot defer commit if not cancelable by the Navigation API's rules.
+      event.cancelable &&
+      // Deferring a traversal commit is currently problematic or not fully supported.
+      event.navigationType !== 'traverse'
+    );
   }
 }
 

--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -199,8 +199,17 @@ export class NavigationStateManager extends StateManager {
         resolve();
       });
     } else if (e instanceof NavigationCancel || e instanceof NavigationError) {
-      // TODO(atscott): We want to keep the navigation event on redirects if
-      // the URL wasn't committed yet rather than cancelling it.
+      // If redirecting and the URL hasn't been committed yet (via precommmitHandler),
+      // the redirect will be handled by `commitUrl` using `controller.redirect` and
+      // we should retain the current NavigateEvent.
+      // Otherwise, a full cancellation and rollback is needed.
+      const redirectingBeforeUrlCommit =
+        e instanceof NavigationCancel &&
+        e.code === NavigationCancellationCode.Redirect &&
+        !!this.currentNavigation.commitUrl;
+      if (redirectingBeforeUrlCommit) {
+        return;
+      }
       void this.cancel(transition, e);
     } else if (e instanceof NavigationEnd) {
       const {resolveHandler, removeAbortListener} = this.currentNavigation;

--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -14,7 +14,11 @@ import {
   Injectable,
 } from '@angular/core';
 
-import {PlatformLocation, PlatformNavigation} from '@angular/common';
+import {
+  PlatformLocation,
+  PlatformNavigation,
+  ɵPRECOMMIT_HANDLER_SUPPORTED as PRECOMMIT_HANDLER_SUPPORTED,
+} from '@angular/common';
 import {StateManager} from './state_manager';
 import {RestoredState, Navigation as RouterNavigation} from '../navigation_transition';
 import {
@@ -59,6 +63,7 @@ export class NavigationStateManager extends StateManager {
   /** The root URL of the Angular application, considering the base href. */
   private readonly appRootURL = new URL(this.location.prepareExternalUrl?.('/') ?? '/', this.base)
     .href;
+  private readonly precommitHandlerSupported = inject(PRECOMMIT_HANDLER_SUPPORTED);
   /**
    * The `NavigationHistoryEntry` from the Navigation API that corresponds to the last successfully
    * activated router state. This is crucial for restoring the browser state if an ongoing navigation

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -23,7 +23,7 @@ import {
   PrivateRouterEvents,
   RoutesRecognized,
 } from '../events';
-import {Navigation, RestoredState} from '../navigation_transition';
+import {Navigation, NavigationExtras, RestoredState} from '../navigation_transition';
 import {ROUTER_CONFIGURATION} from '../router_config';
 import {createEmptyState, RouterState} from '../router_state';
 import {UrlHandlingStrategy} from '../url_handling_strategy';
@@ -143,6 +143,7 @@ export abstract class StateManager {
       url: string,
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
+      extras: NavigationExtras,
     ) => void,
   ): SubscriptionLike;
 
@@ -183,6 +184,7 @@ export class HistoryStateManager extends StateManager {
       url: string,
       state: RestoredState | null | undefined,
       trigger: NavigationTrigger,
+      extras: NavigationExtras,
     ) => void,
   ): SubscriptionLike {
     return this.location.subscribe((event) => {
@@ -190,7 +192,9 @@ export class HistoryStateManager extends StateManager {
         // The `setTimeout` was added in #12160 and is likely to support Angular/AngularJS
         // hybrid apps.
         setTimeout(() => {
-          listener(event['url']!, event.state as RestoredState | null | undefined, 'popstate');
+          listener(event['url']!, event.state as RestoredState | null | undefined, 'popstate', {
+            replaceUrl: true,
+          });
         });
       }
     });

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -932,7 +932,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
 
     navigationErrorsIntegrationSuite(browserAPI);
     eagerUrlUpdateStrategyIntegrationSuite();
-    duplicateInFlightNavigationsIntegrationSuite();
+    duplicateInFlightNavigationsIntegrationSuite(browserAPI);
     navigationIntegrationTestSuite(browserAPI);
     routeDataIntegrationSuite();
     routerLinkIntegrationSpec();

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -317,8 +317,9 @@ export function navigationIntegrationTestSuite(browserAPI: 'history' | 'navigati
       expect(navigation.extras.state).toEqual(state);
 
       // Manually set state rather than using navigate()
-      state = {bar: 'foo'};
+      state = {foo: 'replaced'};
       location.replaceState(location.path(), '', state);
+      await timeout();
       location.back();
       await timeout();
       location.forward();

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -108,11 +108,8 @@ describe('withPlatformNavigation feature', () => {
           children: [],
         },
       ]);
-      const {finished} = navigation.navigate('/somepath');
+      navigation.navigate('/somepath');
       await timeout(5);
-      // note that this finished promise will be rejected because the Router will create a separate 'replace' navigate
-      // since we cannot redirect the original navigation without precommit handler support
-      await expectAsync(finished).not.toBeResolved();
       expect(navigation.transition).not.toBeNull();
       await timeout(10);
       expect(navigation.transition).toBeNull();
@@ -131,7 +128,8 @@ describe('withPlatformNavigation feature', () => {
       // set up navigation
       navigation.addEventListener(
         'navigate',
-        (e: any) => e.intercept({handler: () => new Promise((_, reject) => setTimeout(reject, 5))}),
+        (e: any) =>
+          e.intercept({precommitHandler: () => new Promise((_, reject) => setTimeout(reject, 5))}),
         {once: true},
       );
 

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {provideRouter, Router} from '../src';
+import {NavigationEnd, NavigationStart, provideRouter, Router} from '../src';
 import {withPlatformNavigation, withRouterConfig} from '../src/provide_router';
 import {withBody} from '@angular/private/testing';
 import {
@@ -15,6 +15,7 @@ import {
   Location,
   PlatformNavigation,
   BrowserPlatformLocation,
+  ɵPRECOMMIT_HANDLER_SUPPORTED as PRECOMMIT_HANDLER_SUPPORTED,
 } from '@angular/common';
 import {
   ɵFakeNavigation as FakeNavigation,
@@ -22,6 +23,8 @@ import {
   provideLocationMocks,
 } from '@angular/common/testing';
 import {timeout, useAutoTick} from './helpers';
+import {} from '../../common/src/navigation/platform_navigation';
+import {inject} from '@angular/core';
 
 /// <reference types="dom-navigation" />
 
@@ -156,6 +159,26 @@ describe('withPlatformNavigation feature', () => {
       await navigation.back().finished;
       expect(navigateEvents.length).toBe(1);
       expect(navigateEvents[0].navigationType).toBe('traverse');
+    });
+
+    it('retains a single NavigateEvent across redirects', async () => {
+      const navigateEvents: NavigateEvent[] = [];
+      navigation.addEventListener('navigate', (e: NavigateEvent) => navigateEvents.push(e));
+
+      router.resetConfig([
+        {path: 'first', canActivate: [() => inject(Router).parseUrl('/redirected')], children: []},
+        {path: '**', children: []},
+      ]);
+      const navPromise = router.navigateByUrl('/first');
+      if (TestBed.inject(PRECOMMIT_HANDLER_SUPPORTED)) {
+        router.events.subscribe((e) => {
+          if (e instanceof NavigationStart) {
+            expect(navigateEvents.length).toBe(1);
+          }
+        });
+      }
+      await navPromise;
+      expect(navigateEvents.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This builds off of https://github.com/angular/angular/pull/66197 by retaining the original navigateEvent across redirects
so the NavigateEvent can more accurately track the lifecycle of a navigation,
which may span across several NavigationStart events due to redirects