### PR TITLE
docs(docs-infra): Modernize tests

### DIFF
--- a/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/adev/shared-docs/components/breadcrumb/breadcrumb.component.spec.ts
@@ -13,10 +13,8 @@ import {NavigationState} from '../../services';
 import {NavigationItem} from '../../interfaces';
 import {By} from '@angular/platform-browser';
 import {provideRouter} from '@angular/router';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('Breadcrumb', () => {
-  let fixture: ComponentFixture<Breadcrumb>;
   let navigationStateSpy: jasmine.SpyObj<NavigationState>;
 
   beforeEach(() => {
@@ -26,20 +24,19 @@ describe('Breadcrumb', () => {
       imports: [Breadcrumb],
       providers: [
         provideRouter([]),
-        provideZonelessChangeDetection(),
         {
           provide: NavigationState,
           useValue: navigationStateSpy,
         },
       ],
     });
-    fixture = TestBed.createComponent(Breadcrumb);
   });
 
-  it('should display proper breadcrumb structure based on navigation state', () => {
+  it('should display proper breadcrumb structure based on navigation state', async () => {
     navigationStateSpy.activeNavigationItem.and.returnValue(item);
+    const fixture = TestBed.createComponent(Breadcrumb);
+    await fixture.whenStable();
 
-    fixture.detectChanges();
     const breadcrumbs = fixture.debugElement.queryAll(By.css('.docs-breadcrumb span'));
 
     expect(breadcrumbs.length).toBe(2);
@@ -47,10 +44,11 @@ describe('Breadcrumb', () => {
     expect(breadcrumbs[1].nativeElement.innerText).toEqual('Parent');
   });
 
-  it('should display breadcrumb links when navigation item has got path', () => {
+  it('should display breadcrumb links when navigation item has got path', async () => {
     navigationStateSpy.activeNavigationItem.and.returnValue(exampleItemWithPath);
 
-    fixture.detectChanges();
+    const fixture = TestBed.createComponent(Breadcrumb);
+    await fixture.whenStable();
     const breadcrumbs = fixture.debugElement.queryAll(By.css('.docs-breadcrumb a'));
 
     expect(breadcrumbs.length).toBe(1);

--- a/adev/shared-docs/components/cookie-popup/cookie-popup.component.spec.ts
+++ b/adev/shared-docs/components/cookie-popup/cookie-popup.component.spec.ts
@@ -11,7 +11,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CookiePopup, STORAGE_KEY} from './cookie-popup.component';
 import {LOCAL_STORAGE} from '../../providers/index';
 import {MockLocalStorage} from '../../testing/index';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('CookiePopup', () => {
   let fixture: ComponentFixture<CookiePopup>;
@@ -21,7 +20,6 @@ describe('CookiePopup', () => {
     TestBed.configureTestingModule({
       imports: [CookiePopup],
       providers: [
-        provideZonelessChangeDetection(),
         {
           provide: LOCAL_STORAGE,
           useValue: mockLocalStorage,
@@ -30,34 +28,34 @@ describe('CookiePopup', () => {
     });
   });
 
-  it('should make the popup visible by default', () => {
-    initComponent(false);
+  it('should make the popup visible by default', async () => {
+    await initComponent(false);
 
     expect(getCookiesPopup()).not.toBeNull();
   });
 
-  it('should hide the cookies popup if the user has already accepted cookies', () => {
-    initComponent(true);
+  it('should hide the cookies popup if the user has already accepted cookies', async () => {
+    await initComponent(true);
 
     expect(getCookiesPopup()).toBeNull();
   });
 
-  it('should hide the cookies popup', () => {
-    initComponent(false);
+  it('should hide the cookies popup', async () => {
+    await initComponent(false);
 
     accept();
-
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getCookiesPopup()).toBeNull();
   });
 
-  it('should store the user confirmation', () => {
-    initComponent(false);
+  it('should store the user confirmation', async () => {
+    await initComponent(false);
 
     expect(mockLocalStorage.getItem(STORAGE_KEY)).toBeNull();
 
     accept();
+    await fixture.whenStable();
 
     expect(mockLocalStorage.getItem(STORAGE_KEY)).toBe('true');
   });
@@ -73,10 +71,10 @@ describe('CookiePopup', () => {
       ?.click();
   }
 
-  function initComponent(cookiesAccepted: boolean) {
+  async function initComponent(cookiesAccepted: boolean) {
     mockLocalStorage.setItem(STORAGE_KEY, cookiesAccepted ? 'true' : null);
     fixture = TestBed.createComponent(CookiePopup);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
   }
 });

--- a/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
+++ b/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.spec.ts
@@ -12,12 +12,7 @@ import {
   CONFIRMATION_DISPLAY_TIME_MS,
   CopySourceCodeButton,
 } from './copy-source-code-button.component';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  provideZonelessChangeDetection,
-  signal,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {Clipboard} from '@angular/cdk/clipboard';
 
@@ -32,7 +27,6 @@ describe('CopySourceCodeButton', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [CodeSnippetWrapper],
-      providers: [provideZonelessChangeDetection()],
     });
     fixture = TestBed.createComponent(CodeSnippetWrapper);
     component = fixture.componentInstance;
@@ -56,20 +50,20 @@ describe('CopySourceCodeButton', () => {
     expect(copySpy.calls.argsFor(0)[0].trim()).toBe(expectedCodeToBeCopied);
   });
 
-  it(`should set ${SUCCESSFULLY_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy was executed properly`, () => {
+  it(`should set ${SUCCESSFULLY_COPY_CLASS_NAME} for ${CONFIRMATION_DISPLAY_TIME_MS} ms when copy was executed properly`, async () => {
     const clock = jasmine.clock().install();
     component.code.set('example');
 
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const button = fixture.debugElement.query(By.directive(CopySourceCodeButton)).nativeElement;
     button.click();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(button).toHaveClass(SUCCESSFULLY_COPY_CLASS_NAME);
 
     clock.tick(CONFIRMATION_DISPLAY_TIME_MS);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(button).not.toHaveClass(SUCCESSFULLY_COPY_CLASS_NAME);
     clock.uninstall();
@@ -80,17 +74,17 @@ describe('CopySourceCodeButton', () => {
     component.code.set('example');
     copySpy.and.throwError('Fake copy error');
 
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const button = fixture.debugElement.query(By.directive(CopySourceCodeButton)).nativeElement;
     button.click();
 
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(button).toHaveClass(FAILED_COPY_CLASS_NAME);
 
     clock.tick(CONFIRMATION_DISPLAY_TIME_MS);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(button).not.toHaveClass(FAILED_COPY_CLASS_NAME);
     clock.uninstall();

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
@@ -12,7 +12,7 @@ import {NavigationList} from './navigation-list.component';
 import {By} from '@angular/platform-browser';
 import {NavigationItem} from '../../interfaces';
 import {provideRouter} from '@angular/router';
-import {provideZonelessChangeDetection, signal} from '@angular/core';
+import {signal} from '@angular/core';
 import {NavigationState} from '../../services';
 
 const navigationItems: NavigationItem[] = [
@@ -38,11 +38,7 @@ describe('NavigationList', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavigationList],
-      providers: [
-        provideRouter([]),
-        {provide: NavigationState, useClass: FakeNavigationListState},
-        provideZonelessChangeDetection(),
-      ],
+      providers: [provideRouter([]), {provide: NavigationState, useClass: FakeNavigationListState}],
     });
     fixture = TestBed.createComponent(NavigationList);
     fixture.componentRef.setInput('navigationItems', []);
@@ -50,9 +46,9 @@ describe('NavigationList', () => {
     component = fixture.componentInstance;
   });
 
-  it('should display provided navigation structure', () => {
+  it('should display provided navigation structure', async () => {
     fixture.componentRef.setInput('navigationItems', [...navigationItems]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const links = fixture.debugElement.queryAll(By.css('a'));
     const nonClickableItem = fixture.debugElement.queryAll(By.css('.docs-secondary-nav-header'));
@@ -61,28 +57,28 @@ describe('NavigationList', () => {
     expect(nonClickableItem.length).toBe(1);
   });
 
-  it('should append `docs-navigation-list-dropdown` when isDropdownView is true', () => {
+  it('should append `docs-navigation-list-dropdown` when isDropdownView is true', async () => {
     fixture.componentRef.setInput('isDropdownView', true);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const ulElement = fixture.debugElement.query(By.css('ul.docs-navigation-list-dropdown'));
 
     expect(ulElement).toBeTruthy();
   });
 
-  it('should not append `docs-navigation-list-dropdown` when isDropdownView is false', () => {
+  it('should not append `docs-navigation-list-dropdown` when isDropdownView is false', async () => {
     fixture.componentRef.setInput('isDropdownView', false);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const ulElement = fixture.debugElement.query(By.css('ul.docs-navigation-list-dropdown'));
 
     expect(ulElement).toBeFalsy();
   });
 
-  it('should emit linkClicked when user clicked on link', () => {
+  it('should emit linkClicked when user clicked on link', async () => {
     const emitClickOnLinkSpy = spyOn(component, 'emitClickOnLink');
     fixture.componentRef.setInput('navigationItems', [...navigationItems]);
-    fixture.detectChanges(true);
+    await fixture.whenStable();
 
     const guideLink = fixture.debugElement.query(By.css('a[href="/guide"]'));
     guideLink.nativeElement.click();
@@ -122,10 +118,10 @@ describe('NavigationList', () => {
     expect(toggleItemSpy).toHaveBeenCalledOnceWith(itemToToggle);
   });
 
-  it('should display only items to provided level (Level 1)', () => {
+  it('should display only items to provided level (Level 1)', async () => {
     fixture.componentRef.setInput('navigationItems', [...navigationItems]);
     fixture.componentRef.setInput('displayItemsToLevel', 1);
-    fixture.detectChanges(true);
+    await fixture.whenStable();
 
     const items = fixture.debugElement.queryAll(By.css('li.docs-faceted-list-item'));
 
@@ -134,10 +130,10 @@ describe('NavigationList', () => {
     expect(items[1].nativeElement.innerText).toBe(navigationItems[1].label);
   });
 
-  it('should display all items (Level 2)', () => {
+  it('should display all items (Level 2)', async () => {
     fixture.componentRef.setInput('navigationItems', [...navigationItems]);
     fixture.componentRef.setInput('displayItemsToLevel', 2);
-    fixture.detectChanges(true);
+    await fixture.whenStable();
 
     const items = fixture.debugElement.queryAll(By.css('li.docs-faceted-list-item'));
 

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ApplicationRef} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Router, provideRouter} from '@angular/router';
 
 import {SearchDialog} from './search-dialog.component';
 import {ENVIRONMENT, WINDOW} from '../../providers';
 import {ALGOLIA_CLIENT, Search} from '../../services';
 import {FakeEventTarget} from '../../testing/index';
-import {By} from '@angular/platform-browser';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
-import {Router, provideRouter} from '@angular/router';
-import {ApplicationRef, provideZonelessChangeDetection, ResourceStatus} from '@angular/core';
 import {SearchResult} from '../../interfaces';
 
 describe('SearchDialog', () => {
@@ -34,7 +34,6 @@ describe('SearchDialog', () => {
       imports: [SearchDialog],
       providers: [
         provideRouter([]),
-        provideZonelessChangeDetection(),
         {provide: ENVIRONMENT, useValue: {algolia: {index: 'fakeIndex'}}},
         {provide: ALGOLIA_CLIENT, useValue: {search: searchResults}},
         {provide: WINDOW, useValue: fakeWindow},
@@ -42,8 +41,8 @@ describe('SearchDialog', () => {
     });
 
     fixture = TestBed.createComponent(SearchDialog);
-    fixture.detectChanges();
     search = TestBed.inject(Search);
+    await fixture.whenStable();
   });
 
   it('should navigate to active item when user pressed Enter', async () => {
@@ -98,7 +97,6 @@ describe('SearchDialog', () => {
 
   it('should display `Start typing to see results` message when there are no provided query', () => {
     searchResults.and.returnValue(undefined);
-    fixture.detectChanges();
 
     const startTypingContainer = fixture.debugElement.query(
       By.css('.docs-search-results__start-typing'),

--- a/adev/shared-docs/components/search-history/search-history.component.spec.ts
+++ b/adev/shared-docs/components/search-history/search-history.component.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {provideZonelessChangeDetection, ApplicationRef} from '@angular/core';
+import {ApplicationRef} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideRouter} from '@angular/router';
@@ -75,11 +75,7 @@ describe('SearchHistoryComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      providers: [
-        provideZonelessChangeDetection(),
-        {provide: LOCAL_STORAGE, useClass: MockLocalStorage},
-        provideRouter([]),
-      ],
+      providers: [{provide: LOCAL_STORAGE, useClass: MockLocalStorage}, provideRouter([])],
     });
 
     fixture = TestBed.createComponent(SearchHistoryComponent);

--- a/adev/shared-docs/components/select/select.component.spec.ts
+++ b/adev/shared-docs/components/select/select.component.spec.ts
@@ -9,17 +9,12 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {Select} from './select.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('Select', () => {
   let component: Select;
   let fixture: ComponentFixture<Select>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [Select],
-      providers: [provideZonelessChangeDetection()],
-    });
+  beforeEach(async () => {
     fixture = TestBed.createComponent(Select);
     component = fixture.componentInstance;
 
@@ -28,7 +23,7 @@ describe('Select', () => {
     fixture.componentRef.setInput('name', 'name');
     fixture.componentRef.setInput('options', []);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/shared-docs/components/slide-toggle/slide-toggle.component.spec.ts
+++ b/adev/shared-docs/components/slide-toggle/slide-toggle.component.spec.ts
@@ -9,22 +9,17 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {SlideToggle} from './slide-toggle.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('SlideToggle', () => {
   let component: SlideToggle;
   let fixture: ComponentFixture<SlideToggle>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [SlideToggle],
-      providers: [provideZonelessChangeDetection()],
-    });
+  beforeEach(async () => {
     fixture = TestBed.createComponent(SlideToggle);
     fixture.componentRef.setInput('buttonId', 'id');
     fixture.componentRef.setInput('label', 'foo');
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should toggle the value when clicked', () => {
@@ -49,14 +44,14 @@ describe('SlideToggle', () => {
     expect(onTouchedSpy).toHaveBeenCalled();
   });
 
-  it('should set active class for button when is checked', () => {
+  it('should set active class for button when is checked', async () => {
     component.writeValue(true);
-    fixture.detectChanges();
+    await fixture.whenStable();
     const buttonElement: HTMLButtonElement = fixture.nativeElement.querySelector('input');
     expect(buttonElement.classList.contains('docs-toggle-active')).toBeTrue();
 
     component.writeValue(false);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(buttonElement.classList.contains('docs-toggle-active')).toBeFalse();
   });
 });

--- a/adev/shared-docs/components/tab-group/tab-group.component.spec.ts
+++ b/adev/shared-docs/components/tab-group/tab-group.component.spec.ts
@@ -9,21 +9,20 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TabGroup} from './tab-group.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('TabGroup', () => {
   let fixture: ComponentFixture<TabGroup>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     fixture = TestBed.createComponent(TabGroup);
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should update tabs and tabpanels', () => {
+  it('should update tabs and tabpanels', async () => {
     const testPanel = document.createElement('div');
     testPanel.textContent = 'panel 1';
     fixture.componentRef.setInput('tabs', [{label: 'tab 1', panel: testPanel}]);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const tabs = fixture.nativeElement.querySelectorAll('.docs-tab');
     const tabpanels = fixture.nativeElement.querySelectorAll('.docs-tab-panel');

--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -12,7 +12,6 @@ import {provideRouter} from '@angular/router';
 import {TableOfContentsItem, TableOfContentsLevel} from '../../interfaces/index';
 import {TableOfContentsLoader} from '../../services/index';
 import {WINDOW} from '../../providers/index';
-import {provideZonelessChangeDetection, signal} from '@angular/core';
 
 describe('TableOfContents', () => {
   let component: TableOfContents;
@@ -40,11 +39,10 @@ describe('TableOfContents', () => {
   };
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [TableOfContents],
       providers: [
         provideRouter([]),
-        provideZonelessChangeDetection(),
         {
           provide: WINDOW,
           useValue: fakeWindow,
@@ -59,7 +57,7 @@ describe('TableOfContents', () => {
     fixture.componentRef.setInput('contentSourceElement', document.createElement('div'));
 
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
@@ -69,8 +67,6 @@ describe('TableOfContents', () => {
   it('should call scrollToTop when user click on Back to the top button', () => {
     const spy = spyOn(component, 'scrollToTop');
 
-    fixture.detectChanges();
-
     const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
     button.click();
 
@@ -78,8 +74,6 @@ describe('TableOfContents', () => {
   });
 
   it('should render items when tableOfContentItems has value', () => {
-    fixture.detectChanges();
-
     const renderedItems = fixture.nativeElement.querySelectorAll('li');
 
     expect(renderedItems.length).toBe(3);
@@ -87,8 +81,6 @@ describe('TableOfContents', () => {
   });
 
   it('should append level class to element', () => {
-    fixture.detectChanges();
-
     const h2Items = fixture.nativeElement.querySelectorAll('li.docs-toc-item-h2');
     const h3Items = fixture.nativeElement.querySelectorAll('li.docs-toc-item-h3');
 
@@ -97,8 +89,6 @@ describe('TableOfContents', () => {
   });
 
   it('should append active class when item is active', () => {
-    fixture.detectChanges();
-
     const activeItem = fixture.nativeElement.querySelector('.docs-faceted-list-item-active');
     expect(activeItem).toBeDefined();
   });

--- a/adev/shared-docs/components/text-field/text-field.component.spec.ts
+++ b/adev/shared-docs/components/text-field/text-field.component.spec.ts
@@ -9,29 +9,24 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TextField} from './text-field.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('TextField', () => {
   let component: TextField;
   let fixture: ComponentFixture<TextField>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [TextField],
-      providers: [provideZonelessChangeDetection()],
-    });
+  beforeEach(async () => {
     fixture = TestBed.createComponent(TextField);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should update DOM when setting the value via the CVA', () => {
+  it('should update DOM when setting the value via the CVA', async () => {
     component.setValue('test');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(fixture.nativeElement.querySelector('input').value).toBe('test');
     // If we were using ngModel instead of the value binding, we would get an empty string

--- a/adev/shared-docs/components/top-level-banner/top-level-banner.component.spec.ts
+++ b/adev/shared-docs/components/top-level-banner/top-level-banner.component.spec.ts
@@ -34,13 +34,13 @@ describe('TopLevelBannerComponent', () => {
     fixture.componentRef.setInput('id', EXAMPLE_ID);
 
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should render an anchor element when link is provided', () => {
+  it('should render an anchor element when link is provided', async () => {
     fixture.componentRef.setInput('text', EXAMPLE_TEXT);
     fixture.componentRef.setInput('link', EXAMPLE_LINK);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const bannerElement = fixture.nativeElement.querySelector('a.docs-top-level-banner');
     expect(bannerElement).toBeTruthy();
@@ -48,49 +48,49 @@ describe('TopLevelBannerComponent', () => {
     expect(bannerElement.textContent).toContain(EXAMPLE_TEXT);
   });
 
-  it('should render a div element when link is not provided', () => {
+  it('should render a div element when link is not provided', async () => {
     const EXAMPLE_TEXT = 'No Link Available';
 
     fixture.componentRef.setInput('text', EXAMPLE_TEXT);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const bannerElement = fixture.nativeElement.querySelector('div.docs-top-level-banner');
     expect(bannerElement).toBeTruthy();
     expect(bannerElement.textContent).toContain(EXAMPLE_TEXT);
   });
 
-  it('should correctly render the text input', () => {
+  it('should correctly render the text input', async () => {
     const EXAMPLE_TEXT = 'Lorem ipsum dolor...';
 
     fixture.componentRef.setInput('text', EXAMPLE_TEXT);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const bannerElement = fixture.nativeElement.querySelector('.docs-top-level-banner-cta');
     expect(bannerElement).toBeTruthy();
     expect(bannerElement.textContent).toBe(EXAMPLE_TEXT);
   });
 
-  it('should set hasClosed to true if the banner was closed before', () => {
+  it('should set hasClosed to true if the banner was closed before', async () => {
     mockLocalStorage.getItem.and.returnValue('true');
 
     fixture = TestBed.createComponent(TopLevelBannerComponent);
     fixture.componentRef.setInput('text', EXAMPLE_TEXT);
     fixture.componentRef.setInput('id', EXAMPLE_ID);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.hasClosed()).toBeTrue();
     expect(mockLocalStorage.getItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}${EXAMPLE_ID}`);
   });
 
-  it('should set hasClosed to false if the banner was not closed before', () => {
+  it('should set hasClosed to false if the banner was not closed before', async () => {
     mockLocalStorage.getItem.and.returnValue('false');
 
     fixture = TestBed.createComponent(TopLevelBannerComponent);
     fixture.componentRef.setInput('text', EXAMPLE_TEXT);
     fixture.componentRef.setInput('id', EXAMPLE_ID);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.hasClosed()).toBeFalse();
     expect(mockLocalStorage.getItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}${EXAMPLE_ID}`);

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -19,11 +19,9 @@ import {NavigationState} from '../../../services';
 import {CopySourceCodeButton} from '../../copy-source-code-button/copy-source-code-button.component';
 import {CopyLinkButton} from '../../copy-link-anchor/copy-link-anchor.component';
 import {TableOfContents} from '../../table-of-contents/table-of-contents.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 import {Clipboard} from '@angular/cdk/clipboard';
 
 describe('DocViewer', () => {
-  let fixture: ComponentFixture<DocViewer>;
   let exampleContentSpy: jasmine.SpyObj<ExampleViewerContentLoader>;
   let navigationStateSpy: jasmine.SpyObj<NavigationState>;
 
@@ -83,18 +81,15 @@ describe('DocViewer', () => {
     navigationStateSpy = jasmine.createSpyObj(NavigationState, ['activeNavigationItem']);
   });
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [DocViewer],
       providers: [
         provideRouter([]),
-        provideZonelessChangeDetection(),
         {provide: EXAMPLE_VIEWER_CONTENT_LOADER, useValue: exampleContentSpy},
         {provide: NavigationState, useValue: navigationStateSpy},
       ],
     });
-
-    fixture = TestBed.createComponent(DocViewer);
   });
 
   it('should load doc into innerHTML', async () => {

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.spec.ts
@@ -10,7 +10,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ExampleViewer} from './example-viewer.component';
 import {ExampleMetadata, ExampleViewerContentLoader} from '../../../interfaces';
 import {EXAMPLE_VIEWER_CONTENT_LOADER} from '../../../providers';
-import {Component, provideZonelessChangeDetection, ComponentRef, signal} from '@angular/core';
+import {Component, ComponentRef, signal} from '@angular/core';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
 import {Clipboard} from '@angular/cdk/clipboard';
@@ -32,10 +32,9 @@ describe('ExampleViewer', () => {
   });
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [ExampleViewer],
       providers: [
-        provideZonelessChangeDetection(),
         {provide: EXAMPLE_VIEWER_CONTENT_LOADER, useValue: exampleContentSpy},
         {provide: ActivatedRoute, useValue: {snapshot: {fragment: 'fragment'}}},
       ],
@@ -44,7 +43,7 @@ describe('ExampleViewer', () => {
     component = fixture.componentInstance;
     componentRef = fixture.componentRef;
     loader = TestbedHarnessEnvironment.loader(fixture);
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should set file extensions as tab names when all files have different extension', async () => {
@@ -131,7 +130,7 @@ describe('ExampleViewer', () => {
     );
 
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const hiddenLine = fixture.debugElement.query(By.css('div[class="line hidden"]'));
     expect(hiddenLine).toBeTruthy();
@@ -155,13 +154,13 @@ describe('ExampleViewer', () => {
     );
 
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const expandButton = fixture.debugElement.query(
       By.css('button[aria-label="Expand code example"]'),
     );
     expandButton.nativeElement.click();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const hiddenLine = fixture.debugElement.query(By.css('div[class="line hidden"]'));
     expect(hiddenLine).toBeNull();
@@ -191,7 +190,7 @@ describe('ExampleViewer', () => {
     );
     componentRef.setInput('githubUrl', 'https://github.com/');
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const githubButton = fixture.debugElement.query(
       By.css('a[aria-label="Open example on GitHub"]'),
@@ -212,7 +211,7 @@ describe('ExampleViewer', () => {
     componentRef.setInput('stackblitzUrl', 'https://stackblitz.com/');
 
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const stackblitzButton = fixture.debugElement.query(
       By.css('a[aria-label="Edit example in StackBlitz"]'),
@@ -261,7 +260,7 @@ describe('ExampleViewer', () => {
   it('should call clipboard service when clicked on copy example link', async () => {
     componentRef.setInput('metadata', getMetadata());
     component.expanded.set(true);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const clipboardService = TestBed.inject(Clipboard);
     const spy = spyOn(clipboardService, 'copy');
@@ -283,7 +282,7 @@ describe('ExampleViewer', () => {
     );
 
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     // Initially, the code should be hidden.
     expect(component.showCode()).toBeFalse();
@@ -295,7 +294,7 @@ describe('ExampleViewer', () => {
     componentRef.setInput('metadata', getMetadata());
 
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     // Initially, the code should be visible.
     expect(component.showCode()).toBeTrue();
@@ -304,14 +303,14 @@ describe('ExampleViewer', () => {
 
     const codeToggleButton = fixture.debugElement.query(By.css('.docs-example-code-toggle'));
     codeToggleButton.nativeElement.click();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.showCode()).toBeFalse();
     codeContainer = fixture.debugElement.query(By.css('.docs-example-viewer-code-wrapper'));
     expect(codeContainer).toBeNull();
 
     codeToggleButton.nativeElement.click();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.showCode()).toBeTrue();
     codeContainer = fixture.debugElement.query(By.css('.docs-example-viewer-code-wrapper'));
@@ -328,7 +327,7 @@ describe('ExampleViewer', () => {
       }),
     );
     await component.renderExample();
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(component.exampleComponent).toBeDefined();
 
     const previewContainer = fixture.debugElement.query(By.css('.docs-example-viewer-preview'));

--- a/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.spec.ts
@@ -16,14 +16,14 @@ describe('ClickOutside', () => {
   let component: ExampleComponent;
   let fixture: ComponentFixture<ExampleComponent>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [ExampleComponent],
       providers: [provideRouter([])],
     });
     fixture = TestBed.createComponent(ExampleComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should docsClickOutside be emitted when user click outside `content` element', () => {

--- a/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
+++ b/adev/shared-docs/directives/external-link/external-link.directive.spec.ts
@@ -21,7 +21,7 @@ describe('ExternalLink', () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [ExampleComponentWithLinks],
       providers: [
@@ -33,7 +33,7 @@ describe('ExternalLink', () => {
       ],
     });
     fixture = TestBed.createComponent(ExampleComponentWithLinks);
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should external link have target=_blank attribute', () => {

--- a/adev/shared-docs/testing/testing-helper.ts
+++ b/adev/shared-docs/testing/testing-helper.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectorRef} from '@angular/core';
 import {
   DirEnt,
   FSWatchCallback,
@@ -63,14 +62,6 @@ export class MockLocalStorage implements Pick<Storage, 'getItem' | 'setItem'> {
   setItem(key: string, value: string | null): void {
     this.items.set(key, value);
   }
-}
-
-export class FakeChangeDetectorRef implements ChangeDetectorRef {
-  markForCheck(): void {}
-  detach(): void {}
-  checkNoChanges(): void {}
-  reattach(): void {}
-  detectChanges(): void {}
 }
 
 export class FakeWebContainer extends WebContainer {

--- a/adev/src/app/core/layout/footer/footer.component.spec.ts
+++ b/adev/src/app/core/layout/footer/footer.component.spec.ts
@@ -21,7 +21,7 @@ describe('Footer', () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [Footer],
       providers: [
@@ -34,7 +34,7 @@ describe('Footer', () => {
     });
     fixture = TestBed.createComponent(Footer);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/src/app/core/layout/navigation/navigation.component.spec.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.spec.ts
@@ -38,7 +38,7 @@ describe('Navigation', () => {
   const fakeSearch = {};
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [Navigation],
       providers: [
         provideRouter([]),
@@ -58,23 +58,23 @@ describe('Navigation', () => {
 
     fixture = TestBed.createComponent(Navigation);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should append active class to DOCS_ROUTE when DOCS_ROUTE is active', () => {
+  it('should append active class to DOCS_ROUTE when DOCS_ROUTE is active', async () => {
     component.activeRouteItem.set(PAGE_PREFIX.DOCS);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const docsLink = fixture.debugElement.query(By.css('a[href="/docs"]')).parent?.nativeElement;
 
     expect(docsLink).toHaveClass('adev-nav-item--active');
   });
 
-  it('should not have active class when activeRouteItem is null', () => {
+  it('should not have active class when activeRouteItem is null', async () => {
     component.activeRouteItem.set(null);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const docsLink = fixture.debugElement.query(By.css('a[href="/docs"]')).nativeElement;
     const referenceLink = fixture.debugElement.query(By.css('a[href="/reference"]')).nativeElement;
@@ -83,14 +83,14 @@ describe('Navigation', () => {
     expect(referenceLink).not.toHaveClass('adev-nav-item--active');
   });
 
-  it('should call themeManager.setTheme(dark) when user tries to set dark theme', () => {
+  it('should call themeManager.setTheme(dark) when user tries to set dark theme', async () => {
     const openThemePickerButton = fixture.debugElement.query(
       By.css('button[aria-label^="Change theme. Current theme:"]'),
     ).nativeElement;
     const setThemeSpy = spyOn(fakeThemeManager, 'setTheme');
 
     openThemePickerButton.click();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const setDarkModeButton = fixture.debugElement.query(
       By.css('button[aria-label="Set dark theme"]'),

--- a/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
+++ b/adev/src/app/core/layout/progress-bar/progress-bar.component.spec.ts
@@ -17,14 +17,14 @@ describe('ProgressBarComponent', () => {
   let fixture: ComponentFixture<ProgressBarComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
+    TestBed.configureTestingModule({
       imports: [ProgressBarComponent],
       providers: [provideRouter([])],
     });
 
     fixture = TestBed.createComponent(ProgressBarComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   // This test often timeouts

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.spec.ts
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.spec.ts
@@ -21,7 +21,7 @@ describe('SecondaryNavigation', () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [SecondaryNavigation],
       providers: [
@@ -33,7 +33,7 @@ describe('SecondaryNavigation', () => {
     });
     fixture = TestBed.createComponent(SecondaryNavigation);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/src/app/editor/code-editor/code-editor.component.spec.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.spec.ts
@@ -19,7 +19,7 @@ import {EmbeddedTutorialManager} from '../embedded-tutorial-manager.service';
 
 import {CodeEditor, REQUIRED_FILES} from './code-editor.component';
 import {CodeMirrorEditor} from './code-mirror-editor.service';
-import {FakeChangeDetectorRef, TutorialType} from '@angular/docs';
+import {TutorialType} from '@angular/docs';
 import {MatTooltipHarness} from '@angular/material/tooltip/testing';
 
 const files = [
@@ -45,7 +45,6 @@ class FakeCodeMirrorEditor implements Partial<CodeMirrorEditor> {
   openFiles = this.files;
 }
 const codeMirrorEditorService = new FakeCodeMirrorEditor();
-const fakeChangeDetectorRef = new FakeChangeDetectorRef();
 
 describe('CodeEditor', () => {
   let component: CodeEditor;
@@ -62,10 +61,6 @@ describe('CodeEditor', () => {
         {
           provide: CodeMirrorEditor,
           useValue: codeMirrorEditorService,
-        },
-        {
-          provide: ChangeDetectorRef,
-          useValue: fakeChangeDetectorRef,
         },
         {
           provide: EmbeddedTutorialManager,
@@ -93,7 +88,7 @@ describe('CodeEditor', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
 
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
@@ -105,7 +100,7 @@ describe('CodeEditor', () => {
     const codeMirrorEditorInitSpy = spyOn(codeMirrorEditorService, 'init');
 
     fixture = TestBed.createComponent(CodeEditor);
-    fixture.detectChanges();
+    await fixture.whenStable();
     component = fixture.componentInstance;
 
     expect(component.codeEditorWrapperRef()).toBeDefined();

--- a/adev/src/app/editor/preview/preview.component.spec.ts
+++ b/adev/src/app/editor/preview/preview.component.spec.ts
@@ -50,8 +50,6 @@ describe('Preview', () => {
     const component = fixture.componentInstance;
     const iframeElement = fixture.debugElement.query(By.css('iframe'));
 
-    fixture.detectChanges();
-
     return {
       fixture,
       component,
@@ -64,27 +62,28 @@ describe('Preview', () => {
     };
   };
 
-  it('should set iframe src', () => {
+  it('should set iframe src', async () => {
     const {fixture, PREVIEW_URL} = beforeEach();
+    await fixture.whenStable();
     const iframeElement = fixture.debugElement.query(By.css('iframe'));
     expect(iframeElement?.nativeElement?.src).toBe(PREVIEW_URL);
   });
 
-  it('should not render loading elements if the loadingStep is READY or ERROR', () => {
+  it('should not render loading elements if the loadingStep is READY or ERROR', async () => {
     const {fixture, fakeNodeRuntimeState, getLoadingElementsWrapper} = beforeEach();
 
     fakeNodeRuntimeState.loadingStep.set(LoadingStep.READY);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getLoadingElementsWrapper()).toBeNull();
 
     fakeNodeRuntimeState.loadingStep.set(LoadingStep.ERROR);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getLoadingElementsWrapper()).toBeNull();
   });
 
-  it('should render the correct loading element based on loadingStep', () => {
+  it('should render the correct loading element based on loadingStep', async () => {
     const {fixture, fakeNodeRuntimeState} = beforeEach();
 
     function getDebugElements(): Record<number, DebugElement | null> {
@@ -113,7 +112,7 @@ describe('Preview', () => {
       componentLoadingStep++
     ) {
       fakeNodeRuntimeState.loadingStep.set(componentLoadingStep);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       const loadingElements = getDebugElements();
 
@@ -136,8 +135,6 @@ describe('Preview', () => {
 
     fakeNodeRuntimeState.loadingStep.set(LoadingStep.ERROR);
     fakeNodeRuntimeState.error.set({message: 'Error message', type: undefined});
-    fixture.detectChanges();
-
     await fixture.whenStable();
 
     expect(fixture.debugElement.query(By.directive(PreviewError))).toBeDefined();

--- a/adev/src/app/features/docs/docs.component.spec.ts
+++ b/adev/src/app/features/docs/docs.component.spec.ts
@@ -23,7 +23,7 @@ describe('DocsComponent', () => {
     getContent: (id: string) => undefined,
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [DocsComponent],
       providers: [
@@ -40,7 +40,7 @@ describe('DocsComponent', () => {
     });
     fixture = TestBed.createComponent(DocsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/src/app/features/home/animation/animation.spec.ts
+++ b/adev/src/app/features/home/animation/animation.spec.ts
@@ -81,13 +81,9 @@ describe('Animation', () => {
   const layerObjects = new Map<string, HTMLElement>();
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AnimationHost],
-    });
-
     fixture = TestBed.createComponent(AnimationHost);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
     animation = component.animation;
 
     // Store all layer objects in a map for easier access.

--- a/adev/src/app/features/playground/playground.component.spec.ts
+++ b/adev/src/app/features/playground/playground.component.spec.ts
@@ -26,7 +26,7 @@ describe('TutorialPlayground', () => {
     },
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     class FakeEmbeddedTutorialManager {
       fetchAndSetTutorialFiles() {}
     }
@@ -50,7 +50,7 @@ describe('TutorialPlayground', () => {
 
     fixture = TestBed.createComponent(TutorialPlayground);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
+++ b/adev/src/app/features/references/api-item-label/api-item-label.component.spec.ts
@@ -15,24 +15,21 @@ describe('ApiItemLabel', () => {
   let fixture: ComponentFixture<ApiItemLabel>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ApiItemLabel],
-    });
     fixture = TestBed.createComponent(ApiItemLabel);
   });
 
-  it('should by default display short label for Class', () => {
+  it('should by default display short label for Class', async () => {
     fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const label = fixture.nativeElement.innerText;
 
     expect(label).toBe('C');
   });
 
-  it('should display short label for Class', () => {
+  it('should display short label for Class', async () => {
     fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const label = fixture.nativeElement.innerText;
 

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.spec.ts
@@ -54,18 +54,18 @@ describe('ApiItemsSection', () => {
     component = fixture.componentInstance;
   });
 
-  it('should render list of all APIs of provided group', () => {
+  it('should render list of all APIs of provided group', async () => {
     fixture.componentRef.setInput('group', fakeGroup);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const apis = fixture.debugElement.queryAll(By.css('.adev-api-items-section-grid li'));
 
     expect(apis.length).toBe(2);
   });
 
-  it('should display deprecated icon for deprecated API', () => {
+  it('should display deprecated icon for deprecated API', async () => {
     fixture.componentRef.setInput('group', fakeGroup);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const deprecatedApiIcons = fixture.debugElement.queryAll(
       By.css('.adev-api-items-section-grid li .adev-item-attribute'),

--- a/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-details-page/api-reference-details-page.component.spec.ts
@@ -54,7 +54,6 @@ describe('ApiReferenceDetailsPage', () => {
     const harness = await RouterTestingHarness.create();
     fixture = harness.fixture;
     component = await harness.navigateByUrl('/', ApiReferenceDetailsPage);
-    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.spec.ts
@@ -93,7 +93,7 @@ describe('ApiReferenceList', () => {
     }),
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [ApiReferenceList],
       providers: [
@@ -103,32 +103,32 @@ describe('ApiReferenceList', () => {
     });
     fixture = TestBed.createComponent(ApiReferenceList);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display only items which contains provided query when query is not empty', () => {
+  it('should display only items which contains provided query when query is not empty', async () => {
     fixture.componentRef.setInput('query', 'Item1');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeItem1]);
   });
 
-  it('should display items which match the query by group title', () => {
+  it('should display items which match the query by group title', async () => {
     fixture.componentRef.setInput('query', 'Fake Group');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     // Should find all items whose group title contains the query
     expect(component.filteredGroups()![0].items.length).toBeGreaterThan(0);
     expect(component.filteredGroups()![0].items).toContain(fakeItem1);
   });
 
-  it('should display only class items when user selects Class in the Type select', () => {
+  it('should display only class items when user selects Class in the Type select', async () => {
     fixture.componentRef.setInput('type', ApiItemType.CLASS);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.type()).toEqual(ApiItemType.CLASS);
     expect(component.filteredGroups()![0].items).toEqual([fakeItem2]);
@@ -192,30 +192,30 @@ describe('ApiReferenceList', () => {
     ]);
   });
 
-  it('should not display deprecated and developer-preview and experimental items when status is set to stable', () => {
+  it('should not display deprecated and developer-preview and experimental items when status is set to stable', async () => {
     fixture.componentRef.setInput('status', STATUSES.stable);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeItem1, fakeItem2]);
   });
 
-  it('should only display deprecated items when status is set to deprecated', () => {
+  it('should only display deprecated items when status is set to deprecated', async () => {
     fixture.componentRef.setInput('status', STATUSES.deprecated);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeDeprecatedFeaturedItem]);
   });
 
-  it('should only display developer-preview items when status is set to developer-preview', () => {
+  it('should only display developer-preview items when status is set to developer-preview', async () => {
     fixture.componentRef.setInput('status', STATUSES.developerPreview);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeDeveloperPreviewItem]);
   });
 
-  it('should only display experimental items when status is set to experimental', () => {
+  it('should only display experimental items when status is set to experimental', async () => {
     fixture.componentRef.setInput('status', STATUSES.experimental);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.filteredGroups()![0].items).toEqual([fakeExperimentalItem]);
   });

--- a/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
+++ b/adev/src/app/features/references/cli-reference-details-page/cli-reference-details-page.component.spec.ts
@@ -54,7 +54,7 @@ describe('CliReferenceDetailsPage', () => {
     const harness = await RouterTestingHarness.create();
     fixture = harness.fixture;
     component = await harness.navigateByUrl('/', CliReferenceDetailsPage);
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {

--- a/adev/src/app/features/tutorial/tutorial.component.spec.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.spec.ts
@@ -111,15 +111,13 @@ describe('Tutorial', () => {
       },
     });
 
-    await TestBed;
-
     fixture = TestBed.createComponent(Tutorial);
     component = fixture.componentInstance;
 
     // Replace EmbeddedEditor with FakeEmbeddedEditor
     spyOn(component as any, 'loadEmbeddedEditorComponent').and.resolveTo(FakeEmbeddedEditor);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
@@ -133,7 +131,7 @@ describe('Tutorial', () => {
 
   it('should reset the reveal answer', async () => {
     setupResetRevealAnswerValues();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const revealAnswerButton = component.revealAnswerButton();
     if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
@@ -149,7 +147,7 @@ describe('Tutorial', () => {
 
   it('should reveal the answer on button click', async () => {
     setupRevealAnswerValues();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const revealAnswerButton = component.revealAnswerButton();
     if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
@@ -165,14 +163,13 @@ describe('Tutorial', () => {
     expect(embeddedTutorialManagerRevealAnswerSpy).toHaveBeenCalled();
 
     await fixture.whenStable();
-    fixture.detectChanges();
 
     expect(revealAnswerButton.nativeElement.textContent?.trim()).toBe('Reset');
   });
 
   it('should not reveal the answer when button is disabled', async () => {
     setupDisabledRevealAnswerValues();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const revealAnswerButton = component.revealAnswerButton();
     if (!revealAnswerButton) throw new Error('revealAnswerButton is undefined');
@@ -187,9 +184,9 @@ describe('Tutorial', () => {
     expect(handleRevealAnswerSpy).not.toHaveBeenCalled();
   });
 
-  it('should not render the reveal answer button when there are no answers', () => {
+  it('should not render the reveal answer button when there are no answers', async () => {
     setupNoRevealAnswerValues();
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(component.revealAnswerButton()).toBe(undefined);
   });

--- a/adev/src/app/features/update/update.component.spec.ts
+++ b/adev/src/app/features/update/update.component.spec.ts
@@ -19,14 +19,14 @@ describe('UpdateComponent', () => {
   let component: UpdateComponent;
   let fixture: ComponentFixture<UpdateComponent>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [UpdateComponent],
       providers: [provideRouter([]), provideHttpClient(), provideHttpClientTesting()],
     });
     fixture = TestBed.createComponent(UpdateComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
@@ -60,14 +60,12 @@ describe('UpdateComponent', () => {
 
       expect(showButton).toBeTruthy();
       showButton.click();
-      fixture.detectChanges();
 
       // Wait for all async operations to complete (marked parsing, router navigation, etc.)
       await fixture.whenStable();
 
       // Additional wait for marked parsing
       await new Promise((resolve) => setTimeout(resolve, 300));
-      fixture.detectChanges();
 
       const badges = fixture.nativeElement.querySelectorAll('.adev-complexity-badge');
 


### PR DESCRIPTION
Remove usages of `detectChanges` and rely on `whenStable`. This commit also removed the usage of `provideZonelessChangeDetection` which is no longer necessary.
