### PR TITLE
refactor(forms): bind field state to applicable directive inputs and DOM properties

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_constructor.ts
@@ -17,7 +17,7 @@ import {addParseSpanInfo, wrapForDiagnostics} from '../diagnostics';
 import {tsCreateVariable} from '../ts_util';
 import {unwrapWritableSignal} from './expression';
 import {getAnyExpression} from '../expression';
-import {CustomFieldType, expandBoundAttributesForField} from './signal_forms';
+import {CustomFormControlType, expandBoundAttributesForField} from './signal_forms';
 import {getBoundAttributes, TcbBoundAttribute, TcbDirectiveInput, widenBinding} from './bindings';
 import {translateInput} from './inputs';
 
@@ -39,7 +39,7 @@ export class TcbDirectiveCtorOp extends TcbOp {
     private scope: Scope,
     private node: DirectiveOwner,
     private dir: TypeCheckableDirectiveMeta,
-    private customControlType: CustomFieldType | null,
+    private customFormControlType: CustomFormControlType | null,
   ) {
     super();
   }
@@ -64,11 +64,11 @@ export class TcbDirectiveCtorOp extends TcbOp {
       span = this.node.startSourceSpan || this.node.sourceSpan;
       boundAttrs = getBoundAttributes(this.dir, this.node);
 
-      if (this.customControlType !== null) {
+      if (this.customFormControlType !== null) {
         const additionalBindings = expandBoundAttributesForField(
           this.dir,
           this.node,
-          this.customControlType,
+          this.customFormControlType,
         );
 
         if (additionalBindings !== null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
@@ -30,7 +30,7 @@ import {tcbExpression, unwrapWritableSignal} from './expression';
 import {tsCreateTypeQueryForCoercedInput, tsDeclareVariable} from '../ts_util';
 import {
   checkUnsupportedFieldBindings,
-  CustomFieldType,
+  CustomFormControlType,
   customFormControlBannedInputFields,
   expandBoundAttributesForField,
 } from './signal_forms';
@@ -62,7 +62,8 @@ export class TcbDirectiveInputsOp extends TcbOp {
     private scope: Scope,
     private node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
     private dir: TypeCheckableDirectiveMeta,
-    private customControlType: CustomFieldType | null,
+    private isFormControl: boolean = false,
+    private customFormControlType: CustomFormControlType | null,
   ) {
     super();
   }
@@ -78,13 +79,15 @@ export class TcbDirectiveInputsOp extends TcbOp {
     const seenRequiredInputs = new Set<ClassPropertyName>();
     const boundAttrs = getBoundAttributes(this.dir, this.node);
 
-    if (this.customControlType !== null) {
+    if (this.customFormControlType !== null) {
       checkUnsupportedFieldBindings(this.node, customFormControlBannedInputFields, this.tcb);
+    }
 
+    if (this.customFormControlType !== null || this.isFormControl) {
       const additionalBindings = expandBoundAttributesForField(
         this.dir,
         this.node,
-        this.customControlType,
+        this.customFormControlType,
       );
 
       if (additionalBindings !== null) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
@@ -52,9 +52,9 @@ import {TcbDirectiveInputsOp, TcbUnclaimedInputsOp} from './inputs';
 import {TcbDomSchemaCheckerOp} from './schema';
 import {TcbDirectiveOutputsOp, TcbUnclaimedOutputsOp} from './events';
 import {
-  CustomFieldType,
+  CustomFormControlType,
   getCustomFieldDirectiveType,
-  isFieldDirective,
+  isFormControl,
   isNativeField,
   TcbNativeFieldOp,
   TcbNativeRadioButtonFieldOp,
@@ -766,11 +766,10 @@ export class Scope {
     dirMap: Map<TypeCheckableDirectiveMeta, number>,
     allDirectiveMatches: TypeCheckableDirectiveMeta[],
   ): void {
-    const customFieldType = allDirectiveMatches.some(isFieldDirective)
-      ? getCustomFieldDirectiveType(dir)
-      : null;
+    const nodeIsFormControl = isFormControl(allDirectiveMatches);
+    const customFormControlType = nodeIsFormControl ? getCustomFieldDirectiveType(dir) : null;
 
-    const directiveOp = this.getDirectiveOp(dir, node, customFieldType);
+    const directiveOp = this.getDirectiveOp(dir, node, customFormControlType);
     const dirIndex = this.opQueue.push(directiveOp) - 1;
     dirMap.set(dir, dirIndex);
 
@@ -786,13 +785,15 @@ export class Scope {
       );
     }
 
-    this.opQueue.push(new TcbDirectiveInputsOp(this.tcb, this, node, dir, customFieldType));
+    this.opQueue.push(
+      new TcbDirectiveInputsOp(this.tcb, this, node, dir, nodeIsFormControl, customFormControlType),
+    );
   }
 
   private getDirectiveOp(
     dir: TypeCheckableDirectiveMeta,
     node: DirectiveOwner,
-    customFieldType: CustomFieldType | null,
+    customFieldType: CustomFormControlType | null,
   ): TcbOp {
     const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -32,8 +32,8 @@ import {tcbExpression} from './expression';
 import {markIgnoreDiagnostics} from '../comments';
 import {TcbBoundAttribute} from './bindings';
 
-/** Possible types of custom field directives. */
-export type CustomFieldType = 'value' | 'checkbox';
+/** Possible types of custom form control directives. */
+export type CustomFormControlType = 'value' | 'checkbox';
 
 /** Names of the input fields on custom controls. */
 const formControlInputFields = [
@@ -224,7 +224,7 @@ export class TcbNativeRadioButtonFieldOp extends TcbNativeFieldOp {
 export function expandBoundAttributesForField(
   directive: TypeCheckableDirectiveMeta,
   node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
-  customFieldType: CustomFieldType,
+  customFormControlType: CustomFormControlType | null,
 ): TcbBoundAttribute[] | null {
   const fieldBinding = node.inputs.find(
     (input) => input.type === BindingType.Property && input.name === 'field',
@@ -237,21 +237,21 @@ export function expandBoundAttributesForField(
   let boundInputs: TcbBoundAttribute[] | null = null;
   let primaryInput: TcbBoundAttribute | null;
 
-  if (customFieldType === 'value') {
+  if (customFormControlType === 'value') {
     primaryInput = getSyntheticFieldBoundInput(
       directive,
       'value',
       'value',
       fieldBinding,
-      customFieldType,
+      customFormControlType,
     );
-  } else if (customFieldType === 'checkbox') {
+  } else if (customFormControlType === 'checkbox') {
     primaryInput = getSyntheticFieldBoundInput(
       directive,
       'checked',
       'value',
       fieldBinding,
-      customFieldType,
+      customFormControlType,
     );
   } else {
     primaryInput = null;
@@ -263,7 +263,13 @@ export function expandBoundAttributesForField(
   }
 
   for (const name of formControlInputFields) {
-    const input = getSyntheticFieldBoundInput(directive, name, name, fieldBinding, customFieldType);
+    const input = getSyntheticFieldBoundInput(
+      directive,
+      name,
+      name,
+      fieldBinding,
+      customFormControlType,
+    );
 
     if (input !== null) {
       boundInputs ??= [];
@@ -302,7 +308,7 @@ function getSyntheticFieldBoundInput(
   inputName: string,
   fieldPropertyName: string,
   fieldBinding: TmplAstBoundAttribute,
-  customFieldType: CustomFieldType,
+  customFieldType: CustomFormControlType | null,
 ): TcbBoundAttribute | null {
   const inputs = dir.inputs.getByBindingPropertyName(inputName);
 
@@ -345,7 +351,7 @@ function getSyntheticFieldBoundInput(
 /** Determines if a directive is a custom field and its type. */
 export function getCustomFieldDirectiveType(
   meta: TypeCheckableDirectiveMeta,
-): CustomFieldType | null {
+): CustomFormControlType | null {
   if (hasModelInput('value', meta)) {
     return 'value';
   } else if (hasModelInput('checked', meta)) {
@@ -448,4 +454,24 @@ function hasModelInput(name: string, meta: TypeCheckableDirectiveMeta): boolean 
   return (
     meta.inputs.hasBindingPropertyName(name) && meta.outputs.hasBindingPropertyName(name + 'Change')
   );
+}
+
+/**
+ * Determines whether a node is a form control based on its matching directives.
+ *
+ * A node is a form control if it has a matching `Field` directive, and no other directives match
+ * the `field` input.
+ */
+export function isFormControl(allDirectiveMatches: TypeCheckableDirectiveMeta[]): boolean {
+  let result = false;
+  for (const match of allDirectiveMatches) {
+    if (match.inputs.hasBindingPropertyName('field')) {
+      if (isFieldDirective(match)) {
+        result = true;
+      } else {
+        return false;
+      }
+    }
+  }
+  return result;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -466,11 +466,10 @@ export function isFormControl(allDirectiveMatches: TypeCheckableDirectiveMeta[])
   let result = false;
   for (const match of allDirectiveMatches) {
     if (match.inputs.hasBindingPropertyName('field')) {
-      if (isFieldDirective(match)) {
-        result = true;
-      } else {
+      if (!isFieldDirective(match)) {
         return false;
       }
+      result = true;
     }
   }
   return result;

--- a/packages/forms/signals/test/web/field_directive.spec.ts
+++ b/packages/forms/signals/test/web/field_directive.spec.ts
@@ -140,6 +140,28 @@ describe('field directive', () => {
         expect(comp.customControl().dirty()).toBe(true);
       });
 
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly dirty = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly data = signal('');
+          readonly f = form(this.data);
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const comp = act(() => TestBed.createComponent(TestCmp)).componentInstance;
+        expect(comp.dir().dirty()).toBe(false);
+        act(() => comp.f().markAsDirty());
+        expect(comp.dir().dirty()).toBe(true);
+      });
+
       it('should be reset when field changes on custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
@@ -243,6 +265,33 @@ describe('field directive', () => {
         expect(input.disabled).toBe(true);
       });
 
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly disabled = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly disabled = signal(false);
+          readonly f = form(signal(''), (p) => {
+            disabled(p, this.disabled);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.disabled()).toBe(false);
+
+        act(() => fixture.componentInstance.disabled.set(true));
+        expect(dir.disabled()).toBe(true);
+      });
+
       it('should be reset when field changes on native control', () => {
         @Component({
           imports: [Field],
@@ -322,6 +371,37 @@ describe('field directive', () => {
         ]);
       });
 
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly disabled = signal(false);
+          readonly f = form(signal(''), (p) => {
+            disabled(p, () => {
+              return this.disabled() ? 'b' : false;
+            });
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.disabledReasons()).toEqual([]);
+
+        act(() => fixture.componentInstance.disabled.set(true));
+        expect(dir.disabledReasons()).toEqual([
+          {message: 'b', fieldTree: fixture.componentInstance.f},
+        ]);
+      });
+
       it('should be reset when field changes on custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
@@ -381,6 +461,33 @@ describe('field directive', () => {
 
         act(() => comp.f().value.set('valid'));
         expect(comp.customControl().errors()).toEqual([]);
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly required = signal(false);
+          readonly f = form(signal(''), (p) => {
+            required(p, {when: this.required});
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.errors()).toEqual([]);
+
+        act(() => fixture.componentInstance.required.set(true));
+        expect(dir.errors()).toEqual([requiredError({fieldTree: fixture.componentInstance.f})]);
       });
 
       it('should be reset when field changes on custom control', () => {
@@ -444,6 +551,33 @@ describe('field directive', () => {
         expect(component.customControl().hidden()).toBe(false);
       });
 
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly hidden = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly hidden = signal(false);
+          readonly f = form(signal(''), (p) => {
+            hidden(p, this.hidden);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.hidden()).toBe(false);
+
+        act(() => fixture.componentInstance.hidden.set(true));
+        expect(dir.hidden()).toBe(true);
+      });
+
       it('should be reset when field changes on custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
@@ -499,6 +633,33 @@ describe('field directive', () => {
         expect(comp.customControl().invalid()).toBe(true);
         act(() => comp.f().value.set('valid'));
         expect(comp.customControl().invalid()).toBe(false);
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly invalid = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly invalid = signal(false);
+          readonly f = form(signal(''), (p) => {
+            required(p, {when: this.invalid});
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.invalid()).toBe(false);
+
+        act(() => fixture.componentInstance.invalid.set(true));
+        expect(dir.invalid()).toBe(true);
       });
 
       it('should be reset when field changes on custom control', () => {
@@ -605,6 +766,27 @@ describe('field directive', () => {
         expect(inputs[0].name).toBe('root.0');
         expect(inputs[1].name).toBe('root.1');
       });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly name = input.required<string>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly f = form(signal(''), {name: 'root'});
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.name()).toBe('root');
+      });
     });
 
     describe('pending', () => {
@@ -696,6 +878,44 @@ describe('field directive', () => {
         await fixture.whenStable();
         expect(component.customControl().pending()).toBe(false);
       });
+
+      it('should bind to directive input on native control', async () => {
+        const {promise, resolve} = promiseWithResolvers<ValidationError[]>();
+
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly pending = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly f = form(signal(''), (p) => {
+            validateAsync(p, {
+              params: () => [],
+              factory: (params) =>
+                resource({
+                  params,
+                  loader: () => promise,
+                }),
+              onSuccess: (results) => results,
+              onError: () => null,
+            });
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.pending()).toBe(true);
+        resolve([]);
+        await promise;
+        await fixture.whenStable();
+        expect(dir.pending()).toBe(false);
+      });
     });
 
     describe('readonly', () => {
@@ -770,6 +990,33 @@ describe('field directive', () => {
 
         act(() => component.readonly.set(true));
         expect(input.readOnly).toBe(true);
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly readonly = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly readonly = signal(false);
+          readonly f = form(signal(''), (p) => {
+            readonly(p, this.readonly);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.readonly()).toBe(false);
+
+        act(() => fixture.componentInstance.readonly.set(true));
+        expect(dir.readonly()).toBe(true);
       });
 
       it('should be reset when field changes on native control', () => {
@@ -893,6 +1140,33 @@ describe('field directive', () => {
 
         act(() => component.required.set(true));
         expect(input.required).toBe(true);
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly required = input.required<boolean>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly required = signal(false);
+          readonly f = form(signal(''), (p) => {
+            required(p, {when: this.required});
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.required()).toBe(false);
+
+        act(() => fixture.componentInstance.required.set(true));
+        expect(dir.required()).toBe(true);
       });
 
       it('should be reset when field changes on native control', () => {
@@ -1065,6 +1339,33 @@ describe('field directive', () => {
         act(() => component.field.set(component.f.y));
         expect(component.customControl().max()).toBeUndefined();
       });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly max = input.required<number | undefined>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input type="number" [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly max = signal(10);
+          readonly f = form(signal(5), (p) => {
+            max(p, this.max);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.max()).toBe(10);
+
+        act(() => fixture.componentInstance.max.set(5));
+        expect(dir.max()).toBe(5);
+      });
     });
 
     describe('min', () => {
@@ -1187,6 +1488,33 @@ describe('field directive', () => {
 
         act(() => component.field.set(component.f.y));
         expect(component.customControl().min()).toBeUndefined();
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly min = input.required<number | undefined>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input type="number" [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly min = signal(10);
+          readonly f = form(signal(15), (p) => {
+            min(p, this.min);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.min()).toBe(10);
+
+        act(() => fixture.componentInstance.min.set(5));
+        expect(dir.min()).toBe(5);
       });
     });
 
@@ -1327,6 +1655,33 @@ describe('field directive', () => {
         act(() => component.field.set(component.f.y));
         expect(component.customControl().maxLength()).toBe(undefined);
       });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly maxLength = input.required<number | undefined>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly maxLength = signal(10);
+          readonly f = form(signal('abc'), (p) => {
+            maxLength(p, this.maxLength);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.maxLength()).toBe(10);
+
+        act(() => fixture.componentInstance.maxLength.set(5));
+        expect(dir.maxLength()).toBe(5);
+      });
     });
 
     describe('minLength', () => {
@@ -1466,6 +1821,33 @@ describe('field directive', () => {
         act(() => component.field.set(component.f.y));
         expect(component.customControl().minLength()).toBeUndefined();
       });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly minLength = input.required<number | undefined>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly minLength = signal(10);
+          readonly f = form(signal('abc'), (p) => {
+            minLength(p, this.minLength);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.minLength()).toBe(10);
+
+        act(() => fixture.componentInstance.minLength.set(5));
+        expect(dir.minLength()).toBe(5);
+      });
     });
 
     describe('pattern', () => {
@@ -1521,6 +1903,33 @@ describe('field directive', () => {
 
         act(() => component.field.set(component.f.y));
         expect(component.customControl().pattern()).toEqual([]);
+      });
+
+      it('should bind to directive input on native control', () => {
+        @Directive({selector: '[testDir]'})
+        class TestDir {
+          readonly pattern = input.required<readonly RegExp[]>();
+        }
+
+        @Component({
+          imports: [Field, TestDir],
+          template: `<input [field]="f" testDir />`,
+        })
+        class TestCmp {
+          readonly pattern = signal(/a*/);
+          readonly f = form(signal('abc'), (p) => {
+            pattern(p, this.pattern);
+          });
+          readonly dir = viewChild.required(TestDir);
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const dir = fixture.componentInstance.dir();
+
+        expect(dir.pattern()).toEqual([/a*/]);
+
+        act(() => fixture.componentInstance.pattern.set(/b*/));
+        expect(dir.pattern()).toEqual([/b*/]);
       });
     });
   });

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -90,6 +90,17 @@ describe('ControlValueAccessor', () => {
     }
   }
 
+  @Directive({
+    selector: '[cvaDir]',
+    providers: [{provide: NG_VALUE_ACCESSOR, useExisting: CvaDir, multi: true}],
+  })
+  class CvaDir implements ControlValueAccessor {
+    writeValue(obj: any): void {}
+    registerOnChange(fn: any): void {}
+    registerOnTouched(fn: any): void {}
+    setDisabledState(isDisabled: boolean): void {}
+  }
+
   it('synchronizes value', () => {
     @Component({
       imports: [CustomControl, Field],
@@ -361,6 +372,27 @@ describe('ControlValueAccessor', () => {
         act(() => fixture.componentInstance.disabled.set(true));
         expect(dir.disabled()).toBe(true);
       });
+
+      it('should not bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly disabled = signal(false);
+          readonly f = form(signal(''), (p) => {
+            disabled(p, this.disabled);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.disabled).toBe(false);
+
+        act(() => fixture.componentInstance.disabled.set(true));
+        expect(input.disabled).toBe(false);
+      });
     });
 
     describe('touched', () => {
@@ -556,6 +588,21 @@ describe('ControlValueAccessor', () => {
 
         expect(dir.name()).toBe('root');
       });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly f = form(signal(''), {name: 'root'});
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.getAttribute('name')).toBe('root');
+      });
     });
 
     describe('pending', () => {
@@ -625,6 +672,27 @@ describe('ControlValueAccessor', () => {
         act(() => fixture.componentInstance.isReadonly.set(true));
         expect(dir.readonly()).toBe(true);
       });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly isReadonly = signal(false);
+          readonly f = form(signal(''), (p) => {
+            readonly(p, this.isReadonly);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.readOnly).toBe(false);
+
+        act(() => fixture.componentInstance.isReadonly.set(true));
+        expect(input.readOnly).toBe(true);
+      });
     });
 
     describe('required', () => {
@@ -653,6 +721,27 @@ describe('ControlValueAccessor', () => {
 
         act(() => fixture.componentInstance.required.set(true));
         expect(dir.required()).toBe(true);
+      });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly required = signal(false);
+          readonly f = form(signal(''), (p) => {
+            required(p, {when: this.required});
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.required).toBe(false);
+
+        act(() => fixture.componentInstance.required.set(true));
+        expect(input.required).toBe(true);
       });
     });
 
@@ -683,6 +772,27 @@ describe('ControlValueAccessor', () => {
         act(() => fixture.componentInstance.max.set(5));
         expect(dir.max()).toBe(5);
       });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input type="number" [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly max = signal(10);
+          readonly f = form(signal(0), (p) => {
+            max(p, this.max);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.getAttribute('max')).toBe('10');
+
+        act(() => fixture.componentInstance.max.set(5));
+        expect(input.getAttribute('max')).toBe('5');
+      });
     });
 
     describe('maxLength', () => {
@@ -711,6 +821,27 @@ describe('ControlValueAccessor', () => {
 
         act(() => fixture.componentInstance.maxLength.set(5));
         expect(dir.maxLength()).toBe(5);
+      });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly maxLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            maxLength(p, this.maxLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.getAttribute('maxLength')).toBe('10');
+
+        act(() => fixture.componentInstance.maxLength.set(5));
+        expect(input.getAttribute('maxLength')).toBe('5');
       });
     });
 
@@ -741,6 +872,27 @@ describe('ControlValueAccessor', () => {
         act(() => fixture.componentInstance.min.set(5));
         expect(dir.min()).toBe(5);
       });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input type="number" [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly min = signal(10);
+          readonly f = form(signal(0), (p) => {
+            min(p, this.min);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.getAttribute('min')).toBe('10');
+
+        act(() => fixture.componentInstance.min.set(5));
+        expect(input.getAttribute('min')).toBe('5');
+      });
     });
 
     describe('minLength', () => {
@@ -769,6 +921,27 @@ describe('ControlValueAccessor', () => {
 
         act(() => fixture.componentInstance.minLength.set(5));
         expect(dir.minLength()).toBe(5);
+      });
+
+      it('should bind to native property', () => {
+        @Component({
+          imports: [Field, CvaDir],
+          template: `<input [field]="f" cvaDir />`,
+        })
+        class TestCmp {
+          readonly minLength = signal(10);
+          readonly f = form(signal(''), (p) => {
+            minLength(p, this.minLength);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const input = fixture.nativeElement.querySelector('input');
+
+        expect(input.getAttribute('minLength')).toBe('10');
+
+        act(() => fixture.componentInstance.minLength.set(5));
+        expect(input.getAttribute('minLength')).toBe('5');
       });
     });
 


### PR DESCRIPTION
Bind field state properties to all applicable directive inputs and DOM properties. The exact behavior varies depending on the kind of control.

* **Native controls:** Field state properties are bound to their corresponding DOM properties.
* **Custom controls:** Field state properties are first bound to matching inputs on the custom control. Any properties that didn't match an input are bound to their corresponding DOM property as a fallback, if applicable. This allows custom controls to defer to the native behavior without needing to define and forward inputs to their host element.

For native and custom controls, _all_ properties are also bound to _all_ matching directive inputs.

* **Interop controls:** Only the `disabled` property is handled directly by `ControlValueAccessor`. All remaining properties are treated like regular property bindings on the host element, meaning they'll attempt to bind to matching directive inputs, and fallback to native DOM properties if applicable.

The end result is that the `[field]` binding will always use the supported mechanism to update state explicitly handled by each kind of control, and fallback to native behavior if applicable. In all cases, any other directives applied to a control can receive field state properties as inputs.