### PR TITLE
fix(docs-infra): use margin instead of padding to prevent heading hov…

### DIFF
--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -62,10 +62,10 @@
   }
 
   .docs-reference-section-heading {
-    padding-block-start: 3rem;
+    margin-block-start: 3rem;
 
     &--sub {
-      padding-block-start: 1rem;
+      margin-block-start: 1rem;
     }
 
     & > a {


### PR DESCRIPTION
…er overflow

Replaced padding-block-start with margin-block-start on .docs-reference-section-heading to prevent anchor hover and click areas from extending into empty space above the heading. This ensures hover behavior aligns with the visible text.



## What is the current behavior?
[screen-capture.webm](https://github.com/user-attachments/assets/b40cea2b-f178-44a0-8d58-fe08f8fdddd2)
