### PR TITLE
docs: Add mention of "documentation"

### DIFF
--- a/adev/src/content/introduction/what-is-angular.md
+++ b/adev/src/content/introduction/what-is-angular.md
@@ -7,7 +7,7 @@
   Maintained by a dedicated team at Google, Angular provides a broad suite of tools, APIs, and
   libraries to simplify and streamline your development workflow. Angular gives you
   a solid platform on which to build fast, reliable applications that scale with both the size of
-  your team and the size of your codebase.
+  your team and the size of your codebase. Angular.dev is the official home for Angular documentation.
 </div>
 
 <docs-nav-card title="Want to see some code?" iconImgSrc="adev/src/assets/icons/star.svg">


### PR DESCRIPTION
This should help to bring adev at the top when searching for "angular documentation" or "angular docs"
