### PR TITLE
feat(core): do not reset test module configuration when calling `TestBed.configureTestingModule`

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -2449,6 +2449,16 @@ describe('TestBed', () => {
       expect(fixture.nativeElement.tagName).toBe('MY-TEST-COMP');
     });
 
+    it('should not override the inferTagName option when calling configureTestingModule multiple times', () => {
+      @Component({selector: 'my-test-comp', template: ''})
+      class TestComp {}
+
+      TestBed.configureTestingModule({inferTagName: true});
+      TestBed.configureTestingModule({providers: []});
+      const fixture = TestBed.createComponent(TestComp);
+      expect(fixture.nativeElement.tagName).toBe('MY-TEST-COMP');
+    });
+
     it('should give precedence to inferTagName from createComponent over configureTestingModule', () => {
       @Component({selector: 'my-test-comp', template: ''})
       class TestComp {}
@@ -2523,6 +2533,22 @@ describe('TestBed module teardown', () => {
     expect(TestBedImpl.INSTANCE.shouldTearDownTestingModule()).toBe(false);
     TestBed.resetTestingModule();
     expect(TestBedImpl.INSTANCE.shouldTearDownTestingModule()).toBe(true);
+  });
+
+  it('should not reset test module configuration when TestBed.configureTestingModule is called multiple times', () => {
+    TestBed.configureTestingModule({
+      animationsEnabled: true,
+      deferBlockBehavior: DeferBlockBehavior.Manual,
+      errorOnUnknownElements: true,
+      errorOnUnknownProperties: true,
+      teardown: {destroyAfterEach: false},
+    });
+    TestBed.configureTestingModule({providers: [SimpleService]});
+    expect(TestBedImpl.INSTANCE.getAnimationsEnabled()).toBe(true);
+    expect(TestBedImpl.INSTANCE.getDeferBlockBehavior()).toBe(DeferBlockBehavior.Manual);
+    expect(TestBedImpl.INSTANCE.shouldTearDownTestingModule()).toBe(false);
+    expect(TestBedImpl.INSTANCE.shouldThrowErrorOnUnknownElements()).toBe(true);
+    expect(TestBedImpl.INSTANCE.shouldThrowErrorOnUnknownProperties()).toBe(true);
   });
 
   it('should destroy test module providers when test module teardown is enabled', () => {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -567,14 +567,28 @@ export class TestBedImpl implements TestBed {
     // description for additional info.
     this.checkGlobalCompilationFinished();
 
-    // Always re-assign the options, even if they're undefined.
-    // This ensures that we don't carry them between tests.
-    this._instanceTeardownOptions = moduleDef.teardown;
-    this._instanceErrorOnUnknownElementsOption = moduleDef.errorOnUnknownElements;
-    this._instanceErrorOnUnknownPropertiesOption = moduleDef.errorOnUnknownProperties;
-    this._instanceInferTagName = moduleDef.inferTagName;
-    this._instanceDeferBlockBehavior = moduleDef.deferBlockBehavior ?? DEFER_BLOCK_DEFAULT_BEHAVIOR;
-    this._instanceAnimationsEnabled = moduleDef.animationsEnabled ?? ANIMATIONS_ENABLED_DEFAULT;
+    // Do not re-assign the options if they're already defined.
+    // The cleanup hook will call `TestBed.resetTestingModule` to reset them
+    // and make sure we don't carry them between tests.
+    if (moduleDef.teardown !== undefined) {
+      this._instanceTeardownOptions = moduleDef.teardown;
+    }
+    if (moduleDef.errorOnUnknownElements !== undefined) {
+      this._instanceErrorOnUnknownElementsOption = moduleDef.errorOnUnknownElements;
+    }
+    if (moduleDef.errorOnUnknownProperties !== undefined) {
+      this._instanceErrorOnUnknownPropertiesOption = moduleDef.errorOnUnknownProperties;
+    }
+    if (moduleDef.inferTagName !== undefined) {
+      this._instanceInferTagName = moduleDef.inferTagName;
+    }
+    if (moduleDef.deferBlockBehavior !== undefined) {
+      this._instanceDeferBlockBehavior = moduleDef.deferBlockBehavior;
+    }
+    if (moduleDef.animationsEnabled !== undefined) {
+      this._instanceAnimationsEnabled = moduleDef.animationsEnabled;
+    }
+
     // Store the current value of the strict mode option,
     // so we can restore it later
     this._previousErrorOnUnknownElementsOption = getUnknownElementStrictMode();


### PR DESCRIPTION
This allows users to call `TestBed.configureTestingModule` multiple times to configure different options of the test module.
This fixes a common issue where users might call `TestBed.configureTestingModule({providers: [...]})` and mistakenly override options such as `inferTagName` that were set up in a previous call to `TestBed.configureTestingModule`.

Also, since Angular CLI's Vitest configuration is using a virtual module to call `TestBed.initTestEnvironment`, users can't directly control the options there, therefore, they will have to fallback to `TestBed.configureTestingModule`.

BREAKING CHANGE: `TestBed.configureTestingModule` will not reset test module options that were set by previous calls.
To reproduce the previous behavior, user will have to call `TestBed.resetTestingModule` and reconfigure everything,
or explictely revert the options previously set to the desired value.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

This PR allows users to call `TestBed.configureTestingModule` multiple times to configure different options of the test module.
This fixes a common issue where users might call `TestBed.configureTestingModule({providers: [...]})` and mistakenly override options such as `inferTagName` that were set up in a previous call to `TestBed.configureTestingModule`.
    
Also, since Angular CLI's Vitest configuration is using a virtual module to call `TestBed.initTestEnvironment`, users can't directly control the options there, therefore, they will have to fallback to `TestBed.configureTestingModule`.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

`TestBed.configureTestingModule` will not reset test module options that were set by previous calls, in the rare occurrence where `TestBed.configureTestingModule` is called multiple times and setting test module options such as `inferTagName` or `teardown` etc...
To reproduce the previous behavior, user will have to call `TestBed.resetTestingModule` and reconfigure everything,
or explicitly revert the options previously set to the desired value.

## Other information

The current behavior was introduced here https://github.com/angular/angular/pull/42566
Using Angular CLI's Vitest integration, it is safe to assume that the cleanup hooks are always configured properly.