### PR TITLE
fix(docs-infra): improve skip-to-main-content method to focus <main> …

### DIFF
--- a/adev/src/app/app.component.ts
+++ b/adev/src/app/app.component.ts
@@ -82,6 +82,14 @@ export class AppComponent {
   }
 
   protected focusFirstHeading(): void {
+    const main = this.document.querySelector<HTMLElement>('main');
+    if (main) {
+      main.setAttribute('tabindex', '-1');
+      main.focus();
+      return;
+    }
+
+    // Fallback: focus the first h1 (legacy support for pages without main)
     const h1 = this.document.querySelector<HTMLHeadingElement>('h1:not(docs-top-level-banner h1)');
     h1?.focus();
   }


### PR DESCRIPTION
Updated the skip-to-main-content behavior to focus the ```<main>``` element when present, with a fallback to the first heading for legacy layouts without a main landmark.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The skip-to-main-content action currently moves focus to the first `h1` on the page.
This approach is fragile and inconsistent:
- Not all pages contain an ```<h1>``` like (ex: docs page)
- Focusing a heading does not reliably place keyboard users at the main content
- Some pages require page-specific workarounds (ex: homepage)

Issue Number: N/A

## What is the new behavior?

The skip-to-main-content logic now prioritizes focusing the `<main>` element when present,
with a fallback to the first `h1` for legacy pages that do not define a main landmark.

```ts
protected focusFirstHeading(): void {
  const main = this.document.querySelector<HTMLElement>('main');
  if (main) {
    main.setAttribute('tabindex', '-1');
    main.focus();
    return;
  }

  // Fallback: legacy pages without <main>
  const h1 = this.document.querySelector<HTMLHeadingElement>(
    'h1:not(docs-top-level-banner h1)'
  );
  h1?.focus();
}
```

## Why this change

- Aligns with WCAG 2.1 Success Criterion 2.4.1 (Bypass Blocks)
- Uses the semantic purpose of the ```<main>``` element
- Provides consistent keyboard navigation across all pages
- Removes the need for page-specific focus workarounds

## Some existing edge cases
<img width="1236" height="719" alt="Screenshot 2026-01-14 at 9 54 20 PM" src="https://github.com/user-attachments/assets/8cdef2f9-9da4-48fc-9f28-bf8c0dfbe2a3" />
<figcaption>When users skip to main content they jump to the h1 tag with no way to click on the wrapper link without cycling through the whole site</figcaption>


<img width="1237" height="721" alt="Screenshot 2026-01-14 at 9 55 26 PM" src="https://github.com/user-attachments/assets/684dd4cd-0bca-46f5-8064-dc541ca00f9d" />
<figcaption>No h1 tag so skip to main content feature doesn't work</figcaption>

## References
- [WCAG 2.1 Success Criterion 2.4.1 — Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html) 
- [MDN: The Main Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)