### PR TITLE
refactor(core): remove unused generics & improve tree-shaking

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -391,7 +391,10 @@ function notFoundValueOrThrow<T>(
   if (flags & InternalInjectFlags.Optional || notFoundValue !== undefined) {
     return notFoundValue;
   } else {
-    throwProviderNotFoundError(token, 'NodeInjector');
+    throwProviderNotFoundError(
+      token,
+      typeof ngDevMode !== 'undefined' && ngDevMode ? 'NodeInjector' : '',
+    );
   }
 }
 

--- a/packages/core/src/render3/instructions/control.ts
+++ b/packages/core/src/render3/instructions/control.ts
@@ -125,7 +125,7 @@ export function ɵcontrolUpdate(): void {
  * @param lView The `LView` that contains the control.
  * @param tNode The `TNode` of the control.
  */
-function updateControl<T>(lView: LView, tNode: TNode): void {
+function updateControl(lView: LView, tNode: TNode): void {
   const fieldDirective = getFieldDirective(tNode, lView);
   if (fieldDirective) {
     updateControlClasses(lView, tNode, fieldDirective);
@@ -148,7 +148,7 @@ function updateControl<T>(lView: LView, tNode: TNode): void {
   nextBindingIndex();
 }
 
-function initializeControlFirstCreatePass<T>(tView: TView, tNode: TNode, lView: LView): void {
+function initializeControlFirstCreatePass(tView: TView, tNode: TNode, lView: LView): void {
   ngDevMode && assertFirstCreatePass(tView);
 
   const directiveIndices = tNode.inputs?.['formField'];
@@ -552,7 +552,6 @@ function updateControlClasses(lView: LView, tNode: TNode, control: ɵFormFieldDi
   if (control.classes) {
     const bindings = getControlBindings(lView);
     bindings.classes ??= {};
-    const state = control.state();
     const renderer = lView[RENDERER];
     const element = getNativeByTNode(tNode, lView) as HTMLElement;
 


### PR DESCRIPTION
Removes unused generic parameters from functions where `<T>` was not used. Improves tree-shaking by passing the injector type to 'NodeInjector' only in dev mode.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
