### PR TITLE
Add "all" flag to PristineChangeEvent and TouchedChangeEvent

### DIFF
--- a/goldens/public-api/forms/index.api.md
+++ b/goldens/public-api/forms/index.api.md
@@ -820,7 +820,9 @@ export class PatternValidator extends AbstractValidatorDirective {
 
 // @public
 export class PristineChangeEvent extends ControlEvent {
-    constructor(pristine: boolean, source: AbstractControl);
+    constructor(pristine: boolean, source: AbstractControl, all?: boolean);
+    // (undocumented)
+    readonly all: boolean;
     // (undocumented)
     readonly pristine: boolean;
     // (undocumented)
@@ -918,7 +920,9 @@ export class StatusChangeEvent extends ControlEvent {
 
 // @public
 export class TouchedChangeEvent extends ControlEvent {
-    constructor(touched: boolean, source: AbstractControl);
+    constructor(touched: boolean, source: AbstractControl, all?: boolean);
+    // (undocumented)
+    readonly all: boolean;
     // (undocumented)
     readonly source: AbstractControl;
     // (undocumented)

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -124,6 +124,7 @@ export class PristineChangeEvent extends ControlEvent {
   constructor(
     public readonly pristine: boolean,
     public readonly source: AbstractControl,
+    public readonly all: boolean = false,
   ) {
     super();
   }
@@ -140,6 +141,7 @@ export class TouchedChangeEvent extends ControlEvent {
   constructor(
     public readonly touched: boolean,
     public readonly source: AbstractControl,
+    public readonly all: boolean = false,
   ) {
     super();
   }
@@ -989,9 +991,15 @@ export abstract class AbstractControl<
     onlySelf?: boolean;
     emitEvent?: boolean;
     sourceControl?: AbstractControl;
+    all?: boolean;
   }): void;
   markAsTouched(
-    opts: {onlySelf?: boolean; emitEvent?: boolean; sourceControl?: AbstractControl} = {},
+    opts: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+      sourceControl?: AbstractControl;
+      all?: boolean;
+    } = {},
   ): void {
     const changed = this.touched === false;
     this.touched = true;
@@ -1002,7 +1010,7 @@ export abstract class AbstractControl<
     }
 
     if (changed && opts.emitEvent !== false) {
-      this._events.next(new TouchedChangeEvent(true, sourceControl));
+      this._events.next(new TouchedChangeEvent(true, sourceControl, opts.all ?? false));
     }
   }
 
@@ -1020,7 +1028,7 @@ export abstract class AbstractControl<
    *
    */
   markAllAsDirty(opts: {emitEvent?: boolean} = {}): void {
-    this.markAsDirty({onlySelf: true, emitEvent: opts.emitEvent, sourceControl: this});
+    this.markAsDirty({onlySelf: true, emitEvent: opts.emitEvent, sourceControl: this, all: true});
 
     this._forEachChild((control: AbstractControl) => control.markAllAsDirty(opts));
   }
@@ -1039,7 +1047,7 @@ export abstract class AbstractControl<
    *
    */
   markAllAsTouched(opts: {emitEvent?: boolean} = {}): void {
-    this.markAsTouched({onlySelf: true, emitEvent: opts.emitEvent, sourceControl: this});
+    this.markAsTouched({onlySelf: true, emitEvent: opts.emitEvent, sourceControl: this, all: true});
 
     this._forEachChild((control: AbstractControl) => control.markAllAsTouched(opts));
   }
@@ -1074,9 +1082,15 @@ export abstract class AbstractControl<
     onlySelf?: boolean;
     emitEvent?: boolean;
     sourceControl?: AbstractControl;
+    all?: boolean;
   }): void;
   markAsUntouched(
-    opts: {onlySelf?: boolean; emitEvent?: boolean; sourceControl?: AbstractControl} = {},
+    opts: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+      sourceControl?: AbstractControl;
+      all?: boolean;
+    } = {},
   ): void {
     const changed = this.touched === true;
     this.touched = false;
@@ -1092,7 +1106,7 @@ export abstract class AbstractControl<
     }
 
     if (changed && opts.emitEvent !== false) {
-      this._events.next(new TouchedChangeEvent(false, sourceControl));
+      this._events.next(new TouchedChangeEvent(false, sourceControl, opts.all ?? false));
     }
   }
 
@@ -1123,9 +1137,15 @@ export abstract class AbstractControl<
     onlySelf?: boolean;
     emitEvent?: boolean;
     sourceControl?: AbstractControl;
+    all?: boolean;
   }): void;
   markAsDirty(
-    opts: {onlySelf?: boolean; emitEvent?: boolean; sourceControl?: AbstractControl} = {},
+    opts: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+      sourceControl?: AbstractControl;
+      all?: boolean;
+    } = {},
   ): void {
     const changed = this.pristine === true;
     this.pristine = false;
@@ -1136,7 +1156,7 @@ export abstract class AbstractControl<
     }
 
     if (changed && opts.emitEvent !== false) {
-      this._events.next(new PristineChangeEvent(false, sourceControl));
+      this._events.next(new PristineChangeEvent(false, sourceControl, opts.all ?? false));
     }
   }
 


### PR DESCRIPTION

- Consolidates event emission logic for "markAsDirty", "markAsTouched", and related methods to include a new "all" flag.
- Updates associated test cases to validate the "all" flag behavior.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

You could not differentiate between markAsTouched and markAllAsTouched

Issue Number: https://github.com/angular/angular/issues/60385

## What is the new behavior?
A new "all"-flag that lets you see when the touched/dirty state was changed by calling mark**All**AsTouched

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
