### PR TITLE
docs(docs-infra): use Signals Forms focusBoundControl

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -54,7 +54,6 @@ export class SearchDialog {
   readonly onClose = output();
   readonly dialog = viewChild.required<ElementRef<HTMLDialogElement>>('searchDialog');
   readonly items = viewChildren(SearchItem);
-  readonly textField = viewChild(TextField);
 
   readonly history = inject(SearchHistory);
   private readonly search = inject(Search);
@@ -98,7 +97,7 @@ export class SearchDialog {
         }
         // We want to select the pre-existing text on opening
         // In order to change the search input with minimal user interaction.
-        this.textField()?.input().nativeElement.select();
+        this.searchForm().focusBoundControl();
       },
     });
 

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -18,7 +18,6 @@ import {
   inject,
   input,
   linkedSignal,
-  viewChild,
 } from '@angular/core';
 import {Select, SelectOption, TextField} from '@angular/docs';
 import {FormField, form} from '@angular/forms/signals';
@@ -62,7 +61,6 @@ export default class ApiReferenceList {
   // services
   private readonly apiReferenceManager = inject(ApiReferenceManager);
   private readonly router = inject(Router);
-  private readonly filterInput = viewChild.required(TextField);
   private readonly injector = inject(EnvironmentInjector);
 
   // inputs
@@ -137,13 +135,12 @@ export default class ApiReferenceList {
 
   constructor() {
     effect(() => {
-      const filterInput = this.filterInput();
+      const filterInput = this.form.query();
       afterNextRender(
         {
           write: () => {
-            // Why not improve this once https://github.com/orgs/angular/projects/60?pane=issue&itemId=143488813 is done
             if (matchMedia('(hover: hover) and (pointer:fine)').matches) {
-              scheduleOnIdle(() => filterInput.focus());
+              scheduleOnIdle(() => filterInput.focusBoundControl());
             }
           },
         },


### PR DESCRIPTION
Removes direct `ViewChild` access from `TextField` components and relies on Signals Forms via the `focusBoundControl`  to manage focus.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

 
Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

 
## Other information
