### PR TITLE
refactor(devtools): use `whenStable` instead of `detectChanges`

### DIFF
--- a/devtools/projects/demo-no-zone/src/main.ts
+++ b/devtools/projects/demo-no-zone/src/main.ts
@@ -8,8 +8,5 @@
 
 import {bootstrapApplication} from '@angular/platform-browser';
 import {AppComponent} from './app/app.component';
-import {provideZonelessChangeDetection} from '@angular/core';
 
-bootstrapApplication(AppComponent, {
-  providers: [provideZonelessChangeDetection()],
-}).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, {providers: []}).catch((err) => console.error(err));

--- a/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -16,7 +16,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "highlighter_test",
     deps = [
         ":highlighter_test_lib",
@@ -70,12 +70,12 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "property_mutation_test",
     deps = [":property_mutation_test_lib"],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "router_tree_test",
     deps = [
         ":router_tree_test_lib",
@@ -123,7 +123,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "utils_test",
     deps = [
         ":utils_test_lib",
@@ -145,7 +145,7 @@ ts_project(
     srcs = ["version.ts"],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "client_event_subscribers_test",
     deps = [
         ":client_event_subscribers_test_lib",

--- a/devtools/projects/ng-devtools-backend/src/lib/component-inspector/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-inspector/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -31,7 +31,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -40,7 +40,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [":test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -33,7 +33,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/ng-debug-api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,7 +27,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "ng-debug-api_test",
     deps = [":ng-debug-api_test_lib"],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,7 +26,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -52,7 +52,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":devtools_test",

--- a/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -39,7 +39,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_application_providers_lib",

--- a/devtools/projects/ng-devtools/src/lib/application-services/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/application-services/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -82,7 +82,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test_application_services",
     deps = [
         ":test_application_services_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -62,7 +62,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":devtools_tabs_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -60,7 +60,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":directive_explorer_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -70,7 +70,7 @@ describe('DirectiveExplorerComponent', () => {
   let contentScriptConnected = (frameId: number, name: string, url: string) => {};
   let frameConnected = (frameId: number) => {};
 
-  beforeEach(() => {
+  beforeEach(async () => {
     applicationOperationsSpy = jasmine.createSpyObj<ApplicationOperations>('_appOperations', [
       'viewSource',
       'selectDomElement',
@@ -130,7 +130,7 @@ describe('DirectiveExplorerComponent', () => {
 
     TestBed.inject(FrameManager);
     comp = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create instance from class', () => {
@@ -208,14 +208,14 @@ describe('DirectiveExplorerComponent', () => {
       expect(messageBusMock.emit).toHaveBeenCalledWith('removeHydrationOverlay');
     });
 
-    it('should show hydration checkbox toggle', () => {
+    it('should show hydration checkbox toggle', async () => {
       fixture.componentRef.setInput('isHydrationEnabled', true);
-      fixture.detectChanges();
+      await fixture.whenStable();
       const toggle = fixture.debugElement.query(By.css('#show-hydration-overlays'));
       expect(toggle).toBeTruthy();
 
       fixture.componentRef.setInput('isHydrationEnabled', false);
-      fixture.detectChanges();
+      await fixture.whenStable();
       const toggle2 = fixture.debugElement.query(By.css('#show-hydration-overlays'));
       expect(toggle2).toBeFalsy();
     });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -50,7 +50,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":directive_forest_utils_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,7 +27,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":component_data_source_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -53,7 +53,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":directive-forest-filter-fn-generator_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.spec.ts
@@ -17,43 +17,39 @@ describe('FilterComponent', () => {
   const emitFilterEvent = (filter: string) => component.emitFilter(filter);
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [FilterComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(FilterComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render if there is a single text match', () => {
+  it('should render if there is a single text match', async () => {
     expect(getMatchesCountEl()).toBeFalsy();
 
     fixture.componentRef.setInput('matchesCount', 1);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getMatchesCountEl().nativeElement.innerText).toEqual('1 match');
   });
 
-  it('should render if there is are multiple text matches', () => {
+  it('should render if there is are multiple text matches', async () => {
     expect(getMatchesCountEl()).toBeFalsy();
 
     fixture.componentRef.setInput('matchesCount', 5);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getMatchesCountEl().nativeElement.innerText).toEqual('5 matches');
   });
 
-  it('should render selected match', () => {
+  it('should render selected match', async () => {
     expect(getMatchesCountEl()).toBeFalsy();
 
     fixture.componentRef.setInput('matchesCount', 5);
     fixture.componentRef.setInput('currentMatch', 2);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getMatchesCountEl().nativeElement.innerText).toEqual('2 of 5');
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -20,7 +20,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":index_forest_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -41,7 +41,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     visibility = ["//visibility:public"],
     deps = [

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
@@ -29,10 +29,6 @@ describe('TreeNodeComponent', () => {
   let fixture: ComponentFixture<TreeNodeComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TreeNodeComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(TreeNodeComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('node', srcNode);
@@ -45,52 +41,52 @@ describe('TreeNodeComponent', () => {
         (node) => node.expandable,
       ),
     );
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render node name', () => {
+  it('should render node name', async () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
 
     expect(name.nativeElement.innerText).toEqual('app-test');
   });
 
-  it('should include directive name, if any', () => {
+  it('should include directive name, if any', async () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
       directives: ['TooltipDirective'],
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
 
     expect(name.nativeElement.innerText).toEqual('app-test[TooltipDirective]');
   });
 
-  it('should include directive names (multiple), if any', () => {
+  it('should include directive names (multiple), if any', async () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
       directives: ['TooltipDirective', 'CtxMenuDirective'],
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const name = fixture.debugElement.query(By.css('.node-name'));
 
     expect(name.nativeElement.innerText).toEqual('app-test[TooltipDirective][CtxMenuDirective]');
   });
 
-  it('should render "OnPush" label, if OnPush', () => {
+  it('should render "OnPush" label, if OnPush', async () => {
     let onPush = fixture.debugElement.query(By.css('.on-push'));
     expect(onPush).toBeFalsy();
 
@@ -99,92 +95,92 @@ describe('TreeNodeComponent', () => {
       name: 'app-test',
       onPush: true,
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     onPush = fixture.debugElement.query(By.css('.on-push'));
 
     expect(onPush).toBeTruthy();
   });
 
-  it('should handle selection', () => {
+  it('should handle selection', async () => {
     const consoleRef = fixture.debugElement.query(By.css('.console-reference'));
     expect(getComputedStyle(consoleRef.nativeElement).display).toEqual('none');
 
     fixture.componentRef.setInput('selectedNode', {id: 'node'});
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(getComputedStyle(consoleRef.nativeElement).display).toEqual('block');
     expect(fixture.debugElement.nativeElement.classList.contains('selected')).toBeTrue();
   });
 
-  it('should handle highlighting', () => {
+  it('should handle highlighting', async () => {
     fixture.componentRef.setInput('highlightedId', 1337);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const classList = fixture.debugElement.nativeElement.classList;
     expect(classList.contains('highlighted')).toBeTrue();
   });
 
-  it('should add respective class, if a new node', () => {
+  it('should add respective class, if a new node', async () => {
     fixture.componentRef.setInput('node', {
       ...srcNode,
       newItem: true,
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const classList = fixture.debugElement.nativeElement.classList;
     expect(classList.contains('new-node')).toBeTrue();
   });
 
-  it('should mark the text that matches the filter', () => {
+  it('should mark the text that matches the filter', async () => {
     fixture.componentRef.setInput('textMatches', [{startIdx: 3, endIdx: 27}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'my-long-component-name[WithADirective]',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const marked = fixture.debugElement.query(By.css('mark'));
     expect(marked.nativeElement.innerText).toEqual('long-component-name[With');
   });
 
-  it('should mark the text that matches the filter (beginning of the string)', () => {
+  it('should mark the text that matches the filter (beginning of the string)', async () => {
     fixture.componentRef.setInput('textMatches', [{startIdx: 0, endIdx: 9}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-large-component',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const marked = fixture.debugElement.query(By.css('mark'));
     expect(marked.nativeElement.innerText).toEqual('app-large');
   });
 
-  it('should mark the text that matches the filter (end of the string)', () => {
+  it('should mark the text that matches the filter (end of the string)', async () => {
     fixture.componentRef.setInput('textMatches', [{startIdx: 10, endIdx: 19}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-large-component',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const marked = fixture.debugElement.query(By.css('mark'));
     expect(marked.nativeElement.innerText).toEqual('component');
   });
 
-  it('should mark the whole text, if it matches completely the filter', () => {
+  it('should mark the whole text, if it matches completely the filter', async () => {
     fixture.componentRef.setInput('textMatches', [{startIdx: 0, endIdx: 8}]);
     fixture.componentRef.setInput('node', {
       ...srcNode,
       name: 'app-test',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const marked = fixture.debugElement.query(By.css('mark'));
     expect(marked.nativeElement.innerText).toEqual('app-test');
   });
 
-  it('should mark a sequence of matches', () => {
+  it('should mark a sequence of matches', async () => {
     const matches: NodeTextMatch[] = [
       {startIdx: 0, endIdx: 8}, // app-test
       {startIdx: 13, endIdx: 16}, // Foo
@@ -195,7 +191,7 @@ describe('TreeNodeComponent', () => {
       ...srcNode,
       name: 'app-test-cmp[Foo][Bar][Baz]',
     });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const marked = fixture.debugElement.queryAll(By.css('mark'));
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -44,7 +44,7 @@ ts_test_library(
 )
 
 # todo(aleksanderbodurri): fix this test suite
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":property_resolver_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/dependency-viewer/resolution-path/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/dependency-viewer/resolution-path/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -40,7 +40,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":resolution_path_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/dependency-viewer/resolution-path/resolution-path.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-body/dependency-viewer/resolution-path/resolution-path.component.spec.ts
@@ -17,16 +17,12 @@ describe('ResolutionPath', () => {
   let fixture: ComponentFixture<ResolutionPathComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ResolutionPathComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(ResolutionPathComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should render a proper path in a reverse order', () => {
+  it('should render a proper path in a reverse order', async () => {
     const dummyPath = [
       {
         name: 'Root',
@@ -47,7 +43,7 @@ describe('ResolutionPath', () => {
     ] as SerializedInjector[];
 
     fixture.componentRef.setInput('path', dummyPath);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const nodeElements = fixture.debugElement.queryAll(By.css('.node'));
     expect(nodeElements.length).toEqual(dummyPath.length);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -21,7 +21,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//:__subpackages__"])
 
@@ -36,7 +36,7 @@ ng_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":injector_tree_fns_test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -44,7 +44,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/flamegraph-formatter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/flamegraph-formatter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -32,7 +32,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/tree-map-formatter/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/record-formatter/tree-map-formatter/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,7 +32,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/shared/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/shared/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -20,7 +20,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":test_lib",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -49,7 +49,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":router_details_row_test",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.spec.ts
@@ -16,27 +16,23 @@ describe('RouteDetailsRowComponent', () => {
   let fixture: ComponentFixture<RouteDetailsRowComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RouteDetailsRowComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(RouteDetailsRowComponent);
     component = fixture.componentInstance;
 
     fixture.componentRef.setInput('label', 'Route Title');
     fixture.componentRef.setInput('data', {value: 'Route Data'});
     fixture.componentRef.setInput('dataKey', 'value');
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render a label and text data', () => {
+  it('should render a label and text data', async () => {
     fixture.componentRef.setInput('data', {value: 'Route Data'});
     fixture.componentRef.setInput('dataKey', 'value');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
@@ -46,11 +42,11 @@ describe('RouteDetailsRowComponent', () => {
     expect(dataElements[0].nativeElement.innerText).toEqual('Route Data');
   });
 
-  it('should render a label and flag data true', () => {
+  it('should render a label and flag data true', async () => {
     fixture.componentRef.setInput('type', 'flag');
     fixture.componentRef.setInput('data', {isActive: true});
     fixture.componentRef.setInput('dataKey', 'isActive');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
@@ -60,11 +56,11 @@ describe('RouteDetailsRowComponent', () => {
     expect(dataElements[0].nativeElement.innerText).toEqual('true');
   });
 
-  it('should render a label and flag data false', () => {
+  it('should render a label and flag data false', async () => {
     fixture.componentRef.setInput('type', 'flag');
     fixture.componentRef.setInput('data', {isLazy: false, isRedirect: false});
     fixture.componentRef.setInput('dataKey', 'isLazy');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
@@ -74,12 +70,12 @@ describe('RouteDetailsRowComponent', () => {
     expect(dataElements[0].nativeElement.innerText).toEqual('false');
   });
 
-  it('should render a label with an action button', () => {
+  it('should render a label with an action button', async () => {
     fixture.componentRef.setInput('type', 'chip');
     fixture.componentRef.setInput('data', {name: 'Component Name'});
     fixture.componentRef.setInput('dataKey', 'name');
     fixture.componentRef.setInput('actionBtnType', 'view-source');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
@@ -88,13 +84,13 @@ describe('RouteDetailsRowComponent', () => {
     expect(dataElements.length).toEqual(1);
   });
 
-  it('should render a label with a disabled action button', () => {
+  it('should render a label with a disabled action button', async () => {
     fixture.componentRef.setInput('type', 'chip');
     fixture.componentRef.setInput('data', {name: 'Lazy Component Name'});
     fixture.componentRef.setInput('dataKey', 'name');
     fixture.componentRef.setInput('actionBtnType', 'view-source');
     fixture.componentRef.setInput('actionBtnDisabled', true);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
@@ -104,12 +100,12 @@ describe('RouteDetailsRowComponent', () => {
     expect(dataElements[0].nativeElement.disabled).toEqual(true);
   });
 
-  it('should render a label and list data', () => {
+  it('should render a label and list data', async () => {
     fixture.componentRef.setInput('type', 'list');
     fixture.componentRef.setInput('data', {providers: ['Guard 1', 'Guard 2']});
     fixture.componentRef.setInput('dataKey', 'providers');
     fixture.componentRef.setInput('actionBtnType', 'view-source');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const labelElement = fixture.debugElement.query(By.css('th'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.spec.ts
@@ -33,6 +33,7 @@ describe('RouterTreeComponent', () => {
     await TestBed.configureTestingModule({
       imports: [RouterTreeComponent],
       providers: [
+        // TODO: This test should be migrated to zoneless but its not straightforward.
         provideZoneChangeDetection(),
         {provide: ApplicationOperations, useValue: applicationOperationsSpy},
         {provide: MessageBus, useValue: messageBus},

--- a/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools_spec.ts
@@ -41,46 +41,46 @@ describe('DevtoolsComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('should render ng devtools tabs when Angular Status is EXISTS and is in dev mode and is supported version', () => {
+  it('should render ng devtools tabs when Angular Status is EXISTS and is in dev mode and is supported version', async () => {
     component.angularStatus.set(component.AngularStatus.EXISTS);
     component.angularIsInDevMode.set(true);
     component.angularVersion.set('0.0.0');
     component.ivy.set(true);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement.querySelector('ng-devtools-tabs')).toBeTruthy();
   });
 
-  it('should render Angular Devtools dev mode only support text when Angular Status is EXISTS and is angular is not in dev mode', () => {
+  it('should render Angular Devtools dev mode only support text when Angular Status is EXISTS and is angular is not in dev mode', async () => {
     component.angularStatus.set(component.AngularStatus.EXISTS);
     component.angularIsInDevMode.set(false);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement.querySelector('.devtools-state-screen').textContent).toContain(
       'We detected an application built with a production configuration. Angular DevTools only supports development builds.',
     );
   });
 
-  it('should render version support message when Angular Status is EXISTS and angular version is not supported', () => {
+  it('should render version support message when Angular Status is EXISTS and angular version is not supported', async () => {
     component.angularStatus.set(component.AngularStatus.EXISTS);
     component.angularIsInDevMode.set(true);
     component.angularVersion.set('1.0.0');
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement.querySelector('.devtools-state-screen').textContent).toContain(
       `Angular DevTools only supports Angular versions ${LAST_SUPPORTED_VERSION} and above`,
     );
   });
 
-  it('should render Angular application not detected when Angular Status is DOES_NOT_EXIST', () => {
+  it('should render Angular application not detected when Angular Status is DOES_NOT_EXIST', async () => {
     component.angularStatus.set(component.AngularStatus.DOES_NOT_EXIST);
-    fixture.detectChanges();
+    await fixture.whenStable();
     // expect the text to be "Angular application not detected"
     expect(fixture.nativeElement.querySelector('.devtools-state-screen').textContent).toContain(
       'Angular application not detected',
     );
   });
 
-  it('should render loading svg when Angular Status is UNKNOWN', () => {
+  it('should render loading svg when Angular Status is UNKNOWN', async () => {
     component.angularStatus.set(component.AngularStatus.UNKNOWN);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(fixture.nativeElement.querySelector('.loading svg')).toBeTruthy();
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/shared/button/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/button/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -31,7 +31,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":button_test",

--- a/devtools/projects/ng-devtools/src/lib/shared/button/button.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/button/button.component.spec.ts
@@ -15,14 +15,10 @@ describe('ButtonComponent', () => {
   let element: Element;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ButtonComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(ButtonComponent);
     component = fixture.componentInstance;
     element = fixture.debugElement.nativeElement;
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should be primary type by default', () => {
@@ -35,9 +31,9 @@ describe('ButtonComponent', () => {
     expect(element.classList.contains('size-compact')).toBeFalse();
   });
 
-  it('should be compact size', () => {
+  it('should be compact size', async () => {
     fixture.componentRef.setInput('size', 'compact');
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(element.classList.contains('size-compact')).toBeTrue();
   });

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "sass_library", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "sass_library", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -54,7 +54,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":object-tree-explorer_test",

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.spec.ts
@@ -87,26 +87,26 @@ describe('ObjectTreeExplorerComponent', () => {
   let fixture: ComponentFixture<ObjectTreeExplorerComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ObjectTreeExplorerComponent],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(ObjectTreeExplorerComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('dataSource', mockDataSource);
     fixture.componentRef.setInput('childrenAccessor', (fl: FlatNode) => fl.prop.descriptor.value);
     fixture.componentRef.setInput('editingEnabled', true);
 
-    fixture.detectChanges();
+    await fixture.whenStable();
   });
 
-  it('should throw an error if treeControl and childrenAccessor are missing', () => {
-    expect(() => {
-      fixture.componentRef.setInput('dataSource', mockDataSource);
-      fixture.componentRef.setInput('childrenAccessor', null);
-      fixture.componentRef.setInput('treeControl', null);
-      fixture.detectChanges();
-    }).toThrowError('The object tree explorer requires a "treeControl" or "childrenAccessor"');
+  it('should throw an error if treeControl and childrenAccessor are missing', async () => {
+    await expectAsync(
+      (async () => {
+        fixture.componentRef.setInput('dataSource', mockDataSource);
+        fixture.componentRef.setInput('childrenAccessor', null);
+        fixture.componentRef.setInput('treeControl', null);
+        await fixture.whenStable();
+      })(),
+    ).toBeRejectedWithError(
+      'The object tree explorer requires a "treeControl" or "childrenAccessor"',
+    );
   });
 
   it('should render property preview if the property is NOT editable', () => {
@@ -135,7 +135,7 @@ describe('ObjectTreeExplorerComponent', () => {
 
   it('should NOT render root nodes names when omitRootNodesNames is provided', async () => {
     fixture.componentRef.setInput('omitRootNodesNames', true);
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const nodes = fixture.debugElement.queryAll(By.directive(MatTreeNode));
 

--- a/devtools/projects/ng-devtools/src/lib/shared/split/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/split/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "ng_web_test_suite", "sass_binary", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -48,7 +48,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":responsive-split_test",

--- a/devtools/projects/ng-devtools/src/lib/shared/split/responsive-split.directive.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/split/responsive-split.directive.spec.ts
@@ -76,15 +76,15 @@ class TestComponent {
   };
 }
 
-function initTestComponent(
+async function initTestComponent(
   width: number,
   height: number,
-): {host: DebugElement; split: SplitComponent} {
+): Promise<{host: DebugElement; split: SplitComponent}> {
   TestBed.configureTestingModule({
     providers: [{provide: WINDOW, useValue: {...window, ResizeObserver: ResizeObserverMockImpl}}],
   });
   const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
+  await fixture.whenStable();
 
   const host = fixture.debugElement.query(By.css('as-split'));
   const split = host.componentInstance;
@@ -110,26 +110,26 @@ describe('responsive-split', () => {
     jasmine.clock().install();
   });
 
-  it('should use horizontal direction (ratio == 1)', () => {
-    const {split} = initTestComponent(200, 200);
+  it('should use horizontal direction (ratio == 1)', async () => {
+    const {split} = await initTestComponent(200, 200);
 
     expect(split.direction()).toEqual('horizontal');
   });
 
-  it('should use horizontal direction (ratio == 1.49)', () => {
-    const {split} = initTestComponent(299, 200);
+  it('should use horizontal direction (ratio == 1.49)', async () => {
+    const {split} = await initTestComponent(299, 200);
 
     expect(split.direction()).toEqual('horizontal');
   });
 
-  it('should use vertical direction (ratio == 1.5)', () => {
-    const {split} = initTestComponent(350, 200);
+  it('should use vertical direction (ratio == 1.5)', async () => {
+    const {split} = await initTestComponent(350, 200);
 
     expect(split.direction()).toEqual('vertical');
   });
 
-  it('should use vertical direction (ratio == 2)', () => {
-    const {split} = initTestComponent(400, 200);
+  it('should use vertical direction (ratio == 2)', async () => {
+    const {split} = await initTestComponent(400, 200);
 
     expect(split.direction()).toEqual('vertical');
   });

--- a/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/shared/utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//devtools:__subpackages__"])
 
@@ -18,7 +18,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":utils_tests",

--- a/devtools/projects/protocol/BUILD.bazel
+++ b/devtools/projects/protocol/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,7 +32,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":protocol_test",

--- a/devtools/projects/shared-utils/BUILD.bazel
+++ b/devtools/projects/shared-utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_web_test_suite", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -25,7 +25,7 @@ ts_test_library(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test",
     deps = [
         ":shared_utils_test",

--- a/devtools/projects/shell-browser/src/app/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/app/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "esbuild", "ng_project", "ng_web_test_suite", "sass_binary", "ts_project", "ts_test_library")
+load("//devtools/tools:defaults.bzl", "esbuild", "ng_project", "sass_binary", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -130,7 +130,7 @@ ts_project(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "tab_manager_test",
     deps = [
         ":tab_manager_test_lib",

--- a/devtools/projects/shell-browser/src/app/app.config.ts
+++ b/devtools/projects/shell-browser/src/app/app.config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationConfig, provideZonelessChangeDetection} from '@angular/core';
+import {ApplicationConfig} from '@angular/core';
 import {ApplicationEnvironment, ApplicationOperations, provideSettings} from '../../../ng-devtools';
 
 import {ChromeApplicationEnvironment} from './chrome-application-environment';
@@ -17,7 +17,6 @@ import {ChromeMessageBus} from './chrome-message-bus';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZonelessChangeDetection(),
     {provide: FrameManager, useFactory: () => FrameManager.initialize()},
     {
       provide: ApplicationOperations,

--- a/devtools/src/app/app.config.ts
+++ b/devtools/src/app/app.config.ts
@@ -6,11 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ApplicationConfig,
-  provideZonelessChangeDetection,
-  provideAppInitializer,
-} from '@angular/core';
+import {ApplicationConfig, provideAppInitializer} from '@angular/core';
 import {provideRouter} from '@angular/router';
 import {
   ApplicationEnvironment,
@@ -21,12 +17,9 @@ import {
 import {DemoApplicationEnvironment} from '../demo-application-environment';
 import {DemoApplicationOperations} from '../demo-application-operations';
 import {serializeTransferState} from './transfer-state';
-import {provideHttpClient} from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZonelessChangeDetection(),
-    provideHttpClient(),
     provideRouter([
       {
         path: '',

--- a/devtools/src/main.ts
+++ b/devtools/src/main.ts
@@ -9,9 +9,6 @@
 import {bootstrapApplication} from '@angular/platform-browser';
 import {AppComponent, OtherAppComponent} from './app/app.component';
 import {appConfig} from './app/app.config';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
-bootstrapApplication(OtherAppComponent, {
-  providers: [provideZonelessChangeDetection()],
-}).catch((err) => console.error(err));
+bootstrapApplication(OtherAppComponent, {providers: []}).catch((err) => console.error(err));

--- a/devtools/tools/defaults.bzl
+++ b/devtools/tools/defaults.bzl
@@ -15,6 +15,7 @@ load(
     _sass_library = "sass_library",
     _ts_config = "ts_config",
     _ts_project = "ts_project",
+    _zoneless_web_test_suite = "zoneless_web_test_suite",
 )
 
 sass_binary = _sass_binary
@@ -36,6 +37,19 @@ def ng_web_test_suite(deps = [], **kwargs):
         "//:node_modules/@angular/platform-browser",
     ]
     _ng_web_test_suite(
+        deps = deps,
+        tsconfig = "//devtools:tsconfig_test",
+        **kwargs
+    )
+
+def zoneless_web_test_suite(deps = [], **kwargs):
+    # Provide required modules for the imports in //tools/testing/browser_tests.init.mts
+    deps = deps + [
+        "//:node_modules/@angular/compiler",
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/platform-browser",
+    ]
+    _zoneless_web_test_suite(
         deps = deps,
         tsconfig = "//devtools:tsconfig_test",
         **kwargs


### PR DESCRIPTION
This commits migrates the devtools tests toward to recommendations
