### PR TITLE
refactor(router): Simplifies unsubscribe logic

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -400,10 +400,8 @@ export class Router {
     // RxJS will throw an error.
     this._events.unsubscribe();
     this.navigationTransitions.complete();
-    if (this.nonRouterCurrentEntryChangeSubscription) {
-      this.nonRouterCurrentEntryChangeSubscription.unsubscribe();
-      this.nonRouterCurrentEntryChangeSubscription = undefined;
-    }
+    this.nonRouterCurrentEntryChangeSubscription?.unsubscribe();
+    this.nonRouterCurrentEntryChangeSubscription = undefined;
     this.disposed = true;
     this.eventsSubscription.unsubscribe();
   }

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -115,9 +115,7 @@ export class RouterPreloader implements OnDestroy {
 
   /** @docs-private */
   ngOnDestroy(): void {
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
+    this.subscription?.unsubscribe();
   }
 
   private processRoutes(injector: EnvironmentInjector, routes: Routes): Observable<void> {
@@ -127,7 +125,7 @@ export class RouterPreloader implements OnDestroy {
         route._injector = createEnvironmentInjector(
           route.providers,
           injector,
-          `Route: ${route.path}`,
+          typeof ngDevMode === 'undefined' || ngDevMode ? `Route: ${route.path}` : '',
         );
       }
 


### PR DESCRIPTION
Uses optional chaining to simplify unsubscribe handling. Also improving tree-shaking by limiting injector names to route paths using `ngDevMode`