### PR TITLE
build: update license for vscode extension

### DIFF
--- a/vscode-ng-language-service/client/src/commands.ts
+++ b/vscode-ng-language-service/client/src/commands.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as vscode from 'vscode';

--- a/vscode-ng-language-service/client/src/embedded_support.ts
+++ b/vscode-ng-language-service/client/src/embedded_support.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import * as ts from 'typescript';
 import * as vscode from 'vscode';

--- a/vscode-ng-language-service/client/src/extension.ts
+++ b/vscode-ng-language-service/client/src/extension.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as vscode from 'vscode';

--- a/vscode-ng-language-service/client/src/providers.ts
+++ b/vscode-ng-language-service/client/src/providers.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as vscode from 'vscode';

--- a/vscode-ng-language-service/client/src/tests/embedded_support_spec.ts
+++ b/vscode-ng-language-service/client/src/tests/embedded_support_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import * as vscode from 'vscode';
 import {DocumentUri, TextDocument} from 'vscode-languageserver-textdocument';

--- a/vscode-ng-language-service/common/initialize.ts
+++ b/vscode-ng-language-service/common/initialize.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export interface ServerOptions {

--- a/vscode-ng-language-service/common/notifications.ts
+++ b/vscode-ng-language-service/common/notifications.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {NotificationType, NotificationType0} from 'vscode-jsonrpc';

--- a/vscode-ng-language-service/common/requests.ts
+++ b/vscode-ng-language-service/common/requests.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as lsp from 'vscode-languageserver-protocol';

--- a/vscode-ng-language-service/common/resolver.ts
+++ b/vscode-ng-language-service/common/resolver.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/vscode-ng-language-service/common/tests/resolver_spec.ts
+++ b/vscode-ng-language-service/common/tests/resolver_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {Version} from '../resolver';

--- a/vscode-ng-language-service/integration/e2e/completion_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/completion_spec.ts
@@ -1,3 +1,11 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import * as vscode from 'vscode';
 
 import {activate, COMPLETION_COMMAND, FOO_TEMPLATE_URI} from './helper';

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {fileURLToPath, pathToFileURL} from 'node:url';

--- a/vscode-ng-language-service/integration/lsp/test_utils.ts
+++ b/vscode-ng-language-service/integration/lsp/test_utils.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {fork} from 'child_process';

--- a/vscode-ng-language-service/integration/test_constants.ts
+++ b/vscode-ng-language-service/integration/test_constants.ts
@@ -1,3 +1,11 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import {mkdtempSync} from 'node:fs';
 import {join, resolve} from 'node:path';
 import {pathToFileURL} from 'node:url';

--- a/vscode-ng-language-service/server/src/banner.ts
+++ b/vscode-ng-language-service/server/src/banner.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {parseCommandLine} from './cmdline_utils';

--- a/vscode-ng-language-service/server/src/cmdline_utils.ts
+++ b/vscode-ng-language-service/server/src/cmdline_utils.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function findArgument(argv: string[], argName: string): string | undefined {

--- a/vscode-ng-language-service/server/src/completion.ts
+++ b/vscode-ng-language-service/server/src/completion.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/diagnostic.ts
+++ b/vscode-ng-language-service/server/src/diagnostic.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/embedded_support.ts
+++ b/vscode-ng-language-service/server/src/embedded_support.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/vscode-ng-language-service/server/src/logger.ts
+++ b/vscode-ng-language-service/server/src/logger.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/vscode-ng-language-service/server/src/server.ts
+++ b/vscode-ng-language-service/server/src/server.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {version as tsServerVersion} from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/server_host.ts
+++ b/vscode-ng-language-service/server/src/server_host.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/vscode-ng-language-service/server/src/tests/cmdline_utils_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/cmdline_utils_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {parseCommandLine} from '../cmdline_utils';

--- a/vscode-ng-language-service/server/src/tests/embedded_support_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/embedded_support_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/vscode-ng-language-service/server/src/tests/text_render_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/text_render_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as tss from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/tests/utils_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/utils_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {filePathToUri, MruTracker, uriToFilePath} from '../utils';

--- a/vscode-ng-language-service/server/src/tests/version_provider_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/version_provider_spec.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {isAbsolute, resolve} from 'path';

--- a/vscode-ng-language-service/server/src/text_render.ts
+++ b/vscode-ng-language-service/server/src/text_render.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as tss from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/utils.ts
+++ b/vscode-ng-language-service/server/src/utils.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript/lib/tsserverlibrary';

--- a/vscode-ng-language-service/server/src/version_provider.ts
+++ b/vscode-ng-language-service/server/src/version_provider.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/vscode-ng-language-service/syntaxes/src/build.ts
+++ b/vscode-ng-language-service/syntaxes/src/build.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/vscode-ng-language-service/syntaxes/src/expression.ts
+++ b/vscode-ng-language-service/syntaxes/src/expression.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/host-object-literal.ts
+++ b/vscode-ng-language-service/syntaxes/src/host-object-literal.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/inline-styles.ts
+++ b/vscode-ng-language-service/syntaxes/src/inline-styles.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/inline-template.ts
+++ b/vscode-ng-language-service/syntaxes/src/inline-template.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/template-blocks.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-blocks.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/template-let-declaration.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-let-declaration.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/template-tag.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-tag.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/template.ts
+++ b/vscode-ng-language-service/syntaxes/src/template.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {GrammarDefinition} from './types';

--- a/vscode-ng-language-service/syntaxes/src/types.ts
+++ b/vscode-ng-language-service/syntaxes/src/types.ts
@@ -1,9 +1,9 @@
-/**
+/*!
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export interface GrammarDefinition {


### PR DESCRIPTION
The vscode extension still has the old license headers pointing to AIO.
