### PR TITLE
fix(compiler): stop ThisReceiver inheritance from ImplicitReceiver

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -13,6 +13,7 @@ import {
   ImplicitReceiver,
   ParseSourceSpan,
   PropertyRead,
+  ThisReceiver,
   TmplAstBoundAttribute,
   TmplAstComponent,
   TmplAstDirective,
@@ -352,7 +353,7 @@ class TemplateVisitor extends CombinedRecursiveAstVisitor {
     // impossible to determine by an indexer and unsupported by the indexing module.
     // The indexing module also does not currently support references to identifiers declared in the
     // template itself, which have a non-null expression target.
-    if (!(ast.receiver instanceof ImplicitReceiver)) {
+    if (!(ast.receiver instanceof ImplicitReceiver) && !(ast.receiver instanceof ThisReceiver)) {
       return;
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/completion.ts
@@ -13,6 +13,7 @@ import {
   LiteralPrimitive,
   PropertyRead,
   SafePropertyRead,
+  ThisReceiver,
   TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
@@ -133,7 +134,10 @@ export class CompletionEngine {
       }
     }
 
-    if (node instanceof PropertyRead && node.receiver instanceof ImplicitReceiver) {
+    if (
+      node instanceof PropertyRead &&
+      (node.receiver instanceof ImplicitReceiver || node.receiver instanceof ThisReceiver)
+    ) {
       const nodeLocation = findFirstMatchingNode(this.tcb, {
         filter: ts.isPropertyAccessExpression,
         withSpan: node.sourceSpan,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/events.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/events.ts
@@ -283,7 +283,6 @@ class TcbEventHandlerTranslator extends TcbExpressionTranslator {
     if (
       ast instanceof PropertyRead &&
       ast.receiver instanceof ImplicitReceiver &&
-      !(ast.receiver instanceof ThisReceiver) &&
       ast.name === EVENT_PARAMETER
     ) {
       const event = ts.factory.createIdentifier(EVENT_PARAMETER);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/expression.ts
@@ -95,11 +95,7 @@ export class TcbExpressionTranslator {
    * context). This method assists in resolving those.
    */
   protected resolve(ast: AST): ts.Expression | null {
-    if (
-      ast instanceof PropertyRead &&
-      ast.receiver instanceof ImplicitReceiver &&
-      !(ast.receiver instanceof ThisReceiver)
-    ) {
+    if (ast instanceof PropertyRead && ast.receiver instanceof ImplicitReceiver) {
       // Try to resolve a bound target for this expression. If no such target is available, then
       // the expression is referencing the top-level component context. In that case, `null` is
       // returned here to let it fall through resolution so it will be caught when the
@@ -126,7 +122,7 @@ export class TcbExpressionTranslator {
       ast instanceof Binary &&
       Binary.isAssignmentOperation(ast.operation) &&
       ast.left instanceof PropertyRead &&
-      ast.left.receiver instanceof ImplicitReceiver
+      (ast.left.receiver instanceof ImplicitReceiver || ast.left.receiver instanceof ThisReceiver)
     ) {
       const read = ast.left;
       const target = this.tcb.boundTarget.getExpressionTarget(read);
@@ -150,7 +146,7 @@ export class TcbExpressionTranslator {
       }
 
       return result;
-    } else if (ast instanceof ImplicitReceiver) {
+    } else if (ast instanceof ImplicitReceiver || ast instanceof ThisReceiver) {
       // AST instances representing variables and references look very similar to property reads
       // or method calls from the component context: both have the shape
       // PropertyRead(ImplicitReceiver, 'propName') or Call(ImplicitReceiver, 'methodName').
@@ -218,7 +214,6 @@ export class TcbExpressionTranslator {
       // `$any(expr)` -> `expr as any`
       if (
         ast.receiver.receiver instanceof ImplicitReceiver &&
-        !(ast.receiver.receiver instanceof ThisReceiver) &&
         ast.receiver.name === '$any' &&
         ast.args.length === 1
       ) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/for_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/for_block.ts
@@ -10,6 +10,7 @@ import {
   AST,
   ImplicitReceiver,
   PropertyRead,
+  ThisReceiver,
   TmplAstForLoopBlock,
   TmplAstVariable,
 } from '@angular/compiler';
@@ -102,7 +103,10 @@ export class TcbForLoopTrackTranslator extends TcbExpressionTranslator {
   }
 
   protected override resolve(ast: AST): ts.Expression | null {
-    if (ast instanceof PropertyRead && ast.receiver instanceof ImplicitReceiver) {
+    if (
+      ast instanceof PropertyRead &&
+      (ast.receiver instanceof ImplicitReceiver || ast.receiver instanceof ThisReceiver)
+    ) {
       const target = this.tcb.boundTarget.getExpressionTarget(ast);
 
       if (

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -57,15 +57,7 @@ export class ImplicitReceiver extends AST {
   }
 }
 
-/**
- * Receiver when something is accessed through `this` (e.g. `this.foo`). Note that this class
- * inherits from `ImplicitReceiver`, because accessing something through `this` is treated the
- * same as accessing it implicitly inside of an Angular template (e.g. `[attr.title]="this.title"`
- * is the same as `[attr.title]="title"`.). Inheriting allows for the `this` accesses to be treated
- * the same as implicit ones, except for a couple of exceptions like `$event` and `$any`.
- * TODO: we should find a way for this class not to extend from `ImplicitReceiver` in the future.
- */
-export class ThisReceiver extends ImplicitReceiver {
+export class ThisReceiver extends AST {
   override visit(visitor: AstVisitor, context: any = null): any {
     return visitor.visitThisReceiver?.(this, context);
   }

--- a/packages/compiler/src/expression_parser/serializer.ts
+++ b/packages/compiler/src/expression_parser/serializer.ts
@@ -94,7 +94,10 @@ class SerializeExpressionVisitor implements expr.AstVisitor {
   }
 
   visitPropertyRead(ast: expr.PropertyRead, context: any): string {
-    if (ast.receiver instanceof expr.ImplicitReceiver) {
+    if (
+      ast.receiver instanceof expr.ImplicitReceiver ||
+      ast.receiver instanceof expr.ThisReceiver
+    ) {
       return ast.name;
     } else {
       return `${ast.receiver.visit(this, context)}.${ast.name}`;

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -16,7 +16,6 @@ import {
   LiteralPrimitive,
   PropertyRead,
   RecursiveAstVisitor,
-  ThisReceiver,
 } from '../expression_parser/ast';
 import {Lexer, Token, TokenType} from '../expression_parser/lexer';
 import * as html from '../ml_parser/ast';
@@ -632,11 +631,7 @@ function createViewportTrigger(
       const value = parsed.ast.values[triggerIndex];
       const triggerFilter = (_: unknown, index: number) => index !== triggerIndex;
 
-      if (
-        !(value instanceof PropertyRead) ||
-        !(value.receiver instanceof ImplicitReceiver) ||
-        value.receiver instanceof ThisReceiver
-      ) {
+      if (!(value instanceof PropertyRead) || !(value.receiver instanceof ImplicitReceiver)) {
         throw new Error(`"trigger" option of the "viewport" trigger must be an identifier`);
       }
 

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -12,7 +12,6 @@ import {
   ImplicitReceiver,
   PropertyRead,
   SafePropertyRead,
-  ThisReceiver,
 } from '../../expression_parser/ast';
 import {CssSelector, SelectorlessMatcher, SelectorMatcher} from '../../directive_matching';
 import {
@@ -1004,7 +1003,7 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
   private maybeMap(ast: PropertyRead | SafePropertyRead, name: string): void {
     // If the receiver of the expression isn't the `ImplicitReceiver`, this isn't the root of an
     // `AST` expression that maps to a `Variable` or `Reference`.
-    if (!(ast.receiver instanceof ImplicitReceiver) || ast.receiver instanceof ThisReceiver) {
+    if (!(ast.receiver instanceof ImplicitReceiver)) {
       return;
     }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1067,10 +1067,7 @@ function convertAst(
   if (ast instanceof e.ASTWithSource) {
     return convertAst(ast.ast, job, baseSourceSpan);
   } else if (ast instanceof e.PropertyRead) {
-    // Whether this is an implicit receiver, *excluding* explicit reads of `this`.
-    const isImplicitReceiver =
-      ast.receiver instanceof e.ImplicitReceiver && !(ast.receiver instanceof e.ThisReceiver);
-    if (isImplicitReceiver) {
+    if (ast.receiver instanceof e.ImplicitReceiver) {
       return new ir.LexicalReadExpr(ast.name);
     } else {
       return new o.ReadPropExpr(

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -28,7 +28,6 @@ import {
   SafeKeyedRead,
   SafePropertyRead,
   TemplateBinding,
-  ThisReceiver,
   VariableBinding,
 } from '../expression_parser/ast';
 import {Parser} from '../expression_parser/parser';
@@ -837,8 +836,7 @@ export class BindingParser {
       ast.args.length === 1 &&
       ast.receiver instanceof PropertyRead &&
       ast.receiver.name === '$any' &&
-      ast.receiver.receiver instanceof ImplicitReceiver &&
-      !(ast.receiver.receiver instanceof ThisReceiver)
+      ast.receiver.receiver instanceof ImplicitReceiver
     ) {
       return this._isAllowedAssignmentEvent(ast.args[0]);
     }

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -52,7 +52,10 @@ class Unparser implements AstVisitor {
 
   visitPropertyRead(ast: PropertyRead, context: any) {
     this._visit(ast.receiver);
-    this._expression += ast.receiver instanceof ImplicitReceiver ? `${ast.name}` : `.${ast.name}`;
+    this._expression +=
+      ast.receiver instanceof ImplicitReceiver || ast.receiver instanceof ThisReceiver
+        ? `${ast.name}`
+        : `.${ast.name}`;
   }
 
   visitUnary(ast: Unary, context: any) {

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -123,7 +123,7 @@ export function toStringExpression(expr: e.AST): string {
     expr = expr.ast;
   }
   if (expr instanceof e.PropertyRead) {
-    if (expr.receiver instanceof e.ImplicitReceiver) {
+    if (expr.receiver instanceof e.ImplicitReceiver || expr.receiver instanceof e.ThisReceiver) {
       return expr.name;
     } else {
       return `${toStringExpression(expr.receiver)}.${expr.name}`;

--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
@@ -20,7 +20,6 @@ import {
   PropertyRead,
   RecursiveAstVisitor,
   SafePropertyRead,
-  ThisReceiver,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstBoundText,
@@ -444,7 +443,7 @@ function traverseReceiverAndLookupSymbol(
     path.unshift(node.name);
   }
 
-  if (!(node.receiver instanceof ImplicitReceiver || node.receiver instanceof ThisReceiver)) {
+  if (!(node.receiver instanceof ImplicitReceiver)) {
     return null;
   }
 

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -32,6 +32,7 @@ import {
   TmplAstVariable,
   TmplAstLetDeclaration,
   TmplAstSwitchBlock,
+  ThisReceiver,
 } from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {
@@ -393,7 +394,8 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     if (
       this.node instanceof EmptyExpr ||
       this.node instanceof BoundEvent ||
-      this.node.receiver instanceof ImplicitReceiver
+      this.node.receiver instanceof ImplicitReceiver ||
+      this.node.receiver instanceof ThisReceiver
     ) {
       return this.getGlobalPropertyExpressionCompletion(options);
     } else {
@@ -417,6 +419,7 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
 
       if (
         !(this.node.receiver instanceof ImplicitReceiver) &&
+        !(this.node.receiver instanceof ThisReceiver) &&
         !(this.node instanceof SafePropertyRead) &&
         options?.includeCompletionsWithInsertText &&
         options.includeAutomaticOptionalChainCompletions !== false
@@ -463,7 +466,8 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
     if (
       this.node instanceof EmptyExpr ||
       this.node instanceof BoundEvent ||
-      this.node.receiver instanceof ImplicitReceiver
+      this.node.receiver instanceof ImplicitReceiver ||
+      this.node.receiver instanceof ThisReceiver
     ) {
       details = this.getGlobalPropertyExpressionCompletionDetails(
         entryName,
@@ -505,7 +509,8 @@ export class CompletionBuilder<N extends TmplAstNode | AST> {
       this.node instanceof EmptyExpr ||
       this.node instanceof LiteralPrimitive ||
       this.node instanceof BoundEvent ||
-      this.node.receiver instanceof ImplicitReceiver
+      this.node.receiver instanceof ImplicitReceiver ||
+      this.node.receiver instanceof ThisReceiver
     ) {
       return this.getGlobalPropertyExpressionCompletionSymbol(name);
     } else {

--- a/packages/language-service/src/quick_info_built_ins.ts
+++ b/packages/language-service/src/quick_info_built_ins.ts
@@ -11,7 +11,6 @@ import {
   ImplicitReceiver,
   ParseSourceSpan,
   PropertyRead,
-  ThisReceiver,
   TmplAstBlockNode,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
@@ -32,7 +31,6 @@ export function isDollarAny(node: TmplAstNode | AST): node is Call {
     node instanceof Call &&
     node.receiver instanceof PropertyRead &&
     node.receiver.receiver instanceof ImplicitReceiver &&
-    !(node.receiver.receiver instanceof ThisReceiver) &&
     node.receiver.name === '$any' &&
     node.args.length === 1
   );

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -17,6 +17,7 @@ import {
   PropertyRead,
   RecursiveAstVisitor,
   SafeCall,
+  ThisReceiver,
   TmplAstBoundAttribute,
   TmplAstBoundDeferredTrigger,
   TmplAstBoundEvent,
@@ -723,7 +724,11 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     }
     // The third condition is to account for the implicit receiver, which should
     // not be visited.
-    if (isWithin(this.position, node.sourceSpan) && !(node instanceof ImplicitReceiver)) {
+    if (
+      isWithin(this.position, node.sourceSpan) &&
+      !(node instanceof ImplicitReceiver) &&
+      !(node instanceof ThisReceiver)
+    ) {
       path.push(node);
       node.visit(this, path);
     }

--- a/packages/language-service/src/utils/index.ts
+++ b/packages/language-service/src/utils/index.ts
@@ -17,7 +17,6 @@ import {
   ParseSpan,
   PropertyRead,
   SelectorMatcher,
-  ThisReceiver,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstElement,
@@ -400,12 +399,7 @@ export function filterAliasImports(displayParts: ts.SymbolDisplayPart[]): ts.Sym
 }
 
 export function isDollarEvent(n: TmplAstNode | AST): n is PropertyRead {
-  return (
-    n instanceof PropertyRead &&
-    n.name === '$event' &&
-    n.receiver instanceof ImplicitReceiver &&
-    !(n.receiver instanceof ThisReceiver)
-  );
+  return n instanceof PropertyRead && n.name === '$event' && n.receiver instanceof ImplicitReceiver;
 }
 
 export function isTypeScriptFile(fileName: string): boolean {


### PR DESCRIPTION
Back in #39323, I added a new `ThisReceiver` node to represent accesses done through `this` and I ended up making it inherit from `ImplicitReceiver`. The logic was that in most cases accessing through `this` was the same as the implicit access.

Over the years this has proven to not be a great idea, because no other AST nodes do this and one has to keep it in mind whenever dealing with `ImplicitReceiver`.

These changes remove the inheritance and update all of the usage sites accordingly.
