### PR TITLE
refactor(devtools): use object-tree-explorer in signal-value-tree

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/BUILD.bazel
@@ -5,9 +5,6 @@ package(default_visibility = ["//devtools:__subpackages__"])
 sass_binary(
     name = "signals-value-tree_styles",
     src = "signals-value-tree.component.scss",
-    deps = [
-        "//devtools/projects/ng-devtools/src/styles:typography",
-    ],
 )
 
 ng_project(
@@ -26,6 +23,8 @@ ng_project(
         "//:node_modules/@angular/material",
         "//:node_modules/rxjs",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph",
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer",
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer:types",
         "//devtools/projects/protocol",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signal-data-source.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signal-data-source.ts
@@ -19,8 +19,7 @@ import {
 } from '../../../../../../../../protocol';
 import {BehaviorSubject, merge, Observable, Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
-
-import {FlatNode, Property} from './signals-value-tree.component';
+import {FlatNode, Property} from '../../../../../shared/object-tree-explorer/object-tree-types';
 
 export const arrayifyProps = (
   props: {[prop: string]: Descriptor} | Descriptor[],

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.html
@@ -1,31 +1,5 @@
-@if (node().preview.preview === 'undefined') {
-  <span class="value">undefined</span>
-} @else {
-  <mat-tree class="property-list" [dataSource]="dataSource()" [treeControl]="treeControl()">
-    <mat-tree-node matTreeNodePaddingIndent="14" *matTreeNodeDef="let node" matTreeNodePadding>
-      <p class="non-expandable-node">
-        @if (node.level > 0) {
-          <span class="name">{{ node.prop.name }}</span>
-        }
-        <span class="value">{{ node.prop.descriptor.preview }}</span>
-      </p>
-    </mat-tree-node>
-    <mat-tree-node
-      matTreeNodePaddingIndent="14"
-      *matTreeNodeDef="let node; when: hasChild"
-      matTreeNodePadding
-    >
-      <button class="expandable-node" (click)="toggle(node)" aria-label="Expand node">
-        <mat-icon>
-          {{ treeControl().isExpanded(node) ? 'expand_more' : 'chevron_right' }}
-        </mat-icon>
-        @if (node.level > 0) {
-          <span class="name">{{ node.prop.name }}</span>
-        }
-        <span class="value">
-          {{ node.prop.descriptor.preview }}
-        </span>
-      </button>
-    </mat-tree-node>
-  </mat-tree>
-}
+<ng-object-tree-explorer
+  [dataSource]="dataSource()"
+  [treeControl]="treeControl()"
+  [omitRootNodesNames]="true"
+/>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.scss
@@ -1,65 +1,14 @@
-@use '../../../../../../styles/typography';
-
 :host {
   width: 200px;
   display: block;
-  overflow-x: auto;
-  padding-inline: 0.5rem;
+  overflow: auto;
   border-radius: 0.25rem;
   margin-top: 0.75rem;
   background: var(--nonary-contrast);
-  padding-block: 0.25rem;
   scrollbar-width: thin;
   scrollbar-color: var(--quaternary-contrast) transparent;
 
-  mat-tree {
-    margin-left: 0.625rem;
-
-    mat-tree-node {
-      min-height: 20px !important;
-    }
-  }
-
-  .expandable-node,
-  .name,
-  .value {
-    @extend %monospaced;
-    white-space: nowrap;
-  }
-
-  .expandable-node,
-  .non-expandable-node {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
-
-  .expandable-node {
-    background-color: transparent;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-
-    mat-icon {
-      position: absolute;
-      left: -0.75rem;
-      width: 12px;
-      height: 12px;
-      font-size: 12px;
-    }
-  }
-
-  .non-expandable-node {
-    margin: 0;
-  }
-
-  .name {
-    color: var(--color-tree-node-element-name);
-    margin-right: 0.25rem;
-
-    &::after {
-      content: ':';
-      color: var(--color-text);
-    }
+  ng-object-tree-explorer {
+    --ote-padding: 0.25rem;
   }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-value-tree/signals-value-tree.component.ts
@@ -8,35 +8,19 @@
 
 import {ChangeDetectionStrategy, Component, computed, inject, input} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
-import {
-  MatTree,
-  MatTreeFlattener,
-  MatTreeNode,
-  MatTreeNodeDef,
-  MatTreeNodePadding,
-} from '@angular/material/tree';
-import {MatIcon} from '@angular/material/icon';
-import {Descriptor, MessageBus, PropType} from '../../../../../../../../protocol';
+import {MatTreeFlattener} from '@angular/material/tree';
 import {DataSource} from '@angular/cdk/collections';
+
+import {MessageBus, PropType} from '../../../../../../../../protocol';
 import {DevtoolsSignalNode, SignalGraphManager} from '../../../signal-graph';
 import {arrayifyProps, SignalDataSource} from './signal-data-source';
-
-export interface FlatNode {
-  expandable: boolean;
-  prop: Property;
-  level: number;
-}
-
-export interface Property {
-  name: string;
-  descriptor: Descriptor;
-  parent: Property | null;
-}
+import {ObjectTreeExplorerComponent} from '../../../../../shared/object-tree-explorer/object-tree-explorer.component';
+import {FlatNode, Property} from '../../../../../shared/object-tree-explorer/object-tree-types';
 
 @Component({
   selector: 'ng-signals-value-tree',
   templateUrl: './signals-value-tree.component.html',
-  imports: [MatTree, MatTreeNode, MatTreeNodeDef, MatTreeNodePadding, MatIcon],
+  imports: [ObjectTreeExplorerComponent],
   styleUrl: './signals-value-tree.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -79,10 +63,4 @@ export class SignalsValueTreeComponent {
       this.messageBus,
     );
   });
-
-  toggle(node: FlatNode) {
-    this.treeControl().toggle(node);
-  }
-
-  hasChild = (_: number, node: FlatNode) => node.expandable;
 }


### PR DESCRIPTION
Employ the reusable `object-tree-explorer` in the `signal-value-tree` preview component.