### PR TITLE
refactor(core): remove ngZone property from ComponentFixture

### DIFF
--- a/packages/core/rxjs-interop/test/to_observable_spec.ts
+++ b/packages/core/rxjs-interop/test/to_observable_spec.ts
@@ -11,8 +11,6 @@ import {
   computed,
   createEnvironmentInjector,
   EnvironmentInjector,
-  Injector,
-  Signal,
   signal,
 } from '../../src/core';
 import {toObservable} from '../src';

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -95,9 +95,6 @@ export class ComponentFixture<T> {
 
   private subscriptions = new Subscription();
 
-  // TODO(atscott): Remove this from public API
-  ngZone = this._noZoneOptionIsSet ? null : this._ngZone;
-
   /** @docs-private */
   constructor(public componentRef: ComponentRef<T>) {
     this.changeDetectorRef = componentRef.changeDetectorRef;


### PR DESCRIPTION
Remove the ngZone property from ComponentFixture that was marked as undocumented and had a TODO to remove it from the public API.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
