### PR TITLE
fix(docs-infra): remove trailing slash from sitemap URLs

### DIFF
--- a/.github/actions/deploy-docs-site/lib/sitemap.mts
+++ b/.github/actions/deploy-docs-site/lib/sitemap.mts
@@ -1,33 +1,53 @@
 import {Deployment} from './deployments.mjs';
-import {join} from 'path';
-import {readFileSync, writeFileSync} from 'fs';
+import {join} from 'node:path';
+import {readFile, writeFile} from 'node:fs/promises';
 
-export async function generateSitemap(deployment: Deployment, distDir: string) {
-  const servingUrlWithoutEndingSlash = deployment.servingUrl.endsWith('/')
-    ? deployment.servingUrl.slice(0, -1)
-    : deployment.servingUrl;
-
+export async function generateSitemap(deployment: Deployment, distDir: string): Promise<void> {
   /** Timestamp string used to of the last file update. */
   const lastModifiedTimestamp = new Date().toISOString();
   /** An object containing all of the routes available within the application. */
-  const routes = JSON.parse(readFileSync(join(distDir, 'prerendered-routes.json'), 'utf-8'));
+  const {routes} = JSON.parse(await readFile(join(distDir, 'prerendered-routes.json'), 'utf-8'));
+  const routePaths = Object.keys(routes);
+
   /** The generated sitemap string. */
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  ${Object.keys(routes.routes)
-    .map((route) => {
-      const routeWithoutLeadingSlash = route.startsWith('/') ? route.slice(1) : route;
-      return `
-    <url>
-      <loc>${servingUrlWithoutEndingSlash}/${routeWithoutLeadingSlash}</loc>
+  ${routePaths
+    .map(
+      (route) => `<url>
+      <loc>${joinUrlParts(deployment.servingUrl, route)}</loc>
       <lastmod>${lastModifiedTimestamp}</lastmod>
       <changefreq>daily</changefreq>
       <priority>1.0</priority>
-    </url>
-        `;
-    })
+    </url>`,
+    )
     .join('')}
   </urlset>`;
-  writeFileSync(join(distDir, 'browser', 'sitemap.xml'), sitemap, 'utf-8');
-  console.log(`Generated sitemap with ${Object.keys(routes.routes).length} entries.`);
+
+  await writeFile(join(distDir, 'browser', 'sitemap.xml'), sitemap, 'utf-8');
+
+  console.log(`Generated sitemap with ${routePaths.length} entries.`);
+}
+
+function joinUrlParts(...parts: string[]): string {
+  const normalizeParts: string[] = [];
+  for (const part of parts) {
+    if (part === '') {
+      // Skip any empty parts
+      continue;
+    }
+
+    let normalizedPart = part;
+    if (part[0] === '/') {
+      normalizedPart = normalizedPart.slice(1);
+    }
+    if (part.at(-1) === '/') {
+      normalizedPart = normalizedPart.slice(0, -1);
+    }
+    if (normalizedPart !== '') {
+      normalizeParts.push(normalizedPart);
+    }
+  }
+
+  return normalizeParts.join('/');
 }


### PR DESCRIPTION
Fixes an issue where a trailing slash was sometimes added to the end of URLs in the sitemap, causing unnecessary redirects.

Example of problematic URL:
```xml
<loc>https://angular.dev/</loc>
```

