### PR TITLE
refactor(core): Remove unsued properties in differ factories

### DIFF
--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -21,7 +21,6 @@ import type {
 } from './iterable_differs';
 
 export class DefaultIterableDifferFactory implements IterableDifferFactory {
-  constructor() {}
   supports(obj: Object | null | undefined): boolean {
     return isListLikeIterable(obj);
   }

--- a/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -17,8 +17,7 @@ import type {
   KeyValueDifferFactory,
 } from './keyvalue_differs';
 
-export class DefaultKeyValueDifferFactory<K, V> implements KeyValueDifferFactory {
-  constructor() {}
+export class DefaultKeyValueDifferFactory implements KeyValueDifferFactory {
   supports(obj: any): boolean {
     return obj instanceof Map || isJsObject(obj);
   }
@@ -39,7 +38,6 @@ export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyVal
   private _additionsHead: KeyValueChangeRecord_<K, V> | null = null;
   private _additionsTail: KeyValueChangeRecord_<K, V> | null = null;
   private _removalsHead: KeyValueChangeRecord_<K, V> | null = null;
-  private _removalsTail: KeyValueChangeRecord_<K, V> | null = null;
 
   get isDirty(): boolean {
     return (
@@ -94,8 +92,6 @@ export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyVal
 
     return this.check(map) ? this : null;
   }
-
-  onDestroy() {}
 
   /**
    * Check the current state of the map vs the previous.

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -385,31 +385,3 @@ export function attachInjectFlag(decorator: any, flag: InternalInjectFlags | Dec
 export function getInjectFlag(token: any): number | undefined {
   return token[DI_DECORATOR_FLAG];
 }
-
-export function formatError(
-  text: string,
-  obj: any,
-  injectorErrorName: string,
-  source: string | null = null,
-): string {
-  text = text && text.charAt(0) === '\n' && text.charAt(1) == NO_NEW_LINE ? text.slice(2) : text;
-  let context = stringify(obj);
-  if (Array.isArray(obj)) {
-    context = obj.map(stringify).join(' -> ');
-  } else if (typeof obj === 'object') {
-    let parts = <string[]>[];
-    for (let key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        let value = obj[key];
-        parts.push(
-          key + ':' + (typeof value === 'string' ? JSON.stringify(value) : stringify(value)),
-        );
-      }
-    }
-    context = `{${parts.join(', ')}}`;
-  }
-  return `${injectorErrorName}${source ? '(' + source + ')' : ''}[${context}]: ${text.replace(
-    NEW_LINE,
-    '\n  ',
-  )}`;
-}


### PR DESCRIPTION
Simplifies differ factories by removing unnecessary constructors and properties.

Also removes the formatError function as it is no longer used.

 
 
## Other information
 
There are also unused generic parameters in [`create`](https://github.com/angular/angular/blob/main/packages/core/src/change_detection/differs/keyvalue_differs.ts#L138) and [`extend`](https://github.com/angular/angular/blob/main/packages/core/src/change_detection/differs/keyvalue_differs.ts#L166) on KeyValueDiffers.

Not sure if removing them would be considered a breaking change.
