### PR TITLE
build: remove `tsx` dependency and update release script to use `node` directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "todomvc-common": "^1.0.5",
     "tslib": "^2.3.0",
     "tslint": "6.1.3",
-    "tsx": "^4.7.2",
     "typescript": "5.9.3",
     "webtreemap": "^2.0.1",
     "ws": "^8.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,9 +310,6 @@ importers:
       tslint:
         specifier: 6.1.3
         version: 6.1.3(typescript@5.9.3)
-      tsx:
-        specifier: ^4.7.2
-        version: 4.21.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -257,7 +257,7 @@
     "test:inspect-common": "bazel run --config=debug //vscode-ng-language-service/common/tests:test",
     "test:inspect-server": "bazel run --config=debug //vscode-ng-language-service/server/src/tests:test",
     "test:inspect-syntaxes": "bazel run --config=debug //vscode-ng-language-service/syntaxes/test:test",
-    "release": "tsx tools/release.mts"
+    "release": "node tools/release.mts"
   },
   "dependencies": {
     "@angular/language-service": "workspace:*",

--- a/vscode-ng-language-service/tools/release.mts
+++ b/vscode-ng-language-service/tools/release.mts
@@ -17,7 +17,7 @@ import {input, select} from '@inquirer/prompts';
 import chalk from 'chalk';
 import semver from 'semver';
 import {writeFile, readFile} from 'node:fs/promises';
-import {exec as nodeExec, spawn, SpawnOptions} from 'node:child_process';
+import {exec as nodeExec, spawn, type SpawnOptions} from 'node:child_process';
 import {promisify} from 'node:util';
 import {join} from 'node:path';
 


### PR DESCRIPTION


Node.js can run typescript directly.
