### PR TITLE
refactor(devtools): snap to signal graph nodes selected from the properties panel

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.html
@@ -41,7 +41,7 @@
       @if (signalsOpen() && signalGraph.element()) {
         <as-split-area [size]="signalGraphSplitSize()">
           <ng-signals-tab
-            [preselectedNodeId]="preselectedSignalNodeId()"
+            [externallySelectedNodeId]="externallySelectedSignalNodeId()"
             (close)="signalsOpen.set(false)"
           />
         </as-split-area>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -17,7 +17,6 @@ import {
   viewChild,
   ChangeDetectionStrategy,
   computed,
-  linkedSignal,
   DestroyRef,
 } from '@angular/core';
 import {
@@ -133,10 +132,7 @@ export class DirectiveExplorerComponent {
   private readonly snackBar = inject(MatSnackBar);
   protected readonly signalGraph = inject(SignalGraphManager);
 
-  protected readonly preselectedSignalNodeId = linkedSignal<IndexedNode | null, string | null>({
-    source: this.currentSelectedElement,
-    computation: () => null,
-  });
+  protected readonly externallySelectedSignalNodeId = signal<{id: string} | null>(null);
 
   protected readonly responsiveSplitConfig: ResponsiveSplitConfig = {
     defaultDirection: 'vertical',
@@ -390,7 +386,8 @@ export class DirectiveExplorerComponent {
 
   showSignalGraph(node: DevtoolsSignalGraphNode | null) {
     if (node) {
-      this.preselectedSignalNodeId.set(node.id);
+      // We want to trigger an update each time we intercept an update.
+      this.externallySelectedSignalNodeId.set({id: node.id});
     }
     this.signalsOpen.set(true);
   }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
@@ -2,6 +2,7 @@
   #visualizer
   [graph]="signalGraph.graph()"
   [selectedNodeId]="selectedNodeId()"
+  [externallySelectedNodeId]="externallySelectedNodeId()?.id ?? null"
   [element]="signalGraph.element()"
   (nodeClick)="onNodeClick($event)"
   (clusterCollapse)="detailsVisible.set(false)"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
@@ -71,7 +71,7 @@ export class SignalsTabComponent {
       }
       // In all other cases (e.g. initialization,  externally selected node change),
       // use the externally selected node as a value.
-      return source?.externallySelectedNodeId;
+      return source.externallySelectedNodeId;
     },
   });
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
@@ -10,6 +10,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   input,
   linkedSignal,
@@ -24,8 +25,14 @@ import {FrameManager} from '../../../application-services/frame_manager';
 import {SignalsDetailsComponent} from './signals-details/signals-details.component';
 import {ButtonComponent} from '../../../shared/button/button.component';
 import {SignalGraphManager} from '../signal-graph/signal-graph-manager';
-import {DevtoolsSignalGraph, DevtoolsSignalGraphNode} from '../signal-graph';
+import {DevtoolsSignalGraphNode} from '../signal-graph';
 import {SignalsVisualizerComponent} from './signals-visualizer/signals-visualizer.component';
+import {ElementPosition} from '../../../../../../protocol';
+
+type SelectedNodeSource = {
+  element: ElementPosition | undefined;
+  externallySelectedNodeId: string | null;
+};
 
 @Component({
   templateUrl: './signals-tab.component.html',
@@ -41,17 +48,30 @@ export class SignalsTabComponent {
   private readonly appOperations = inject(ApplicationOperations);
   private readonly frameManager = inject(FrameManager);
 
-  protected readonly preselectedNodeId = input<string | null>(null);
   protected readonly close = output<void>();
 
-  // selected is automatically reset to null whenever `graph` changes
-  protected readonly selectedNodeId = linkedSignal<DevtoolsSignalGraph | null, string | null>({
-    source: this.signalGraph.graph,
+  // Source for selected node ID.
+  // Use only for triggering behavior dependent on external node ID changes.
+  protected readonly externallySelectedNodeId = input<{id: string} | null>(null);
+
+  private readonly selectedNodeSource = computed<SelectedNodeSource>(() => ({
+    element: this.signalGraph.element(),
+    externallySelectedNodeId: this.externallySelectedNodeId()?.id ?? null,
+  }));
+
+  // Use a single source of truth for the selected node ID.
+  // The selected node ID computation is triggered either
+  // by an element (graph) change or externally selected node ID change.
+  protected readonly selectedNodeId = linkedSignal<SelectedNodeSource, string | null>({
+    source: this.selectedNodeSource,
     computation: (source, prev) => {
-      if (prev?.value && source?.nodes.find((n) => n.id === prev.value)) {
-        return prev.value;
+      // If the element changes, this means we have a new graph => reset
+      if (prev?.value && source.element !== prev.source.element) {
+        return null;
       }
-      return this.preselectedNodeId();
+      // In all other cases (e.g. initialization,  externally selected node change),
+      // use the externally selected node as a value.
+      return source?.externallySelectedNodeId;
     },
   });
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
@@ -101,26 +101,19 @@ export class SignalsGraphVisualizer {
     d3svg.call(this.zoomController);
   }
 
-  /** Snaps to the root node – either the template or the first node depending which exists. */
-  snapToRootNode() {
-    let node =
-      this.inputGraph?.nodes.find((n) => isSignalNode(n) && n.kind === 'template') ??
-      this.inputGraph?.nodes[0];
-
-    if (!node) {
-      return;
-    }
-
-    // TODO(Georgi): Drop `any` when Dagre is updated.
-    const dagreNode = this.graph.node(node.id) as any;
+  snapToNode(nodeId: string): void;
+  snapToNode(node: DevtoolsSignalGraphNode): void;
+  snapToNode(node: string | DevtoolsSignalGraphNode) {
+    const nodeId = typeof node === 'string' ? node : node.id;
+    const dagreNode = this.graph.node(nodeId);
     if (!dagreNode) {
       return;
     }
 
     const contWidth = this.svg.clientWidth;
     const contHeight = this.svg.clientHeight;
-    const x = contWidth / 2 - dagreNode.x * TEMPL_NODE_ZOOM_SCALE;
-    const y = contHeight / 2 - dagreNode.y * TEMPL_NODE_ZOOM_SCALE;
+    const x = contWidth / 2 - dagreNode.x! * TEMPL_NODE_ZOOM_SCALE;
+    const y = contHeight / 2 - dagreNode.y! * TEMPL_NODE_ZOOM_SCALE;
 
     d3.select(this.svg)
       .transition()
@@ -131,11 +124,22 @@ export class SignalsGraphVisualizer {
       );
   }
 
-  setSelected(selected: string | null) {
+  /** Snaps to the root node – either the template or the first node depending which exists. */
+  snapToRootNode() {
+    const node =
+      this.inputGraph?.nodes.find((n) => isSignalNode(n) && n.kind === 'template') ??
+      this.inputGraph?.nodes[0];
+
+    if (node) {
+      this.snapToNode(node);
+    }
+  }
+
+  setSelected(selectedId: string | null) {
     d3.select(this.svg)
       .select('.output .nodes')
       .selectAll<SVGGElement, string>('g.node')
-      .classed('selected', (d) => d === selected);
+      .classed('selected', (d) => d === selectedId);
   }
 
   zoomScale(scale: number) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/visualizer-types.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/visualizer-types.ts
@@ -4,26 +4,31 @@
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
+ *
  */
 
+interface DagreNodeBase {
+  x?: number;
+  y?: number;
+  style?: string;
+}
+
 // Non-exhaustive; Alter based on Dagre D3 docs if required
-export interface DagreRegularNode {
+export interface DagreRegularNode extends DagreNodeBase {
   label: HTMLDivElement;
   labelType: string;
   shape: string;
   padding: number;
   width: number;
   height: number;
-  style?: string;
   epoch?: number;
 }
 
 // Non-exhaustive; Alter based on Dagre D3 docs if required
-export interface DagreCluster {
+export interface DagreCluster extends DagreNodeBase {
   label: string;
   clusterLabelPos: string;
   class?: string;
-  style?: string;
 }
 
 export type DagreNode = DagreRegularNode | DagreCluster;


### PR DESCRIPTION
Snap to the signal graph node of a corresponding property when the user uses "Show 'prop' signal graph" button.
