### PR TITLE
docs(docs-infra): Fixes the visibility of the copy link button in CLI…

### DIFF
--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -73,7 +73,8 @@
     }
   }
 
-  .docs-api {
+  .docs-api,
+  .docs-cli {
     h1,
     h2,
     h3,


### PR DESCRIPTION
… headings

Fixes the visibility of the copy link button in CLI documentation headings.
 
## What is the current behavior?
 https://angular.dev/cli/add#arguments

<img width="318" height="263" alt="image" src="https://github.com/user-attachments/assets/1ba952d9-33ac-4828-a0a2-d6f8b9c260c1" />


## What is the new behavior?

 
<img width="242" height="230" alt="image" src="https://github.com/user-attachments/assets/bf21a80d-5ada-4cb3-853e-a6c3fae7638c" />
