### PR TITLE
refactor(router): Retain original navigateEvent across redirects

### DIFF
--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -199,8 +199,17 @@ export class NavigationStateManager extends StateManager {
         resolve();
       });
     } else if (e instanceof NavigationCancel || e instanceof NavigationError) {
-      // TODO(atscott): We want to keep the navigation event on redirects if
-      // the URL wasn't committed yet rather than cancelling it.
+      // If redirecting and the URL hasn't been committed yet (via precommmitHandler),
+      // the redirect will be handled by `commitUrl` using `controller.redirect` and
+      // we should retain the current NavigateEvent.
+      // Otherwise, a full cancellation and rollback is needed.
+      const redirectingBeforeUrlCommit =
+        e instanceof NavigationCancel &&
+        e.code === NavigationCancellationCode.Redirect &&
+        !!this.currentNavigation.commitUrl;
+      if (redirectingBeforeUrlCommit) {
+        return;
+      }
       void this.cancel(transition, e);
     } else if (e instanceof NavigationEnd) {
       const {resolveHandler, removeAbortListener} = this.currentNavigation;

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {provideRouter, Router} from '../src';
+import {NavigationStart, provideRouter, Router} from '../src';
 import {withExperimentalPlatformNavigation, withRouterConfig} from '../src/provide_router';
 import {withBody} from '@angular/private/testing';
 import {
@@ -15,6 +15,7 @@ import {
   Location,
   PlatformNavigation,
   BrowserPlatformLocation,
+  ɵPRECOMMIT_HANDLER_SUPPORTED as PRECOMMIT_HANDLER_SUPPORTED,
 } from '@angular/common';
 import {
   ɵFakeNavigation as FakeNavigation,
@@ -22,6 +23,7 @@ import {
   provideLocationMocks,
 } from '@angular/common/testing';
 import {timeout, useAutoTick} from './helpers';
+import {inject} from '@angular/core';
 
 /// <reference types="dom-navigation" />
 
@@ -158,6 +160,26 @@ describe('withPlatformNavigation feature', () => {
       await navigation.back().finished;
       expect(navigateEvents.length).toBe(1);
       expect(navigateEvents[0].navigationType).toBe('traverse');
+    });
+
+    it('retains a single NavigateEvent across redirects', async () => {
+      const navigateEvents: NavigateEvent[] = [];
+      navigation.addEventListener('navigate', (e: NavigateEvent) => navigateEvents.push(e));
+
+      router.resetConfig([
+        {path: 'first', canActivate: [() => inject(Router).parseUrl('/redirected')], children: []},
+        {path: '**', children: []},
+      ]);
+      const navPromise = router.navigateByUrl('/first');
+      if (TestBed.inject(PRECOMMIT_HANDLER_SUPPORTED)) {
+        router.events.subscribe((e) => {
+          if (e instanceof NavigationStart) {
+            expect(navigateEvents.length).toBe(1);
+          }
+        });
+      }
+      await navPromise;
+      expect(navigateEvents.length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This builds off of https://github.com/angular/angular/pull/66197 by retaining the original navigateEvent across redirects
so the NavigateEvent can more accurately track the lifecycle of a navigation,
which may span across several NavigationStart events due to redirects

Resubmit of #66200 which was reverted due to changes in #66197 being reverted

Reviewer note: This is a resubmit of a PR that was rolled back (due to commits that it depended on being rolled back)