### PR TITLE
mark top-level symbols as side-effect free

### DIFF
--- a/packages/core/primitives/di/src/not_found.ts
+++ b/packages/core/primitives/di/src/not_found.ts
@@ -10,7 +10,7 @@
  * Value returned if the key-value pair couldn't be found in the context
  * hierarchy.
  */
-export const NOT_FOUND: unique symbol = Symbol('NotFound');
+export const NOT_FOUND: unique symbol = /* @__PURE__ */ Symbol('NotFound');
 
 /**
  * Error thrown when the key-value pair couldn't be found in the context

--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -9,7 +9,7 @@ import {Signal} from '../reactivity/api';
 import {WritableSignal} from '../reactivity/signal';
 
 /** A unique symbol used to identify {@link ɵControl} implementations. */
-export const ɵCONTROL: unique symbol = Symbol('CONTROL');
+export const ɵCONTROL: unique symbol = /* @__PURE__ */ Symbol('CONTROL');
 
 /**
  * Instructions for dynamically binding a {@link ɵControl} to a form control.

--- a/packages/forms/signals/src/schema/path_node.ts
+++ b/packages/forms/signals/src/schema/path_node.ts
@@ -13,7 +13,7 @@ import type {SchemaImpl} from './schema';
 /**
  * Special key which is used to retrieve the `FieldPathNode` instance from its `FieldPath` proxy wrapper.
  */
-const PATH = Symbol('PATH');
+const PATH: unique symbol = /* @__PURE__ */ Symbol('PATH');
 
 /**
  * A path in the schema on which logic is stored so that it can be added to the corresponding field


### PR DESCRIPTION
 Marks top-level symbols as pure (PATH, ɵCONTROL, NOT_FOUND) to allow proper tree-shaking.

Neither Terser nor esbuild treat `Symbol` as side-effect free by default, which caused
exported symbols to be retained. This was observed during signals prototyping, where
symbols from `computed` appeared in bundling tests.



Similar to #51776 and #61312