### PR TITLE
fix(docs-infra): improve symbolic green contrast for WCAG compliance

### DIFF
--- a/adev/shared-docs/styles/_colors.scss
+++ b/adev/shared-docs/styles/_colors.scss
@@ -40,7 +40,7 @@
   --symbolic-pink: oklch(63.67% 0.254 13.47); // #ff025c
   --symbolic-orange: oklch(64.73% 0.23769984683784018 33.18328352127882); // #fe3700
   --symbolic-yellow: oklch(78.09% 0.163 65.69); // #fd9f28
-  --symbolic-green: oklch(67.83% 0.229 142.73); // #00b80a
+  --symbolic-green: oklch(48% 0.16 145); // #008B38
   --symbolic-cyan: oklch(67.05% 0.1205924489987394 181.34025902203868); // #00ad9a
   --symbolic-magenta: oklch(51.74% 0.25453048882711515 315.26261625862725); // #9c00c8
   --symbolic-teal: oklch(57.59% 0.083 230.58); // #3f82a1
@@ -288,7 +288,7 @@
     var(--full-contrast) 65%
   );
   --symbolic-yellow: color-mix(in srgb, oklch(78.09% 0.163 65.69), var(--full-contrast) 65%);
-  --symbolic-green: color-mix(in srgb, oklch(67.83% 0.229 142.73), var(--full-contrast) 65%);
+  --symbolic-green: color-mix(in srgb, oklch(48% 0.16 145), var(--full-contrast) 65%);
   --symbolic-cyan: color-mix(
     in srgb,
     oklch(67.05% 0.1205924489987394 181.34025902203868),


### PR DESCRIPTION
The `.docs-new-item` tag (and other uses of `--symbolic-green`) failed WCAG 2.1 SC 1.4.3 in light mode (2.4:1). This change updates `--symbolic-green` to `oklch(48% 0.16 145)` (~`#008B38`) so the elements meet 4.5:1+ contrast (WCAG AA) in both light and dark modes.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Instances using `--symbolic-green` (e.g. the "New" tag) have insufficient color contrast in light mode, failing WCAG 2.1 SC 1.4.3 (Contrast Minimum).

Issue Number: N/A

## What is the new behavior?

`--symbolic-green` is updated to a darker value derived from Material Design Green 700-800 range that meets WCAG AA contrast requirements on both light and dark mode, improving readability of the "New" tag and any other usage. Light and dark mode definitions share the same base color, consistent with other symbolic colors in the design system.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Updated `--symbolic-green` to: `oklch(48% 0.16 145)` (~`#008B38`)
- No changes to `color-mix()` usage—only the base token value was updated
- Addresses WCAG 2.1 SC 1.4.3 (Contrast Minimum)

### Before
<img width="199" height="95" alt="Screenshot 2026-01-12 at 11 14 33 AM" src="https://github.com/user-attachments/assets/d3db4069-71a4-4740-a6cd-1e261c567f58" />
<img width="189" height="98" alt="Screenshot 2026-01-12 at 11 14 19 AM" src="https://github.com/user-attachments/assets/0f42f26e-824c-4937-a0a2-00a63125bc70" />


<img width="1252" height="719" alt="light-mode-old" src="https://github.com/user-attachments/assets/79cf94b6-f1f6-40bb-b1fd-3c321ebb5ff4" />
<img width="1251" height="722" alt="dark-mode-old" src="https://github.com/user-attachments/assets/fde962e9-0ba5-40cf-bbfb-e828f9ebcfa1" />


### After
<img width="199" height="96" alt="Screenshot 2026-01-12 at 11 12 55 AM" src="https://github.com/user-attachments/assets/8045a6bb-8b49-41b0-a6da-2f8a127cf576" />
<img width="177" height="99" alt="Screenshot 2026-01-12 at 11 16 34 AM" src="https://github.com/user-attachments/assets/01819fd0-4443-487c-8aca-a08c77c7f982" />
<img width="1252" height="716" alt="light-mode-new" src="https://github.com/user-attachments/assets/3897af45-8443-40f8-9c3f-bb4270ee7cca" />
<img width="1249" height="718" alt="dark-mode-new" src="https://github.com/user-attachments/assets/98fc79e8-b28c-4d17-9f72-f5e31917d466" />