### PR TITLE
fix(router): Fix RouterLink href not updating with `queryParamsHandling`

### DIFF
--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -254,27 +254,14 @@ export class RouterLink implements OnChanges, OnDestroy {
         )
       );
 
-    if (!this.isAnchorElement) {
-      this.subscribeToNavigationEventsIfNecessary();
-    } else {
+    if (this.isAnchorElement) {
       this.setTabIndexIfNotOnNativeEl('0');
+      this.subscribeToNavigationEventsIfNecessary();
     }
   }
 
   private subscribeToNavigationEventsIfNecessary() {
-    if (this.subscription !== undefined || !this.isAnchorElement) {
-      return;
-    }
-
-    // preserving fragment in router state
-    let createSubcription = this.preserveFragment;
-    // preserving or merging with query params in router state
-    const dependsOnRouterState = (handling?: QueryParamsHandling | null) =>
-      handling === 'merge' || handling === 'preserve';
-    createSubcription ||= dependsOnRouterState(this.queryParamsHandling);
-    createSubcription ||=
-      !this.queryParamsHandling && !dependsOnRouterState(this.options?.defaultQueryParamsHandling);
-    if (!createSubcription) {
+    if (this.subscription !== undefined) {
       return;
     }
 
@@ -339,7 +326,6 @@ export class RouterLink implements OnChanges, OnDestroy {
     }
     if (this.isAnchorElement) {
       this.updateHref();
-      this.subscribeToNavigationEventsIfNecessary();
     }
     // This is subscribed to by `RouterLinkActive` so that it knows to update when there are changes
     // to the RouterLinks it's tracking.

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -10,12 +10,9 @@ import {Component, inject, signal, provideZonelessChangeDetection} from '@angula
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Router, RouterLink, RouterModule, provideRouter} from '../index';
+import {RouterTestingHarness} from '../testing';
 
 describe('RouterLink', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({providers: [provideZonelessChangeDetection()]});
-  });
-
   it('does not modify tabindex if already set on non-anchor element', async () => {
     @Component({
       template: `<div [routerLink]="link" tabindex="1"></div>`,
@@ -314,5 +311,22 @@ describe('RouterLink', () => {
 
     const fixture = TestBed.createComponent(WithUrlTree);
     expect(() => fixture.changeDetectorRef.detectChanges()).toThrow();
+  });
+
+  it('correctly updates when relativeTo segments change', async () => {
+    @Component({
+      template: `<a [routerLink]="['./child']" queryParamsHandling="'replace'">link</a>`,
+      imports: [RouterLink],
+    })
+    class WithLink {}
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{path: '**', component: WithLink}])],
+    });
+
+    const harness = await RouterTestingHarness.create('/initial');
+    const anchor = harness.fixture.nativeElement.querySelector('a');
+    expect(anchor.getAttribute('href')).toBe('/initial/child');
+    await harness.navigateByUrl('/different');
+    expect(anchor.getAttribute('href')).toBe('/different/child');
   });
 });


### PR DESCRIPTION
There was a bug introduced in #60875. While RouterLink doesn't necessarily depend on Router state, its link can change when navigations cause the `ActivatedRoute` paths to change. It is difficult to determine which segments the link depends on. Luckily, the commit had flawed logic:

```
!this.queryParamsHandling && !dependsOnRouterState(this.options?.defaultQueryParamsHandling);
```

The subscription gets created whenever `queryParamsHandling` was not defined, or it was non-default. This is pretty much all scenarios since nobody is likely to set it explicitly to the default value. In addition, the `click` handler recomputes the tree because `urlTree` is a getter that does the computation.

This commit effectively rolls back #60875
