### PR TITLE
docs(docs-infra): add external link styles to API reference documenta…

### DIFF
--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -1,3 +1,5 @@
+@use './links' as links;
+
 /* Common styles for the API & CLI references */
 @mixin reference-common() {
   .docs-code {
@@ -83,6 +85,13 @@
       // Show copy link button when hovering the heading
       &:hover docs-copy-link-button {
         opacity: 1;
+      }
+    }
+
+    a:not(.docs-github-links):not(.docs-pill):not(.docs-example-github-link) {
+      &[href^='http:'],
+      &[href^='https:'] {
+        @include links.external-link-with-icon();
       }
     }
   }


### PR DESCRIPTION
…tion

Adds the missing icon external link styling to the API reference documentation.

 
## What is the current behavior?
For example, the external link in https://next.angular.dev/api/core/QueryList#map does not display the external link icon.

<img width="838" height="245" alt="image" src="https://github.com/user-attachments/assets/184dde07-19af-42a7-838b-48415c659657" />


## What is the new behavior?


Add external link icon 

<img width="826" height="236" alt="image" src="https://github.com/user-attachments/assets/0465ed96-ea8f-4b71-b6ad-12411bf14a19" />
