### PR TITLE
refactor(core): remove ng when invoking `enableProdMode`

### DIFF
--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -40,5 +40,8 @@ export function enableProdMode(): void {
   // `global['ngDevMode'] = false;` is also dropped.
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     global['ngDevMode'] = false;
+    // The ngGlobal might already be init, for because initNgDevMode() is invoked from the top level,
+    // an this function might executed later. So we need to clean up the global.ng as well.
+    global['ng'] = undefined;
   }
 }


### PR DESCRIPTION
This was caught while investigating a leak.
