### PR TITLE
refactor(common): update copyright to Google LLC

### DIFF
--- a/packages/zone.js/test/rxjs/rxjs.retry.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.retry.spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC. All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license

--- a/tools/symbol-extractor/symbol_extractor_spec/hello_world_min_debug.js
+++ b/tools/symbol-extractor/symbol_extractor_spec/hello_world_min_debug.js
@@ -10,14 +10,14 @@
   'use strict';
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
    */
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -37,7 +37,7 @@
   ViewEncapsulation || (ViewEncapsulation = {});
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -48,15 +48,15 @@
    *
    * Use of this source code is governed by an MIT-style license that can be
    * found in the LICENSE file at https://angular.dev/license
-   */ 'undefined' != typeof window && window,
+   */ ('undefined' != typeof window && window,
     'undefined' != typeof self &&
       'undefined' != typeof WorkerGlobalScope &&
       self instanceof WorkerGlobalScope &&
       self,
-    'undefined' != typeof global && global;
+    'undefined' != typeof global && global);
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -64,7 +64,7 @@
   String;
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -88,12 +88,12 @@
   Error;
   var RendererStyleFlags2,
     Symbol$1 = _root.Symbol;
-  'function' == typeof Symbol$1 &&
+  ('function' == typeof Symbol$1 &&
     'function' == typeof Symbol$1.for &&
     Symbol$1.for('rxSubscriber'),
     (function () {
       Object.setPrototypeOf || Array;
-    })();
+    })());
   !(function (context) {
     var $$observable,
       Symbol = _root.Symbol;
@@ -105,16 +105,16 @@
       }
     else $$observable = '@@observable';
   })();
-  (function () {
+  ((function () {
     Object.setPrototypeOf || Array;
   })(),
     (function () {
       Object.setPrototypeOf || Array;
-    })();
+    })());
   !(function () {
     Object.setPrototypeOf || Array;
   })();
-  (function (root) {
+  ((function (root) {
     var Symbol = root.Symbol;
     if ('function' == typeof Symbol) {
       Symbol.iterator || (Symbol.iterator = Symbol('iterator polyfill'));
@@ -132,17 +132,17 @@
   })(_root),
     (function () {
       Object.setPrototypeOf || Array;
-    })();
-  (function () {
+    })());
+  ((function () {
     Object.setPrototypeOf || Array;
   })(),
     (function () {
       Object.setPrototypeOf || Array;
-    })();
+    })());
   !(function () {
     Object.setPrototypeOf || Array;
   })();
-  Error,
+  (Error,
     (function () {
       Object.setPrototypeOf || Array;
     })(),
@@ -151,7 +151,7 @@
     })(),
     (function () {
       Object.setPrototypeOf || Array;
-    })();
+    })());
   !(function () {
     Object.setPrototypeOf || Array;
   })();
@@ -205,7 +205,7 @@
   };
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -255,7 +255,7 @@
   }
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
@@ -469,28 +469,28 @@
   }
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
    */
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
    */
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license
    */
   /**
    *@license
-   *Copyright Google Inc. All Rights Reserved.
+   *Copyright Google LLC. All Rights Reserved.
    *
    *Use of this source code is governed by an MIT-style license that can be
    *found in the LICENSE file at https://angular.dev/license

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google Inc. All Rights Reserved.
+ * Copyright Google LLC. All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license


### PR DESCRIPTION
Replaces outdated Google Inc copyright headers with Google LLC to align with current licensing standards.
