### PR TITLE
docs(docs-infra): : Exempts animation-related symbols from linking

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -23,6 +23,9 @@ const LINK_EXEMPT = new Set([
   'animation',
   'transition',
   'trigger',
+  'group()',
+  'keyframes',
+  '@keyframes',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {


### PR DESCRIPTION
 
## What is the current behavior?
http://next.angular.dev/guide/animations/css#creating-reusable-animations


<img width="751" height="247" alt="image" src="https://github.com/user-attachments/assets/00f9c1b4-dbf7-4a18-9948-11c48633b5e0" />

 https://next.angular.dev/guide/forms/reactive-forms#generate-form-controls

<img width="688" height="139" alt="image" src="https://github.com/user-attachments/assets/5f41a52d-60b8-483f-b41d-1ab69961f569" />


## What is the new behavior?

Exempts 'group()', 'keyframes', and `@keyframes` symbols from automatic linking.
