### PR TITLE
Revert "fix(router): Ensure createUrlTree does not reuse segments of …

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -794,10 +794,7 @@ export function squashSegmentGroup(segmentGroup: UrlSegmentGroup): UrlSegmentGro
       newChildren[childOutlet] = childCandidate;
     }
   }
-  const s = new UrlSegmentGroup(
-    segmentGroup.segments.map((s) => new UrlSegment(s.path, {...s.parameters})),
-    newChildren,
-  );
+  const s = new UrlSegmentGroup(segmentGroup.segments, newChildren);
   return mergeTrivialChildren(s);
 }
 

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -758,24 +758,6 @@ describe('createUrlTreeFromSnapshot', () => {
     await advance(fixture);
     expect(router.url).toEqual('/parent/sibling');
   });
-  it('should not affect the input snapshot when the result is mutated', async () => {
-    TestBed.configureTestingModule({
-      providers: [provideRouter([{path: 'a', children: [{path: 'b', component: class {}}]}])],
-    });
-    const router = TestBed.inject(Router);
-    await router.navigateByUrl('/a/b');
-    const snapshot = router.routerState.snapshot.root.firstChild!;
-
-    // createUrlTreeFromSnapshot will squash the segment group
-    const tree = createUrlTreeFromSnapshot(snapshot, []);
-
-    // Mutate the result's segments array (e.g. simulating what applyRedirects might do)
-    tree.root.children[PRIMARY_OUTLET].segments[0].path = 'c';
-
-    // The input snapshot should remain unchanged
-    expect(snapshot.url.length).toBe(1);
-    expect(snapshot.url[0].path).toBe('a');
-  });
 });
 
 async function advance(fixture: ComponentFixture<unknown>) {


### PR DESCRIPTION
…input"

This reverts commit 39efb62c0f4d72e7ca72ca458083b54fb76eec2d. (breaks g3)
