### PR TITLE
fix(devtools): support for @defer-only blocks; defer declared blocks

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
@@ -41,7 +41,7 @@
 
   @if (defer) {
     @if (defer.renderedBlock && defer.renderedBlock !== 'defer') {
-      <span class="trait">(&#64;{{ defer.renderedBlock }})</span>
+      <span class="trait">(@{{ defer.renderedBlock }})</span>
     } @else if (!defer.renderedBlock) {
       <span class="trait">(non-rendered)</span>
     }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.html
@@ -29,18 +29,22 @@
   </div>
 
   @if (node().onPush) {
-    <span class="on-push">OnPush</span>
+    <span class="trait">OnPush</span>
   }
 
   @let defer = node().defer;
 
   @if (!defer && (!hydration || hydration.status !== 'dehydrated')) {
     <!-- Shown/hidden via CSS -->
-    <span class="console-reference"> == $ng0 </span>
+    <span class="console-reference trait"> == $ng0 </span>
   }
 
-  @if (defer && defer.currentBlock) {
-    <span class="on-push">(&#64;{{ defer.currentBlock }})</span>
+  @if (defer) {
+    @if (defer.renderedBlock && defer.renderedBlock !== 'defer') {
+      <span class="trait">(&#64;{{ defer.renderedBlock }})</span>
+    } @else if (!defer.renderedBlock) {
+      <span class="trait">(non-rendered)</span>
+    }
   }
 
   @switch (hydration?.status) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.scss
@@ -99,8 +99,7 @@
       display: none;
     }
 
-    .console-reference,
-    .on-push {
+    .trait {
       color: var(--color-tree-node-console-ref);
       padding-left: 8px;
       font-style: italic;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.spec.ts
@@ -97,9 +97,9 @@ describe('TreeNodeComponent', () => {
     });
     await fixture.whenStable();
 
-    onPush = fixture.debugElement.query(By.css('.on-push'));
+    onPush = fixture.debugElement.query(By.css('.trait'));
 
-    expect(onPush).toBeTruthy();
+    expect(onPush.nativeElement.textContent).toEqual('OnPush');
   });
 
   it('should handle selection', async () => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.html
@@ -1,30 +1,36 @@
-<mat-toolbar>Current block</mat-toolbar>
+<mat-toolbar>Rendered block</mat-toolbar>
 <div class="defer-details">
-  <span class="pill"> &#64;{{ defer().currentBlock ?? 'defer' }}</span>
+  @if (defer().renderedBlock) {
+    <span class="pill"> &#64;{{ defer().renderedBlock }}</span>
+  } @else {
+    <em>Nothing rendered yet</em>
+  }
 </div>
+
+@if (hasDeclaredBlocks()) {
+  @let blocks = defer().blocks;
+  <mat-toolbar>Declared blocks</mat-toolbar>
+  <div class="defer-details">
+    @if (blocks.placeholderBlock.exists) {
+      <span class="pill">
+        &#64;placeholder<!--
+        -->{{
+          blocks.placeholderBlock.minimumTime
+            ? `(minimum ${blocks.placeholderBlock.minimumTime} ms)`
+            : ''
+        }}</span
+      >
+    }
+    @if (blocks.loadingBlock.exists) {
+      <span class="pill">&#64;loading{{ loadingBlockInfo() }}</span>
+    }
+    @if (blocks.hasErrorBlock) {
+      <span class="pill">&#64;error</span>
+    }
+  </div>
+}
 
 @let triggers = defer().triggers;
-@let blocks = defer().blocks;
-<mat-toolbar>Declared blocks</mat-toolbar>
-<div class="defer-details">
-  @if (blocks.placeholderBlock) {
-    <span class="pill">
-      &#64;placeholder<!--
-      -->{{
-        blocks.placeholderBlock.minimumTime
-          ? `(minimum ${blocks.placeholderBlock.minimumTime} ms)`
-          : ''
-      }}</span
-    >
-  }
-  @if (blocks.loadingBlock) {
-    <span class="pill">&#64;loading{{ loadingBlockInfo() }}</span>
-  }
-  @if (blocks.hasErrorBlock) {
-    <span class="pill">&#64;error</span>
-  }
-</div>
-
 <mat-toolbar>Triggers</mat-toolbar>
 <div class="defer-details">
   <h3>Defer triggers</h3>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/defer-view/defer-view.component.ts
@@ -22,7 +22,7 @@ export class DeferViewComponent {
 
   readonly loadingBlockInfo = computed(() => {
     const loadingBlock = this.defer().blocks.loadingBlock;
-    if (!loadingBlock) {
+    if (!loadingBlock.exists) {
       return null;
     }
 
@@ -34,5 +34,10 @@ export class DeferViewComponent {
       info.push(`after ${loadingBlock.afterTime}ms`);
     }
     return info.length ? `(${info.join(', ')})` : null;
+  });
+
+  readonly hasDeclaredBlocks = computed(() => {
+    const blocks = this.defer().blocks;
+    return blocks.hasErrorBlock || blocks.placeholderBlock.exists || blocks.loadingBlock.exists;
   });
 }

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -78,12 +78,12 @@ export type HydrationStatus =
       actualNodeDetails: string | null;
     };
 
-export type CurrentDeferBlock = 'placeholder' | 'loading' | 'error';
+export type RenderedDeferBlock = 'defer' | 'placeholder' | 'loading' | 'error';
 
 export interface DeferInfo {
   id: string;
   state: 'placeholder' | 'loading' | 'complete' | 'error' | 'initial';
-  currentBlock: CurrentDeferBlock | null;
+  renderedBlock: RenderedDeferBlock | null;
   triggers: {
     defer: string[];
     hydrate: string[];
@@ -94,8 +94,8 @@ export interface DeferInfo {
 
 export interface BlockDetails {
   hasErrorBlock: boolean;
-  placeholderBlock: null | {minimumTime: number | null};
-  loadingBlock: null | {minimumTime: number | null; afterTime: number | null};
+  placeholderBlock: {exists: boolean; minimumTime: number | null};
+  loadingBlock: {exists: boolean; minimumTime: number | null; afterTime: number | null};
 }
 
 // TODO: refactor to remove nativeElement as it is not serializable

--- a/packages/core/src/render3/util/defer.ts
+++ b/packages/core/src/render3/util/defer.ts
@@ -27,7 +27,7 @@ import {assertLView} from '../assert';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {getLContext} from '../context_discovery';
 import {CONTAINER_HEADER_OFFSET, NATIVE} from '../interfaces/container';
-import {INJECTOR, LView, TVIEW} from '../interfaces/view';
+import {HOST, INJECTOR, LView, TVIEW} from '../interfaces/view';
 import {getNativeByTNode} from './view_utils';
 
 /** Retrieved information about a `@defer` block. */
@@ -64,6 +64,9 @@ export interface DeferBlockData {
 
   /** Stringified version of the block's triggers. */
   triggers: string[];
+
+  /** The comment host/container node next to which all of the root nodes are rendered. */
+  hostNode: Node;
 
   /** Element root nodes that are currently being shown in the block. */
   rootNodes: Node[];
@@ -156,6 +159,7 @@ function findDeferBlocks(node: Node, lView: LView, results: DeferBlockData[]) {
         minimumTime: tDetails.placeholderBlockConfig?.[MINIMUM_SLOT] ?? null,
       },
       triggers: tDetails.debug?.triggers ? Array.from(tDetails.debug.triggers).sort() : [],
+      hostNode: details.lContainer[HOST] as Node,
       rootNodes,
     };
 

--- a/packages/core/test/acceptance/defer_utils_spec.ts
+++ b/packages/core/test/acceptance/defer_utils_spec.ts
@@ -301,6 +301,26 @@ describe('@defer debugging utilities', () => {
     await block.render(DeferBlockState.Complete);
   });
 
+  it('should return the host comment node of the currently-rendered block', () => {
+    @Component({
+      template: `
+        @defer (when false) {
+          Loaded
+        }
+      `,
+    })
+    class App {}
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const results = getDeferBlocks(fixture.nativeElement);
+
+    expect(results.length).toBe(1);
+    expect(results[0].hostNode).toBeTruthy();
+    expect(stringifyNodes([results[0].hostNode])).toEqual(['Comment(container)']);
+  });
+
   function stringifyNodes(nodes: Node[]): string[] {
     return nodes.map((node) => {
       switch (node.nodeType) {


### PR DESCRIPTION
The PR includes two commits:

### feat(core): add host node to DeferBlockData

Add the host/container comment node to the `DeferBlockData`. This node can be used as a `@defer` block locator, in the DOM tree, in the absence of root nodes.

### fix(devtools): support for @defer-only blocks; defer declared blocks

With the help of the above-mentioned commit (i.e. the host node), we can now locate and render in the component tree the `@defer` blocks that don't have a placeholder. Additionally, the commit fixes a couple of minor bugs related to showing `@placeholder` and `@loading` blocks pills in the details panel even if they are not declared.