### PR TITLE
docs(docs-infra): fixes copy-to-clipboard icon moves to a new line fo…

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -54,6 +54,7 @@
       display: inline-block;
       color: inherit;
       max-width: 100%;
+      text-wrap: pretty;
 
       code {
         // This can be useful on mobile if the heading contains a long code block


### PR DESCRIPTION
…r long heading text

Fixes an issue where the copy-to-clipboard icon moves to a new line when heading text is long and wraps. Applies improved text wrapping for headings to keep the icon visually aligned.

Fixes #66239


## What is the current behavior?
<img width="803" height="90" alt="Image" src="https://github.com/user-attachments/assets/368ad121-716c-42d4-9258-ae1b7bbc9f89" />

## What is the new behavior?
I personally like how it looks when we use `text-wrap: pretty;`
<img width="834" height="660" alt="Image" src="https://github.com/user-attachments/assets/5cb16a87-2362-409a-aa05-51336d1be55a" />

