### PR TITLE
feat(compiler): Exhaustive checks for switch blocks

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -1372,6 +1372,65 @@ class TestComponent {
     });
   });
 
+  describe('switch exhaustiveness', () => {
+    it('should report an error when a case is missing in a switch block', () => {
+      const messages = diagnose(
+        `
+          @switch (value) {
+            @case ('a') {}
+            @default never;
+          }
+        `,
+        `
+          export class TestComponent {
+            value: 'a' | 'b';
+          }
+        `,
+      );
+
+      expect(messages).toEqual([
+        `TestComponent.html(2, 20): Type '"b"' is not assignable to type 'never'.`,
+      ]);
+    });
+
+    it('should not report an error when all cases are handled', () => {
+      const messages = diagnose(
+        `
+          @switch (value) {
+            @case ('a') {}
+            @case ('b') {}
+            @default never;
+          }
+        `,
+        `
+          export class TestComponent {
+            value: 'a' | 'b';
+          }
+        `,
+      );
+
+      expect(messages).toEqual([]);
+    });
+
+    it('should not report an error when a default case is provided', () => {
+      const messages = diagnose(
+        `
+          @switch (value) {
+            @case ('a') {}
+            @default {}
+          }
+        `,
+        `
+          export class TestComponent {
+            value: 'a' | 'b';
+          }
+        `,
+      );
+
+      expect(messages).toEqual([]);
+    });
+  });
+
   // https://github.com/angular/angular/issues/43970
   describe('template parse failures', () => {
     afterEach(resetParseTemplateAsSourceFileForTest);

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -101,6 +101,8 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
     this.visitAllTemplateNodes(block.children);
   }
 
+  visitSwitchExhaustiveCheck(block: t.SwitchExhaustiveCheck): void {}
+
   visitForLoopBlock(block: t.ForLoopBlock): void {
     block.item.visit(this);
     this.visitAllTemplateNodes(block.contextVariables);

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -169,6 +169,7 @@ export {
   SwitchBlock as TmplAstSwitchBlock,
   SwitchBlockCase as TmplAstSwitchBlockCase,
   SwitchBlockCaseGroup as TmplAstSwitchBlockCaseGroup,
+  SwitchExhaustiveCheck as TmplAstSwitchExhaustiveCheck,
   Template as TmplAstTemplate,
   Text as TmplAstText,
   TextAttribute as TmplAstTextAttribute,

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -299,6 +299,14 @@ class _Tokenizer {
     this._beginToken(TokenType.BLOCK_OPEN_START, start);
     const startToken = this._endToken([this._getBlockName()]);
 
+    if (startToken.parts[0] === 'default never' && this._attemptCharCode(chars.$SEMICOLON)) {
+      this._beginToken(TokenType.BLOCK_OPEN_END);
+      this._endToken([]);
+      this._beginToken(TokenType.BLOCK_CLOSE);
+      this._endToken([]);
+      return;
+    }
+
     if (this._cursor.peek() === chars.$LPAREN) {
       // Advance past the opening paren.
       this._cursor.advance();

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -410,6 +410,7 @@ export class SwitchBlock extends BlockNode implements Node {
      * aren't meant to be processed in any other way.
      */
     public unknownBlocks: UnknownBlock[],
+    public exhaustiveCheck: SwitchExhaustiveCheck | null,
     sourceSpan: ParseSourceSpan,
     startSourceSpan: ParseSourceSpan,
     endSourceSpan: ParseSourceSpan | null,
@@ -454,6 +455,21 @@ export class SwitchBlockCaseGroup extends BlockNode implements Node {
 
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitSwitchBlockCaseGroup(this);
+  }
+}
+
+export class SwitchExhaustiveCheck extends BlockNode implements Node {
+  constructor(
+    sourceSpan: ParseSourceSpan,
+    startSourceSpan: ParseSourceSpan,
+    endSourceSpan: ParseSourceSpan | null,
+    nameSpan: ParseSourceSpan,
+  ) {
+    super(nameSpan, sourceSpan, startSourceSpan, endSourceSpan);
+  }
+
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitSwitchExhaustiveCheck(this);
   }
 }
 
@@ -725,6 +741,7 @@ export interface Visitor<Result = any> {
   visitSwitchBlock(block: SwitchBlock): Result;
   visitSwitchBlockCase(block: SwitchBlockCase): Result;
   visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup): Result;
+  visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck): Result;
   visitForLoopBlock(block: ForLoopBlock): Result;
   visitForLoopBlockEmpty(block: ForLoopBlockEmpty): Result;
   visitIfBlock(block: IfBlock): Result;
@@ -773,6 +790,7 @@ export class RecursiveVisitor implements Visitor<void> {
     visitAll(this, block.cases);
     visitAll(this, block.children);
   }
+  visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck): void {}
   visitForLoopBlock(block: ForLoopBlock): void {
     const blockItems = [block.item, ...block.contextVariables, ...block.children];
     block.empty && blockItems.push(block.empty);

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {CssSelector, SelectorlessMatcher, SelectorMatcher} from '../../directive_matching';
 import {
   AST,
   BindingPipe,
@@ -13,7 +14,6 @@ import {
   PropertyRead,
   SafePropertyRead,
 } from '../../expression_parser/ast';
-import {CssSelector, SelectorlessMatcher, SelectorMatcher} from '../../directive_matching';
 import {
   BoundAttribute,
   BoundEvent,
@@ -42,6 +42,7 @@ import {
   SwitchBlock,
   SwitchBlockCase,
   SwitchBlockCaseGroup,
+  SwitchExhaustiveCheck,
   Template,
   Text,
   TextAttribute,
@@ -51,6 +52,7 @@ import {
   Visitor,
 } from '../r3_ast';
 
+import {CombinedRecursiveAstVisitor} from '../../combined_visitor';
 import {
   BoundTarget,
   DirectiveMeta,
@@ -63,7 +65,6 @@ import {
 } from './t2_api';
 import {parseTemplate} from './template';
 import {createCssSelectorFromNode} from './util';
-import {CombinedRecursiveAstVisitor} from '../../combined_visitor';
 
 /**
  * Computes a difference between full list (first argument) and
@@ -397,6 +398,8 @@ class Scope implements Visitor {
     this.ingestScopedNode(block);
   }
 
+  visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck) {}
+
   visitForLoopBlock(block: ForLoopBlock) {
     this.ingestScopedNode(block);
     block.empty?.visit(this);
@@ -588,6 +591,8 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup) {
     block.children.forEach((node) => node.visit(this));
   }
+
+  visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck) {}
 
   visitForLoopBlock(block: ForLoopBlock) {
     block.item.visit(this);
@@ -945,6 +950,10 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
   override visitSwitchBlockCaseGroup(block: SwitchBlockCaseGroup) {
     block.cases.forEach((caseNode) => caseNode.visit(this));
     this.ingestScopedNode(block);
+  }
+
+  override visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck) {
+    // There are no bindings/references in the exhaustive check block.
   }
 
   override visitForLoopBlock(block: ForLoopBlock) {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1088,6 +1088,21 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should parse exhaustive default checks in a switch block', () => {
+        expect(
+          humanizeDom(
+            parser.parse(`@switch (expr) {@case ('foo') {} @default never;}`, `TestComp`),
+          ),
+        ).toEqual([
+          [html.Block, 'switch', 0],
+          [html.BlockParameter, 'expr'],
+          [html.Block, 'case', 1],
+          [html.BlockParameter, `'foo'`],
+          [html.Text, ' ', 1, [' ']],
+          [html.Block, 'default never', 1],
+        ]);
+      });
+
       it('should close void elements used right before a block', () => {
         expect(humanizeDom(parser.parse('<img>@defer {hello}', 'TestComp'))).toEqual([
           [html.Element, 'img', 0],

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -3366,6 +3366,24 @@ describe('HtmlLexer', () => {
       expect(tokenizeAndHumanizeParts('@if(){hello}')).toEqual(expected);
     });
 
+    it('should parse @default never;', () => {
+      expect(tokenizeAndHumanizeParts('@default never;')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'default never'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse @default never ;', () => {
+      expect(tokenizeAndHumanizeParts('@default never ;')).toEqual([
+        [TokenType.BLOCK_OPEN_START, 'default never'],
+        [TokenType.BLOCK_OPEN_END],
+        [TokenType.BLOCK_CLOSE],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse a block with parameters', () => {
       expect(tokenizeAndHumanizeParts('@for (item of items; track item.id) {hello}')).toEqual([
         [TokenType.BLOCK_OPEN_START, 'for'],

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -137,6 +137,7 @@ class R3AstSourceSpans implements t.Visitor<void> {
       humanizeSpan(block.endSourceSpan),
     ]);
     this.visitAll([block.groups]);
+    block.exhaustiveCheck?.visit(this);
   }
 
   visitSwitchBlockCase(block: t.SwitchBlockCase): void {
@@ -154,6 +155,14 @@ class R3AstSourceSpans implements t.Visitor<void> {
       humanizeSpan(block.startSourceSpan),
     ]);
     this.visitAll([block.cases, block.children]);
+  }
+
+  visitSwitchExhaustiveCheck(block: t.SwitchExhaustiveCheck): void {
+    this.result.push([
+      'SwitchExhaustiveCheck',
+      humanizeSpan(block.sourceSpan),
+      humanizeSpan(block.startSourceSpan),
+    ]);
   }
 
   visitForLoopBlock(block: t.ForLoopBlock): void {
@@ -876,6 +885,23 @@ describe('R3 AST source spans', () => {
         ['SwitchBlockCaseGroup', '@default {No case matched}', '@default {'],
         ['SwitchBlockCase', '@default {No case matched}', '@default {'],
         ['Text', 'No case matched'],
+      ]);
+    });
+
+    it('is correct for switch blocks with exhaustive checking', () => {
+      const html = `@switch (cond.kind) {` + `@case (x()) {X case}` + `@default never;` + `}`;
+
+      expectFromHtml(html).toEqual([
+        [
+          'SwitchBlock',
+          '@switch (cond.kind) {@case (x()) {X case}@default never;}',
+          '@switch (cond.kind) {',
+          '}',
+        ],
+        ['SwitchBlockCaseGroup', '@case (x()) {X case}', '@case (x()) {'],
+        ['SwitchBlockCase', '@case (x()) {X case}', '@case (x()) {'],
+        ['Text', 'X case'],
+        ['SwitchExhaustiveCheck', '@default never;', '@default never;'],
       ]);
     });
   });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -219,6 +219,8 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     t.visitAll(this, block.children);
   }
 
+  visitSwitchExhaustiveCheck(block: t.SwitchExhaustiveCheck) {}
+
   visitForLoopBlock(block: t.ForLoopBlock) {
     block.item.visit(this);
     t.visitAll(this, block.contextVariables);

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -10,32 +10,33 @@ import type {
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstContent,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
   TmplAstDeferredBlockPlaceholder,
   TmplAstDeferredTrigger,
+  TmplAstDirective,
   TmplAstElement,
-  TmplAstIfBlockBranch,
   TmplAstForLoopBlock,
   TmplAstForLoopBlockEmpty,
   TmplAstIcu,
   TmplAstIfBlock,
+  TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstRecursiveVisitor,
   TmplAstReference,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
+  TmplAstSwitchExhaustiveCheck,
   TmplAstTemplate,
   TmplAstText,
   TmplAstTextAttribute,
-  TmplAstVariable,
   TmplAstUnknownBlock,
-  TmplAstLetDeclaration,
-  TmplAstComponent,
-  TmplAstDirective,
+  TmplAstVariable,
 } from '@angular/compiler';
 
 /**
@@ -87,6 +88,7 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitLetDeclaration(decl: TmplAstLetDeclaration): void {}
   visitComponent(component: TmplAstComponent): void {}
   visitDirective(directive: TmplAstDirective): void {}
+  visitSwitchExhaustiveCheck(block: TmplAstSwitchExhaustiveCheck): void {}
 
   /**
    * Visits all the provided nodes in order using this Visitor's visit methods.

--- a/packages/core/test/acceptance/control_flow_switch_spec.ts
+++ b/packages/core/test/acceptance/control_flow_switch_spec.ts
@@ -372,4 +372,32 @@ describe('control flow - switch', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toBe(' default ');
   });
+
+  it('should support exhaustive switch checking', () => {
+    @Component({
+      template: `
+        Between here
+        @switch (case) {
+          @case (0) {
+            case 0
+          }
+          @case (1) {
+            case 1
+          }
+          @default never; 
+        }
+        and there.
+      `,
+    })
+    class TestComponent {
+      case: 0 | 1 = 2 as 1; // Intentionally incorrect to test exhaustive checking at runtime
+    }
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' Between here  and there. ');
+    fixture.componentInstance.case = 0;
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe(' Between here  case 0  and there. ');
+  });
 });

--- a/packages/language-service/src/semantic_tokens.ts
+++ b/packages/language-service/src/semantic_tokens.ts
@@ -7,36 +7,37 @@
  */
 
 import {
-  TmplAstElement,
-  TmplAstNode,
-  TmplAstTemplate,
-  TmplAstVisitor,
+  ParseSourceSpan,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstContent,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
   TmplAstDeferredBlockPlaceholder,
   TmplAstDeferredTrigger,
+  TmplAstDirective,
+  TmplAstElement,
   TmplAstForLoopBlock,
   TmplAstForLoopBlockEmpty,
   TmplAstIcu,
   TmplAstIfBlock,
   TmplAstIfBlockBranch,
   TmplAstLetDeclaration,
+  TmplAstNode,
   TmplAstReference,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
+  TmplAstSwitchExhaustiveCheck,
+  TmplAstTemplate,
   TmplAstText,
   TmplAstTextAttribute,
   TmplAstUnknownBlock,
   TmplAstVariable,
-  TmplAstComponent,
-  TmplAstDirective,
-  ParseSourceSpan,
+  TmplAstVisitor,
 } from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {PotentialDirective} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
@@ -179,6 +180,8 @@ class ClassificationVisitor implements TmplAstVisitor {
   visitSwitchBlockCaseGroup(block: TmplAstSwitchBlockCaseGroup) {
     this.visitAll(block.children);
   }
+
+  visitSwitchExhaustiveCheck(block: TmplAstSwitchExhaustiveCheck) {}
 
   visitForLoopBlock(block: TmplAstForLoopBlock) {
     this.visitAll(block.children);

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -43,6 +43,7 @@ import {
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
+  TmplAstSwitchExhaustiveCheck,
   TmplAstTemplate,
   TmplAstText,
   TmplAstTextAttribute,
@@ -662,6 +663,9 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     this.visitBinding(block.expression);
     this.visitAll(block.groups);
     this.visitAll(block.unknownBlocks);
+    if (block.exhaustiveCheck) {
+      this.visit(block.exhaustiveCheck);
+    }
   }
 
   visitSwitchBlockCase(block: TmplAstSwitchBlockCase) {
@@ -672,6 +676,8 @@ class TemplateTargetVisitor implements TmplAstVisitor {
     this.visitAll(block.cases);
     this.visitAll(block.children);
   }
+
+  visitSwitchExhaustiveCheck(block: TmplAstSwitchExhaustiveCheck) {}
 
   visitForLoopBlock(block: TmplAstForLoopBlock) {
     this.visit(block.item);

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -39,6 +39,7 @@ import {
   SafePropertyRead,
   TmplAstSwitchBlock as SwitchBlock,
   TmplAstSwitchBlockCase as SwitchBlockCase,
+  TmplAstSwitchExhaustiveCheck as SwitchExhaustiveCheck,
   TmplAstTemplate as Template,
   TmplAstTextAttribute as TextAttribute,
   TmplAstTimerDeferredTrigger as TimerDeferredTrigger,
@@ -1058,6 +1059,14 @@ describe('blocks', () => {
     const {node} = context as SingleNodeTarget;
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(SwitchBlockCase);
+  });
+
+  it('should visit exhautive default block on switch', () => {
+    const {nodes, position} = parse(`@switch (foo) { @d¦efault never; }`);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isTemplateNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(SwitchExhaustiveCheck);
   });
 
   it('should visit if block main branch', () => {


### PR DESCRIPTION
`@switch` blocks can now enable exhaustive typechecking by adding `@default never;` at the end of a `@switch` block.

fixes #52107

ex: 

```
foo : 1 | 2 = 1;

// --- 

@switch(foo) {
   @case(1) {}
   @default never; // throws 
}
```