### PR TITLE
docs(docs-infra): Fix combobox dialog styles for dark theme

### DIFF
--- a/adev/src/content/examples/aria/combobox/src/dialog/app/app.css
+++ b/adev/src/content/examples/aria/combobox/src/dialog/app/app.css
@@ -3,8 +3,8 @@
 :host {
   display: flex;
   justify-content: center;
-  font-family: var(--inter-font);
-  --border-color: color-mix(in srgb, var(--full-contrast) 20%, var(--page-background));
+  font-family: var(--inter-font, system-ui, sans-serif);
+  --border-color: color-mix(in srgb, var(--full-contrast, #000) 20%, var(--page-background, #fff));
 }
 
 [ngCombobox] {
@@ -37,8 +37,8 @@
 }
 
 [ngCombobox]:focus-within [ngComboboxInput] {
-  outline: 1.5px solid var(--vivid-pink);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink) 25%, transparent);
+  outline: 1.5px solid var(--vivid-pink, #f542a4);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink, #f542a4) 25%, transparent);
 }
 
 .icon {
@@ -74,7 +74,8 @@
   outline: none;
   font-size: 1rem;
   padding: 0.7rem 1rem 0.7rem 2.5rem;
-  background-color: var(--mat-sys-surface);
+  background-color: var(--septenary-contrast, #f5f5f5);
+  color: var(--primary-contrast, #1a1a1a);
 }
 
 .popover {
@@ -82,7 +83,7 @@
   padding: 0;
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
-  background-color: var(--mat-sys-surface);
+  background-color: var(--septenary-contrast, #f5f5f5);
 }
 
 [ngListbox] {
@@ -104,17 +105,17 @@
 }
 
 [ngOption]:hover {
-  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+  background-color: color-mix(in srgb, var(--primary-contrast, #1a1a1a) 5%, transparent);
 }
 
 [ngOption][data-active='true'] {
   outline-offset: -2px;
-  outline: 2px solid var(--vivid-pink);
+  outline: 2px solid var(--vivid-pink, #f542a4);
 }
 
 [ngOption][aria-selected='true'] {
-  color: var(--vivid-pink);
-  background-color: color-mix(in srgb, var(--vivid-pink) 5%, transparent);
+  color: var(--vivid-pink, #f542a4);
+  background-color: color-mix(in srgb, var(--vivid-pink, #f542a4) 5%, transparent);
 }
 
 [ngOption]:not([aria-selected='true']) .check-icon {
@@ -138,6 +139,8 @@
   padding: 0;
   border: 1px solid var(--border-color);
   border-radius: 0.25rem;
+  background-color: var(--septenary-contrast, #f5f5f5);
+  color: inherit;
 }
 
 .dialog .combobox-input-container {

--- a/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.css
+++ b/adev/src/content/examples/aria/combobox/src/dialog/material/app/app.css
@@ -3,8 +3,9 @@
 :host {
   display: flex;
   justify-content: center;
-  font-family: var(--inter-font);
-  --border-color: color-mix(in srgb, var(--full-contrast) 20%, var(--page-background));
+  font-family: var(--inter-font, system-ui, sans-serif);
+  --border-color: color-mix(in srgb, var(--full-contrast, #000) 20%, var(--page-background, #fff));
+  --primary: var(--vivid-pink, #f542a4);
 }
 
 [ngCombobox] {
@@ -37,8 +38,8 @@
 }
 
 [ngCombobox]:focus-within [ngComboboxInput] {
-  outline: 1.5px solid var(--vivid-pink);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink) 25%, transparent);
+  outline: 1.5px solid var(--vivid-pink, #f542a4);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink, #f542a4) 25%, transparent);
 }
 
 .icon {
@@ -74,7 +75,8 @@
   outline: none;
   font-size: 1rem;
   padding: 0.7rem 1rem 0.7rem 2.5rem;
-  background-color: var(--mat-sys-surface);
+  background-color: var(--septenary-contrast, #f5f5f5);
+  color: var(--primary-contrast, #1a1a1a);
 }
 
 [ngListbox] {
@@ -97,7 +99,7 @@
 
 [ngOption]:hover,
 [ngOption][data-active='true'] {
-  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+  background-color: color-mix(in srgb, var(--primary-contrast, #1a1a1a) 5%, transparent);
 }
 
 [ngOption][data-active='true'] {
@@ -131,6 +133,8 @@
   bottom: auto;
   border: 1px solid var(--border-color);
   border-radius: 1rem;
+  background-color: var(--septenary-contrast, #f5f5f5);
+  color: inherit;
 }
 
 .dialog .combobox-input-container {

--- a/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.css
+++ b/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.css
@@ -59,8 +59,8 @@
 }
 
 [ngCombobox]:focus-within [ngComboboxInput] {
-  outline: 1.5px solid var(--vivid-pink);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink) 25%, transparent);
+  outline: 1.5px solid var(--vivid-pink, #f542a4);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--vivid-pink, #f542a4) 25%, transparent);
 }
 
 .icon {
@@ -76,6 +76,7 @@
   padding: 0 0.5rem;
   position: absolute;
   opacity: 0.8;
+  color: #000;
 }
 
 .arrow-icon {
@@ -84,6 +85,7 @@
   right: 0;
   opacity: 0.8;
   transition: transform 0.2s ease;
+  color: #000;
 }
 
 [ngComboboxInput][aria-expanded='true'] + .arrow-icon {
@@ -136,16 +138,17 @@
 }
 
 [ngOption][aria-selected='true'] {
-  color: var(--vivid-pink);
-  background-color: color-mix(in srgb, var(--vivid-pink) 10%, transparent);
+  color: var(--vivid-pink, #f542a4);
+  background-color: color-mix(in srgb, var(--vivid-pink, #f542a4) 10%, transparent);
 }
 
 [ngOption]:hover {
-  background-color: color-mix(in srgb, var(--mat-sys-on-surface) 10%, transparent);
+  background-color: color-mix(in srgb, var(--mat-sys-on-surface, #1a1a1a) 10%, transparent);
 }
 
 [ngCombobox]:focus-within [data-active='true'] {
-  outline: 2px solid color-mix(in srgb, var(--vivid-pink) 80%, transparent);
+  outline: 2px dashed var(--vivid-pink, #f542a4);
+  outline-offset: -2px;
 }
 
 .dialog {
@@ -158,6 +161,8 @@
   padding: 0;
   border: none;
   box-shadow: var(--retro-flat-shadow);
+  background-color: var(--septenary-contrast, #f5f5f5);
+  color: inherit;
 }
 
 .dialog .combobox-input-container {
@@ -170,7 +175,7 @@
 }
 
 .dialog [ngComboboxInput] {
-  border-bottom: 4px solid #000;
+  border-bottom: 4px solid var(--gray-700, #374151);
 }
 
 .dialog [ngCombobox]:focus-within [ngComboboxInput] {


### PR DESCRIPTION
Fixes combobox dialog styles to ensure correct text color and contrast in dark theme. This improves readability and visual consistency when using the docs in dark mode.


 
## What is the current behavior?
Currently, it is not displaying correctly when we are in dark theme mode.
<img width="761" height="428" alt="image" src="https://github.com/user-attachments/assets/63225c38-b801-4244-b80f-55d0d04e57b7" />


## What is the new behavior?
<img width="823" height="405" alt="image" src="https://github.com/user-attachments/assets/88acfcfd-653a-44d4-90fa-ad125a92d388" />




