### PR TITLE
fix(docs): correct line number highlighting in query examples

### DIFF
--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -107,7 +107,7 @@ By default, content queries find only _direct_ children of the component and do 
 
 You can also query for multiple results with the `contentChildren` function.
 
-```angular-ts {highlight: [14, 16, 17, 18, 19, 20]}
+```angular-ts {highlight: [15, 16]}
 @Component({
   selector: 'custom-menu-item',
   /*...*/


### PR DESCRIPTION
Updates incorrect highlighted line numbers so they match the intended code being referenced in the documentation.


## What is the current behavior?

<img width="1704" height="796" alt="image" src="https://github.com/user-attachments/assets/a486eb01-a04d-48cc-bab2-4d4375a08b2e" />


## What is the new behavior?
<img width="1682" height="752" alt="image" src="https://github.com/user-attachments/assets/3d407140-4e31-4df7-a894-98a983800028" />

