### PR TITLE
build: begin requring usage of release mode for releases

### DIFF
--- a/.ng-dev/github.mjs
+++ b/.ng-dev/github.mjs
@@ -9,4 +9,5 @@ export const github = {
   name: 'angular',
   mainBranchName: 'main',
   mergeMode: 'caretaker-only',
+  requireReleaseModeForRelease: true,
 };


### PR DESCRIPTION
Start requiring the usage of the release merge-mode for allowing releases to be made from the repository
