### PR TITLE
refactor(forms): accept transforms for `FormUiControl`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1050,7 +1050,7 @@ export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
     // (undocumented)
     [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
     // (undocumented)
-    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: TransformT;
+    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: (value: TransformT) => void;
 }
 
 // @public

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -242,24 +242,24 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
 
 // @public
 export interface FormUiControl {
-    readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly disabledReasons?: InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]> | InputSignalWithTransform<readonly WithOptionalFieldTree<DisabledReason>[], unknown>;
-    readonly errors?: InputSignal<readonly ValidationError.WithOptionalFieldTree[]> | InputSignalWithTransform<readonly ValidationError.WithOptionalFieldTree[], unknown>;
+    readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly disabledReasons?: InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]> | InputSignalWithTransform<unknown, readonly WithOptionalFieldTree<DisabledReason>[]>;
+    readonly errors?: InputSignal<readonly ValidationError.WithOptionalFieldTree[]> | InputSignalWithTransform<unknown, readonly ValidationError.WithOptionalFieldTree[]>;
     focus?(options?: FocusOptions): void;
-    readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly max?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly maxLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly min?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
-    readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
-    readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], unknown>;
-    readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
-    readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+    readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly max?: InputSignal<number | undefined> | InputSignalWithTransform<unknown, number | undefined>;
+    readonly maxLength?: InputSignal<number | undefined> | InputSignalWithTransform<unknown, number | undefined>;
+    readonly min?: InputSignal<number | undefined> | InputSignalWithTransform<unknown, number | undefined>;
+    readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<unknown, number | undefined>;
+    readonly name?: InputSignal<string> | InputSignalWithTransform<unknown, string>;
+    readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<unknown, readonly RegExp[]>;
+    readonly pending?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
+    readonly required?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
     readonly touch?: OutputRef<void>;
-    readonly touched?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+    readonly touched?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
 }
 
 // @public

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -880,6 +880,29 @@ describe('type check blocks', () => {
     expect(block).toContain('_t2 = $event;');
   });
 
+  it('should handle narrowing down a signal input passed down to a child component', () => {
+    const TEMPLATE = `@if(value(); as value) {<child [input]="value"></child>}`;
+    const DIRECTIVES: TestDeclaration[] = [
+      {
+        type: 'directive',
+        name: 'Child',
+        selector: 'child',
+        inputs: {
+          input: {
+            classPropertyName: 'input',
+            bindingPropertyName: 'input',
+            required: false,
+            isSignal: true,
+            transform: null,
+          },
+        },
+      },
+    ];
+    const block = tcb(TEMPLATE, DIRECTIVES);
+    expect(block).toContain('var _t2 = null! as i0.Child;');
+    expect(block).toContain('const _t3: i1.ɵInputSignalWriteType<(typeof _t2)["input"]> = (_t1);');
+  });
+
   it('should handle a two-way binding to a model()', () => {
     const TEMPLATE = `<div twoWay [(input)]="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [
@@ -902,10 +925,10 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
     expect(block).toContain(
-      '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));',
+      'const _t2: i1.ɵInputSignalWriteType<(typeof _t1)["input"]> = i1.ɵunwrapWritableSignal((((this).value)));',
     );
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t3 = $event;');
   });
 
   it('should handle a two-way binding to an input with a transform', () => {
@@ -2432,7 +2455,7 @@ describe('type check blocks', () => {
       const result = tcb(TEMPLATE, [DIRECTIVE]);
 
       expect(result).toContain(`import * as i1 from '@angular/core';`);
-      expect(result).toContain(`[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]`);
+      expect(result).toContain(`i1.ɵInputSignalWriteType`);
     });
 
     it('should re-use existing imports from original source files', () => {
@@ -2460,9 +2483,9 @@ describe('type check blocks', () => {
 
       const testSf = getSourceFileOrError(programStrategy.getProgram(), absoluteFrom('/test.ts'));
       expect(testSf.text).toContain(
-        `import { Component, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE } from '@angular/core'; // should be re-used`,
+        `import { Component, ɵInputSignalWriteType } from '@angular/core'; // should be re-used`,
       );
-      expect(testSf.text).toContain(`[ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]`);
+      expect(testSf.text).toContain(`ɵInputSignalWriteType`);
     });
   });
 
@@ -2879,10 +2902,10 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        'const _t2: i1.ɵInputSignalWriteType<(typeof _t1)["value"]> = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
-      expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('var _t3 = null! as i0.FormField;');
+      expect(block).toContain('_t3.field = (((this).f));');
     });
 
     it('should generate a custom checkbox control', () => {
@@ -2909,10 +2932,10 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.checked[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        'const _t2: i1.ɵInputSignalWriteType<(typeof _t1)["checked"]> = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
-      expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('var _t3 = null! as i0.FormField;');
+      expect(block).toContain('_t3.field = (((this).f));');
     });
 
     it('should add implicit bindings to other field-related inputs on a custom control', () => {
@@ -2960,19 +2983,18 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        'const _t2: i1.ɵInputSignalWriteType<(typeof _t1)["value"]> = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
       expect(block).toContain(
-        '_t1.required[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).required());',
+        'const _t3: i1.ɵInputSignalWriteType<(typeof _t1)["disabled"]> = ((((this).f)()).disabled());',
       );
       expect(block).toContain(
-        '_t1.disabled[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).disabled());',
+        'const _t4: i1.ɵInputSignalWriteType<(typeof _t1)["name"]> = ((((this).f)()).name());',
       );
       expect(block).toContain(
-        '_t1.name[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((((this).f)()).name());',
+        'const _t5: i1.ɵInputSignalWriteType<(typeof _t1)["required"]> = ((((this).f)()).required());',
       );
-      expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('_t6.field = (((this).f));');
     });
 
     it('should produce safe reads for the fields that are optional', () => {
@@ -3006,13 +3028,13 @@ describe('type check blocks', () => {
 
       expect(block).toContain('var _t1 = null! as i0.CustomControl;');
       expect(block).toContain(
-        '_t1.value[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
+        'const _t2: i1.ɵInputSignalWriteType<(typeof _t1)["value"]> = i1.ɵunwrapWritableSignal((((((this).f)()).value)));',
       );
       expect(block).toContain(
-        '_t1.max[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = ((0 as any ? (((((this).f)()).max))!() : undefined));',
+        'const _t3: i1.ɵInputSignalWriteType<(typeof _t1)["max"]> = ((0 as any ? (((((this).f)()).max))!() : undefined));',
       );
-      expect(block).toContain('var _t2 = null! as i0.FormField;');
-      expect(block).toContain('_t2.field = (((this).f));');
+      expect(block).toContain('var _t4 = null! as i0.FormField;');
+      expect(block).toContain('_t4.field = (((this).f));');
     });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -7,26 +7,26 @@
  */
 
 import {
+  AST,
   ASTWithSource,
   Binary,
   BindingPipe,
   Conditional,
   Interpolation,
+  LiteralArray,
+  LiteralMap,
+  ParseTemplateOptions,
   PropertyRead,
   TmplAstBoundAttribute,
   TmplAstBoundText,
+  TmplAstComponent,
   TmplAstElement,
   TmplAstForLoopBlock,
+  TmplAstIfBlock,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
   TmplAstTemplate,
-  AST,
-  LiteralArray,
-  LiteralMap,
-  TmplAstIfBlock,
-  TmplAstLetDeclaration,
-  ParseTemplateOptions,
-  TmplAstComponent,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -52,17 +52,16 @@ import {
   TypeCheckingConfig,
   VariableSymbol,
 } from '../api';
+import {findNodeInFile} from '../src/tcb_util';
 import {
+  setup as baseTestSetup,
+  createNgCompilerForFile,
   getClass,
   ngForDeclaration,
   ngForTypeCheckTarget,
-  setup as baseTestSetup,
-  TypeCheckingTarget,
-  createNgCompilerForFile,
   TestDirective,
+  TypeCheckingTarget,
 } from '../testing';
-import {TsCreateProgramDriver} from '../../program_driver';
-import {findNodeInFile} from '../src/tcb_util';
 
 runInEachFileSystem(() => {
   describe('TemplateTypeChecker.getSymbolOfNode', () => {
@@ -1378,13 +1377,11 @@ runInEachFileSystem(() => {
         const testElement = ifBranchNode.children[0] as TmplAstElement;
 
         const inputAbinding = testElement.inputs[0];
-        const aSymbol = templateTypeChecker.getSymbolOfNode(inputAbinding, cmp);
-        expect(aSymbol)
-          .withContext(
-            'Symbol builder does not return symbols for restricted inputs with ' +
-              '`honorAccessModifiersForInputBindings = false` (same for decorator inputs)',
-          )
-          .toBe(null);
+        const aSymbol = templateTypeChecker.getSymbolOfNode(inputAbinding, cmp)!;
+        assertInputBindingSymbol(aSymbol);
+        expect(
+          (aSymbol.bindings[0].tsSymbol!.declarations![0] as ts.PropertyDeclaration).name.getText(),
+        ).toEqual('inputA');
       });
 
       it('does not retrieve a symbol for an input when undeclared', () => {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -489,6 +489,7 @@ export class Identifiers {
 
   // type-checking
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
+  static InputSignalWriteType = {name: 'ɵInputSignalWriteType', moduleName: CORE};
   static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
   static unwrapWritableSignal = {name: 'ɵunwrapWritableSignal', moduleName: CORE};
   static assertType = {name: 'ɵassertType', moduleName: CORE};

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -17,14 +17,15 @@ export {
   InputSignal,
   InputSignalWithTransform,
   ɵINPUT_SIGNAL_BRAND_WRITE_TYPE,
+  ɵInputSignalWriteType,
 } from './authoring/input/input_signal';
 export {ɵUnwrapDirectiveSignalInputs} from './authoring/input/input_type_checking';
 export {ModelFunction} from './authoring/model/model';
 export {ModelOptions, ModelSignal} from './authoring/model/model_signal';
 export {output, OutputOptions} from './authoring/output/output';
 export {
-  getOutputDestroyRef as ɵgetOutputDestroyRef,
   OutputEmitterRef,
+  getOutputDestroyRef as ɵgetOutputDestroyRef,
 } from './authoring/output/output_emitter_ref';
 export {OutputRef, OutputRefSubscription} from './authoring/output/output_ref';
 export {ContentChildFunction, ViewChildFunction} from './authoring/queries';

--- a/packages/core/src/authoring/input/input_signal.ts
+++ b/packages/core/src/authoring/input/input_signal.ts
@@ -62,6 +62,9 @@ export type InputOptionsWithTransform<T, TransformT> = Required<
 export const ɵINPUT_SIGNAL_BRAND_READ_TYPE: unique symbol = /* @__PURE__ */ Symbol();
 export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE: unique symbol = /* @__PURE__ */ Symbol();
 
+export type ɵInputSignalWriteType<T> =
+  T extends InputSignalWithTransform<any, infer TransformT> ? TransformT : never;
+
 /**
  * `InputSignalWithTransform` represents a special `Signal` for a
  * directive/component input with a `transform` function.
@@ -89,7 +92,7 @@ export const ɵINPUT_SIGNAL_BRAND_WRITE_TYPE: unique symbol = /* @__PURE__ */ Sy
 export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
   [SIGNAL]: InputSignalNode<T, TransformT>;
   [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
-  [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: TransformT;
+  [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: (value: TransformT) => void;
 }
 
 /**

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -38,6 +38,7 @@ const AOT_ONLY = new Set<string>([
 
   // used in type-checking.
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
+  'ɵInputSignalWriteType',
   'ɵUnwrapDirectiveSignalInputs',
   'ɵunwrapWritableSignal',
   'ɵassertType',

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -24,94 +24,94 @@ export interface FormUiControl {
    */
   readonly errors?:
     | InputSignal<readonly ValidationError.WithOptionalFieldTree[]>
-    | InputSignalWithTransform<readonly ValidationError.WithOptionalFieldTree[], unknown>;
+    | InputSignalWithTransform<unknown, readonly ValidationError.WithOptionalFieldTree[]>;
   /**
    * An input to receive the disabled status for the field. If implemented, the `Field` directive
    * will automatically bind the disabled status from the bound field to this input.
    */
-  readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the reasons for the disablement of the field. If implemented, the `Field`
    * directive will automatically bind the disabled reason from the bound field to this input.
    */
   readonly disabledReasons?:
     | InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]>
-    | InputSignalWithTransform<readonly WithOptionalFieldTree<DisabledReason>[], unknown>;
+    | InputSignalWithTransform<unknown, readonly WithOptionalFieldTree<DisabledReason>[]>;
   /**
    * An input to receive the readonly status for the field. If implemented, the `Field` directive
    * will automatically bind the readonly status from the bound field to this input.
    */
-  readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the hidden status for the field. If implemented, the `Field` directive
    * will automatically bind the hidden status from the bound field to this input.
    */
-  readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly hidden?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the invalid status for the field. If implemented, the `Field` directive
    * will automatically bind the invalid status from the bound field to this input.
    */
-  readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly invalid?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the pending status for the field. If implemented, the `Field` directive
    * will automatically bind the pending status from the bound field to this input.
    */
-  readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly pending?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the touched status for the field. If implemented, the `Field` directive
    * will automatically bind the touched status from the bound field to this input.
    */
-  readonly touched?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly touched?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the dirty status for the field. If implemented, the `Field` directive
    * will automatically bind the dirty status from the bound field to this input.
    */
-  readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the name for the field. If implemented, the `Field` directive will
    * automatically bind the name from the bound field to this input.
    */
-  readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
+  readonly name?: InputSignal<string> | InputSignalWithTransform<unknown, string>;
   /**
    * An input to receive the required status for the field. If implemented, the `Field` directive
    * will automatically bind the required status from the bound field to this input.
    */
-  readonly required?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
+  readonly required?: InputSignal<boolean> | InputSignalWithTransform<unknown, boolean>;
   /**
    * An input to receive the min value for the field. If implemented, the `Field` directive will
    * automatically bind the min value from the bound field to this input.
    */
   readonly min?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<unknown, number | undefined>;
   /**
    * An input to receive the min length for the field. If implemented, the `Field` directive will
    * automatically bind the min length from the bound field to this input.
    */
   readonly minLength?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<unknown, number | undefined>;
   /**
    * An input to receive the max value for the field. If implemented, the `Field` directive will
    * automatically bind the max value from the bound field to this input.
    */
   readonly max?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<unknown, number | undefined>;
   /**
    * An input to receive the max length for the field. If implemented, the `Field` directive will
    * automatically bind the max length from the bound field to this input.
    */
   readonly maxLength?:
     | InputSignal<number | undefined>
-    | InputSignalWithTransform<number | undefined, unknown>;
+    | InputSignalWithTransform<unknown, number | undefined>;
   /**
    * An input to receive the value patterns for the field. If implemented, the `Field` directive
    * will automatically bind the value patterns from the bound field to this input.
    */
   readonly pattern?:
     | InputSignal<readonly RegExp[]>
-    | InputSignalWithTransform<readonly RegExp[], unknown>;
+    | InputSignalWithTransform<unknown, readonly RegExp[]>;
   /**
    * An output to emit when the control is touched.
    */

--- a/packages/forms/signals/test/web/form_field_directive.spec.ts
+++ b/packages/forms/signals/test/web/form_field_directive.spec.ts
@@ -3031,6 +3031,32 @@ describe('field directive', () => {
       expect(fixture.componentInstance).toBeDefined();
     });
 
+    it('should accept InputSignalWithTransform for boolean properties with stricter pre-transform types', () => {
+      @Component({selector: 'custom-control', template: ``})
+      class CustomControl implements FormValueControl<string> {
+        readonly value = model('');
+        readonly disabled = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly readonly = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly required = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly hidden = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly invalid = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly pending = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly dirty = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+        readonly touched = input<boolean, boolean | string>(false, {transform: booleanAttribute});
+      }
+
+      @Component({
+        imports: [FormField, CustomControl],
+        template: `<custom-control [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(''));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      expect(fixture.componentInstance).toBeDefined();
+    });
+
     it('should accept InputSignalWithTransform for number properties', () => {
       @Component({selector: 'custom-control', template: ``})
       class CustomControl implements FormValueControl<number> {
@@ -3041,6 +3067,36 @@ describe('field directive', () => {
           transform: numberAttribute,
         });
         readonly maxLength = input<number | undefined, unknown>(undefined, {
+          transform: numberAttribute,
+        });
+      }
+
+      @Component({
+        imports: [FormField, CustomControl],
+        template: `<custom-control [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(0));
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      expect(fixture.componentInstance).toBeDefined();
+    });
+
+    it('should accept InputSignalWithTransform for number properties with stricter pre-transform types', () => {
+      @Component({selector: 'custom-control', template: ``})
+      class CustomControl implements FormValueControl<number> {
+        readonly value = model(0);
+        readonly min = input<number | undefined, number | string | undefined>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly max = input<number | undefined, number | string | undefined>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly minLength = input<number | undefined, number | string | undefined>(undefined, {
+          transform: numberAttribute,
+        });
+        readonly maxLength = input<number | undefined, number | string | undefined>(undefined, {
           transform: numberAttribute,
         });
       }

--- a/packages/language-service/test/grp1/completions_spec.ts
+++ b/packages/language-service/test/grp1/completions_spec.ts
@@ -324,7 +324,7 @@ describe('completions', () => {
     `,
     };
 
-    it('should return property access completions', () => {
+    it('should return property access completions (method suggestions)', () => {
       const {templateFile} = setup(
         `<input dir [myInput]="'foo'.">`,
         '',
@@ -337,6 +337,18 @@ describe('completions', () => {
         `charAt`,
         'toLowerCase' /* etc. */,
       ]);
+    });
+
+    it('should return property access completions (name completion)', () => {
+      const {templateFile} = setup(
+        `<input dir [myInput]="foo">`,
+        'foobar: string = "";',
+        signalInputDirectiveWithUnionType,
+      );
+      templateFile.moveCursorToText(`dir [myInput]="foo¦">`);
+
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(completions, ts.ScriptElementKind.memberVariableElement, [`foobar`]);
     });
 
     it(
@@ -414,7 +426,7 @@ describe('completions', () => {
       expectContain(completions, DisplayInfoKind.EVENT, ['(bla)']);
     });
 
-    it('should return property access completions', () => {
+    it('should return property access completions (method suggestions on listener)', () => {
       const {templateFile} = setup(
         `<input dir (bla)="'foo'.">`,
         '',
@@ -472,21 +484,6 @@ describe('completions', () => {
       templateFile.moveCursorToText(`<button dir ¦>`);
       const completions = templateFile.getCompletionsAtPosition();
       expectContain(completions, DisplayInfoKind.EVENT, ['(bla)']);
-    });
-
-    it('should return property access completions', () => {
-      const {templateFile} = setup(
-        `<input dir (bla)="'foo'.">`,
-        '',
-        initializerOutputDirectiveWithUnionType,
-      );
-      templateFile.moveCursorToText(`dir (bla)="'foo'.¦">`);
-
-      const completions = templateFile.getCompletionsAtPosition();
-      expectContain(completions, ts.ScriptElementKind.memberFunctionElement, [
-        `charAt`,
-        'toLowerCase' /* etc. */,
-      ]);
     });
 
     it(


### PR DESCRIPTION
#65760 implemented the transform support backwards. `FormUiControl` should expect the given type as input but it shouldn't care what the output of the transform is.

fixes  #66562