### PR TITLE
docs: release notes for the v19.2.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="19.2.18"></a>
+# 19.2.18 (2026-01-07)
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [26cdc53d9c](https://github.com/angular/angular/commit/26cdc53d9cf99ec41ffc0c71f58f8a14efc828d9) | fix | sanitize sensitive attributes on SVG script elements |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.7"></a>
 # 21.0.7 (2026-01-07)
 ### compiler


### PR DESCRIPTION
Cherry-picks the changelog from the "19.2.x" branch to the next branch (main).