### PR TITLE
feat(compiler): support `AstVisitor.visitEmptyExpr()`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -129,13 +129,6 @@ class AstTranslator implements AstVisitor {
       ast = ast.ast;
     }
 
-    // The `EmptyExpr` doesn't have a dedicated method on `AstVisitor`, so it's special cased here.
-    if (ast instanceof EmptyExpr) {
-      const res = ts.factory.createIdentifier('undefined');
-      addParseSpanInfo(res, ast.sourceSpan);
-      return res;
-    }
-
     // First attempt to let any custom resolution logic provide a translation for the given node.
     const resolved = this.maybeResolve(ast);
     if (resolved !== null) {
@@ -490,6 +483,12 @@ class AstTranslator implements AstVisitor {
   visitSpreadElement(ast: SpreadElement) {
     const expression = wrapForDiagnostics(this.translate(ast.expression));
     const node = ts.factory.createSpreadElement(expression);
+    addParseSpanInfo(node, ast.sourceSpan);
+    return node;
+  }
+
+  visitEmptyExpr(ast: EmptyExpr, context: any) {
+    const node = ts.factory.createIdentifier('undefined');
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
   }

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -47,7 +47,7 @@ export abstract class ASTWithName extends AST {
 
 export class EmptyExpr extends AST {
   override visit(visitor: AstVisitor, context: any = null) {
-    // do nothing
+    return visitor.visitEmptyExpr?.(this, context);
   }
 }
 
@@ -651,6 +651,7 @@ export interface AstVisitor {
   visitRegularExpressionLiteral(ast: RegularExpressionLiteral, context: any): any;
   visitSpreadElement(ast: SpreadElement, context: any): any;
   visitASTWithSource?(ast: ASTWithSource, context: any): any;
+  visitEmptyExpr?(ast: EmptyExpr, context: any): any;
   /**
    * This function is optionally defined to allow classes that implement this
    * interface to selectively decide if the specified `ast` should be visited.
@@ -756,6 +757,7 @@ export class RecursiveAstVisitor implements AstVisitor {
   visitSpreadElement(ast: SpreadElement, context: any) {
     this.visit(ast.expression, context);
   }
+  visitEmptyExpr(ast: EmptyExpr, context: any): any {}
   // This is not part of the AstVisitor interface, just a helper method
   visitAll(asts: AST[], context: any): any {
     for (const ast of asts) {


### PR DESCRIPTION
Add support for `AstVisitor.visitEmptyExpr()`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 66436

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Didn't add test for it because there seems no existing tests for `AstVisitor`, refactor `AstTranslator` to use it, should be good enough?
