### PR TITLE
ci: update Renovate configuration to replace Bazel module dependency command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,12 +27,12 @@
     },
     {
       "matchManagers": ["bazel", "bazel-module", "bazelisk", "npm"],
-      "matchDepNames": ["!pnpm", "!typescript", "*"],
       "postUpgradeTasks": {
         "commands": [
           "git restore .npmrc",
           "pnpm install --frozen-lockfile",
           "pnpm bazel mod deps --lockfile_mode=update",
+          "pnpm ng-dev misc sync-module-bazel",
           "pnpm bazel run //.github/actions/deploy-docs-site:main",
           "pnpm bazel run //packages/common:base_currencies_file",
           "pnpm bazel run //packages/common/locales:closure_locale_file",
@@ -41,6 +41,7 @@
         "fileFilters": [
           ".github/actions/deploy-docs-site/**/*",
           "packages/**/*",
+          "MODULE.bazel",
           "MODULE.bazel.lock"
         ],
         "executionMode": "branch"


### PR DESCRIPTION


This uses `ng-dev misc sync-module-bazel`, add `MODULE.bazel` to file filters, and remove specific dependency name matching.
