### PR TITLE
fix(vscode-extension): convert enum member kind in completions correctly

### DIFF
--- a/vscode-ng-language-service/server/src/completion.ts
+++ b/vscode-ng-language-service/server/src/completion.ts
@@ -28,6 +28,7 @@ enum CompletionKind {
   reference = 'reference',
   variable = 'variable',
   entity = 'entity',
+  enumMember = 'enum member',
 }
 
 /**
@@ -95,6 +96,8 @@ function ngCompletionKindToLspCompletionItemKind(kind: CompletionKind): lsp.Comp
       return lsp.CompletionItemKind.Variable;
     case CompletionKind.block:
       return lsp.CompletionItemKind.Keyword;
+    case CompletionKind.enumMember:
+      return lsp.CompletionItemKind.EnumMember;
     case CompletionKind.entity:
     default:
       return lsp.CompletionItemKind.Text;


### PR DESCRIPTION
This converts enum member kinds to the correct completion kind for displa in the completions popup

<img width="524" height="115" alt="image" src="https://github.com/user-attachments/assets/cfc519b4-6ed6-41b4-a42f-aecdaae950ce" />
