### PR TITLE
fix(compiler-cli): attach source spans to object literal keys in TCB

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -244,7 +244,9 @@ class AstTranslator implements AstVisitor {
       const value = this.translate(ast.values[idx]);
 
       if (key.kind === 'property') {
-        return ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(key.key), value);
+        const keyNode = ts.factory.createStringLiteral(key.key);
+        addParseSpanInfo(keyNode, key.sourceSpan);
+        return ts.factory.createPropertyAssignment(keyNode, value);
       } else {
         return ts.factory.createSpreadAssignment(value);
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/input_signal_diagnostics_spec.ts
@@ -289,8 +289,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="'text'"
                        #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -311,8 +311,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="'text'"
                        #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -333,8 +333,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="{u: null}"
                    #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 57): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 63): Type 'number' is not assignable to type 'null'.`,
+          `TestComponent.html(3, 54): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 60): Type 'number' is not assignable to type 'null'.`,
         ],
       },
       // differing Write and ReadT
@@ -400,9 +400,9 @@ runInEachFileSystem(() => {
         component: `prop: HTMLElement = null!`,
         expected: [
           // This verifies that the `ref.tester.t` is correctly inferred to be `HTMLElement`.
-          `TestComponent.html(3, 46): Type 'number' is not assignable to type 'HTMLElement'.`,
+          `TestComponent.html(3, 43): Type 'number' is not assignable to type 'HTMLElement'.`,
           // This verifies that the `bla` input value is still a `string` when accessed.
-          `TestComponent.html(3, 59): Type 'string' is not assignable to type 'never'.`,
+          `TestComponent.html(3, 49): Type 'string' is not assignable to type 'never'.`,
         ],
       },
       {
@@ -422,7 +422,7 @@ runInEachFileSystem(() => {
         component: `prop: HTMLElement = null!`,
         expected: [
           // This verifies that the `ref.tester.t` is correctly inferred to be `HTMLElement`.
-          `TestComponent.html(1, 60): Type 'number' is not assignable to type 'HTMLElement'.`,
+          `TestComponent.html(1, 57): Type 'number' is not assignable to type 'HTMLElement'.`,
         ],
       },
     ];

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
@@ -285,8 +285,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="'text'"
                        #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -308,8 +308,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="'text'"
                        #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -334,8 +334,8 @@ runInEachFileSystem(() => {
               <div dir [gen]="false" [other]="{u: null}"
                    #ref="dir" (click)="ref.tester = {t: 1, u: 0}">`,
         expected: [
-          `TestComponent.html(3, 57): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 63): Type 'number' is not assignable to type 'null'.`,
+          `TestComponent.html(3, 54): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 60): Type 'number' is not assignable to type 'null'.`,
         ],
       },
       {
@@ -356,7 +356,7 @@ runInEachFileSystem(() => {
         component: `prop: HTMLElement = null!`,
         expected: [
           // This verifies that the `ref.tester.ts` is correctly inferred to be `HTMLElement`.
-          `TestComponent.html(1, 60): Type 'number' is not assignable to type 'HTMLElement'.`,
+          `TestComponent.html(1, 57): Type 'number' is not assignable to type 'HTMLElement'.`,
         ],
       },
       {
@@ -490,8 +490,8 @@ runInEachFileSystem(() => {
           otherVal!: string;
         `,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -520,8 +520,8 @@ runInEachFileSystem(() => {
           otherVal!: string;
         `,
         expected: [
-          `TestComponent.html(3, 61): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 67): Type 'number' is not assignable to type 'string'.`,
+          `TestComponent.html(3, 58): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 64): Type 'number' is not assignable to type 'string'.`,
         ],
       },
       {
@@ -550,8 +550,8 @@ runInEachFileSystem(() => {
           otherVal!: {u: null};
         `,
         expected: [
-          `TestComponent.html(3, 57): Type 'number' is not assignable to type 'boolean'.`,
-          `TestComponent.html(3, 63): Type 'number' is not assignable to type 'null'.`,
+          `TestComponent.html(3, 54): Type 'number' is not assignable to type 'boolean'.`,
+          `TestComponent.html(3, 60): Type 'number' is not assignable to type 'null'.`,
         ],
       },
       {
@@ -572,7 +572,7 @@ runInEachFileSystem(() => {
         component: `prop: HTMLElement = null!`,
         expected: [
           // This verifies that the `ref.tester.ts` is correctly inferred to be `HTMLElement`.
-          `TestComponent.html(1, 62): Type 'number' is not assignable to type 'HTMLElement'.`,
+          `TestComponent.html(1, 59): Type 'number' is not assignable to type 'HTMLElement'.`,
         ],
       },
       {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -40,7 +40,7 @@ describe('type check blocks diagnostics', () => {
       // statement, which would wrap it into parenthesis that clutter the expected output.
       const TEMPLATE = '{{ m({foo: a, bar: b}) }}';
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '(this).m /*3,4*/({ "foo": ((this).a /*11,12*/) /*11,12*/, "bar": ((this).b /*19,20*/) /*19,20*/ } /*5,21*/) /*3,22*/',
+        '(this).m /*3,4*/({ "foo" /*6,9*/: ((this).a /*11,12*/) /*11,12*/, "bar" /*14,17*/: ((this).b /*19,20*/) /*19,20*/ } /*5,21*/) /*3,22*/',
       );
     });
 
@@ -49,7 +49,7 @@ describe('type check blocks diagnostics', () => {
       // statement, which would wrap it into parenthesis that clutter the expected output.
       const TEMPLATE = '{{ m({a, b}) }}';
       expect(tcbWithSpans(TEMPLATE)).toContain(
-        '((this).m /*3,4*/({ "a": ((this).a /*6,7*/) /*6,7*/, "b": ((this).b /*9,10*/) /*9,10*/ } /*5,11*/) /*3,12*/)',
+        '((this).m /*3,4*/({ "a" /*6,7*/: ((this).a /*6,7*/) /*6,7*/, "b" /*9,10*/: ((this).b /*9,10*/) /*9,10*/ } /*5,11*/) /*3,12*/)',
       );
     });
 


### PR DESCRIPTION
Previously, object literal keys in the TCB did not have source spans attached. This made it difficult for the Language Service to distinguish between keys and values, leading to incorrect completion contexts and diagnostic locations.

This commit ensures that source spans are properly attached to the keys in the TCB.
