### PR TITLE
docs(docs-infra): prevent API autolinking in headings

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/transformations/code.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/code.mts
@@ -10,7 +10,22 @@ import {Tokens} from 'marked';
 import {AdevDocsRenderer} from '../renderer.mjs';
 import {getSymbolUrl} from '../../linking.mjs';
 
+/**
+ * Tracks whether the current renderer is inside a heading.
+ *
+ * This is necessary to prevent API autolinking in headings.
+ */
+let insideHeading = false;
+export function setInsideHeading(value: boolean) {
+  insideHeading = value;
+}
+
 export function codespanRender(this: AdevDocsRenderer, token: Tokens.Codespan) {
+  // Skip API autolinking inside headings
+  if (insideHeading) {
+    return this.defaultRenderer.codespan(token);
+  }
+
   const apiLink = getSymbolUrl(token.text, this.context.apiEntries ?? {});
   if (apiLink) {
     const htmlToken: Tokens.HTML = {

--- a/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
@@ -8,12 +8,16 @@
 
 import {Tokens} from 'marked';
 import {AdevDocsRenderer} from '../renderer.mjs';
+import {setInsideHeading} from './code.mjs';
 
 export function headingRender(
   this: AdevDocsRenderer,
-  {depth, tokens, text: headingText, raw}: Tokens.Heading,
+  {depth, tokens, text: headingText}: Tokens.Heading,
 ): string {
+  setInsideHeading(true);
   const parsedText = this?.parser.parseInline(tokens);
+  setInsideHeading(false);
+
   if (depth === 1) {
     return `
     <header class="docs-header">

--- a/adev/shared-docs/pipeline/shared/marked/transformations/link.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/link.mts
@@ -7,7 +7,7 @@
  */
 
 import {anchorTarget} from '../helpers.mjs';
-import {Renderer, Tokens} from 'marked';
+import {Tokens} from 'marked';
 import {AdevDocsRenderer} from '../renderer.mjs';
 
 /**


### PR DESCRIPTION
Prevents API autolinking in headings to avoid broken rendering
 

## What is the current behavior?
https://next.angular.dev/guide/components#imports-in-the-component-decorator
<img width="730" height="245" alt="image" src="https://github.com/user-attachments/assets/a230d39d-591a-40e5-9bb2-ce8fab8a913e" />


## What is the new behavior?
 <img width="739" height="513" alt="image" src="https://github.com/user-attachments/assets/da6b7fce-5162-4e80-8eaa-66c4e8fcd751" />
 
## Other information
I couldn't think of a better solution considering that there might be titles like `FormRecord` and clicking on them would take us to the API description
See https://next.angular.dev/guide/forms/typed-forms#formrecord