### PR TITLE
fix(core): handle Set in class bindings

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -163,7 +163,13 @@ export function styleStringParser(keyValueArray: KeyValueArray<any>, text: strin
  * @codeGenApi
  */
 export function ɵɵclassMap(
-  classes: {[className: string]: boolean | undefined | null} | string | undefined | null,
+  classes:
+    | {[className: string]: boolean | undefined | null}
+    | string
+    | string[]
+    | Set<string>
+    | undefined
+    | null,
 ): void {
   checkStylingMap(classKeyValueArraySet, classStringParser, classes, true);
 }
@@ -673,14 +679,22 @@ function collectStylingFromTAttrs(
 export function toStylingKeyValueArray(
   keyValueArraySet: (keyValueArray: KeyValueArray<any>, key: string, value: any) => void,
   stringParser: (styleKeyValueArray: KeyValueArray<any>, text: string) => void,
-  value: string | string[] | {[key: string]: any} | SafeValue | null | undefined,
+  value: string | string[] | Set<string> | {[key: string]: any} | SafeValue | null | undefined,
 ): KeyValueArray<any> {
   if (value == null /*|| value === undefined */ || value === '') return EMPTY_ARRAY as any;
   const styleKeyValueArray: KeyValueArray<any> = [] as any;
-  const unwrappedValue = unwrapSafeValue(value) as string | string[] | {[key: string]: any};
+  const unwrappedValue = unwrapSafeValue(value) as
+    | string
+    | string[]
+    | Set<string>
+    | {[key: string]: any};
   if (Array.isArray(unwrappedValue)) {
     for (let i = 0; i < unwrappedValue.length; i++) {
       keyValueArraySet(styleKeyValueArray, unwrappedValue[i], true);
+    }
+  } else if (unwrappedValue instanceof Set) {
+    for (const current of unwrappedValue) {
+      keyValueArraySet(styleKeyValueArray, current, true);
     }
   } else if (typeof unwrappedValue === 'object') {
     for (const key in unwrappedValue) {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -4013,7 +4013,7 @@ describe('styling', () => {
     expect(div.classList).not.toContain(className);
   });
 
-  it('should class bindings to classes with special characters in a host binding', () => {
+  it('should support class bindings to classes with special characters in a host binding', () => {
     const className = `data-active:text-green-300/80`;
 
     @Component({
@@ -4038,6 +4038,20 @@ describe('styling', () => {
     fixture.componentInstance.value = false;
     fixture.detectChanges();
     expect(fixture.nativeElement.classList).not.toContain(className);
+  });
+
+  it('should support Set in a class binding', () => {
+    @Component({
+      template: '<div [class]="classes" [class.extra]="true"></div>',
+    })
+    class Cmp {
+      classes = new Set(['a', 'b', 'c']);
+    }
+
+    const fixture = TestBed.createComponent(Cmp);
+    fixture.detectChanges();
+    const div = fixture.nativeElement.querySelector('div');
+    expect(div.getAttribute('class')).toBe('a b c extra');
   });
 
   describe('regression', () => {


### PR DESCRIPTION
Currently migrating from `[ngClass]` to `[class]` isn't entirely supported, because `[ngClass]` supports `Set` values while `[class]` ignores them.

These changes add a bit of logic to bring them closer together and make the migration easier.
