### PR TITLE
docs: Add section on `animate.leave` for clarity

### DIFF
--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.css
@@ -1,0 +1,35 @@
+:host {
+  display: block;
+  height: 200px;
+}
+
+.leave-container {
+  border: 1px solid #dddddd;
+  margin-top: 1em;
+  padding: 20px 20px 0px 20px;
+  font-weight: bold;
+  font-size: 20px;
+  opacity: 1;
+  transition: opacity 200ms ease-in;
+
+  @starting-style {
+    opacity: 0;
+  }
+}
+
+.leaving {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 500ms ease-out,
+    transform 500ms ease-out;
+}
+
+.toggle-btn {
+  background: transparent;
+  border: 1px solid var(--primary-contrast, black);
+  color: var(--primary-contrast, black);
+  padding: 10px 24px;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.html
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.html
@@ -1,0 +1,15 @@
+<!-- #docplaster -->
+<h2><code>animate.leave</code> Parent Sub-tree No Animation Example</h2>
+
+<button type="button" class="toggle-btn" (click)="toggle()">Toggle Element</button>
+
+@if (isShown()) {
+  <!-- the child node with `animate.leave` will not animate out because the
+       parent node removal happens first and will take the child dom tree
+       with it. -->
+  <div class="leave-parent">
+    <div class="leave-container" animate.leave="leaving">
+      <p>Goodbye</p>
+    </div>
+  </div>
+}

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.ts
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.ts
@@ -1,0 +1,15 @@
+// #docplaster
+import {Component, signal} from '@angular/core';
+
+@Component({
+  selector: 'app-leave-parent',
+  templateUrl: 'leave-parent.html',
+  styleUrls: ['leave-parent.css'],
+})
+export class LeaveParent {
+  isShown = signal(false);
+
+  toggle() {
+    this.isShown.update((isShown) => !isShown);
+  }
+}

--- a/adev/src/content/guide/animations/enter-and-leave.md
+++ b/adev/src/content/guide/animations/enter-and-leave.md
@@ -55,6 +55,16 @@ NOTE: When using multiple keyframe animations or transition properties on a an e
     <docs-code header="leave-binding.css" path="adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css"/>
 </docs-code-multifile>
 
+### Element removal order matters
+
+There is some nuance to how `animate.leave` animations are run and when an animation will occur. `animate.leave` works if it is placed on the element that is being removed. However, `animate.leave` will **not** animate if it is on an element that is a _descendent_ of the element being removed. This is because when a parent node is removed, it takes the entire sub tree with it, and since there are no animations on that parent node, it will be removed immediately. This means there's no element to animate away with `animate.leave`. You will need to consider this in your usage of `animate.leave`.
+
+<docs-code-multifile preview path="adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.ts">
+    <docs-code header="leave.ts" path="adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.ts" />
+    <docs-code header="leave.html" path="adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.html" />
+    <docs-code header="leave.css" path="adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.css"/>
+</docs-code-multifile>
+
 ## Event Bindings, Functions, and Third-party Libraries
 
 Both `animate.enter` and `animate.leave` support event binding syntax that allows for function calls. You can use this syntax to call a function in your component code or utilize third-party animation libraries, like [GSAP](https://gsap.com/), [anime.js](https://animejs.com/), or any other JavaScript animation library.


### PR DESCRIPTION
There has been a bunch of confusion as to how `animate.leave` works on child nodes when the non-animated parent is removed. This section addition should clarify that.
