### PR TITLE
fix(core): prevent event replay from retaining elements with listeners

### DIFF
--- a/packages/core/src/hydration/event_replay.ts
+++ b/packages/core/src/hydration/event_replay.ts
@@ -18,13 +18,13 @@ import {
   EventPhase,
 } from '../../primitives/event-dispatch';
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef} from '../application/application_ref';
-import {ENVIRONMENT_INITIALIZER, Injector} from '../di';
-import {inject} from '../di/injector_compatibility';
-import {Provider} from '../di/interface/provider';
-import {RElement, RNode} from '../render3/interfaces/renderer_dom';
-import {CLEANUP, LView, TView} from '../render3/interfaces/view';
-import {unwrapRNode} from '../render3/util/view_utils';
+import { APP_BOOTSTRAP_LISTENER, ApplicationRef } from '../application/application_ref';
+import { ENVIRONMENT_INITIALIZER, Injector } from '../di';
+import { inject } from '../di/injector_compatibility';
+import { Provider } from '../di/interface/provider';
+import { RElement, RNode } from '../render3/interfaces/renderer_dom';
+import { CLEANUP, LView, TView } from '../render3/interfaces/view';
+import { unwrapRNode } from '../render3/util/view_utils';
 
 import {
   JSACTION_BLOCK_ELEMENT_MAP,
@@ -44,10 +44,10 @@ import {
   enableStashEventListenerImpl,
   setStashFn,
 } from '../event_delegation_utils';
-import {APP_ID} from '../application/application_tokens';
-import {performanceMarkFeature} from '../util/performance';
-import {triggerHydrationFromBlockName} from '../defer/triggering';
-import {isIncrementalHydrationEnabled} from './utils';
+import { APP_ID } from '../application/application_tokens';
+import { performanceMarkFeature } from '../util/performance';
+import { triggerHydrationFromBlockName } from '../defer/triggering';
+import { isIncrementalHydrationEnabled } from './utils';
 
 /** Apps in which we've enabled event replay.
  *  This is to prevent initializing event replay more than once per app.
@@ -100,7 +100,7 @@ export function withEventReplay(): Provider[] {
         provide: ENVIRONMENT_INITIALIZER,
         useValue: () => {
           const appRef = inject(ApplicationRef);
-          const {injector} = appRef;
+          const { injector } = appRef;
           // We have to check for the appRef here due to the possibility of multiple apps
           // being present on the same page. We only want to enable event replay for the
           // apps that actually want it.
@@ -120,10 +120,13 @@ export function withEventReplay(): Provider[] {
                   sharedMapFunction(rEl as RElement, jsActionMap);
                 },
               );
+              // The app becomes stable after hydration is done.
               // Clean up the reference to the function set by the environment initializer,
               // as the function closure may capture injected elements and prevent them
               // from being properly garbage collected.
-              appRef.onDestroy(clearStashFn);
+              appRef.whenStable().then(() => {
+                clearStashFn();
+              });
             }
           }
         },
@@ -133,7 +136,7 @@ export function withEventReplay(): Provider[] {
         provide: APP_BOOTSTRAP_LISTENER,
         useFactory: () => {
           const appRef = inject(ApplicationRef);
-          const {injector} = appRef;
+          const { injector } = appRef;
 
           return () => {
             // We have to check for the appRef here due to the possibility of multiple apps
@@ -230,7 +233,7 @@ const initEventReplay = (eventDelegation: EventContractDetails, injector: Inject
 export function collectDomEventsInfo(
   tView: TView,
   lView: LView,
-  eventTypesToReplay: {regular: Set<string>; capture: Set<string>},
+  eventTypesToReplay: { regular: Set<string>; capture: Set<string> },
 ): Map<Element, string[]> {
   const domEventsInfo = new Map<Element, string[]>();
   const lCleanup = lView[CLEANUP];
@@ -238,7 +241,7 @@ export function collectDomEventsInfo(
   if (!tCleanup || !lCleanup) {
     return domEventsInfo;
   }
-  for (let i = 0; i < tCleanup.length; ) {
+  for (let i = 0; i < tCleanup.length;) {
     const firstParam = tCleanup[i++];
     const secondParam = tCleanup[i++];
     if (typeof firstParam !== 'string') {
@@ -293,7 +296,7 @@ function hydrateAndInvokeBlockListeners(
   currentTarget: Element,
 ) {
   const queue = injector.get(EVENT_REPLAY_QUEUE);
-  queue.push({event, currentTarget});
+  queue.push({ event, currentTarget });
   triggerHydrationFromBlockName(injector, blockName, createReplayQueuedBlockEventsFn(queue));
 }
 
@@ -301,13 +304,13 @@ function createReplayQueuedBlockEventsFn(queue: EventReplayQueue) {
   return (hydratedBlocks: string[]) => {
     const hydrated = new Set<string>(hydratedBlocks);
     const newQueue: EventReplayQueue = [];
-    for (let {event, currentTarget} of queue) {
+    for (let { event, currentTarget } of queue) {
       const blockName = currentTarget.getAttribute(DEFER_BLOCK_SSR_ID_ATTRIBUTE)!;
       if (hydrated.has(blockName)) {
         invokeListeners(event, currentTarget);
       } else {
         // requeue events that weren't yet hydrated
-        newQueue.push({event, currentTarget});
+        newQueue.push({ event, currentTarget });
       }
     }
     queue.length = 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In Server-Side Rendering (SSR) scenarios with Event Replay enabled, the `setStashFn` callback in [packages/core/src/hydration/event_replay.ts](cci:7://file:///c:/Angular/angular/packages/core/src/hydration/event_replay.ts:0:0-0:0) creates a closure that retains references to DOM elements (via `jsActionMap`).

Currently, the cleanup function (`clearStashFn`) is only scheduled to execute when the application is destroyed (`appRef.onDestroy`). This means that elements captured during the hydration phase are pinned in memory for the entire lifetime of the application, causing a memory leak. This is particularly noticeable when components are destroyed (e.g., via `*ngIf`), but their DOM nodes remain referenced by the event replay stash.

Issue Number: #66506

## What is the new behavior?

The fix adjusts the timing of the cleanup in [packages/core/src/hydration/event_replay.ts](cci:7://file:///c:/Angular/angular/packages/core/src/hydration/event_replay.ts:0:0-0:0).

Instead of waiting for the application to be destroyed, we now invoke `clearStashFn()` as soon as the application becomes **stable** using `appRef.whenStable()`.

- **Why this works**: The "stable" state signalizes that the initial hydration process is complete. At this point, Angular has taken over the page, and the temporary event stashing mechanism used for replay is no longer needed.
- **Impact**: Clearing the stash function immediately after stability ensures that the references to the DOM elements are released early. This allows the JavaScript engine's garbage collector to correctly reclaim memory for elements and components as they are destroyed during the application's lifecycle, fixing the leak.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Files changed:**
- [packages/core/src/hydration/event_replay.ts](cci:7://file:///c:/Angular/angular/packages/core/src/hydration/event_replay.ts:0:0-0:0) - Updated [withEventReplay](cci:1://file:///c:/Angular/angular/angular/packages/core/src/hydration/event_replay.ts:68:0-204:1) to call `clearStashFn()` on `whenStable()` instead of `onDestroy`.