### PR TITLE
docs: prevent mobile overflow in the route behavior customization exa…

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -87,7 +87,11 @@ export class CustomerComponent {
 }
 ```
 
-Using `'always'` ensures matrix parameters, route data, and resolved values are available further down the route tree—handy when you share contextual identifiers across feature areas such as `/org/:orgId/projects/:projectId/customers/:customerId`.
+Using `'always'` ensures matrix parameters, route data, and resolved values are available further down the route tree—handy when you share contextual identifiers across feature areas such as:
+
+```text {hideCopy}
+/org/:orgId/projects/:projectId/customers/:customerId
+```
 
 ```ts
 @Component({


### PR DESCRIPTION
…mple

## What is the current behavior?
https://next.angular.dev/guide/routing/customizing-route-behavior#control-parameter-inheritance

<img width="408" height="176" alt="image" src="https://github.com/user-attachments/assets/edd65223-be14-4375-83cd-7f18fd7e37e3" />



## What is the new behavior?
<img width="378" height="220" alt="image" src="https://github.com/user-attachments/assets/8a09a92a-d544-4aca-9bb8-b0dd366f99e6" />


 