### PR TITLE
docs: add IMPORTANT prefix to pipe usage warning and

### DIFF
--- a/adev/src/content/guide/templates/pipes.md
+++ b/adev/src/content/guide/templates/pipes.md
@@ -271,7 +271,7 @@ export class MyCustomTransformationPipe implements PipeTransform {
 
 When you want a pipe to detect changes within arrays or objects, it must be marked as an impure function by passing the `pure` flag with a value of `false`.
 
-Avoid creating impure pipes unless absolutely necessary, as they can incur a significant performance penalty if used without care.
+IMPORTANT: Avoid creating impure pipes unless absolutely necessary, as they can incur a significant performance penalty if used without care.
 
 ```angular-ts
 import { Pipe, PipeTransform } from '@angular/core';


### PR DESCRIPTION
Adds an IMPORTANT label to emphasize the guidance about avoiding impure pipes due to potential performance impact.

## What is the current behavior?
<img width="1622" height="650" alt="image" src="https://github.com/user-attachments/assets/8d4a57ac-006e-4ba1-86f6-8188a016531e" />

## What is the new behavior?
<img width="1542" height="336" alt="image" src="https://github.com/user-attachments/assets/f34dd4df-b3bd-471d-8939-9e5896460cf4" />

