### PR TITLE
ci: add pnpm and typescript exclusions to a Renovate package rule.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,7 @@
     },
     {
       "matchManagers": ["bazel", "bazel-module", "bazelisk", "npm"],
+      "matchDepNames": ["!pnpm", "!typescript", "*"],
       "postUpgradeTasks": {
         "commands": [
           "git restore .npmrc",


### PR DESCRIPTION
This will be handled in dev-infra preset, see: https://github.com/angular/dev-infra/pull/3340
