### PR TITLE
fix(docs-infra): improve dark mode button hover contrast for WCAG com…

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -179,7 +179,8 @@
   --white-to-light-blue-diagonal-gradient: linear-gradient(
     132.83deg,
     hsl(from color-mix(in srgb, var(--bright-blue), white 60%) h s l / 0) 45.38%,
-    hsl(from color-mix(in srgb, var(--bright-blue), white 60%) h s l / 0.3) 159.03%);
+    hsl(from color-mix(in srgb, var(--bright-blue), white 60%) h s l / 0.3) 159.03%
+  );
 
   --white-to-light-pink-diagonal-gradient: linear-gradient(
     135deg,
@@ -230,8 +231,7 @@
   // for the "unfilled" portion of the word that hasn't
   // been highlighted by the gradient
   --gray-unfilled: var(--gray-400);
-  --webgl-page-background: var(var(--page-background))
-  --webgl-gray-unfilled: var(--gray-400);
+  --webgl-page-background: var(var(--page-background)) --webgl-gray-unfilled: var(--gray-400);
 }
 
 @mixin dark-mode-definitions() {
@@ -261,9 +261,16 @@
   --super-green: color-mix(in srgb, oklch(79.12% 0.257 155.13), var(--full-contrast) 70%);
   --light-vivid-pink-to-light-electric-violet-horizontal-gradient:
     linear-gradient(hsl(from var(--gray-1000) h s l / 0.9), hsl(from var(--gray-1000) h s l / 0.9)),
-    linear-gradient(hsl(from var(--full-contrast) h s l / 0.2), hsl(from var(--full-contrast) h s l / 0.2)),
+    linear-gradient(
+      hsl(from var(--full-contrast) h s l / 0.2),
+      hsl(from var(--full-contrast) h s l / 0.2)
+    ),
     var(--pink-to-purple-horizontal-gradient);
-  --white-to-light-pink-diagonal-gradient: color-mix(in srgb, var(--french-violet), var(--full-contrast) 60%);
+  --white-to-light-pink-diagonal-gradient: color-mix(
+    in srgb,
+    var(--french-violet),
+    var(--full-contrast) 60%
+  );
 
   --deprecated-dark: oklch(30% 0.02 304.04); // Base color
   --deprecated-docs-bg: var(--deprecated-dark); // Alias specifically for deprecated docs
@@ -301,10 +308,7 @@
   );
 
   --page-bg-radial-gradient: radial-gradient(circle, black 0%, black 100%);
-  --soft-pink-radial-gradient:
-    linear-gradient(119.77deg, 
-    hsl(from color-mix(in srgb, var(--french-violet), white 60%) h s l / 0) 24.32%,
-    hsl(from color-mix(in srgb, var(--french-violet), white 60%) h s l / 0.3) 116.25%);
+  --soft-pink-radial-gradient: var(--hot-pink-to-electric-violet-radial-gradient);
 
   // Use light values hot pink and electric violet since this gradient used for
   // the decorative header which looks the same in both modes


### PR DESCRIPTION
The .docs-primary-btn hover state in dark mode had a contrast ratio of 2.18:1, failing WCAG 2.1 SC 1.4.3. This change reuses the existing --hot-pink-to-electric-violet-radial-gradient to achieve 4.5:1+ contrast.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes

## What is the current behavior?

The `.docs-primary-btn` hover state in dark mode uses `--soft-pink-radial-gradient` with `--french-violet` mixed with 60% white (~#cc99e8). Combined with text color #fbfbfb, this produces a **contrast ratio of 2.18:1**, failing WCAG 2.1 SC 1.4.3 (minimum 4.5:1).

This issue is not auto-detected by accessibility checkers because the gradient is applied to the `::before` pseudo-element.

## What is the new behavior?

The dark mode `--soft-pink-radial-gradient` now uses `--hot-pink-to-electric-violet-radial-gradient`, achieving:
- `--hot-pink-header` (~#eb2877) → **4.7:1 contrast** ✅
- `--electric-violet-header` (~#9a3cf7) → **4.5:1 contrast** ✅

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

### Before
<img width="1347" height="704" alt="Screenshot 2026-01-08 at 10 57 34 AM" src="https://github.com/user-attachments/assets/d4344ef5-4aa9-48c4-b2ad-9d80c54799e4" />
<img width="1268" height="721" alt="Screenshot 2026-01-08 at 10 56 04 AM" src="https://github.com/user-attachments/assets/9a407fab-8f2d-47bd-82c9-ce8c303f61d3" />

### After
<img width="1255" height="711" alt="Screenshot 2026-01-08 at 10 58 59 AM" src="https://github.com/user-attachments/assets/04e69771-d1ab-42ca-87b4-a13ebd5bf730" />
<img width="1270" height="716" alt="Screenshot 2026-01-08 at 10 57 05 AM" src="https://github.com/user-attachments/assets/8dcccbb8-9e83-4578-9847-872a25544ebf" />



**References:**
- [WCAG 2.1 SC 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)