### PR TITLE
docs(docs-infra): Exempts animation-related symbols from linking

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -20,6 +20,9 @@ const LINK_EXEMPT = new Set([
   'hidden',
   'state',
   'group',
+  'animation',
+  'transition',
+  'trigger',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {


### PR DESCRIPTION

## What is the current behavior?

<img width="739" height="553" alt="image" src="https://github.com/user-attachments/assets/d6888f31-e676-4b8d-8a2b-937ef9b90de3" />


## What is the new behavior?
Exempts 'animation', 'transition', and 'trigger' symbols from automatic linking.
