### PR TITLE
feat(compiler): Add support for multiple swich cases matching

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,6 +25,7 @@ packages/compiler-cli/test/compliance/test_cases/**/*.ts
 
 # Ignore testing data files for language service
 vscode-ng-language-service/syntaxes/test/data/*.ts
+vscode-ng-language-service/syntaxes/test/data/*.html
 
 # Ignore goldens MD files
 goldens/**/*.api.md

--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -106,9 +106,7 @@ While the `@if` block is great for most scenarios, the `@switch` block provides 
   @case ('admin') {
     <app-admin-dashboard />
   }
-  @case ('reviewer') {
-    <app-reviewer-dashboard />
-  }
+  @case ('reviewer')
   @case ('editor') {
     <app-editor-dashboard />
   }
@@ -121,6 +119,8 @@ While the `@if` block is great for most scenarios, the `@switch` block provides 
 The value of the conditional expression is compared to the case expression using the triple-equals (`===`) operator.
 
 **`@switch` does not have a fallthrough**, so you do not need an equivalent to a `break` or `return` statement in the block.
+
+You can specify multiple conditions for a single block by have consecutive `@case` statements.
 
 You can optionally include a `@default` block. The content of the `@default` block displays if none of the preceding case expressions match the switch value.
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/content_projection.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/content_projection.ts
@@ -18,7 +18,7 @@ import {
   TmplAstIfBlockBranch,
   TmplAstNode,
   TmplAstSwitchBlock,
-  TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
   TmplAstTemplate,
   TmplAstText,
 } from '@angular/compiler';
@@ -96,7 +96,10 @@ export class TcbControlFlowContentProjectionOp extends TcbOp {
 
   private findPotentialControlFlowNodes() {
     const result: Array<
-      TmplAstIfBlockBranch | TmplAstSwitchBlockCase | TmplAstForLoopBlock | TmplAstForLoopBlockEmpty
+      | TmplAstIfBlockBranch
+      | TmplAstSwitchBlockCaseGroup
+      | TmplAstForLoopBlock
+      | TmplAstForLoopBlockEmpty
     > = [];
 
     for (const child of this.element.children) {
@@ -114,7 +117,7 @@ export class TcbControlFlowContentProjectionOp extends TcbOp {
           }
         }
       } else if (child instanceof TmplAstSwitchBlock) {
-        for (const current of child.cases) {
+        for (const current of child.groups) {
           if (this.shouldCheck(current)) {
             result.push(current);
           }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -2002,6 +2002,50 @@ describe('type check blocks', () => {
       );
     });
 
+    it('should generate a switch block with a falltrough for consecutive cases', () => {
+      const TEMPLATE = `
+        @switch (expr) {
+          @case ('one')
+          @case ('two') {
+            {{oneOrTwo()}}
+          }
+          @case ('three') {
+            {{three()}}
+          }
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'switch (((this).expr)) { ' +
+          'case "one": ' +
+          'case "two": "" + ((this).oneOrTwo()); break; ' +
+          'case "three": "" + ((this).three()); break; }',
+      );
+    });
+
+    it('should generate a switch block with a fallthrough to default case', () => {
+      const TEMPLATE = `
+        @switch (expr) {
+          @case (1)
+          @case (2) {
+            {{oneOrTwo()}}
+          }
+          @case (3)
+          @default {
+            {{default()}}
+          }
+        }
+      `;
+
+      expect(tcb(TEMPLATE)).toContain(
+        'switch (((this).expr)) { ' +
+          'case 1: ' +
+          'case 2: "" + ((this).oneOrTwo()); break; ' +
+          'case 3: ' +
+          'default: "" + ((this).default()); break; }',
+      );
+    });
+
     it('should generate a switch block that only has a default case', () => {
       const TEMPLATE = `
         @switch (expr) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -2328,6 +2328,68 @@ export declare class MyApp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: switch_multiple_cases.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    message = 'hello';
+    value() {
+        return 1;
+    }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0) @case(1) {
+          case 01
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
+    </div>
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0) @case(1) {
+          case 01
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
+    </div>
+  `,
+                    standalone: false
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_multiple_cases.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value(): number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: nested_for_computed_template_variables.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -632,6 +632,21 @@
       ]
     },
     {
+      "description": "should generate a switch block with multiple/consecutive case expressions",
+      "inputFiles": ["switch_multiple_cases.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_multiple_cases_template.js",
+              "generated": "switch_multiple_cases.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should generate computed for loop variables that depend on shadowed $index and $count",
       "inputFiles": ["nested_for_computed_template_variables.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases.ts
@@ -1,0 +1,28 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    <div>
+      {{message}}
+      @switch (value()) {
+        @case (0) @case(1) {
+          case 01
+        }
+        @case (2) {
+          case 2
+        }
+        @default {
+          default
+        }
+      }
+    </div>
+  `,
+    standalone: false
+})
+export class MyApp {
+  message = 'hello';
+
+  value() {
+    return 1;
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
@@ -1,0 +1,33 @@
+function MyApp_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 01 ");
+  }
+}
+
+function MyApp_Case_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 2 ");
+  }
+}
+
+function MyApp_Case_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " default ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵconditionalCreate(2, MyApp_Case_2_Template, 1, 0)(3, MyApp_Case_3_Template, 1, 0)(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+  let $MyApp_contFlowTmp$;
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance();
+    $r3$.ɵɵconditional(($MyApp_contFlowTmp$ = ctx.value()) === 0 ? 2 : $MyApp_contFlowTmp$ === 1 ? 2 : $MyApp_contFlowTmp$ === 2 ? 3 : 4);
+  }
+}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -7019,6 +7019,37 @@ suppress
             `not be projected into the specific slot because the surrounding @default has more than one node at its root.`,
         );
       });
+
+      it('should work with @switch block declared in an ng-template with template scoped variables', () => {
+        env.write(
+          'test.ts',
+          `import {Component} from '@angular/core'; 
+           import {CommonModule} from '@angular/common'; 
+
+          @Component({
+            imports: [CommonModule],
+            template: \`
+                <ng-template #template let-foo="fooValue" let-bar="fooValue">
+                  @switch (bar) {
+                    @case (foo) {
+                      {{bar}}
+                    }
+                  }
+                </ng-template>
+
+                <ng-container *ngTemplateOutlet="template; context: {fooValue: expr}"></ng-container>
+            \`,
+          })
+          class TestCmp {
+            expr = 2;
+          }
+        `,
+        );
+        const diags = env
+          .driveDiagnostics()
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ''));
+        expect(diags.length).toBe(0); // Template variables should be accessible
+      });
     });
 
     describe('@let declarations', () => {

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -89,11 +89,15 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
 
   visitSwitchBlock(block: t.SwitchBlock): void {
     this.visit(block.expression);
-    this.visitAllTemplateNodes(block.cases);
+    this.visitAllTemplateNodes(block.groups);
   }
 
   visitSwitchBlockCase(block: t.SwitchBlockCase): void {
     block.expression && this.visit(block.expression);
+  }
+
+  visitSwitchBlockCaseGroup(block: t.SwitchBlockCaseGroup): void {
+    this.visitAllTemplateNodes(block.cases);
     this.visitAllTemplateNodes(block.children);
   }
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -165,6 +165,7 @@ export {
   Reference as TmplAstReference,
   SwitchBlock as TmplAstSwitchBlock,
   SwitchBlockCase as TmplAstSwitchBlockCase,
+  SwitchBlockCaseGroup as TmplAstSwitchBlockCaseGroup,
   Template as TmplAstTemplate,
   Text as TmplAstText,
   TextAttribute as TmplAstTextAttribute,

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -153,12 +153,9 @@ const SUPPORTED_BLOCKS = [
   '@placeholder',
   '@loading',
   '@error',
-];
+] as const;
 
-const INTERPOLATION = {
-  start: '{{',
-  end: '}}',
-};
+const INTERPOLATION = {start: '{{', end: '}}'} as const;
 
 // See https://www.w3.org/TR/html51/syntax.html#writing-html-documents
 class _Tokenizer {
@@ -321,6 +318,15 @@ class _Tokenizer {
 
     if (this._attemptCharCode(chars.$LBRACE)) {
       this._beginToken(TokenType.BLOCK_OPEN_END);
+      this._endToken([]);
+    } else if (
+      this._isBlockStart() &&
+      (startToken.parts[0] === 'case' || startToken.parts[0] === 'default')
+    ) {
+      // We only allow @case statements to be consecutive without a block in between.
+      this._beginToken(TokenType.BLOCK_OPEN_END);
+      this._endToken([]);
+      this._beginToken(TokenType.BLOCK_CLOSE);
       this._endToken([]);
     } else {
       startToken.type = TokenType.INCOMPLETE_BLOCK_OPEN;

--- a/packages/compiler/src/render3/partial/component.ts
+++ b/packages/compiler/src/render3/partial/component.ts
@@ -281,4 +281,8 @@ class BlockPresenceVisitor extends RecursiveVisitor {
   override visitSwitchBlockCase(): void {
     this.hasBlocks = true;
   }
+
+  override visitSwitchBlockCaseGroup(): void {
+    this.hasBlocks = true;
+  }
 }

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ASTWithSource, EmptyExpr, RecursiveAstVisitor, AST} from '../expression_parser/ast';
+import {AST, ASTWithSource, EmptyExpr, RecursiveAstVisitor} from '../expression_parser/ast';
 import * as html from '../ml_parser/ast';
 import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
@@ -228,9 +228,10 @@ export function createSwitchBlock(
     ast.parameters.length > 0
       ? parseBlockParameterToBinding(ast.parameters[0], bindingParser)
       : bindingParser.parseBinding('', false, ast.sourceSpan, 0);
-  const cases: t.SwitchBlockCase[] = [];
+  const groups: t.SwitchBlockCaseGroup[] = [];
   const unknownBlocks: t.UnknownBlock[] = [];
-  let defaultCase: t.SwitchBlockCase | null = null;
+  let collectedCases: t.SwitchBlockCase[] = [];
+  let firstCaseStart: ParseSourceSpan | null = null;
 
   // Here we assume that all the blocks are valid given that we validated them above.
   for (const node of ast.children) {
@@ -243,42 +244,64 @@ export function createSwitchBlock(
       continue;
     }
 
-    const expression =
-      node.name === 'case' ? parseBlockParameterToBinding(node.parameters[0], bindingParser) : null;
-    const ast = new t.SwitchBlockCase(
+    const isCase = node.name === 'case';
+    let expression: AST | null = null;
+
+    if (isCase) {
+      expression = parseBlockParameterToBinding(node.parameters[0], bindingParser);
+    }
+
+    const switchCase = new t.SwitchBlockCase(
       expression,
-      html.visitAll(visitor, node.children, node.children),
       node.sourceSpan,
       node.startSourceSpan,
       node.endSourceSpan,
       node.nameSpan,
+    );
+    collectedCases.push(switchCase);
+
+    const caseWithoutBody = node.children.length === 0;
+    if (caseWithoutBody) {
+      if (firstCaseStart === null) {
+        firstCaseStart = node.sourceSpan;
+      }
+      // we'll collect the cases until we find a body.
+      continue;
+    }
+
+    let sourceSpan = node.sourceSpan;
+    let startSourceSpan = node.startSourceSpan;
+    if (firstCaseStart !== null) {
+      // We need to create a new sourceSpan that represents all the cases that fallthrough to a single block body
+      sourceSpan = new ParseSourceSpan(firstCaseStart.start, node.sourceSpan.end);
+      startSourceSpan = new ParseSourceSpan(firstCaseStart.start, node.startSourceSpan.end);
+      firstCaseStart = null;
+    }
+
+    const group = new t.SwitchBlockCaseGroup(
+      collectedCases,
+      html.visitAll(visitor, node.children, node.children),
+      sourceSpan,
+      startSourceSpan,
+      node.endSourceSpan,
+      node.nameSpan,
       node.i18n,
     );
-
-    if (expression === null) {
-      defaultCase = ast;
-    } else {
-      cases.push(ast);
-    }
+    groups.push(group);
+    collectedCases = [];
   }
 
-  // Ensure that the default case is last in the array.
-  if (defaultCase !== null) {
-    cases.push(defaultCase);
-  }
+  const node = new t.SwitchBlock(
+    primaryExpression,
+    groups,
+    unknownBlocks,
+    ast.sourceSpan,
+    ast.startSourceSpan,
+    ast.endSourceSpan,
+    ast.nameSpan,
+  );
 
-  return {
-    node: new t.SwitchBlock(
-      primaryExpression,
-      cases,
-      unknownBlocks,
-      ast.sourceSpan,
-      ast.startSourceSpan,
-      ast.endSourceSpan,
-      ast.nameSpan,
-    ),
-    errors,
-  };
+  return {node, errors};
 }
 
 /** Parses the parameters of a `for` loop block. */

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -26,7 +26,7 @@ import {
   LetDeclaration,
   Node,
   Reference,
-  SwitchBlockCase,
+  SwitchBlockCaseGroup,
   Template,
   TextAttribute,
   Variable,
@@ -35,7 +35,7 @@ import {
 /** Node that has a `Scope` associated with it. */
 export type ScopedNode =
   | Template
-  | SwitchBlockCase
+  | SwitchBlockCaseGroup
   | IfBlockBranch
   | ForLoopBlock
   | ForLoopBlockEmpty

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -41,6 +41,7 @@ import {
   Reference,
   SwitchBlock,
   SwitchBlockCase,
+  SwitchBlockCaseGroup,
   Template,
   Text,
   TextAttribute,
@@ -327,7 +328,7 @@ class Scope implements Visitor {
       nodeOrNodes.contextVariables.forEach((v) => this.visitVariable(v));
       nodeOrNodes.children.forEach((node) => node.visit(this));
     } else if (
-      nodeOrNodes instanceof SwitchBlockCase ||
+      nodeOrNodes instanceof SwitchBlockCaseGroup ||
       nodeOrNodes instanceof ForLoopBlockEmpty ||
       nodeOrNodes instanceof DeferredBlock ||
       nodeOrNodes instanceof DeferredBlockError ||
@@ -387,10 +388,12 @@ class Scope implements Visitor {
   }
 
   visitSwitchBlock(block: SwitchBlock) {
-    block.cases.forEach((node) => node.visit(this));
+    block.groups.forEach((node) => node.visit(this));
   }
 
-  visitSwitchBlockCase(block: SwitchBlockCase) {
+  visitSwitchBlockCase(block: SwitchBlockCase) {}
+
+  visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup) {
     this.ingestScopedNode(block);
   }
 
@@ -575,10 +578,14 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   visitSwitchBlock(block: SwitchBlock) {
-    block.cases.forEach((node) => node.visit(this));
+    block.groups.forEach((node) => node.visit(this));
   }
 
   visitSwitchBlockCase(block: SwitchBlockCase) {
+    // DirectiveBinder does not visit expressions
+  }
+
+  visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup) {
     block.children.forEach((node) => node.visit(this));
   }
 
@@ -864,7 +871,7 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
       nodeOrNodes.children.forEach((node) => node.visit(this));
       this.nestingLevel.set(nodeOrNodes, this.level);
     } else if (
-      nodeOrNodes instanceof SwitchBlockCase ||
+      nodeOrNodes instanceof SwitchBlockCaseGroup ||
       nodeOrNodes instanceof ForLoopBlockEmpty ||
       nodeOrNodes instanceof DeferredBlockError ||
       nodeOrNodes instanceof DeferredBlockPlaceholder ||
@@ -933,6 +940,10 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
 
   override visitSwitchBlockCase(block: SwitchBlockCase) {
     block.expression?.visit(this);
+  }
+
+  override visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup) {
+    block.cases.forEach((caseNode) => caseNode.visit(this));
     this.ingestScopedNode(block);
   }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -572,24 +572,24 @@ function ingestIfBlock(unit: ViewCompilationUnit, ifBlock: t.IfBlock): void {
  */
 function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock): void {
   // Don't ingest empty switches since they won't render anything.
-  if (switchBlock.cases.length === 0) {
+  if (switchBlock.groups.length === 0) {
     return;
   }
 
   let firstXref: ir.XrefId | null = null;
   let conditions: Array<ir.ConditionalCaseExpr> = [];
-  for (let i = 0; i < switchBlock.cases.length; i++) {
-    const switchCase = switchBlock.cases[i];
+  for (let i = 0; i < switchBlock.groups.length; i++) {
+    const switchCaseGroup = switchBlock.groups[i];
     const cView = unit.job.allocateView(unit.xref);
-    const tagName = ingestControlFlowInsertionPoint(unit, cView.xref, switchCase);
+    const tagName = ingestControlFlowInsertionPoint(unit, cView.xref, switchCaseGroup);
     let switchCaseI18nMeta: i18n.BlockPlaceholder | undefined = undefined;
-    if (switchCase.i18n !== undefined) {
-      if (!(switchCase.i18n instanceof i18n.BlockPlaceholder)) {
+    if (switchCaseGroup.i18n !== undefined) {
+      if (!(switchCaseGroup.i18n instanceof i18n.BlockPlaceholder)) {
         throw Error(
-          `Unhandled i18n metadata type for switch block: ${switchCase.i18n?.constructor.name}`,
+          `Unhandled i18n metadata type for switch block: ${switchCaseGroup.i18n?.constructor.name}`,
         );
       }
-      switchCaseI18nMeta = switchCase.i18n;
+      switchCaseI18nMeta = switchCaseGroup.i18n;
     }
 
     const createOp = i === 0 ? ir.createConditionalCreateOp : ir.createConditionalBranchCreateOp;
@@ -601,24 +601,27 @@ function ingestSwitchBlock(unit: ViewCompilationUnit, switchBlock: t.SwitchBlock
       'Case',
       ir.Namespace.HTML,
       switchCaseI18nMeta,
-      switchCase.startSourceSpan,
-      switchCase.sourceSpan,
+      switchCaseGroup.startSourceSpan,
+      switchCaseGroup.sourceSpan,
     );
     unit.create.push(conditionalCreateOp);
 
     if (firstXref === null) {
       firstXref = cView.xref;
     }
-    const caseExpr = switchCase.expression
-      ? convertAst(switchCase.expression, unit.job, switchBlock.startSourceSpan)
-      : null;
-    const conditionalCaseExpr = new ir.ConditionalCaseExpr(
-      caseExpr,
-      conditionalCreateOp.xref,
-      conditionalCreateOp.handle,
-    );
-    conditions.push(conditionalCaseExpr);
-    ingestNodes(cView, switchCase.children);
+
+    for (const switchCase of switchCaseGroup.cases) {
+      const caseExpr = switchCase.expression
+        ? convertAst(switchCase.expression, unit.job, switchBlock.startSourceSpan)
+        : null;
+      const conditionalCaseExpr = new ir.ConditionalCaseExpr(
+        caseExpr,
+        conditionalCreateOp.xref,
+        conditionalCreateOp.handle,
+      );
+      conditions.push(conditionalCaseExpr);
+    }
+    ingestNodes(cView, switchCaseGroup.children);
   }
   unit.update.push(
     ir.createConditionalOp(
@@ -1831,7 +1834,7 @@ function convertSourceSpan(
 function ingestControlFlowInsertionPoint(
   unit: ViewCompilationUnit,
   xref: ir.XrefId,
-  node: t.IfBlockBranch | t.SwitchBlockCase | t.ForLoopBlock | t.ForLoopBlockEmpty,
+  node: t.IfBlockBranch | t.SwitchBlockCaseGroup | t.ForLoopBlock | t.ForLoopBlockEmpty,
 ): string | null {
   let root: t.Element | t.Template | null = null;
 

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1075,6 +1075,24 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should parse consecutive @case statements', () => {
+        expect(
+          humanizeDom(
+            parser.parse(`@switch (expr) {@case ('foo') @case ('bar') { <input> }}`, `TestComp`),
+          ),
+        ).toEqual([
+          [html.Block, 'switch', 0],
+          [html.BlockParameter, 'expr'],
+          [html.Block, 'case', 1],
+          [html.BlockParameter, `'foo'`],
+          [html.Block, 'case', 1],
+          [html.BlockParameter, `'bar'`],
+          [html.Text, ' ', 2, [' ']],
+          [html.Element, 'input', 2],
+          [html.Text, ' ', 2, [' ']],
+        ]);
+      });
+
       it('should close void elements used right before a block', () => {
         expect(humanizeDom(parser.parse('<img>@defer {hello}', 'TestComp'))).toEqual([
           [html.Element, 'img', 0],
@@ -1126,6 +1144,18 @@ describe('HtmlParser', () => {
             null,
             'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:28',
+          ],
+        ]);
+      });
+
+      it('should report a final @case without a body', () => {
+        const errors = parser.parse('@switch (expr) {@case (1)}', 'TestComp').errors;
+        expect(errors.length).toEqual(1);
+        expect(humanizeErrors(errors)).toEqual([
+          [
+            'case',
+            'Incomplete block "case". If you meant to write the @ character, you should use the "&#64;" HTML entity instead.',
+            '0:16',
           ],
         ]);
       });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -198,11 +198,15 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
 
   visitSwitchBlock(block: t.SwitchBlock) {
     block.expression.visit(this);
-    t.visitAll(this, block.cases);
+    t.visitAll(this, block.groups);
   }
 
   visitSwitchBlockCase(block: t.SwitchBlockCase) {
     block.expression?.visit(this);
+  }
+
+  visitSwitchBlockCaseGroup(block: t.SwitchBlockCaseGroup) {
+    t.visitAll(this, block.cases);
     t.visitAll(this, block.children);
   }
 

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -27,6 +27,7 @@ import type {
   TmplAstReference,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
   TmplAstTemplate,
   TmplAstText,
   TmplAstTextAttribute,
@@ -78,6 +79,7 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitUnknownBlock(block: TmplAstUnknownBlock): void {}
   visitSwitchBlock(block: TmplAstSwitchBlock): void {}
   visitSwitchBlockCase(block: TmplAstSwitchBlockCase): void {}
+  visitSwitchBlockCaseGroup(block: TmplAstSwitchBlockCaseGroup): void {}
   visitForLoopBlock(block: TmplAstForLoopBlock): void {}
   visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {}
   visitIfBlock(block: TmplAstIfBlock): void {}

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -251,4 +251,75 @@ describe('control flow - switch', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toBe('case 1: (), case 2: (), case 3: (value 3)');
   });
+
+  it('should support consecutive cases for the same block', () => {
+    @Component({
+      template: `
+        @switch (case) {
+          @case (0)
+          @case (1) {
+            case 0 or 1
+          }
+          @case (2) {
+            case 2
+          }
+          @default {
+            default
+          }
+        }
+      `,
+    })
+    class TestComponent {
+      case = 0;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toBe(' case 0 or 1 ');
+
+    fixture.componentInstance.case = 1;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' case 0 or 1 ');
+
+    fixture.componentInstance.case = 2;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' case 2 ');
+
+    fixture.componentInstance.case = 3;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' default ');
+  });
+
+  it('should support a case following a default case in the same group', () => {
+    @Component({
+      template: `
+        @switch (case) {
+          @case (0) {
+            case 0
+          }
+          @default
+          @case (1) {
+            default or case 1
+          }
+        }
+      `,
+    })
+    class TestComponent {
+      case = 0;
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toBe(' case 0 ');
+
+    fixture.componentInstance.case = 1;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' default or case 1 ');
+
+    fixture.componentInstance.case = 5;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' default or case 1 ');
+  });
 });

--- a/packages/language-service/src/outlining_spans.ts
+++ b/packages/language-service/src/outlining_spans.ts
@@ -15,6 +15,7 @@ import {
   TmplAstIfBlock,
   TmplAstNode,
   TmplAstRecursiveVisitor,
+  TmplAstSwitchBlockCase,
   tmplAstVisitAll,
 } from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
@@ -89,7 +90,9 @@ class BlockVisitor extends TmplAstRecursiveVisitor {
     if (
       node instanceof TmplAstBlockNode &&
       // Omit `IfBlock` because we include the branches individually
-      !(node instanceof TmplAstIfBlock)
+      !(node instanceof TmplAstIfBlock) &&
+      // Omit `SwitchBlockCase` because we include the groups
+      !(node instanceof TmplAstSwitchBlockCase)
     ) {
       this.blocks.push(node);
     }

--- a/packages/language-service/src/semantic_tokens.ts
+++ b/packages/language-service/src/semantic_tokens.ts
@@ -29,6 +29,7 @@ import {
   TmplAstReference,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
   TmplAstText,
   TmplAstTextAttribute,
   TmplAstUnknownBlock,
@@ -170,10 +171,12 @@ class ClassificationVisitor implements TmplAstVisitor {
   visitDeferredTrigger(trigger: TmplAstDeferredTrigger) {}
 
   visitSwitchBlock(block: TmplAstSwitchBlock) {
-    this.visitAll(block.cases);
+    this.visitAll(block.groups);
   }
 
-  visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
+  visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {}
+
+  visitSwitchBlockCaseGroup(block: TmplAstSwitchBlockCaseGroup) {
     this.visitAll(block.children);
   }
 

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -42,6 +42,7 @@ import {
   TmplAstReference,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
   TmplAstTemplate,
   TmplAstText,
   TmplAstTextAttribute,
@@ -659,12 +660,16 @@ class TemplateTargetVisitor implements TmplAstVisitor {
 
   visitSwitchBlock(block: TmplAstSwitchBlock) {
     this.visitBinding(block.expression);
-    this.visitAll(block.cases);
+    this.visitAll(block.groups);
     this.visitAll(block.unknownBlocks);
   }
 
   visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
     block.expression && this.visitBinding(block.expression);
+  }
+
+  visitSwitchBlockCaseGroup(block: TmplAstSwitchBlockCaseGroup) {
+    this.visitAll(block.cases);
     this.visitAll(block.children);
   }
 

--- a/tools/manual_api_docs/blocks/switch.md
+++ b/tools/manual_api_docs/blocks/switch.md
@@ -7,8 +7,9 @@ The `@switch` block is inspired by the JavaScript `switch` statement:
   @case (caseA) {
     Case A.
   }
-  @case (caseB) {
-    Case B.
+  @case (caseB)
+  @case (caseC) {
+    Case B or C.
   }
   @default {
     Default case.
@@ -24,6 +25,8 @@ the `===` operator.
 
 The `@default` block is optional and can be omitted. If no `@case` matches the expression and there
 is no `@default` block, nothing is shown.
+
+You can specify multiple conditions for a single block by having consecutive `@case(...)` statements.
 
 **`@switch` does not have fallthrough**, so you do not need an equivalent to a `break` or `return`
 statement.

--- a/vscode-ng-language-service/syntaxes/README.md
+++ b/vscode-ng-language-service/syntaxes/README.md
@@ -4,7 +4,7 @@
 
 If you need to make modification, the respective files should be changed within the repository's [`syntaxes/src`](https://github.com/angular/vscode-ng-language-service/tree/main/syntaxes/src) directory.
 
-Running `pnpm build:syntaxes` will then appropriately update the files in this directory.
+Running `pnpm bazel run //vscode-ng-language-service/syntaxes:syntaxes` will then appropriately update the files in this directory.
 
 # Syntaxes
 
@@ -41,7 +41,7 @@ Snapshot test cases are specified in [test/cases.json](./test/cases.json).
 Snapshot golden files can be updated by running
 
 ```bash
-pnpm test:legacy-syntaxes -u
+pnpm bazel run //vscode-ng-language-service/syntaxes/test:test -- -u
 ```
 
 in the root directory of this repository. Goldens must be updated when a new

--- a/vscode-ng-language-service/syntaxes/src/template-blocks.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-blocks.ts
@@ -19,8 +19,7 @@ export const TemplateBlocks: GrammarDefinition = {
     },
 
     block: {
-      begin:
-        /(@)(if|else if|else|defer|placeholder|loading|error|switch|case|default|for|empty)(?:\s*)/,
+      begin: /(@)(if|else if|else|defer|placeholder|loading|error|switch|for|empty)(?:\s*)/,
       beginCaptures: {
         1: {
           patterns: [{include: '#transition'}],
@@ -33,7 +32,22 @@ export const TemplateBlocks: GrammarDefinition = {
       // by the #blockBody.
       end: /(?<=\})/,
     },
-
+    caseHeader: {
+      begin: /(@)(case|default)(?:\s*)/,
+      beginCaptures: {
+        1: {patterns: [{include: '#transition'}]},
+        2: {name: 'keyword.control.block.kind.ng'},
+      },
+      patterns: [{include: '#blockExpression'}],
+      end: /(?=@|{)/,
+      name: 'control.block.case.header.ng',
+    },
+    caseBlock: {
+      begin: /(?=@(?:case|default))/,
+      patterns: [{include: '#caseHeader'}, {include: '#blockBody'}],
+      end: /(?<=\})/,
+      name: 'control.block.case.ng',
+    },
     blockExpression: {
       begin: /\(/,
       beginCaptures: {
@@ -90,7 +104,11 @@ export const TemplateBlocks: GrammarDefinition = {
         0: {name: 'punctuation.definition.block.ts'},
       },
       contentName: 'control.block.body.ng',
-      patterns: [{include: 'text.html.derivative'}, {include: 'template.ng'}],
+      patterns: [
+        {include: '#caseBlock'},
+        {include: 'text.html.derivative'},
+        {include: 'template.ng'},
+      ],
     },
   },
 };

--- a/vscode-ng-language-service/syntaxes/template-blocks.json
+++ b/vscode-ng-language-service/syntaxes/template-blocks.json
@@ -12,7 +12,7 @@
       "name": "keyword.control.block.transition.ng"
     },
     "block": {
-      "begin": "(@)(if|else if|else|defer|placeholder|loading|error|switch|case|default|for|empty)(?:\\s*)",
+      "begin": "(@)(if|else if|else|defer|placeholder|loading|error|switch|for|empty)(?:\\s*)",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -35,6 +35,41 @@
       ],
       "name": "control.block.ng",
       "end": "(?<=\\})"
+    },
+    "caseHeader": {
+      "begin": "(@)(case|default)(?:\\s*)",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.block.kind.ng"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#blockExpression"
+        }
+      ],
+      "end": "(?=@|{)",
+      "name": "control.block.case.header.ng"
+    },
+    "caseBlock": {
+      "begin": "(?=@(?:case|default))",
+      "patterns": [
+        {
+          "include": "#caseHeader"
+        },
+        {
+          "include": "#blockBody"
+        }
+      ],
+      "end": "(?<=\\})",
+      "name": "control.block.case.ng"
     },
     "blockExpression": {
       "begin": "\\(",
@@ -125,6 +160,9 @@
       },
       "contentName": "control.block.body.ng",
       "patterns": [
+        {
+          "include": "#caseBlock"
+        },
         {
           "include": "text.html.derivative"
         },

--- a/vscode-ng-language-service/syntaxes/test/data/template-blocks.html
+++ b/vscode-ng-language-service/syntaxes/test/data/template-blocks.html
@@ -7,10 +7,10 @@
 }
 
 @switch (a) {
-    @case (1) {
+    @case(0) @case (1) {
         {{getCase1()}}
     }
-    @case (2) {
+    @case (2) @case(3) {
         {{a.b.c}}
     }
     @default {

--- a/vscode-ng-language-service/syntaxes/test/data/template-blocks.html.snap
+++ b/vscode-ng-language-service/syntaxes/test/data/template-blocks.html.snap
@@ -36,53 +36,73 @@
 #          ^ template.blocks.ng control.block.ng meta.brace.round.ts
 #           ^ template.blocks.ng control.block.ng
 #            ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
->    @case (1) {
-#^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
+>    @case(0) @case (1) {
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.transition.ng
+#     ^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.kind.ng
+#         ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#          ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng control.block.expression.ng constant.numeric.decimal.ts
+#           ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#            ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#             ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.transition.ng
+#              ^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.kind.ng
+#                  ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#                   ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#                    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng control.block.expression.ng constant.numeric.decimal.ts
+#                     ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#                      ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#                       ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
 >        {{getCase1()}}
-#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#        ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
-#          ^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng expression.ng entity.name.function.ts
-#                  ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng meta.brace.round.ts
-#                   ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng meta.brace.round.ts
-#                    ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+#        ^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng punctuation.definition.block.ts
+#          ^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng entity.name.function.ts
+#                  ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng meta.brace.round.ts
+#                   ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng meta.brace.round.ts
+#                    ^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng punctuation.definition.block.ts
 >    }
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
+>    @case (2) @case(3) {
 #^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
->    @case (2) {
-#^^^^ template.blocks.ng
-#    ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
-#     ^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
-#         ^ template.blocks.ng control.block.ng
-#          ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#           ^ template.blocks.ng control.block.ng control.block.expression.ng constant.numeric.decimal.ts
-#            ^ template.blocks.ng control.block.ng meta.brace.round.ts
-#             ^ template.blocks.ng control.block.ng
-#              ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.transition.ng
+#     ^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.kind.ng
+#         ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#          ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#           ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng control.block.expression.ng constant.numeric.decimal.ts
+#            ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#             ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#              ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.transition.ng
+#               ^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.kind.ng
+#                   ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#                    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng control.block.expression.ng constant.numeric.decimal.ts
+#                     ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng meta.brace.round.ts
+#                      ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#                       ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
 >        {{a.b.c}}
-#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#        ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
-#          ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.object.ts
-#           ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng punctuation.accessor.ts
-#            ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.object.property.ts
-#             ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng punctuation.accessor.ts
-#              ^ template.blocks.ng control.block.ng control.block.body.ng expression.ng variable.other.property.ts
-#               ^^ template.blocks.ng control.block.ng control.block.body.ng punctuation.definition.block.ts
+#^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+#        ^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng punctuation.definition.block.ts
+#          ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng variable.other.object.ts
+#           ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng punctuation.accessor.ts
+#            ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng variable.other.object.property.ts
+#             ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng punctuation.accessor.ts
+#              ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng expression.ng variable.other.property.ts
+#               ^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng punctuation.definition.block.ts
 >    }
-#^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
 >    @default {
-#^^^^ template.blocks.ng
-#    ^ template.blocks.ng control.block.ng keyword.control.block.transition.ng
-#     ^^^^^^^ template.blocks.ng control.block.ng keyword.control.block.kind.ng
-#            ^ template.blocks.ng control.block.ng
-#             ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
->        default case
-#^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng
->    }
 #^^^^ template.blocks.ng control.block.ng control.block.body.ng
-#    ^ template.blocks.ng control.block.ng punctuation.definition.block.ts
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.transition.ng
+#     ^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng keyword.control.block.kind.ng
+#            ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.case.header.ng
+#             ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
+>        default case
+#^^^^^^^^^^^^^^^^^^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+>    }
+#^^^^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng control.block.body.ng
+#    ^ template.blocks.ng control.block.ng control.block.body.ng control.block.case.ng punctuation.definition.block.ts
 >}
-#^^ template.blocks.ng
+#^ template.blocks.ng control.block.ng punctuation.definition.block.ts
 >
 >@if (a==b) { hello } @else  { goodbye }
 #^ template.blocks.ng control.block.ng keyword.control.block.transition.ng

--- a/vscode-ng-language-service/syntaxes/test/driver.ts
+++ b/vscode-ng-language-service/syntaxes/test/driver.ts
@@ -39,13 +39,22 @@ function spawn(...args: Parameters<typeof cp.spawn>): Promise<number> {
 async function snapshotTest({scopeName, grammarFiles, testFile}: TestCase): Promise<number> {
   grammarFiles.push(...DUMMY_GRAMMARS);
   const grammarOptions = grammarFiles.reduce((acc, file) => [...acc, '-g', file], [] as string[]);
+
+  const resolvedTestFile = process.env.BUILD_WORKSPACE_DIRECTORY
+    ? path.join(process.env.BUILD_WORKSPACE_DIRECTORY, 'vscode-ng-language-service', testFile)
+    : testFile;
+
   const options = [
     'node_modules/vscode-tmgrammar-test/dist/snapshot.js',
     '-s',
     scopeName,
     ...grammarOptions,
-    testFile,
+    resolvedTestFile,
   ];
+
+  if (process.argv.includes('-u')) {
+    options.push('-u');
+  }
 
   return spawn('node', options, {stdio: 'inherit' /* use parent process IO */}).catch(
     (code) => code,


### PR DESCRIPTION
Happy Hollidays & Merry Christmas 🎅🏻 🎄

Consecutive `@case` blocks are now supported:

```ts
@switch (case) {
  @case (0)
  @case (1) {
    <div>case 0 or 1</div>
  }
  @case (2) {
    <div>case 2</div>
  }
  @default {
    <div>default</div>
  }
}
```

fixes #14659
