### PR TITLE
fix(compiler-cli): fix up spelling of diagnostic

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -433,7 +433,7 @@ export function parseTemplateDeclaration(
     throw new FatalDiagnosticError(
       ErrorCode.COMPONENT_MISSING_TEMPLATE,
       decorator.node,
-      'component is missing a template',
+      '@Component is missing a template. Add either a `template` or `templateUrl`',
     );
   }
 }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7721,7 +7721,9 @@ runInEachFileSystem((os: string) => {
           );
 
           const diags = await driveDiagnostics();
-          expect(diags[0].messageText).toBe('component is missing a template');
+          expect(diags[0].messageText).toBe(
+            '@Component is missing a template. Add either a `template` or `templateUrl`',
+          );
           expect(diags[0].file!.fileName).toBe(absoluteFrom('/test.ts'));
         });
 

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -285,7 +285,9 @@ describe('getSemanticDiagnostics', () => {
 
     const project = createModuleAndProjectWithDeclarations(env, 'test', files);
     const diags = project.getDiagnosticsForFile('app.ts');
-    expect(diags.map((x) => x.messageText)).toEqual(['component is missing a template']);
+    expect(diags.map((x) => x.messageText)).toEqual([
+      '@Component is missing a template. Add either a `template` or `templateUrl`',
+    ]);
   });
 
   it('reports a warning when the project configuration prevents good type inference', () => {


### PR DESCRIPTION
Fixes the spelling for the `component is missing a template` diagnostic and expands it a bit.
