### PR TITLE
fix(compiler): remove legacy partial output input support

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -9,7 +9,6 @@ import {
   compileDirectiveFromMetadata,
   ConstantPool,
   ForwardRefHandling,
-  LegacyInputPartialMapping,
   makeBindingParser,
   outputAst as o,
   ParseLocation,
@@ -114,59 +113,15 @@ function toInputMapping<TExpression>(
   value: AstValue<NonNullable<R3DeclareDirectiveMetadata['inputs']>[string], TExpression>,
   key: string,
 ): R3InputMetadata {
-  if (value.isObject()) {
-    const obj = value.getObject();
-    const transformValue = obj.getValue('transformFunction');
-
-    return {
-      classPropertyName: obj.getString('classPropertyName'),
-      bindingPropertyName: obj.getString('publicName'),
-      isSignal: obj.getBoolean('isSignal'),
-      required: obj.getBoolean('isRequired'),
-      transformFunction: transformValue.isNull() ? null : transformValue.getOpaque(),
-    };
-  }
-
-  return parseLegacyInputPartialOutput(
-    key,
-    value as AstValue<LegacyInputPartialMapping, TExpression>,
-  );
-}
-
-/**
- * Parses the legacy partial output for inputs.
- *
- * More details, see: `legacyInputsPartialMetadata` in `partial/directive.ts`.
- * TODO(legacy-partial-output-inputs): Remove function in v18.
- */
-function parseLegacyInputPartialOutput<TExpression>(
-  key: string,
-  value: AstValue<LegacyInputPartialMapping, TExpression>,
-): R3InputMetadata {
-  if (value.isString()) {
-    return {
-      bindingPropertyName: value.getString(),
-      classPropertyName: key,
-      required: false,
-      transformFunction: null,
-      isSignal: false,
-    };
-  }
-
-  const values = value.getArray();
-  if (values.length !== 2 && values.length !== 3) {
-    throw new FatalLinkerError(
-      value.expression,
-      'Unsupported input, expected a string or an array containing two strings and an optional function',
-    );
-  }
+  const obj = value.getObject();
+  const transformValue = obj.getValue('transformFunction');
 
   return {
-    bindingPropertyName: values[0].getString(),
-    classPropertyName: values[1].getString(),
-    transformFunction: values.length > 2 ? values[2].getOpaque() : null,
-    required: false,
-    isSignal: false,
+    classPropertyName: obj.getString('classPropertyName'),
+    bindingPropertyName: obj.getString('publicName'),
+    isSignal: obj.getBoolean('isSignal'),
+    required: obj.getBoolean('isRequired'),
+    transformFunction: transformValue.isNull() ? null : transformValue.getOpaque(),
   };
 }
 

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -218,26 +218,18 @@ export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   hasDirectiveDependencies: boolean;
 }
 
-// TODO(legacy-partial-output-inputs): Remove in v18.
-// https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
-export type LegacyInputPartialMapping =
-  | string
-  | [bindingPropertyName: string, classPropertyName: string, transformFunction?: Function];
-
 export interface R3DeclareDirectiveFacade {
   selector?: string;
   type: Type;
   version: string;
   inputs?: {
-    [fieldName: string]:
-      | {
-          classPropertyName: string;
-          publicName: string;
-          isSignal: boolean;
-          isRequired: boolean;
-          transformFunction: Function | null;
-        }
-      | LegacyInputPartialMapping;
+    [fieldName: string]: {
+      classPropertyName: string;
+      publicName: string;
+      isSignal: boolean;
+      isRequired: boolean;
+      transformFunction: Function | null;
+    };
   };
   outputs?: {[classPropertyName: string]: string};
   host?: {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -11,7 +11,6 @@ import {
   CoreEnvironment,
   ExportedCompilerFacade,
   FactoryTarget,
-  LegacyInputPartialMapping,
   OpaqueValue,
   R3ComponentMetadataFacade,
   R3DeclareComponentFacade,
@@ -914,50 +913,20 @@ function inputsPartialMetadataToInputMetadata(
     (result, minifiedClassName) => {
       const value = inputs[minifiedClassName];
 
-      // Handle legacy partial input output.
-      if (typeof value === 'string' || Array.isArray(value)) {
-        result[minifiedClassName] = parseLegacyInputPartialOutput(value);
-      } else {
-        result[minifiedClassName] = {
-          bindingPropertyName: value.publicName,
-          classPropertyName: minifiedClassName,
-          transformFunction:
-            value.transformFunction !== null ? new WrappedNodeExpr(value.transformFunction) : null,
-          required: value.isRequired,
-          isSignal: value.isSignal,
-        };
-      }
+      // Always expect new format (object)
+      result[minifiedClassName] = {
+        bindingPropertyName: value.publicName,
+        classPropertyName: minifiedClassName,
+        transformFunction:
+          value.transformFunction !== null ? new WrappedNodeExpr(value.transformFunction) : null,
+        required: value.isRequired,
+        isSignal: value.isSignal,
+      };
 
       return result;
     },
     {},
   );
-}
-
-/**
- * Parses the legacy input partial output. For more details see `partial/directive.ts`.
- * TODO(legacy-partial-output-inputs): Remove in v18.
- */
-function parseLegacyInputPartialOutput(value: LegacyInputPartialMapping): R3InputMetadata {
-  if (typeof value === 'string') {
-    return {
-      bindingPropertyName: value,
-      classPropertyName: value,
-      transformFunction: null,
-      required: false,
-      // legacy partial output does not capture signal inputs.
-      isSignal: false,
-    };
-  }
-
-  return {
-    bindingPropertyName: value[0],
-    classPropertyName: value[1],
-    transformFunction: value[2] ? new WrappedNodeExpr(value[2]) : null,
-    required: false,
-    // legacy partial output does not capture signal inputs.
-    isSignal: false,
-  };
 }
 
 function parseInputsArray(

--- a/packages/compiler/src/render3/partial/api.ts
+++ b/packages/compiler/src/render3/partial/api.ts
@@ -33,12 +33,6 @@ export interface R3PartialDeclaration {
   type: o.Expression;
 }
 
-// TODO(legacy-partial-output-inputs): Remove in v18.
-// https://github.com/angular/angular/blob/d4b423690210872b5c32a322a6090beda30b05a3/packages/core/src/compiler/compiler_facade_interface.ts#L197-L199
-export type LegacyInputPartialMapping =
-  | string
-  | [bindingPropertyName: string, classPropertyName: string, transformFunction?: o.Expression];
-
 /**
  * Describes the shape of the object that the `ɵɵngDeclareDirective()` function accepts.
  */
@@ -53,15 +47,13 @@ export interface R3DeclareDirectiveMetadata extends R3PartialDeclaration {
    * binding property name and class property name if the names are different.
    */
   inputs?: {
-    [fieldName: string]:
-      | {
-          classPropertyName: string;
-          publicName: string;
-          isSignal: boolean;
-          isRequired: boolean;
-          transformFunction: o.Expression | null;
-        }
-      | LegacyInputPartialMapping;
+    [fieldName: string]: {
+      classPropertyName: string;
+      publicName: string;
+      isSignal: boolean;
+      isRequired: boolean;
+      transformFunction: o.Expression | null;
+    };
   };
 
   /**


### PR DESCRIPTION
Removes backward compatibility code for Angular versions before 17.1.0 that couldn't handle the new input metadata structure with signal inputs and required flags. This cleanup was originally scheduled for v18 but is now safe since Angular is at v21.

Changes:
- Always use new input metadata format in directive compilation
- Remove LegacyInputPartialMapping type from all interfaces
- Delete legacy parsing functions from linker and JIT compiler
- Simplify input mapping functions to only handle new format

BREAKING CHANGE: Libraries compiled with this change will no longer be compatible with Angular versions before 17.1.0

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
