### PR TITLE
feat(forms): introduce parse errors in signal forms

### DIFF
--- a/packages/core/src/render3/interfaces/control.ts
+++ b/packages/core/src/render3/interfaces/control.ts
@@ -39,6 +39,13 @@ export interface ɵFormFieldDirective<T> {
   /** Options for the control. */
   readonly classes: ReadonlyArray<readonly [string, Signal<boolean>]>;
 
+  /**
+   * A subset of the field state errors that apply specifically to this binding directive.
+   * While standard validation errors produced by the schema apply to all binding directives that
+   * bind that particular field, parse errors belong to a specific binding directive.
+   */
+  readonly errors: Signal<unknown[]>;
+
   /** A reference to the interoperable control, if one is present. */
   readonly ɵinteropControl: ɵInteropControl | undefined;
 

--- a/packages/forms/signals/compat/src/compat_validation_state.ts
+++ b/packages/forms/signals/compat/src/compat_validation_state.ts
@@ -32,6 +32,8 @@ export class CompatValidationState implements ValidationState {
   readonly invalid: Signal<boolean>;
   readonly valid: Signal<boolean>;
 
+  readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(() => []);
+
   constructor(options: CompatFieldNodeOptions) {
     this.syncValid = getControlStatusSignal(options, (c: AbstractControl) => c.status === 'VALID');
     this.errors = getControlStatusSignal(options, extractNestedReactiveErrors);
@@ -46,8 +48,8 @@ export class CompatValidationState implements ValidationState {
     });
   }
 
-  asyncErrors: Signal<(ValidationError.WithField | 'pending')[]> = EMPTY_ARRAY_SIGNAL;
-  errorSummary: Signal<ValidationError.WithField[]> = EMPTY_ARRAY_SIGNAL;
+  asyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = EMPTY_ARRAY_SIGNAL;
+  errorSummary: Signal<ValidationError.WithFieldTree[]> = EMPTY_ARRAY_SIGNAL;
 
   // Those are irrelevant for compat mode, as it has no children
   rawSyncTreeErrors = EMPTY_ARRAY_SIGNAL;

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -6,9 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InputSignal, InputSignalWithTransform, ModelSignal, OutputRef} from '@angular/core';
+import {
+  InputSignal,
+  InputSignalWithTransform,
+  ModelSignal,
+  OutputRef,
+  type Signal,
+} from '@angular/core';
 import type {FormFieldBindingOptions} from './form_field_directive';
-import {ValidationError, type WithOptionalField} from './rules/validation/validation_errors';
+import {ValidationError, type WithOptionalFieldTree} from './rules/validation/validation_errors';
 import type {DisabledReason} from './types';
 
 /**
@@ -17,14 +23,14 @@ import type {DisabledReason} from './types';
  * @category control
  * @experimental 21.0.0
  */
-export interface FormUiControl {
+export interface FormUiControl<TValue> {
   /**
    * An input to receive the errors for the field. If implemented, the `Field` directive will
    * automatically bind errors from the bound field to this input.
    */
   readonly errors?:
-    | InputSignal<readonly WithOptionalField<ValidationError>[]>
-    | InputSignalWithTransform<readonly WithOptionalField<ValidationError>[], unknown>;
+    | InputSignal<readonly ValidationError.WithOptionalFieldTree[]>
+    | InputSignalWithTransform<readonly ValidationError.WithOptionalFieldTree[], unknown>;
   /**
    * An input to receive the disabled status for the field. If implemented, the `Field` directive
    * will automatically bind the disabled status from the bound field to this input.
@@ -35,8 +41,8 @@ export interface FormUiControl {
    * directive will automatically bind the disabled reason from the bound field to this input.
    */
   readonly disabledReasons?:
-    | InputSignal<readonly WithOptionalField<DisabledReason>[]>
-    | InputSignalWithTransform<readonly WithOptionalField<DisabledReason>[], unknown>;
+    | InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]>
+    | InputSignalWithTransform<readonly WithOptionalFieldTree<DisabledReason>[], unknown>;
   /**
    * An input to receive the readonly status for the field. If implemented, the `Field` directive
    * will automatically bind the readonly status from the bound field to this input.
@@ -117,6 +123,12 @@ export interface FormUiControl {
     | InputSignal<readonly RegExp[]>
     | InputSignalWithTransform<readonly RegExp[], unknown>;
   /**
+   * A signal containing the current parse errors for the control.
+   * This allows the control to communicate to the form that there are additional validation errors
+   * beyond those produced by the schema, due to being unable to parse the user's input.
+   */
+  readonly parseErrors?: Signal<ValidationError.WithoutFieldTree[]>;
+  /**
    * Focuses the UI control.
    *
    * If the focus method is not implemented, Signal Forms will attempt to focus the host element
@@ -130,7 +142,7 @@ export interface FormUiControl {
 // However, we don't want to add it as an actual `extends` clause to avoid confusing users.
 type Check<T extends true> = T;
 type FormUiControlImplementsFormFieldBindingOptions = Check<
-  FormUiControl extends FormFieldBindingOptions ? true : false
+  FormUiControl<unknown> extends FormFieldBindingOptions<unknown> ? true : false
 >;
 
 /**
@@ -146,7 +158,7 @@ type FormUiControlImplementsFormFieldBindingOptions = Check<
  * @category control
  * @experimental 21.0.0
  */
-export interface FormValueControl<TValue> extends FormUiControl {
+export interface FormValueControl<TValue> extends FormUiControl<TValue> {
   /**
    * The value is the only required property in this contract. A component that wants to integrate
    * with the `Field` directive via this contract, *must* provide a `model()` that will be kept in
@@ -175,7 +187,8 @@ export interface FormValueControl<TValue> extends FormUiControl {
  * @category control
  * @experimental 21.0.0
  */
-export interface FormCheckboxControl extends FormUiControl {
+// TODO: should we make this generic extends `boolean | null` so people can use `null` for parse error?
+export interface FormCheckboxControl extends FormUiControl<boolean> {
   /**
    * The checked is the only required property in this contract. A component that wants to integrate
    * with the `Field` directive, *must* provide a `model()` that will be kept in sync with the

--- a/packages/forms/signals/src/api/rules/validation/validation_errors.ts
+++ b/packages/forms/signals/src/api/rules/validation/validation_errors.ts
@@ -7,7 +7,8 @@
  */
 
 import type {StandardSchemaV1} from '@standard-schema/spec';
-import {FieldTree} from '../../types';
+import type {FormField} from '../../form_field_directive';
+import type {FieldTree} from '../../types';
 
 /**
  * Options used to create a `ValidationError`.
@@ -23,7 +24,9 @@ interface ValidationErrorOptions {
  *
  * @experimental 21.0.0
  */
-export type WithField<T> = T & {fieldTree: FieldTree<unknown>};
+export type WithFieldTree<T> = T & {fieldTree: FieldTree<unknown>};
+/** @deprecated Use `WithFieldTree` instead  */
+export type WithField<T> = WithFieldTree<T>;
 
 /**
  * A type that allows the given type `T` to optionally have a `field` property.
@@ -31,7 +34,9 @@ export type WithField<T> = T & {fieldTree: FieldTree<unknown>};
  *
  * @experimental 21.0.0
  */
-export type WithOptionalField<T> = Omit<T, 'fieldTree'> & {fieldTree?: FieldTree<unknown>};
+export type WithOptionalFieldTree<T> = Omit<T, 'fieldTree'> & {fieldTree?: FieldTree<unknown>};
+/** @deprecated Use `WithOptionalFieldTree` instead  */
+export type WithOptionalField<T> = WithOptionalFieldTree<T>;
 
 /**
  * A type that ensures the given type `T` does not have a `field` property.
@@ -39,7 +44,9 @@ export type WithOptionalField<T> = Omit<T, 'fieldTree'> & {fieldTree?: FieldTree
  *
  * @experimental 21.0.0
  */
-export type WithoutField<T> = T & {fieldTree: never};
+export type WithoutFieldTree<T> = T & {fieldTree: never};
+/** @deprecated Use `WithoutFieldTree` instead  */
+export type WithoutField<T> = WithoutFieldTree<T>;
 
 /**
  * Create a required error associated with the target field
@@ -47,7 +54,9 @@ export type WithoutField<T> = T & {fieldTree: never};
  *
  * @experimental 21.0.0
  */
-export function requiredError(options: WithField<ValidationErrorOptions>): RequiredValidationError;
+export function requiredError(
+  options: WithFieldTree<ValidationErrorOptions>,
+): RequiredValidationError;
 /**
  * Create a required error
  * @param options The optional validation error options
@@ -57,10 +66,10 @@ export function requiredError(options: WithField<ValidationErrorOptions>): Requi
  */
 export function requiredError(
   options?: ValidationErrorOptions,
-): WithoutField<RequiredValidationError>;
+): WithoutFieldTree<RequiredValidationError>;
 export function requiredError(
   options?: ValidationErrorOptions,
-): WithOptionalField<RequiredValidationError> {
+): WithOptionalFieldTree<RequiredValidationError> {
   return new RequiredValidationError(options);
 }
 
@@ -74,7 +83,7 @@ export function requiredError(
  */
 export function minError(
   min: number,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): MinValidationError;
 /**
  * Create a min value error
@@ -87,11 +96,11 @@ export function minError(
 export function minError(
   min: number,
   options?: ValidationErrorOptions,
-): WithoutField<MinValidationError>;
+): WithoutFieldTree<MinValidationError>;
 export function minError(
   min: number,
   options?: ValidationErrorOptions,
-): WithOptionalField<MinValidationError> {
+): WithOptionalFieldTree<MinValidationError> {
   return new MinValidationError(min, options);
 }
 
@@ -105,7 +114,7 @@ export function minError(
  */
 export function maxError(
   max: number,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): MaxValidationError;
 /**
  * Create a max value error
@@ -118,11 +127,11 @@ export function maxError(
 export function maxError(
   max: number,
   options?: ValidationErrorOptions,
-): WithoutField<MaxValidationError>;
+): WithoutFieldTree<MaxValidationError>;
 export function maxError(
   max: number,
   options?: ValidationErrorOptions,
-): WithOptionalField<MaxValidationError> {
+): WithOptionalFieldTree<MaxValidationError> {
   return new MaxValidationError(max, options);
 }
 
@@ -136,7 +145,7 @@ export function maxError(
  */
 export function minLengthError(
   minLength: number,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): MinLengthValidationError;
 /**
  * Create a minLength error
@@ -149,11 +158,11 @@ export function minLengthError(
 export function minLengthError(
   minLength: number,
   options?: ValidationErrorOptions,
-): WithoutField<MinLengthValidationError>;
+): WithoutFieldTree<MinLengthValidationError>;
 export function minLengthError(
   minLength: number,
   options?: ValidationErrorOptions,
-): WithOptionalField<MinLengthValidationError> {
+): WithOptionalFieldTree<MinLengthValidationError> {
   return new MinLengthValidationError(minLength, options);
 }
 
@@ -167,7 +176,7 @@ export function minLengthError(
  */
 export function maxLengthError(
   maxLength: number,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): MaxLengthValidationError;
 /**
  * Create a maxLength error
@@ -180,11 +189,11 @@ export function maxLengthError(
 export function maxLengthError(
   maxLength: number,
   options?: ValidationErrorOptions,
-): WithoutField<MaxLengthValidationError>;
+): WithoutFieldTree<MaxLengthValidationError>;
 export function maxLengthError(
   maxLength: number,
   options?: ValidationErrorOptions,
-): WithOptionalField<MaxLengthValidationError> {
+): WithOptionalFieldTree<MaxLengthValidationError> {
   return new MaxLengthValidationError(maxLength, options);
 }
 
@@ -198,7 +207,7 @@ export function maxLengthError(
  */
 export function patternError(
   pattern: RegExp,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): PatternValidationError;
 /**
  * Create a pattern matching error
@@ -211,11 +220,11 @@ export function patternError(
 export function patternError(
   pattern: RegExp,
   options?: ValidationErrorOptions,
-): WithoutField<PatternValidationError>;
+): WithoutFieldTree<PatternValidationError>;
 export function patternError(
   pattern: RegExp,
   options?: ValidationErrorOptions,
-): WithOptionalField<PatternValidationError> {
+): WithOptionalFieldTree<PatternValidationError> {
   return new PatternValidationError(pattern, options);
 }
 
@@ -226,7 +235,7 @@ export function patternError(
  * @category validation
  * @experimental 21.0.0
  */
-export function emailError(options: WithField<ValidationErrorOptions>): EmailValidationError;
+export function emailError(options: WithFieldTree<ValidationErrorOptions>): EmailValidationError;
 /**
  * Create an email format error
  * @param options The optional validation error options
@@ -234,10 +243,12 @@ export function emailError(options: WithField<ValidationErrorOptions>): EmailVal
  * @category validation
  * @experimental 21.0.0
  */
-export function emailError(options?: ValidationErrorOptions): WithoutField<EmailValidationError>;
 export function emailError(
   options?: ValidationErrorOptions,
-): WithOptionalField<EmailValidationError> {
+): WithoutFieldTree<EmailValidationError>;
+export function emailError(
+  options?: ValidationErrorOptions,
+): WithOptionalFieldTree<EmailValidationError> {
   return new EmailValidationError(options);
 }
 
@@ -251,7 +262,7 @@ export function emailError(
  */
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
-  options: WithField<ValidationErrorOptions>,
+  options: WithFieldTree<ValidationErrorOptions>,
 ): StandardSchemaValidationError;
 /**
  * Create a standard schema issue error
@@ -264,11 +275,11 @@ export function standardSchemaError(
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
   options?: ValidationErrorOptions,
-): WithoutField<StandardSchemaValidationError>;
+): WithoutFieldTree<StandardSchemaValidationError>;
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
   options?: ValidationErrorOptions,
-): WithOptionalField<StandardSchemaValidationError> {
+): WithOptionalFieldTree<StandardSchemaValidationError> {
   return new StandardSchemaValidationError(issue, options);
 }
 
@@ -294,14 +305,24 @@ export interface ValidationError {
 
 export declare namespace ValidationError {
   /**
-   * Validation error with a field.
+   * Validation error with an associated field tree.
    *
    * This is returned from field state, e.g., catField.errors() would be of a list of errors with
    * `field: catField` bound to state.
    */
-  export interface WithField extends ValidationError {
+  export interface WithFieldTree extends ValidationError {
     /** The field associated with this error. */
     readonly fieldTree: FieldTree<unknown>;
+    readonly formField?: FormField<unknown>;
+  }
+  /** @deprecated Use `ValidationError.WithFieldTree` instead  */
+  export type WithField = WithFieldTree;
+
+  /**
+   * Validation error with an associated field tree and specific form field binding.
+   */
+  export interface WithFormField extends WithFieldTree {
+    readonly formField: FormField<unknown>;
   }
 
   /**
@@ -310,20 +331,25 @@ export declare namespace ValidationError {
    * This is generally used in places where the result might have a field.
    * e.g., as a result of a `validateTree`, or when handling form submission.
    */
-  export interface WithOptionalField extends ValidationError {
+  export interface WithOptionalFieldTree extends ValidationError {
     /** The field associated with this error. */
     readonly fieldTree?: FieldTree<unknown>;
   }
+  /** @deprecated Use `ValidationError.WithOptionalFieldTree` instead  */
+  export type WithOptionalField = WithOptionalFieldTree;
 
   /**
    * Validation error with no field.
    *
    * This is used to strongly enforce that fields are not allowed in validation result.
    */
-  export interface WithoutField extends ValidationError {
+  export interface WithoutFieldTree extends ValidationError {
     /** The field associated with this error. */
     readonly fieldTree?: never;
+    readonly formField?: never;
   }
+  /** @deprecated Use `ValidationError.WithoutFieldTree` instead  */
+  export type WithoutField = WithoutFieldTree;
 }
 
 /**

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -393,12 +393,12 @@ export async function submit<TModel>(
  */
 function setSubmissionErrors(
   submittedField: FieldNode,
-  errors: OneOrMany<ValidationError.WithOptionalField>,
+  errors: OneOrMany<ValidationError.WithOptionalFieldTree>,
 ) {
   if (!isArray(errors)) {
     errors = [errors];
   }
-  const errorsByField = new Map<FieldNode, ValidationError.WithField[]>();
+  const errorsByField = new Map<FieldNode, ValidationError.WithFieldTree[]>();
   for (const error of errors) {
     const errorWithField = addDefaultField(error, submittedField.fieldProxy);
     const field = errorWithField.fieldTree() as FieldNode;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -94,7 +94,7 @@ export type ValidationSuccess = null | undefined | void;
  * @experimental 21.0.0
  */
 export type TreeValidationResult<
-  E extends ValidationError.WithOptionalField = ValidationError.WithOptionalField,
+  E extends ValidationError.WithOptionalFieldTree = ValidationError.WithOptionalFieldTree,
 > = ValidationSuccess | OneOrMany<E>;
 
 /**
@@ -240,12 +240,12 @@ export interface FieldState<
    */
   readonly hidden: Signal<boolean>;
   readonly disabledReasons: Signal<readonly DisabledReason[]>;
-  readonly errors: Signal<ValidationError.WithField[]>;
+  readonly errors: Signal<ValidationError.WithFieldTree[]>;
 
   /**
    * A signal containing the {@link errors} of the field and its descendants.
    */
-  readonly errorSummary: Signal<ValidationError.WithField[]>;
+  readonly errorSummary: Signal<ValidationError.WithFieldTree[]>;
 
   /**
    * A signal indicating whether the field's value is currently valid.
@@ -542,7 +542,7 @@ export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root>
  */
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
-  ValidationResult<ValidationError.WithoutField>,
+  ValidationResult<ValidationError.WithoutFieldTree>,
   TPathKind
 >;
 

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -145,11 +145,15 @@ export class FieldNode implements FieldState<unknown> {
     return this.structure.keyInParent;
   }
 
-  get errors(): Signal<ValidationError.WithField[]> {
+  get errors(): Signal<ValidationError.WithFieldTree[]> {
     return this.validationState.errors;
   }
 
-  get errorSummary(): Signal<ValidationError.WithField[]> {
+  get parseErrors(): Signal<ValidationError.WithFormField[]> {
+    return this.validationState.parseErrors;
+  }
+
+  get errorSummary(): Signal<ValidationError.WithFieldTree[]> {
     return this.validationState.errorSummary;
   }
 

--- a/packages/forms/signals/src/field/submit.ts
+++ b/packages/forms/signals/src/field/submit.ts
@@ -21,12 +21,12 @@ export class FieldSubmitState {
   readonly selfSubmitting = signal<boolean>(false);
 
   /** Submission errors that are associated with this field. */
-  readonly submissionErrors: WritableSignal<readonly ValidationError.WithField[]>;
+  readonly submissionErrors: WritableSignal<readonly ValidationError.WithFieldTree[]>;
 
   constructor(private readonly node: FieldNode) {
     this.submissionErrors = linkedSignal({
       source: this.node.structure.value,
-      computation: () => [] as readonly ValidationError.WithField[],
+      computation: () => [] as readonly ValidationError.WithFieldTree[],
     });
   }
 

--- a/packages/forms/signals/src/schema/logic.ts
+++ b/packages/forms/signals/src/schema/logic.ts
@@ -254,11 +254,11 @@ export class LogicContainer {
   /** Logic that determines if the field is read-only. */
   readonly readonly: BooleanOrLogic;
   /** Logic that produces synchronous validation errors for the field. */
-  readonly syncErrors: ArrayMergeIgnoreLogic<ValidationError.WithField, null>;
+  readonly syncErrors: ArrayMergeIgnoreLogic<ValidationError.WithFieldTree, null>;
   /** Logic that produces synchronous validation errors for the field's subtree. */
-  readonly syncTreeErrors: ArrayMergeIgnoreLogic<ValidationError.WithField, null>;
+  readonly syncTreeErrors: ArrayMergeIgnoreLogic<ValidationError.WithFieldTree, null>;
   /** Logic that produces asynchronous validation results (errors or 'pending'). */
-  readonly asyncErrors: ArrayMergeIgnoreLogic<ValidationError.WithField | 'pending', null>;
+  readonly asyncErrors: ArrayMergeIgnoreLogic<ValidationError.WithFieldTree | 'pending', null>;
   /** A map of metadata keys to the `AbstractLogic` instances that compute their values. */
   private readonly metadata = new Map<
     MetadataKey<unknown, unknown, unknown>,
@@ -274,9 +274,10 @@ export class LogicContainer {
     this.hidden = new BooleanOrLogic(predicates);
     this.disabledReasons = new ArrayMergeLogic(predicates);
     this.readonly = new BooleanOrLogic(predicates);
-    this.syncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithField>(predicates);
-    this.syncTreeErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithField>(predicates);
-    this.asyncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithField | 'pending'>(
+    this.syncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithFieldTree>(predicates);
+    this.syncTreeErrors =
+      ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithFieldTree>(predicates);
+    this.asyncErrors = ArrayMergeIgnoreLogic.ignoreNull<ValidationError.WithFieldTree | 'pending'>(
       predicates,
     );
   }

--- a/packages/forms/signals/src/schema/logic_node.ts
+++ b/packages/forms/signals/src/schema/logic_node.ts
@@ -9,7 +9,7 @@
 import {ɵRuntimeError as RuntimeError} from '@angular/core';
 import {SignalFormsErrorCode} from '../errors';
 
-import type {ValidationError, MetadataKey} from '../api/rules';
+import type {MetadataKey, ValidationError} from '../api/rules';
 import type {AsyncValidationResult, DisabledReason, LogicFn, ValidationResult} from '../api/types';
 import {setBoundPathDepthForResolution} from '../field/resolution';
 import {type BoundPredicate, DYNAMIC, LogicContainer, type Predicate} from './logic';
@@ -105,19 +105,19 @@ export class LogicNodeBuilder extends AbstractLogicNodeBuilder {
   }
 
   override addSyncErrorRule(
-    logic: LogicFn<any, ValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, ValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.getCurrent().addSyncErrorRule(logic);
   }
 
   override addSyncTreeErrorRule(
-    logic: LogicFn<any, ValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, ValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.getCurrent().addSyncTreeErrorRule(logic);
   }
 
   override addAsyncErrorRule(
-    logic: LogicFn<any, AsyncValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, AsyncValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.getCurrent().addAsyncErrorRule(logic);
   }
@@ -235,19 +235,19 @@ class NonMergeableLogicNodeBuilder extends AbstractLogicNodeBuilder {
   }
 
   override addSyncErrorRule(
-    logic: LogicFn<any, ValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, ValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.logic.syncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
   override addSyncTreeErrorRule(
-    logic: LogicFn<any, ValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, ValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.logic.syncTreeErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }
 
   override addAsyncErrorRule(
-    logic: LogicFn<any, AsyncValidationResult<ValidationError.WithField>>,
+    logic: LogicFn<any, AsyncValidationResult<ValidationError.WithFieldTree>>,
   ): void {
     this.logic.asyncErrors.push(setBoundPathDepthForResolution(logic, this.depth));
   }

--- a/packages/forms/signals/test/node/BUILD.bazel
+++ b/packages/forms/signals/test/node/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
+load("//tools:defaults.bzl", "ng_project", "zoneless_jasmine_test")
 
-ts_project(
+ng_project(
     name = "test_lib",
     testonly = True,
     srcs = glob(["**/*.spec.ts"]),

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -1120,7 +1120,7 @@ describe('FieldNode', () => {
           cat,
           (p) => {
             validateTree(p, ({value, fieldTreeOf}) => {
-              const errors: ValidationError.WithOptionalField[] = [];
+              const errors: ValidationError.WithOptionalFieldTree[] = [];
               if (value().name.length > 8) {
                 errors.push({kind: 'long_name', fieldTree: fieldTreeOf(p.name)});
               }
@@ -1152,7 +1152,7 @@ describe('FieldNode', () => {
           cat,
           (p) => {
             validateTree(p, ({value, fieldTreeOf}) => {
-              const errors: ValidationError.WithOptionalField[] = [];
+              const errors: ValidationError.WithOptionalFieldTree[] = [];
               if (value().name.length > 8) {
                 errors.push({kind: 'long_name', fieldTree: fieldTreeOf(p.name)});
               }

--- a/packages/forms/signals/test/node/parse_errors.spec.ts
+++ b/packages/forms/signals/test/node/parse_errors.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  ApplicationRef,
+  Component,
+  computed,
+  inject,
+  input,
+  linkedSignal,
+  model,
+  signal,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {
+  form,
+  FormField,
+  type FieldTree,
+  type FormValueControl,
+  type ValidationError,
+} from '../../public_api';
+
+describe('parse errors', () => {
+  it('should show parse error', async () => {
+    @Component({
+      selector: 'custom-control',
+      template: ``,
+    })
+    class CustomControl implements FormValueControl<string> {
+      readonly value = model.required<string>();
+      readonly parseErrors = computed(() => (this.value() === 'ERROR' ? [{kind: 'parse'}] : []));
+    }
+
+    @Component({
+      imports: [CustomControl, FormField],
+      template: `<custom-control [formField]="f" />`,
+    })
+    class TestCmp {
+      state = signal<string>('');
+      f = form(this.state);
+    }
+
+    const cmp = await act(() => TestBed.createComponent(TestCmp).componentInstance);
+    expect(cmp.f().errors().length).toBe(0);
+
+    await act(() => cmp.state.set('ERROR'));
+    expect(cmp.f().errors().length).toBe(1);
+    expect(cmp.f().errors()[0]).toEqual(jasmine.objectContaining({kind: 'parse'}));
+  });
+
+  it('should only pass parse errors through to the originating custom control', async () => {
+    @Component({
+      imports: [TestNumberInput, FormField],
+      template: `
+        <test-number-input id="input1" [formField]="f" />
+        <test-number-input id="input2" [formField]="f" />
+      `,
+    })
+    class TestCmp {
+      state = signal<number | null>(5);
+      f = form(this.state);
+    }
+
+    const testEl = (await act(() => TestBed.createComponent(TestCmp))).nativeElement as HTMLElement;
+    const input1: HTMLInputElement = testEl.querySelector('#input1 input')!;
+    const input2: HTMLInputElement = testEl.querySelector('#input2 input')!;
+
+    input1.value = 'joe';
+    await act(() => input1.dispatchEvent(new Event('input')));
+    let errors1 = [...testEl.querySelectorAll('#input1 .error')].map((el) => el.textContent);
+    let errors2 = [...testEl.querySelectorAll('#input2 .error')].map((el) => el.textContent);
+    expect(errors1).toEqual(['joe is not numeric']);
+    expect(errors2).toEqual([]);
+
+    input2.value = 'bob';
+    await act(() => input2.dispatchEvent(new Event('input')));
+    errors1 = [...testEl.querySelectorAll('#input1 .error')].map((el) => el.textContent);
+    errors2 = [...testEl.querySelectorAll('#input2 .error')].map((el) => el.textContent);
+    expect(errors1).toEqual(['joe is not numeric']);
+    expect(errors2).toEqual(['bob is not numeric']);
+  });
+
+  it('should have all errors on field state', async () => {
+    @Component({
+      imports: [TestNumberInput, FormField],
+      template: `
+        <test-number-input id="input1" [formField]="f" />
+        <test-number-input id="input2" [formField]="f" />
+      `,
+    })
+    class TestCmp {
+      state = signal<number | null>(5);
+      f = form(this.state);
+    }
+
+    const fix = await act(() => TestBed.createComponent(TestCmp));
+    const comp = fix.componentInstance;
+    const input1: HTMLInputElement = fix.nativeElement.querySelector('#input1 input')!;
+    const input2: HTMLInputElement = fix.nativeElement.querySelector('#input2 input')!;
+
+    input1.value = 'joe';
+    await act(() => input1.dispatchEvent(new Event('input')));
+    input2.value = 'bob';
+    await act(() => input2.dispatchEvent(new Event('input')));
+    expect(comp.f().errors()).toEqual([
+      jasmine.objectContaining({message: 'joe is not numeric'}),
+      jasmine.objectContaining({message: 'bob is not numeric'}),
+    ]);
+    expect(comp.f().errorSummary()).toEqual([
+      jasmine.objectContaining({message: 'joe is not numeric'}),
+      jasmine.objectContaining({message: 'bob is not numeric'}),
+    ]);
+  });
+
+  it('should allow pass-through style control to register parse errors', async () => {
+    @Component({
+      selector: 'custom-control',
+      template: ``,
+    })
+    class CustomControl {
+      readonly fieldTree = input.required<FieldTree<string>>({alias: 'formField'});
+      readonly formField = inject(FormField, {optional: true, self: true});
+
+      constructor() {
+        this.formField?.registerAsBinding({
+          parseErrors: computed(() =>
+            this.fieldTree()().value() === 'ERROR' ? [{kind: 'parse'}] : [],
+          ),
+        });
+      }
+    }
+
+    @Component({
+      imports: [CustomControl, FormField],
+      template: `<custom-control [formField]="f" />`,
+    })
+    class TestCmp {
+      state = signal<string>('');
+      f = form(this.state);
+    }
+
+    const cmp = await act(() => TestBed.createComponent(TestCmp).componentInstance);
+    expect(cmp.f().errors().length).toBe(0);
+
+    await act(() => cmp.state.set('ERROR'));
+    expect(cmp.f().errors().length).toBe(1);
+    expect(cmp.f().errors()[0]).toEqual(jasmine.objectContaining({kind: 'parse'}));
+  });
+});
+
+@Component({
+  selector: 'test-number-input',
+  template: `
+    <input type="text" [value]="rawValue()" (input)="write($event.target.value)" />
+    @for (e of errors(); track $index) {
+      <p class="error">{{ e.message }}</p>
+    }
+  `,
+})
+class TestNumberInput implements FormValueControl<number | null> {
+  readonly value = model.required<number | null>();
+  readonly errors = input<readonly ValidationError[]>([]);
+  readonly parseErrors = computed(() => this.parsedResult().errors ?? []);
+
+  protected rawValue = linkedSignal(() => this.format(this.value()));
+  private parsedResult = computed(() => this.parse(this.rawValue()));
+
+  private format(value: number | null) {
+    if (value === null || Number.isNaN(value)) return '';
+    return value.toString();
+  }
+
+  private parse(
+    rawValue: string,
+  ): {value: number | null; errors?: never} | {value?: never; errors: ValidationError[]} {
+    if (rawValue === '') return {value: null};
+    const value = Number(rawValue);
+    if (Number.isNaN(value)) {
+      return {errors: [{kind: 'parse', message: `${rawValue} is not numeric`}]};
+    }
+    return {value};
+  }
+
+  protected write(rawValue: string) {
+    this.rawValue.set(rawValue);
+    const result = this.parsedResult();
+    this.value.set(result.value === undefined ? NaN : result.value);
+    this.rawValue.set(rawValue);
+  }
+}
+
+async function act<T>(fn: () => T): Promise<T> {
+  const result = fn();
+  await TestBed.inject(ApplicationRef).whenStable();
+  return result;
+}

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -27,7 +27,7 @@ function validateValue(value: string): ValidationError[] {
 function validateValueForChild(
   value: string,
   fieldTree: FieldTree<unknown> | undefined,
-): ValidationError.WithOptionalField[] {
+): ValidationError.WithOptionalFieldTree[] {
   return value === 'INVALID' ? [{kind: 'custom', fieldTree: fieldTree}] : [];
 }
 

--- a/packages/forms/signals/test/web/form_field_directive.spec.ts
+++ b/packages/forms/signals/test/web/form_field_directive.spec.ts
@@ -51,7 +51,7 @@ import {
   type FormCheckboxControl,
   type FormValueControl,
   type ValidationError,
-  type WithOptionalField,
+  type WithOptionalFieldTree,
 } from '../../public_api';
 
 @Component({
@@ -414,7 +414,8 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<string> {
           readonly value = model.required<string>();
-          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+          readonly disabledReasons =
+            input.required<readonly WithOptionalFieldTree<DisabledReason>[]>();
         }
 
         @Component({
@@ -439,7 +440,8 @@ describe('field directive', () => {
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+          readonly disabledReasons =
+            input.required<readonly WithOptionalFieldTree<DisabledReason>[]>();
         }
 
         @Component({
@@ -470,7 +472,8 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+          readonly disabledReasons =
+            input.required<readonly WithOptionalFieldTree<DisabledReason>[]>();
         }
 
         @Component({
@@ -510,7 +513,8 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model.required<string>();
-          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+          readonly disabledReasons =
+            input.required<readonly WithOptionalFieldTree<DisabledReason>[]>();
         }
 
         @Component({
@@ -545,7 +549,7 @@ describe('field directive', () => {
         })
         class CustomControl implements FormValueControl<string> {
           readonly value = model.required<string>();
-          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+          readonly errors = input.required<readonly WithOptionalFieldTree<ValidationError>[]>();
         }
 
         @Component({
@@ -570,7 +574,7 @@ describe('field directive', () => {
       it('should bind to directive input on native control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+          readonly errors = input.required<readonly WithOptionalFieldTree<ValidationError>[]>();
         }
 
         @Component({
@@ -597,7 +601,7 @@ describe('field directive', () => {
       it('should bind to directive input on custom control', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+          readonly errors = input.required<readonly WithOptionalFieldTree<ValidationError>[]>();
         }
 
         @Component({
@@ -633,7 +637,7 @@ describe('field directive', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<string> {
           readonly value = model.required<string>();
-          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+          readonly errors = input.required<readonly WithOptionalFieldTree<ValidationError>[]>();
         }
 
         @Component({
@@ -2541,10 +2545,10 @@ describe('field directive', () => {
         readonly pattern = input<readonly RegExp[], unknown>([], {
           transform: (v: unknown) => (Array.isArray(v) ? v : []),
         });
-        readonly errors = input<readonly WithOptionalField<ValidationError>[], unknown>([], {
+        readonly errors = input<readonly WithOptionalFieldTree<ValidationError>[], unknown>([], {
           transform: (v: unknown) => (Array.isArray(v) ? v : []),
         });
-        readonly disabledReasons = input<readonly WithOptionalField<DisabledReason>[], unknown>(
+        readonly disabledReasons = input<readonly WithOptionalFieldTree<DisabledReason>[], unknown>(
           [],
           {
             transform: (v: unknown) => (Array.isArray(v) ? v : []),
@@ -3346,7 +3350,7 @@ describe('field directive', () => {
     })
     class CustomInput implements FormValueControl<string> {
       value = model('');
-      disabledReasons = input<readonly WithOptionalField<DisabledReason>[]>([]);
+      disabledReasons = input<readonly WithOptionalFieldTree<DisabledReason>[]>([]);
     }
 
     @Component({
@@ -3571,8 +3575,8 @@ describe('field directive', () => {
     })
     class CustomInput implements FormValueControl<string> {
       value = model('');
-      disabledReasons = input<readonly WithOptionalField<DisabledReason>[]>([]);
-      errors = input<readonly WithOptionalField<ValidationError>[]>([]);
+      disabledReasons = input<readonly WithOptionalFieldTree<DisabledReason>[]>([]);
+      errors = input<readonly WithOptionalFieldTree<ValidationError>[]>([]);
     }
 
     @Component({

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -35,7 +35,7 @@ import {
   requiredError,
   validateAsync,
   ValidationError,
-  WithOptionalField,
+  WithOptionalFieldTree,
 } from '@angular/forms/signals';
 
 describe('ControlValueAccessor', () => {
@@ -451,7 +451,8 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly disabledReasons = input.required<readonly WithOptionalField<DisabledReason>[]>();
+          readonly disabledReasons =
+            input.required<readonly WithOptionalFieldTree<DisabledReason>[]>();
         }
 
         @Component({
@@ -484,7 +485,7 @@ describe('ControlValueAccessor', () => {
       it('should bind to directive input', () => {
         @Directive({selector: '[testDir]'})
         class TestDir {
-          readonly errors = input.required<readonly WithOptionalField<ValidationError>[]>();
+          readonly errors = input.required<readonly WithOptionalFieldTree<ValidationError>[]>();
         }
 
         @Component({


### PR DESCRIPTION
Parse errors allow a custom control to communicate that it is currently
unable to produce a valid value.

Parse errors are reported by implementing the optional `parseErrors`
property on the `FormUiControl`. The property should be a signal of the
current parse errors.