### PR TITLE
feat(router): Add partial ActivatedRouteSnapshot information to `canMatch` params

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -224,7 +224,7 @@ When implementing a custom `RouteReuseStrategy`, you may need to manually destro
 Since `DetachedRouteHandle` is an opaque type, you cannot call a destroy method directly on it. Instead, use the `destroyDetachedRouteHandle` function provided by the Router.
 
 ```ts
-import { destroyDetachedRouteHandle } from '@angular/router';
+import {destroyDetachedRouteHandle} from '@angular/router';
 
 // ... inside your strategy
 if (this.handles.size > MAX_CACHE_SIZE) {
@@ -245,12 +245,10 @@ By default, Angular does not destroy the injectors of detached routes, even if t
 To enable automatic cleanup of unused route injectors, you can use the `withExperimentalAutoCleanupInjectors` feature in your router configuration. This feature checks which routes are currently stored by the strategy after navigations and destroys the injectors of any detached routes that are not currently stored by the reuse strategy.
 
 ```ts
-import { provideRouter, withExperimentalAutoCleanupInjectors } from '@angular/router';
+import {provideRouter, withExperimentalAutoCleanupInjectors} from '@angular/router';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes, withExperimentalAutoCleanupInjectors())
-  ]
+  providers: [provideRouter(routes, withExperimentalAutoCleanupInjectors())],
 };
 ```
 

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -572,6 +572,9 @@ export type Params = {
 };
 
 // @public
+export type PartialMatchRouteSnapshot = Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title' | 'paramMap' | 'queryParamMap'>;
+
+// @public
 export class PreloadAllModules implements PreloadingStrategy {
     // (undocumented)
     preload(route: Route, fn: () => Observable<any>): Observable<any>;
@@ -612,7 +615,7 @@ export class RedirectCommand {
 }
 
 // @public
-export type RedirectFunction = (redirectData: Pick<ActivatedRouteSnapshot, 'routeConfig' | 'url' | 'params' | 'queryParams' | 'fragment' | 'data' | 'outlet' | 'title' | 'paramMap' | 'queryParamMap'>) => MaybeAsync<string | UrlTree>;
+export type RedirectFunction = (redirectData: PartialMatchRouteSnapshot) => MaybeAsync<string | UrlTree>;
 
 // @public
 export interface Resolve<T> {

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -151,11 +151,11 @@ export type CanLoadFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<Gua
 // @public
 export interface CanMatch {
     // (undocumented)
-    canMatch(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
+    canMatch(route: Route, segments: UrlSegment[], currentSnapshot?: PartialMatchRouteSnapshot): MaybeAsync<GuardResult>;
 }
 
 // @public
-export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;
+export type CanMatchFn = (route: Route, segments: UrlSegment[], currentSnapshot?: PartialMatchRouteSnapshot) => MaybeAsync<GuardResult>;
 
 // @public
 export class ChildActivationEnd {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -520,6 +520,7 @@
       "createOrReusePlatformInjector",
       "createPlatformInjector",
       "createPositionApplyingDoubleDots",
+      "createPreMatchRouteSnapshot",
       "createProvidersConfig",
       "createResultByTNodeType",
       "createResultForNode",

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -64,6 +64,7 @@ export {
   CanLoad,
   CanMatch,
   Resolve,
+  PartialMatchRouteSnapshot,
 } from './models';
 export {ViewTransitionInfo, ViewTransitionsFeatureOptions} from './utils/view_transition';
 

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1151,7 +1151,11 @@ export type CanDeactivateFn<T> = (
  * @see [CanMatch](guide/routing/route-guards#canmatch)
  */
 export interface CanMatch {
-  canMatch(route: Route, segments: UrlSegment[]): MaybeAsync<GuardResult>;
+  canMatch(
+    route: Route,
+    segments: UrlSegment[],
+    currentSnapshot?: PartialMatchRouteSnapshot,
+  ): MaybeAsync<GuardResult>;
 }
 
 /**
@@ -1168,12 +1172,19 @@ export interface CanMatch {
  *
  * @param route The route configuration.
  * @param segments The URL segments that have not been consumed by previous parent route evaluations.
+ * @param currentSnapshot The current route snapshot up to this point in the matching process. While this parameter is optional,
+ * it will always be defined when called by the Router. It is only optional for backwards compatibility with functions defined prior
+ * to the introduction of this parameter.
  *
  * @publicApi
  * @see {@link Route}
  * @see [CanMatch](guide/routing/route-guards#canmatch)
  */
-export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;
+export type CanMatchFn = (
+  route: Route,
+  segments: UrlSegment[],
+  currentSnapshot?: PartialMatchRouteSnapshot,
+) => MaybeAsync<GuardResult>;
 
 /**
  * A subset of the `ActivatedRouteSnapshot` interface that includes only the known data

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -300,32 +300,16 @@ export type QueryParamsHandling = 'merge' | 'preserve' | 'replace' | '';
 /**
  * The type for the function that can be used to handle redirects when the path matches a `Route` config.
  *
- * The `RedirectFunction` does _not_ have access to the full
- * `ActivatedRouteSnapshot` interface. Some data are not accurately known
- * at the route matching phase. For example, resolvers are not run until
- * later, so any resolved title would not be populated. The same goes for lazy
- * loaded components. This is also true for all the snapshots up to the
- * root, so properties that include parents (root, parent, pathFromRoot)
- * are also excluded. And naturally, the full route matching hasn't yet
- * happened so firstChild and children are not available either.
+ * The `RedirectFunction` does not have access to the full
+ * `ActivatedRouteSnapshot` interface because Route matching has not
+ * yet completed when the function is called. See {@link PartialMatchRouteSnapshot}
+ * for more information.
  *
  * @see {@link Route#redirectTo}
  * @publicApi
  */
 export type RedirectFunction = (
-  redirectData: Pick<
-    ActivatedRouteSnapshot,
-    | 'routeConfig'
-    | 'url'
-    | 'params'
-    | 'queryParams'
-    | 'fragment'
-    | 'data'
-    | 'outlet'
-    | 'title'
-    | 'paramMap'
-    | 'queryParamMap'
-  >,
+  redirectData: PartialMatchRouteSnapshot,
 ) => MaybeAsync<string | UrlTree>;
 
 /**
@@ -1190,6 +1174,32 @@ export interface CanMatch {
  * @see [CanMatch](guide/routing/route-guards#canmatch)
  */
 export type CanMatchFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<GuardResult>;
+
+/**
+ * A subset of the `ActivatedRouteSnapshot` interface that includes only the known data
+ * up to the route matching phase. Some data are not accurately known
+ * at in this phase. For example, resolvers are not run until
+ * later, so any resolved title would not be populated. The same goes for lazy
+ * loaded components. This is also true for all the snapshots up to the
+ * root, so properties that include parents (root, parent, pathFromRoot)
+ * are also excluded. And naturally, the full route matching hasn't yet
+ * happened so firstChild and children are not available either.
+ *
+ * @publicApi
+ */
+export type PartialMatchRouteSnapshot = Pick<
+  ActivatedRouteSnapshot,
+  | 'routeConfig'
+  | 'url'
+  | 'params'
+  | 'queryParams'
+  | 'fragment'
+  | 'data'
+  | 'outlet'
+  | 'title'
+  | 'paramMap'
+  | 'queryParamMap'
+>;
 
 /**
  * @description

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -28,6 +28,7 @@ import {
   CanLoadFn,
   CanMatchFn,
   Route,
+  PartialMatchRouteSnapshot,
 } from '../models';
 import {redirectingNavigationError} from '../navigation_canceling_error';
 import type {NavigationTransition} from '../navigation_transition';
@@ -266,6 +267,7 @@ export function runCanMatchGuards(
   route: Route,
   segments: UrlSegment[],
   urlSerializer: UrlSerializer,
+  currentSnapshot: PartialMatchRouteSnapshot,
   abortSignal: AbortSignal,
 ): Observable<GuardResult> {
   const canMatch = route.canMatch;
@@ -274,8 +276,10 @@ export function runCanMatchGuards(
   const canMatchObservables = canMatch.map((injectionToken) => {
     const guard = getTokenOrFunctionIdentity(injectionToken as ProviderToken<any>, injector);
     const guardVal = isCanMatch(guard)
-      ? guard.canMatch(route, segments)
-      : runInInjectionContext(injector, () => (guard as CanMatchFn)(route, segments));
+      ? guard.canMatch(route, segments, currentSnapshot)
+      : runInInjectionContext(injector, () =>
+          (guard as CanMatchFn)(route, segments, currentSnapshot),
+        );
     return wrapIntoObservable(guardVal).pipe(takeUntilAbort(abortSignal));
   });
 

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -24,8 +24,10 @@ import {Params, PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {getOutlet, sortByMatchingOutlets} from './utils/config';
 import {
+  createPreMatchRouteSnapshot,
   emptyPathMatch,
   match,
+  MatchResult,
   matchWithChecks,
   noLeftoversInUrl,
   split,
@@ -356,7 +358,7 @@ export class Recognizer {
       consumedSegments,
       route.redirectTo!,
       positionalParamSegments,
-      currentSnapshot,
+      createPreMatchRouteSnapshot(currentSnapshot),
       injector,
     );
 
@@ -408,8 +410,19 @@ export class Recognizer {
     if (this.abortSignal.aborted) {
       throw new Error(this.abortSignal.reason);
     }
+
+    const createSnapshot = (result: MatchResult) =>
+      this.createSnapshot(injector, route, result.consumedSegments, result.parameters, parentRoute);
     const result = await firstValueFrom(
-      matchWithChecks(rawSegment, route, segments, injector, this.urlSerializer, this.abortSignal),
+      matchWithChecks(
+        rawSegment,
+        route,
+        segments,
+        injector,
+        this.urlSerializer,
+        createSnapshot,
+        this.abortSignal,
+      ),
     );
     if (route.path === '**') {
       // Prior versions of the route matching algorithm would stop matching at the wildcard route.


### PR DESCRIPTION
This commit adds partial `ActivatedRouteSnapshot` information as the
third parameter of the `canMatch` guard.

resolves https://github.com/angular/angular/issues/49309