### PR TITLE
Update next branch to reflect new release-train "v21.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,59 @@
+<a name="21.1.0-rc.0"></a>
+# 21.1.0-rc.0 (2026-01-08)
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [d8790972be](https://github.com/angular/angular/commit/d8790972bea4c59a208219dd36d158b5d7e4fdde) | feat | Add custom transformations for Cloudflare and Cloudinary image loaders |
+| [a6b8cb68af](https://github.com/angular/angular/commit/a6b8cb68afaded6999ee68f495512be1a9932ae4) | feat | support custom transformations in ImageKit and Imgix loaders |
+### compiler
+| Commit | Type | Description |
+| -- | -- | -- |
+| [640693da8e](https://github.com/angular/angular/commit/640693da8e667c015662246152236585d9b24e7f) | feat | Add support for multiple swich cases matching |
+| [10da2f9029](https://github.com/angular/angular/commit/10da2f9029720e7a647d57921548b39cf11f55dd) | fix | better types for a few expression AST nodes |
+| [3a56c1367f](https://github.com/angular/angular/commit/3a56c1367f336a7da0ed8dd00c299c8be8da848c) | fix | produce accurate span for typeof and void expressions |
+| [76fa180005](https://github.com/angular/angular/commit/76fa180005a30b431c133285b68e8398df2e0e52) | fix | provide location information for literal map keys |
+| [fa7cb4b87a](https://github.com/angular/angular/commit/fa7cb4b87af39f64a77ba930d891ac371a6858e9) | fix | stop ThisReceiver inheritance from ImplicitReceiver |
+| [0ad3adc7c6](https://github.com/angular/angular/commit/0ad3adc7c6d4094f1e3432a3f2e3bdc9862cb4fa) | fix | Support empty cases |
+### compiler-cli
+| Commit | Type | Description |
+| -- | -- | -- |
+| [106ba63650](https://github.com/angular/angular/commit/106ba63650340cc828e302dc4eb46dbd4fb43a3b) | fix | ensure component import diagnostics are reported within the `imports` expression |
+| [3a26244d61](https://github.com/angular/angular/commit/3a26244d61c9233e237817dc861be12dfc4bc918) | fix | fix up spelling of diagnostic |
+| [f12e160bc1](https://github.com/angular/angular/commit/f12e160bc1010daf582d5f0ab863a16e4b94ca4c) | fix | support qualified names in `typeof` type references |
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [99ad18a4ee](https://github.com/angular/angular/commit/99ad18a4ee82ecc5524106d1d403ccfa9bae2304) | feat | Add stability debugging utility |
+| [a0dfa5fa86](https://github.com/angular/angular/commit/a0dfa5fa86f40520b0e368a021b3c72009a45e8e) | feat | support rest arguments in function calls |
+| [6e18fa8bc9](https://github.com/angular/angular/commit/6e18fa8bc9d7e6801e2e89e635c2f759dc422317) | feat | support spread elements in array literals |
+| [e407280ab5](https://github.com/angular/angular/commit/e407280ab53cde5f93c3a643457c848845c6ec8b) | feat | support spread expressions in object literals |
+| [80b0fbba1f](https://github.com/angular/angular/commit/80b0fbba1f9e3a8ce9a89aa88ae3efd4a1f60271) | fix | avoid leaking view data in animations |
+| [e2a9938c51](https://github.com/angular/angular/commit/e2a9938c517b1e0429818e285ef70b69bf61181b) | fix | explicitly cast signal node value to String |
+| [30e9c62bdf](https://github.com/angular/angular/commit/30e9c62bdfb8af73c24833473bd4492869538d2d) | fix | fix memory leak with event replay |
+| [86dc1283e8](https://github.com/angular/angular/commit/86dc1283e8cad0eac1a31bc2c6cff137e6cb2542) | fix | handle cancelled traversals in fake navigation |
+| [91dc91bae4](https://github.com/angular/angular/commit/91dc91bae4a1bbefc58bef6ef739d0e02ab44d56) | fix | sanitize sensitive attributes on SVG script elements |
+### forms
+| Commit | Type | Description |
+| -- | -- | -- |
+| [2d85ae5811](https://github.com/angular/angular/commit/2d85ae58115690507d4a47ca5c6a7a642abd1c2e) | feat | add `[formField]` directive |
+| [89c37f1f7f](https://github.com/angular/angular/commit/89c37f1f7f93ec3746479c73b87b948a6e93dcaa) | fix | allow custom controls to require `dirty` input |
+| [82edf18427](https://github.com/angular/angular/commit/82edf18427b1fcf7e63cb3ac930dfa1d065a25f1) | fix | allow custom controls to require `hidden` input |
+| [1a4c3eb1d0](https://github.com/angular/angular/commit/1a4c3eb1d09a5db57a07ea5ed593cbe3e47e8125) | fix | allow custom controls to require `pending` input |
+| [e7d99f02cb](https://github.com/angular/angular/commit/e7d99f02cba503aa7a30f71d388aef353205fff7) | fix | clean up abort listener after timeout |
+| [cb09fb8308](https://github.com/angular/angular/commit/cb09fb8308a7c94cca9af6074ef523ce094d5f67) | fix | support custom controls with non signal-based models |
+| [282220d032](https://github.com/angular/angular/commit/282220d032a64d32c466bb37057c6f91df39bfb3) | fix | Support readonly arrays in signal forms |
+### router
+| Commit | Type | Description |
+| -- | -- | -- |
+| [5edceffd04](https://github.com/angular/angular/commit/5edceffd0431f5a25e111a731db521e966b91f86) | feat | add controls for route cleanup |
+| [e44839b016](https://github.com/angular/angular/commit/e44839b01640505e554fff16f24e08f282a557c0) | feat | Add standalone function to create a comptued for isActive |
+| [1c00ab42f8](https://github.com/angular/angular/commit/1c00ab42f8714f2775ed75bbf3cdf0fd44ee32c3) | feat | extend paramters of RedirectFunction to include paramMap and queryParamMap |
+| [7003e8d241](https://github.com/angular/angular/commit/7003e8d2417660f71b3a2a017aff3e650c8d9646) | feat | Publish Router's integration with platform Navigation API as experimental |
+| [bcef77d950](https://github.com/angular/angular/commit/bcef77d9507e9778c35a6186ef4a8c1d67cd5992) | fix | Fix RouterLink href not updating with `queryParamsHandling` |
+| [9e043decaf](https://github.com/angular/angular/commit/9e043decaf01dc622236814a2a2db73ec2bffe28) | fix | handle errors from view transition `updateCallbackDone` promise |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.8"></a>
 # 21.0.8 (2026-01-08)
 ### core

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "21.1.0-next.4",
+  "version": "21.2.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "baseBranchPatterns": ["main", "21.0.x"],
+  "baseBranchPatterns": ["main", "21.1.x"],
   "ignoreDeps": [
     "@types/selenium-webdriver",
     "angular-1.5",


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v21.1.0-rc.0 into the main branch so that the changelog is up to date.