### PR TITLE
fix(docs-infra): stop auto-linking "state" and "group" to APIs

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -18,6 +18,8 @@ const LINK_EXEMPT = new Set([
   'readonly',
   'disabled',
   'hidden',
+  'state',
+  'group',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
@@ -6,3 +6,9 @@ this is code
 <docs-code path="./example-with-region.ts" />
 
 <docs-code header="src/locale/messages.fr.xlf (<trans-unit>)" path="./messages.fr.xlf" />
+
+<docs-code header="Property names should not be linked" language="ts">  
+const form = {  
+  state: ['']  
+};  
+</docs-code>

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
@@ -47,4 +47,9 @@ describe('markdown to html', () => {
     const codeBlock = markdownDocument.querySelectorAll('code')[3];
     expect(codeBlock).toBeTruthy();
   });
+
+  it('should not link property names in object literals', () => {
+    const codeBlock = markdownDocument.querySelectorAll('code')[4];
+    expect(codeBlock?.innerHTML).not.toContain('<a href="/api/animations/state">state</a>');
+  });
 });


### PR DESCRIPTION
Prevents common words used in code examples from being incorrectly linked to API references.

Fixes: #66292
