### PR TITLE
docs: update hierarchical-dependency-injection.md

### DIFF
--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -959,8 +959,8 @@ export class VillainsList {}
 
 By providing `VillainsService` in the `VillainsList` metadata and nowhere else, the service becomes available only in the `VillainsList` and its subcomponent tree.
 
-`VillainService` is a singleton with respect to `VillainsList` because that is where it is declared.
-As long as `VillainsList` does not get destroyed it will be the same instance of `VillainService` but if there are multiple instances of `VillainsList`, then each instance of `VillainsList` will have its own instance of `VillainService`.
+`VillainsService` is a singleton with respect to `VillainsList` because that is where it is declared.
+As long as `VillainsList` does not get destroyed it will be the same instance of `VillainsService` but if there are multiple instances of `VillainsList`, then each instance of `VillainsList` will have its own instance of `VillainsService`.
 
 ### Scenario: multiple edit sessions
 


### PR DESCRIPTION
VillainsService highly likely misspelled and then written as VillainService with 's' missing
https://angular.dev/guide/di/hierarchical-dependency-injection#scenario-service-isolation

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md

## PR Type

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [x] No