### PR TITLE
docs(docs-infra): improve label fallback logic in search results

### DIFF
--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -105,17 +105,23 @@ export class Search {
       const content = hitItem._snippetResult.content;
       const hierarchy = hitItem._snippetResult.hierarchy;
       const category = hitItem.hierarchy?.lvl0 ?? null;
-      const hasSubLabel = hierarchy?.lvl2 || hierarchy?.lvl3 || hierarchy?.lvl4;
+
+      const lvl1Value = hierarchy?.lvl1?.value || hitItem.hierarchy?.lvl1;
+
+      const sublabelSnippet = this.getBestSnippetForMatch(hitItem);
+
+      // If no lvl1, promote sublabel to label to avoid empty titles
+      const label = lvl1Value || sublabelSnippet || '';
+
+      const hasSubLabel = lvl1Value && (hierarchy?.lvl2 || hierarchy?.lvl3 || hierarchy?.lvl4);
 
       return {
         id: hitItem.objectID,
         type: hitItem.hierarchy.lvl0 === 'Tutorials' ? 'code' : 'doc',
         url: hitItem.url,
 
-        labelHtml: this.parseLabelToHtml(hitItem._snippetResult.hierarchy?.lvl1?.value ?? ''),
-        subLabelHtml: this.parseLabelToHtml(
-          hasSubLabel ? this.getBestSnippetForMatch(hitItem) : null,
-        ),
+        labelHtml: this.parseLabelToHtml(label),
+        subLabelHtml: this.parseLabelToHtml(hasSubLabel ? sublabelSnippet : null),
         contentHtml: content ? this.parseLabelToHtml(content.value) : null,
         package: category === 'Reference' ? extractPackageNameFromUrl(hitItem.url) : null,
 


### PR DESCRIPTION
Improves label fallback in search results by providing a fallback to the top-level category when a more specific label is missing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
https://next.angular.dev/ , search `inject function`

Also a similar case when searching for  `standalone`

<img width="792" height="702" alt="image" src="https://github.com/user-attachments/assets/26ea22dc-6869-47e3-b314-a318f1bc97bf" />

## What is the new behavior?

<img width="758" height="638" alt="image" src="https://github.com/user-attachments/assets/744aca56-2795-4a98-b582-da7142368811" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

 