### PR TITLE
build: update cherrypick changelog to stash

### DIFF
--- a/vscode-ng-language-service/tools/release.mts
+++ b/vscode-ng-language-service/tools/release.mts
@@ -481,6 +481,7 @@ async function publishExtension(): Promise<void> {
 async function cherryPickChangelog(changelog: string, newVersion: string): Promise<void> {
   console.log(chalk.blue('Cherry-picking changelog to main...'));
 
+  await exec(`git stash`);
   await exec(`git fetch ${angularRepoRemote} main`);
   const cherryPickBranch = `vscode-changelog-cherry-pick${newVersion}`;
   await exec(`git branch -D ${cherryPickBranch}`).catch(() => {});


### PR DESCRIPTION
there are often some formatting/newline changes caused by other steps. just stash anything
