### PR TITLE
fix(docs-infra): support providing links to multiple symbols within a single line of a code block

### DIFF
--- a/adev/shared-docs/pipeline/BUILD.bazel
+++ b/adev/shared-docs/pipeline/BUILD.bazel
@@ -47,6 +47,7 @@ js_binary(
         "//adev:node_modules/jsdom",
         "//adev:node_modules/mermaid",
         "//adev:node_modules/playwright-core",
+        "//adev:node_modules/typescript",
         "@rules_browsers//browsers/chromium",
     ],
     entry_point = "//adev/shared-docs/pipeline/guides:guides.mjs",
@@ -61,6 +62,7 @@ js_binary(
     name = "markdown_no_mermaid",
     data = [
         "//adev:node_modules/jsdom",
+        "//adev:node_modules/typescript",
     ],
     entry_point = "//adev/shared-docs/pipeline/guides:guides-no-mermaid.mjs",
     visibility = ["//visibility:public"],

--- a/adev/shared-docs/pipeline/api-gen/manifest/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/manifest/BUILD.bazel
@@ -7,6 +7,7 @@ esbuild(
     entry_point = ":index.mts",
     external = [
         "@angular/compiler-cli",
+        "typescript",
     ],
     format = "esm",
     output = "bin.mjs",

--- a/adev/shared-docs/pipeline/api-gen/rendering/BUILD.bazel
+++ b/adev/shared-docs/pipeline/api-gen/rendering/BUILD.bazel
@@ -8,6 +8,7 @@ esbuild(
     external = [
         "jsdom",
         "playwright-core",
+        "typescript",
     ],
     format = "esm",
     output = "bin.mjs",

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-reference.tsx
@@ -28,6 +28,7 @@ import {RawHtml} from './raw-html';
 import {DeprecationWarning} from './deprecation-warning';
 import {codeToHtml} from '../../../shared/shiki.mjs';
 import {getHighlighterInstance} from '../shiki/shiki.mjs';
+import {getSymbolsAsApiEntries} from '../symbol-context.mjs';
 
 /** Component to render a class API reference document. */
 export function ClassReference(
@@ -43,6 +44,7 @@ export function ClassReference(
             <RawHtml
               value={codeToHtml(getHighlighterInstance(), (entry as PipeEntry).usage, {
                 language: 'angular-html',
+                apiEntries: getSymbolsAsApiEntries(),
               })}
             />
           </div>

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/highlight-ts.tsx
@@ -10,10 +10,14 @@ import {h} from 'preact';
 import {RawHtml} from './raw-html';
 import {codeToHtml} from '../../../shared/shiki.mjs';
 import {getHighlighterInstance} from '../shiki/shiki.mjs';
+import {getSymbolsAsApiEntries} from '../symbol-context.mjs';
 
 /** Component to render a header of the CLI page. */
 export function HighlightTypeScript(props: {code: string}) {
-  const result = codeToHtml(getHighlighterInstance(), props.code, {language: 'typescript'});
+  const result = codeToHtml(getHighlighterInstance(), props.code, {
+    language: 'typescript',
+    apiEntries: getSymbolsAsApiEntries(),
+  });
   const withScrollTrack = result.replace(/^(<pre class="shiki)/, '$1 docs-mini-scroll-track');
 
   return <RawHtml value={withScrollTrack} className="docs-code" />;

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -39,7 +39,7 @@ import {
   insertParenthesesForDecoratorInShikiHtml,
   replaceKeywordFromShikiHtml,
 } from '../shiki/shiki.mjs';
-import {getSymbolUrl} from '../symbol-context.mjs';
+import {getSymbolsAsApiEntries, getSymbolUrl} from '../symbol-context.mjs';
 
 import {codeToHtml} from '../../../shared/shiki.mjs';
 import {formatJs} from './format-code.mjs';
@@ -92,7 +92,10 @@ export async function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
   let codeWithSyntaxHighlighting = codeToHtml(
     getHighlighterInstance(),
     formattedCode ?? metadata?.contents,
-    {language: 'typescript'},
+    {
+      language: 'typescript',
+      apiEntries: getSymbolsAsApiEntries(),
+    },
   );
 
   if (isDecoratorEntry(entry)) {
@@ -110,11 +113,6 @@ export async function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
     );
     // }
   }
-
-  // Note: Don't expect enum value in signatures to be linked correctly
-  // as shiki already splits them into separate span blocks.
-  // Only the enum itself will recieve a link
-  codeWithSyntaxHighlighting = addApiLinksToHtml(codeWithSyntaxHighlighting);
 
   // shiki returns the lines wrapped by 2 node : 1 pre node, 1 code node.
   // As leveraging jsdom isn't trivial here, we rely on a regex to extract the line nodes

--- a/adev/shared-docs/pipeline/guides/BUILD.bazel
+++ b/adev/shared-docs/pipeline/guides/BUILD.bazel
@@ -14,6 +14,7 @@ esbuild(
     external = [
         "jsdom",
         "playwright-core",
+        "typescript",
     ],
     format = "esm",
     output = "guides.mjs",
@@ -38,6 +39,7 @@ esbuild(
     entry_point = ":index.mts",
     external = [
         "jsdom",
+        "typescript",
     ],
     output = "guides-no-mermaid.mjs",
     platform = "node",

--- a/adev/shared-docs/pipeline/shared/BUILD.bazel
+++ b/adev/shared-docs/pipeline/shared/BUILD.bazel
@@ -17,7 +17,9 @@ ts_project(
         "//adev/shared-docs/pipeline:__subpackages__",
     ],
     deps = [
+        ":linking",
         "//adev:node_modules/shiki",
+        "//adev:node_modules/typescript",
     ],
 )
 

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/highlight.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/highlight.mts
@@ -11,13 +11,18 @@ import {expandRangeStringValues} from './range.mjs';
 import {JSDOM} from 'jsdom';
 import {HighlighterGeneric} from 'shiki';
 import {codeToHtml} from '../../../../shiki.mjs';
+import {RendererContext} from '../../../renderer.mjs';
 
 const lineNumberClassName: string = 'shiki-ln-number';
 
 /**
  * Updates the provided token's code value to include syntax highlighting.
  */
-export function highlightCode(highlighter: HighlighterGeneric<any, any>, token: CodeToken) {
+export function highlightCode(
+  highlighter: HighlighterGeneric<any, any>,
+  token: CodeToken,
+  context: RendererContext,
+) {
   // TODO(josephperrott): Handle mermaid usages i.e. language == mermaidClassName
   if (token.language !== 'none' && token.language !== 'file') {
     // Decode the code content to replace HTML entities to characters
@@ -27,7 +32,11 @@ export function highlightCode(highlighter: HighlighterGeneric<any, any>, token: 
       ? new Set(expandRangeStringValues(token.highlight))
       : undefined;
 
-    token.code = codeToHtml(highlighter, token.code, {language, highlight});
+    token.code = codeToHtml(highlighter, token.code, {
+      language,
+      highlight,
+      apiEntries: context.apiEntries,
+    });
   }
 
   if (token.linenums) {

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
@@ -50,7 +50,7 @@ export function formatCode(token: CodeToken, context: RendererContext): string {
   }
 
   extractRegions(token);
-  highlightCode(context.highlighter, token);
+  highlightCode(context.highlighter, token, context);
 
   const containerEl = JSDOM.fragment(`
   <div class="docs-code${token.style ? ' docs-code-' + token.style : ''}">

--- a/adev/shared-docs/pipeline/shared/shiki.mts
+++ b/adev/shared-docs/pipeline/shared/shiki.mts
@@ -6,8 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import ts from 'typescript';
 import {HighlighterGeneric, ShikiTransformer} from 'shiki';
+import {ApiEntries, getSymbolUrl} from './linking.mjs';
 
+const scanner = ts.createScanner(ts.ScriptTarget.Latest, true);
 const LIGHT_THEME = 'github-light';
 const DARK_THEME = 'github-dark';
 
@@ -36,6 +39,7 @@ export function codeToHtml(
   highlighter: HighlighterGeneric<any, any>,
   code: string,
   config: {
+    apiEntries?: ApiEntries;
     language?: string;
     highlight?: Set<number>;
   },
@@ -48,9 +52,12 @@ export function codeToHtml(
     },
     cssVariablePrefix: '--shiki-',
     defaultColor: false,
-    transformers: [removeWhitespaceTransformer(), highlightTransformer(config.highlight)],
+    transformers: [
+      removeWhitespaceTransformer(),
+      highlightTransformer(config.highlight),
+      linkApiEntriesTransformer(config.apiEntries),
+    ],
   });
-
   return html;
 }
 
@@ -66,12 +73,47 @@ function highlightTransformer(highlight?: Set<number>): ShikiTransformer {
 }
 
 /** A custom transformer which removes all of the whitespace between lines of code in the generated output. */
-function removeWhitespaceTransformer(highlight?: Set<number>): ShikiTransformer {
+function removeWhitespaceTransformer(): ShikiTransformer {
   return {
     code(code) {
       code.children = code.children.filter(
         (line) => line.type !== 'text' || line.value.trim().length !== 0,
       );
+    },
+  };
+}
+
+/** A custom transformer which adds a link to local API entries whenever a matching identifier is discovered in the code block. */
+function linkApiEntriesTransformer(apiEntries?: ApiEntries): ShikiTransformer {
+  if (apiEntries === undefined) {
+    return {};
+  }
+  return {
+    preprocess(code, options) {
+      options.decorations ??= [];
+      scanner.setText(code);
+      let token = scanner.scan();
+
+      while (token !== ts.SyntaxKind.EndOfFileToken) {
+        if (token === ts.SyntaxKind.Identifier) {
+          const symbolUrl = getSymbolUrl(scanner.getTokenText(), apiEntries);
+          if (symbolUrl !== undefined) {
+            options.decorations.push({
+              transform: (el) => {
+                el.tagName = 'a';
+                el.properties['href'] = symbolUrl;
+                return el;
+              },
+              start: scanner.getTokenStart(),
+              end: scanner.getTokenEnd(),
+            });
+          }
+        }
+
+        token = scanner.scan();
+      }
+
+      return code;
     },
   };
 }


### PR DESCRIPTION
Previously our system only found the first matching symboling to link to within a code block on each line, now we set up a link for all of the discovered symbols on each line

Fixes #65403