### PR TITLE
refactor(devtools): make release script compatible with type stripping

### DIFF
--- a/devtools/tools/release.mts
+++ b/devtools/tools/release.mts
@@ -11,7 +11,7 @@ import {input} from '@inquirer/prompts';
 import chalk from 'chalk';
 import semver from 'semver';
 import {writeFile, mkdir, rm, readFile} from 'node:fs/promises';
-import {exec as nodeExec, spawn, SpawnOptions} from 'node:child_process';
+import {exec as nodeExec, spawn, type SpawnOptions} from 'node:child_process';
 import {promisify} from 'node:util';
 import {join} from 'node:path';
 


### PR DESCRIPTION
When running this script with node directly, it requires explicit markers for type-only imports to work.

Follow-up to https://github.com/angular/angular/pull/66182