### PR TITLE
fix(adev): guard History API usage during NavigationStart

### DIFF
--- a/adev/src/app/routing/router_providers.ts
+++ b/adev/src/app/routing/router_providers.ts
@@ -133,7 +133,13 @@ const initializeNavigationAdapter = () => {
     }
     if (e instanceof NavigationStart) {
       intercept = true;
-      window.history.replaceState(window.history.state, '', window.location.href);
+
+      const href = window.location.href;
+
+      if (!href.includes(':~:text=') && window?.history?.replaceState) {
+        window.history.replaceState(window.history.state, '', href);
+      }
+
       intercept = false;
     } else if (
       // viewtransition happens before NavigateEnd


### PR DESCRIPTION
### What changed
Adds a browser guard around History API usage during `NavigationStart`.

### Why
Direct access to the History API can throw errors in SSR and non-browser
environments. This preserves existing behavior while improving stability.

### Scope
- No behavior change in browser environments
- Improves SSR and test stability

### Related issue
- Related: angular/angular#65119