### PR TITLE
fix(forms): clean up abort listener after timeout

### DIFF
--- a/packages/forms/signals/src/api/rules/debounce.ts
+++ b/packages/forms/signals/src/api/rules/debounce.ts
@@ -42,8 +42,18 @@ export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(
 function debounceForDuration(durationInMilliseconds: number): Debouncer<unknown> {
   return (_context, abortSignal) => {
     return new Promise((resolve) => {
-      const timeoutId = setTimeout(resolve, durationInMilliseconds);
-      abortSignal.addEventListener('abort', () => clearTimeout(timeoutId));
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+      };
+
+      timeoutId = setTimeout(() => {
+        abortSignal.removeEventListener('abort', onAbort);
+        resolve();
+      }, durationInMilliseconds);
+
+      abortSignal.addEventListener('abort', onAbort, {once: true});
     });
   };
 }

--- a/packages/forms/signals/test/node/api/debounce.spec.ts
+++ b/packages/forms/signals/test/node/api/debounce.spec.ts
@@ -237,6 +237,34 @@ describe('debounce', () => {
         expect(abortSpy).toHaveBeenCalledTimes(1);
         expect(street.value()).toBe('1600 Amphitheatre Pkwy');
       });
+
+      it('should remove abort listener when debounce completes', async () => {
+        const addListenerSpy = spyOn(AbortSignal.prototype, 'addEventListener').and.callThrough();
+        const removeListenerSpy = spyOn(
+          AbortSignal.prototype,
+          'removeEventListener',
+        ).and.callThrough();
+
+        const address = signal({street: ''});
+        const addressForm = form(
+          address,
+          (address) => {
+            debounce(address.street, 1);
+          },
+          options(),
+        );
+        const street = addressForm.street();
+
+        street.setControlValue('1600 Amphitheatre Pkwy');
+        expect(addListenerSpy).toHaveBeenCalledOnceWith('abort', jasmine.any(Function), {
+          once: true,
+        });
+        expect(removeListenerSpy).not.toHaveBeenCalled();
+
+        await timeout(10);
+        expect(street.value()).toBe('1600 Amphitheatre Pkwy');
+        expect(removeListenerSpy).toHaveBeenCalledOnceWith('abort', jasmine.any(Function));
+      });
     });
   });
 


### PR DESCRIPTION
Removes the abort event listener once the debounce timeout completes.

This avoids lingering listeners, prevents potential memory leaks, and ensures the abort logic runs at most once.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
