### PR TITLE
Add support for spread syntax in templates

### DIFF
--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -163,6 +163,10 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
   createObjectLiteral(properties: ObjectLiteralProperty<t.Expression>[]): t.Expression {
     return t.objectExpression(
       properties.map((prop) => {
+        if (prop.kind === 'spread') {
+          return t.spreadElement(prop.expression);
+        }
+
         const key = prop.quoted
           ? t.stringLiteral(prop.propertyName)
           : t.identifier(prop.propertyName);

--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_factory.ts
@@ -21,7 +21,7 @@ import {
 /**
  * A Babel flavored implementation of the AstFactory.
  */
-export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
+export class BabelAstFactory implements AstFactory<t.Statement, t.Expression | t.SpreadElement> {
   constructor(
     /** The absolute path to the source file being compiled. */
     private sourceUrl: string,
@@ -74,7 +74,11 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
 
   createBlock = t.blockStatement;
 
-  createCallExpression(callee: t.Expression, args: t.Expression[], pure: boolean): t.Expression {
+  createCallExpression(
+    callee: t.Expression,
+    args: (t.Expression | t.SpreadElement)[],
+    pure: boolean,
+  ): t.Expression {
     const call = t.callExpression(callee, args);
     if (pure) {
       t.addComment(call, 'leading', ' @__PURE__ ', /* line */ false);
@@ -89,6 +93,10 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
   }
 
   createExpressionStatement = t.expressionStatement;
+
+  createSpreadElement(expression: t.Expression): t.SpreadElement {
+    return t.spreadElement(expression);
+  }
 
   createFunctionDeclaration(
     functionName: string,
@@ -158,7 +166,9 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     }
   }
 
-  createNewExpression = t.newExpression;
+  createNewExpression(expression: t.Expression, args: t.Expression[]): t.Expression {
+    return t.newExpression(expression, args);
+  }
 
   createObjectLiteral(properties: ObjectLiteralProperty<t.Expression>[]): t.Expression {
     return t.objectExpression(
@@ -181,7 +191,9 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     return t.memberExpression(expression, t.identifier(propertyName), /* computed */ false);
   }
 
-  createReturnStatement = t.returnStatement;
+  createReturnStatement(expression: t.Expression | null): t.Statement {
+    return t.returnStatement(expression);
+  }
 
   createTaggedTemplate(tag: t.Expression, template: TemplateLiteral<t.Expression>): t.Expression {
     return t.taggedTemplateExpression(tag, this.createTemplateLiteral(template));
@@ -223,7 +235,7 @@ export class BabelAstFactory implements AstFactory<t.Statement, t.Expression> {
     return t.regExpLiteral(body, flags ?? undefined);
   }
 
-  setSourceMapRange<T extends t.Statement | t.Expression | t.TemplateElement>(
+  setSourceMapRange<T extends t.Statement | t.Expression | t.TemplateElement | t.SpreadElement>(
     node: T,
     sourceMapRange: SourceMapRange | null,
   ): T {

--- a/packages/compiler-cli/linker/babel/src/es2015_linker_plugin.ts
+++ b/packages/compiler-cli/linker/babel/src/es2015_linker_plugin.ts
@@ -26,7 +26,11 @@ export function createEs2015LinkerPlugin({
   logger,
   ...options
 }: LinkerPluginOptions): PluginObj {
-  let fileLinker: FileLinker<ConstantScopePath, t.Statement, t.Expression> | null = null;
+  let fileLinker: FileLinker<
+    ConstantScopePath,
+    t.Statement,
+    t.Expression | t.SpreadElement
+  > | null = null;
 
   return {
     visitor: {
@@ -47,13 +51,10 @@ export function createEs2015LinkerPlugin({
           }
           const sourceUrl = fileSystem.resolve(file.opts.cwd ?? '.', filename);
 
-          const linkerEnvironment = LinkerEnvironment.create<t.Statement, t.Expression>(
-            fileSystem,
-            logger,
-            new BabelAstHost(),
-            new BabelAstFactory(sourceUrl),
-            options,
-          );
+          const linkerEnvironment = LinkerEnvironment.create<
+            t.Statement,
+            t.Expression | t.SpreadElement
+          >(fileSystem, logger, new BabelAstHost(), new BabelAstFactory(sourceUrl), options);
           fileLinker = new FileLinker(linkerEnvironment, sourceUrl, file.code);
         },
 

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -288,11 +288,15 @@ describe('BabelAstFactory', () => {
     it('should create an object literal node, with the given properties', () => {
       const prop1 = expression.ast`42`;
       const prop2 = expression.ast`"moo"`;
+      const prop3 = expression.ast`foo`;
       const obj = factory.createObjectLiteral([
-        {propertyName: 'prop1', value: prop1, quoted: false},
-        {propertyName: 'prop2', value: prop2, quoted: true},
+        {propertyName: 'prop1', value: prop1, kind: 'property', quoted: false},
+        {propertyName: 'prop2', value: prop2, kind: 'property', quoted: true},
+        {expression: prop3, kind: 'spread'},
       ]);
-      expect(generate(obj).code).toEqual(['{', '  prop1: 42,', '  "prop2": "moo"', '}'].join('\n'));
+      expect(generate(obj).code).toEqual(
+        ['{', '  prop1: 42,', '  "prop2": "moo",', '  ...foo', '}'].join('\n'),
+      );
     });
   });
 

--- a/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
+++ b/packages/compiler-cli/linker/babel/test/ast/babel_ast_factory_spec.ts
@@ -412,6 +412,23 @@ describe('BabelAstFactory', () => {
     });
   });
 
+  describe('createSpreadElement()', () => {
+    it('should create a spread element in an array', () => {
+      const before = factory.createIdentifier('a');
+      const spread = factory.createSpreadElement(factory.createIdentifier('b'));
+      const array = factory.createArrayLiteral([before, spread]);
+      expect(generate(array).code).toEqual('[a, ...b]');
+    });
+
+    it('should create a spread in a call expression', () => {
+      const fn = factory.createIdentifier('fn');
+      const before = factory.createIdentifier('a');
+      const spread = factory.createSpreadElement(factory.createIdentifier('b'));
+      const call = factory.createCallExpression(fn, [before, spread], false);
+      expect(generate(call).code).toEqual('fn(a, ...b)');
+    });
+  });
+
   describe('setSourceMapRange()', () => {
     it('should attach the `sourceMapRange` to the given `node`', () => {
       const expr = expression.ast`42`;

--- a/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
+++ b/packages/compiler-cli/linker/test/ast/ast_value_spec.ts
@@ -25,8 +25,8 @@ interface TestObject {
 const host: AstHost<ts.Expression> = new TypeScriptAstHost();
 const factory = new TypeScriptAstFactory(/* annotateForClosureCompiler */ false);
 const nestedObj = factory.createObjectLiteral([
-  {propertyName: 'x', quoted: false, value: factory.createLiteral(42)},
-  {propertyName: 'y', quoted: false, value: factory.createLiteral('X')},
+  {propertyName: 'x', kind: 'property', quoted: false, value: factory.createLiteral(42)},
+  {propertyName: 'y', kind: 'property', quoted: false, value: factory.createLiteral('X')},
 ]);
 const nestedArray = factory.createArrayLiteral([
   factory.createLiteral(1),
@@ -34,11 +34,11 @@ const nestedArray = factory.createArrayLiteral([
 ]);
 const obj = AstObject.parse<TestObject, ts.Expression>(
   factory.createObjectLiteral([
-    {propertyName: 'a', quoted: false, value: factory.createLiteral(42)},
-    {propertyName: 'b', quoted: false, value: factory.createLiteral('X')},
-    {propertyName: 'c', quoted: false, value: factory.createLiteral(true)},
-    {propertyName: 'd', quoted: false, value: nestedObj},
-    {propertyName: 'e', quoted: false, value: nestedArray},
+    {propertyName: 'a', kind: 'property', quoted: false, value: factory.createLiteral(42)},
+    {propertyName: 'b', kind: 'property', quoted: false, value: factory.createLiteral('X')},
+    {propertyName: 'c', kind: 'property', quoted: false, value: factory.createLiteral(true)},
+    {propertyName: 'd', kind: 'property', quoted: false, value: nestedObj},
+    {propertyName: 'e', kind: 'property', quoted: false, value: nestedArray},
   ]),
   host,
 );

--- a/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
+++ b/packages/compiler-cli/linker/test/file_linker/file_linker_spec.ts
@@ -44,9 +44,9 @@ describe('FileLinker', () => {
       const version = factory.createLiteral('0.0.0-PLACEHOLDER');
       const ngImport = factory.createIdentifier('core');
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'minVersion', quoted: false, value: version},
-        {propertyName: 'version', quoted: false, value: version},
-        {propertyName: 'ngImport', quoted: false, value: ngImport},
+        {propertyName: 'minVersion', quoted: false, kind: 'property', value: version},
+        {propertyName: 'version', quoted: false, kind: 'property', value: version},
+        {propertyName: 'ngImport', quoted: false, kind: 'property', value: ngImport},
       ]);
       expect(() =>
         fileLinker.linkPartialDeclaration('foo', [declarationArg], new MockDeclarationScope()),
@@ -58,8 +58,8 @@ describe('FileLinker', () => {
       const version = factory.createLiteral('0.0.0-PLACEHOLDER');
       const ngImport = factory.createIdentifier('core');
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'version', quoted: false, value: version},
-        {propertyName: 'ngImport', quoted: false, value: ngImport},
+        {propertyName: 'version', quoted: false, kind: 'property', value: version},
+        {propertyName: 'ngImport', quoted: false, kind: 'property', value: ngImport},
       ]);
       expect(() =>
         fileLinker.linkPartialDeclaration(
@@ -75,8 +75,8 @@ describe('FileLinker', () => {
       const version = factory.createLiteral('0.0.0-PLACEHOLDER');
       const ngImport = factory.createIdentifier('core');
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'minVersion', quoted: false, value: version},
-        {propertyName: 'ngImport', quoted: false, value: ngImport},
+        {propertyName: 'minVersion', quoted: false, kind: 'property', value: version},
+        {propertyName: 'ngImport', quoted: false, kind: 'property', value: ngImport},
       ]);
       expect(() =>
         fileLinker.linkPartialDeclaration(
@@ -91,8 +91,8 @@ describe('FileLinker', () => {
       const {fileLinker} = createFileLinker();
       const version = factory.createLiteral('0.0.0-PLACEHOLDER');
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'minVersion', quoted: false, value: version},
-        {propertyName: 'version', quoted: false, value: version},
+        {propertyName: 'minVersion', quoted: false, kind: 'property', value: version},
+        {propertyName: 'version', quoted: false, kind: 'property', value: version},
       ]);
       expect(() =>
         fileLinker.linkPartialDeclaration(
@@ -116,9 +116,9 @@ describe('FileLinker', () => {
       const ngImport = factory.createIdentifier('core');
       const version = factory.createLiteral('0.0.0-PLACEHOLDER');
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'ngImport', quoted: false, value: ngImport},
-        {propertyName: 'minVersion', quoted: false, value: version},
-        {propertyName: 'version', quoted: false, value: version},
+        {propertyName: 'ngImport', quoted: false, kind: 'property', value: ngImport},
+        {propertyName: 'minVersion', quoted: false, kind: 'property', value: version},
+        {propertyName: 'version', quoted: false, kind: 'property', value: version},
       ]);
 
       const compilationResult = fileLinker.linkPartialDeclaration(
@@ -187,13 +187,24 @@ describe('FileLinker', () => {
       // Here we use the `core` identifier for `ngImport` to trigger the use of a shared scope for
       // constant statements.
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'ngImport', quoted: false, value: factory.createIdentifier('core')},
+        {
+          propertyName: 'ngImport',
+          quoted: false,
+          kind: 'property',
+          value: factory.createIdentifier('core'),
+        },
         {
           propertyName: 'minVersion',
           quoted: false,
+          kind: 'property',
           value: factory.createLiteral('0.0.0-PLACEHOLDER'),
         },
-        {propertyName: 'version', quoted: false, value: factory.createLiteral('0.0.0-PLACEHOLDER')},
+        {
+          propertyName: 'version',
+          quoted: false,
+          kind: 'property',
+          value: factory.createLiteral('0.0.0-PLACEHOLDER'),
+        },
       ]);
 
       const replacement = fileLinker.linkPartialDeclaration(
@@ -217,15 +228,22 @@ describe('FileLinker', () => {
       // Here we use a string literal `"not-a-module"` for `ngImport` to cause constant
       // statements to be emitted in an IIFE rather than added to the shared constant scope.
       const declarationArg = factory.createObjectLiteral([
-        {propertyName: 'ngImport', quoted: false, value: factory.createLiteral('not-a-module')},
+        {
+          propertyName: 'ngImport',
+          quoted: false,
+          kind: 'property',
+          value: factory.createLiteral('not-a-module'),
+        },
         {
           propertyName: 'minVersion',
           quoted: false,
+          kind: 'property',
           value: factory.createLiteral('0.0.0-PLACEHOLDER'),
         },
         {
           propertyName: 'version',
           quoted: false,
+          kind: 'property',
           value: factory.createLiteral('0.0.0-PLACEHOLDER'),
         },
       ]);

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -361,9 +361,11 @@ export interface SourceMapRange {
 }
 
 /**
- * Information used by the `AstFactory` to create a property on an object literal expression.
+ * Information used by the `AstFactory` to create a property assignment
+ * on an object literal expression.
  */
-export interface ObjectLiteralProperty<TExpression> {
+export interface ObjectLiteralAssignment<TExpression> {
+  kind: 'property';
   propertyName: string;
   value: TExpression;
   /**
@@ -371,6 +373,19 @@ export interface ObjectLiteralProperty<TExpression> {
    */
   quoted: boolean;
 }
+
+/**
+ * Information used by the `AstFactory` to create a spread on an object literal expression.
+ */
+export interface ObjectLiteralSpread<TExpression> {
+  kind: 'spread';
+  expression: TExpression;
+}
+
+/** Possible properties in an object literal. */
+export type ObjectLiteralProperty<TExpression> =
+  | ObjectLiteralAssignment<TExpression>
+  | ObjectLiteralSpread<TExpression>;
 
 /**
  * Information used by the `AstFactory` to create a template literal string (i.e. a back-ticked

--- a/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/api/ast_factory.ts
@@ -281,6 +281,13 @@ export interface AstFactory<TStatement, TExpression> {
   createRegularExpressionLiteral(body: string, flags: string | null): TExpression;
 
   /**
+   * Create a spread element, typically in an array or function call. E.g. `[...a]` or `fn(...b)`.
+   *
+   * @param target Expression of the spread element.
+   */
+  createSpreadElement(expression: TExpression): TExpression;
+
+  /**
    * Attach a source map range to the given node.
    *
    * @param node the node to which the range should be attached.

--- a/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/translator.ts
@@ -415,6 +415,11 @@ export class ExpressionTranslatorVisitor<TFile, TStatement, TExpression>
     throw new Error('Method not implemented');
   }
 
+  visitSpreadElementExpr(ast: o.outputAst.SpreadElementExpr, context: any): TExpression {
+    const expression = ast.expression.visitExpression(this, context);
+    return this.setSourceMapRange(this.factory.createSpreadElement(expression), ast.sourceSpan);
+  }
+
   visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, _context: Context): any {
     this.recordWrappedNode(ast);
     return ast.node;

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -280,6 +280,11 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     throw new Error('Method not implemented.');
   }
 
+  visitSpreadElementExpr(ast: o.outputAst.SpreadElementExpr, context: any) {
+    const typeNode = this.translateExpression(ast.expression, context);
+    return ts.factory.createRestTypeNode(typeNode);
+  }
+
   private translateType(type: o.Type, context: Context): ts.TypeNode {
     const typeNode = type.visitType(this, context);
     if (!ts.isTypeNode(typeNode)) {

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -228,6 +228,10 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
 
   visitLiteralMapExpr(ast: o.LiteralMapExpr, context: Context): ts.TypeLiteralNode {
     const entries = ast.entries.map((entry) => {
+      if (entry instanceof o.LiteralMapSpreadAssignment) {
+        throw new Error('Spread is not supported in this context');
+      }
+
       const {key, quoted} = entry;
       const type = this.translateExpression(entry.value, context);
       return ts.factory.createPropertySignature(

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -243,14 +243,18 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
 
   createObjectLiteral(properties: ObjectLiteralProperty<ts.Expression>[]): ts.Expression {
     return ts.factory.createObjectLiteralExpression(
-      properties.map((prop) =>
-        ts.factory.createPropertyAssignment(
+      properties.map((prop) => {
+        if (prop.kind === 'spread') {
+          return ts.factory.createSpreadAssignment(prop.expression);
+        }
+
+        return ts.factory.createPropertyAssignment(
           prop.quoted
             ? ts.factory.createStringLiteral(prop.propertyName)
             : ts.factory.createIdentifier(prop.propertyName),
           prop.value,
-        ),
-      ),
+        );
+      }),
     );
   }
 

--- a/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/typescript_ast_factory.ts
@@ -262,6 +262,8 @@ export class TypeScriptAstFactory implements AstFactory<ts.Statement, ts.Express
 
   createPropertyAccess = ts.factory.createPropertyAccessExpression;
 
+  createSpreadElement = ts.factory.createSpreadElement;
+
   createReturnStatement(expression: ts.Expression | null): ts.Statement {
     return ts.factory.createReturnStatement(expression ?? undefined);
   }

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -330,14 +330,15 @@ describe('TypeScriptAstFactory', () => {
   describe('createObjectLiteral()', () => {
     it('should create an object literal node, with the given properties', () => {
       const {
-        items: [prop1, prop2],
+        items: [prop1, prop2, prop3],
         generate,
-      } = setupExpressions('42', '"moo"');
+      } = setupExpressions('42', '"moo"', 'foo');
       const obj = factory.createObjectLiteral([
-        {propertyName: 'prop1', value: prop1, quoted: false},
-        {propertyName: 'prop2', value: prop2, quoted: true},
+        {propertyName: 'prop1', value: prop1, kind: 'property', quoted: false},
+        {propertyName: 'prop2', value: prop2, kind: 'property', quoted: true},
+        {expression: prop3, kind: 'spread'},
       ]);
-      expect(generate(obj)).toEqual('{ prop1: 42, "prop2": "moo" }');
+      expect(generate(obj)).toEqual('{ prop1: 42, "prop2": "moo", ...foo }');
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/typescript_ast_factory_spec.ts
@@ -490,6 +490,25 @@ describe('TypeScriptAstFactory', () => {
     });
   });
 
+  describe('createSpreadElement()', () => {
+    it('should create a spread element in an array', () => {
+      const {generate} = setupStatements();
+      const before = factory.createIdentifier('a');
+      const spread = factory.createSpreadElement(factory.createIdentifier('b'));
+      const array = factory.createArrayLiteral([before, spread]);
+      expect(generate(array)).toEqual('[a, ...b]');
+    });
+
+    it('should create a spread in a call expression', () => {
+      const {generate} = setupStatements();
+      const fn = factory.createIdentifier('fn');
+      const before = factory.createIdentifier('a');
+      const spread = factory.createSpreadElement(factory.createIdentifier('b'));
+      const call = factory.createCallExpression(fn, [before, spread], false);
+      expect(generate(call)).toEqual('fn(a, ...b)');
+    });
+  });
+
   describe('setSourceMapRange()', () => {
     it('should attach the `sourceMapRange` to the given `node`', () => {
       const {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -239,9 +239,14 @@ class AstTranslator implements AstVisitor {
   }
 
   visitLiteralMap(ast: LiteralMap): ts.Expression {
-    const properties = ast.keys.map(({key}, idx) => {
+    const properties = ast.keys.map((key, idx) => {
       const value = this.translate(ast.values[idx]);
-      return ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(key), value);
+
+      if (key.kind === 'property') {
+        return ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(key.key), value);
+      } else {
+        return ts.factory.createSpreadAssignment(value);
+      }
     });
     const literal = ts.factory.createObjectLiteralExpression(properties, true);
     // If strictLiteralTypes is disabled, object literals are cast to `any`.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -30,6 +30,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  SpreadElement,
   TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
@@ -484,6 +485,13 @@ class AstTranslator implements AstVisitor {
     return ts.factory.createParenthesizedExpression(this.translate(ast.expression));
   }
 
+  visitSpreadElement(ast: SpreadElement) {
+    const expression = wrapForDiagnostics(this.translate(ast.expression));
+    const node = ts.factory.createSpreadElement(expression);
+    addParseSpanInfo(node, ast.sourceSpan);
+    return node;
+  }
+
   private convertToSafeCall(
     ast: Call | SafeCall,
     expr: ts.Expression,
@@ -546,40 +554,40 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
   visitBinary(ast: Binary): boolean {
     return ast.left.visit(this) || ast.right.visit(this);
   }
-  visitChain(ast: Chain): boolean {
+  visitChain(): boolean {
     return false;
   }
   visitConditional(ast: Conditional): boolean {
     return ast.condition.visit(this) || ast.trueExp.visit(this) || ast.falseExp.visit(this);
   }
-  visitCall(ast: Call): boolean {
+  visitCall(): boolean {
     return true;
   }
-  visitSafeCall(ast: SafeCall): boolean {
+  visitSafeCall(): boolean {
     return false;
   }
-  visitImplicitReceiver(ast: ImplicitReceiver): boolean {
+  visitImplicitReceiver(): boolean {
     return false;
   }
-  visitThisReceiver(ast: ThisReceiver): boolean {
+  visitThisReceiver(): boolean {
     return false;
   }
   visitInterpolation(ast: Interpolation): boolean {
     return ast.expressions.some((exp) => exp.visit(this));
   }
-  visitKeyedRead(ast: KeyedRead): boolean {
+  visitKeyedRead(): boolean {
     return false;
   }
-  visitLiteralArray(ast: LiteralArray): boolean {
+  visitLiteralArray(): boolean {
     return true;
   }
-  visitLiteralMap(ast: LiteralMap): boolean {
+  visitLiteralMap(): boolean {
     return true;
   }
-  visitLiteralPrimitive(ast: LiteralPrimitive): boolean {
+  visitLiteralPrimitive(): boolean {
     return false;
   }
-  visitPipe(ast: BindingPipe): boolean {
+  visitPipe(): boolean {
     return true;
   }
   visitPrefixNot(ast: PrefixNot): boolean {
@@ -594,28 +602,31 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
   visitNonNullAssert(ast: NonNullAssert): boolean {
     return ast.expression.visit(this);
   }
-  visitPropertyRead(ast: PropertyRead): boolean {
+  visitPropertyRead(): boolean {
     return false;
   }
-  visitSafePropertyRead(ast: SafePropertyRead): boolean {
+  visitSafePropertyRead(): boolean {
     return false;
   }
-  visitSafeKeyedRead(ast: SafeKeyedRead): boolean {
+  visitSafeKeyedRead(): boolean {
     return false;
   }
-  visitTemplateLiteral(ast: TemplateLiteral, context: any) {
+  visitTemplateLiteral() {
     return false;
   }
-  visitTemplateLiteralElement(ast: TemplateLiteralElement, context: any) {
+  visitTemplateLiteralElement() {
     return false;
   }
-  visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any) {
+  visitTaggedTemplateLiteral() {
     return false;
   }
-  visitParenthesizedExpression(ast: ParenthesizedExpression, context: any) {
+  visitParenthesizedExpression(ast: ParenthesizedExpression) {
     return ast.expression.visit(this);
   }
-  visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
+  visitRegularExpressionLiteral() {
     return false;
+  }
+  visitSpreadElement(ast: SpreadElement) {
+    return ast.expression.visit(this);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -514,6 +514,55 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: array_literal_spread.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ArrayComp {
+    constructor() {
+        this.foo = [];
+        this.bar = [];
+        this.baz = [];
+    }
+}
+ArrayComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ArrayComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+ArrayComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ArrayComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @let simple = [...foo];
+    @let otherEntries = [1, ...foo, 2];
+    @let multipleSpreads = [...foo, 1, ...bar, ...baz, 2];
+    @let inlineArraySpread = [1, ...[2, ...[3]]];
+
+    <!-- Use the arrays so they don't get flagged as unused. -->
+    {{simple}} {{otherEntries}} {{multipleSpreads}} {{inlineArraySpread}}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ArrayComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @let simple = [...foo];
+    @let otherEntries = [1, ...foo, 2];
+    @let multipleSpreads = [...foo, 1, ...bar, ...baz, 2];
+    @let inlineArraySpread = [1, ...[2, ...[3]]];
+
+    <!-- Use the arrays so they don't get flagged as unused. -->
+    {{simple}} {{otherEntries}} {{multipleSpreads}} {{inlineArraySpread}}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: array_literal_spread.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class ArrayComp {
+    foo: never[];
+    bar: never[];
+    baz: never[];
+    static ɵfac: i0.ɵɵFactoryDeclaration<ArrayComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ArrayComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: object_literals.js
  ****************************************************************************************************/
 import { Component, Input, NgModule } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -589,6 +589,53 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: object_literal_spread.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ObjectComp {
+    foo = {};
+    bar = {};
+    baz = {};
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ObjectComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ObjectComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @let simple = {...foo};
+    @let otherProps = {a: 1, ...foo, b: 2};
+    @let multipleSpreads = {...foo, a: 1, ...bar, ...baz, b: 2};
+    @let objectLiteral = {a: 1, ...{b: {...{c: 3}}}};
+
+    <!-- Use the objects so they don't get flagged as unused. -->
+    {{simple}} {{otherProps}} {{multipleSpreads}} {{objectLiteral}}
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ObjectComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @let simple = {...foo};
+    @let otherProps = {a: 1, ...foo, b: 2};
+    @let multipleSpreads = {...foo, a: 1, ...bar, ...baz, b: 2};
+    @let objectLiteral = {a: 1, ...{b: {...{c: 3}}}};
+
+    <!-- Use the objects so they don't get flagged as unused. -->
+    {{simple}} {{otherProps}} {{multipleSpreads}} {{objectLiteral}}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: object_literal_spread.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class ObjectComp {
+    foo: {};
+    bar: {};
+    baz: {};
+    static ɵfac: i0.ɵɵFactoryDeclaration<ObjectComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ObjectComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: literal_nested_expression.js
  ****************************************************************************************************/
 import { Component, Input, NgModule } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -519,14 +519,11 @@ export declare class MyModule {
 import { Component } from '@angular/core';
 import * as i0 from "@angular/core";
 export class ArrayComp {
-    constructor() {
-        this.foo = [];
-        this.bar = [];
-        this.baz = [];
-    }
-}
-ArrayComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ArrayComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-ArrayComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ArrayComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    foo = [];
+    bar = [];
+    baz = [];
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ArrayComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: ArrayComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
     @let simple = [...foo];
     @let otherEntries = [1, ...foo, 2];
     @let multipleSpreads = [...foo, 1, ...bar, ...baz, 2];
@@ -535,6 +532,7 @@ ArrayComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.
     <!-- Use the arrays so they don't get flagged as unused. -->
     {{simple}} {{otherEntries}} {{multipleSpreads}} {{inlineArraySpread}}
   `, isInline: true });
+}
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ArrayComp, decorators: [{
             type: Component,
             args: [{
@@ -978,6 +976,55 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 import * as i0 from "@angular/core";
 export declare class TestComp {
     value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: call_rest.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestComp {
+    foo = [];
+    bar = [];
+    baz = [];
+    fn(..._) { }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    {{fn(...foo)}}
+    <hr>
+    {{fn(1, ...foo, 2)}}
+    <hr>
+    {{fn(...foo, 1, ...bar, ...baz, 2)}}
+    <hr>
+    {{fn(1, ...[2, ...[3]])}}
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{fn(...foo)}}
+    <hr>
+    {{fn(1, ...foo, 2)}}
+    <hr>
+    {{fn(...foo, 1, ...bar, ...baz, 2)}}
+    <hr>
+    {{fn(1, ...[2, ...[3]])}}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: call_rest.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestComp {
+    foo: never[];
+    bar: never[];
+    baz: never[];
+    fn(..._: any[]): void;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -239,6 +239,19 @@
       ]
     },
     {
+      "description": "should support object literals with spread assignments",
+      "inputFiles": ["object_literal_spread.ts"],
+      "compilerOptions": {
+        "target": "es2022"
+      },
+      "expectations": [
+        {
+          "failureMessage": "Invalid object literal binding",
+          "files": ["object_literal_spread.js"]
+        }
+      ]
+    },
+    {
       "description": "should support expressions nested deeply in object/array literals",
       "inputFiles": ["literal_nested_expression.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -229,6 +229,16 @@
       ]
     },
     {
+      "description": "should support spread elements in array literals",
+      "inputFiles": ["array_literal_spread.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid array emit",
+          "files": ["array_literal_spread.js"]
+        }
+      ]
+    },
+    {
       "description": "should support object literals",
       "inputFiles": ["object_literals.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -60,11 +60,7 @@
           ]
         }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile",
-        "declaration-only emit"
-      ]
+      "compilationModeFilter": ["full compile", "local compile", "declaration-only emit"]
     },
     {
       "description": "should support complex selectors",
@@ -318,6 +314,16 @@
         {
           "failureMessage": "Invalid template",
           "files": ["regular_expression_with_global_flag.js"]
+        }
+      ]
+    },
+    {
+      "description": "should support rest arguments in a function call",
+      "inputFiles": ["call_rest.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid object literal binding",
+          "files": ["call_rest.js"]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literal_spread.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literal_spread.js
@@ -1,0 +1,25 @@
+const $c0$ = a0 => [...a0];
+const $c1$ = a0 => [1, ...a0, 2];
+const $c2$ = (a0, a1, a2) => [...a0, 1, ...a1, ...a2, 2];
+const $c3$ = () => [3];
+const $c4$ = a0 => [2, ...a0];
+const $c5$ = a0 => [1, ...a0];
+
+…
+
+$r3$.ɵɵdefineComponent({
+  …
+  decls: 1,
+  vars: 17,
+  template: function ArrayComp_Template(rf, ctx) {
+    …
+    if (rf & 2) {
+      const simple_r1 = $r3$.ɵɵpureFunction1(4, $c0$, ctx.foo);
+      const otherEntries_r2 = $r3$.ɵɵpureFunction1(6, $c1$, ctx.foo);
+      const multipleSpreads_r3 = $r3$.ɵɵpureFunction3(8, $c2$, ctx.foo, ctx.bar, ctx.baz);
+      const inlineArraySpread_r4 = $r3$.ɵɵpureFunction1(15, $c5$, $r3$.ɵɵpureFunction1(13, $c4$, $r3$.ɵɵpureFunction0(12, $c3$)));
+      …
+    }
+  },
+  …
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literal_spread.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/array_literal_spread.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    @let simple = [...foo];
+    @let otherEntries = [1, ...foo, 2];
+    @let multipleSpreads = [...foo, 1, ...bar, ...baz, 2];
+    @let inlineArraySpread = [1, ...[2, ...[3]]];
+
+    <!-- Use the arrays so they don't get flagged as unused. -->
+    {{simple}} {{otherEntries}} {{multipleSpreads}} {{inlineArraySpread}}
+  `,
+})
+export class ArrayComp {
+  foo = [];
+  bar = [];
+  baz = [];
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/call_rest.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/call_rest.js
@@ -1,0 +1,23 @@
+const $c0$ = () => [3];
+const $c1$ = a0 => [2, ...a0];
+
+…
+
+$r3$.ɵɵdefineComponent({
+  …
+  decls: 7,
+  vars: 7,
+  template: function TestComp_Template(rf, ctx) {
+    …
+    if (rf & 2) {
+      $r3$.ɵɵtextInterpolate1(" ", ctx.fn(...ctx.foo), " ");
+      $r3$.ɵɵadvance(2);
+      $r3$.ɵɵtextInterpolate1(" ", ctx.fn(1, ...ctx.foo, 2), " ");
+      $r3$.ɵɵadvance(2);
+      $r3$.ɵɵtextInterpolate1(" ", ctx.fn(...ctx.foo, 1, ...ctx.bar, ...ctx.baz, 2), " ");
+      $r3$.ɵɵadvance(2);
+      $r3$.ɵɵtextInterpolate1(" ", ctx.fn(1, ...$r3$.ɵɵpureFunction1(5, $c1$, $r3$.ɵɵpureFunction0(4, $c0$))), " ");
+    }
+  },
+  …
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/call_rest.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/call_rest.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {{fn(...foo)}}
+    <hr>
+    {{fn(1, ...foo, 2)}}
+    <hr>
+    {{fn(...foo, 1, ...bar, ...baz, 2)}}
+    <hr>
+    {{fn(1, ...[2, ...[3]])}}
+  `,
+})
+export class TestComp {
+  foo = [];
+  bar = [];
+  baz = [];
+  fn(..._: any[]) {}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literal_spread.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literal_spread.js
@@ -1,0 +1,25 @@
+const $c0$ = a0 => ({ ...a0 });
+const $c1$ = a0 => ({ a: 1, ...a0, b: 2 });
+const $c2$ = (a0, a1, a2) => ({ ...a0, a: 1, ...a1, ...a2, b: 2 });
+const $c3$ = () => ({ c: 3 });
+const $c4$ = a0 => ({ b: a0 });
+const $c5$ = a0 => ({ a: 1, ...a0 });
+
+…
+
+$r3$.ɵɵdefineComponent({
+  …
+  decls: 1,
+  vars: 19,
+  template: function ObjectComp_Template(rf, ctx) {
+    …
+    if (rf & 2) {
+      const simple_r1 = $r3$.ɵɵpureFunction1(4, $c0$, ctx.foo);
+      const otherProps_r2 = $r3$.ɵɵpureFunction1(6, $c1$, ctx.foo);
+      const multipleSpreads_r3 = $r3$.ɵɵpureFunction3(8, $c2$, ctx.foo, ctx.bar, ctx.baz);
+      const objectLiteral_r4 = $r3$.ɵɵpureFunction1(17, $c5$, $r3$.ɵɵpureFunction1(15, $c4$, $r3$.ɵɵpureFunction1(13, $c0$, $r3$.ɵɵpureFunction0(12, $c3$))));
+      …
+    }
+  },
+  …
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literal_spread.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/object_literal_spread.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    @let simple = {...foo};
+    @let otherProps = {a: 1, ...foo, b: 2};
+    @let multipleSpreads = {...foo, a: 1, ...bar, ...baz, b: 2};
+    @let objectLiteral = {a: 1, ...{b: {...{c: 3}}}};
+
+    <!-- Use the objects so they don't get flagged as unused. -->
+    {{simple}} {{otherProps}} {{multipleSpreads}} {{objectLiteral}}
+  `,
+})
+export class ObjectComp {
+  foo = {};
+  bar = {};
+  baz = {};
+}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3365,6 +3365,31 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should type check array spread elements in templates', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '@let array = [1, ...foo]; {{checkArray(array)}}',
+        })
+        export class TestCmp {
+          foo = ['two'];
+
+          checkArray(arr: number[]) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toEqual(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toBe(
+        `Argument of type '(string | number)[]' is not assignable to parameter of type 'number[]'.`,
+      );
+    });
+
     describe('template literals', () => {
       it('should treat template literals as strings', () => {
         env.write(

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3390,6 +3390,30 @@ runInEachFileSystem(() => {
       );
     });
 
+    it('should type check rest arguments in a function call', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: \`{{fn('one', ...rest)}}\`,
+        })
+        export class TestCmp {
+          rest = [2];
+          fn(first: string, ...rest: string[]) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toEqual(1);
+      expect(diags[0].messageText).toBe(
+        `Argument of type 'number' is not assignable to parameter of type 'string'.`,
+      );
+    });
+
     describe('template literals', () => {
       it('should treat template literals as strings', () => {
         env.write(

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -3340,6 +3340,31 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(0);
     });
 
+    it('should type check object spread assignments in templates', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test',
+          template: '@let obj = {a: 1, ...foo}; {{checkObj(obj)}}',
+        })
+        export class TestCmp {
+          foo = {b: 'two'};
+
+          checkObj(obj: {a: number, b: number}) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toEqual(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toContain(
+        `Argument of type '{ b: string; a: number; }' is not assignable to parameter of type '{ a: number; b: number; }'.`,
+      );
+    });
+
     describe('template literals', () => {
       it('should treat template literals as strings', () => {
         env.write(

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -116,6 +116,8 @@ export {
   UnaryOperatorExpr,
   VoidExpr,
   WrappedNodeExpr,
+  LiteralMapPropertyAssignment,
+  LiteralMapSpreadAssignment,
 } from './output/output_ast';
 export {JitEvaluator} from './output/output_jit';
 export {SourceMap} from './output/source_map';

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -118,6 +118,7 @@ export {
   WrappedNodeExpr,
   LiteralMapPropertyAssignment,
   LiteralMapSpreadAssignment,
+  SpreadElementExpr,
 } from './output/output_ast';
 export {JitEvaluator} from './output/output_jit';
 export {SourceMap} from './output/source_map';

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -11,16 +11,6 @@ import * as o from './output/output_ast';
 const CONSTANT_PREFIX = '_c';
 
 /**
- * `ConstantPool` tries to reuse literal factories when two or more literals are identical.
- * We determine whether literals are identical by creating a key out of their AST using the
- * `KeyVisitor`. This constant is used to replace dynamic expressions which can't be safely
- * converted into a key. E.g. given an expression `{foo: bar()}`, since we don't know what
- * the result of `bar` will be, we create a key that looks like `{foo: <unknown>}`. Note
- * that we use a variable, rather than something like `null` in order to avoid collisions.
- */
-const UNKNOWN_VALUE_KEY = o.variable('<unknown>');
-
-/**
  * Context to use when producing a key.
  *
  * This ensures we see the constant not the reference variable when producing
@@ -277,16 +267,14 @@ export class GenericKeyFn implements ExpressionKeyFn {
       return `read(${expr.name})`;
     } else if (expr instanceof o.TypeofExpr) {
       return `typeof(${this.keyOf(expr.expr)})`;
+    } else if (expr instanceof o.SpreadElementExpr) {
+      return `...${this.keyOf(expr.expression)}`;
     } else {
       throw new Error(
         `${this.constructor.name} does not handle expressions of type ${expr.constructor.name}`,
       );
     }
   }
-}
-
-function isVariable(e: o.Expression): e is o.ReadVarExpr {
-  return e instanceof o.ReadVarExpr;
 }
 
 function isLongStringLiteral(expr: o.Expression): boolean {

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -210,6 +210,19 @@ export class LiteralArray extends AST {
   }
 }
 
+export class SpreadElement extends AST {
+  constructor(
+    span: ParseSpan,
+    sourceSpan: AbsoluteSourceSpan,
+    readonly expression: AST,
+  ) {
+    super(span, sourceSpan);
+  }
+  override visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitSpreadElement(this, context);
+  }
+}
+
 export interface LiteralMapPropertyKey {
   kind: 'property';
   key: string;
@@ -636,6 +649,7 @@ export interface AstVisitor {
   visitTaggedTemplateLiteral(ast: TaggedTemplateLiteral, context: any): any;
   visitParenthesizedExpression(ast: ParenthesizedExpression, context: any): any;
   visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any;
+  visitSpreadElement(ast: SpreadElement, context: any): any;
   visitASTWithSource?(ast: ASTWithSource, context: any): any;
   /**
    * This function is optionally defined to allow classes that implement this
@@ -739,6 +753,9 @@ export class RecursiveAstVisitor implements AstVisitor {
     this.visit(ast.expression, context);
   }
   visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {}
+  visitSpreadElement(ast: SpreadElement, context: any) {
+    this.visit(ast.expression, context);
+  }
   // This is not part of the AstVisitor interface, just a helper method
   visitAll(asts: AST[], context: any): any {
     for (const ast of asts) {

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -210,13 +210,22 @@ export class LiteralArray extends AST {
   }
 }
 
-export interface LiteralMapKey {
+export interface LiteralMapPropertyKey {
+  kind: 'property';
   key: string;
   quoted: boolean;
   span: ParseSpan;
   sourceSpan: AbsoluteSourceSpan;
   isShorthandInitialized?: boolean;
 }
+
+export interface LiteralMapSpreadKey {
+  kind: 'spread';
+  span: ParseSpan;
+  sourceSpan: AbsoluteSourceSpan;
+}
+
+export type LiteralMapKey = LiteralMapPropertyKey | LiteralMapSpreadKey;
 
 export class LiteralMap extends AST {
   constructor(

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -288,9 +288,21 @@ class _Scanner {
     switch (peek) {
       case chars.$PERIOD:
         this.advance();
-        return chars.isDigit(this.peek)
-          ? this.scanNumber(start)
-          : newCharacterToken(start, this.index, chars.$PERIOD);
+
+        if (chars.isDigit(this.peek)) {
+          return this.scanNumber(start);
+        }
+
+        if (this.peek !== chars.$PERIOD) {
+          return newCharacterToken(start, this.index, chars.$PERIOD);
+        }
+
+        this.advance();
+        if (this.peek === chars.$PERIOD) {
+          this.advance();
+          return newOperatorToken(start, this.index, '...');
+        }
+        return this.error(`Unexpected character [${String.fromCharCode(peek)}]`, 0);
       case chars.$LPAREN:
       case chars.$RPAREN:
       case chars.$LBRACKET:

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -1200,6 +1200,7 @@ class _ParseAST {
         const keySpan = this.span(keyStart);
         const keySourceSpan = this.sourceSpan(keyStart);
         const literalMapKey: LiteralMapKey = {
+          kind: 'property',
           key,
           quoted,
           span: keySpan,

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -32,6 +32,8 @@ import {
   LiteralArray,
   LiteralMap,
   LiteralMapKey,
+  LiteralMapPropertyKey,
+  LiteralMapSpreadKey,
   LiteralPrimitive,
   NonNullAssert,
   ParenthesizedExpression,
@@ -1195,11 +1197,23 @@ class _ParseAST {
       this.rbracesExpected++;
       do {
         const keyStart = this.inputIndex;
+
+        if (this.next.isOperator('...')) {
+          this.advance();
+          keys.push({
+            kind: 'spread',
+            span: this.span(keyStart),
+            sourceSpan: this.sourceSpan(keyStart),
+          } satisfies LiteralMapSpreadKey);
+          values.push(this.parsePipe());
+          continue;
+        }
+
         const quoted = this.next.isString();
         const key = this.expectIdentifierOrKeywordOrString();
         const keySpan = this.span(keyStart);
         const keySourceSpan = this.sourceSpan(keyStart);
-        const literalMapKey: LiteralMapKey = {
+        const literalMapKey: LiteralMapPropertyKey = {
           kind: 'property',
           key,
           quoted,

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -58,7 +58,12 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
 
   visitLiteralMap(ast: expr.LiteralMap, context: any): string {
     return `{${zip(
-      ast.keys.map((literal) => (literal.quoted ? `'${literal.key}'` : literal.key)),
+      ast.keys.map((literal) => {
+        if (literal.kind === 'spread') {
+          return '...';
+        }
+        return literal.quoted ? `'${literal.key}'` : literal.key;
+      }),
       ast.values.map((value) => value.visit(this, context)),
     )
       .map(([key, value]) => `${key}: ${value}`)

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -165,6 +165,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
     return ast.tag.visit(this, context) + ast.template.visit(this, context);
   }
 
+  visitSpreadElement(ast: expr.SpreadElement, context: any) {
+    return `...${ast.expression.visit(this, context)}`;
+  }
+
   visitParenthesizedExpression(ast: expr.ParenthesizedExpression, context: any) {
     return '(' + ast.expression.visit(this, context) + ')';
   }

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -486,6 +486,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     // TODO: Do we *need* to parenthesize everything?
     ast.expr.visitExpression(this, ctx);
   }
+  visitSpreadElementExpr(ast: o.SpreadElementExpr, ctx: EmitterVisitorContext) {
+    ctx.print(ast, '...');
+    ast.expression.visitExpression(this, ctx);
+  }
   visitAllExpressions(
     expressions: o.Expression[],
     ctx: EmitterVisitorContext,

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -456,11 +456,16 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(ast, `{`);
     this.visitAllObjects(
       (entry) => {
-        ctx.print(
-          ast,
-          `${escapeIdentifier(entry.key, this._escapeDollarInStrings, entry.quoted)}:`,
-        );
-        entry.value.visitExpression(this, ctx);
+        if (entry instanceof o.LiteralMapSpreadAssignment) {
+          ctx.print(ast, '...');
+          entry.expression.visitExpression(this, ctx);
+        } else {
+          ctx.print(
+            ast,
+            `${escapeIdentifier(entry.key, this._escapeDollarInStrings, entry.quoted)}:`,
+          );
+          entry.value.visitExpression(this, ctx);
+        }
       },
       ast.entries,
       ctx,

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1425,6 +1425,31 @@ export class CommaExpr extends Expression {
   }
 }
 
+export class SpreadElementExpr extends Expression {
+  constructor(
+    public expression: Expression,
+    sourceSpan?: ParseSourceSpan | null,
+  ) {
+    super(null, sourceSpan);
+  }
+
+  override isEquivalent(e: Expression): boolean {
+    return e instanceof SpreadElementExpr && this.expression.isEquivalent(e.expression);
+  }
+
+  override isConstant() {
+    return this.expression.isConstant();
+  }
+
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitSpreadElementExpr(this, context);
+  }
+
+  override clone(): SpreadElementExpr {
+    return new SpreadElementExpr(this.expression.clone(), this.sourceSpan);
+  }
+}
+
 export interface ExpressionVisitor {
   visitReadVarExpr(ast: ReadVarExpr, context: any): any;
   visitInvokeFunctionExpr(ast: InvokeFunctionExpr, context: any): any;
@@ -1452,6 +1477,7 @@ export interface ExpressionVisitor {
   visitArrowFunctionExpr(ast: ArrowFunctionExpr, context: any): any;
   visitParenthesizedExpr(ast: ParenthesizedExpr, context: any): any;
   visitRegularExpressionLiteral(ast: RegularExpressionLiteralExpr, context: any): any;
+  visitSpreadElementExpr(ast: SpreadElementExpr, context: any): any;
 }
 
 export const NULL_EXPR = new LiteralExpr(null, null, null);
@@ -1770,6 +1796,10 @@ export class RecursiveAstVisitor implements StatementVisitor, ExpressionVisitor 
   }
   visitParenthesizedExpr(ast: ParenthesizedExpr, context: any) {
     ast.expr.visitExpression(this, context);
+    return this.visitExpression(ast, context);
+  }
+  visitSpreadElementExpr(ast: SpreadElementExpr, context: any): any {
+    ast.expression.visitExpression(this, context);
     return this.visitExpression(ast, context);
   }
   visitAllExpressions(exprs: Expression[], context: any): void {

--- a/packages/compiler/src/output/output_jit.ts
+++ b/packages/compiler/src/output/output_jit.ts
@@ -115,7 +115,8 @@ export class JitEmitterVisitor extends AbstractJsEmitterVisitor {
     const stmt = new o.ReturnStatement(
       new o.LiteralMapExpr(
         this._evalExportedVars.map(
-          (resultVar) => new o.LiteralMapEntry(resultVar, o.variable(resultVar), false),
+          (resultVar) =>
+            new o.LiteralMapPropertyAssignment(resultVar, o.variable(resultVar), false),
         ),
       ),
     );

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -616,13 +616,17 @@ function createViewportTrigger(
 
     if (!(parsed.ast instanceof LiteralMap)) {
       throw new Error('Options parameter of the "viewport" trigger must be an object literal');
-    } else if (parsed.ast.keys.some((key) => key.key === 'root')) {
+    } else if (parsed.ast.keys.some((key) => key.kind === 'spread')) {
+      throw new Error('Spread operator are not allowed in this context');
+    } else if (parsed.ast.keys.some((key) => key.kind === 'property' && key.key === 'root')) {
       throw new Error(
         'The "root" option is not supported in the options parameter of the "viewport" trigger',
       );
     }
 
-    const triggerIndex = parsed.ast.keys.findIndex((key) => key.key === 'trigger');
+    const triggerIndex = parsed.ast.keys.findIndex(
+      (key) => key.kind === 'property' && key.key === 'trigger',
+    );
 
     if (triggerIndex === -1) {
       reference = null;

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1275,12 +1275,12 @@ export function transformExpressionsInExpression(
       expr.entries[i] = transformExpressionsInExpression(expr.entries[i], transform, flags);
     }
   } else if (expr instanceof o.LiteralMapExpr) {
-    for (let i = 0; i < expr.entries.length; i++) {
-      expr.entries[i].value = transformExpressionsInExpression(
-        expr.entries[i].value,
-        transform,
-        flags,
-      );
+    for (const entry of expr.entries) {
+      if (entry instanceof o.LiteralMapSpreadAssignment) {
+        entry.expression = transformExpressionsInExpression(entry.expression, transform, flags);
+      } else {
+        entry.value = transformExpressionsInExpression(entry.value, transform, flags);
+      }
     }
   } else if (expr instanceof o.ConditionalExpr) {
     expr.condition = transformExpressionsInExpression(expr.condition, transform, flags);

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1319,6 +1319,8 @@ export function transformExpressionsInExpression(
     }
   } else if (expr instanceof o.ParenthesizedExpr) {
     expr.expr = transformExpressionsInExpression(expr.expr, transform, flags);
+  } else if (expr instanceof o.SpreadElementExpr) {
+    expr.expression = transformExpressionsInExpression(expr.expression, transform, flags);
   } else if (
     expr instanceof o.ReadVarExpr ||
     expr instanceof o.ExternalExpr ||

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1135,10 +1135,13 @@ function convertAst(
     throw new Error(`AssertionError: Chain in unknown context`);
   } else if (ast instanceof e.LiteralMap) {
     const entries = ast.keys.map((key, idx) => {
-      const value = ast.values[idx];
+      const value = convertAst(ast.values[idx], job, baseSourceSpan);
+
       // TODO: should literals have source maps, or do we just map the whole surrounding
       // expression?
-      return new o.LiteralMapEntry(key.key, convertAst(value, job, baseSourceSpan), key.quoted);
+      return key.kind === 'spread'
+        ? new o.LiteralMapSpreadAssignment(value)
+        : new o.LiteralMapPropertyAssignment(key.key, value, key.quoted);
     });
     return new o.LiteralMapExpr(entries, undefined, convertSourceSpan(ast.span, baseSourceSpan));
   } else if (ast instanceof e.LiteralArray) {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1213,6 +1213,8 @@ function convertAst(
     );
   } else if (ast instanceof e.RegularExpressionLiteral) {
     return new o.RegularExpressionLiteralExpr(ast.body, ast.flags, baseSourceSpan);
+  } else if (ast instanceof e.SpreadElement) {
+    return new o.SpreadElementExpr(convertAst(ast.expression, job, baseSourceSpan));
   } else {
     throw new Error(
       `Unhandled expression type "${ast.constructor.name}" in file "${baseSourceSpan?.start.file.url}"`,

--- a/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
@@ -38,6 +38,17 @@ function transformLiteralArray(expr: o.LiteralArrayExpr): o.Expression {
   const derivedEntries: o.Expression[] = [];
   const nonConstantArgs: o.Expression[] = [];
   for (const entry of expr.entries) {
+    if (entry instanceof o.SpreadElementExpr) {
+      if (entry.expression.isConstant()) {
+        derivedEntries.push(entry);
+      } else {
+        const idx = nonConstantArgs.length;
+        nonConstantArgs.push(entry.expression);
+        derivedEntries.push(new o.SpreadElementExpr(new ir.PureFunctionParameterExpr(idx)));
+      }
+      continue;
+    }
+
     if (entry.isConstant()) {
       derivedEntries.push(entry);
     } else {

--- a/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
@@ -53,15 +53,32 @@ function transformLiteralMap(expr: o.LiteralMapExpr): o.Expression {
   let derivedEntries: o.LiteralMapEntry[] = [];
   const nonConstantArgs: o.Expression[] = [];
   for (const entry of expr.entries) {
+    if (entry instanceof o.LiteralMapSpreadAssignment) {
+      if (entry.expression.isConstant()) {
+        derivedEntries.push(entry);
+      } else {
+        const idx = nonConstantArgs.length;
+        nonConstantArgs.push(entry.expression);
+        derivedEntries.push(
+          new o.LiteralMapSpreadAssignment(new ir.PureFunctionParameterExpr(idx)),
+        );
+      }
+      continue;
+    }
+
     if (entry.value.isConstant()) {
       derivedEntries.push(entry);
     } else {
       const idx = nonConstantArgs.length;
       nonConstantArgs.push(entry.value);
       derivedEntries.push(
-        new o.LiteralMapEntry(entry.key, new ir.PureFunctionParameterExpr(idx), entry.quoted),
+        new o.LiteralMapPropertyAssignment(
+          entry.key,
+          new ir.PureFunctionParameterExpr(idx),
+          entry.quoted,
+        ),
       );
     }
   }
-  return new ir.PureFunctionExpr(o.literalMap(derivedEntries), nonConstantArgs);
+  return new ir.PureFunctionExpr(new o.LiteralMapExpr(derivedEntries), nonConstantArgs);
 }

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -430,6 +430,29 @@ describe('lexer', () => {
       expectOperatorToken(lex('??=')[0], 0, 3, '??=');
     });
 
+    it('should tokenize a spread operator', () => {
+      const tokens = lex('{...foo}');
+      expect(tokens.length).toEqual(4);
+      expectCharacterToken(tokens[0], 0, 1, '{');
+      expectOperatorToken(tokens[1], 1, 4, '...');
+      expectIdentifierToken(tokens[2], 4, 7, 'foo');
+      expectCharacterToken(tokens[3], 7, 8, '}');
+    });
+
+    it('should produce an error for a spread with two dots', () => {
+      const tokens = lex('{..foo}');
+      expect(tokens.length).toEqual(4);
+      expectCharacterToken(tokens[0], 0, 1, '{');
+      expectErrorToken(
+        tokens[1],
+        3,
+        3,
+        'Lexer Error: Unexpected character [.] at column 3 in expression [{..foo}]',
+      );
+      expectIdentifierToken(tokens[2], 3, 6, 'foo');
+      expectCharacterToken(tokens[3], 6, 7, '}');
+    });
+
     describe('template literals', () => {
       it('should tokenize template literal with no interpolations', () => {
         const tokens: Token[] = lex('`hello world`');

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -209,6 +209,14 @@ describe('parser', () => {
         checkAction('{...foo, middle: true, ...bar}');
         checkAction('{...{...{...{foo: 1}}}}');
       });
+
+      it('should spread elements in array literals', () => {
+        checkAction('[...foo]');
+        checkAction('[1, ...foo, 2]');
+        checkAction('[...foo, middle, ...bar]');
+        checkAction('[...[...[...[1]]]]');
+        checkAction('[a, ...b, ...[1, 2, 3]]');
+      });
     });
 
     describe('member access', () => {
@@ -753,6 +761,16 @@ describe('parser', () => {
       expect(getSource(literal.keys[2].span)).toBe('three');
       expect(getSource(literal.keys[3].span)).toBe('"four"');
       expect(getSource(literal.keys[4].span)).toBe('...');
+    });
+
+    it('should record span for spread elements', () => {
+      expect(unparseWithSpan(parseBinding('[...foo]'))).toEqual([
+        ['[...foo]', '[...foo]'],
+        ['...foo', '...foo'],
+        ['foo', 'foo'],
+        ['foo', '[nameSpan] foo'],
+        ['', ''],
+      ]);
     });
   });
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -202,6 +202,13 @@ describe('parser', () => {
         expectActionError('{a["b"]}', 'expected } at column 3');
         expectActionError('{1234}', ' expected identifier, keyword, or string at column 2');
       });
+
+      it('should parse spread assignments in object literals', () => {
+        checkAction('{...foo}');
+        checkAction('{one: 1, ...foo, two: 2}');
+        checkAction('{...foo, middle: true, ...bar}');
+        checkAction('{...{...{...{foo: 1}}}}');
+      });
     });
 
     describe('member access', () => {
@@ -737,7 +744,7 @@ describe('parser', () => {
     });
 
     it('should record span for literal map keys', () => {
-      const ast = parseBinding('{one: 1, two: "the number two", three, "four": 4}');
+      const ast = parseBinding('{one: 1, two: "the number two", three, "four": 4, ...five}');
       const literal = ast.ast as LiteralMap;
       const getSource = (span: ParseSpan) => ast.source?.substring(span.start, span.end);
 
@@ -745,6 +752,7 @@ describe('parser', () => {
       expect(getSource(literal.keys[1].span)).toBe('two');
       expect(getSource(literal.keys[2].span)).toBe('three');
       expect(getSource(literal.keys[3].span)).toBe('"four"');
+      expect(getSource(literal.keys[4].span)).toBe('...');
     });
   });
 

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -317,6 +317,20 @@ describe('parser', () => {
         checkAction('fn?.().add?.(1, 2)');
         checkAction('fn?.()?.(1, 2)');
       });
+
+      it('should parse rest arguments in calls', () => {
+        checkAction('fn(...foo)');
+        checkAction('fn(1, ...foo, 2)');
+        checkAction('fn(...foo, middle, ...bar)');
+        checkAction('fn(a, ...b, ...[1, 2, 3])');
+      });
+
+      it('should parse rest arguments in safe calls', () => {
+        checkAction('fn?.(...foo)');
+        checkAction('fn?.(1, ...foo, 2)');
+        checkAction('fn?.(...foo, middle, ...bar)');
+        checkAction('fn?.(a, ...b, ...[1, 2, 3])');
+      });
     });
 
     describe('keyed read', () => {
@@ -766,6 +780,21 @@ describe('parser', () => {
     it('should record span for spread elements', () => {
       expect(unparseWithSpan(parseBinding('[...foo]'))).toEqual([
         ['[...foo]', '[...foo]'],
+        ['...foo', '...foo'],
+        ['foo', 'foo'],
+        ['foo', '[nameSpan] foo'],
+        ['', ''],
+      ]);
+    });
+
+    it('should record span for rest arguments in functions', () => {
+      expect(unparseWithSpan(parseBinding('fn(1, ...foo)'))).toEqual([
+        ['fn(1, ...foo)', 'fn(1, ...foo)'],
+        ['fn(1, ...foo)', '[argumentSpan] 1, ...foo'],
+        ['fn', 'fn'],
+        ['fn', '[nameSpan] fn'],
+        ['', ''],
+        ['1', '1'],
         ['...foo', '...foo'],
         ['foo', 'foo'],
         ['foo', '[nameSpan] foo'],

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -19,6 +19,7 @@ import {
   VariableBinding,
   BindingPipeType,
   ParseSpan,
+  LiteralMapPropertyKey,
 } from '../../src/expression_parser/ast';
 import {ParseError} from '../../src/parse_util';
 import {Lexer} from '../../src/expression_parser/lexer';
@@ -914,9 +915,10 @@ describe('parser', () => {
     it('should expose object shorthand information in AST', () => {
       const parser = new Parser(new Lexer());
       const ast = parser.parseBinding('{bla}', getFakeSpan(), 0);
-      expect(ast.ast instanceof LiteralMap).toBe(true);
-      expect((ast.ast as LiteralMap).keys.length).toBe(1);
-      expect((ast.ast as LiteralMap).keys[0].isShorthandInitialized).toBe(true);
+      const map = ast.ast as LiteralMap;
+      expect(map instanceof LiteralMap).toBe(true);
+      expect(map.keys.length).toBe(1);
+      expect((map.keys[0] as LiteralMapPropertyKey).isShorthandInitialized).toBe(true);
     });
   });
 

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -30,6 +30,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  SpreadElement,
   TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
@@ -246,6 +247,11 @@ class Unparser implements AstVisitor {
 
   visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any) {
     this._expression += `/${ast.body}/${ast.flags || ''}`;
+  }
+
+  visitSpreadElement(ast: SpreadElement, context: any) {
+    this._expression += '...';
+    this._visit(ast.expression);
   }
 
   private _visit(ast: AST) {

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -161,8 +161,14 @@ class Unparser implements AstVisitor {
       if (!isFirst) this._expression += ', ';
       isFirst = false;
       const key = ast.keys[i];
-      this._expression += key.quoted ? JSON.stringify(key.key) : key.key;
-      this._expression += ': ';
+
+      if (key.kind === 'spread') {
+        this._expression += '...';
+      } else {
+        this._expression += key.quoted ? JSON.stringify(key.key) : key.key;
+        this._expression += ': ';
+      }
+
       this._visit(ast.values[i]);
     }
 

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -28,6 +28,7 @@ import {
   SafeCall,
   SafeKeyedRead,
   SafePropertyRead,
+  SpreadElement,
   TaggedTemplateLiteral,
   TemplateLiteral,
   TemplateLiteralElement,
@@ -159,6 +160,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): void {
     this.validate(ast, () => super.visitRegularExpressionLiteral(ast, context));
+  }
+
+  override visitSpreadElement(ast: SpreadElement, context: any): void {
+    this.validate(ast, () => super.visitSpreadElement(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -2202,8 +2202,8 @@ describe('R3 template transform', () => {
       });
 
       it('should report syntax error in for loop expression', () => {
-        expect(() => parse(`@for (item of items..foo) {hello}`)).toThrowError(
-          /Unexpected token \./,
+        expect(() => parse(`@for (item of items#foo) {hello}`)).toThrowError(
+          /Unexpected token '#foo'/,
         );
       });
 

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -111,25 +111,29 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitSafeCall(ast, null);
   }
-  override visitTemplateLiteral(ast: e.TemplateLiteral, context: any): void {
+  override visitTemplateLiteral(ast: e.TemplateLiteral): void {
     this.recordAst(ast);
     super.visitTemplateLiteral(ast, null);
   }
-  override visitTemplateLiteralElement(ast: e.TemplateLiteralElement, context: any): void {
+  override visitTemplateLiteralElement(ast: e.TemplateLiteralElement): void {
     this.recordAst(ast);
     super.visitTemplateLiteralElement(ast, null);
   }
-  override visitTaggedTemplateLiteral(ast: e.TaggedTemplateLiteral, context: any): void {
+  override visitTaggedTemplateLiteral(ast: e.TaggedTemplateLiteral): void {
     this.recordAst(ast);
     super.visitTaggedTemplateLiteral(ast, null);
   }
-  override visitParenthesizedExpression(ast: e.ParenthesizedExpression, context: any): void {
+  override visitParenthesizedExpression(ast: e.ParenthesizedExpression): void {
     this.recordAst(ast);
     super.visitParenthesizedExpression(ast, null);
   }
-  override visitRegularExpressionLiteral(ast: e.RegularExpressionLiteral, context: any): void {
+  override visitRegularExpressionLiteral(ast: e.RegularExpressionLiteral): void {
     this.recordAst(ast);
     super.visitRegularExpressionLiteral(ast, null);
+  }
+  override visitSpreadElement(ast: e.SpreadElement): void {
+    this.recordAst(ast);
+    super.visitSpreadElement(ast, null);
   }
 
   visitTemplate(ast: t.Template) {

--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
@@ -272,7 +272,8 @@ export class TemplateExpressionReferenceVisitor<
   // E.g. `{bla}` may be transformed to `{bla: bla()}`.
   override visitLiteralMap(ast: LiteralMap, context: any) {
     for (const [idx, key] of ast.keys.entries()) {
-      this.isInsideObjectShorthandExpression = !!key.isShorthandInitialized;
+      this.isInsideObjectShorthandExpression =
+        key.kind === 'property' && !!key.isShorthandInitialized;
       (ast.values[idx] as AST).visit(this, context);
       this.isInsideObjectShorthandExpression = false;
     }

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2775,6 +2775,27 @@ describe('acceptance integration tests', () => {
     expect(fixture.nativeElement.textContent).toContain('Hello, Bilbo Baggins');
   });
 
+  it('should support calls with rest arguments in templates', () => {
+    @Component({
+      template: "{{fn('Hello', ...foo)}}",
+    })
+    class TestComponent {
+      foo = ['Frodo', 'Baggins'];
+
+      fn(prefix: string, ...args: string[]) {
+        return `${prefix}, ${args.join(' ')}`;
+      }
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, Frodo Baggins');
+
+    fixture.componentInstance.foo = ['J.', 'R.', 'R.', 'Tolkien'];
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, J. R. R. Tolkien');
+  });
+
   it('should have correct operator precedence', () => {
     @Component({
       template: '{{1 + 10 ** -2 * 3}}',

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2758,6 +2758,23 @@ describe('acceptance integration tests', () => {
     expect(fixture.nativeElement.textContent).toContain('Hello, Bilbo');
   });
 
+  it('should support arrays with spread elements in templates', () => {
+    @Component({
+      template: "@let arr = [...[...[...foo]], 'Baggins']; Hello, {{arr[0]}} {{arr[1]}}",
+    })
+    class TestComponent {
+      foo = ['Frodo'];
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, Frodo Baggins');
+
+    fixture.componentInstance.foo = ['Bilbo'];
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, Bilbo Baggins');
+  });
+
   it('should have correct operator precedence', () => {
     @Component({
       template: '{{1 + 10 ** -2 * 3}}',

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2741,6 +2741,23 @@ describe('acceptance integration tests', () => {
     expect(fixture.componentInstance.e!.defaultPrevented).toBe(false);
   });
 
+  it('should support object spread assigments in templates', () => {
+    @Component({
+      template: '@let obj = {a: {...foo}}; Hello, {{obj.a.b}}',
+    })
+    class TestComponent {
+      foo = {b: 'Frodo'};
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, Frodo');
+
+    fixture.componentInstance.foo = {b: 'Bilbo'};
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Hello, Bilbo');
+  });
+
   it('should have correct operator precedence', () => {
     @Component({
       template: '{{1 + 10 ** -2 * 3}}',


### PR DESCRIPTION
Adds support for spread/rest syntax in the following places in the template syntax:
* Object literals, e.g. `{a: 1, ...foo}`.
* Array literals, e.g. `[1, ...foo]`.
* Function calls, e.g. `fn(1, ...foo)`.

For arrays and object literals the spread arguments integrate into the existing pure function infrastructure in order to avoid re-creating the object on each change detection.

Fixes #11850.
Fixes #61800.

Note: I took a couple of commits from #66206 and #66190 to avoid conflicts.