### PR TITLE
fix(core): Remove note to skip arrow functions in best practices

### DIFF
--- a/adev/src/context/guidelines.md
+++ b/adev/src/context/guidelines.md
@@ -111,7 +111,6 @@ Here is a link to the most recent Angular style guide https://angular.dev/style-
 - Keep templates simple and avoid complex logic
 - Use native control flow (`@if`, `@for`, `@switch`) instead of `*ngIf`, `*ngFor`, `*ngSwitch`
 - Do not assume globals like (`new Date()`) are available.
-- Do not write arrow functions in templates (they are not supported).
 - Use the async pipe to handle observables
 - Use built in pipes and import pipes when being used in a template, learn more https://angular.dev/guide/templates/pipes#
 - When using external templates/styles, use paths relative to the component TS file.

--- a/packages/core/resources/best-practices.md
+++ b/packages/core/resources/best-practices.md
@@ -46,7 +46,6 @@ You are an expert in TypeScript, Angular, and scalable web application developme
 - Use native control flow (`@if`, `@for`, `@switch`) instead of `*ngIf`, `*ngFor`, `*ngSwitch`
 - Use the async pipe to handle observables
 - Do not assume globals like (`new Date()`) are available.
-- Do not write arrow functions in templates (they are not supported).
 
 ## Services
 


### PR DESCRIPTION
Arrow functions are now supported and this note is no longer needed
