### PR TITLE
refactor(core): make special element injector providers visible in getNodeInjectorProviders

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -13,6 +13,7 @@ import {DECLARATION_COMPONENT_VIEW, LView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {getComponentLViewByIndex} from '../render3/util/view_utils';
 import {ViewRef} from '../render3/view_ref';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * Base class that provides change detection functionality.
@@ -112,6 +113,10 @@ export abstract class ChangeDetectorRef {
    */
   static __NG_ELEMENT_ID__: (flags: InternalInjectFlags) => ChangeDetectorRef =
     injectChangeDetectorRef;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(ChangeDetectorRef);
 }
 
 /** Returns a ChangeDetectorRef (a.k.a. a ViewRef) */

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -15,6 +15,7 @@ import {InjectOptions} from './interface/injector';
 import {Provider, StaticProvider} from './interface/provider';
 import {NullInjector} from './null_injector';
 import {ProviderToken} from './provider_token';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * Concrete injectors implement this interface. Injectors are configured
@@ -129,6 +130,11 @@ export abstract class Injector {
    * @nocollapse
    */
   static __NG_ELEMENT_ID__ = InjectorMarkers.Injector;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  // tslint:disable-next-line: no-toplevel-property-access
+  registerSpecialProvider(Injector);
 }
 
 /**

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationRef} from '../application/application_ref';
+import type {ApplicationRef} from '../application/application_ref';
 import {DehydratedDeferBlock} from '../defer/interfaces';
 import {DehydratedBlockRegistry} from '../defer/registry';
 import {

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -11,6 +11,7 @@ import {isDestroyed} from '../render3/interfaces/type_checks';
 import {LView} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {removeLViewOnDestroy, storeLViewOnDestroy} from '../render3/util/view_utils';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * `DestroyRef` lets you set callbacks to run for any cleanup or destruction behavior.
@@ -68,6 +69,10 @@ export abstract class DestroyRef {
    * @nocollapse
    */
   static __NG_ENV_ID__: (injector: EnvironmentInjector) => DestroyRef = (injector) => injector;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(DestroyRef);
 }
 
 export class NodeInjectorDestroyRef extends DestroyRef {

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -11,6 +11,7 @@ import {isDestroyed} from '../render3/interfaces/type_checks';
 import {LView} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
 import {removeLViewOnDestroy, storeLViewOnDestroy} from '../render3/util/view_utils';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * `DestroyRef` lets you set callbacks to run for any cleanup or destruction behavior.
@@ -61,6 +62,10 @@ export abstract class DestroyRef {
    * @internal
    * @nocollapse
    */
+  /**
+   * @internal
+   * @nocollapse
+   */
   static __NG_ELEMENT_ID__: () => DestroyRef = injectDestroyRef;
 
   /**
@@ -68,6 +73,10 @@ export abstract class DestroyRef {
    * @nocollapse
    */
   static __NG_ENV_ID__: (injector: EnvironmentInjector) => DestroyRef = (injector) => injector;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(DestroyRef);
 }
 
 export class NodeInjectorDestroyRef extends DestroyRef {

--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -12,6 +12,8 @@ import {LView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {getNativeByTNode} from '../render3/util/view_utils';
 
+import {registerSpecialProvider} from '../render3/debug/special_providers';
+
 /**
  * Creates an ElementRef from the most recent node.
  *
@@ -72,6 +74,10 @@ export class ElementRef<T = any> {
    * @nocollapse
    */
   static __NG_ELEMENT_ID__: () => ElementRef = injectElementRef;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(ElementRef);
 }
 
 /**

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -79,6 +79,7 @@ import {createElementRef, ElementRef} from './element_ref';
 import {NgModuleRef} from './ng_module_factory';
 import {TemplateRef} from './template_ref';
 import {EmbeddedViewRef, ViewRef} from './view_ref';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * Represents a container where one or more views can be attached to a component.
@@ -290,6 +291,10 @@ export abstract class ViewContainerRef {
    * @nocollapse
    */
   static __NG_ELEMENT_ID__: () => ViewContainerRef = injectViewContainerRef;
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(ViewContainerRef);
 }
 
 /**

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -12,6 +12,7 @@ import {getCurrentTNode, getLView} from '../render3/state';
 import {getComponentLViewByIndex} from '../render3/util/view_utils';
 
 import {RendererStyleFlags2, RendererType2} from './api_flags';
+import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * Creates and initializes a custom renderer that implements the `Renderer2` base class.
@@ -246,6 +247,10 @@ export abstract class Renderer2 {
    * @nocollapse
    */
   static __NG_ELEMENT_ID__: () => Renderer2 = () => injectRenderer2();
+}
+
+if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  registerSpecialProvider(Renderer2);
 }
 
 /** Injects a Renderer2 for the current component. */

--- a/packages/core/src/render3/debug/special_providers.ts
+++ b/packages/core/src/render3/debug/special_providers.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+const specialProviders = new Set<any>();
+
+/**
+ * Registers a class as a special provider for debug tooling.
+ *
+ * @param clazz The class to register
+ */
+export function registerSpecialProvider(clazz: any): void {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    specialProviders.add(clazz);
+  }
+}
+
+/**
+ * Gets all special providers that have been registered.
+ */
+export function getAllSpecialProviders(): ReadonlySet<any> {
+  return specialProviders;
+}

--- a/packages/core/src/render3/util/injector_discovery_utils.ts
+++ b/packages/core/src/render3/util/injector_discovery_utils.ts
@@ -38,6 +38,7 @@ import {INJECTOR, LView, TVIEW} from '../interfaces/view';
 
 import {getParentInjectorIndex, getParentInjectorView, hasParentInjector} from './injector_utils';
 import {getNativeByTNode} from './view_utils';
+import {getAllSpecialProviders} from '../debug/special_providers';
 
 /**
  * Discovers the dependencies of an injectable instance. Provides DI information about each
@@ -218,7 +219,15 @@ function getProviderImportsContainer(injector: Injector): Type<unknown> | null {
 function getNodeInjectorProviders(injector: NodeInjector): ProviderRecord[] {
   const diResolver = getNodeInjectorTNode(injector);
   const {resolverToProviders} = getFrameworkDIDebugData();
-  return resolverToProviders.get(diResolver as TNode) ?? [];
+  const existingProviders = resolverToProviders.get(diResolver as TNode) ?? [];
+
+  const specialProviders: ProviderRecord[] = Array.from(getAllSpecialProviders()).map((token) => ({
+    token: token as any,
+    isViewProvider: false,
+    provider: token as any,
+  }));
+
+  return [...existingProviders, ...specialProviders];
 }
 
 /**

--- a/packages/core/test/acceptance/injector_profiler_spec.ts
+++ b/packages/core/test/acceptance/injector_profiler_spec.ts
@@ -11,8 +11,10 @@ import {BrowserModule} from '@angular/platform-browser';
 import {Router, RouterModule, RouterOutlet} from '@angular/router';
 import {
   afterEveryRender,
+  ChangeDetectorRef,
   ClassProvider,
   Component,
+  DestroyRef,
   Directive,
   ElementRef,
   inject,
@@ -22,8 +24,10 @@ import {
   NgModule,
   NgModuleRef,
   QueryList,
+  Renderer2,
   ViewChild,
   ViewChildren,
+  ViewContainerRef,
 } from '../../src/core';
 import {InternalInjectFlags} from '../../src/di/interface/injector';
 import {NullInjector} from '../../src/di/null_injector';
@@ -579,10 +583,11 @@ describe('getInjectorProviders', () => {
     const fixture = TestBed.createComponent(MyComponent);
 
     const providers = getInjectorProviders(fixture.debugElement.injector);
-    expect(providers.length).toBe(1);
-    expect(providers[0].token).toBe(MyService);
-    expect(providers[0].provider).toBe(MyService);
-    expect(providers[0].isViewProvider).toBe(false);
+    const myServiceProvider = providers.find((p) => p.token === MyService)!;
+    expect(myServiceProvider).toBeDefined();
+    expect(myServiceProvider.token).toBe(MyService);
+    expect(myServiceProvider.provider).toBe(MyService);
+    expect(myServiceProvider.isViewProvider).toBe(false);
   });
 
   it('should be able to get determine if a provider is a view provider', () => {
@@ -600,10 +605,11 @@ describe('getInjectorProviders', () => {
     const fixture = TestBed.createComponent(MyComponent);
 
     const providers = getInjectorProviders(fixture.debugElement.injector);
-    expect(providers.length).toBe(1);
-    expect(providers[0].token).toBe(MyService);
-    expect(providers[0].provider).toBe(MyService);
-    expect(providers[0].isViewProvider).toBe(true);
+    const myServiceProvider = providers.find((p) => p.token === MyService)!;
+    expect(myServiceProvider).toBeDefined();
+    expect(myServiceProvider.token).toBe(MyService);
+    expect(myServiceProvider.provider).toBe(MyService);
+    expect(myServiceProvider.isViewProvider).toBe(true);
   });
 
   it('should be able to determine import paths after module provider flattening in the NgModule bootstrap case', () => {
@@ -968,11 +974,12 @@ describe('getInjectorProviders', () => {
     expect(itemComponents?.length).toBe(3);
     itemComponents!.forEach((item) => {
       const itemProviders = getInjectorProviders(item.injector);
+      const myServiceProvider = itemProviders.find((p) => p.token === MyService)!;
       expect(itemProviders).toBeInstanceOf(Array);
-      expect(itemProviders.length).toBe(1);
-      expect(itemProviders[0].token).toBe(MyService);
-      expect(itemProviders[0].provider).toBe(MyService);
-      expect(itemProviders[0].isViewProvider).toBe(false);
+      expect(myServiceProvider).toBeDefined();
+      expect(myServiceProvider.token).toBe(MyService);
+      expect(myServiceProvider.provider).toBe(MyService);
+      expect(myServiceProvider.isViewProvider).toBe(false);
     });
   });
 
@@ -1009,12 +1016,34 @@ describe('getInjectorProviders', () => {
     expect(itemComponents?.length).toBe(3);
     itemComponents!.forEach((item) => {
       const itemProviders = getInjectorProviders(item.injector);
+      const myServiceProvider = itemProviders.find((p) => p.token === MyService)!;
       expect(itemProviders).toBeInstanceOf(Array);
-      expect(itemProviders.length).toBe(1);
-      expect(itemProviders[0].token).toBe(MyService);
-      expect(itemProviders[0].provider).toBe(MyService);
-      expect(itemProviders[0].isViewProvider).toBe(false);
+      expect(myServiceProvider).toBeDefined();
+      expect(myServiceProvider.token).toBe(MyService);
+      expect(myServiceProvider.provider).toBe(MyService);
+      expect(myServiceProvider.isViewProvider).toBe(false);
     });
+  });
+
+  it('should include special providers in NodeInjector', () => {
+    @Component({
+      selector: 'my-comp',
+      template: 'hello',
+      standalone: false,
+    })
+    class MyComponent {}
+    TestBed.configureTestingModule({declarations: [MyComponent]});
+    const fixture = TestBed.createComponent(MyComponent);
+
+    const providers = getInjectorProviders(fixture.debugElement.injector);
+    const tokens = providers.map((p) => p.token);
+
+    expect(tokens).toContain(ElementRef);
+    expect(tokens).toContain(Renderer2);
+    expect(tokens).toContain(ViewContainerRef);
+    expect(tokens).toContain(DestroyRef);
+    expect(tokens).toContain(ChangeDetectorRef);
+    expect(tokens).toContain(Injector);
   });
 });
 

--- a/packages/core/test/debug/di_graph_spec.ts
+++ b/packages/core/test/debug/di_graph_spec.ts
@@ -47,12 +47,12 @@ describe('diGraphTool', () => {
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
             type: 'element',
-            providers: [
+            providers: jasmine.arrayContaining([
               {
                 token: CustomService,
                 value: jasmine.any(CustomService),
               },
-            ],
+            ]),
             viewProviders: [],
             children: [],
           }),
@@ -93,21 +93,21 @@ describe('diGraphTool', () => {
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
             type: 'element',
-            providers: [
+            providers: jasmine.arrayContaining([
               {
                 token: ComponentService,
                 value: jasmine.any(ComponentService),
               },
-            ],
+            ]),
             children: [
               jasmine.objectContaining({
                 type: 'element',
-                providers: [
+                providers: jasmine.arrayContaining([
                   {
                     token: DirectiveService,
                     value: jasmine.any(DirectiveService),
                   },
-                ],
+                ]),
                 children: [],
               }),
             ],
@@ -192,10 +192,10 @@ describe('diGraphTool', () => {
 
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
-            providers: [{token: Service1, value: jasmine.any(Service1)}],
+            providers: jasmine.arrayContaining([{token: Service1, value: jasmine.any(Service1)}]),
           }),
           jasmine.objectContaining({
-            providers: [{token: Service2, value: jasmine.any(Service2)}],
+            providers: jasmine.arrayContaining([{token: Service2, value: jasmine.any(Service2)}]),
           }),
         ]);
       } finally {
@@ -243,7 +243,7 @@ describe('diGraphTool', () => {
 
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
-            providers: jasmine.arrayWithExactContents([
+            providers: jasmine.arrayContaining([
               {
                 token: TestService,
                 value: jasmine.any(TestService),
@@ -251,7 +251,7 @@ describe('diGraphTool', () => {
             ]),
             children: [
               jasmine.objectContaining({
-                providers: jasmine.arrayWithExactContents([
+                providers: jasmine.arrayContaining([
                   {
                     token: ProjectorService,
                     value: jasmine.any(ProjectorService),
@@ -260,7 +260,7 @@ describe('diGraphTool', () => {
                 children: [
                   jasmine.objectContaining({
                     type: 'element',
-                    providers: jasmine.arrayWithExactContents([
+                    providers: jasmine.arrayContaining([
                       {
                         token: ChildService,
                         value: jasmine.any(ChildService),
@@ -307,21 +307,21 @@ describe('diGraphTool', () => {
 
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
-            providers: [
+            providers: jasmine.arrayContaining([
               {
                 token: ComponentService,
                 value: jasmine.any(ComponentService),
               },
-            ],
+            ]),
             children: [
               jasmine.objectContaining({
                 type: 'element',
-                providers: [
+                providers: jasmine.arrayContaining([
                   {
                     token: DirectiveService,
                     value: jasmine.any(DirectiveService),
                   },
-                ],
+                ]),
               }),
             ],
           }),
@@ -362,7 +362,7 @@ describe('diGraphTool', () => {
         expect(result.elementInjectorRoots).toEqual([
           // Components and host directives share the same `Injector`.
           jasmine.objectContaining({
-            providers: jasmine.arrayWithExactContents([
+            providers: jasmine.arrayContaining([
               {
                 token: HostService,
                 value: jasmine.any(HostService),
@@ -403,12 +403,12 @@ describe('diGraphTool', () => {
 
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
-            providers: [
+            providers: jasmine.arrayContaining([
               {
                 token: TestService,
                 value: jasmine.any(TestService),
               },
-            ],
+            ]),
             viewProviders: [
               {
                 token: ViewService,
@@ -459,10 +459,14 @@ describe('diGraphTool', () => {
         const result = await diGraphTool.execute({});
         expect(result.elementInjectorRoots).toEqual([
           jasmine.objectContaining({
-            providers: [{token: TestService, value: jasmine.any(TestService)}],
+            providers: jasmine.arrayContaining([
+              {token: TestService, value: jasmine.any(TestService)},
+            ]),
           }),
           jasmine.objectContaining({
-            providers: [{token: DynamicService, value: jasmine.any(DynamicService)}],
+            providers: jasmine.arrayContaining([
+              {token: DynamicService, value: jasmine.any(DynamicService)},
+            ]),
           }),
         ]);
       } finally {
@@ -559,10 +563,10 @@ describe('diGraphTool', () => {
             // There should only be one `multiToken`, but the framework profiler currently records
             // multi-providers once per configuration rather than aggregating them by token. This
             // causes them to appear multiple times in the providers array.
-            providers: [
+            providers: jasmine.arrayContaining([
               {token: multiToken, value: ['val1', 'val2']},
               {token: multiToken, value: ['val1', 'val2']},
-            ],
+            ]),
           }),
         ]);
       } finally {


### PR DESCRIPTION

Element injectors have some special providers that we previously were not making present in the getNodeInjector result because they are provided through separate means than other providers. These providers are
- ElementRef
- Renderer2
- ViewContainerRef
- DestroyRef
- ChangeDetectorRef

Now we make these providers present in the result of getNodeInjector. Notably this makes them visible and debuggable in DevTools.