### PR TITLE
fix(router): handle errors from view transition `updateCallbackDone` promise

### DIFF
--- a/packages/router/src/utils/view_transition.ts
+++ b/packages/router/src/utils/view_transition.ts
@@ -94,6 +94,11 @@ export function createViewTransition(
     // complete (below), which includes the update phase of the routed components.
     return createRenderPromise(injector);
   });
+  transition.updateCallbackDone.catch((error) => {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.error(error);
+    }
+  });
   transition.ready.catch((error) => {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       console.error(error);


### PR DESCRIPTION
Firefox-specific workaround: Firefox 144+ creates the `updateCallbackDone` promise internally during error handling (e.g., duplicate view-transition-name), even before the property is accessed. This can cause unhandled promise rejections to appear in error tracking tools like Rollbar/Sentry. We must attach catch handlers to all three promises immediately to prevent these unhandled rejections.
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1999336
Spec: https://drafts.csswg.org/css-view-transitions-1/#dom-viewtransition-updatecallbackdone