### PR TITLE
docs: release notes for the v21.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+<a name="21.1.0"></a>
+# 21.1.0 (2026-01-14)
+## Deprecations
+### upgrade
+- `VERSION` from `@angular/upgrade` is deprecated. Please use the entry from `@angular/upgrade/static` instead.
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [d8790972be](https://github.com/angular/angular/commit/d8790972bea4c59a208219dd36d158b5d7e4fdde) | feat | Add custom transformations for Cloudflare and Cloudinary image loaders |
+| [a6b8cb68af](https://github.com/angular/angular/commit/a6b8cb68afaded6999ee68f495512be1a9932ae4) | feat | support custom transformations in ImageKit and Imgix loaders |
+### compiler
+| Commit | Type | Description |
+| -- | -- | -- |
+| [640693da8e](https://github.com/angular/angular/commit/640693da8e667c015662246152236585d9b24e7f) | feat | Add support for multiple swich cases matching |
+| [0ad3adc7c6](https://github.com/angular/angular/commit/0ad3adc7c6d4094f1e3432a3f2e3bdc9862cb4fa) | fix | Support empty cases |
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [99ad18a4ee](https://github.com/angular/angular/commit/99ad18a4ee82ecc5524106d1d403ccfa9bae2304) | feat | Add stability debugging utility |
+| [a0dfa5fa86](https://github.com/angular/angular/commit/a0dfa5fa86f40520b0e368a021b3c72009a45e8e) | feat | support rest arguments in function calls |
+| [6e18fa8bc9](https://github.com/angular/angular/commit/6e18fa8bc9d7e6801e2e89e635c2f759dc422317) | feat | support spread elements in array literals |
+| [e407280ab5](https://github.com/angular/angular/commit/e407280ab53cde5f93c3a643457c848845c6ec8b) | feat | support spread expressions in object literals |
+| [06be8034bb](https://github.com/angular/angular/commit/06be8034bb9b9adfc07ab0d40cd87c6ae5de02de) | fix | Microtask scheduling should be used after any application synchronization |
+| [b4f584cf42](https://github.com/angular/angular/commit/b4f584cf42235c94bb8389fa55bc634e23d7b010) | fix | return `StaticProvider` for `providePlatformInitializer` |
+### forms
+| Commit | Type | Description |
+| -- | -- | -- |
+| [1ea5c97703](https://github.com/angular/angular/commit/1ea5c97703ad3c6d8e4cb1b4297eec57629ce117) | feat | allow focusing bound control from field state |
+### platform-browser
+| Commit | Type | Description |
+| -- | -- | -- |
+| [ec9dc94cee](https://github.com/angular/angular/commit/ec9dc94ceeb3c026c64e01c6889b7f5c6fd25a66) | feat | add `context` to `createApplication` |
+| [ab67988d2e](https://github.com/angular/angular/commit/ab67988d2e5242eff0034483f984428d684acd02) | feat | resolve JIT resources in `createApplication` |
+### router
+| Commit | Type | Description |
+| -- | -- | -- |
+| [5edceffd04](https://github.com/angular/angular/commit/5edceffd0431f5a25e111a731db521e966b91f86) | feat | add controls for route cleanup |
+| [a03c82564d](https://github.com/angular/angular/commit/a03c82564da6824e199ff48d5249ea8708040951) | feat | Add scroll behavior controls on router navigation |
+| [e44839b016](https://github.com/angular/angular/commit/e44839b01640505e554fff16f24e08f282a557c0) | feat | Add standalone function to create a comptued for isActive |
+| [c25d749d85](https://github.com/angular/angular/commit/c25d749d85374fff7745980cd9bb2673c661105a) | feat | Execute RunGuardsAndResolvers function in injection context |
+| [1c00ab42f8](https://github.com/angular/angular/commit/1c00ab42f8714f2775ed75bbf3cdf0fd44ee32c3) | feat | extend paramters of RedirectFunction to include paramMap and queryParamMap |
+| [7003e8d241](https://github.com/angular/angular/commit/7003e8d2417660f71b3a2a017aff3e650c8d9646) | feat | Publish Router's integration with platform Navigation API as experimental |
+| [c84d372778](https://github.com/angular/angular/commit/c84d37277874cf7cbd7582a295d796ff113b9cc1) | feat | Support wildcard params with segments trailing ([#64737](https://github.com/angular/angular/pull/64737)) |
+### upgrade
+| Commit | Type | Description |
+| -- | -- | -- |
+| [75fe8f8af9](https://github.com/angular/angular/commit/75fe8f8af9488bae6f7068b64d44500643c5d63f) | refactor | deprecate `VERSION` export |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.0.9"></a>
 # 21.0.9 (2026-01-14)
 ### forms
@@ -9,62 +59,6 @@
 | Commit | Type | Description |
 | -- | -- | -- |
 | [e4bfa5c9e7](https://github.com/angular/angular/commit/e4bfa5c9e7feec48d3c4e9425a21a2ccf6532bdb) | fix | prevent duplicate imports in common-to-standalone migration |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="21.1.0-rc.0"></a>
-# 21.1.0-rc.0 (2026-01-08)
-### common
-| Commit | Type | Description |
-| -- | -- | -- |
-| [d8790972be](https://github.com/angular/angular/commit/d8790972bea4c59a208219dd36d158b5d7e4fdde) | feat | Add custom transformations for Cloudflare and Cloudinary image loaders |
-| [a6b8cb68af](https://github.com/angular/angular/commit/a6b8cb68afaded6999ee68f495512be1a9932ae4) | feat | support custom transformations in ImageKit and Imgix loaders |
-### compiler
-| Commit | Type | Description |
-| -- | -- | -- |
-| [640693da8e](https://github.com/angular/angular/commit/640693da8e667c015662246152236585d9b24e7f) | feat | Add support for multiple swich cases matching |
-| [10da2f9029](https://github.com/angular/angular/commit/10da2f9029720e7a647d57921548b39cf11f55dd) | fix | better types for a few expression AST nodes |
-| [3a56c1367f](https://github.com/angular/angular/commit/3a56c1367f336a7da0ed8dd00c299c8be8da848c) | fix | produce accurate span for typeof and void expressions |
-| [76fa180005](https://github.com/angular/angular/commit/76fa180005a30b431c133285b68e8398df2e0e52) | fix | provide location information for literal map keys |
-| [fa7cb4b87a](https://github.com/angular/angular/commit/fa7cb4b87af39f64a77ba930d891ac371a6858e9) | fix | stop ThisReceiver inheritance from ImplicitReceiver |
-| [0ad3adc7c6](https://github.com/angular/angular/commit/0ad3adc7c6d4094f1e3432a3f2e3bdc9862cb4fa) | fix | Support empty cases |
-### compiler-cli
-| Commit | Type | Description |
-| -- | -- | -- |
-| [106ba63650](https://github.com/angular/angular/commit/106ba63650340cc828e302dc4eb46dbd4fb43a3b) | fix | ensure component import diagnostics are reported within the `imports` expression |
-| [3a26244d61](https://github.com/angular/angular/commit/3a26244d61c9233e237817dc861be12dfc4bc918) | fix | fix up spelling of diagnostic |
-| [f12e160bc1](https://github.com/angular/angular/commit/f12e160bc1010daf582d5f0ab863a16e4b94ca4c) | fix | support qualified names in `typeof` type references |
-### core
-| Commit | Type | Description |
-| -- | -- | -- |
-| [99ad18a4ee](https://github.com/angular/angular/commit/99ad18a4ee82ecc5524106d1d403ccfa9bae2304) | feat | Add stability debugging utility |
-| [a0dfa5fa86](https://github.com/angular/angular/commit/a0dfa5fa86f40520b0e368a021b3c72009a45e8e) | feat | support rest arguments in function calls |
-| [6e18fa8bc9](https://github.com/angular/angular/commit/6e18fa8bc9d7e6801e2e89e635c2f759dc422317) | feat | support spread elements in array literals |
-| [e407280ab5](https://github.com/angular/angular/commit/e407280ab53cde5f93c3a643457c848845c6ec8b) | feat | support spread expressions in object literals |
-| [80b0fbba1f](https://github.com/angular/angular/commit/80b0fbba1f9e3a8ce9a89aa88ae3efd4a1f60271) | fix | avoid leaking view data in animations |
-| [e2a9938c51](https://github.com/angular/angular/commit/e2a9938c517b1e0429818e285ef70b69bf61181b) | fix | explicitly cast signal node value to String |
-| [30e9c62bdf](https://github.com/angular/angular/commit/30e9c62bdfb8af73c24833473bd4492869538d2d) | fix | fix memory leak with event replay |
-| [86dc1283e8](https://github.com/angular/angular/commit/86dc1283e8cad0eac1a31bc2c6cff137e6cb2542) | fix | handle cancelled traversals in fake navigation |
-| [91dc91bae4](https://github.com/angular/angular/commit/91dc91bae4a1bbefc58bef6ef739d0e02ab44d56) | fix | sanitize sensitive attributes on SVG script elements |
-### forms
-| Commit | Type | Description |
-| -- | -- | -- |
-| [2d85ae5811](https://github.com/angular/angular/commit/2d85ae58115690507d4a47ca5c6a7a642abd1c2e) | feat | add `[formField]` directive |
-| [89c37f1f7f](https://github.com/angular/angular/commit/89c37f1f7f93ec3746479c73b87b948a6e93dcaa) | fix | allow custom controls to require `dirty` input |
-| [82edf18427](https://github.com/angular/angular/commit/82edf18427b1fcf7e63cb3ac930dfa1d065a25f1) | fix | allow custom controls to require `hidden` input |
-| [1a4c3eb1d0](https://github.com/angular/angular/commit/1a4c3eb1d09a5db57a07ea5ed593cbe3e47e8125) | fix | allow custom controls to require `pending` input |
-| [e7d99f02cb](https://github.com/angular/angular/commit/e7d99f02cba503aa7a30f71d388aef353205fff7) | fix | clean up abort listener after timeout |
-| [cb09fb8308](https://github.com/angular/angular/commit/cb09fb8308a7c94cca9af6074ef523ce094d5f67) | fix | support custom controls with non signal-based models |
-| [282220d032](https://github.com/angular/angular/commit/282220d032a64d32c466bb37057c6f91df39bfb3) | fix | Support readonly arrays in signal forms |
-### router
-| Commit | Type | Description |
-| -- | -- | -- |
-| [5edceffd04](https://github.com/angular/angular/commit/5edceffd0431f5a25e111a731db521e966b91f86) | feat | add controls for route cleanup |
-| [e44839b016](https://github.com/angular/angular/commit/e44839b01640505e554fff16f24e08f282a557c0) | feat | Add standalone function to create a comptued for isActive |
-| [1c00ab42f8](https://github.com/angular/angular/commit/1c00ab42f8714f2775ed75bbf3cdf0fd44ee32c3) | feat | extend paramters of RedirectFunction to include paramMap and queryParamMap |
-| [7003e8d241](https://github.com/angular/angular/commit/7003e8d2417660f71b3a2a017aff3e650c8d9646) | feat | Publish Router's integration with platform Navigation API as experimental |
-| [bcef77d950](https://github.com/angular/angular/commit/bcef77d9507e9778c35a6186ef4a8c1d67cd5992) | fix | Fix RouterLink href not updating with `queryParamsHandling` |
-| [9e043decaf](https://github.com/angular/angular/commit/9e043decaf01dc622236814a2a2db73ec2bffe28) | fix | handle errors from view transition `updateCallbackDone` promise |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -135,53 +129,6 @@
 
 <!-- CHANGELOG SPLIT MARKER -->
 
-<a name="21.1.0-next.4"></a>
-# 21.1.0-next.4 (2025-12-17)
-## Breaking Changes
-### forms
-- The shape of `SignalFormsConfig.classes` has changed
-  
-  Previously each function in the `classes` map took a `FieldState`. Now
-  it takes a `Field` directive.
-  
-  For example if you previously had:
-  ```
-  provideSignalFormsConfig({
-    classes: {
-      'my-valid': (state) => state.valid()
-    }
-  })
-  ```
-  
-  You would need to update to:
-  ```
-  provideSignalFormsConfig({
-    classes: {
-      'my-valid': ({state}) => state().valid()
-    }
-  })
-  ```
-- 
-### core
-| Commit | Type | Description |
-| -- | -- | -- |
-| [06be8034bb](https://github.com/angular/angular/commit/06be8034bb9b9adfc07ab0d40cd87c6ae5de02de) | fix | Microtask scheduling should be used after any application synchronization |
-| [b4f584cf42](https://github.com/angular/angular/commit/b4f584cf42235c94bb8389fa55bc634e23d7b010) | fix | return `StaticProvider` for `providePlatformInitializer` |
-| [7be4ddef1c](https://github.com/angular/angular/commit/7be4ddef1ccb9a6b330b52b9bbdd174089755503) | fix | throw better errors for potential circular references |
-| [f516370c8e](https://github.com/angular/angular/commit/f516370c8e8e96806bad757d43c857ab5f2051ed) | fix | use mutable ResponseInit type for RESPONSE_INIT token |
-### forms
-| Commit | Type | Description |
-| -- | -- | -- |
-| [348f149e8b](https://github.com/angular/angular/commit/348f149e8b06d6885f54bac4cf03a9481a8b19b7) | feat | pass field directive to class config |
-| [ae0c59028a](https://github.com/angular/angular/commit/ae0c59028a2f393ea5716bf222db2c38e7a3989f) | refactor | rename field to fieldTree in FieldContext and ValidationError |
-### language-service
-| Commit | Type | Description |
-| -- | -- | -- |
-| [9f5744a92d](https://github.com/angular/angular/commit/9f5744a92dda4219e93bf7e6236d32a93bc167e6) | fix | avoid interpolation highlighting inside @let |
-| [ce1a4769f9](https://github.com/angular/angular/commit/ce1a4769f987e96e2a1b1cbc7654ed5bac9ce91d) | fix | Prevent language service from crashing on suggestion diagnostic errors |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="21.0.6"></a>
 # 21.0.6 (2025-12-17)
 ## Breaking Changes (affecting only experimental features)
@@ -229,24 +176,6 @@
 
 <!-- CHANGELOG SPLIT MARKER -->
 
-<a name="21.1.0-next.3"></a>
-
-# 21.1.0-next.3 (2025-12-11)
-
-### core
-
-| Commit                                                                                            | Type | Description                                                                    |
-| ------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------ |
-| [4f6014a756a](https://github.com/angular/angular/commit/4f6014a756a95ff9cb55e91deb27039b7eb079ee) | fix  | avoid false-positive deprecation when using `InjectionToken` with factory only |
-
-### forms
-
-| Commit                                                                                            | Type | Description                 |
-| ------------------------------------------------------------------------------------------------- | ---- | --------------------------- |
-| [d0097f7d0c2](https://github.com/angular/angular/commit/d0097f7d0c214c5c3d715e7f1dfa3723b31f4065) | fix  | fix signal forms type error |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="21.0.5"></a>
 
 # 21.0.5 (2025-12-11)
@@ -262,47 +191,6 @@
 | Commit                                                                                            | Type | Description                 |
 | ------------------------------------------------------------------------------------------------- | ---- | --------------------------- |
 | [4fd2b722b40](https://github.com/angular/angular/commit/4fd2b722b4054181a6e5f09a3cc657ae05541782) | fix  | fix signal forms type error |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="21.1.0-next.2"></a>
-
-# 21.1.0-next.2 (2025-12-10)
-
-## Deprecations
-
-### upgrade
-
-- `VERSION` from `@angular/upgrade` is deprecated. Please use the entry from `@angular/upgrade/static` instead.
-
-### compiler
-
-| Commit                                                                                            | Type | Description                       |
-| ------------------------------------------------------------------------------------------------- | ---- | --------------------------------- |
-| [ae1c0dc4900](https://github.com/angular/angular/commit/ae1c0dc49002665c10d4e44f530f4cb8d1e35b8d) | perf | chain query creation instructions |
-
-### compiler-cli
-
-| Commit                                                                                            | Type | Description                                         |
-| ------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------- |
-| [8a3f3a91cf6](https://github.com/angular/angular/commit/8a3f3a91cf6919f11c1583afeb71b65488f8cba4) | fix  | expand type for native controls with a dynamic type |
-
-### forms
-
-| Commit                                                                                            | Type | Description                                                                                             |
-| ------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------- |
-| [aff8b248b35](https://github.com/angular/angular/commit/aff8b248b35931cbe7d644ad2594144b75064ca6) | feat | expose element on signal forms `Field` directive                                                        |
-| [ebc5c2b083a](https://github.com/angular/angular/commit/ebc5c2b083a90fde6fced3521be434a414ef29dd) | feat | redo the signal forms metadata API                                                                      |
-| [9fe95665813](https://github.com/angular/angular/commit/9fe95665813e24544d00dcf463658067da745ac2) | fix  | add signals for dirty, hidden, and pending states in custom controls                                    |
-| [14713d09923](https://github.com/angular/angular/commit/14713d09923b5315ac7c6f20acc06fc69ff0ed79) | fix  | allow resetting with empty string                                                                       |
-| [b96f65a963f](https://github.com/angular/angular/commit/b96f65a963febab376f2a783cf4313a8b8140efe) | fix  | memoize reads of child fields in signal forms ([#65802](https://github.com/angular/angular/pull/65802)) |
-| [179b4cba67b](https://github.com/angular/angular/commit/179b4cba67b95563da27fd5f12dd2acc910a1a52) | fix  | Reuse key in parent in compat structure                                                                 |
-
-### upgrade
-
-| Commit                                                                                            | Type     | Description                |
-| ------------------------------------------------------------------------------------------------- | -------- | -------------------------- |
-| [75fe8f8af94](https://github.com/angular/angular/commit/75fe8f8af9488bae6f7068b64d44500643c5d63f) | refactor | deprecate `VERSION` export |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -332,52 +220,6 @@
 | [cbb10179c80](https://github.com/angular/angular/commit/cbb10179c8098f6a20b0bc365a492f14e4d2a51a) | fix  | allow resetting with empty string                                                                       |
 | [bf1c12cd932](https://github.com/angular/angular/commit/bf1c12cd932028dc4bb50914c64bbb6d882b6ec1) | fix  | memoize reads of child fields in signal forms ([#65802](https://github.com/angular/angular/pull/65802)) |
 | [6d7475582f9](https://github.com/angular/angular/commit/6d7475582f95720b4487f663d339a18a25374481) | fix  | Reuse key in parent in compat structure                                                                 |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="21.1.0-next.1"></a>
-
-# 21.1.0-next.1 (2025-12-03)
-
-### compiler
-
-| Commit                                                                                           | Type | Description                                                       |
-| ------------------------------------------------------------------------------------------------ | ---- | ----------------------------------------------------------------- |
-| [1c6b0704fb](https://github.com/angular/angular/commit/1c6b0704fb63d051fab8acff84d076abfbc4893a) | fix  | prevent XSS via SVG animation `attributeName` and MathML/SVG URLs |
-
-### compiler-cli
-
-| Commit                                                                                           | Type | Description                                               |
-| ------------------------------------------------------------------------------------------------ | ---- | --------------------------------------------------------- |
-| [e30e61b789](https://github.com/angular/angular/commit/e30e61b7893a9b04ada54ab184c24e652dcd114e) | fix  | avoid allocating an object for signals in production mode |
-| [6773d3b97d](https://github.com/angular/angular/commit/6773d3b97d07dcbf7760c0c12d9384fa60f7082e) | fix  | check that field radio button values are strings          |
-
-### core
-
-| Commit                                                                                           | Type | Description                                                                                                        |
-| ------------------------------------------------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------ |
-| [d8ab83ca82](https://github.com/angular/angular/commit/d8ab83ca82c36faacae9fc1a01e9eb9762e679fc) | fix  | run animation queue in environment injector context                                                                |
-| [886cf6c452](https://github.com/angular/angular/commit/886cf6c452abcf85b70058caeb080ff3a5c51cb9) | fix  | unable to inject viewProviders when host directive with providers is present                                       |
-| [e6d5632a30](https://github.com/angular/angular/commit/e6d5632a3059a4920f19eb6b193ec7edb11645d4) | perf | tree shake unused dynamic `[field]` binding instructions ([#65599](https://github.com/angular/angular/pull/65599)) |
-
-### forms
-
-| Commit                                                                                           | Type | Description                                                                                  |
-| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------------------------------------------------------- |
-| [7d1e502345](https://github.com/angular/angular/commit/7d1e50234515185ee73c8bdd39f7af2a26635ca2) | feat | Allows transforms on `FormUiControl` signals                                                 |
-| [cd7ae7e2ce](https://github.com/angular/angular/commit/cd7ae7e2ce4648edf62c047b3e453c8b32539d4a) | fix  | support dynamic `[field]` bindings ([#65599](https://github.com/angular/angular/pull/65599)) |
-
-### http
-
-| Commit                                                                                           | Type | Description                                          |
-| ------------------------------------------------------------------------------------------------ | ---- | ---------------------------------------------------- |
-| [0659d11c85](https://github.com/angular/angular/commit/0659d11c854c9c6b886a2e925afef98d70bb005f) | fix  | enable XSRF protection for same-origin absolute URLs |
-
-### router
-
-| Commit                                                                                           | Type | Description                                         |
-| ------------------------------------------------------------------------------------------------ | ---- | --------------------------------------------------- |
-| [b74a0693f2](https://github.com/angular/angular/commit/b74a0693f2409812ad1ab02f19eb3fbe7ce1b83e) | fix  | handle errors from view transition finished promise |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -466,27 +308,6 @@
 | Commit                                                                                           | Type | Description                                          |
 | ------------------------------------------------------------------------------------------------ | ---- | ---------------------------------------------------- |
 | [05fe6686a9](https://github.com/angular/angular/commit/05fe6686a97fa0bcd3cf157805b3612033f975bc) | fix  | prevent XSRF token leakage to protocol-relative URLs |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="21.1.0-next.0"></a>
-
-# 21.1.0-next.0 (2025-11-25)
-
-### platform-browser
-
-| Commit                                                                                           | Type | Description                                  |
-| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------- |
-| [ec9dc94cee](https://github.com/angular/angular/commit/ec9dc94ceeb3c026c64e01c6889b7f5c6fd25a66) | feat | add `context` to `createApplication`         |
-| [ab67988d2e](https://github.com/angular/angular/commit/ab67988d2e5242eff0034483f984428d684acd02) | feat | resolve JIT resources in `createApplication` |
-
-### router
-
-| Commit                                                                                           | Type | Description                                                                                              |
-| ------------------------------------------------------------------------------------------------ | ---- | -------------------------------------------------------------------------------------------------------- |
-| [a03c82564d](https://github.com/angular/angular/commit/a03c82564da6824e199ff48d5249ea8708040951) | feat | Add scroll behavior controls on router navigation                                                        |
-| [c25d749d85](https://github.com/angular/angular/commit/c25d749d85374fff7745980cd9bb2673c661105a) | feat | Execute RunGuardsAndResolvers function in injection context                                              |
-| [c84d372778](https://github.com/angular/angular/commit/c84d37277874cf7cbd7582a295d796ff113b9cc1) | feat | Support wildcard params with segments trailing ([#64737](https://github.com/angular/angular/pull/64737)) |
 
 <!-- CHANGELOG SPLIT MARKER -->
 


### PR DESCRIPTION
Cherry-picks the changelog from the "21.1.x" branch to the next branch (main).