### PR TITLE
docs: fixed incorrect link in migrating-to-vitest.md

### DIFF
--- a/adev/src/content/guide/testing/migrating-to-vitest.md
+++ b/adev/src/content/guide/testing/migrating-to-vitest.md
@@ -228,7 +228,7 @@ If you set `runnerConfig` to `true`, the builder will automatically search for a
 ## `zone.js` based helpers are not supported
 
 The zone.js patches are not applied when running tests with Vitest, there for you won't be able use functions like `fakeAsync`, `flush` or `waitForAsync`.
-To migrate to Vitest you will also need to migrate your tests to native async and Vitest fake timers. See [an example here](/components-scenarios#async-test-with-a-vitest-fake-timers) for fake timers usages with Vitest.
+To migrate to Vitest you will also need to migrate your tests to native async and Vitest fake timers. See [an example here](/guide/testing/components-scenarios#async-test-with-a-vitest-fake-timers) for fake timers usages with Vitest.
 
 ## Bug reports
 


### PR DESCRIPTION
provided correct link to section about vitest fake timer

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Current link shows Page not found (https://angular.dev/components-scenarios#async-test-with-a-vitest-fake-timers)

Issue Number: N/A

## What is the new behavior?

Correct link

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
