### PR TITLE
docs: mark injected dependencies as readonly in examples

### DIFF
--- a/adev/src/app/features/home/animation/README.md
+++ b/adev/src/app/features/home/animation/README.md
@@ -30,7 +30,7 @@ To create a new animation instance, you should use the `AnimationCreatorService`
 
 ```typescript
 class AnimationHost implements AfterViewInit {
-  private animationCreator = inject(AnimationCreatorService);
+  private readonly animationCreator = inject(AnimationCreatorService);
   layers = viewChildren(AnimationLayerDirective);
 
   constructor() {

--- a/adev/src/content/best-practices/runtime-performance/zone-pollution.md
+++ b/adev/src/content/best-practices/runtime-performance/zone-pollution.md
@@ -26,7 +26,7 @@ import { Component, NgZone, OnInit, inject } from '@angular/core';
 
 @Component(...)
 class AppComponent implements OnInit {
-  private ngZone = inject(NgZone);
+  private readonly ngZone = inject(NgZone);
 
   ngOnInit() {
     this.ngZone.runOutsideAngular(() => setInterval(pollForUpdates, 500));
@@ -44,7 +44,7 @@ import * as Plotly from 'plotly.js-dist-min';
 
 @Component(...)
 class AppComponent implements OnInit {
-  private ngZone = inject(NgZone);
+  private readonly ngZone = inject(NgZone);
 
   ngOnInit() {
     this.ngZone.runOutsideAngular(() => {
@@ -66,7 +66,7 @@ import * as Plotly from 'plotly.js-dist-min';
 
 @Component(...)
 class AppComponent implements OnInit {
-  private ngZone = inject(NgZone);
+  private readonly ngZone = inject(NgZone);
 
   plotlyClick = output<Plotly.PlotMouseEvent>();
 
@@ -98,7 +98,7 @@ import * as Plotly from 'plotly.js-dist-min';
 
 @Component(...)
 class AppComponent implements OnInit {
-  private ngZone = inject(NgZone);
+  private readonly ngZone = inject(NgZone);
 
   plotlyClick = output<Plotly.PlotMouseEvent>();
 

--- a/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
@@ -96,8 +96,8 @@ import {toObservable} from '@angular/core/rxjs-interop';
 
 @Component(/* ... */)
 export class SearchResults {
-  query: Signal<string> = inject(QueryService).query;
-  query$ = toObservable(this.query);
+  readonly query: Signal<string> = inject(QueryService).query;
+  readonly query$ = toObservable(this.query);
 
   results$ = this.query$.pipe(switchMap((query) => this.http.get('/search?q=' + query)));
 }

--- a/adev/src/content/ecosystem/rxjs-interop/take-until-destroyed.md
+++ b/adev/src/content/ecosystem/rxjs-interop/take-until-destroyed.md
@@ -11,8 +11,8 @@ import {NotificationDispatcher, CustomPopupShower} from './some-shared-project-c
 
 @Component(/* ... */)
 export class UserProfile {
-  private dispatcher = inject(NotificationDispatcher);
-  private popup = inject(CustomPopupShower);
+  private readonly dispatcher = inject(NotificationDispatcher);
+  private readonly popup = inject(CustomPopupShower);
 
   constructor() {
     // This subscription the 'notifications' Observable is automatically
@@ -30,9 +30,9 @@ The `takeUntilDestroyed` operator accepts a single optional [`DestroyRef`](/api/
 ```typescript
 @Component(/* ... */)
 export class UserProfile {
-  private dispatcher = inject(NotificationDispatcher);
-  private popup = inject(CustomPopupShower);
-  private destroyRef = inject(DestroyRef);
+  private readonly dispatcher = inject(NotificationDispatcher);
+  private readonly popup = inject(CustomPopupShower);
+  private readonly destroyRef = inject(DestroyRef);
 
   startListeningToNotifications() {
     // Always pass a `DestroyRef` if you call `takeUntilDestroyed` outside

--- a/adev/src/content/guide/components/host-elements.md
+++ b/adev/src/content/guide/components/host-elements.md
@@ -176,7 +176,7 @@ import { Component, HostAttributeToken, inject } from '@angular/core';
   ...,
 })
 export class Button {
-  variation = inject(new HostAttributeToken('variation'));
+  readonly variation = inject(new HostAttributeToken('variation'));
 }
 ```
 

--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -80,7 +80,7 @@ export class OuterContainer {}
   `,
 })
 export class InnerItem {
-  private viewContainer = inject(ViewContainerRef);
+  private readonly viewContainer = inject(ViewContainerRef);
 
   loadContent() {
     this.viewContainer.createComponent(LeafContent);
@@ -190,7 +190,7 @@ import {ThemeDirective} from '../theme.directive';
   template: `<ng-container #container />`,
 })
 export class HostComponent {
-  private vcr = inject(ViewContainerRef);
+  private readonly vcr = inject(ViewContainerRef);
   readonly canClose = signal(true);
   readonly isExpanded = signal(true);
 

--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -66,7 +66,7 @@ import { BasicDataStore } from './basic-data-store';
   `
 })
 export class ExampleComponent {
-  dataStore = inject(BasicDataStore);
+  readonly dataStore = inject(BasicDataStore);
 }
 ```
 
@@ -80,7 +80,7 @@ import {AdvancedDataStore} from './advanced-data-store';
   providedIn: 'root',
 })
 export class BasicDataStore {
-  private advancedDataStore = inject(AdvancedDataStore);
+  private readonly advancedDataStore = inject(AdvancedDataStore);
   private data: string[] = [];
 
   addData(item: string): void {

--- a/adev/src/content/guide/di/creating-injectable-service.md
+++ b/adev/src/content/guide/di/creating-injectable-service.md
@@ -45,8 +45,8 @@ import {inject} from '@angular/core';
 export class HeroService {
   private heroes: Hero[] = [];
 
-  private backend = inject(BackendService);
-  private logger = inject(Logger);
+  private readonly backend = inject(BackendService);
+  private readonly logger = inject(Logger);
 
   async getHeroes() {
     // Fetch
@@ -115,7 +115,7 @@ The type of `heroService` is `HeroService`.
 import {inject} from '@angular/core';
 
 export class HeroListComponent {
-  private heroService = inject(HeroService);
+  private readonly heroService = inject(HeroService);
 }
 ```
 
@@ -141,7 +141,7 @@ import {Logger} from '../logger.service';
   providedIn: 'root',
 })
 export class HeroService {
-  private logger = inject(Logger);
+  private readonly logger = inject(Logger);
 
   getHeroes() {
     this.logger.log('Getting heroes.');

--- a/adev/src/content/guide/di/defining-dependency-providers.md
+++ b/adev/src/content/guide/di/defining-dependency-providers.md
@@ -168,7 +168,7 @@ export class LocalDataStore {
   template: `...`,
 })
 export class ExampleComponent {
-  dataStore = inject(LocalDataStore);
+  readonly dataStore = inject(LocalDataStore);
 }
 ```
 
@@ -192,7 +192,7 @@ export class DataStore {
   template: `...`,
 })
 export class IsolatedComponent {
-  dataStore = inject(DataStore); // Component-specific instance
+  readonly dataStore = inject(DataStore); // Component-specific instance
 }
 ```
 
@@ -324,7 +324,7 @@ import { DATA_SERVICE_TOKEN } from './tokens';
   ]
 })
 export class ExampleComponent {
-  private dataService = inject(DATA_SERVICE_TOKEN);
+  private readonly dataService = inject(DATA_SERVICE_TOKEN);
 }
 ```
 
@@ -345,7 +345,7 @@ interface DataService {
   ],
 })
 export class ExampleComponent {
-  private dataService = inject(DataService); // Error!
+  private readonly dataService = inject(DataService); // Error!
 }
 
 // ✅ Use InjectionToken instead
@@ -355,7 +355,7 @@ export const DATA_SERVICE_TOKEN = new InjectionToken<DataService>('DataService')
   providers: [{provide: DATA_SERVICE_TOKEN, useClass: LocalDataService}],
 })
 export class ExampleComponent {
-  private dataService = inject(DATA_SERVICE_TOKEN); // Works!
+  private readonly dataService = inject(DATA_SERVICE_TOKEN); // Works!
 }
 ```
 
@@ -412,7 +412,7 @@ export class BetterLogger extends Logger {
 // Logger that includes user context
 @Injectable()
 export class EvenBetterLogger extends Logger {
-  private userService = inject(UserService);
+  private readonly userService = inject(UserService);
 
   override log(message: string) {
     const name = this.userService.user.name;
@@ -429,7 +429,7 @@ export class EvenBetterLogger extends Logger {
   ],
 })
 export class ExampleComponent {
-  private logger = inject(Logger); // Gets EvenBetterLogger instance
+  private readonly logger = inject(Logger); // Gets EvenBetterLogger instance
 }
 ```
 
@@ -486,7 +486,7 @@ bootstrapApplication(AppComponent, {
   template: `<h1>{{ title }}</h1>`,
 })
 export class HeaderComponent {
-  private config = inject(APP_CONFIG);
+  private readonly config = inject(APP_CONFIG);
   title = this.config.appTitle;
 }
 ```
@@ -576,7 +576,7 @@ export const apiClientProvider = {
   providers: [apiClientProvider],
 })
 export class DashboardComponent {
-  private apiClient = inject(ApiClient);
+  private readonly apiClient = inject(ApiClient);
 }
 ```
 
@@ -757,7 +757,7 @@ const ANALYTICS_CONFIG = new InjectionToken<AnalyticsConfig>('analytics.config')
 
 // Main service that uses the configuration
 export class AnalyticsService {
-  private config = inject(ANALYTICS_CONFIG);
+  private readonly config = inject(ANALYTICS_CONFIG);
 
   track(event: string, properties?: any) {
     // Implementation using config
@@ -815,8 +815,8 @@ const HTTP_FEATURES = new InjectionToken<Set<HttpFeatures>>('http.features');
 
 // Core service
 class HttpClientService {
-  private config = inject(HTTP_CONFIG, {optional: true});
-  private features = inject(HTTP_FEATURES);
+  private readonly config = inject(HTTP_CONFIG, {optional: true});
+  private readonly features = inject(HTTP_FEATURES);
 
   get(url: string) {
     // Use config and check features
@@ -825,7 +825,7 @@ class HttpClientService {
 
 // Feature services
 class RetryInterceptor {
-  private config = inject(RETRY_CONFIG);
+  private readonly config = inject(RETRY_CONFIG);
   // Retry logic
 }
 

--- a/adev/src/content/guide/di/dependency-injection-context.md
+++ b/adev/src/content/guide/di/dependency-injection-context.md
@@ -41,7 +41,7 @@ This requires access to a given injector, like the `EnvironmentInjector`, for ex
   providedIn: 'root',
 })
 export class HeroService {
-  private environmentInjector = inject(EnvironmentInjector);
+  private readonly environmentInjector = inject(EnvironmentInjector);
 
   someMethod() {
     runInInjectionContext(this.environmentInjector, () => {

--- a/adev/src/content/guide/di/di-in-action.md
+++ b/adev/src/content/guide/di/di-in-action.md
@@ -18,7 +18,7 @@ import {Directive, ElementRef, inject} from '@angular/core';
   selector: '[appHighlight]',
 })
 export class HighlightDirective {
-  private element = inject(ElementRef);
+  private readonly element = inject(ElementRef);
 
   update() {
     this.element.nativeElement.style.color = 'red';
@@ -37,7 +37,7 @@ import {Directive, HOST_TAG_NAME, inject} from '@angular/core';
   selector: '[roleButton]',
 })
 export class RoleButtonDirective {
-  private tagName = inject(HOST_TAG_NAME);
+  private readonly tagName = inject(HOST_TAG_NAME);
 
   onAction() {
     switch (this.tagName) {

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -195,7 +195,7 @@ In the following example, the service, `OptionalService`, isn't provided in the 
 
 ```ts {header:"src/app/optional/optional.component.ts"}
 export class OptionalComponent {
-  public optional? = inject(OptionalService, {optional: true});
+  public readonly optional? = inject(OptionalService, {optional: true});
 }
 ```
 
@@ -215,7 +215,7 @@ For example, in the following `SelfNoDataComponent`, notice the injected `LeafSe
   styleUrls: ['./self-no-data.component.css'],
 })
 export class SelfNoDataComponent {
-  public leaf = inject(LeafService, {optional: true, self: true});
+  public readonly leaf = inject(LeafService, {optional: true, self: true});
 }
 ```
 
@@ -263,7 +263,7 @@ This is when you'd use `skipSelf`:
 })
 export class SkipselfComponent {
   // Use skipSelf as inject option
-  public leaf = inject(LeafService, {skipSelf: true});
+  public readonly leaf = inject(LeafService, {skipSelf: true});
 }
 ```
 
@@ -278,7 +278,7 @@ In the following example, the `Person` service is injected during property initi
 
 ```ts
 class Person {
-  parent = inject(Person, {optional: true, skipSelf: true});
+  readonly parent = inject(Person, {optional: true, skipSelf: true});
 }
 ```
 
@@ -301,7 +301,7 @@ Use `host` as follows:
 })
 export class HostComponent {
   // use host when injecting the service
-  flower = inject(FlowerService, {host: true, optional: true});
+  readonly flower = inject(FlowerService, {host: true, optional: true});
 }
 ```
 
@@ -422,7 +422,7 @@ Now, consider that `<app-root>` injects the `FlowerService`:
 
 ```typescript
 export class AppComponent {
-  flower = inject(FlowerService);
+  readonly flower = inject(FlowerService);
 }
 ```
 
@@ -486,7 +486,7 @@ Now, in the `ChildComponent` class, add a provider for `FlowerService` to demons
 })
 export class ChildComponent {
   // inject the service
-  flower = inject(FlowerService);
+  readonly flower = inject(FlowerService);
 }
 ```
 
@@ -559,8 +559,8 @@ Following the same pattern as with the `FlowerService`, inject the `AnimalServic
 
 ```ts
 export class AppComponent {
-  public flower = inject(FlowerService);
-  public animal = inject(AnimalService);
+  public readonly flower = inject(FlowerService);
+  public readonly animal = inject(AnimalService);
 }
 ```
 
@@ -580,8 +580,8 @@ Here, it has a value of dog 🐶.
 })
 export class ChildComponent {
   // inject services
-  flower = inject(FlowerService);
-  animal = inject(AnimalService);
+  readonly flower = inject(FlowerService);
+  readonly animal = inject(AnimalService);
 }
 ```
 
@@ -643,8 +643,8 @@ In `inspector.component.ts`, inject the `FlowerService` and `AnimalService` duri
 
 ```typescript
 export class InspectorComponent {
-  flower = inject(FlowerService);
-  animal = inject(AnimalService);
+  readonly flower = inject(FlowerService);
+  readonly animal = inject(AnimalService);
 }
 ```
 
@@ -754,7 +754,7 @@ To alter where the injector starts looking for `FlowerService`, add `skipSelf` t
 This invocation is a property initializer the `<app-child>` as shown in `child.component.ts`:
 
 ```typescript
-flower = inject(FlowerService, {skipSelf: true});
+readonly flower = inject(FlowerService, {skipSelf: true});
 ```
 
 With `skipSelf`, the `<app-child>` injector doesn't look to itself for the `FlowerService`.
@@ -859,7 +859,7 @@ You can also see `host` the `inject()`:
   ]
 })
 export class ChildComponent {
-  animal = inject(AnimalService, { host: true })
+  readonly animal = inject(AnimalService, { host: true })
 }
 ```
 
@@ -897,7 +897,7 @@ Here are `host` and `skipSelf` in the `animal` property initialization:
 
 ```typescript
 export class ChildComponent {
-  animal = inject(AnimalService, {host: true, skipSelf: true});
+  readonly animal = inject(AnimalService, {host: true, skipSelf: true});
 }
 ```
 
@@ -996,7 +996,7 @@ export class HeroTaxReturnService {
   private currentTaxReturn!: HeroTaxReturn;
   private originalTaxReturn!: HeroTaxReturn;
 
-  private heroService = inject(HeroesService);
+  private readonly heroService = inject(HeroesService);
 
   set taxReturn(htr: HeroTaxReturn) {
     this.originalTaxReturn = htr;
@@ -1048,7 +1048,7 @@ export class HeroTaxReturnComponent {
     });
   }
 
-  private heroTaxReturnService = inject(HeroTaxReturnService);
+  private readonly heroTaxReturnService = inject(HeroTaxReturnService);
 
   onCanceled() {
     this.flashMessage('Canceled');

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -80,8 +80,8 @@ import { AnalyticsLogger } from './analytics-logger';
   `,
 })
 export class NavbarComponent {
-  private router = inject(Router);
-  private analytics = inject(AnalyticsLogger);
+  private readonly router = inject(Router);
+  private readonly analytics = inject(AnalyticsLogger);
 
   navigateToDetail(event: Event) {
     event.preventDefault();
@@ -99,7 +99,7 @@ You can inject dependencies during construction of a component, directive, or se
 @Component({...})
 export class MyComponent {
   // ✅ In class field initializer
-  private service = inject(MyService);
+  private readonly service = inject(MyService);
 
   // ✅ In constructor body
   private anotherService: MyService;
@@ -114,7 +114,7 @@ export class MyComponent {
 @Directive({...})
 export class MyDirective {
   // ✅ In class field initializer
-  private element = inject(ElementRef);
+  private readonly element = inject(ElementRef);
 }
 ```
 
@@ -125,7 +125,7 @@ import {HttpClient} from '@angular/common/http';
 @Injectable({providedIn: 'root'})
 export class MyService {
   // ✅ In a service
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
 }
 ```
 

--- a/adev/src/content/guide/directives/structural-directives.md
+++ b/adev/src/content/guide/directives/structural-directives.md
@@ -82,8 +82,8 @@ import {Directive, TemplateRef, ViewContainerRef} from '@angular/core';
   selector: '[select]',
 })
 export class SelectDirective {
-  private templateRef = inject(TemplateRef);
-  private viewContainerRef = inject(ViewContainerRef);
+  private readonly templateRef = inject(TemplateRef);
+  private readonly viewContainerRef = inject(ViewContainerRef);
 }
 ```
 

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -213,7 +213,7 @@ export class UserProfileComponent {
   });
 
   userForm = form(this.userModel);
-  private userService = inject(UserService);
+  private readonly userService = inject(UserService);
 
   ngOnInit() {
     this.loadUserProfile();

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -611,7 +611,7 @@ import { form, Field, required, validateHttp } from '@angular/forms/signals'
   `
 })
 export class UsernameFormComponent {
-  http = inject(HttpClient)
+  readonly http = inject(HttpClient)
 
   usernameModel = signal({ username: '' })
 

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -137,7 +137,7 @@ export class CustomHttpParamEncoder implements HttpParameterCodec {
 }
 
 export class ApiService {
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
 
   search() {
     const params = new HttpParams({
@@ -637,7 +637,7 @@ While `HttpClient` can be injected and used directly from components, generally 
 ```ts
 @Injectable({providedIn: 'root'})
 export class UserService {
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
 
   getUser(id: string): Observable<User> {
     return this.http.get<User>(`/api/user/${id}`);
@@ -663,7 +663,7 @@ export class UserProfileComponent {
   userId = input.required<string>();
   user$!: Observable<User>;
 
-  private userService = inject(UserService);
+  private readonly userService = inject(UserService);
 
   constructor(): void {
     effect(() => {

--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -27,7 +27,7 @@ You can then inject the `HttpClient` service as a dependency of your components,
 ```ts
 @Injectable({providedIn: 'root'})
 export class ConfigService {
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
   // This service can now make HTTP requests via `this.http`.
 }
 ```

--- a/adev/src/content/guide/http/testing.md
+++ b/adev/src/content/guide/http/testing.md
@@ -188,7 +188,7 @@ A similar interceptor could be implemented with class based interceptors:
 ```ts
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  private authService = inject(AuthService);
+  private readonly authService = inject(AuthService);
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     const clonedRequest = request.clone({

--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -79,7 +79,7 @@ export const routes: Routes = [
   /* ... */
 })
 export class CustomerComponent {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   orgId = this.route.parent?.parent?.snapshot.params['orgId'];
   projectId = this.route.parent?.snapshot.params['projectId'];
@@ -94,7 +94,7 @@ Using `'always'` ensures matrix parameters, route data, and resolved values are 
   /* ... */
 })
 export class CustomerComponent {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   // All parent parameters are available directly
   orgId = this.route.snapshot.params['orgId'];
@@ -472,7 +472,7 @@ export class DocumentationComponent {
   version = input.required<string>();  // Receives the version parameter
   section = input.required<string>();  // Receives the section parameter
 
-  private docsService = inject(DocumentationService);
+  private readonly docsService = inject(DocumentationService);
 
   // Resource automatically loads documentation when version or section changes
   documentation = resource({

--- a/adev/src/content/guide/routing/data-resolvers.md
+++ b/adev/src/content/guide/routing/data-resolvers.md
@@ -89,7 +89,7 @@ import type { User, Settings } from './types';
   `
 })
 export class UserDetail {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
   private data = toSignal(this.route.data);
   user = computed(() => this.data().user as User);
   settings = computed(() => this.data().settings as Settings);
@@ -204,7 +204,7 @@ import { map } from 'rxjs';
   `
 })
 export class App {
-  private router = inject(Router);
+  private readonly router = inject(Router);
   private lastFailedUrl = signal('');
 
   private navigationErrors = toSignal(
@@ -290,7 +290,7 @@ import { map } from 'rxjs';
   `
 })
 export class App {
-  private router = inject(Router);
+  private readonly router = inject(Router);
   isNavigating = computed(() => !!this.router.currentNavigation());
 }
 ```

--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -97,7 +97,7 @@ import { map } from 'rxjs/operators';
   `
 })
 export class AppComponent {
-  private router = inject(Router);
+  private readonly router = inject(Router);
 
   readonly loading = toSignal(
     this.router.events.pipe(
@@ -119,8 +119,8 @@ import {Router, NavigationEnd} from '@angular/router';
 
 @Injectable({providedIn: 'root'})
 export class AnalyticsService {
-  private router = inject(Router);
-  private destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
 
   startTracking() {
     this.router.events.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((event) => {
@@ -161,7 +161,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   `
 })
 export class ErrorHandlerComponent {
-  private router = inject(Router);
+  private readonly router = inject(Router);
   readonly errorMessage = signal('');
 
   constructor() {

--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -88,7 +88,7 @@ import { Router } from '@angular/router';
   `
 })
 export class AppDashboard {
-  private router = inject(Router);
+  private readonly router = inject(Router);
 
   navigateToProfile() {
     // Standard navigation
@@ -123,8 +123,8 @@ import { Router, ActivatedRoute } from '@angular/router';
   `
 })
 export class UserDetailComponent {
-  private route = inject(ActivatedRoute);
-  private router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
   constructor() {}
 

--- a/adev/src/content/guide/routing/read-route-state.md
+++ b/adev/src/content/guide/routing/read-route-state.md
@@ -14,7 +14,7 @@ import { ActivatedRoute } from '@angular/router';
   selector: 'app-product',
 })
 export class ProductComponent {
-  private activatedRoute = inject(ActivatedRoute);
+  private readonly activatedRoute = inject(ActivatedRoute);
 
   constructor() {
     console.log(this.activatedRoute);
@@ -47,7 +47,7 @@ import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
 @Component({ ... })
 export class UserProfileComponent {
   readonly userId: string;
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   constructor() {
     // Example URL: https://www.angular.dev/users/123?role=admin&status=active#contact
@@ -101,7 +101,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class ProductDetailComponent {
   productId = signal('');
-  private activatedRoute = inject(ActivatedRoute);
+  private readonly activatedRoute = inject(ActivatedRoute);
 
   constructor() {
     // Access route parameters
@@ -154,8 +154,8 @@ import { ActivatedRoute, Router } from '@angular/router';
   `
 })
 export class ProductListComponent implements OnInit {
-  private route = inject(ActivatedRoute);
-  private router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
   constructor() {
     // Access query parameters reactively
@@ -204,7 +204,7 @@ import {ActivatedRoute} from '@angular/router';
 
 @Component(/* ... */)
 export class AwesomeProducts {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
 
   constructor() {
     // Access matrix parameters via params

--- a/adev/src/content/guide/routing/show-routes-with-outlets.md
+++ b/adev/src/content/guide/routing/show-routes-with-outlets.md
@@ -195,7 +195,7 @@ import { ROUTER_OUTLET_DATA } from '@angular/router';
   template: `<p>Stats view (layout: {{ outletData().layout }})</p>`,
 })
 export class StatsComponent {
-  outletData = inject(ROUTER_OUTLET_DATA) as Signal<{ layout: string }>;
+  readonly outletData = inject(ROUTER_OUTLET_DATA) as Signal<{ layout: string }>;
 }
 ```
 

--- a/adev/src/content/guide/routing/testing.md
+++ b/adev/src/content/guide/routing/testing.md
@@ -51,7 +51,7 @@ import { ActivatedRoute } from '@angular/router';
   template: '<h1>User Profile: {{userId}}</h1>'
 })
 export class UserProfile {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
   userId: string | null = this.route.snapshot.paramMap.get('id');
 }
 ```
@@ -314,7 +314,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
   template: '<div>Search term: {{searchTerm()}}</div>'
 })
 export class Search {
-  private route = inject(ActivatedRoute);
+  private readonly route = inject(ActivatedRoute);
   private queryParams = toSignal(this.route.queryParams, { initialValue: {} });
 
   searchTerm = computed(() => this.queryParams()['q'] || null);

--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -55,7 +55,7 @@ To create an effect outside the constructor, you can pass an `Injector` to `effe
 @Component({...})
 export class EffectiveCounterComponent {
   readonly count = signal(0);
-  private injector = inject(Injector);
+  private readonly injector = inject(Injector);
 
   initializeLogging(): void {
     effect(() => {

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -332,7 +332,7 @@ Inject and use the service in your components:
   /* ... */
 })
 export class Checkout {
-  private analytics = inject(AnalyticsService);
+  private readonly analytics = inject(AnalyticsService);
 
   onAction() {
     this.analytics.trackEvent('action');

--- a/adev/src/content/guide/templates/ng-template.md
+++ b/adev/src/content/guide/templates/ng-template.md
@@ -114,7 +114,7 @@ A directive can inject a `TemplateRef` if that directive is applied directly to 
   selector: '[myDirective]'
 })
 export class MyDirective {
-  private fragment = inject(TemplateRef);
+  private readonly fragment = inject(TemplateRef);
 }
 ```
 
@@ -187,7 +187,7 @@ export class ComponentWithFragment { }
   template: `<button (click)="showFragment()">Show</button>`,
 })
 export class MyOutlet {
-  private viewContainer = inject(ViewContainerRef);
+  private readonly viewContainer = inject(ViewContainerRef);
   fragment = input<TemplateRef<unknown> | undefined>();
 
   showFragment() {

--- a/adev/src/content/introduction/essentials/dependency-injection.md
+++ b/adev/src/content/introduction/essentials/dependency-injection.md
@@ -45,7 +45,7 @@ import { Calculator } from './calculator';
 })
 
 export class Receipt {
-  private calculator = inject(Calculator);
+  private readonly calculator = inject(Calculator);
   totalCost = this.calculator.add(50, 25);
 }
 ```

--- a/adev/src/content/reference/errors/NG0203.md
+++ b/adev/src/content/reference/errors/NG0203.md
@@ -11,7 +11,7 @@ export class Car {
   radio: Radio | undefined;
 
   // OK: field initializer
-  spareTyre = inject(Tyre);
+  readonly spareTyre = inject(Tyre);
 
   constructor() {
     // OK: constructor body

--- a/adev/src/content/reference/errors/NG0500.md
+++ b/adev/src/content/reference/errors/NG0500.md
@@ -14,7 +14,7 @@ The following example will trigger the error.
   template: '<div><span>world</span></div>',
 })
 export class ExampleComponent {
-  hostElement = inject(ElementRef).nativeElement;
+  readonly hostElement = inject(ElementRef).nativeElement;
 
   ngOnInit() {
     // Create a new <p> element with the `Hello` text inside

--- a/adev/src/content/reference/errors/NG0503.md
+++ b/adev/src/content/reference/errors/NG0503.md
@@ -22,7 +22,7 @@ class DynamicComponent {
 })
 class SimpleComponent {
   @ViewChild('target', {read: ViewContainerRef}) vcr!: ViewContainerRef;
-  envInjector = inject(EnvironmentInjector);
+  readonly envInjector = inject(EnvironmentInjector);
 
   ngAfterViewInit() {
     const div = document.createElement('div');

--- a/adev/src/content/reference/errors/NG3003.md
+++ b/adev/src/content/reference/errors/NG3003.md
@@ -24,7 +24,7 @@ import {ParentComponent} from './parent.component';
   template: 'The child!',
 })
 export class ChildComponent {
-  private parent = inject(ParentComponent);
+  private readonly parent = inject(ParentComponent);
 }
 ```
 

--- a/adev/src/content/tools/cli/aot-compiler.md
+++ b/adev/src/content/tools/cli/aot-compiler.md
@@ -50,7 +50,7 @@ In the following example, the `@Component()` metadata object and the class const
 })
 export class TypicalComponent {
   data = input.required<TypicalData>();
-  private someService = inject(SomeService);
+  private readonly someService = inject(SomeService);
 }
 
 ```

--- a/adev/src/content/tools/cli/schematics-for-libraries.md
+++ b/adev/src/content/tools/cli/schematics-for-libraries.md
@@ -151,7 +151,7 @@ Schematic templates support special syntax to execute code and variable substitu
       providedIn: 'root'
    })
    export class <%= classify(name) %>Service {
-      private http = inject(HttpClient);
+      private readonly http = inject(HttpClient);
    }
 
    ```

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
@@ -58,10 +58,11 @@ In this step, you will get the route parameter in the `Details`. Currently, the 
 
          ```ts
          export class Details {
-            route: ActivatedRoute = inject(ActivatedRoute);
+            readonly route: ActivatedRoute = inject(ActivatedRoute);
             housingLocationId = -1;
+
             constructor() {
-            this.housingLocationId = Number(this.route.snapshot.params['id']);
+              this.housingLocationId = Number(this.route.snapshot.params['id']);
             }
          }
          ```

--- a/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/README.md
@@ -13,7 +13,7 @@ It is often helpful to initialize class properties with values provided by the D
 ```ts {highlight:[3]}
 @Component({...})
 class PetCareDashboard {
-  petRosterService = inject(PetRosterService);
+   readonly petRosterService = inject(PetRosterService);
 }
 ```
 

--- a/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/README.md
+++ b/adev/src/content/tutorials/signals/steps/7-using-signals-with-services/README.md
@@ -85,7 +85,7 @@ import {CartDisplay} from './cart-display';
   styleUrl: './app.css',
 })
 export class App {
-  cartStore = inject(CartStore);
+  readonly cartStore = inject(CartStore);
 }
 ```
 


### PR DESCRIPTION
Update documentation examples to declare values returned from inject() as readonly, aligning with the Angular style guide and reinforcing that injected dependencies should not be reassigned.
