### PR TITLE
docs: fix typo in word 'unnecessary' in effect.md

### DIFF
--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -151,7 +151,7 @@ TIP: You often don't need `afterRenderEffect` to check for DOM changes. APIs lik
 
 ### Render phases
 
-Accessing the DOM and mutating it can impact the performance of your application, for example by triggering to many unecesary [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).
+Accessing the DOM and mutating it can impact the performance of your application, for example by triggering too many unnecessary [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).
 
 To optimize those operations, `afterRenderEffect` offers four phases to group the callbacks and execute them in an optimized order.
 


### PR DESCRIPTION
typo here https://angular.dev/guide/signals/effect#render-phases
<img width="1137" height="202" alt="image" src="https://github.com/user-attachments/assets/d3ed1906-b66d-4e02-b033-821a6857a163" />
highly likely should be:
Accessing the DOM and mutating it can impact the performance of your application, for example by triggering **too** many **unnecessary** [reflows](https://developer.mozilla.org/en-US/docs/Glossary/Reflow).

## PR Type

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No