### PR TITLE
refactor(compiler-cli): detect unused standalone imports in local arrays

### DIFF
--- a/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
+++ b/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
@@ -291,6 +291,14 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       return false;
     }
 
+    const usedDirectiveNames = new Set<string>();
+
+    for (const dir of usedDirectives) {
+      if (dir.name) {
+        usedDirectiveNames.add(dir.name.text);
+      }
+    }
+
     for (const element of arrayLiteral.elements) {
       if (!ts.isIdentifier(element)) {
         return false;
@@ -298,10 +306,8 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
 
       const elementName = element.text;
 
-      for (const usedDir of usedDirectives) {
-        if (usedDir.name?.text === elementName) {
-          return false;
-        }
+      if (usedDirectiveNames.has(elementName)) {
+        return false;
       }
 
       if (usedPipes.has(elementName)) {

--- a/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
+++ b/packages/compiler-cli/src/ngtsc/validation/src/rules/unused_standalone_imports_rule.ts
@@ -62,15 +62,13 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       return null;
     }
 
-    const unused = this.getUnusedSymbols(
-      metadata,
-      new Set(usedDirectives.map((dir) => dir.ref.node as ts.ClassDeclaration)),
-      new Set(usedPipes),
+    const usedDirectivesSet = new Set(
+      usedDirectives.map((dir) => dir.ref.node as ts.ClassDeclaration),
     );
 
-    if (unused === null) {
-      return null;
-    }
+    const usedPipesSet = new Set(usedPipes);
+
+    const unused = this.getUnusedSymbols(metadata, usedDirectivesSet, usedPipesSet);
 
     const propertyAssignment = closestNode(metadata.rawImports, ts.isPropertyAssignment);
     const category =
@@ -78,7 +76,11 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
         ? ts.DiagnosticCategory.Error
         : ts.DiagnosticCategory.Warning;
 
-    if (unused.length === metadata.imports.length && propertyAssignment !== null) {
+    if (
+      unused !== null &&
+      unused.length === metadata.imports.length &&
+      propertyAssignment !== null
+    ) {
       return makeDiagnostic(
         ErrorCode.UNUSED_STANDALONE_IMPORTS,
         propertyAssignment.name,
@@ -88,20 +90,37 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       );
     }
 
-    return unused.map((ref) => {
-      const diagnosticNode =
-        ref.getIdentityInExpression(metadata.rawImports!) ||
-        ref.getIdentityIn(node.getSourceFile()) ||
-        metadata.rawImports!;
+    const diagnostics: ts.Diagnostic[] = [];
 
-      return makeDiagnostic(
-        ErrorCode.UNUSED_STANDALONE_IMPORTS,
-        diagnosticNode,
-        `${ref.node.name.text} is not used within the template of ${metadata.name}`,
-        undefined,
-        category,
-      );
-    });
+    const localArrayDiagnostics = this.checkLocalArraysAllUnused(
+      metadata,
+      usedDirectivesSet,
+      usedPipesSet,
+      category,
+    );
+
+    diagnostics.push(...localArrayDiagnostics);
+
+    if (unused !== null) {
+      for (const ref of unused) {
+        const diagnosticNode =
+          ref.getIdentityInExpression(metadata.rawImports!) ||
+          ref.getIdentityIn(node.getSourceFile()) ||
+          metadata.rawImports!;
+
+        diagnostics.push(
+          makeDiagnostic(
+            ErrorCode.UNUSED_STANDALONE_IMPORTS,
+            diagnosticNode,
+            `${ref.node.name.text} is not used within the template of ${metadata.name}`,
+            undefined,
+            category,
+          ),
+        );
+      }
+    }
+
+    return diagnostics.length > 0 ? diagnostics : null;
   }
 
   private getUnusedSymbols(
@@ -161,27 +180,177 @@ export class UnusedStandaloneImportsRule implements SourceFileValidatorRule {
       return false;
     }
 
-    // The reference might be shared if it comes from an exported array. If the variable is local
-    /// to the file, then it likely isn't shared. Note that this has the potential for false
-    // positives if a non-exported array of imports is shared between components in the same
-    // file. This scenario is unlikely and even if we report the diagnostic for it, it would be
-    // okay since the user only has to refactor components within the same file, rather than the
-    // entire application.
-    let current: ts.Node | null = reference.getIdentityIn(rawImports.getSourceFile());
+    // If the reference comes from any array variable (local or exported), we treat it as
+    // potentially shared and don't report individual unused items. The checkLocalArraysAllUnused
+    // method will report "All imports are unused" for local arrays where ALL elements are unused.
+    // This avoids noisy diagnostics for users who use arrays to group related imports.
+    return true;
+  }
 
-    while (current !== null) {
-      if (ts.isVariableStatement(current)) {
-        return !!current.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
-      }
-
-      // `Node.parent` can be undefined, but the TS types don't reflect it.
-      // Coerce to null so the value is consitent with the type.
-      current = current.parent ?? null;
+  private checkLocalArraysAllUnused(
+    metadata: TypeCheckableDirectiveMeta,
+    usedDirectives: Set<ts.ClassDeclaration>,
+    usedPipes: Set<string>,
+    category: ts.DiagnosticCategory,
+  ): ts.Diagnostic[] {
+    const {rawImports} = metadata;
+    if (rawImports === null) {
+      return [];
     }
 
-    // Otherwise the reference likely comes from an imported
-    // symbol like an array of shared common components.
+    const diagnostics: ts.Diagnostic[] = [];
+    const arrayIdentifiers = this.collectArrayIdentifiers(rawImports);
+
+    for (const {identifier, node: arrayNode} of arrayIdentifiers) {
+      const sourceFile = identifier.getSourceFile();
+      const declaration = this.findVariableDeclaration(identifier, sourceFile);
+
+      if (declaration === null || !declaration.initializer) {
+        continue;
+      }
+
+      // Check if this is a local (non-exported) variable
+      const variableStatement = this.findParentVariableStatement(declaration);
+      if (variableStatement === null) {
+        continue;
+      }
+
+      const isExported = variableStatement.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+      );
+
+      if (isExported) {
+        continue;
+      }
+
+      if (!ts.isArrayLiteralExpression(declaration.initializer)) {
+        continue;
+      }
+
+      const allUnused = this.areAllArrayElementsUnused(
+        declaration.initializer,
+        usedDirectives,
+        usedPipes,
+      );
+
+      if (allUnused) {
+        diagnostics.push(
+          makeDiagnostic(
+            ErrorCode.UNUSED_STANDALONE_IMPORTS,
+            arrayNode,
+            'All imports are unused',
+            undefined,
+            category,
+          ),
+        );
+      }
+    }
+
+    return diagnostics;
+  }
+
+  /**
+   * Collects array identifiers from rawImports (both spread and direct references).
+   */
+  private collectArrayIdentifiers(
+    rawImports: ts.Expression,
+  ): Array<{identifier: ts.Identifier; node: ts.Node}> {
+    const result: Array<{identifier: ts.Identifier; node: ts.Node}> = [];
+
+    // Handle case where imports is directly an identifier (e.g., imports: importsAsArray)
+    if (ts.isIdentifier(rawImports)) {
+      result.push({identifier: rawImports, node: rawImports});
+      return result;
+    }
+
+    if (!ts.isArrayLiteralExpression(rawImports)) {
+      return result;
+    }
+
+    for (const element of rawImports.elements) {
+      if (ts.isSpreadElement(element)) {
+        // Handle spread syntax: ...ARRAY
+        if (ts.isIdentifier(element.expression)) {
+          result.push({identifier: element.expression, node: element});
+        }
+      } else if (ts.isIdentifier(element)) {
+        // Handle direct nested array: ARRAY (without spread)
+        result.push({identifier: element, node: element});
+      }
+    }
+
+    return result;
+  }
+
+  private areAllArrayElementsUnused(
+    arrayLiteral: ts.ArrayLiteralExpression,
+    usedDirectives: Set<ts.ClassDeclaration>,
+    usedPipes: Set<string>,
+  ): boolean {
+    if (arrayLiteral.elements.length === 0) {
+      return false;
+    }
+
+    for (const element of arrayLiteral.elements) {
+      if (!ts.isIdentifier(element)) {
+        return false;
+      }
+
+      const elementName = element.text;
+
+      for (const usedDir of usedDirectives) {
+        if (usedDir.name?.text === elementName) {
+          return false;
+        }
+      }
+
+      if (usedPipes.has(elementName)) {
+        return false;
+      }
+    }
+
     return true;
+  }
+
+  private findVariableDeclaration(
+    identifier: ts.Identifier,
+    sourceFile: ts.SourceFile,
+  ): ts.VariableDeclaration | null {
+    const targetText = identifier.text;
+    let foundDeclaration: ts.VariableDeclaration | null = null;
+
+    const visit = (node: ts.Node): void => {
+      if (foundDeclaration) {
+        return;
+      }
+
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === targetText
+      ) {
+        if (node.name.pos < identifier.pos) {
+          foundDeclaration = node;
+          return;
+        }
+      }
+
+      ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+    return foundDeclaration;
+  }
+
+  private findParentVariableStatement(node: ts.Node): ts.VariableStatement | null {
+    let current: ts.Node | undefined = node;
+    while (current) {
+      if (ts.isVariableStatement(current)) {
+        return current;
+      }
+      current = current.parent;
+    }
+    return null;
   }
 }
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2913,7 +2913,7 @@ runInEachFileSystem(() => {
             value: number;
           }
 
-          @Directive({standalone: true})
+          @Directive({})
           export class HostDir {
             @Input({transform: (val: HostDirType) => 1}) val!: number;
           }
@@ -2967,7 +2967,7 @@ runInEachFileSystem(() => {
             value: number;
           }
 
-          @Directive({standalone: true})
+          @Directive({})
           export class Parent {
             @Input({transform: (val: ParentType) => 1}) val!: number;
           }
@@ -8222,7 +8222,7 @@ suppress
         expect(diags[1].messageText).toBe('PercentPipe is not used within the template of MyComp');
       });
 
-      it('should report unused imports coming from a nested array from the same file', () => {
+      it('should not report unused imports coming from a nested array from the same file when some are used', () => {
         env.write(
           'used.ts',
           `
@@ -8277,11 +8277,10 @@ suppress
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedDir is not used within the template of MyComp');
+        expect(diags.length).toBe(0);
       });
 
-      it('should report unused imports coming from an array used as the `imports` initializer', () => {
+      it('should not report unused imports coming from an array used as the `imports` initializer when some are used', () => {
         env.write(
           'used.ts',
           `
@@ -8325,8 +8324,40 @@ suppress
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toBe('UnusedDir is not used within the template of MyComp');
+        expect(diags.length).toBe(0);
+      });
+
+      it('should not report unused imports when imports is directly assigned to a local array identifier and some are used', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-1',
+            template: '',
+          })
+          export class AppComponent1 {}
+
+          @Component({
+            selector: 'app-2',
+            template: '',
+          })
+          export class AppComponent2 {}
+
+          const importsAsArray = [AppComponent1, AppComponent2];
+
+          @Component({
+            selector: 'app-4',
+            template: '<app-2/>',
+            imports: importsAsArray,
+          })
+          export class AppComponent4 {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
       });
 
       it('should not report unused imports coming from an array through a spread expression from a different file', () => {
@@ -8515,6 +8546,182 @@ suppress
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
+      });
+
+      it('should report all imports unused when all elements of a local spread array are unused', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive} from '@angular/core';
+
+          @Component({ 
+            selector: 'app-dummy',
+            template: '',
+          })
+          export class DummyComponent {}
+
+          @Component({ 
+            selector: 'app-dummy2',
+            template: '',          
+          })
+          export class Dummy2Component {}
+
+          @Directive({
+            selector: '[used]',  
+          })
+          export class UsedDir {}
+
+          const LIST_OF_COMPONENTS = [DummyComponent, Dummy2Component];
+
+          @Component({
+            selector: 'app-test-img',
+            imports: [UsedDir, ...LIST_OF_COMPONENTS],
+            template: \`<div used></div>\`,
+          })
+          export default class TestImg {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe('All imports are unused');
+      });
+
+      it('should not report unused imports from a local spread array when some are used', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive} from '@angular/core';
+
+          @Directive({selector: '[used]'})
+          export class UsedDir {}
+
+          @Directive({selector: '[unused1]' })
+          export class UnusedDir1 {}
+
+          @Directive({selector: '[unused2]' })
+          export class UnusedDir2 {}
+
+          const LIST_OF_DIRECTIVES = [UsedDir, UnusedDir1, UnusedDir2];
+
+          @Component({
+            selector: 'app-test',
+            imports: [...LIST_OF_DIRECTIVES],
+            template: \`<div used></div>\`,
+          })
+          export class TestComponent {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should report all imports unused for local spread arrays where all elements are unused', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive} from '@angular/core';
+
+          @Directive({selector: '[dir1]' })
+          export class Dir1 {}
+
+          @Directive({selector: '[dir2]' })
+          export class Dir2 {}
+
+          @Directive({selector: '[dir3]' })
+          export class Dir3 {}
+
+          @Directive({selector: '[dir4]' })
+          export class Dir4 {}
+
+          const LIST1 = [Dir1, Dir2];
+          const LIST2 = [Dir3, Dir4];
+
+          @Component({
+            selector: 'app-test',
+            imports: [...LIST1, ...LIST2],
+            template: \`<div dir1></div>\`,
+          })
+          export class TestComponent {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe('All imports are unused');
+      });
+
+      it('should report direct unused imports and not report spread arrays where some are used', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive} from '@angular/core';
+
+          @Directive({selector: '[direct-used]' })
+          export class DirectUsed {}
+
+          @Directive({selector: '[direct-unused]' })
+          export class DirectUnused {}
+
+          @Directive({selector: '[spread-used]' })
+          export class SpreadUsed {}
+
+          @Directive({selector: '[spread-unused]' })
+          export class SpreadUnused {}
+
+          const SPREAD_LIST = [SpreadUsed, SpreadUnused];
+
+          @Component({
+            selector: 'app-test',
+            imports: [DirectUsed, DirectUnused, ...SPREAD_LIST],
+            template: \`<div direct-used spread-used></div>\`,
+          })
+          export class TestComponent {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(
+          'DirectUnused is not used within the template of TestComponent',
+        );
+      });
+
+      it('should report direct unused imports and not report nested arrays where some are used', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive} from '@angular/core';
+
+          @Directive({selector: '[direct-used]'})
+          export class DirectUsed {}
+
+          @Directive({selector: '[direct-unused]'})
+          export class DirectUnused {}
+
+          @Directive({selector: '[nested-used]'})
+          export class NestedUsed {}
+
+          @Directive({selector: '[nested-unused]'})
+          export class NestedUnused {}
+
+          const NESTED_LIST = [NestedUsed, NestedUnused];
+
+          @Component({
+            selector: 'app-test',
+            imports: [DirectUsed, DirectUnused, NESTED_LIST],
+            template: \`<div direct-used nested-used></div>\`,
+          })
+          export class TestComponent {}
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(
+          'DirectUnused is not used within the template of TestComponent',
+        );
       });
     });
 


### PR DESCRIPTION
Extends the unused standalone imports rule to correctly identify and report unused imports that are part of local arrays (with or without spread syntax) or assigned to a local array identifier.

Fixes  #59754

## What is the new behavior?
```ts
const sharedImports = [UnusedComponent, UsedComponent];

@Component({
  selector: 'app-using-array-imports',
  imports: sharedImports, //  no warning (at least one import is used)
  template: '<used-comp />',
})
export class UsingArrayImports {}


const unusedImports = [UnusedComponent , Other];

@Component({
  selector: 'app-array-all-unused',
  imports: unusedImports, //  NG8113: all imports in this array are unused
  template: ' ',
})
export class ArrayAllUnused {}


```

 