### PR TITLE
feat(common): Add location strategies to manage trailing slash on write

### DIFF
--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -127,6 +127,33 @@ provideRouter(routes, withRouterConfig({defaultQueryParamsHandling: 'merge'}));
 
 This is especially helpful for search and filter pages to automatically retain existing filters when additional parameters are provided.
 
+### Configure trailing slash handling
+
+By default, the `Location` service strips trailing slashes from URLs on read.
+
+You can configure the `Location` service to force a trailing slash on all URLs written to the browser by providing the `TrailingSlashPathLocationStrategy` in your application.
+
+```ts
+import {LocationStrategy, TrailingSlashPathLocationStrategy} from '@angular/common';
+
+bootstrapApplication(App, {
+  providers: [{provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy}],
+});
+```
+
+You can also force the `Location` service to never have a trailing slash on all URLs written to the browser by providing the `NoTrailingSlashPathLocationStrategy` in your application.
+
+```ts
+import {LocationStrategy, NoTrailingSlashPathLocationStrategy} from '@angular/common';
+
+bootstrapApplication(App, {
+  providers: [{provide: LocationStrategy, useClass: NoTrailingSlashPathLocationStrategy}],
+});
+```
+
+These strategies only affect the URL written to the browser.
+`Location.path()` and `Location.normalize()` will continue to strip trailing slashes when reading the URL.
+
 Angular Router exposes four main areas for customization:
 
   <docs-pill-row>
@@ -224,7 +251,7 @@ When implementing a custom `RouteReuseStrategy`, you may need to manually destro
 Since `DetachedRouteHandle` is an opaque type, you cannot call a destroy method directly on it. Instead, use the `destroyDetachedRouteHandle` function provided by the Router.
 
 ```ts
-import { destroyDetachedRouteHandle } from '@angular/router';
+import {destroyDetachedRouteHandle} from '@angular/router';
 
 // ... inside your strategy
 if (this.handles.size > MAX_CACHE_SIZE) {
@@ -245,12 +272,10 @@ By default, Angular does not destroy the injectors of detached routes, even if t
 To enable automatic cleanup of unused route injectors, you can use the `withExperimentalAutoCleanupInjectors` feature in your router configuration. This feature checks which routes are currently stored by the strategy after navigations and destroys the injectors of any detached routes that are not currently stored by the reuse strategy.
 
 ```ts
-import { provideRouter, withExperimentalAutoCleanupInjectors } from '@angular/router';
+import {provideRouter, withExperimentalAutoCleanupInjectors} from '@angular/router';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes, withExperimentalAutoCleanupInjectors())
-  ]
+  providers: [provideRouter(routes, withExperimentalAutoCleanupInjectors())],
 };
 ```
 

--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -738,6 +738,16 @@ export class NgTemplateOutlet<C = unknown> implements OnChanges {
     static ɵfac: i0.ɵɵFactoryDeclaration<NgTemplateOutlet<any>, never>;
 }
 
+// @public
+export class NoTrailingSlashPathLocationStrategy extends PathLocationStrategy {
+    // (undocumented)
+    prepareExternalUrl(internal: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<NoTrailingSlashPathLocationStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<NoTrailingSlashPathLocationStrategy>;
+}
+
 // @public @deprecated
 export enum NumberFormatStyle {
     // (undocumented)
@@ -984,6 +994,16 @@ export class TitleCasePipe implements PipeTransform {
     static ɵfac: i0.ɵɵFactoryDeclaration<TitleCasePipe, never>;
     // (undocumented)
     static ɵpipe: i0.ɵɵPipeDeclaration<TitleCasePipe, "titlecase", true>;
+}
+
+// @public
+export class TrailingSlashPathLocationStrategy extends PathLocationStrategy {
+    // (undocumented)
+    prepareExternalUrl(internal: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<TrailingSlashPathLocationStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<TrailingSlashPathLocationStrategy>;
 }
 
 // @public @deprecated

--- a/packages/common/src/location/index.ts
+++ b/packages/common/src/location/index.ts
@@ -8,7 +8,13 @@
 
 export {HashLocationStrategy} from './hash_location_strategy';
 export {Location, PopStateEvent} from './location';
-export {APP_BASE_HREF, LocationStrategy, PathLocationStrategy} from './location_strategy';
+export {
+  APP_BASE_HREF,
+  LocationStrategy,
+  NoTrailingSlashPathLocationStrategy,
+  PathLocationStrategy,
+  TrailingSlashPathLocationStrategy,
+} from './location_strategy';
 export {
   BrowserPlatformLocation,
   LOCATION_INITIALIZED,

--- a/packages/router/test/trailing_slash_integration.spec.ts
+++ b/packages/router/test/trailing_slash_integration.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  LocationStrategy,
+  NoTrailingSlashPathLocationStrategy,
+  PlatformLocation,
+  TrailingSlashPathLocationStrategy,
+} from '@angular/common';
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {provideRouter, RouterLink} from '@angular/router';
+import {RouterTestingHarness} from '@angular/router/testing';
+
+@Component({
+  template: 'home',
+  standalone: true,
+})
+class HomeCmp {}
+
+@Component({
+  template: 'child',
+  standalone: true,
+})
+class ChildCmp {}
+
+describe('Trailing Slash Integration', () => {
+  describe('NoTrailingSlashPathLocationStrategy', () => {
+    it('should strip trailing slashes and match full path', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: 'a', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: NoTrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      // Navigate to /a
+      await harness.navigateByUrl('/a');
+      expect(location.pathname).toBe('/a');
+      expect(harness.routeNativeElement?.textContent).toBe('home');
+    });
+  });
+
+  describe('TrailingSlashPathLocationStrategy', () => {
+    it('should add trailing slashes and match full path', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: 'a', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      // Navigate to /a
+      await harness.navigateByUrl('/a');
+      expect(location.pathname).toBe('/a/');
+      expect(harness.routeNativeElement?.textContent).toBe('home');
+    });
+
+    it('should handle root path', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: '', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      await harness.navigateByUrl('/');
+      expect(location.pathname).toBe('/');
+      expect(harness.routeNativeElement?.textContent).toBe('home');
+    });
+
+    it('should generate correct href in RouterLink', async () => {
+      @Component({
+        template: '<a routerLink="/a">link</a>',
+        imports: [RouterLink],
+        standalone: true,
+      })
+      class LinkCmp {}
+
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([
+            {path: 'a', pathMatch: 'full', component: HomeCmp},
+            {path: 'link', component: LinkCmp},
+          ]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      await harness.navigateByUrl('/link');
+      const link = harness.fixture.nativeElement.querySelector('a');
+      expect(link.getAttribute('href')).toBe('/a/');
+    });
+
+    it('should handle query params with trailing slash', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: 'a', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      await harness.navigateByUrl('/a?q=val');
+      expect(location.pathname).toBe('/a/');
+      expect(location.search).toBe('?q=val');
+    });
+
+    it('should handle hash with trailing slash', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: 'a', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      await harness.navigateByUrl('/a#frag');
+      expect(location.pathname).toBe('/a/');
+      expect(location.hash).toBe('#frag');
+    });
+
+    it('should handle both query params and hash with trailing slash', async () => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideRouter([{path: 'a', pathMatch: 'full', component: HomeCmp}]),
+          {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+        ],
+      });
+
+      const harness = await RouterTestingHarness.create();
+      const location = TestBed.inject(PlatformLocation);
+
+      await harness.navigateByUrl('/a?q=val#frag');
+      expect(location.pathname).toBe('/a/');
+      expect(location.search).toBe('?q=val');
+      expect(location.hash).toBe('#frag');
+    });
+  });
+
+  it('should handle auxiliary routes with trailing slash', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {path: 'a', component: HomeCmp},
+          {path: 'b', outlet: 'aux', component: ChildCmp},
+        ]),
+        {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy},
+      ],
+    });
+
+    const harness = await RouterTestingHarness.create();
+    const location = TestBed.inject(PlatformLocation);
+
+    // /a(aux:b)
+    await harness.navigateByUrl('/a(aux:b)');
+    expect(location.pathname).toBe('/a(aux:b)/');
+  });
+});


### PR DESCRIPTION
Adds dedicated `LocationStrategy` subclasses: `NoTrailingSlashPathLocationStrategy` and `TrailingSlashPathLocationStrategy`.

The `TrailingSlashPathLocationStrategy` ensures that URLs prepared for the browser always end with a slash, while `NoTrailingSlashPathLocationStrategy` ensures they never do. This configuration only affects the URL written to the browser history; the `Location` service continues to normalize paths by stripping trailing slashes when reading from the browser.

Example:
```typescript
providers: [
  {provide: LocationStrategy, useClass: TrailingSlashPathLocationStrategy}
]
```

This approach to the trailing slash problem isolates the changes to the
existing LocationStrategy abstraction without changes to Router, as was
attempted in two other options (https://github.com/angular/angular/pull/66452 and https://github.com/angular/angular/pull/66423).

From an architectural perspective, this is the cleanest approach for several reasons:

1. Separation of Concerns and "Router Purity": The Router's primary job is to map a URL structure to an application state (ActivatedRoutes). It shouldn't necessarily be burdened with the formatting nuances of the underlying platform unless those nuances affect the state itself. By pushing trailing slash handling to the LocationStrategy, you treat the trailing slash as a "platform serialization format" rather than a "router state" concern. This avoids the "weirdness" in https://github.com/angular/angular/pull/66423 where the UrlTree (serialization format) disagrees with the ActivatedRouteSnapshot (logical state).

2. Tree Shakability: If an application doesn't care about trailing slashes (which is the default "never" behavior), they don't pay the cost for that logic. It essentially becomes a swappable "driver" for the URL interaction.

3. Simplicity for the Router: https://github.com/angular/angular/pull/66452 (consuming the slash as a segment) bleeds into the matching logic, potentially causing issues with child routes or wildcards effectively "eating" a segment that should be invisible. This option leaves the matching logic purely focused on meaningful path segments by continuing to strip the trailing slash on read.

4. Consistency with Existing Patterns: Angular already uses LocationStrategy to handle Hash vs Path routing. Adding "Trailing Slash" nuances there is a natural extension of that pattern—it's just another variation of "how do we represent this logic in the browser's address bar?"

fixes https://github.com/angular/angular/issues/16051