### PR TITLE
refactor(core): remove legacy SCHEDULE_IN_ROOT_ZONE token and related…

### DIFF
--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -24,11 +24,7 @@ import {performanceMarkFeature} from '../../util/performance';
 import {NgZone} from '../../zone';
 import {InternalNgZoneOptions} from '../../zone/ng_zone';
 
-import {
-  ChangeDetectionScheduler,
-  ZONELESS_ENABLED,
-  SCHEDULE_IN_ROOT_ZONE,
-} from './zoneless_scheduling';
+import {ChangeDetectionScheduler, ZONELESS_ENABLED} from './zoneless_scheduling';
 import {SCHEDULE_IN_ROOT_ZONE_DEFAULT} from './flags';
 import {INTERNAL_APPLICATION_ERROR_HANDLER} from '../../error_handler';
 
@@ -121,10 +117,6 @@ export function internalProvideZoneChangeDetection({
           service.initialize();
         };
       },
-    },
-    {
-      provide: SCHEDULE_IN_ROOT_ZONE,
-      useValue: scheduleInRootZone ?? SCHEDULE_IN_ROOT_ZONE_DEFAULT,
     },
   ];
 }

--- a/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/zoneless_scheduling.ts
@@ -74,8 +74,3 @@ export const PROVIDED_ZONELESS = new InjectionToken<boolean>(
   typeof ngDevMode === 'undefined' || ngDevMode ? 'Zoneless provided' : '',
   {factory: () => false},
 );
-
-// TODO(atscott): Remove in v19. Scheduler should be done with runOutsideAngular.
-export const SCHEDULE_IN_ROOT_ZONE = new InjectionToken<boolean>(
-  typeof ngDevMode === 'undefined' || ngDevMode ? 'run changes outside zone in root' : '',
-);


### PR DESCRIPTION
… code

Remove the SCHEDULE_IN_ROOT_ZONE injection token and associated conditional logic that was needed for transitioning the scheduler to use runOutsideAngular. Since v19 has been released and the transition is complete, this token is no longer needed.

This cleanup simplifies the zoneless scheduler to always run outside Angular's zone, removing the legacy root zone scheduling path.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
