### PR TITLE
build: initial test of TypeScript 6

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -293,7 +293,7 @@ export function isOnPushDirective(dir: any): boolean {
     case Framework.Wiz:
       return false;
     default:
-      throw new Error(`Unknown framework: "${metadata.framework}".`);
+      throw new Error(`Unknown framework: "${(metadata as {framework: string}).framework}".`);
   }
 }
 

--- a/modules/benchmarks/src/change_detection/change_detection.e2e-spec.ts
+++ b/modules/benchmarks/src/change_detection/change_detection.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 describe('change detection benchmark', () => {

--- a/modules/benchmarks/src/change_detection/change_detection.perf-spec.ts
+++ b/modules/benchmarks/src/change_detection/change_detection.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/change_detection/util.ts
+++ b/modules/benchmarks/src/change_detection/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getIntParameter} from '../util';
+import {getIntParameter} from '../util.js';
 
 export const numViews: number = getIntParameter('viewCount');
 

--- a/modules/benchmarks/src/class_bindings/class_bindings.perf-spec.ts
+++ b/modules/benchmarks/src/class_bindings/class_bindings.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark} from '../../../utilities/index';
+import {runBenchmark} from '../../../utilities/index.js';
 import {$, browser} from 'protractor';
 
 describe('class bindings perf', () => {

--- a/modules/benchmarks/src/defer/defer.e2e-spec.ts
+++ b/modules/benchmarks/src/defer/defer.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 describe('defer benchmark', () => {

--- a/modules/benchmarks/src/defer/defer.perf-spec.ts
+++ b/modules/benchmarks/src/defer/defer.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/expanding_rows/expanding_rows.perf-spec.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_rows.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark} from '../../../utilities/index';
+import {runBenchmark} from '../../../utilities/index.js';
 import {$, browser} from 'protractor';
 
 describe('benchmarks', () => {

--- a/modules/benchmarks/src/hydration/hydration.e2e-spec.ts
+++ b/modules/benchmarks/src/hydration/hydration.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 describe('hydration benchmark', () => {

--- a/modules/benchmarks/src/hydration/hydration.perf-spec.ts
+++ b/modules/benchmarks/src/hydration/hydration.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
+++ b/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/largeform/largeform.e2e-spec.ts
+++ b/modules/benchmarks/src/largeform/largeform.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$, By, element} from 'protractor';
 
 describe('largeform benchmark', () => {

--- a/modules/benchmarks/src/largeform/largeform.perf-spec.ts
+++ b/modules/benchmarks/src/largeform/largeform.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/largetable/largetable.e2e-spec.ts
+++ b/modules/benchmarks/src/largetable/largetable.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 describe('largetable benchmark', () => {

--- a/modules/benchmarks/src/largetable/largetable.perf-spec.ts
+++ b/modules/benchmarks/src/largetable/largetable.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/largetable/util.ts
+++ b/modules/benchmarks/src/largetable/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getIntParameter} from '../util';
+import {getIntParameter} from '../util.js';
 
 export class TableCell {
   constructor(

--- a/modules/benchmarks/src/ng_template_outlet_context/ng_template_outlet_context.perf-spec.ts
+++ b/modules/benchmarks/src/ng_template_outlet_context/ng_template_outlet_context.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/styling/styling_perf.spec.ts
+++ b/modules/benchmarks/src/styling/styling_perf.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index';
+import {openBrowser, runBenchmark, verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$, by, element} from 'protractor';
 
 /** List of possible scenarios that should be tested.  */

--- a/modules/benchmarks/src/tree/test_utils.ts
+++ b/modules/benchmarks/src/tree/test_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {openBrowser, runBenchmark} from '../../../utilities/index';
+import {openBrowser, runBenchmark} from '../../../utilities/index.js';
 import {browser} from 'protractor';
 
 export function runTreeBenchmark({

--- a/modules/benchmarks/src/tree/tree.e2e-spec.ts
+++ b/modules/benchmarks/src/tree/tree.e2e-spec.ts
@@ -8,7 +8,7 @@
 
 import {$} from 'protractor';
 
-import {openTreeBenchmark} from './test_utils';
+import {openTreeBenchmark} from './test_utils.js';
 
 describe('tree benchmark', () => {
   it('should work for createDestroy', async () => {

--- a/modules/benchmarks/src/tree/tree.perf-spec.ts
+++ b/modules/benchmarks/src/tree/tree.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$} from 'protractor';
-import {runTreeBenchmark} from './test_utils';
+import {runTreeBenchmark} from './test_utils.js';
 
 describe('tree benchmark perf', () => {
   it('should work for createOnly', async () => {

--- a/modules/benchmarks/src/tree/tree_detect_changes.e2e-spec.ts
+++ b/modules/benchmarks/src/tree/tree_detect_changes.e2e-spec.ts
@@ -8,7 +8,7 @@
 
 import {$} from 'protractor';
 
-import {openTreeBenchmark} from './test_utils';
+import {openTreeBenchmark} from './test_utils.js';
 
 describe('tree benchmark detect changes', () => {
   it('should work for detectChanges', async () => {

--- a/modules/benchmarks/src/tree/tree_detect_changes.perf-spec.ts
+++ b/modules/benchmarks/src/tree/tree_detect_changes.perf-spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {$} from 'protractor';
-import {runTreeBenchmark} from './test_utils';
+import {runTreeBenchmark} from './test_utils.js';
 
 describe('tree benchmark detect changes perf', () => {
   it('should work for detectChanges', async () => {

--- a/modules/benchmarks/src/tree/util.ts
+++ b/modules/benchmarks/src/tree/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {getIntParameter} from '../util';
+import {getIntParameter} from '../util.js';
 
 export class TreeNode {
   transitiveChildCount: number;

--- a/modules/benchmarks/tsconfig-build.json
+++ b/modules/benchmarks/tsconfig-build.json
@@ -3,7 +3,7 @@
     "lib": ["dom", "es2022"],
     "types": [],
     "module": "esnext",
-    "moduleResolution": "node10",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "sourceMap": true,
     "paths": {

--- a/modules/benchmarks/tsconfig-e2e.json
+++ b/modules/benchmarks/tsconfig-e2e.json
@@ -3,9 +3,9 @@
     "lib": ["es2015"],
     "types": ["node", "jasmine"],
     "module": "esnext",
-    "moduleResolution": "node10",
+    "moduleResolution": "nodenext",
     "strict": true,
     "sourceMap": true,
-    "declaration": true,
+    "declaration": true
   }
 }

--- a/modules/playground/e2e_test/async/async_spec.ts
+++ b/modules/playground/e2e_test/async/async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {$, browser} from 'protractor';
 import {promise} from 'selenium-webdriver';
 

--- a/modules/playground/e2e_test/hello_world/hello_world_spec.ts
+++ b/modules/playground/e2e_test/hello_world/hello_world_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser} from 'protractor';
 
 describe('hello world', function () {

--- a/modules/playground/e2e_test/http/http_spec.ts
+++ b/modules/playground/e2e_test/http/http_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser} from 'protractor';
 
 describe('http', function () {

--- a/modules/playground/e2e_test/jsonp/jsonp_spec.ts
+++ b/modules/playground/e2e_test/jsonp/jsonp_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser} from 'protractor';
 
 describe('jsonp', function () {

--- a/modules/playground/e2e_test/key_events/key_events_spec.ts
+++ b/modules/playground/e2e_test/key_events/key_events_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser, by, element, protractor} from 'protractor';
 
 const Key = protractor.Key;

--- a/modules/playground/e2e_test/svg/svg_spec.ts
+++ b/modules/playground/e2e_test/svg/svg_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser, by, element} from 'protractor';
 
 describe('SVG', function () {

--- a/modules/playground/e2e_test/template_driven_forms/template_driven_forms_spec.ts
+++ b/modules/playground/e2e_test/template_driven_forms/template_driven_forms_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser, by, element} from 'protractor';
 
 describe('Template-Driven Forms', function () {

--- a/modules/playground/e2e_test/zippy_component/zippy_spec.ts
+++ b/modules/playground/e2e_test/zippy_component/zippy_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {verifyNoBrowserErrors} from '../../../utilities/index';
+import {verifyNoBrowserErrors} from '../../../utilities/index.js';
 import {browser, by, element} from 'protractor';
 
 describe('Zippy Component', function () {

--- a/modules/playground/tsconfig-e2e.json
+++ b/modules/playground/tsconfig-e2e.json
@@ -3,9 +3,9 @@
     "lib": ["es2015"],
     "types": ["node", "jasmine"],
     "module": "esnext",
-    "moduleResolution": "node10",
+    "moduleResolution": "nodenext",
     "strict": true,
     "sourceMap": true,
-    "declaration": true,
+    "declaration": true
   }
 }

--- a/packages/compiler-cli/src/ngtsc/transform/jit/test/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/jit/test/downlevel_decorators_transform_spec.ts
@@ -921,7 +921,7 @@ describe('downlevel decorator transform', () => {
     const program = ts.createProgram(
       files,
       {
-        moduleResolution: ts.ModuleResolutionKind.Node10,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
         importHelpers: true,
         lib: [],
         module: ts.ModuleKind.ESNext,

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -224,7 +224,7 @@ function getExtendedConfigPathWorker(
     const {resolvedModule} = ts.nodeModuleNameResolver(
       extendsValue,
       configFile,
-      {moduleResolution: ts.ModuleResolutionKind.Node10, resolveJsonModule: true},
+      {moduleResolution: ts.ModuleResolutionKind.NodeNext, resolveJsonModule: true},
       parseConfigHost,
     );
     if (resolvedModule) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -137,7 +137,6 @@
         }
       ],
       "compilerOptions": {
-        "baseUrl": ".",
         "paths": {
           "external_library": ["./external_library"]
         }

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -126,7 +126,6 @@ function getOptions(
     strictNullChecks: true,
     outDir,
     rootDir,
-    baseUrl: '.',
     allowJs: true,
     declaration: true,
     target: ts.ScriptTarget.ES2022,

--- a/packages/compiler-cli/test/extract_i18n_spec.ts
+++ b/packages/compiler-cli/test/extract_i18n_spec.ts
@@ -223,7 +223,6 @@ describe('extract_i18n command line', () => {
         "types": [],
         "outDir": "built",
         "rootDir": ".",
-        "baseUrl": ".",
         "declaration": true,
         "target": "es2015",
         "module": "es2015",

--- a/packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/declaration_only_emission_spec.ts
@@ -19,7 +19,6 @@ const testFiles = loadStandardTestFiles();
 const tsconfigBase = {
   extends: '../tsconfig-base.json',
   compilerOptions: {
-    baseUrl: '.',
     rootDirs: ['/app'],
     emitDeclarationOnly: true,
     noCheck: true,
@@ -636,11 +635,11 @@ runInEachFileSystem(() => {
         'test.ts',
         `
         import {Component} from '@angular/core';
-        
+
         export function Custom() {
           return function(target: any) {};
         }
-        
+
         @Custom()
         @Component({template: '', selector: 'comp'})
         export class Comp {}

--- a/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/doc_extraction/reexport_docs_extraction_spec.ts
@@ -85,7 +85,7 @@ runInEachFileSystem(() => {
       env.write(
         'middle.ts',
         `
-        export * from 'implementation';
+        export * from './implementation';
       `,
       );
 

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -102,7 +102,6 @@ export class NgtscTestEnvironment {
         "strictNullChecks": true,
         "outDir": "built",
         "rootDir": ".",
-        "baseUrl": ".",
         "allowJs": true,
         "declaration": true,
         "target": "es2015",

--- a/packages/compiler-cli/test/ngtsc/imports_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/imports_spec.ts
@@ -24,7 +24,6 @@ runInEachFileSystem(() => {
       const tsconfig: {[key: string]: any} = {
         extends: '../tsconfig-base.json',
         compilerOptions: {
-          baseUrl: '.',
           rootDirs: ['/app'],
         },
         angularCompilerOptions: {},

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -23,10 +23,6 @@ runInEachFileSystem(() => {
     function tsconfig(extraOpts: TsConfigOptions = {}) {
       const tsconfig: {[key: string]: any} = {
         extends: '../tsconfig-base.json',
-        compilerOptions: {
-          baseUrl: '.',
-          rootDirs: ['/app'],
-        },
         angularCompilerOptions: {
           compilationMode: 'experimental-local',
           ...extraOpts,
@@ -58,10 +54,6 @@ runInEachFileSystem(() => {
       beforeEach(() => {
         const tsconfig: {[key: string]: any} = {
           extends: '../tsconfig-base.json',
-          compilerOptions: {
-            baseUrl: '.',
-            rootDirs: ['/app'],
-          },
           angularCompilerOptions: {
             compilationMode: 'experimental-local',
             generateExtraImportsInLocalMode: true,
@@ -86,7 +78,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -100,7 +92,7 @@ runInEachFileSystem(() => {
         import {SomeExternalStuff} from '/some_external_file';
         import {SomeExternalStuff2} from '/some_external_file2';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [SomeExternalStuff, BModule]})
         export class AModule {
@@ -131,7 +123,7 @@ runInEachFileSystem(() => {
           .not.toContain('import "/some_external_file2"');
         expect(Comp1Contents)
           .withContext('NgModule internal import should not be included in the global import')
-          .not.toContain('import "b"');
+          .not.toContain('import "./b"');
       });
 
       it('should include global imports only in the eligible files', () => {
@@ -174,7 +166,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -188,7 +180,7 @@ runInEachFileSystem(() => {
         import {SomeExternalStuff} from '/some_external_file';
         import {SomeExternalStuff2} from '/some_external_file2';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [SomeExternalStuff, BModule]})
         export class AModule {
@@ -251,7 +243,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -264,7 +256,7 @@ runInEachFileSystem(() => {
         import {NgModule} from '@angular/core';
         import * as n from '/some_external_file';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [n.SomeExternalStuff]})
         export class AModule {
@@ -299,7 +291,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -312,7 +304,7 @@ runInEachFileSystem(() => {
         import {NgModule} from '@angular/core';
         import {SomeExternalStuff} from '/some_external_file';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [[[SomeExternalStuff]]]})
         export class AModule {
@@ -341,7 +333,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -354,7 +346,7 @@ runInEachFileSystem(() => {
         import {NgModule} from '@angular/core';
         import * as n from '/some_external_file';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [[[n.SomeExternalStuff]]]})
         export class AModule {
@@ -383,7 +375,7 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {Comp1} from 'comp1';
+        import {Comp1} from './comp1';
 
         @NgModule({declarations:[Comp1]})
         export class Module1 {
@@ -397,7 +389,7 @@ runInEachFileSystem(() => {
         import {SomeExternalStuff} from '/some_external_file';
         import * as n from '/some_external_file2';
 
-        import {BModule} from 'b';
+        import {BModule} from './b';
 
         @NgModule({imports: [[SomeExternalStuff], [n.SomeExternalStuff]]})
         export class AModule {
@@ -460,9 +452,9 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {InternalComp} from 'internal_comp';
-        import {InternalDir} from 'internal_dir';
-        import {InternalPipe} from 'internal_pipe';
+        import {InternalComp} from './internal_comp';
+        import {InternalDir} from './internal_dir';
+        import {InternalPipe} from './internal_pipe';
 
         @NgModule({declarations: [InternalComp, InternalDir, InternalPipe], exports: [InternalComp, InternalDir, InternalPipe]})
         export class InternalModule {
@@ -484,8 +476,8 @@ runInEachFileSystem(() => {
           `
         import {NgModule} from '@angular/core';
 
-        import {MainComp} from 'main_comp';
-        import {InternalModule} from 'internal_module';
+        import {MainComp} from './main_comp';
+        import {InternalModule} from './internal_module';
 
         @NgModule({declarations: [MainComp], imports: [InternalModule]})
         export class MainModule {
@@ -495,9 +487,9 @@ runInEachFileSystem(() => {
 
         env.driveMain();
 
-        expect(env.getContents('main_comp.js')).toContain('import "internal_comp"');
-        expect(env.getContents('main_comp.js')).toContain('import "internal_dir"');
-        expect(env.getContents('main_comp.js')).toContain('import "internal_pipe"');
+        expect(env.getContents('main_comp.js')).toContain('import "./internal_comp"');
+        expect(env.getContents('main_comp.js')).toContain('import "./internal_dir"');
+        expect(env.getContents('main_comp.js')).toContain('import "./internal_pipe"');
       });
 
       it('should not include extra import and remote scope runtime for the local component dependencies when cycle is produced', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -2213,9 +2213,8 @@ runInEachFileSystem((os: string) => {
         JSON.stringify({
           extends: './tsconfig-base.json',
           compilerOptions: {
-            baseUrl: '.',
             paths: {
-              '*': ['*', 'shared/*'],
+              'foo': ['./shared/foo/index'],
             },
           },
         }),
@@ -2388,6 +2387,18 @@ runInEachFileSystem((os: string) => {
     });
 
     it('should use absolute import for forward references that were resolved from an absolute file', () => {
+      env.write(
+        'tsconfig.json',
+        JSON.stringify({
+          extends: './tsconfig-base.json',
+          compilerOptions: {
+            paths: {
+              'dir': ['./dir.ts'],
+            },
+          },
+        }),
+      );
+
       env.write(
         'dir.ts',
         `

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4691,7 +4691,7 @@ suppress
 
       it('generates diagnostic when the library does not export the host directive', () => {
         env.tsconfig({
-          paths: {'post': ['dist/post']},
+          paths: {'post': ['./dist/post']},
           strictTemplates: true,
           _enableTemplateTypeChecker: true,
         });
@@ -4701,37 +4701,37 @@ suppress
         env.write(
           'dist/post/index.d.ts',
           `
-      export { PostComponent, PostModule } from './lib/post.component';
-    `,
+            export { PostComponent, PostModule } from './lib/post.component';
+          `,
         );
 
         env.write(
           'dist/post/lib/post.component.d.ts',
           `
-      import * as i0 from "@angular/core";
-      export declare class HostBindDirective {
-          static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindDirective, never, never, {}, {}, never, never, true, never>;
-      }
-      export declare class PostComponent {
-          static ɵcmp: i0.ɵɵComponentDeclaration<PostComponent, "lib-post", never, {}, {}, never, never, false, [{ directive: typeof HostBindDirective; inputs: {}; outputs: {}; }]>;
-      }
-      export declare class PostModule {
-          static ɵmod: i0.ɵɵNgModuleDeclaration<PostModule, [typeof PostComponent], never, [typeof PostComponent]>;
-          static ɵinj: i0.ɵɵInjectorDeclaration<PostModule>;
-      }
-      `,
+            import * as i0 from "@angular/core";
+            export declare class HostBindDirective {
+                static ɵdir: i0.ɵɵDirectiveDeclaration<HostBindDirective, never, never, {}, {}, never, never, true, never>;
+            }
+            export declare class PostComponent {
+                static ɵcmp: i0.ɵɵComponentDeclaration<PostComponent, "lib-post", never, {}, {}, never, never, false, [{ directive: typeof HostBindDirective; inputs: {}; outputs: {}; }]>;
+            }
+            export declare class PostModule {
+                static ɵmod: i0.ɵɵNgModuleDeclaration<PostModule, [typeof PostComponent], never, [typeof PostComponent]>;
+                static ɵinj: i0.ɵɵInjectorDeclaration<PostModule>;
+            }
+        `,
         );
         env.write(
           'test.ts',
           `
-      import {Component} from '@angular/core';
-      import {PostModule} from 'post';
+            import {Component} from '@angular/core';
+            import {PostModule} from 'post';
 
-      @Component({
-        template: '<lib-post />',
-        imports: [PostModule],
-      })
-      export class Main { }
+            @Component({
+              template: '<lib-post />',
+              imports: [PostModule],
+            })
+            export class Main { }
        `,
         );
         const diags = env.driveDiagnostics();
@@ -7117,8 +7117,8 @@ suppress
       it('should work with @switch block declared in an ng-template with template scoped variables', () => {
         env.write(
           'test.ts',
-          `import {Component} from '@angular/core'; 
-           import {CommonModule} from '@angular/common'; 
+          `import {Component} from '@angular/core';
+           import {CommonModule} from '@angular/common';
 
           @Component({
             imports: [CommonModule],

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -55,8 +55,8 @@ function createTestSupportFor(basePath: string) {
     'declaration': true,
     'target': ts.ScriptTarget.ES5,
     'newLine': ts.NewLineKind.LineFeed,
-    'module': ts.ModuleKind.ES2015,
-    'moduleResolution': ts.ModuleResolutionKind.Node10,
+    'module': ts.ModuleKind.NodeNext,
+    'moduleResolution': ts.ModuleResolutionKind.NodeNext,
     'lib': Object.freeze([
       path.resolve(basePath, 'node_modules/typescript/lib/lib.es6.d.ts'),
     ]) as string[],

--- a/packages/compiler/test/shadow_css/utils.ts
+++ b/packages/compiler/test/shadow_css/utils.ts
@@ -45,7 +45,7 @@ beforeEach(function () {
 });
 
 declare global {
-  module jasmine {
+  namespace jasmine {
     interface Matchers<T> {
       /**
        * Expect the actual css value to be equal to the expected css,

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/tsconfig.json
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node10",
+    "moduleResolution": "nodenext",
     "experimentalDecorators": true,
     "strict": true,
     "skipLibCheck": true,

--- a/packages/core/test/acceptance/authoring/authoring_test_compiler.ts
+++ b/packages/core/test/acceptance/authoring/authoring_test_compiler.ts
@@ -27,7 +27,7 @@ async function main() {
     skipLibCheck: true,
     module: ts.ModuleKind.ESNext,
     target: ts.ScriptTarget.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Node10,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
   });
 
   const host = new TypeScriptReflectionHost(program.getTypeChecker());

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -3513,6 +3513,7 @@ describe('@defer', () => {
       root = null;
       rootMargin = null!;
       thresholds = null!;
+      scrollMargin = null!;
 
       observedElements = new Set<Element>();
       private elementsInView = new Set<Element>();

--- a/packages/language-service/test/legacy/definitions_spec.ts
+++ b/packages/language-service/test/legacy/definitions_spec.ts
@@ -9,7 +9,7 @@
 import {LanguageService} from '../../src/language_service';
 
 import {APP_COMPONENT, MockService, setup} from './mock_host';
-import {humanizeDefinitionInfo} from './test_utils';
+import {humanizeDefinitionInfo} from './test_utils.js';
 
 describe('definitions', () => {
   let service: MockService;

--- a/packages/language-service/test/legacy/type_definitions_spec.ts
+++ b/packages/language-service/test/legacy/type_definitions_spec.ts
@@ -9,7 +9,7 @@
 import {LanguageService} from '../../src/language_service';
 
 import {APP_COMPONENT, MockService, setup} from './mock_host';
-import {HumanizedDefinitionInfo, humanizeDefinitionInfo} from './test_utils';
+import {HumanizedDefinitionInfo, humanizeDefinitionInfo} from './test_utils.js';
 
 describe('type definitions', () => {
   let service: MockService;

--- a/packages/localize/tools/BUILD.bazel
+++ b/packages/localize/tools/BUILD.bazel
@@ -4,6 +4,7 @@ load("//tools:defaults.bzl", "npm_package", "ts_config", "ts_project")
 ts_config(
     name = "tsconfig_build",
     src = "tsconfig.json",
+    visibility = ["//packages/localize/tools:__subpackages__"],
     deps = [
         "//:node_modules/@types/node",
         "//packages:tsconfig_build",

--- a/packages/localize/tools/test/extract/integration/BUILD.bazel
+++ b/packages/localize/tools/test/extract/integration/BUILD.bazel
@@ -26,7 +26,6 @@ jasmine_test(
         "//:node_modules/tinyglobby",
         "//:node_modules/yargs",
         "//packages/localize/tools/test/extract/integration/test_files",
-        "//packages/localize/tools/test/extract/integration/test_files:compile_es2015",
-        "//packages/localize/tools/test/extract/integration/test_files:compile_es5",
+        "//packages/localize/tools/test/extract/integration/test_files:bundle",
     ],
 )

--- a/packages/localize/tools/test/extract/integration/main_spec.ts
+++ b/packages/localize/tools/test/extract/integration/main_spec.ts
@@ -389,49 +389,46 @@ runInNativeFileSystem(() => {
       });
     }
 
-    for (const target of ['es2015', 'es5']) {
-      it(`should render the original location of translations, when processing an ${target} bundle with source-maps`, () => {
-        extractTranslations({
-          rootPath,
-          sourceLocale: 'en-CA',
-          sourceFilePaths: [fs.resolve(rootPath, `test_files/dist_${target}/index.js`)],
-          format: 'xliff',
-          outputPath,
-          logger,
-          useSourceMaps: true,
-          useLegacyIds: false,
-          duplicateMessageHandling: 'ignore',
-          fileSystem: fs,
-        });
-        expect(fs.readFile(outputPath)).toEqual(
-          [
-            `<?xml version="1.0" encoding="UTF-8" ?>`,
-            `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-            `  <file source-language="en-CA" datatype="plaintext" original="ng2.template">`,
-            `    <body>`,
-            `      <trans-unit id="157258427077572998" datatype="html">`,
-            `        <source>Message in <x id="a-file" equiv-text="file"/>!</source>`,
-            `        <context-group purpose="location">`,
-            // These source file paths are due to how Bazel TypeScript compilation source-maps
-            // work
-            `          <context context-type="sourcefile">test_files/src/a.ts</context>`,
-            `          <context context-type="linenumber">3</context>`,
-            `        </context-group>`,
-            `      </trans-unit>`,
-            `      <trans-unit id="7829869508202074508" datatype="html">`,
-            `        <source>Message in <x id="b-file" equiv-text="file"/>!</source>`,
-            `        <context-group purpose="location">`,
-            `          <context context-type="sourcefile">test_files/src/b.ts</context>`,
-            `          <context context-type="linenumber">3</context>`,
-            `        </context-group>`,
-            `      </trans-unit>`,
-            `    </body>`,
-            `  </file>`,
-            `</xliff>\n`,
-          ].join('\n'),
-        );
+    it('should render the original location of translations, when processing a bundle with source-maps', () => {
+      extractTranslations({
+        rootPath,
+        sourceLocale: 'en-CA',
+        sourceFilePaths: [fs.resolve(rootPath, 'test_files/bundle.js')],
+        format: 'xliff',
+        outputPath,
+        logger,
+        useSourceMaps: true,
+        useLegacyIds: false,
+        duplicateMessageHandling: 'ignore',
+        fileSystem: fs,
       });
-    }
+      expect(fs.readFile(outputPath)).toEqual(
+        [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en-CA" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="157258427077572998" datatype="html">`,
+          `        <source>Message in <x id="a-file" equiv-text="file"/>!</source>`,
+          `        <context-group purpose="location">`,
+          `          <context context-type="sourcefile">test_files/src/a.ts</context>`,
+          `          <context context-type="linenumber">3</context>`,
+          `        </context-group>`,
+          `      </trans-unit>`,
+          `      <trans-unit id="7829869508202074508" datatype="html">`,
+          `        <source>Message in <x id="b-file" equiv-text="file"/>!</source>`,
+          `        <context-group purpose="location">`,
+          `          <context context-type="sourcefile">test_files/src/b.ts</context>`,
+          `          <context context-type="linenumber">3</context>`,
+          `        </context-group>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+          ``,
+        ].join('\n'),
+      );
+    });
 
     describe('[duplicateMessageHandling]', () => {
       it('should throw if set to "error"', () => {

--- a/packages/localize/tools/test/extract/integration/test_files/BUILD.bazel
+++ b/packages/localize/tools/test/extract/integration/test_files/BUILD.bazel
@@ -1,48 +1,19 @@
-load("@npm//:typescript/package_json.bzl", tsc = "bin")
-load("//tools:defaults.bzl", "copy_to_bin")
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("//tools:defaults.bzl", "copy_to_bin", "ts_project")
 
 package(default_visibility = ["//packages/localize/tools/test/extract/integration:__pkg__"])
 
-tsc.tsc(
-    name = "compile_es5",
+ts_project(
+    name = "src",
     srcs = glob(["src/*.ts"]),
-    outs = [
-        "dist_es5/index.js",
-        "dist_es5/index.js.map",
-    ],
-    args = [
-        "--target",
-        "es5",
-        "--module",
-        "amd",
-        "--outFile",
-        "$(rootpath dist_es5/index.js)",
-        "--skipLibCheck",
-        "--sourceMap",
-        "--inlineSources",
-        "$(rootpath src/index.ts)",
-    ],
 )
 
-tsc.tsc(
-    name = "compile_es2015",
-    srcs = glob(["src/*.ts"]),
-    outs = [
-        "dist_es2015/index.js",
-        "dist_es2015/index.js.map",
-    ],
-    args = [
-        "--target",
-        "es2015",
-        "--module",
-        "amd",
-        "--outFile",
-        "$(rootpath dist_es2015/index.js)",
-        "--skipLibCheck",
-        "--sourceMap",
-        "--inlineSources",
-        "$(rootpath src/index.ts)",
-    ],
+esbuild(
+    name = "bundle",
+    entry_point = ":src/index.ts",
+    platform = "browser",
+    target = "es2015",
+    deps = [":src"],
 )
 
 # Use copy_to_bin since filegroup doesn't seem to work on Windows.

--- a/tools/legacy-saucelabs/tsconfig.json
+++ b/tools/legacy-saucelabs/tsconfig.json
@@ -1,10 +1,9 @@
 {
-    "compilerOptions": {
-        "target": "ES2020",
-        "module": "ES2020",
-        "baseUrl": ".",
-        "esModuleInterop": true,
-        "moduleResolution": "Node",
-        "rootDirs": ["./", "../../"]
-    }
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "rootDirs": ["./", "../../"]
+  }
 }

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -6,10 +6,10 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "types": ["node"],
     "paths": {
-      "@angular/*": ["../packages/*/index"],
+      "@angular/*": ["../packages/*/index"]
     }
   }
 }

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -43,7 +43,7 @@ import {
   initializeServer,
   openTextDocument,
   ServerOptions,
-} from './test_utils';
+} from './test_utils.js';
 
 describe('Angular language server', () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; /* 10 seconds */

--- a/vscode-ng-language-service/integration/project/tsconfig.json
+++ b/vscode-ng-language-service/integration/project/tsconfig.json
@@ -4,14 +4,9 @@
     "experimentalDecorators": true,
     "target": "es2015",
     "strict": true,
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "baseUrl": ".",
+    "typeRoots": ["node_modules/@types"],
     "paths": {
-      "post": [
-        "dist/post"
-      ]
+      "post": ["./dist/post"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Resolves some initial test failures after updating to TypeScript 6. High-level set of breaking changes:
* `baseUrl` isn't supported anymore. I removed it everywhere and had to update some paths.
* Some `paths` had to be updated to be explicitly relative.
* `--outFile` is deprecated so I had to rework the build for an integration test.
* `"moduleResolution": "node10"` is deprecated so I switched to `nodenext`. As a result, I had to add extensions to some imports.
* There were a handful of type errors that had to be resolved.
