### PR TITLE
refactor(compiler): Improve ternary error message for unescaped quote…

### DIFF
--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -454,6 +454,15 @@ describe('parser', () => {
       it('should report incorrect ternary operator syntax', () => {
         expectActionError('true?1', 'Conditional expression true?1 requires all 3 expressions');
       });
+
+      it('should hint about quote escaping when ternary fails with adjacent quotes', () => {
+        // Simulates: {{ filter ? ' your filter: \'' + filter + '\'' : '' }} in an inline template.
+        // TypeScript consumes the backslash, so Angular receives the input below with '''.
+        expectActionError(
+          "filter ? ' your filter: '' + filter + ''' : ''",
+          'quotes that were not escaped correctly',
+        );
+      });
     });
 
     describe('assignment', () => {


### PR DESCRIPTION
…s in inline templates

Provides a clearer error when ternary parsing fails due to unescaped quotes in inline templates.

Fix #61768

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #61768

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
