### PR TITLE
refactor(core): remove unused restriction parameter

### DIFF
--- a/goldens/public-api/core/primitives/event-dispatch/index.api.md
+++ b/goldens/public-api/core/primitives/event-dispatch/index.api.md
@@ -118,7 +118,7 @@ export const isCaptureEventType: (eventType: string) => boolean;
 export const isEarlyEventType: (eventType: string) => boolean;
 
 // @public
-export function registerAppScopedDispatcher(restriction: Restriction, appId: string, dispatcher: (eventInfo: EventInfo) => void, dataContainer?: EarlyJsactionDataContainer): void;
+export function registerAppScopedDispatcher(appId: string, dispatcher: (eventInfo: EventInfo) => void, dataContainer?: EarlyJsactionDataContainer): void;
 
 // @public
 export function registerDispatcher(eventContract: UnrenamedEventContract, dispatcher: EventDispatcher): void;

--- a/packages/core/primitives/event-dispatch/src/bootstrap_app_scoped.ts
+++ b/packages/core/primitives/event-dispatch/src/bootstrap_app_scoped.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Restriction} from './restriction';
 import {
   EarlyJsactionDataContainer,
   addEvents,
@@ -50,7 +49,6 @@ export function getAppScopedQueuedEventInfos(
  * window.
  */
 export function registerAppScopedDispatcher(
-  restriction: Restriction,
   appId: string,
   dispatcher: (eventInfo: EventInfo) => void,
   dataContainer: EarlyJsactionDataContainer = window,

--- a/packages/core/primitives/event-dispatch/src/bootstrap_global.ts
+++ b/packages/core/primitives/event-dispatch/src/bootstrap_global.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Restriction} from './restriction';
 import {
   addEvents,
   createEarlyJsactionData,
@@ -33,10 +32,7 @@ export function getGlobalQueuedEventInfos() {
 }
 
 /** Registers a dispatcher function on the `EarlyJsactionData` present on the window. */
-export function registerGlobalDispatcher(
-  restriction: Restriction,
-  dispatcher: (eventInfo: EventInfo) => void,
-) {
+export function registerGlobalDispatcher(dispatcher: (eventInfo: EventInfo) => void) {
   registerDispatcher(window._ejsa, dispatcher);
 }
 


### PR DESCRIPTION
Removes the `restriction` parameter from `registerAppScopedDispatcher` and `registerGlobalDispatcher`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
