### PR TITLE
refactor(compiler-cli): add statementType field to simplify class ent…

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/extraction/test/interpolate_code_examples.spec.mts
@@ -15,6 +15,7 @@ import {
   FunctionSignatureMetadata,
   MemberType,
   MethodEntry,
+  StatementType,
 } from '@angular/compiler-cli';
 import {mockReadFileSync} from './fake-examples.mjs';
 
@@ -170,6 +171,7 @@ class Baz {
         description: '',
         rawComment: '',
         entryType: EntryType.UndecoratedClass,
+        statementType: StatementType.Class,
         name: 'Test',
         jsdocTags: [],
         isAbstract: false,
@@ -185,10 +187,12 @@ class Baz {
             memberType: MemberType.Method,
             signatures: [],
             entryType: EntryType.Function,
+            statementType: StatementType.Function,
             rawComment: '',
             implementation: {
               name: 'test',
               entryType: EntryType.Function,
+              statementType: StatementType.Function,
               rawComment: '',
               params: [],
               returnType: 'void',

--- a/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/manifest/test/manifest.spec.mts
@@ -7,7 +7,13 @@
  */
 
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
-import {DocEntry, EntryType, FunctionEntry, JsDocTagEntry} from '@angular/compiler-cli';
+import {
+  DocEntry,
+  EntryType,
+  FunctionEntry,
+  JsDocTagEntry,
+  StatementType,
+} from '@angular/compiler-cli';
 import {generateManifest, Manifest} from '../generate_manifest.mjs';
 
 describe('api manifest generation', () => {
@@ -243,6 +249,7 @@ describe('api manifest generation', () => {
                 jsdocTags: [],
                 description: '',
                 entryType: EntryType.Function,
+                statementType: StatementType.Function,
                 params: [],
                 generics: [],
                 isNewType: false,
@@ -254,6 +261,7 @@ describe('api manifest generation', () => {
                 jsdocTags: jsdocTags('deprecated'),
                 description: '',
                 entryType: EntryType.Function,
+                statementType: StatementType.Function,
                 params: [],
                 generics: [],
                 isNewType: false,
@@ -304,6 +312,7 @@ describe('api manifest generation', () => {
                 jsdocTags: jsdocTags('deprecated'),
                 description: '',
                 entryType: EntryType.Function,
+                statementType: StatementType.Function,
                 params: [],
                 generics: [],
                 isNewType: false,
@@ -315,6 +324,7 @@ describe('api manifest generation', () => {
                 jsdocTags: jsdocTags('deprecated'),
                 description: '',
                 entryType: EntryType.Function,
+                statementType: StatementType.Function,
                 params: [],
                 generics: [],
                 isNewType: false,
@@ -458,6 +468,7 @@ function entry(patch: Partial<DocEntry>): DocEntry {
     name: '',
     description: '',
     entryType: EntryType.Constant,
+    statementType: StatementType.Variable,
     jsdocTags: [],
     rawComment: '',
     ...patch,

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities.mts
@@ -28,6 +28,14 @@ export enum EntryType {
   InitializerApiFunction = 'initializer_api_function',
 }
 
+export enum StatementType {
+  Class = 'class',
+  Interface = 'interface',
+  Function = 'function',
+  Variable = 'variable',
+  Enum = 'enum',
+}
+
 /** Types of class members */
 export enum MemberType {
   Property = 'property',
@@ -88,6 +96,7 @@ export interface DocEntry {
   description: string;
   rawComment: string;
   jsdocTags: JsDocTagEntry[];
+  statementType: StatementType;
 }
 
 /** Documentation entity for a constant. */

--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/categorization.mts
@@ -45,15 +45,7 @@ import {HasJsDocTags} from './traits.mjs';
 export function isClassEntry(entry: DocEntryRenderable): entry is ClassEntryRenderable;
 export function isClassEntry(entry: DocEntry): entry is ClassEntry;
 export function isClassEntry(entry: DocEntry): entry is ClassEntry {
-  // TODO: add something like `statementType` to extraction so we don't have to check so many
-  //     entry types here.
-  return (
-    entry.entryType === EntryType.UndecoratedClass ||
-    entry.entryType === EntryType.Component ||
-    entry.entryType === EntryType.Pipe ||
-    entry.entryType === EntryType.NgModule ||
-    entry.entryType === EntryType.Directive
-  );
+  return entry.statementType === 'class';
 }
 
 export function isDecoratorEntry(entry: DocEntryRenderable): entry is DecoratorEntryRenderable;

--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -25,6 +25,7 @@ import {
   MemberTags,
   PipeEntry,
   PropertyEntry,
+  StatementType,
 } from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 import {ClassDeclarationLike, PropertiesExtractor} from './properties_extractor';
@@ -50,6 +51,7 @@ class ClassExtractor extends PropertiesExtractor {
       rawComment: extractRawJsDoc(this.declaration),
       extends: this.extractInheritance(this.declaration),
       implements: this.extractInterfaceConformance(this.declaration),
+      statementType: StatementType.Class,
     };
   }
 
@@ -102,6 +104,7 @@ class DirectiveExtractor extends ClassExtractor {
       exportAs: this.metadata.exportAs ?? [],
       entryType: this.metadata.isComponent ? EntryType.Component : EntryType.Directive,
       ...(aliases.length > 0 && {aliases}),
+      statementType: StatementType.Class,
     };
   }
 
@@ -157,6 +160,7 @@ class PipeExtractor extends ClassExtractor {
       isStandalone: this.metadata.isStandalone,
       usage: extractPipeSyntax(this.metadata, this.declaration as ts.ClassDeclaration),
       isPure: this.metadata.isPure,
+      statementType: StatementType.Class,
     };
   }
 }
@@ -176,6 +180,7 @@ class NgModuleExtractor extends ClassExtractor {
     return {
       ...super.extract(),
       entryType: EntryType.NgModule,
+      statementType: StatementType.Class,
     };
   }
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/constant_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/constant_extractor.ts
@@ -8,7 +8,14 @@
 
 import ts from 'typescript';
 
-import {ConstantEntry, EntryType, EnumEntry, EnumMemberEntry, MemberType} from './entities';
+import {
+  ConstantEntry,
+  EntryType,
+  EnumEntry,
+  EnumMemberEntry,
+  MemberType,
+  StatementType,
+} from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 
 /** Name of the tag indicating that an object literal should be shown as an enum in docs. */
@@ -46,6 +53,7 @@ export function extractConstant(
       rawComment,
       description,
       jsdocTags: jsdocTags.filter((tag) => tag.name !== LITERAL_AS_ENUM_TAG),
+      statementType: StatementType.Enum,
     };
   }
 
@@ -56,6 +64,7 @@ export function extractConstant(
     rawComment,
     description,
     jsdocTags,
+    statementType: StatementType.Variable,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/decorator_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/decorator_extractor.ts
@@ -15,6 +15,7 @@ import {
   JsDocTagEntry,
   ParameterEntry,
   PropertyEntry,
+  StatementType,
 } from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 import {extractInterface} from './interface_extractor';
@@ -49,6 +50,7 @@ export function extractorDecorator(
     jsdocTags: extractJsDocTags(documentedNode),
     members,
     signatures,
+    statementType: StatementType.Variable,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/entities.ts
@@ -40,6 +40,17 @@ export enum EntryType {
   Namespace = 'namespace',
 }
 
+/** Types of statements */
+export enum StatementType {
+  Class = 'class',
+  Interface = 'interface',
+  Function = 'function',
+  Variable = 'variable',
+  Enum = 'enum',
+  Namespace = 'namespace',
+  TypeAlias = 'type_alias',
+}
+
 /** Types of class members */
 export enum MemberType {
   Property = 'property',
@@ -100,6 +111,7 @@ export interface DocEntry {
   description: string;
   rawComment: string;
   jsdocTags: JsDocTagEntry[];
+  statementType: StatementType;
 }
 
 /** Documentation entity for a constant. */
@@ -166,7 +178,7 @@ export interface FunctionSignatureMetadata extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
   returnDescription?: string;
-
+  statementType: StatementType.Function;
   generics: GenericEntry[];
   isNewType: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/enum_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/enum_extractor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EntryType, EnumEntry, EnumMemberEntry, MemberType} from './entities';
+import {EntryType, EnumEntry, EnumMemberEntry, MemberType, StatementType} from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 import {extractResolvedTypeString} from './type_extractor';
 import ts from 'typescript';
@@ -23,6 +23,7 @@ export function extractEnum(
     rawComment: extractRawJsDoc(declaration),
     description: extractJsDocDescription(declaration),
     jsdocTags: extractJsDocTags(declaration),
+    statementType: StatementType.Enum,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/function_extractor.ts
@@ -8,7 +8,13 @@
 
 import ts from 'typescript';
 
-import {EntryType, FunctionEntry, FunctionSignatureMetadata, ParameterEntry} from './entities';
+import {
+  EntryType,
+  FunctionEntry,
+  FunctionSignatureMetadata,
+  ParameterEntry,
+  StatementType,
+} from './entities';
 import {extractGenerics} from './generics_extractor';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 import {extractResolvedTypeString} from './type_extractor';
@@ -57,10 +63,12 @@ export class FunctionExtractor {
         name: this.name,
         description,
         entryType: EntryType.Function,
+        statementType: StatementType.Function,
         jsdocTags: jsdocsTags,
         rawComment: extractRawJsDoc(implementation),
       },
       entryType: EntryType.Function,
+      statementType: StatementType.Function,
       description,
       jsdocTags: jsdocsTags,
       rawComment: extractRawJsDoc(implementation),
@@ -90,6 +98,7 @@ function constructorOverloads(
       rawComment: extractRawJsDoc(n),
       generics: extractGenerics(n),
       isNewType: false,
+      statementType: StatementType.Function,
     };
   });
 }
@@ -132,7 +141,11 @@ function filterSignatureDeclarations(signatures: readonly ts.Signature[]) {
   return result;
 }
 
-export function extractCallSignatures(name: string, typeChecker: ts.TypeChecker, type: ts.Type) {
+export function extractCallSignatures(
+  name: string,
+  typeChecker: ts.TypeChecker,
+  type: ts.Type,
+): FunctionSignatureMetadata[] {
   return filterSignatureDeclarations(type.getCallSignatures()).map(({decl, signature}) => ({
     name,
     entryType: EntryType.Function,
@@ -143,6 +156,7 @@ export function extractCallSignatures(name: string, typeChecker: ts.TypeChecker,
     params: extractAllParams(decl.parameters, typeChecker),
     rawComment: extractRawJsDoc(decl),
     returnType: extractReturnType(signature, typeChecker),
+    statementType: StatementType.Function,
   }));
 }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/initializer_api_function_extractor.ts
@@ -13,6 +13,7 @@ import {
   FunctionDefinitionEntry,
   InitializerApiFunctionEntry,
   JsDocTagEntry,
+  StatementType,
 } from './entities';
 import {
   extractAllParams,
@@ -118,6 +119,7 @@ export function extractInitializerApiFunction(
     callFunction.implementation = {
       name,
       entryType: EntryType.Function,
+      statementType: StatementType.Function,
       isNewType: false,
       description: extractJsDocDescription(implementation),
       generics: extractGenerics(implementation),
@@ -160,6 +162,7 @@ export function extractInitializerApiFunction(
 
   return {
     entryType: EntryType.InitializerApiFunction,
+    statementType: StatementType.Function,
     name,
     description,
     jsdocTags,

--- a/packages/compiler-cli/src/ngtsc/docs/src/interface_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/interface_extractor.ts
@@ -10,7 +10,7 @@ import ts from 'typescript';
 
 import {ClassDeclaration} from '../../reflection';
 
-import {EntryType, InterfaceEntry} from './entities';
+import {EntryType, InterfaceEntry, StatementType} from './entities';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 import {PropertiesExtractor} from './properties_extractor';
 
@@ -36,6 +36,7 @@ class InterfaceExtractor extends PropertiesExtractor {
       rawComment: extractRawJsDoc(this.declaration),
       extends: this.extractInheritance(this.declaration),
       implements: this.extractInterfaceConformance(this.declaration),
+      statementType: StatementType.Interface,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/namespace_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/namespace_extractor.ts
@@ -7,7 +7,7 @@
  */
 
 import ts from 'typescript';
-import {DocEntry, EntryType, NamespaceEntry} from './entities';
+import {DocEntry, EntryType, NamespaceEntry, StatementType} from './entities';
 import {FunctionExtractor} from './function_extractor';
 import {extractInterface} from './interface_extractor';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
@@ -61,5 +61,6 @@ export function extractNamespace(
     rawComment: extractRawJsDoc(node),
     jsdocTags: extractJsDocTags(node),
     members,
+    statementType: StatementType.Namespace,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/docs/src/type_alias_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/type_alias_extractor.ts
@@ -7,12 +7,12 @@
  */
 import ts from 'typescript';
 
-import {EntryType} from './entities';
+import {EntryType, StatementType, TypeAliasEntry} from './entities';
 import {extractGenerics} from './generics_extractor';
 import {extractJsDocDescription, extractJsDocTags, extractRawJsDoc} from './jsdoc_extractor';
 
 /** Extract the documentation entry for a type alias. */
-export function extractTypeAlias(declaration: ts.TypeAliasDeclaration) {
+export function extractTypeAlias(declaration: ts.TypeAliasDeclaration): TypeAliasEntry {
   // TODO: this does not yet resolve type queries (`typeof`). We may want to
   //     fix this eventually, but for now it does not appear that any type aliases in
   //     Angular's public API rely on this.
@@ -20,6 +20,7 @@ export function extractTypeAlias(declaration: ts.TypeAliasDeclaration) {
   return {
     name: declaration.name.getText(),
     type: declaration.type.getText(),
+    statementType: StatementType.TypeAlias,
     entryType: EntryType.TypeAlias,
     generics: extractGenerics(declaration),
     rawComment: extractRawJsDoc(declaration),

--- a/tools/manual_api_docs/generate_block_api_json.mts
+++ b/tools/manual_api_docs/generate_block_api_json.mts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {
-  DocEntry,
-  DocEntryWithSourceInfo,
-  EntryType,
-  EntryCollection,
+import {
+  type DocEntry,
+  type DocEntryWithSourceInfo,
+  type EntryType,
+  type EntryCollection,
+  type StatementType,
 } from '@angular/compiler-cli/src/ngtsc/docs';
 import {readFileSync, writeFileSync} from 'fs';
 import {basename, join} from 'path';
@@ -33,6 +34,7 @@ function main() {
     return {
       name: `@${basename(sourceFilePath, '.md')}`,
       entryType: 'block' as EntryType.Block,
+      statementType: 'variable' as StatementType.Variable,
       description: filteredContent,
       rawComment: filteredContent,
       source: {

--- a/tools/manual_api_docs/generate_element_api_json.mts
+++ b/tools/manual_api_docs/generate_element_api_json.mts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {DocEntry, EntryCollection, EntryType} from '@angular/compiler-cli/src/ngtsc/docs';
+import {
+  type StatementType,
+  type DocEntry,
+  type EntryCollection,
+  type EntryType,
+} from '@angular/compiler-cli/src/ngtsc/docs';
 import {readFileSync, writeFileSync} from 'fs';
 import {basename, join} from 'path';
 
@@ -28,6 +33,7 @@ function main() {
         endLine: 0,
       },
       entryType: 'element' as EntryType.Element,
+      statementType: 'variable' as StatementType.Variable,
       description: fileContent,
       rawComment: fileContent,
       jsdocTags: [],


### PR DESCRIPTION
…ry detection

Add statementType field to DocEntry to clean TODO during extraction to avoid checking multiple EntryType values in isClassEntry function

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
