### PR TITLE
docs: fix typo - change comma to dot at the end of the sentence

### DIFF
--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -82,7 +82,7 @@ The execution of both kinds of `effect` are tied to the change detection process
 - "View effects" are executed _before_ their corresponding component is checked by the change detection process.
 - "Root effects" are executed prior to all components being checked by the change detection process.
 
-In both cases, if at least one of the effect dependencies changed during the effect execution, the effect will re-run before moving ahead on the change detection process,
+In both cases, if at least one of the effect dependencies changed during the effect execution, the effect will re-run before moving ahead on the change detection process.
 
 ### Destroying effects
 


### PR DESCRIPTION
There is a typo at the end of one of the sentences - should be '.' instead of ','.
On this https://angular.dev/guide/signals/effect page.

<img width="3813" height="705" alt="image" src="https://github.com/user-attachments/assets/a9eb9331-24da-49c1-8fe8-e0948c4ed1b4" />

## PR Type

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

