### PR TITLE
refactor(core): Make `toString` implementations tree-shakable

### DIFF
--- a/packages/core/src/di/host_attribute_token.ts
+++ b/packages/core/src/di/host_attribute_token.ts
@@ -37,6 +37,10 @@ export class HostAttributeToken {
   __NG_ELEMENT_ID__ = () => ɵɵinjectAttribute(this.attributeName);
 
   toString(): string {
-    return `HostAttributeToken ${this.attributeName}`;
+    if (ngDevMode) {
+      return `HostAttributeToken ${this.attributeName}`;
+    }
+
+    return '';
   }
 }

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -124,7 +124,11 @@ export class InjectionToken<T> {
   }
 
   toString(): string {
-    return `InjectionToken ${this._desc}`;
+    if (ngDevMode) {
+      return `InjectionToken ${this._desc}`;
+    }
+
+    return '';
   }
 }
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -455,12 +455,16 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
   }
 
   override toString() {
-    const tokens: string[] = [];
-    const records = this.records;
-    for (const token of records.keys()) {
-      tokens.push(stringify(token));
+    if (ngDevMode) {
+      const tokens: string[] = [];
+      const records = this.records;
+      for (const token of records.keys()) {
+        tokens.push(stringify(token));
+      }
+      return `R3Injector[${tokens.join(', ')}]`;
     }
-    return `R3Injector[${tokens.join(', ')}]`;
+
+    return '';
   }
 
   /**


### PR DESCRIPTION
Guards `toString` methods in `HostAttributeToken`, `InjectionToken`, and `R3Injector` with `ngDevMode` to remove debug-only stringification from production builds.
 
### Other information

As I understand it, `toString`  is only intended for debugging in development.