### PR TITLE
fix(compiler): better types for a few expression AST nodes

### DIFF
--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -78,7 +78,7 @@ export class Chain extends AST {
   constructor(
     span: ParseSpan,
     sourceSpan: AbsoluteSourceSpan,
-    public expressions: any[],
+    public expressions: AST[],
   ) {
     super(span, sourceSpan);
   }
@@ -181,7 +181,7 @@ export class BindingPipe extends ASTWithName {
     sourceSpan: AbsoluteSourceSpan,
     public exp: AST,
     public name: string,
-    public args: any[],
+    public args: AST[],
     readonly type: BindingPipeType,
     nameSpan: AbsoluteSourceSpan,
   ) {
@@ -196,7 +196,7 @@ export class LiteralPrimitive extends AST {
   constructor(
     span: ParseSpan,
     sourceSpan: AbsoluteSourceSpan,
-    public value: any,
+    public value: string | number | boolean | null | undefined,
   ) {
     super(span, sourceSpan);
   }
@@ -209,7 +209,7 @@ export class LiteralArray extends AST {
   constructor(
     span: ParseSpan,
     sourceSpan: AbsoluteSourceSpan,
-    public expressions: any[],
+    public expressions: AST[],
   ) {
     super(span, sourceSpan);
   }
@@ -229,7 +229,7 @@ export class LiteralMap extends AST {
     span: ParseSpan,
     sourceSpan: AbsoluteSourceSpan,
     public keys: LiteralMapKey[],
-    public values: any[],
+    public values: AST[],
   ) {
     super(span, sourceSpan);
   }

--- a/packages/language-service/src/references_and_rename_utils.ts
+++ b/packages/language-service/src/references_and_rename_utils.ts
@@ -387,13 +387,12 @@ export function getRenameTextAndSpanAtPosition(
     return getRenameTextAndSpanAtPosition(node.left, position);
   } else if (node instanceof LiteralPrimitive) {
     const span = toTextSpan(node.sourceSpan);
-    const text = node.value;
-    if (typeof text === 'string') {
+    if (typeof node.value === 'string') {
       // The span of a string literal includes the quotes but they should be removed for renaming.
       span.start += 1;
       span.length -= 2;
     }
-    return {text, span};
+    return {text: `${node.value}`, span};
   } else if (node instanceof TmplAstElement || node instanceof TmplAstDirective) {
     return {text: node.name, span: toTextSpan(node.startSourceSpan)};
   } else if (node instanceof TmplAstComponent) {


### PR DESCRIPTION
We had `any` types for `LiteralArray.expressions`, `Chain.expressions`, `BindingPipe.args`, `LiteralPrimitive.value` and `LiteralMap.values`. These changes add proper types to them.
