### PR TITLE
docs: fix typo in input signal field name, change comma to dot at the end of the sentence, fix typo in word unnecessary

### DIFF
--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -82,7 +82,7 @@ The execution of both kinds of `effect` are tied to the change detection process
 - "View effects" are executed _before_ their corresponding component is checked by the change detection process.
 - "Root effects" are executed prior to all components being checked by the change detection process.
 
-In both cases, if at least one of the effect dependencies changed during the effect execution, the effect will re-run before moving ahead on the change detection process,
+In both cases, if at least one of the effect dependencies changed during the effect execution, the effect will re-run before moving ahead on the change detection process.
 
 ### Destroying effects
 
@@ -133,7 +133,7 @@ export class MyFancyChart {
     // Run a single time to create the chart instance
     afterNextRender({
       write: () => {
-        this.chart = initializeChart(this.canvas().nativeElement(), this.charData());
+        this.chart = initializeChart(this.canvas().nativeElement(), this.chartData());
       },
     });
 
@@ -151,7 +151,7 @@ TIP: You often don't need `afterRenderEffect` to check for DOM changes. APIs lik
 
 ### Render phases
 
-Accessing the DOM and mutating it can impact the performance of your application, for example by triggering to many unecesary [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).
+Accessing the DOM and mutating it can impact the performance of your application, for example by triggering too many unnecessary [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).
 
 To optimize those operations, `afterRenderEffect` offers four phases to group the callbacks and execute them in an optimized order.
 


### PR DESCRIPTION
1) typo in this.chartData()
on this page https://angular.dev/guide/signals/effect#side-effects-on-dom-elements
currently called as this.charData() should be this.chartData()
<img width="1251" height="1363" alt="image" src="https://github.com/user-attachments/assets/37599cf3-79b5-4de0-aff1-ade3ff02f973" />

2) typo - at the end of one sentences there should be '.' instead of ','.
https://angular.dev/guide/signals/effect#execution-of-effects
<img width="1173" height="647" alt="image" src="https://github.com/user-attachments/assets/c90ff22b-d635-4fc7-860c-ac817bd047c9" />

3) typo here https://angular.dev/guide/signals/effect#render-phases
<img width="1053" height="184" alt="image" src="https://github.com/user-attachments/assets/38f68dd5-e7e9-4176-910e-63654b955591" />
highly likely should be:
Accessing the DOM and mutating it can impact the performance of your application, for example by triggering too many unnecessary [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).


## PR Type
- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
