### PR TITLE
docs: update tsDoc code examples to use TypeScript syntax highlighting

### DIFF
--- a/packages/core/src/render3/dynamic_bindings.ts
+++ b/packages/core/src/render3/dynamic_bindings.ts
@@ -130,7 +130,7 @@ function controlBinding(binding: BindingInternal, tNode: TNode): ControlBinding 
  * In this example we create an instance of the `MyButton` component and bind the value of
  * the `isDisabled` signal to its `disabled` input.
  *
- * ```
+ * ```ts
  * const isDisabled = signal(false);
  *
  * createComponent(MyButton, {
@@ -177,7 +177,7 @@ export function inputBinding(publicName: string, value: () => unknown): Binding 
  * In this example we create an instance of the `MyCheckbox` component and listen
  * to its `onChange` event.
  *
- * ```
+ * ```ts
  * interface CheckboxChange {
  *   value: string;
  * }
@@ -217,7 +217,7 @@ export function outputBinding<T>(eventName: string, listener: (event: T) => unkn
  * In this example we create an instance of the `MyCheckbox` component and bind to its `value`
  * input using a two-way binding.
  *
- * ```
+ * ```ts
  * const checkboxValue = signal('');
  *
  * createComponent(MyCheckbox, {

--- a/packages/forms/signals/src/field/resolution.ts
+++ b/packages/forms/signals/src/field/resolution.ts
@@ -24,7 +24,7 @@ export function getBoundPathDepth() {
  *
  * Consider this example:
  *
- * ```
+ * ```ts
  * const s = schema(p => {
  *   disabled(p.next, ({valueOf}) => valueOf(p.data));
  *   apply(p.next, s);

--- a/packages/forms/signals/src/schema/logic.ts
+++ b/packages/forms/signals/src/schema/logic.ts
@@ -48,7 +48,7 @@ export interface Predicate {
  *
  * Consider the following example:
  *
- * ```
+ * ```ts
  * const s = schema(p => {
  *   disabled(p.data);
  *   applyWhen(p.next, ({valueOf}) => valueOf(p.data) === 1, s);

--- a/packages/forms/signals/src/schema/schema.ts
+++ b/packages/forms/signals/src/schema/schema.ts
@@ -23,7 +23,7 @@ let currentCompilingNode: FieldPathNode | undefined = undefined;
  * A cache of all schemas compiled under the current root compilation. This is used to avoid doing
  * extra work when compiling a schema that reuses references to the same sub-schema. For example:
  *
- * ```
+ * ```ts
  * const sub = schema(p => ...);
  * const s = schema(p => {
  *   apply(p.a, sub);

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -867,7 +867,7 @@ export abstract class AbstractControl<
    *
    * ### Reference to a ValidatorFn
    *
-   * ```
+   * ```ts
    * // Reference to the RequiredValidator
    * const ctrl = new FormControl<string | null>('', Validators.required);
    * ctrl.removeValidators(Validators.required);
@@ -913,7 +913,7 @@ export abstract class AbstractControl<
    *
    * ### Reference to a ValidatorFn
    *
-   * ```
+   * ```ts
    * // Reference to the RequiredValidator
    * const ctrl = new FormControl<number | null>(0, Validators.required);
    * expect(ctrl.hasValidator(Validators.required)).toEqual(true)


### PR DESCRIPTION
## What is the current behavior?
https://angular.dev/api/core/inputBinding
 
<img width="807" height="313" alt="image" src="https://github.com/user-attachments/assets/03b53882-8f12-4c5a-8924-7b8882b2e855" />

## What is the new behavior?

 <img width="794" height="284" alt="image" src="https://github.com/user-attachments/assets/277dc07a-6e43-4980-a4b7-d2103c6a2fb9" />