### PR TITLE
refactor(common): remove unused imports and `standalone: false` from …

### DIFF
--- a/adev/src/content/best-practices/a11y.md
+++ b/adev/src/content/best-practices/a11y.md
@@ -99,7 +99,7 @@ The following example shows how to make a progress bar accessible by using host 
     path="adev/src/content/examples/accessibility/src/app/progress-bar.component.ts"
     language="ts"
     linenums
-    highlight="[12, 20]"/>
+    highlight="[12, 19]"/>
   <docs-code
     path="adev/src/content/examples/accessibility/src/app/app.component.html"
     language="html"

--- a/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
+++ b/packages/examples/core/ts/metadata/lifecycle_hooks_spec.ts
@@ -29,7 +29,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements OnInit {
         ngOnInit() {
@@ -46,7 +45,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements DoCheck {
         ngDoCheck() {
@@ -63,7 +61,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements AfterContentChecked {
         ngAfterContentChecked() {
@@ -80,7 +77,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements AfterContentInit {
         ngAfterContentInit() {
@@ -97,7 +93,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements AfterViewChecked {
         ngAfterViewChecked() {
@@ -114,7 +109,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements AfterViewInit {
         ngAfterViewInit() {
@@ -131,7 +125,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements OnDestroy {
         ngOnDestroy() {
@@ -148,7 +141,6 @@ import {TestBed} from '@angular/core/testing';
       @Component({
         selector: 'my-cmp',
         template: `...`,
-        standalone: false,
       })
       class MyComponent implements OnChanges {
         @Input() prop: number = 0;
@@ -175,12 +167,12 @@ import {TestBed} from '@angular/core/testing';
 
     @Component({
       template: `<my-cmp ${inputBindings}></my-cmp>`,
-      standalone: false,
+      imports: [clazz],
     })
     class ParentComponent {}
 
     const fixture = TestBed.configureTestingModule({
-      declarations: [ParentComponent, clazz],
+      imports: [ParentComponent],
     }).createComponent(ParentComponent);
     fixture.detectChanges();
     fixture.destroy();


### PR DESCRIPTION
…examples

Cleans up example code by removing explicit `standalone: false`, since standalone components are the default and recommended approach.


## What is the current behavior?
<img width="1576" height="908" alt="image" src="https://github.com/user-attachments/assets/34c84479-3149-418e-9ea0-3cbcf556ebf8" />
