### PR TITLE
fix(compiler-cli): handle FormField in signal forms type checking

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -245,6 +245,7 @@ export interface OutOfBandDiagnosticRecorder {
   formFieldUnsupportedBinding(
     id: TypeCheckId,
     node: TmplAstBoundAttribute | TmplAstTextAttribute,
+    bindingName: string,
   ): void;
 }
 
@@ -864,6 +865,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   formFieldUnsupportedBinding(
     id: TypeCheckId,
     node: TmplAstBoundAttribute | TmplAstTextAttribute,
+    bindingName: string,
   ): void {
     let message: string;
 
@@ -879,9 +881,9 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
         name = node.name;
       }
 
-      message = `Binding to '${name}' is not allowed on nodes using the '[field]' directive`;
+      message = `Binding to '${name}' is not allowed on nodes using the '[${bindingName}]' directive`;
     } else {
-      message = `Setting the '${node.name}' attribute is not allowed on nodes using the '[field]' directive`;
+      message = `Setting the '${node.name}' attribute is not allowed on nodes using the '[${bindingName}]' directive`;
     }
 
     this._diagnostics.push(

--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -14,150 +14,155 @@ import {NgtscTestEnvironment} from './env';
 const testFiles = loadStandardTestFiles({forms: true});
 
 runInEachFileSystem(() => {
-  describe('signal forms', () => {
-    let env!: NgtscTestEnvironment;
+  ['Field', 'FormField'].forEach((directiveName) => {
+    const bindingName = directiveName === 'Field' ? 'field' : 'formField';
 
-    beforeEach(() => {
-      env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({
-        // This is the default in Angular apps so we enable it to ensure consistent behavior.
-        strict: true,
-        strictTemplates: true,
+    describe(`signal forms with ${directiveName}`, () => {
+      let env!: NgtscTestEnvironment;
+
+      beforeEach(() => {
+        env = NgtscTestEnvironment.setup(testFiles);
+        env.tsconfig({
+          // This is the default in Angular apps so we enable it to ensure consistent behavior.
+          strict: true,
+          strictTemplates: true,
+        });
       });
-    });
 
-    function extractMessage(diag: ts.Diagnostic) {
-      return typeof diag.messageText === 'string' ? diag.messageText : diag.messageText.messageText;
-    }
+      function extractMessage(diag: ts.Diagnostic) {
+        return typeof diag.messageText === 'string'
+          ? diag.messageText
+          : diag.messageText.messageText;
+      }
 
-    it('should check that the field is present', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should check that the field is present', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component} from '@angular/core';
-          import {Field} from '@angular/forms/signals';
+          import {${directiveName}} from '@angular/forms/signals';
 
           @Component({
-            template: '<input [field]="null"/>',
-            imports: [Field]
+            template: '<input [${bindingName}]="null"/>',
+            imports: [${directiveName}]
           })
           export class Comp {}
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Type 'null' is not assignable to type 'FieldTree<any, string | number>'.`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Type 'null' is not assignable to type 'FieldTree<any, string | number>'.`,
+        );
+      });
 
-    it('should check that the field type is correct', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should check that the field type is correct', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component} from '@angular/core';
-          import {Field} from '@angular/forms/signals';
+          import {${directiveName}} from '@angular/forms/signals';
 
           @Component({
-            template: '<input field="staticString"/>',
-            imports: [Field]
+            template: '<input ${bindingName}="staticString"/>',
+            imports: [${directiveName}]
           })
           export class Comp {}
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Type 'string' is not assignable to type 'FieldTree<any, string | number>'.`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Type 'string' is not assignable to type 'FieldTree<any, string | number>'.`,
+        );
+      });
 
-    it('should treat Field directives not coming from the forms module as regular directives', () => {
-      env.write(
-        'field.ts',
-        `
+      it(`should treat ${directiveName} directives not coming from the forms module as regular directives`, () => {
+        env.write(
+          'field.ts',
+          `
           import {Directive, input} from '@angular/core';
 
-          @Directive({selector: '[field]'})
-          export class Field {
-            readonly field = input.required<string>();
+          @Directive({selector: '[${bindingName}]'})
+          export class ${directiveName} {
+            readonly ${bindingName} = input.required<string>();
           }
         `,
-      );
+        );
 
-      env.write(
-        'test.ts',
-        `
+        env.write(
+          'test.ts',
+          `
           import {Component} from '@angular/core';
-          import {Field} from './field';
+          import {${directiveName}} from './field';
 
           @Component({
-            template: '<input [field]="null"/>',
-            imports: [Field]
+            template: '<input [${bindingName}]="null"/>',
+            imports: [${directiveName}]
           })
           export class Comp {}
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(`Type 'null' is not assignable to type 'string'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(`Type 'null' is not assignable to type 'string'.`);
+      });
 
-    it('should infer an input without a `type` as a string field', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer an input without a `type` as a string field', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input [field]="f"/>',
-            imports: [Field]
+            template: '<input [${bindingName}]="f"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal(0));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(`Type 'number' is not assignable to type 'string'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(`Type 'number' is not assignable to type 'string'.`);
+      });
 
-    it('should infer the type of the field from the input `type`', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer the type of the field from the input `type`', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input type="date" [field]="f"/>',
-            imports: [Field]
+            template: '<input type="date" [${bindingName}]="f"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal({}));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Type '{}' is not assignable to type 'string | number | Date | null'.`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Type '{}' is not assignable to type 'string | number | Date | null'.`,
+        );
+      });
 
-    it('should infer the type of a custom value control', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer the type of a custom value control', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormValueControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormValueControl} from '@angular/forms/signals';
 
           interface User {
             firstName: string;
@@ -170,28 +175,28 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<user-control [field]="f"/>',
-            imports: [Field, UserControl]
+            template: '<user-control [${bindingName}]="f"/>',
+            imports: [${directiveName}, UserControl]
           })
           export class Comp {
             f = form(signal({name: 'Bilbo'}));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Type '{ name: string; }' is missing the following properties from type 'User': firstName, lastName`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Type '{ name: string; }' is missing the following properties from type 'User': firstName, lastName`,
+        );
+      });
 
-    it('should infer the type of a custom checkbox control', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer the type of a custom checkbox control', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormCheckboxControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormCheckboxControl} from '@angular/forms/signals';
 
           @Component({selector: 'my-checkbox', template: ''})
           export class MyCheckbox implements FormCheckboxControl {
@@ -199,26 +204,26 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<my-checkbox [field]="f"/>',
-            imports: [Field, MyCheckbox]
+            template: '<my-checkbox [${bindingName}]="f"/>',
+            imports: [${directiveName}, MyCheckbox]
           })
           export class Comp {
             f = form(signal(''));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(`Type 'string' is not assignable to type 'boolean'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(`Type 'string' is not assignable to type 'boolean'.`);
+      });
 
-    it('should infer the type of a generic custom control', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer the type of a generic custom control', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormValueControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormValueControl} from '@angular/forms/signals';
 
           @Component({selector: 'custom-control', template: ''})
           export class CustomControl<T> implements FormValueControl<T> {
@@ -227,31 +232,31 @@ runInEachFileSystem(() => {
 
           @Component({
             template: \`
-              <custom-control [field]="f" #comp/>
+              <custom-control [${bindingName}]="f" #comp/>
               {{expectsString(comp.value())}}
             \`,
-            imports: [Field, CustomControl]
+            imports: [${directiveName}, CustomControl]
           })
           export class Comp {
             f = form(signal(0));
             expectsString(value: string) {}
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Argument of type 'number' is not assignable to parameter of type 'string'.`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Argument of type 'number' is not assignable to parameter of type 'string'.`,
+        );
+      });
 
-    it('should not report a custom control that conforms to `FormValueControl`', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should not report a custom control that conforms to `FormValueControl`', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormValueControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormValueControl} from '@angular/forms/signals';
 
           @Component({ selector: 'string-control', template: '' })
           class StringControl implements FormValueControl<string> {
@@ -260,74 +265,74 @@ runInEachFileSystem(() => {
 
           @Component({
             selector: 'app-root',
-            imports: [Field, StringControl],
-            template: '<string-control [field]="field" />',
+            imports: [${directiveName}, StringControl],
+            template: '<string-control [${bindingName}]="field" />',
           })
           class App {
             field = form(signal(''));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should report unsupported property bindings on a field', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should report unsupported property bindings on a field', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input type="number" [field]="f" [max]="10"/>',
-            imports: [Field]
+            template: '<input type="number" [${bindingName}]="f" [max]="10"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal(0));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Binding to '[max]' is not allowed on nodes using the '[field]' directive`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Binding to '[max]' is not allowed on nodes using the '[${bindingName}]' directive`,
+        );
+      });
 
-    it('should report unsupported attribute bindings on a field', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should report unsupported attribute bindings on a field', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input [field]="f" [attr.maxlength]="maxLength"/>',
-            imports: [Field]
+            template: '<input [${bindingName}]="f" [attr.maxlength]="maxLength"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal(''));
             maxLength = 10;
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Binding to '[attr.maxlength]' is not allowed on nodes using the '[field]' directive`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Binding to '[attr.maxlength]' is not allowed on nodes using the '[${bindingName}]' directive`,
+        );
+      });
 
-    it('should report unsupported property bindings on a field with a custom control', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should report unsupported property bindings on a field with a custom control', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model, input} from '@angular/core';
-          import {Field, form, FormValueControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormValueControl} from '@angular/forms/signals';
 
           @Component({selector: 'custom-control', template: ''})
           export class CustomControl implements FormValueControl<number> {
@@ -336,106 +341,106 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<custom-control [field]="f" [max]="2"/>',
-            imports: [Field, CustomControl]
+            template: '<custom-control [${bindingName}]="f" [max]="2"/>',
+            imports: [${directiveName}, CustomControl]
           })
           export class Comp {
             f = form(signal(0));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Binding to '[max]' is not allowed on nodes using the '[field]' directive`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Binding to '[max]' is not allowed on nodes using the '[${bindingName}]' directive`,
+        );
+      });
 
-    it('should allow binding to `value` on radio controls', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should allow binding to `value` on radio controls', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
             template: \`
               <form>
-                <input type="radio" value="a" [field]="f">
-                <input type="radio" value="b" [field]="f">
-                <input type="radio" value="c" [field]="f">
+                <input type="radio" value="a" [${bindingName}]="f">
+                <input type="radio" value="b" [${bindingName}]="f">
+                <input type="radio" value="c" [${bindingName}]="f">
               </form>
             \`,
-            imports: [Field]
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal('a'), {name: 'test'});
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should check that the radio button value is a string', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should check that the radio button value is a string', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
             template: \`
               <form>
-                <input type="radio" [value]="num" [field]="f">
+                <input type="radio" [value]="num" [${bindingName}]="f">
               </form>
             \`,
-            imports: [Field]
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal('a'), {name: 'test'});
             num = 1;
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(`Type 'number' is not assignable to type 'string'.`);
+      });
 
-    it('should report unsupported static attributes of a field', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should report unsupported static attributes of a field', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input value="Hello" [field]="f"/>',
-            imports: [Field]
+            template: '<input value="Hello" [${bindingName}]="f"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             f = form(signal(''));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Setting the 'value' attribute is not allowed on nodes using the '[field]' directive`,
-      );
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Setting the 'value' attribute is not allowed on nodes using the '[${bindingName}]' directive`,
+        );
+      });
 
-    it('should check that a custom value control conforms to FormValueControl', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should check that a custom value control conforms to FormValueControl', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model, input} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({selector: 'user-control', template: ''})
           export class UserControl {
@@ -444,26 +449,26 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<user-control [field]="f"/>',
-            imports: [Field, UserControl]
+            template: '<user-control [${bindingName}]="f"/>',
+            imports: [${directiveName}, UserControl]
           })
           export class Comp {
             f = form(signal(1));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+      });
 
-    it('should check that a custom checkbox control conforms to FormCheckboxControl', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should check that a custom checkbox control conforms to FormCheckboxControl', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model, input} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({selector: 'user-control', template: ''})
           export class UserControl {
@@ -472,26 +477,26 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<user-control [field]="f"/>',
-            imports: [Field, UserControl]
+            template: '<user-control [${bindingName}]="f"/>',
+            imports: [${directiveName}, UserControl]
           })
           export class Comp {
             f = form(signal(true));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(`Type 'boolean' is not assignable to type 'number'.`);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(`Type 'boolean' is not assignable to type 'number'.`);
+      });
 
-    it('should not report `value` as a missing required input when the `Field` directive is present', () => {
-      env.write(
-        'test.ts',
-        `
+      it(`should not report \`value\` as a missing required input when the \`${directiveName}\` directive is present`, () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormValueControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormValueControl} from '@angular/forms/signals';
 
           @Component({selector: 'custom-control', template: ''})
           export class CustomControl implements FormValueControl<string> {
@@ -499,25 +504,25 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<custom-control [field]="f"/>',
-            imports: [Field, CustomControl]
+            template: '<custom-control [${bindingName}]="f"/>',
+            imports: [${directiveName}, CustomControl]
           })
           export class Comp {
             f = form(signal(''));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should not report `checked` as a missing required input when the `Field` directive is present', () => {
-      env.write(
-        'test.ts',
-        `
+      it(`should not report \`checked\` as a missing required input when the \`${directiveName}\` directive is present`, () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal, model} from '@angular/core';
-          import {Field, form, FormCheckboxControl} from '@angular/forms/signals';
+          import {${directiveName}, form, FormCheckboxControl} from '@angular/forms/signals';
 
           @Component({selector: 'custom-control', template: ''})
           export class CustomControl implements FormCheckboxControl {
@@ -525,26 +530,26 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<custom-control [field]="f"/>',
-            imports: [Field, CustomControl]
+            template: '<custom-control [${bindingName}]="f"/>',
+            imports: [${directiveName}, CustomControl]
           })
           export class Comp {
             f = form(signal(false));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should not check field on native control that has a ControlValueAccessor directive', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should not check field on native control that has a ControlValueAccessor directive', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, Directive, signal} from '@angular/core';
           import {ControlValueAccessor} from '@angular/forms';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Directive({selector: '[customCva]'})
           export class CustomCva implements ControlValueAccessor {
@@ -554,26 +559,26 @@ runInEachFileSystem(() => {
           }
 
           @Component({
-            template: '<input customCva [field]="f"/>',
-            imports: [Field, CustomCva]
+            template: '<input customCva [${bindingName}]="f"/>',
+            imports: [${directiveName}, CustomCva]
           })
           export class Comp {
             f = form(signal(0));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should not check field on native control that has a directive inheriting from a ControlValueAccessor', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should not check field on native control that has a directive inheriting from a ControlValueAccessor', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, Directive, signal} from '@angular/core';
           import {ControlValueAccessor} from '@angular/forms';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Directive()
           export class Grandparent implements ControlValueAccessor {
@@ -589,42 +594,43 @@ runInEachFileSystem(() => {
           export class CustomCva extends Parent {}
 
           @Component({
-            template: '<input customCva [field]="f"/>',
-            imports: [Field, CustomCva]
+            template: '<input customCva [${bindingName}]="f"/>',
+            imports: [${directiveName}, CustomCva]
           })
           export class Comp {
             f = form(signal(0));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(0);
-    });
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
 
-    it('should infer an input with a dynamic `type` as being any of the other types', () => {
-      env.write(
-        'test.ts',
-        `
+      it('should infer an input with a dynamic `type` as being any of the other types', () => {
+        env.write(
+          'test.ts',
+          `
           import {Component, signal} from '@angular/core';
-          import {Field, form} from '@angular/forms/signals';
+          import {${directiveName}, form} from '@angular/forms/signals';
 
           @Component({
-            template: '<input [type]="type" [field]="f"/>',
-            imports: [Field]
+            template: '<input [type]="type" [${bindingName}]="f"/>',
+            imports: [${directiveName}]
           })
           export class Comp {
             type = '';
             f = form(signal({test: true}));
           }
         `,
-      );
+        );
 
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(extractMessage(diags[0])).toBe(
-        `Type '{ test: boolean; }' is not assignable to type 'string | number | boolean | Date | null'.`,
-      );
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(extractMessage(diags[0])).toBe(
+          `Type '{ test: boolean; }' is not assignable to type 'string | number | boolean | Date | null'.`,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `isFormControl` check previously only looked for directives with a `field` input. This caused the `FormField` directive (which uses the `formField` selector) to be skipped during type checking for custom form controls, leading to false positive `NG8008` errors (missing required inputs) because the synthetic inputs were not generated.

## What is the new behavior?

This commit fixes `isFormControl` to also recognize the `formField` input. It also updates the error reporting logic for unsupported bindings to dynamically display the correct directive name (`[field]` or `[formField]`) in error messages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
