### PR TITLE
docs: Incorrect Highlighting in Content Queries Example

### DIFF
--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -337,7 +337,7 @@ export class CustomCard {
 
 You can query for a single result with the `@ContentChild` decorator.
 
-```angular-ts {highlight: [14, 16, 17, 18, 25]}
+```angular-ts {highlight: [15, 16, 17, 18, 19, 26]}
 @Component({
   selector: 'custom-toggle',
   /*...*/


### PR DESCRIPTION
Fixes: #66284

Current: 
<img width="797" height="501" alt="image" src="https://github.com/user-attachments/assets/b0a5fc2c-9b0b-4618-8776-ae30125fc9c0" />


New:

<img width="797" height="501" alt="image" src="https://github.com/user-attachments/assets/5a568956-bf18-4703-9484-f3438c4134f6" />
