### PR TITLE
ci: update algolia synonym updater to use node directly rather than tsx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,6 @@ jobs:
           configPath: 'adev/firebase.json'
           distDir: 'dist/bin/adev/dist'
       - name: Update Algolia synonym record
-        run: pnpm tsx adev/scripts/synonyms/update-synonyms.mts
+        run: node adev/scripts/synonyms/update-synonyms.mts
         env:
           ALGOLIA_KEY: ${{ secrets.ALGOLIA_SYNONYM_MANAGER }}

--- a/adev/scripts/synonyms/algolia-synonyms.mts
+++ b/adev/scripts/synonyms/algolia-synonyms.mts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SynonymHit} from 'algoliasearch';
+import {type SynonymHit} from 'algoliasearch';
 
 /**
  * List of synonyms to upload to algolia.

--- a/adev/scripts/synonyms/tsconfig.json
+++ b/adev/scripts/synonyms/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "bundler",
+    "preserveSymlinks": true,
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2022"],
+    "types": [],
+    "skipLibCheck": true
+  }
+}

--- a/adev/scripts/synonyms/update-synonyms.mts
+++ b/adev/scripts/synonyms/update-synonyms.mts
@@ -7,7 +7,7 @@
  */
 
 import {algoliasearch} from 'algoliasearch';
-import synonyms from './algolia-synonyms.mjs';
+import synonyms from './algolia-synonyms.mts';
 
 /** The name of the index being updated. */
 const INDEX_NAME = 'angular_v17';


### PR DESCRIPTION
With new version of node we can import ts files directly in our scripts rather than using tsx
