### PR TITLE
build: Update prettier to 3.8

### DIFF
--- a/adev/package.json
+++ b/adev/package.json
@@ -68,7 +68,7 @@
     "playwright-core": "1.57.0",
     "preact": "10.28.2",
     "preact-render-to-string": "6.6.5",
-    "prettier": "3.7.4",
+    "prettier": "3.8.0",
     "rxjs": "7.8.2",
     "shiki": "3.21.0",
     "style-mod": "4.1.3",

--- a/adev/src/content/ai/design-patterns.md
+++ b/adev/src/content/ai/design-patterns.md
@@ -80,14 +80,14 @@ The following example demonstrates how to create a responsive UI to dynamically 
   <div class="img-placeholder">
     <mat-spinner [diameter]="50" />
   </div>
-<!-- Dynamically populates the src attribute with the generated image URL -->
+  <!-- Dynamically populates the src attribute with the generated image URL -->
 } @else if (imgResource.hasValue()) {
   <img [src]="imgResource.value()" />
-<!-- Provides a retry option if the request fails  -->
+  <!-- Provides a retry option if the request fails  -->
 } @else {
   <div class="img-placeholder" (click)="imgResource.reload()">
     <mat-icon fontIcon="refresh" />
-      <p>Failed to load image. Click to retry.</p>
+    <p>Failed to load image. Click to retry.</p>
   </div>
 }
 ```
@@ -130,9 +130,9 @@ The `characters` member is updated asynchronously and can be displayed in the te
 @if (characters.isLoading()) {
   <p>Loading...</p>
 } @else if (characters.hasValue()) {
-  <p>{{characters.value()}}</p>
+  <p>{{ characters.value() }}</p>
 } @else {
-  <p>{{characters.error()}}</p>
+  <p>{{ characters.error() }}</p>
 }
 ```
 

--- a/adev/src/content/best-practices/a11y.md
+++ b/adev/src/content/best-practices/a11y.md
@@ -37,13 +37,10 @@ Some ARIA patterns expose DOM APIs or directive inputs that accept structured va
     <h2 #dialogTitle>Attention</h2>
     <p #dialogDescription>Please review your answers before continuing.</p>
 
-    <section
-      role="dialog"
-      [ariaLabelledByElements]="[dialogTitle, dialogDescription]">
+    <section role="dialog" [ariaLabelledByElements]="[dialogTitle, dialogDescription]">
       <ng-content />
     </section>
-
-`,
+  `,
 })
 export class ReviewDialog {}
 ```
@@ -145,21 +142,9 @@ The following example shows how to apply the `active-page` class to active links
 
 ```angular-html
 <nav>
-  <a routerLink="home"
-      routerLinkActive="active-page"
-      ariaCurrentWhenActive="page">
-    Home
-  </a>
-  <a routerLink="about"
-      routerLinkActive="active-page"
-      ariaCurrentWhenActive="page">
-    About
-  </a>
-  <a routerLink="shop"
-      routerLinkActive="active-page"
-      ariaCurrentWhenActive="page">
-    Shop
-  </a>
+  <a routerLink="home" routerLinkActive="active-page" ariaCurrentWhenActive="page"> Home </a>
+  <a routerLink="about" routerLinkActive="active-page" ariaCurrentWhenActive="page"> About </a>
+  <a routerLink="shop" routerLinkActive="active-page" ariaCurrentWhenActive="page"> Shop </a>
 </nav>
 ```
 

--- a/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
+++ b/adev/src/content/ecosystem/rxjs-interop/signals-interop.md
@@ -7,10 +7,10 @@ The `@angular/core/rxjs-interop` package offers APIs that help you integrate RxJ
 Use the `toSignal` function to create a signal which tracks the value of an Observable. It behaves similarly to the `async` pipe in templates, but is more flexible and can be used anywhere in an application.
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { interval } from 'rxjs';
-import { toSignal } from '@angular/core/rxjs-interop';
+import {Component} from '@angular/core';
+import {AsyncPipe} from '@angular/common';
+import {interval} from 'rxjs';
+import {toSignal} from '@angular/core/rxjs-interop';
 
 @Component({
   template: `{{ counter() }}`,

--- a/adev/src/content/guide/aria/accordion.md
+++ b/adev/src/content/guide/aria/accordion.md
@@ -145,13 +145,11 @@ Use the `ngAccordionContent` directive on an `ng-template` to defer rendering co
 ```angular-html
 <div ngAccordionGroup>
   <div>
-    <button ngAccordionTrigger panelId="item-1">
-      Trigger Text
-    </button>
+    <button ngAccordionTrigger panelId="item-1">Trigger Text</button>
     <div ngAccordionPanel panelId="item-1">
       <ng-template ngAccordionContent>
         <!-- This content only renders when the panel first opens -->
-        <img src="large-image.jpg" alt="Description">
+        <img src="large-image.jpg" alt="Description" />
         <app-expensive-component />
       </ng-template>
     </div>

--- a/adev/src/content/guide/aria/grid.md
+++ b/adev/src/content/guide/aria/grid.md
@@ -135,11 +135,13 @@ Instead of tabbing through each button, users navigate with arrow keys and only 
 Enable selection with `[enableSelection]="true"` and configure how focus and selection interact.
 
 ```angular-html
-<table ngGrid
-       [enableSelection]="true"
-       [selectionMode]="'explicit'"
-       [multi]="true"
-       [focusMode]="'roving'">
+<table
+  ngGrid
+  [enableSelection]="true"
+  [selectionMode]="'explicit'"
+  [multi]="true"
+  [focusMode]="'roving'"
+>
   <tr ngGridRow>
     <td ngGridCell>Cell 1</td>
     <td ngGridCell>Cell 2</td>

--- a/adev/src/content/guide/components/anatomy-of-components.md
+++ b/adev/src/content/guide/components/anatomy-of-components.md
@@ -14,9 +14,9 @@ You provide Angular-specific information for a component by adding a `@Component
 ```angular-ts {highlight: [1, 2, 3, 4]}
 @Component({
   selector: 'profile-photo',
-  template: `<img src="profile-photo.jpg" alt="Your profile photo">`,
+  template: `<img src="profile-photo.jpg" alt="Your profile photo" />`,
 })
-export class ProfilePhoto { }
+export class ProfilePhoto {}
 ```
 
 For full details on writing Angular templates, including data binding, event handling, and control flow, see the [Templates guide](guide/templates).
@@ -28,10 +28,14 @@ Components can optionally include a list of CSS styles that apply to that compon
 ```angular-ts {highlight: [4]}
 @Component({
   selector: 'profile-photo',
-  template: `<img src="profile-photo.jpg" alt="Your profile photo">`,
-  styles: `img { border-radius: 50%; }`,
+  template: `<img src="profile-photo.jpg" alt="Your profile photo" />`,
+  styles: `
+    img {
+      border-radius: 50%;
+    }
+  `,
 })
-export class ProfilePhoto { }
+export class ProfilePhoto {}
 ```
 
 By default, a component's styles only affect elements defined in that component's template. See [Styling Components](guide/components/styling) for details on Angular's approach to styling.
@@ -94,13 +98,13 @@ You show a component by creating a matching HTML element in the template of _oth
 @Component({
   selector: 'profile-photo',
 })
-export class ProfilePhoto { }
+export class ProfilePhoto {}
 
 @Component({
   imports: [ProfilePhoto],
-  template: `<profile-photo />`
+  template: `<profile-photo />`,
 })
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 Angular creates an instance of the component for every matching HTML element it encounters. The DOM element that matches a component's selector is referred to as that component's **host element**. The contents of a component's template are rendered inside its host element.

--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -10,7 +10,9 @@ example, you may want to create a custom card component:
   selector: 'custom-card',
   template: '<div class="card-shadow"> <!-- card content goes here --> </div>',
 })
-export class CustomCard {/* ... */}
+export class CustomCard {
+  /* ... */
+}
 ```
 
 **You can use the `<ng-content>` element as a placeholder to mark where content should go**:
@@ -20,7 +22,9 @@ export class CustomCard {/* ... */}
   selector: 'custom-card',
   template: '<div class="card-shadow"> <ng-content/> </div>',
 })
-export class CustomCard {/* ... */}
+export class CustomCard {
+  /* ... */
+}
 ```
 
 TIP: `<ng-content>` works similarly
@@ -40,7 +44,9 @@ rendered, or **projected**, at the location of that `<ng-content>`:
     </div>
   `,
 })
-export class CustomCard {/* ... */}
+export class CustomCard {
+  /* ... */
+}
 ```
 
 ```angular-html

--- a/adev/src/content/guide/components/host-elements.md
+++ b/adev/src/content/guide/components/host-elements.md
@@ -10,7 +10,7 @@ The contents of a component's template are rendered inside its host element.
 // Component source
 @Component({
   selector: 'profile-photo',
-  template: ` <img src="profile-photo.jpg" alt="Your profile photo" /> `,
+  template: `<img src="profile-photo.jpg" alt="Your profile photo" />`,
 })
 export class ProfilePhoto {}
 ```
@@ -155,7 +155,7 @@ Alternatively, it is also possible to set css custom properties on the host elem
 ```angular-ts
 @Component({
   selector: 'my-component',
-  template: `<my-child [style.--my-background]="color()"></my-child>`,
+  template: `<my-child [style.--my-background]="color()" />`,
 })
 export class MyComponent {
   color = signal('lightgreen');

--- a/adev/src/content/guide/components/host-elements.md
+++ b/adev/src/content/guide/components/host-elements.md
@@ -10,9 +10,7 @@ The contents of a component's template are rendered inside its host element.
 // Component source
 @Component({
   selector: 'profile-photo',
-  template: `
-    <img src="profile-photo.jpg" alt="Your profile photo" />
-  `,
+  template: ` <img src="profile-photo.jpg" alt="Your profile photo" /> `,
 })
 export class ProfilePhoto {}
 ```
@@ -141,7 +139,7 @@ You can set such custom properties on a host element with a [style binding][styl
   /* ... */
   host: {
     '[style.--my-background]': 'color()',
-  }
+  },
 })
 export class MyComponent {
   color = signal('lightgreen');
@@ -157,7 +155,7 @@ Alternatively, it is also possible to set css custom properties on the host elem
 ```angular-ts
 @Component({
   selector: 'my-component',
-  template: `<my-child [style.--my-background]="color()">`,
+  template: `<my-child [style.--my-background]="color()"></my-child>`,
 })
 export class MyComponent {
   color = signal('lightgreen');

--- a/adev/src/content/guide/components/inheritance.md
+++ b/adev/src/content/guide/components/inheritance.md
@@ -29,9 +29,7 @@ host bindings, inputs, outputs, lifecycle methods.
 ```angular-ts
 @Component({
   selector: 'base-listbox',
-  template: `
-    ...
-  `,
+  template: ` ... `,
   host: {
     '(keydown)': 'handleKey($event)',
   },
@@ -45,9 +43,7 @@ export class ListboxBase {
 
 @Component({
   selector: 'custom-listbox',
-  template: `
-    ...
-  `,
+  template: ` ... `,
   host: {
     '(click)': 'focusActiveOption()',
   },

--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -63,7 +63,7 @@ export class UserGreeting {
 @Component({
   selector: 'profile-view',
   imports: [NgComponentOutlet],
-  template: ` <ng-container *ngComponentOutlet="greetingComponent; inputs: greetingInputs()" /> `,
+  template: `<ng-container *ngComponentOutlet="greetingComponent; inputs: greetingInputs()" />`,
 })
 export class ProfileView {
   greetingComponent = UserGreeting;
@@ -137,7 +137,7 @@ export class ThemedPanel {
 @Component({
   selector: 'dynamic-panel',
   imports: [NgComponentOutlet],
-  template: ` <ng-container *ngComponentOutlet="panelComponent; injector: customInjector" /> `,
+  template: `<ng-container *ngComponentOutlet="panelComponent; injector: customInjector" />`,
 })
 export class DynamicPanel {
   panelComponent = ThemedPanel;
@@ -195,7 +195,7 @@ DOM as the next sibling of the component or directive that injected the `ViewCon
 ```angular-ts
 @Component({
   selector: 'leaf-content',
-  template: ` This is the leaf content `,
+  template: `This is the leaf content`,
 })
 export class LeafContent {}
 
@@ -211,7 +211,7 @@ export class OuterContainer {}
 
 @Component({
   selector: 'inner-item',
-  template: ` <button (click)="loadContent()">Load content</button> `,
+  template: `<button (click)="loadContent()">Load content</button>`,
 })
 export class InnerItem {
   private viewContainer = inject(ViewContainerRef);

--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -49,10 +49,10 @@ You can pass inputs to the dynamically rendered component using the `ngComponent
 @Component({
   selector: 'user-greeting',
   template: `
-  <div>
-    <p>User: {{ username() }}</p>
-    <p>Role: {{ role() }}</p>
-  </div>
+    <div>
+      <p>User: {{ username() }}</p>
+      <p>Role: {{ role() }}</p>
+    </div>
   `,
 })
 export class UserGreeting {
@@ -63,15 +63,11 @@ export class UserGreeting {
 @Component({
   selector: 'profile-view',
   imports: [NgComponentOutlet],
-  template: `
-    <ng-container
-      *ngComponentOutlet="greetingComponent; inputs: greetingInputs()"
-    />
-  `
+  template: ` <ng-container *ngComponentOutlet="greetingComponent; inputs: greetingInputs()" /> `,
 })
 export class ProfileView {
   greetingComponent = UserGreeting;
-  greetingInputs = signal({ username: 'ngAwesome' , role: 'admin' });
+  greetingInputs = signal({username: 'ngAwesome', role: 'admin'});
 }
 ```
 
@@ -88,22 +84,20 @@ Use `ngComponentOutletContent` to pass projected content to the dynamically rend
     <div class="card">
       <ng-content />
     </div>
-  `
+  `,
 })
-export class CardWrapper { }
+export class CardWrapper {}
 
 @Component({
   imports: [NgComponentOutlet],
   template: `
-    <ng-container
-      *ngComponentOutlet="cardComponent; content: cardContent()"
-    />
+    <ng-container *ngComponentOutlet="cardComponent; content: cardContent()" />
 
     <ng-template #contentTemplate>
       <h3>Dynamic Content</h3>
       <p>This content is projected into the card.</p>
     </ng-template>
-  `
+  `,
 })
 export class DynamicCard {
   private vcr = inject(ViewContainerRef);
@@ -134,7 +128,7 @@ export const THEME_DATA = new InjectionToken<string>('THEME_DATA', {
 
 @Component({
   selector: 'themed-panel',
-  template: `<div [class]="theme">...</div>`
+  template: `<div [class]="theme">...</div>`,
 })
 export class ThemedPanel {
   theme = inject(THEME_DATA);
@@ -143,19 +137,13 @@ export class ThemedPanel {
 @Component({
   selector: 'dynamic-panel',
   imports: [NgComponentOutlet],
-  template: `
-    <ng-container
-      *ngComponentOutlet="panelComponent; injector: customInjector"
-    />
-  `
+  template: ` <ng-container *ngComponentOutlet="panelComponent; injector: customInjector" /> `,
 })
 export class DynamicPanel {
   panelComponent = ThemedPanel;
 
   customInjector = Injector.create({
-    providers: [
-      { provide: THEME_DATA, useValue: 'dark' }
-    ],
+    providers: [{provide: THEME_DATA, useValue: 'dark'}],
   });
 }
 ```
@@ -167,27 +155,22 @@ You can access the dynamically created component's instance using the directive'
 ```angular-ts
 @Component({
   selector: 'counter',
-  template: `<p>Count: {{count()}}</p>`
+  template: `<p>Count: {{ count() }}</p>`,
 })
 export class Counter {
   count = signal(0);
   increment() {
-    this.count.update(c => c + 1);
+    this.count.update((c) => c + 1);
   }
 }
 
 @Component({
   imports: [NgComponentOutlet],
   template: `
-    <ng-container
-      [ngComponentOutlet]="counterComponent"
-      #outlet="ngComponentOutlet"
-    />
+    <ng-container [ngComponentOutlet]="counterComponent" #outlet="ngComponentOutlet" />
 
-    <button (click)="outlet.componentInstance?.increment()">
-      Increment
-    </button>
-  `
+    <button (click)="outlet.componentInstance?.increment()">Increment</button>
+  `,
 })
 export class CounterHost {
   counterComponent = Counter;
@@ -212,9 +195,7 @@ DOM as the next sibling of the component or directive that injected the `ViewCon
 ```angular-ts
 @Component({
   selector: 'leaf-content',
-  template: `
-    This is the leaf content
-  `,
+  template: ` This is the leaf content `,
 })
 export class LeafContent {}
 
@@ -230,9 +211,7 @@ export class OuterContainer {}
 
 @Component({
   selector: 'inner-item',
-  template: `
-    <button (click)="loadContent()">Load content</button>
-  `,
+  template: ` <button (click)="loadContent()">Load content</button> `,
 })
 export class InnerItem {
   private viewContainer = inject(ViewContainerRef);
@@ -308,18 +287,18 @@ To simplify this, both `createComponent` and `ViewContainerRef.createComponent` 
 By contrast, the standalone `createComponent` API does not attach the new component to any existing view or DOM location — it returns a `ComponentRef` and gives you explicit control over where to place the component’s host element.
 
 ```angular-ts
-import { Component, input, model, output } from "@angular/core";
+import {Component, input, model, output} from '@angular/core';
 
 @Component({
   selector: 'app-warning',
   template: `
-      @if(isExpanded()) {
-        <section>
-            <p>Warning: Action needed!</p>
-            <button (click)="close.emit(true)">Close</button>
-        </section>
-      }
-  `
+    @if (isExpanded()) {
+      <section>
+        <p>Warning: Action needed!</p>
+        <button (click)="close.emit(true)">Close</button>
+      </section>
+    }
+  `,
 })
 export class AppWarning {
   readonly canClose = input.required<boolean>();

--- a/adev/src/content/guide/components/queries.md
+++ b/adev/src/content/guide/components/queries.md
@@ -58,7 +58,7 @@ export class CustomCardAction {
 })
 export class CustomCard {
   actions = viewChildren(CustomCardAction);
-  actionsTexts = computed(() => this.actions().map(action => action.text));
+  actionsTexts = computed(() => this.actions().map((action) => action.text));
 }
 ```
 
@@ -89,16 +89,15 @@ export class CustomExpando {
 }
 
 @Component({
-/* ... */
-// CustomToggle is used inside CustomExpando as content.
-template: `
+  /* ... */
+  // CustomToggle is used inside CustomExpando as content.
+  template: `
     <custom-expando>
       <custom-toggle>Show</custom-toggle>
     </custom-expando>
-  `
+  `,
 })
-
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 If the query does not find a result, its value is `undefined`. This may occur if the target element is absent or hidden by `@if`. Angular keeps the result of `contentChild` up to date as your application state changes.
@@ -120,10 +119,9 @@ export class CustomMenuItem {
   selector: 'custom-menu',
   /*...*/
 })
-
 export class CustomMenu {
   items = contentChildren(CustomMenuItem);
-  itemTexts = computed(() => this.items().map(item => item.text));
+  itemTexts = computed(() => this.items().map((item) => item.text));
 }
 
 @Component({
@@ -133,9 +131,9 @@ export class CustomMenu {
       <custom-menu-item>Cheese</custom-menu-item>
       <custom-menu-item>Tomato</custom-menu-item>
     </custom-menu>
-  `
+  `,
 })
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 `contentChildren` creates a signal with an `Array` of the query results.
@@ -175,7 +173,7 @@ a [template reference variable](guide/templates/variables#template-reference-var
   template: `
     <button #save>Save</button>
     <button #cancel>Cancel</button>
-  `
+  `,
 })
 export class ActionBar {
   saveButton = viewChild<ElementRef<HTMLButtonElement>>('save');
@@ -199,9 +197,11 @@ const SUB_ITEM = new InjectionToken<string>('sub-item');
   /*...*/
   providers: [{provide: SUB_ITEM, useValue: 'special-item'}],
 })
-export class SpecialItem { }
+export class SpecialItem {}
 
-@Component({/*...*/})
+@Component({
+  /*...*/
+})
 export class CustomList {
   subItemType = contentChild(SUB_ITEM);
 }
@@ -254,9 +254,9 @@ export class CustomExpando {
         <custom-toggle>Show</custom-toggle>
       </some-other-component>
     </custom-expando>
-  `
+  `,
 })
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 In the example above, `CustomExpando` cannot find `<custom-toggle>` with `contentChildren` because it is not a direct child of `<custom-expando>`. By setting `descendants: true`, you configure the query to traverse all descendants in the same template. Queries, however, _never_ pierce into components to traverse elements in other templates.
@@ -324,7 +324,7 @@ export class CustomCard {
   @ViewChildren(CustomCardAction) actions: QueryList<CustomCardAction>;
 
   ngAfterViewInit() {
-    this.actions.forEach(action => {
+    this.actions.forEach((action) => {
       console.log(action.text);
     });
   }
@@ -350,7 +350,6 @@ export class CustomToggle {
   selector: 'custom-expando',
   /*...*/
 })
-
 export class CustomExpando {
   @ContentChild(CustomToggle) toggle: CustomToggle;
 
@@ -365,9 +364,9 @@ export class CustomExpando {
     <custom-expando>
       <custom-toggle>Show</custom-toggle>
     </custom-expando>
-  `
+  `,
 })
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 In this example, the `CustomExpando` component queries for a child `CustomToggle` and accesses the result in `ngAfterContentInit`.
@@ -391,12 +390,11 @@ export class CustomMenuItem {
   selector: 'custom-menu',
   /*...*/
 })
-
 export class CustomMenu {
   @ContentChildren(CustomMenuItem) items: QueryList<CustomMenuItem>;
 
   ngAfterContentInit() {
-    this.items.forEach(item => {
+    this.items.forEach((item) => {
       console.log(item.text);
     });
   }
@@ -409,9 +407,9 @@ export class CustomMenu {
       <custom-menu-item>Cheese</custom-menu-item>
       <custom-menu-item>Tomato</custom-menu-item>
     </custom-menu>
-  `
+  `,
 })
-export class UserProfile { }
+export class UserProfile {}
 ```
 
 `@ContentChildren` creates a `QueryList` object that contains the query results. You can subscribe to changes to the query results over time via the `changes` property.

--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -7,10 +7,14 @@ Components can optionally include CSS styles that apply to that component's DOM:
 ```angular-ts {highlight:[4]}
 @Component({
   selector: 'profile-photo',
-  template: `<img src="profile-photo.jpg" alt="Your profile photo">`,
-  styles: ` img { border-radius: 50%; } `,
+  template: `<img src="profile-photo.jpg" alt="Your profile photo" />`,
+  styles: `
+    img {
+      border-radius: 50%;
+    }
+  `,
 })
-export class ProfilePhoto { }
+export class ProfilePhoto {}
 ```
 
 You can also choose to write your styles in separate files:
@@ -21,7 +25,7 @@ You can also choose to write your styles in separate files:
   templateUrl: 'profile-photo.html',
   styleUrl: 'profile-photo.css',
 })
-export class ProfilePhoto { }
+export class ProfilePhoto {}
 ```
 
 When Angular compiles your component, these styles are emitted with your component's JavaScript

--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -51,19 +51,17 @@ Once you've created a service with `providedIn: 'root'`, you can inject it anywh
 ### Injecting into a component
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { BasicDataStore } from './basic-data-store';
+import {Component, inject} from '@angular/core';
+import {BasicDataStore} from './basic-data-store';
 
 @Component({
   selector: 'app-example',
   template: `
     <div>
       <p>{{ dataStore.getData() }}</p>
-      <button (click)="dataStore.addData('More data')">
-        Add more data
-      </button>
+      <button (click)="dataStore.addData('More data')">Add more data</button>
     </div>
-  `
+  `,
 })
 export class Example {
   dataStore = inject(BasicDataStore);

--- a/adev/src/content/guide/di/defining-dependency-providers.md
+++ b/adev/src/content/guide/di/defining-dependency-providers.md
@@ -235,14 +235,14 @@ Think of Angular's dependency injection system as a hash map or dictionary. Each
 When manually providing dependencies, you typically see this shorthand syntax:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { LocalService } from './local-service';
+import {Component} from '@angular/core';
+import {LocalService} from './local-service';
 
 @Component({
   selector: 'app-example',
-  providers: [LocalService]  // Service without providedIn
+  providers: [LocalService], // Service without providedIn
 })
-export class Example { }
+export class Example {}
 ```
 
 This is actually a shorthand for a more detailed provider configuration:
@@ -282,16 +282,16 @@ Provider identifiers allow Angular's dependency injection (DI) system to retriev
 Class name use the imported class directly as the identifier:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { LocalService } from './local-service';
+import {Component} from '@angular/core';
+import {LocalService} from './local-service';
 
 @Component({
   selector: 'app-example',
-  providers: [
-    { provide: LocalService, useClass: LocalService }
-  ]
+  providers: [{provide: LocalService, useClass: LocalService}],
 })
-export class Example { /* ... */ }
+export class Example {
+  /* ... */
+}
 ```
 
 The class serves as both the identifier and the implementation, which is why Angular provides the shorthand `providers: [LocalService]`.
@@ -313,15 +313,13 @@ NOTE: The string `'DataService'` is a description used purely for debugging purp
 Use the token in your provider configuration:
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { LocalDataService } from './local-data-service';
-import { DATA_SERVICE_TOKEN } from './tokens';
+import {Component, inject} from '@angular/core';
+import {LocalDataService} from './local-data-service';
+import {DATA_SERVICE_TOKEN} from './tokens';
 
 @Component({
   selector: 'app-example',
-  providers: [
-    { provide: DATA_SERVICE_TOKEN, useClass: LocalDataService }
-  ]
+  providers: [{provide: DATA_SERVICE_TOKEN, useClass: LocalDataService}],
 })
 export class Example {
   private dataService = inject(DATA_SERVICE_TOKEN);
@@ -672,20 +670,20 @@ Use component or directive providers when:
 @Component({
   selector: 'app-advanced-form',
   providers: [
-    FormValidationService,  // Each form gets its own validator
-    { provide: FORM_CONFIG, useValue: { strictMode: true } }
-  ]
+    FormValidationService, // Each form gets its own validator
+    {provide: FORM_CONFIG, useValue: {strictMode: true}},
+  ],
 })
-export class AdvancedForm { }
+export class AdvancedForm {}
 
 // Modal component with isolated state management
 @Component({
   selector: 'app-modal',
   providers: [
-    ModalStateService  // Each modal manages its own state
-  ]
+    ModalStateService, // Each modal manages its own state
+  ],
 })
-export class Modal { }
+export class Modal {}
 ```
 
 **Benefits:**

--- a/adev/src/content/guide/di/lightweight-injection-tokens.md
+++ b/adev/src/content/guide/di/lightweight-injection-tokens.md
@@ -23,10 +23,7 @@ To better explain the condition under which token retention occurs, consider a l
 This component contains a body and can contain an optional header:
 
 ```angular-html
-
-<lib-card>;
-<lib-header>…</lib-header>;
-</lib-card>;
+<lib-card>; <lib-header>…</lib-header>; </lib-card>;
 ```
 
 In a likely implementation, the `<lib-card>` component uses `contentChild` or `contentChildren` to get `<lib-header>` and `<lib-body>`, as in the following:

--- a/adev/src/content/guide/di/lightweight-injection-tokens.md
+++ b/adev/src/content/guide/di/lightweight-injection-tokens.md
@@ -22,8 +22,10 @@ To prevent the retention of unused components, your library should use the light
 To better explain the condition under which token retention occurs, consider a library that provides a library-card component.
 This component contains a body and can contain an optional header:
 
-```angular-html
-<lib-card>; <lib-header>…</lib-header>; </lib-card>;
+```html
+<lib-card>
+  <lib-header>…</lib-header>
+</lib-card>
 ```
 
 In a likely implementation, the `<lib-card>` component uses `contentChild` or `contentChildren` to get `<lib-header>` and `<lib-body>`, as in the following:

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -69,15 +69,13 @@ You can inject dependencies using Angular's `inject()` function.
 Here is an example of a navigation bar that injects `AnalyticsLogger` and Angular `Router` service to allow users to navigate to a different page while tracking the event.
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
-import { AnalyticsLogger } from './analytics-logger';
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
+import {AnalyticsLogger} from './analytics-logger';
 
 @Component({
   selector: 'app-navbar',
-  template: `
-    <a href="#" (click)="navigateToDetail($event)">Detail Page</a>
-  `,
+  template: ` <a href="#" (click)="navigateToDetail($event)">Detail Page</a> `,
 })
 export class Navbar {
   private router = inject(Router);

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -75,7 +75,7 @@ import {AnalyticsLogger} from './analytics-logger';
 
 @Component({
   selector: 'app-navbar',
-  template: ` <a href="#" (click)="navigateToDetail($event)">Detail Page</a> `,
+  template: `<a href="#" (click)="navigateToDetail($event)">Detail Page</a>`,
 })
 export class Navbar {
   private router = inject(Router);

--- a/adev/src/content/guide/directives/directive-composition-api.md
+++ b/adev/src/content/guide/directives/directive-composition-api.md
@@ -60,8 +60,7 @@ By explicitly specifying the inputs and outputs, consumers of the component with
 bind them in a template:
 
 ```angular-html
-
-<admin-menu menuId="top-menu" (menuClosed)="logMenuClosed()">
+<admin-menu menuId="top-menu" (menuClosed)="logMenuClosed()"></admin-menu>
 ```
 
 Furthermore, you can alias inputs and outputs from `hostDirective` to customize the API of your
@@ -83,8 +82,7 @@ export class AdminMenu {}
 ```
 
 ```angular-html
-
-<admin-menu id="top-menu" (closed)="logMenuClosed()">
+<admin-menu id="top-menu" (closed)="logMenuClosed()"></admin-menu>
 ```
 
 ## Adding directives to another directive

--- a/adev/src/content/guide/directives/structural-directives.md
+++ b/adev/src/content/guide/directives/structural-directives.md
@@ -31,7 +31,7 @@ Structural directives can be applied directly on an element by prefixing the dir
 You can use this with `SelectDirective` as follows:
 
 ```angular-html
-<p *select="let data from source">The data is: {{data}}</p>
+<p *select="let data; from: source">The data is: {{ data }}</p>
 ```
 
 This example shows the flexibility of structural directive shorthand syntax, which is sometimes called _microsyntax_.
@@ -40,11 +40,11 @@ When used in this way, only the structural directive and its bindings are applie
 
 ```angular-html
 <!-- Shorthand syntax: -->
-<p class="data-view" *select="let data from source">The data is: {{data}}</p>
+<p class="data-view" *select="let data; from: source">The data is: {{ data }}</p>
 
 <!-- Long-form syntax: -->
 <ng-template select let-data [selectFrom]="source">
-  <p class="data-view">The data is: {{data}}</p>
+  <p class="data-view">The data is: {{ data }}</p>
 </ng-template>
 ```
 

--- a/adev/src/content/guide/drag-drop.md
+++ b/adev/src/content/guide/drag-drop.md
@@ -96,7 +96,7 @@ Use the `cdkDropListGroup` directive if you have an unknown number of connected 
 <div cdkDropListGroup>
   <!-- All lists in here will be connected. -->
   @for (list of lists; track list) {
-  <div cdkDropList></div>
+    <div cdkDropList></div>
   }
 </div>
 ```
@@ -125,11 +125,11 @@ You can associate some arbitrary data with both `cdkDrag` and `cdkDropList` by s
 
 ```angular-html
 @for (list of lists; track list) {
-<div cdkDropList [cdkDropListData]="list" (cdkDropListDropped)="drop($event)">
-  @for (item of list; track item) {
-  <div cdkDrag [cdkDragData]="item"></div>
-  }
-</div>
+  <div cdkDropList [cdkDropListData]="list" (cdkDropListDropped)="drop($event)">
+    @for (item of list; track item) {
+      <div cdkDrag [cdkDragData]="item"></div>
+    }
+  </div>
 }
 ```
 

--- a/adev/src/content/guide/forms/form-validation.md
+++ b/adev/src/content/guide/forms/form-validation.md
@@ -250,9 +250,9 @@ A common UI pattern is to show a spinner while the async validation is being per
 The following example shows how to achieve this in a template-driven form.
 
 ```angular-html
-<input [(ngModel)]="name" #model="ngModel" appSomeAsyncValidator>
+<input [(ngModel)]="name" #model="ngModel" appSomeAsyncValidator />
 
-@if(model.pending) {
+@if (model.pending) {
   <app-spinner />
 }
 ```
@@ -330,7 +330,7 @@ You can delay updating the form validity by changing the `updateOn` property fro
 With template-driven forms, set the property in the template.
 
 ```angular-html
-<input [(ngModel)]="name" [ngModelOptions]="{updateOn: 'blur'}">
+<input [(ngModel)]="name" [ngModelOptions]="{updateOn: 'blur'}" />
 ```
 
 With reactive forms, set the property in the `FormControl` instance.

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -387,25 +387,21 @@ You can bind a `FormArray` directly to a `<form>` element by using the `FormArra
 This is useful when the form does not use a top-level `FormGroup`, and the array itself represents the full form model.
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { FormArray, FormControl } from '@angular/forms';
+import {Component} from '@angular/core';
+import {FormArray, FormControl} from '@angular/forms';
 
 @Component({
   selector: 'form-array-example',
   template: `
     <form [formArray]="form">
       @for (control of form.controls; track $index) {
-        <input [formControlName]="$index">
+        <input [formControlName]="$index" />
       }
     </form>
   `,
 })
 export class FormArrayExampleComponent {
-  controls = [
-    new FormControl('fish'),
-    new FormControl('cat'),
-    new FormControl('dog'),
-  ];
+  controls = [new FormControl('fish'), new FormControl('cat'), new FormControl('dog')];
 
   form = new FormArray(this.controls);
 }

--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -15,8 +15,8 @@ Let's start with a minimal implementation and add features as needed.
 A basic custom input only needs to implement the `FormValueControl` interface and define the required `value` model signal.
 
 ```angular-ts
-import { Component, model } from '@angular/core';
-import { FormValueControl } from '@angular/forms/signals';
+import {Component, model} from '@angular/core';
+import {FormValueControl} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-basic-input',
@@ -45,17 +45,13 @@ A checkbox-style control needs two things:
 2. Provide a `checked` model signal
 
 ```angular-ts
-import { Component, model, ChangeDetectionStrategy } from '@angular/core';
-import { FormCheckboxControl } from '@angular/forms/signals';
+import {Component, model, ChangeDetectionStrategy} from '@angular/core';
+import {FormCheckboxControl} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-basic-toggle',
   template: `
-    <button
-      type="button"
-      [class.active]="checked()"
-      (click)="toggle()"
-    >
+    <button type="button" [class.active]="checked()" (click)="toggle()">
       <span class="toggle-slider"></span>
     </button>
   `,
@@ -66,7 +62,7 @@ export class BasicToggle implements FormCheckboxControl {
   checked = model<boolean>(false);
 
   toggle() {
-    this.checked.update(val => !val);
+    this.checked.update((val) => !val);
   }
 }
 ```
@@ -76,10 +72,10 @@ export class BasicToggle implements FormCheckboxControl {
 Once you've created a control, you can use it anywhere you would use a built-in input by adding the `FormField` directive to it:
 
 ```angular-ts
-import { Component, signal, ChangeDetectionStrategy } from '@angular/core';
-import { form, FormField, required } from '@angular/forms/signals';
-import { BasicInput } from './basic-input';
-import { BasicToggle } from './basic-toggle';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
+import {form, FormField, required} from '@angular/forms/signals';
+import {BasicInput} from './basic-input';
+import {BasicToggle} from './basic-toggle';
 
 @Component({
   imports: [FormField, BasicInput, BasicToggle],
@@ -95,12 +91,7 @@ import { BasicToggle } from './basic-toggle';
         <app-basic-toggle [formField]="registrationForm.acceptTerms" />
       </label>
 
-      <button
-        type="submit"
-        [disabled]="registrationForm().invalid()"
-      >
-        Register
-      </button>
+      <button type="submit" [disabled]="registrationForm().invalid()">Register</button>
     </form>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -108,12 +99,12 @@ import { BasicToggle } from './basic-toggle';
 export class Registration {
   registrationModel = signal({
     email: '',
-    acceptTerms: false
+    acceptTerms: false,
   });
 
   registrationForm = form(this.registrationModel, (schemaPath) => {
-    required(schemaPath.email, { message: 'Email is required' });
-    required(schemaPath.acceptTerms, { message: 'You must accept the terms' });
+    required(schemaPath.email, {message: 'Email is required'});
+    required(schemaPath.acceptTerms, {message: 'You must accept the terms'});
   });
 }
 ```
@@ -213,10 +204,10 @@ The "[Adding state signals](#adding-state-signals)" section below shows how to i
 The `[formField]` directive detects which interface your control implements and automatically binds the appropriate signals:
 
 ```angular-ts
-import { Component, signal, ChangeDetectionStrategy } from '@angular/core';
-import { form, FormField, required } from '@angular/forms/signals';
-import { CustomInput } from './custom-input';
-import { CustomToggle } from './custom-toggle';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
+import {form, FormField, required} from '@angular/forms/signals';
+import {CustomInput} from './custom-input';
+import {CustomToggle} from './custom-toggle';
 
 @Component({
   selector: 'app-my-form',
@@ -232,11 +223,11 @@ import { CustomToggle } from './custom-toggle';
 export class MyForm {
   formModel = signal({
     username: '',
-    subscribe: false
+    subscribe: false,
   });
 
   userForm = form(this.formModel, (schemaPath) => {
-    required(schemaPath.username, { message: 'Username is required' });
+    required(schemaPath.username, {message: 'Username is required'});
   });
 }
 ```
@@ -257,9 +248,9 @@ The minimal controls shown above work, but they don't respond to form state. You
 Here's a comprehensive example that implements common state properties:
 
 ```angular-ts
-import { Component, model, input, ChangeDetectionStrategy } from '@angular/core';
-import { FormValueControl } from '@angular/forms/signals';
-import type { ValidationError, DisabledReason } from '@angular/forms/signals';
+import {Component, model, input, ChangeDetectionStrategy} from '@angular/core';
+import {FormValueControl} from '@angular/forms/signals';
+import type {ValidationError, DisabledReason} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-stateful-input',
@@ -317,9 +308,9 @@ export class StatefulInput implements FormValueControl<string> {
 As a result, you can use the control with validation and state management:
 
 ```angular-ts
-import { Component, signal, ChangeDetectionStrategy } from '@angular/core';
-import { form, FormField, required, email } from '@angular/forms/signals';
-import { StatefulInput } from './stateful-input';
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
+import {form, FormField, required, email} from '@angular/forms/signals';
+import {StatefulInput} from './stateful-input';
 
 @Component({
   imports: [FormField, StatefulInput],
@@ -334,11 +325,11 @@ import { StatefulInput } from './stateful-input';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Login {
-  loginModel = signal({ email: '' });
+  loginModel = signal({email: ''});
 
   loginForm = form(this.loginModel, (schemaPath) => {
-    required(schemaPath.email, { message: 'Email is required' });
-    email(schemaPath.email, { message: 'Enter a valid email address' });
+    required(schemaPath.email, {message: 'Email is required'});
+    email(schemaPath.email, {message: 'Enter a valid email address'});
   });
 }
 ```
@@ -356,8 +347,8 @@ Controls sometimes display values differently than the form model stores them - 
 Use `linkedSignal()` (from `@angular/core`) to transform the model value for display, and handle input events to parse user input back to the storage format:
 
 ```angular-ts
-import { ChangeDetectionStrategy, Component, linkedSignal, model } from '@angular/core';
-import { FormValueControl } from '@angular/forms/signals';
+import {ChangeDetectionStrategy, Component, linkedSignal, model} from '@angular/core';
+import {FormValueControl} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-currency-input',

--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -11,8 +11,8 @@ When you create a form with the `form()` function, it returns a **field tree** -
 When you call any field in the field tree as a function (like `form.email()`), it returns a `FieldState` object containing reactive signals that track the field's validation, interaction, and availability state. For example, the `invalid()` signal tells you whether the field has validation errors:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, required, email } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, required, email} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-registration',
@@ -28,18 +28,18 @@ import { form, FormField, required, email } from '@angular/forms/signals'
         }
       </ul>
     }
-  `
+  `,
 })
 export class Registration {
   registrationModel = signal({
     email: '',
-    password: ''
-  })
+    password: '',
+  });
 
   registrationForm = form(this.registrationModel, (schemaPath) => {
-    required(schemaPath.email, { message: 'Email is required' })
-    email(schemaPath.email, { message: 'Enter a valid email address' })
-  })
+    required(schemaPath.email, {message: 'Email is required'});
+    email(schemaPath.email, {message: 'Enter a valid email address'});
+  });
 }
 ```
 
@@ -87,14 +87,15 @@ Use `valid()` and `invalid()` to check validation status:
 
     @if (loginForm.email().invalid()) {
       <p class="error">Email is invalid</p>
-    } @if (loginForm.email().valid()) {
+    }
+    @if (loginForm.email().valid()) {
       <p class="success">Email looks good</p>
     }
-  `
+  `,
 })
 export class Login {
-  loginModel = signal({ email: '', password: '' })
-  loginForm = form(this.loginModel)
+  loginModel = signal({email: '', password: ''});
+  loginForm = form(this.loginModel);
 }
 ```
 
@@ -184,11 +185,11 @@ The `dirty()` signal becomes `true` when the user modifies an interactive field'
         <p class="warning">You have unsaved changes</p>
       }
     </form>
-  `
+  `,
 })
 export class Profile {
-  profileModel = signal({ name: 'Alice', bio: 'Developer' })
-  profileForm = form(this.profileModel)
+  profileModel = signal({name: 'Alice', bio: 'Developer'});
+  profileForm = form(this.profileModel);
 }
 ```
 
@@ -264,8 +265,8 @@ Disabled fields don't contribute to the parent form's validation state. Even if 
 The `hidden()` signal indicates whether a field is conditionally hidden. Use `hidden()` with `@if` to show or hide fields based on conditions:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, hidden } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, hidden} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-profile',
@@ -282,17 +283,17 @@ import { form, FormField, hidden } from '@angular/forms/signals'
         <input [formField]="profileForm.publicUrl" />
       </label>
     }
-  `
+  `,
 })
 export class Profile {
   profileModel = signal({
     isPublic: false,
-    publicUrl: ''
-  })
+    publicUrl: '',
+  });
 
-  profileForm = form(this.profileModel, schemaPath => {
-    hidden(schemaPath.publicUrl, ({valueOf}) => !valueOf(schemaPath.isPublic))
-  })
+  profileForm = form(this.profileModel, (schemaPath) => {
+    hidden(schemaPath.publicUrl, ({valueOf}) => !valueOf(schemaPath.isPublic));
+  });
 }
 ```
 
@@ -303,8 +304,8 @@ Hidden fields don't participate in validation. If a required field is hidden, it
 The `readonly()` signal indicates whether a field is readonly. Readonly fields display their value but users cannot edit them:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, readonly } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, readonly} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-account',
@@ -319,17 +320,17 @@ import { form, FormField, readonly } from '@angular/forms/signals'
       Email
       <input [formField]="accountForm.email" />
     </label>
-  `
+  `,
 })
 export class Account {
   accountModel = signal({
     username: 'johndoe',
-    email: 'john@example.com'
-  })
+    email: 'john@example.com',
+  });
 
-  accountForm = form(this.accountModel, schemaPath => {
-    readonly(schemaPath.username)
-  })
+  accountForm = form(this.accountModel, (schemaPath) => {
+    readonly(schemaPath.username);
+  });
 }
 ```
 
@@ -360,11 +361,11 @@ The root form is also a field in the field tree. When you call it as a function,
 
       <button [disabled]="!loginForm().valid()">Sign In</button>
     </form>
-  `
+  `,
 })
 export class Login {
-  loginModel = signal({ email: '', password: '' })
-  loginForm = form(this.loginModel)
+  loginModel = signal({email: '', password: ''});
+  loginForm = form(this.loginModel);
 }
 ```
 
@@ -455,8 +456,8 @@ Field state signals integrate seamlessly with Angular templates, enabling reacti
 Show errors only after a user has interacted with a field:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, email } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, email} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-signup',
@@ -470,14 +471,14 @@ import { form, FormField, email } from '@angular/forms/signals'
     @if (signupForm.email().touched() && signupForm.email().invalid()) {
       <p class="error">{{ signupForm.email().errors()[0].message }}</p>
     }
-  `
+  `,
 })
 export class Signup {
-  signupModel = signal({ email: '', password: '' })
+  signupModel = signal({email: '', password: ''});
 
-  signupForm = form(this.signupModel, schemaPath => {
-    email(schemaPath.email)
-  })
+  signupForm = form(this.signupModel, (schemaPath) => {
+    email(schemaPath.email);
+  });
 }
 ```
 
@@ -488,8 +489,8 @@ This pattern prevents showing errors before users have had a chance to interact 
 Use the `hidden()` signal with `@if` to show or hide fields conditionally:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, hidden } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, hidden} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-order',
@@ -506,17 +507,17 @@ import { form, FormField, hidden } from '@angular/forms/signals'
         <input [formField]="orderForm.shippingAddress" />
       </label>
     }
-  `
+  `,
 })
 export class Order {
   orderModel = signal({
     requiresShipping: false,
-    shippingAddress: ''
-  })
+    shippingAddress: '',
+  });
 
-  orderForm = form(this.orderModel, schemaPath => {
-    hidden(schemaPath.shippingAddress, ({valueOf}) => !valueOf(schemaPath.requiresShipping))
-  })
+  orderForm = form(this.orderModel, (schemaPath) => {
+    hidden(schemaPath.shippingAddress, ({valueOf}) => !valueOf(schemaPath.requiresShipping));
+  });
 }
 ```
 
@@ -653,8 +654,8 @@ This two-step reset ensures the form is ready for new input without showing stal
 You can apply custom styles to your form by binding CSS classes based on the validation state:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, email } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, email} from '@angular/forms/signals';
 
 @Component({
   template: `
@@ -674,14 +675,14 @@ import { form, FormField, email } from '@angular/forms/signals'
     input.is-valid {
       border: 2px solid green;
     }
-  `
+  `,
 })
 export class StyleExample {
-  model = signal({ email: '' })
+  model = signal({email: ''});
 
-  form = form(this.model, schemaPath => {
-    email(schemaPath.email)
-  })
+  form = form(this.model, (schemaPath) => {
+    email(schemaPath.email);
+  });
 }
 ```
 

--- a/adev/src/content/guide/forms/signals/migration.md
+++ b/adev/src/content/guide/forms/signals/migration.md
@@ -55,14 +55,14 @@ In the template, use standard reactive syntax by binding the underlying control:
   <div>
     <label>
       Email:
-      <input [formField]="f.email">
+      <input [formField]="f.email" />
     </label>
   </div>
 
   <div>
     <label>
       Password:
-      <input [formField]="f.password" type="password">
+      <input [formField]="f.password" type="password" />
     </label>
 
     @if (f.password().touched() && f.password().invalid()) {
@@ -118,7 +118,7 @@ template by accessing the underlying legacy controls via `.control()`:
   <div>
     <label>
       Customer Name:
-      <input [formField]="f.customerName">
+      <input [formField]="f.customerName" />
     </label>
 
     @if (f.customerName().touched() && f.customerName().invalid()) {
@@ -135,7 +135,7 @@ template by accessing the underlying legacy controls via `.control()`:
     <div>
       <label>
         Street:
-        <input [formControl]="street">
+        <input [formControl]="street" />
       </label>
       @if (street.touched && street.invalid) {
         <div class="error-list">
@@ -148,7 +148,7 @@ template by accessing the underlying legacy controls via `.control()`:
     <div>
       <label>
         City:
-        <input [formControl]="city">
+        <input [formControl]="city" />
       </label>
       @if (city.touched && city.invalid) {
         <div class="error-list">
@@ -161,7 +161,7 @@ template by accessing the underlying legacy controls via `.control()`:
     <div>
       <label>
         Zip Code:
-        <input [formControl]="zip">
+        <input [formControl]="zip" />
       </label>
       @if (zip.touched && zip.invalid) {
         <div class="error-list">

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -15,8 +15,8 @@ Form models solve this by centralizing form data in a single writable signal. Wh
 A form model is a writable signal created with Angular's `signal()` function. The signal holds an object that represents your form's data structure.
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-login',
@@ -24,15 +24,15 @@ import { form, FormField } from '@angular/forms/signals'
   template: `
     <input type="email" [formField]="loginForm.email" />
     <input type="password" [formField]="loginForm.password" />
-  `
+  `,
 })
 export class LoginComponent {
   loginModel = signal({
     email: '',
-    password: ''
-  })
+    password: '',
+  });
 
-  loginForm = form(this.loginModel)
+  loginForm = form(this.loginModel);
 }
 ```
 
@@ -139,15 +139,15 @@ Access field state when working with individual fields in templates or reactive 
   template: `
     <p>Current email: {{ loginForm.email().value() }}</p>
     <p>Password length: {{ passwordLength() }}</p>
-  `
+  `,
 })
 export class LoginComponent {
-  loginModel = signal({ email: '', password: '' })
-  loginForm = form(this.loginModel)
+  loginModel = signal({email: '', password: ''});
+  loginForm = form(this.loginModel);
 
   passwordLength = computed(() => {
-    return this.loginForm.password().value().length
-  })
+    return this.loginForm.password().value().length;
+  });
 }
 ```
 
@@ -260,11 +260,11 @@ This synchronization happens automatically. You don't write subscriptions or eve
     <input type="text" [formField]="userForm.name" />
     <button (click)="setName('Bob')">Set Name to Bob</button>
     <p>Current name: {{ userModel().name }}</p>
-  `
+  `,
 })
 export class UserComponent {
-  userModel = signal({ name: '' })
-  userForm = form(this.userModel)
+  userModel = signal({name: ''});
+  userForm = form(this.userModel);
 
   setName(name: string) {
     this.userForm.name().value.set(name);

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -61,8 +61,8 @@ Signal Forms provides validation rules for common validation scenarios. All buil
 The `required()` validation rule ensures a field has a value:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, required } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, required} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-registration',
@@ -81,18 +81,18 @@ import { form, FormField, required } from '@angular/forms/signals'
 
       <button type="submit">Register</button>
     </form>
-  `
+  `,
 })
 export class RegistrationComponent {
   registrationModel = signal({
     username: '',
-    email: ''
-  })
+    email: '',
+  });
 
   registrationForm = form(this.registrationModel, (schemaPath) => {
-    required(schemaPath.username, { message: 'Username is required' })
-    required(schemaPath.email, { message: 'Email is required' })
-  })
+    required(schemaPath.username, {message: 'Username is required'});
+    required(schemaPath.email, {message: 'Email is required'});
+  });
 }
 ```
 
@@ -122,8 +122,8 @@ The validation rule only runs when the `when` function returns `true`.
 The `email()` validation rule checks for valid email format:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, email } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, email} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-contact',
@@ -135,14 +135,14 @@ import { form, FormField, email } from '@angular/forms/signals'
         <input type="email" [formField]="contactForm.email" />
       </label>
     </form>
-  `
+  `,
 })
 export class ContactComponent {
-  contactModel = signal({ email: '' })
+  contactModel = signal({email: ''});
 
   contactForm = form(this.contactModel, (schemaPath) => {
-    email(schemaPath.email, { message: 'Please enter a valid email address' })
-  })
+    email(schemaPath.email, {message: 'Please enter a valid email address'});
+  });
 }
 ```
 
@@ -153,8 +153,8 @@ The `email()` validation rule uses a standard email format regex. It accepts add
 The `min()` and `max()` validation rules work with numeric values:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, min, max } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, min, max} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-age-form',
@@ -171,21 +171,21 @@ import { form, FormField, min, max } from '@angular/forms/signals'
         <input type="number" [formField]="ageForm.rating" />
       </label>
     </form>
-  `
+  `,
 })
 export class AgeFormComponent {
   ageModel = signal({
     age: 0,
-    rating: 0
-  })
+    rating: 0,
+  });
 
   ageForm = form(this.ageModel, (schemaPath) => {
-    min(schemaPath.age, 18, { message: 'You must be at least 18 years old' })
-    max(schemaPath.age, 120, { message: 'Please enter a valid age' })
+    min(schemaPath.age, 18, {message: 'You must be at least 18 years old'});
+    max(schemaPath.age, 120, {message: 'Please enter a valid age'});
 
-    min(schemaPath.rating, 1, { message: 'Rating must be at least 1' })
-    max(schemaPath.rating, 5, { message: 'Rating cannot exceed 5' })
-  })
+    min(schemaPath.rating, 1, {message: 'Rating must be at least 1'});
+    max(schemaPath.rating, 5, {message: 'Rating cannot exceed 5'});
+  });
 }
 ```
 
@@ -204,8 +204,8 @@ ageForm = form(this.ageModel, (schemaPath) => {
 The `minLength()` and `maxLength()` validation rules work with strings and arrays:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, minLength, maxLength } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, minLength, maxLength} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-password-form',
@@ -222,20 +222,20 @@ import { form, FormField, minLength, maxLength } from '@angular/forms/signals'
         <textarea [formField]="passwordForm.bio"></textarea>
       </label>
     </form>
-  `
+  `,
 })
 export class PasswordFormComponent {
   passwordModel = signal({
     password: '',
-    bio: ''
-  })
+    bio: '',
+  });
 
   passwordForm = form(this.passwordModel, (schemaPath) => {
-    minLength(schemaPath.password, 8, { message: 'Password must be at least 8 characters' })
-    maxLength(schemaPath.password, 100, { message: 'Password is too long' })
+    minLength(schemaPath.password, 8, {message: 'Password must be at least 8 characters'});
+    maxLength(schemaPath.password, 100, {message: 'Password is too long'});
 
-    maxLength(schemaPath.bio, 500, { message: 'Bio cannot exceed 500 characters' })
-  })
+    maxLength(schemaPath.bio, 500, {message: 'Bio cannot exceed 500 characters'});
+  });
 }
 ```
 
@@ -246,8 +246,8 @@ For strings, "length" means the number of characters. For arrays, "length" means
 The `pattern()` validation rule validates against a regular expression:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, pattern } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, pattern} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-phone-form',
@@ -264,23 +264,23 @@ import { form, FormField, pattern } from '@angular/forms/signals'
         <input [formField]="phoneForm.postalCode" placeholder="12345" />
       </label>
     </form>
-  `
+  `,
 })
 export class PhoneFormComponent {
   phoneModel = signal({
     phone: '',
-    postalCode: ''
-  })
+    postalCode: '',
+  });
 
   phoneForm = form(this.phoneModel, (schemaPath) => {
     pattern(schemaPath.phone, /^\d{3}-\d{3}-\d{4}$/, {
-      message: 'Phone must be in format: 555-123-4567'
-    })
+      message: 'Phone must be in format: 555-123-4567',
+    });
 
     pattern(schemaPath.postalCode, /^\d{5}$/, {
-      message: 'Postal code must be 5 digits'
-    })
-  })
+      message: 'Postal code must be 5 digits',
+    });
+  });
 }
 ```
 
@@ -355,8 +355,8 @@ Built-in validation rules automatically set the `kind` property. The `message` p
 All built-in validation rules accept a `message` option for custom error text:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, required, minLength } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, required, minLength} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-signup',
@@ -373,26 +373,26 @@ import { form, FormField, required, minLength } from '@angular/forms/signals'
         <input type="password" [formField]="signupForm.password" />
       </label>
     </form>
-  `
+  `,
 })
 export class SignupComponent {
   signupModel = signal({
     username: '',
-    password: ''
-  })
+    password: '',
+  });
 
   signupForm = form(this.signupModel, (schemaPath) => {
     required(schemaPath.username, {
-      message: 'Please choose a username'
-    })
+      message: 'Please choose a username',
+    });
 
     required(schemaPath.password, {
-      message: 'Password cannot be empty'
-    })
+      message: 'Password cannot be empty',
+    });
     minLength(schemaPath.password, 12, {
-      message: 'Password must be at least 12 characters for security'
-    })
-  })
+      message: 'Password must be at least 12 characters for security',
+    });
+  });
 }
 ```
 
@@ -428,8 +428,8 @@ The `validate()` function creates custom validation rules. It receives a validat
 | `null` or `undefined` | Value is valid   |
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, validate } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, validate} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-url-form',
@@ -441,23 +441,23 @@ import { form, FormField, validate } from '@angular/forms/signals'
         <input [formField]="urlForm.website" />
       </label>
     </form>
-  `
+  `,
 })
 export class UrlFormComponent {
-  urlModel = signal({ website: '' })
+  urlModel = signal({website: ''});
 
   urlForm = form(this.urlModel, (schemaPath) => {
     validate(schemaPath.website, ({value}) => {
       if (!value().startsWith('https://')) {
         return {
           kind: 'https',
-          message: 'URL must start with https://'
-        }
+          message: 'URL must start with https://',
+        };
       }
 
-      return null
-    })
-  })
+      return null;
+    });
+  });
 }
 ```
 
@@ -541,8 +541,8 @@ Cross-field validation compares or relates multiple field values.
 A common scenario for cross-field validation is password confirmation:
 
 ```angular-ts
-import { Component, signal } from '@angular/core'
-import { form, FormField, required, minLength, validate } from '@angular/forms/signals'
+import {Component, signal} from '@angular/core';
+import {form, FormField, required, minLength, validate} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-password-change',
@@ -561,34 +561,34 @@ import { form, FormField, required, minLength, validate } from '@angular/forms/s
 
       <button type="submit">Change Password</button>
     </form>
-  `
+  `,
 })
 export class PasswordChangeComponent {
   passwordModel = signal({
     password: '',
-    confirmPassword: ''
-  })
+    confirmPassword: '',
+  });
 
   passwordForm = form(this.passwordModel, (schemaPath) => {
-    required(schemaPath.password, { message: 'Password is required' })
-    minLength(schemaPath.password, 8, { message: 'Password must be at least 8 characters' })
+    required(schemaPath.password, {message: 'Password is required'});
+    minLength(schemaPath.password, 8, {message: 'Password must be at least 8 characters'});
 
-    required(schemaPath.confirmPassword, { message: 'Please confirm your password' })
+    required(schemaPath.confirmPassword, {message: 'Please confirm your password'});
 
     validate(schemaPath.confirmPassword, ({value, valueOf}) => {
-      const confirmPassword = value()
-      const password = valueOf(schemaPath.password)
+      const confirmPassword = value();
+      const password = valueOf(schemaPath.password);
 
       if (confirmPassword !== password) {
         return {
           kind: 'passwordMismatch',
-          message: 'Passwords do not match'
-        }
+          message: 'Passwords do not match',
+        };
       }
 
-      return null
-    })
-  })
+      return null;
+    });
+  });
 }
 ```
 
@@ -603,9 +603,9 @@ Async validation handles validation that requires external data sources, like ch
 The `validateHttp()` function performs HTTP-based validation:
 
 ```angular-ts
-import { Component, signal, inject } from '@angular/core'
-import { HttpClient } from '@angular/common/http'
-import { form, FormField, required, validateHttp } from '@angular/forms/signals'
+import {Component, signal, inject} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {form, FormField, required, validateHttp} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-username-form',
@@ -621,15 +621,15 @@ import { form, FormField, required, validateHttp } from '@angular/forms/signals'
         }
       </label>
     </form>
-  `
+  `,
 })
 export class UsernameFormComponent {
-  http = inject(HttpClient)
+  http = inject(HttpClient);
 
-  usernameModel = signal({ username: '' })
+  usernameModel = signal({username: ''});
 
   usernameForm = form(this.usernameModel, (schemaPath) => {
-    required(schemaPath.username, { message: 'Username is required' })
+    required(schemaPath.username, {message: 'Username is required'});
 
     validateHttp(schemaPath.username, {
       request: ({value}) => `/api/check-username?username=${value()}`,
@@ -637,17 +637,17 @@ export class UsernameFormComponent {
         if (response.taken) {
           return {
             kind: 'usernameTaken',
-            message: 'Username is already taken'
-          }
+            message: 'Username is already taken',
+          };
         }
-        return null
+        return null;
       },
       onError: (error) => ({
         kind: 'networkError',
-        message: 'Could not verify username availability'
-      })
-    })
-  })
+        message: 'Could not verify username availability',
+      }),
+    });
+  });
 }
 ```
 

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -648,7 +648,7 @@ export class UserService {
 Within a component, you can combine `@if` with the `async` pipe to render the UI for the data only after it's finished loading:
 
 ```angular-ts
-import { AsyncPipe } from '@angular/common';
+import {AsyncPipe} from '@angular/common';
 
 @Component({
   imports: [AsyncPipe],

--- a/adev/src/content/guide/i18n/format-data-locale.md
+++ b/adev/src/content/guide/i18n/format-data-locale.md
@@ -25,7 +25,7 @@ Add the `locale` parameter to the pipe to override the current value of `LOCALE_
 To force the currency to use American English \(`en-US`\), use the following format for the `CurrencyPipe`
 
 ```angular-html
-{{ amount | currency : 'en-US' }}
+{{ amount | currency: 'en-US' }}
 ```
 
 HELPFUL: The locale specified for the `CurrencyPipe` overrides the global `LOCALE_ID` token of your application.

--- a/adev/src/content/guide/incremental-hydration.md
+++ b/adev/src/content/guide/incremental-hydration.md
@@ -175,7 +175,7 @@ Hydrate triggers are additional triggers that are used alongside regular trigger
 ```angular-html
 @defer (on idle; hydrate on interaction) {
   <example-cmp />
-} @placeholder{
+} @placeholder {
   <div>Example Placeholder</div>
 }
 ```
@@ -194,7 +194,7 @@ Angular's component and dependency system is hierarchical, which means hydrating
   } @placeholder {
     <div>Child placeholder</div>
   }
-} @placeholder{
+} @placeholder {
   <div>Parent Placeholder</div>
 }
 ```

--- a/adev/src/content/guide/routing/common-router-tasks.md
+++ b/adev/src/content/guide/routing/common-router-tasks.md
@@ -92,14 +92,15 @@ The following is a two-element array when specifying a route parameter:
 
 ```angular-html
 <a [routerLink]="['/hero', hero.id]">
-  <span class="badge">{{ hero.id }}</span>{{ hero.name }}
+  <span class="badge">{{ hero.id }}</span
+  >{{ hero.name }}
 </a>
 ```
 
 Provide optional route parameters in an object, as in `{ foo: 'foo' }`:
 
 ```angular-html
-<a [routerLink]="['/crisis-center', { foo: 'foo' }]">Crisis Center</a>
+<a [routerLink]="['/crisis-center', {foo: 'foo'}]">Crisis Center</a>
 ```
 
 This syntax passes matrix parameters, which are optional parameters associated with a specific URL segment. Learn more about [matrix parameters](/guide/routing/read-route-state#matrix-parameters).
@@ -141,11 +142,11 @@ You could also redefine the `AppComponent` template with Crisis Center routes ex
     <h1 class="title">Angular Router</h1>
     <nav>
       <a [routerLink]="['/crisis-center']">Crisis Center</a>
-      <a [routerLink]="['/crisis-center/1', { foo: 'foo' }]">Dragon Crisis</a>
+      <a [routerLink]="['/crisis-center/1', {foo: 'foo'}]">Dragon Crisis</a>
       <a [routerLink]="['/crisis-center/2']">Shark Crisis</a>
     </nav>
     <router-outlet />
-  `
+  `,
 })
 export class AppComponent {}
 ```

--- a/adev/src/content/guide/routing/customizing-route-behavior.md
+++ b/adev/src/content/guide/routing/customizing-route-behavior.md
@@ -224,7 +224,7 @@ When implementing a custom `RouteReuseStrategy`, you may need to manually destro
 Since `DetachedRouteHandle` is an opaque type, you cannot call a destroy method directly on it. Instead, use the `destroyDetachedRouteHandle` function provided by the Router.
 
 ```ts
-import { destroyDetachedRouteHandle } from '@angular/router';
+import {destroyDetachedRouteHandle} from '@angular/router';
 
 // ... inside your strategy
 if (this.handles.size > MAX_CACHE_SIZE) {
@@ -245,12 +245,10 @@ By default, Angular does not destroy the injectors of detached routes, even if t
 To enable automatic cleanup of unused route injectors, you can use the `withExperimentalAutoCleanupInjectors` feature in your router configuration. This feature checks which routes are currently stored by the strategy after navigations and destroys the injectors of any detached routes that are not currently stored by the reuse strategy.
 
 ```ts
-import { provideRouter, withExperimentalAutoCleanupInjectors } from '@angular/router';
+import {provideRouter, withExperimentalAutoCleanupInjectors} from '@angular/router';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes, withExperimentalAutoCleanupInjectors())
-  ]
+  providers: [provideRouter(routes, withExperimentalAutoCleanupInjectors())],
 };
 ```
 
@@ -528,8 +526,8 @@ export const routes: Routes = [
 The component receives the extracted parameters through route inputs:
 
 ```angular-ts
-import { Component, input, inject } from '@angular/core';
-import { resource } from '@angular/core';
+import {Component, input, inject} from '@angular/core';
+import {resource} from '@angular/core';
 
 @Component({
   selector: 'app-documentation',
@@ -541,12 +539,12 @@ import { resource } from '@angular/core';
     } @else if (documentation.value(); as docs) {
       <article>{{ docs.content }}</article>
     }
-  `
+  `,
 })
 export class DocumentationComponent {
   // Route parameters are automatically bound to signal inputs
-  version = input.required<string>();  // Receives the version parameter
-  section = input.required<string>();  // Receives the section parameter
+  version = input.required<string>(); // Receives the version parameter
+  section = input.required<string>(); // Receives the section parameter
 
   private docsService = inject(DocumentationService);
 
@@ -557,13 +555,13 @@ export class DocumentationComponent {
 
       return {
         version: this.version(),
-        section: this.section()
-      }
+        section: this.section(),
+      };
     },
-    loader: ({ params }) => {
+    loader: ({params}) => {
       return this.docsService.loadDocumentation(params.version, params.section);
-    }
-  })
+    },
+  });
 }
 ```
 

--- a/adev/src/content/guide/routing/data-resolvers.md
+++ b/adev/src/content/guide/routing/data-resolvers.md
@@ -76,17 +76,17 @@ You can learn more about the [`resolve` configuration in the API docs](api/route
 You can access the resolved data in a component by accessing the snapshot data from the `ActivatedRoute` using the `signal` function:
 
 ```angular-ts
-import { Component, inject, computed } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
-import type { User, Settings } from './types';
+import {Component, inject, computed} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {toSignal} from '@angular/core/rxjs-interop';
+import type {User, Settings} from './types';
 
 @Component({
   template: `
     <h1>{{ user().name }}</h1>
     <p>{{ user().email }}</p>
     <div>Theme: {{ settings().theme }}</div>
-  `
+  `,
 })
 export class UserDetail {
   private route = inject(ActivatedRoute);
@@ -113,15 +113,15 @@ bootstrapApplication(App, {
 With this configuration, you can define inputs in your component that match the resolver keys using the `input` function and `input.required` for required inputs:
 
 ```angular-ts
-import { Component, input } from '@angular/core';
-import type { User, Settings } from './types';
+import {Component, input} from '@angular/core';
+import type {User, Settings} from './types';
 
 @Component({
   template: `
     <h1>{{ user().name }}</h1>
     <p>{{ user().email }}</p>
     <div>Theme: {{ settings().theme }}</div>
-  `
+  `,
 })
 export class UserDetail {
   user = input.required<User>();
@@ -186,10 +186,10 @@ export const userResolver: ResolveFn<User> = (route) => {
 You can also handle resolver errors by subscribing to router events and listening for `NavigationError` events. This approach gives you more granular control over error handling and allows you to implement custom error recovery logic.
 
 ```angular-ts
-import { Component, inject, signal } from '@angular/core';
-import { Router, NavigationError } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { map } from 'rxjs';
+import {Component, inject, signal} from '@angular/core';
+import {Router, NavigationError} from '@angular/router';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {map} from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -201,7 +201,7 @@ import { map } from 'rxjs';
       </div>
     }
     <router-outlet />
-  `
+  `,
 })
 export class App {
   private router = inject(Router);
@@ -209,20 +209,20 @@ export class App {
 
   private navigationErrors = toSignal(
     this.router.events.pipe(
-      map(event => {
+      map((event) => {
         if (event instanceof NavigationError) {
           this.lastFailedUrl.set(event.url);
 
           if (event.error) {
-            console.error('Navigation error', event.error)
+            console.error('Navigation error', event.error);
           }
 
           return 'Navigation failed. Please try again.';
         }
         return '';
-      })
+      }),
     ),
-    { initialValue: '' }
+    {initialValue: ''},
   );
 
   errorMessage = this.navigationErrors;
@@ -275,8 +275,8 @@ While data resolvers prevent loading states within components, they introduce a 
 To improve user experience during resolver execution, you can listen to router events and show loading indicators:
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-root',
@@ -285,7 +285,7 @@ import { Router } from '@angular/router';
       <div class="loading-bar">Loading...</div>
     }
     <router-outlet />
-  `
+  `,
 })
 export class App {
   private router = inject(Router);

--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -85,8 +85,8 @@ Router events enable many practical features in real-world applications. Here ar
 Show loading indicators during navigation:
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-root',
@@ -95,7 +95,7 @@ import { Router } from '@angular/router';
       <div class="loading-bar">Loading...</div>
     }
     <router-outlet />
-  `
+  `,
 })
 export class App {
   private router = inject(Router);
@@ -140,9 +140,15 @@ export class AnalyticsService {
 Handle navigation errors gracefully and provide user feedback:
 
 ```angular-ts
-import { Component, inject, signal } from '@angular/core';
-import { Router, NavigationStart, NavigationError, NavigationCancel, NavigationCancellationCode } from '@angular/router';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {Component, inject, signal} from '@angular/core';
+import {
+  Router,
+  NavigationStart,
+  NavigationError,
+  NavigationCancel,
+  NavigationCancellationCode,
+} from '@angular/router';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-error-handler',
@@ -153,14 +159,14 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         <button (click)="dismissError()">Dismiss</button>
       </div>
     }
-  `
+  `,
 })
 export class ErrorHandlerComponent {
   private router = inject(Router);
   readonly errorMessage = signal('');
 
   constructor() {
-    this.router.events.pipe(takeUntilDestroyed()).subscribe(event => {
+    this.router.events.pipe(takeUntilDestroyed()).subscribe((event) => {
       if (event instanceof NavigationStart) {
         this.errorMessage.set('');
       } else if (event instanceof NavigationError) {

--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -79,13 +79,11 @@ While `RouterLink` handles declarative navigation in templates, Angular provides
 You can use the `router.navigate()` method to programmatically navigate between routes by specifying a URL path array.
 
 ```angular-ts
-import { Router } from '@angular/router';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
-  template: `
-    <button (click)="navigateToProfile()">View Profile</button>
-  `
+  template: ` <button (click)="navigateToProfile()">View Profile</button> `,
 })
 export class AppDashboard {
   private router = inject(Router);
@@ -99,11 +97,11 @@ export class AppDashboard {
 
     // With query parameters
     this.router.navigate(['/search'], {
-      queryParams: { category: 'books', sort: 'price' }
+      queryParams: {category: 'books', sort: 'price'},
     });
 
     // With matrix parameters
-    this.router.navigate(['/products', { featured: true, onSale: true }]);
+    this.router.navigate(['/products', {featured: true, onSale: true}]);
   }
 }
 ```
@@ -113,14 +111,14 @@ export class AppDashboard {
 You can also build dynamic navigation paths relative to your component’s location in the routing tree using the `relativeTo` option.
 
 ```angular-ts
-import { Router, ActivatedRoute } from '@angular/router';
+import {Router, ActivatedRoute} from '@angular/router';
 
 @Component({
   selector: 'app-user-detail',
   template: `
     <button (click)="navigateToEdit()">Edit User</button>
     <button (click)="navigateToParent()">Back to List</button>
-  `
+  `,
 })
 export class UserDetailComponent {
   private route = inject(ActivatedRoute);
@@ -132,14 +130,14 @@ export class UserDetailComponent {
   navigateToEdit() {
     // From: /users/123
     // To:   /users/123/edit
-    this.router.navigate(['edit'], { relativeTo: this.route });
+    this.router.navigate(['edit'], {relativeTo: this.route});
   }
 
   // Navigate to parent
   navigateToParent() {
     // From: /users/123
     // To:   /users
-    this.router.navigate(['..'], { relativeTo: this.route });
+    this.router.navigate(['..'], {relativeTo: this.route});
   }
 }
 ```

--- a/adev/src/content/guide/routing/read-route-state.md
+++ b/adev/src/content/guide/routing/read-route-state.md
@@ -7,8 +7,8 @@ Angular Router allows you to read and use information associated with a route to
 `ActivatedRoute` is a service from `@angular/router` that provides all the information associated with the current route.
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import {Component} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
   selector: 'app-product',
@@ -42,9 +42,11 @@ Route snapshots contain essential information about the route, including its par
 Here’s an example of how you’d access a route snapshot:
 
 ```angular-ts
-import { ActivatedRoute, ActivatedRouteSnapshot } from '@angular/router';
+import {ActivatedRoute, ActivatedRouteSnapshot} from '@angular/router';
 
-@Component({/*...*/})
+@Component({
+  /*...*/
+})
 export class UserProfileComponent {
   readonly userId: string;
   private route = inject(ActivatedRoute);
@@ -58,11 +60,11 @@ export class UserProfileComponent {
     // Access multiple route elements
     const snapshot = this.route.snapshot;
     console.log({
-      url: snapshot.url,           // https://www.angular.dev
+      url: snapshot.url, // https://www.angular.dev
       // Route parameters object: {id: '123'}
       params: snapshot.params,
       // Query parameters object: {role: 'admin', status: 'active'}
-      queryParams: snapshot.queryParams,  // Query parameters
+      queryParams: snapshot.queryParams, // Query parameters
     });
   }
 }
@@ -81,19 +83,17 @@ Route parameters allow you to pass data to a component through the URL. This is 
 You can [define route parameters](/guide/routing/define-routes#define-url-paths-with-route-parameters) by prefixing the parameter name with a colon (`:`).
 
 ```angular-ts
-import { Routes } from '@angular/router';
-import { ProductComponent } from './product/product.component';
+import {Routes} from '@angular/router';
+import {ProductComponent} from './product/product.component';
 
-const routes: Routes = [
-  { path: 'product/:id', component: ProductComponent }
-];
+const routes: Routes = [{path: 'product/:id', component: ProductComponent}];
 ```
 
 You can access parameters by subscribing to `route.params`.
 
 ```angular-ts
-import { Component, inject, signal } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import {Component, inject, signal} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
   selector: 'app-product-detail',
@@ -120,7 +120,7 @@ export class ProductDetailComponent {
 // Single parameter structure
 // /products?category=electronics
 router.navigate(['/products'], {
-  queryParams: { category: 'electronics' }
+  queryParams: {category: 'electronics'},
 });
 
 // Multiple parameters
@@ -129,8 +129,8 @@ router.navigate(['/products'], {
   queryParams: {
     category: 'electronics',
     sort: 'price',
-    page: 1
-  }
+    page: 1,
+  },
 });
 ```
 
@@ -139,7 +139,7 @@ You can access query parameters with `route.queryParams`.
 Here is an example of a `ProductListComponent` that updates the query parameters that affect how it displays a list of products:
 
 ```angular-ts
-import { ActivatedRoute, Router } from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 
 @Component({
   selector: 'app-product-list',
@@ -151,7 +151,7 @@ import { ActivatedRoute, Router } from '@angular/router';
       </select>
       <!-- Products list -->
     </div>
-  `
+  `,
 })
 export class ProductListComponent implements OnInit {
   private route = inject(ActivatedRoute);
@@ -159,7 +159,7 @@ export class ProductListComponent implements OnInit {
 
   constructor() {
     // Access query parameters reactively
-    this.route.queryParams.subscribe(params => {
+    this.route.queryParams.subscribe((params) => {
       const sort = params['sort'] || 'price';
       const page = Number(params['page']) || 1;
       this.loadProducts(sort, page);
@@ -170,8 +170,8 @@ export class ProductListComponent implements OnInit {
     const sort = (event.target as HTMLSelectElement).value;
     // Update URL with new query parameter
     this.router.navigate([], {
-      queryParams: { sort },
-      queryParamsHandling: 'merge' // Preserve other query parameters
+      queryParams: {sort},
+      queryParamsHandling: 'merge', // Preserve other query parameters
     });
   }
 }
@@ -224,16 +224,21 @@ You can use the `RouterLinkActive` directive to dynamically style navigation ele
 
 ```angular-html
 <nav>
-  <a class="button"
-     routerLink="/about"
-     routerLinkActive="active-button"
-     ariaCurrentWhenActive="page">
+  <a
+    class="button"
+    routerLink="/about"
+    routerLinkActive="active-button"
+    ariaCurrentWhenActive="page"
+  >
     About
-  </a> |
-  <a class="button"
-     routerLink="/settings"
-     routerLinkActive="active-button"
-     ariaCurrentWhenActive="page">
+  </a>
+  |
+  <a
+    class="button"
+    routerLink="/settings"
+    routerLinkActive="active-button"
+    ariaCurrentWhenActive="page"
+  >
     Settings
   </a>
 </nav>
@@ -260,12 +265,8 @@ If you want to define a different value for aria, you’ll need to explicitly se
 By default, `RouterLinkActive` considers any ancestors in the route a match.
 
 ```angular-html
-<a [routerLink]="['/user/jane']" routerLinkActive="active-link">
-  User
-</a>
-<a [routerLink]="['/user/jane/role/admin']" routerLinkActive="active-link">
-  Role
-</a>
+<a [routerLink]="['/user/jane']" routerLinkActive="active-link"> User </a>
+<a [routerLink]="['/user/jane/role/admin']" routerLinkActive="active-link"> Role </a>
 ```
 
 When the user visits `/user/jane/role/admin`, both links would have the `active-link` class.
@@ -275,13 +276,15 @@ When the user visits `/user/jane/role/admin`, both links would have the `active-
 If you only want to apply the class on an exact match, you need to provide the `routerLinkActiveOptions` directive with a configuration object that contains the value `exact: true`.
 
 ```angular-html
-<a [routerLink]="['/user/jane']"
+<a
+  [routerLink]="['/user/jane']"
   routerLinkActive="active-link"
   [routerLinkActiveOptions]="{exact: true}"
 >
   User
 </a>
-<a [routerLink]="['/user/jane/role/admin']"
+<a
+  [routerLink]="['/user/jane/role/admin']"
   routerLinkActive="active-link"
   [routerLinkActiveOptions]="{exact: true}"
 >
@@ -337,7 +340,7 @@ import {isActive, Router} from '@angular/router';
     <div [class.active]="isSettingsActive()">
       <h2>Settings</h2>
     </div>
-  `
+  `,
 })
 export class Panel {
   private router = inject(Router);
@@ -346,7 +349,7 @@ export class Panel {
     paths: 'subset',
     queryParams: 'ignored',
     fragment: 'ignored',
-    matrixParams: 'ignored'
+    matrixParams: 'ignored',
   });
 }
 ```

--- a/adev/src/content/guide/routing/router-reference.md
+++ b/adev/src/content/guide/routing/router-reference.md
@@ -83,7 +83,7 @@ While the router uses the [HTML5 pushState](https://developer.mozilla.org/docs/W
 The preferred way to configure the strategy is to add a [`<base href>` element](https://developer.mozilla.org/docs/Web/HTML/Element/base 'base href') tag in the `<head>` of the `index.html`.
 
 ```angular-html
-<base href="/">
+<base href="/" />
 ```
 
 Without that tag, the browser might not be able to load resources \(images, CSS, scripts\) when "deep linking" into the application.

--- a/adev/src/content/guide/routing/show-routes-with-outlets.md
+++ b/adev/src/content/guide/routing/show-routes-with-outlets.md
@@ -3,8 +3,8 @@
 The `RouterOutlet` directive is a placeholder that marks the location where the router should render the component for the current URL.
 
 ```angular-html
-<app-header />
-<router-outlet />  <!-- Angular inserts your route content here -->
+<app-header /> <router-outlet />
+<!-- Angular inserts your route content here -->
 <app-footer />
 ```
 
@@ -124,8 +124,8 @@ Pages may have multiple outlets— you can assign a name to each outlet to speci
 ```angular-html
 <app-header />
 <router-outlet />
-<router-outlet name='read-more' />
-<router-outlet name='additional-actions' />
+<router-outlet name="read-more" />
+<router-outlet name="additional-actions" />
 <app-footer />
 ```
 
@@ -156,10 +156,10 @@ You can add event listeners with the standard event binding syntax:
 
 ```angular-html
 <router-outlet
-  (activate)='onActivate($event)'
-  (deactivate)='onDeactivate($event)'
-  (attach)='onAttach($event)'
-  (detach)='onDetach($event)'
+  (activate)="onActivate($event)"
+  (deactivate)="onDeactivate($event)"
+  (attach)="onAttach($event)"
+  (detach)="onDetach($event)"
 />
 ```
 
@@ -170,15 +170,15 @@ Check out the [API docs for RouterOutlet](/api/router/RouterOutlet?tab=api) if y
 Passing contextual data to routed components often requires global state or complicated route configurations. To make this easier, each `RouterOutlet` supports a `routerOutletData` input. Routed components and their children can read this data as a signal using the `ROUTER_OUTLET_DATA` injection token, allowing outlet-specific configuration without modifying route definitions.
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import {Component} from '@angular/core';
+import {RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
   imports: [RouterOutlet],
   template: `
     <h2>Dashboard</h2>
-    <router-outlet [routerOutletData]="{ layout: 'sidebar' }" />
+    <router-outlet [routerOutletData]="{layout: 'sidebar'}" />
   `,
 })
 export class DashboardComponent {}
@@ -187,15 +187,15 @@ export class DashboardComponent {}
 The routed component can inject the provided outlet data using `ROUTER_OUTLET_DATA`:
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { ROUTER_OUTLET_DATA } from '@angular/router';
+import {Component, inject} from '@angular/core';
+import {ROUTER_OUTLET_DATA} from '@angular/router';
 
 @Component({
   selector: 'app-stats',
   template: `<p>Stats view (layout: {{ outletData().layout }})</p>`,
 })
 export class StatsComponent {
-  outletData = inject(ROUTER_OUTLET_DATA) as Signal<{ layout: string }>;
+  outletData = inject(ROUTER_OUTLET_DATA) as Signal<{layout: string}>;
 }
 ```
 

--- a/adev/src/content/guide/routing/show-routes-with-outlets.md
+++ b/adev/src/content/guide/routing/show-routes-with-outlets.md
@@ -2,9 +2,10 @@
 
 The `RouterOutlet` directive is a placeholder that marks the location where the router should render the component for the current URL.
 
-```angular-html
-<app-header /> <router-outlet />
+```html
+<app-header />
 <!-- Angular inserts your route content here -->
+<router-outlet />
 <app-footer />
 ```
 

--- a/adev/src/content/guide/routing/testing.md
+++ b/adev/src/content/guide/routing/testing.md
@@ -43,11 +43,11 @@ describe('UserProfile', () => {
 
 ```angular-ts
 // user-profile.component.ts
-import { Component, inject } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import {Component, inject} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
-  template: '<h1>User Profile: {{userId}}</h1>'
+  template: '<h1>User Profile: {{userId}}</h1>',
 })
 export class UserProfile {
   private route = inject(ActivatedRoute);
@@ -183,8 +183,8 @@ describe('App Router Outlet', () => {
 
 ```angular-ts
 // app.component.ts
-import { Component } from '@angular/core';
-import { RouterOutlet, RouterLink } from '@angular/router';
+import {Component} from '@angular/core';
+import {RouterOutlet, RouterLink} from '@angular/router';
 
 @Component({
   imports: [RouterOutlet, RouterLink],
@@ -194,7 +194,7 @@ import { RouterOutlet, RouterLink } from '@angular/router';
       <a routerLink="/about">About</a>
     </nav>
     <router-outlet />
-  `
+  `,
 })
 export class App {}
 ```
@@ -249,20 +249,20 @@ describe('Nested Routes', () => {
 
 ```angular-ts
 // nested-components.ts
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import {Component} from '@angular/core';
+import {RouterOutlet} from '@angular/router';
 
 @Component({
   imports: [RouterOutlet],
   template: `
     <h1>Parent Component</h1>
     <router-outlet />
-  `
+  `,
 })
 export class Parent {}
 
 @Component({
-  template: '<h2>Child Component</h2>'
+  template: '<h2>Child Component</h2>',
 })
 export class Child {}
 ```
@@ -305,16 +305,16 @@ describe('Search', () => {
 
 ```angular-ts
 // search.component.ts
-import { Component, inject, computed } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
+import {Component, inject, computed} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {toSignal} from '@angular/core/rxjs-interop';
 
 @Component({
-  template: '<div>Search term: {{searchTerm()}}</div>'
+  template: '<div>Search term: {{searchTerm()}}</div>',
 })
 export class Search {
   private route = inject(ActivatedRoute);
-  private queryParams = toSignal(this.route.queryParams, { initialValue: {} });
+  private queryParams = toSignal(this.route.queryParams, {initialValue: {}});
 
   searchTerm = computed(() => this.queryParams()['q'] || null);
 }

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -246,7 +246,7 @@ Some common browser APIs and capabilities might not be available on the server. 
 In general, code which relies on browser-specific symbols should only be executed in the browser, not on the server. This can be enforced through the `afterEveryRender` and `afterNextRender` lifecycle hooks. These are only executed on the browser and skipped on the server.
 
 ```angular-ts
-import { Component, viewChild, afterNextRender } from '@angular/core';
+import {Component, viewChild, afterNextRender} from '@angular/core';
 
 @Component({
   selector: 'my-cmp',
@@ -373,7 +373,7 @@ The `@angular/core` package provides several tokens for interacting with the ser
 - **[`REQUEST_CONTEXT`](api/core/REQUEST_CONTEXT 'API reference'):** Provides access to additional context related to the current request. This context can be passed as the second parameter of the [`handle`](api/ssr/AngularAppEngine#handle 'API reference') function. Typically, this is used to provide additional request-related information that is not part of the standard Web API.
 
 ```angular-ts
-import { inject, REQUEST } from '@angular/core';
+import {inject, REQUEST} from '@angular/core';
 
 @Component({
   selector: 'app-my-component',

--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -95,9 +95,10 @@ You can bind to directive properties as well.
 
 When you need to set HTML attributes that do not have corresponding DOM properties, such as SVG attributes, you can bind attributes to elements in your template with the `attr.` prefix.
 
+<!-- prettier-ignore -->
 ```angular-html
 <!-- Bind the `role` attribute on the `<ul>` element to the component's `listRole` property. -->
-<ul [attr.role]="listRole()"></ul>
+<ul [attr.role]="listRole()">
 ```
 
 In this example, every time `listRole` changes, Angular automatically sets the `role` attribute of the `<ul>` element by calling `setAttribute`.
@@ -121,9 +122,10 @@ Angular supports additional features for binding CSS classes and CSS style prope
 
 You can create a CSS class binding to conditionally add or remove a CSS class on an element based on whether the bound value is [truthy or falsy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy).
 
+<!-- prettier-ignore -->
 ```angular-html
 <!-- When `isExpanded` is truthy, add the `expanded` CSS class. -->
-<ul [class.expanded]="isExpanded()"></ul>
+<ul [class.expanded]="isExpanded()">
 ```
 
 You can also bind directly to the `class` property. Angular accepts three types of value:
@@ -155,12 +157,11 @@ export class UserProfile {
 
 The above example renders the following DOM:
 
+<!-- prettier-ignore -->
 ```angular-html
-<ul class="full-width outlined">
-  ...
-</ul>
-<section class="expandable elevated">...</section>
-<button class="highlighted">...</button>
+<ul class="full-width outlined"> ... </ul>
+<section class="expandable elevated"> ... </section>
+<button class="highlighted"> ... </button>
 ```
 
 Angular ignores any string values that are not valid CSS class names.
@@ -180,8 +181,9 @@ export class Listbox {
 
 In the example above, Angular renders the `ul` element with all three CSS classes.
 
+<!-- prettier-ignore -->
 ```angular-html
-<ul class="list box expanded"></ul>
+<ul class="list box expanded">
 ```
 
 Angular does not guarantee any specific order of CSS classes on rendered elements.
@@ -196,16 +198,18 @@ NOTE: Class bindings do not support space-separated class names in a single key.
 
 You can also bind to CSS style properties directly on an element.
 
+<!-- prettier-ignore -->
 ```angular-html
 <!-- Set the CSS `display` property based on the `isExpanded` property. -->
-<section [style.display]="isExpanded() ? 'block' : 'none'"></section>
+<section [style.display]="isExpanded() ? 'block' : 'none'">
 ```
 
 You can further specify units for CSS properties that accept units.
 
+<!-- prettier-ignore -->
 ```angular-html
 <!-- Set the CSS `height` property to a pixel value based on the `sectionHeightInPixels` property. -->
-<section [style.height.px]="sectionHeightInPixels()"></section>
+<section [style.height.px]="sectionHeightInPixels()">
 ```
 
 You can also set multiple style values in one binding. Angular accepts the following types of value:
@@ -234,11 +238,10 @@ export class UserProfile {
 
 The above example renders the following DOM.
 
+<!-- prettier-ignore -->
 ```angular-html
-<ul style="display: flex; padding: 8px">
-  ...
-</ul>
-<section style="border: 1px solid black; font-weight: bold">...</section>
+<ul style="display: flex; padding: 8px"> ... </ul>
+<section style="border: 1px solid black; font-weight: bold"> ... </section>
 ```
 
 When binding `style` to an object, Angular compares the previous value to the current value with the triple-equals operator (`===`). You must create a new object instance when you modify these values in order to Angular to apply any updates.

--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -88,7 +88,7 @@ You can bind to directive properties as well.
 
 ```angular-html
 <!-- Bind to the `ngSrc` property of the `NgOptimizedImage` directive  -->
-<img [ngSrc]="profilePhotoUrl()" alt="The current user's profile photo">
+<img [ngSrc]="profilePhotoUrl()" alt="The current user's profile photo" />
 ```
 
 ### Attributes
@@ -97,7 +97,7 @@ When you need to set HTML attributes that do not have corresponding DOM properti
 
 ```angular-html
 <!-- Bind the `role` attribute on the `<ul>` element to the component's `listRole` property. -->
-<ul [attr.role]="listRole()">
+<ul [attr.role]="listRole()"></ul>
 ```
 
 In this example, every time `listRole` changes, Angular automatically sets the `role` attribute of the `<ul>` element by calling `setAttribute`.
@@ -110,7 +110,7 @@ You can also use text interpolation syntax in properties and attributes by using
 
 ```angular-html
 <!-- Binds a value to the `alt` property of the image element's DOM object. -->
-<img src="profile-photo.jpg" alt="Profile photo of {{ firstName() }}" >
+<img src="profile-photo.jpg" alt="Profile photo of {{ firstName() }}" />
 ```
 
 ## CSS class and style property bindings
@@ -123,7 +123,7 @@ You can create a CSS class binding to conditionally add or remove a CSS class on
 
 ```angular-html
 <!-- When `isExpanded` is truthy, add the `expanded` CSS class. -->
-<ul [class.expanded]="isExpanded()">
+<ul [class.expanded]="isExpanded()"></ul>
 ```
 
 You can also bind directly to the `class` property. Angular accepts three types of value:
@@ -156,9 +156,11 @@ export class UserProfile {
 The above example renders the following DOM:
 
 ```angular-html
-<ul class="full-width outlined"> ... </ul>
-<section class="expandable elevated"> ... </section>
-<button class="highlighted"> ... </button>
+<ul class="full-width outlined">
+  ...
+</ul>
+<section class="expandable elevated">...</section>
+<button class="highlighted">...</button>
 ```
 
 Angular ignores any string values that are not valid CSS class names.
@@ -179,7 +181,7 @@ export class Listbox {
 In the example above, Angular renders the `ul` element with all three CSS classes.
 
 ```angular-html
-<ul class="list box expanded">
+<ul class="list box expanded"></ul>
 ```
 
 Angular does not guarantee any specific order of CSS classes on rendered elements.
@@ -196,14 +198,14 @@ You can also bind to CSS style properties directly on an element.
 
 ```angular-html
 <!-- Set the CSS `display` property based on the `isExpanded` property. -->
-<section [style.display]="isExpanded() ? 'block' : 'none'">
+<section [style.display]="isExpanded() ? 'block' : 'none'"></section>
 ```
 
 You can further specify units for CSS properties that accept units.
 
 ```angular-html
 <!-- Set the CSS `height` property to a pixel value based on the `sectionHeightInPixels` property. -->
-<section [style.height.px]="sectionHeightInPixels()">
+<section [style.height.px]="sectionHeightInPixels()"></section>
 ```
 
 You can also set multiple style values in one binding. Angular accepts the following types of value:
@@ -233,8 +235,10 @@ export class UserProfile {
 The above example renders the following DOM.
 
 ```angular-html
-<ul style="display: flex; padding: 8px"> ... </ul>
-<section style="border: 1px solid black; font-weight: bold"> ... </section>
+<ul style="display: flex; padding: 8px">
+  ...
+</ul>
+<section style="border: 1px solid black; font-weight: bold">...</section>
 ```
 
 When binding `style` to an object, Angular compares the previous value to the current value with the triple-equals operator (`===`). You must create a new object instance when you modify these values in order to Angular to apply any updates.

--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -8,7 +8,7 @@ The `@if` block conditionally displays its content when its condition expression
 
 ```angular-html
 @if (a > b) {
-  <p>{{a}} is greater than {{b}}</p>
+  <p>{{ a }} is greater than {{ b }}</p>
 }
 ```
 
@@ -16,11 +16,11 @@ If you want to display alternative content, you can do so by providing any numbe
 
 ```angular-html
 @if (a > b) {
-  {{a}} is greater than {{b}}
+  {{ a }} is greater than {{ b }}
 } @else if (b > a) {
-  {{a}} is less than {{b}}
+  {{ a }} is less than {{ b }}
 } @else {
-  {{a}} is equal to {{b}}
+  {{ a }} is equal to {{ b }}
 }
 ```
 
@@ -99,9 +99,9 @@ You can optionally include an `@empty` section immediately after the `@for` bloc
 
 ```angular-html
 @for (item of items; track item.name) {
-  <li> {{ item.name }}</li>
+  <li>{{ item.name }}</li>
 } @empty {
-  <li> There are no items. </li>
+  <li>There are no items.</li>
 }
 ```
 

--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -317,7 +317,7 @@ it('should render a defer block in different states', async () => {
       } @loading {
         Loading...
       }
-    `
+    `,
   })
   class ExampleA {}
   // Create component fixture.

--- a/adev/src/content/guide/templates/ng-container.md
+++ b/adev/src/content/guide/templates/ng-container.md
@@ -37,11 +37,11 @@ You can use Angular's built-in `NgComponentOutlet` directive to dynamically rend
   template: `
     <h2>Your profile</h2>
     <ng-container [ngComponentOutlet]="profileComponent()" />
-  `
+  `,
 })
 export class UserProfile {
   isAdmin = input(false);
-  profileComponent = computed(() => this.isAdmin() ? AdminProfile : BasicUserProfile);
+  profileComponent = computed(() => (this.isAdmin() ? AdminProfile : BasicUserProfile));
 }
 ```
 
@@ -59,13 +59,13 @@ You can use Angular's built-in `NgTemplateOutlet` directive to dynamically rende
 
     <ng-template #admin>This is the admin profile</ng-template>
     <ng-template #basic>This is the basic profile</ng-template>
-  `
+  `,
 })
 export class UserProfile {
   isAdmin = input(false);
   adminTemplate = viewChild('admin', {read: TemplateRef});
   basicTemplate = viewChild('basic', {read: TemplateRef});
-  profileTemplate = computed(() => this.isAdmin() ? this.adminTemplate() : this.basicTemplate());
+  profileTemplate = computed(() => (this.isAdmin() ? this.adminTemplate() : this.basicTemplate()));
 }
 ```
 

--- a/adev/src/content/guide/templates/ng-content.md
+++ b/adev/src/content/guide/templates/ng-content.md
@@ -10,7 +10,7 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'button[baseButton]',
-  template: ` <ng-content /> `,
+  template: `<ng-content />`,
 })
 export class BaseButton {}
 ```
@@ -23,7 +23,7 @@ import {BaseButton} from './base-button';
 @Component({
   selector: 'app-root',
   imports: [BaseButton],
-  template: ` <button baseButton>Next <span class="icon arrow-right"></span></button> `,
+  template: `<button baseButton>Next <span class="icon arrow-right"></span></button>`,
 })
 export class App {}
 ```

--- a/adev/src/content/guide/templates/ng-content.md
+++ b/adev/src/content/guide/templates/ng-content.md
@@ -6,30 +6,24 @@ Here is an example of a `BaseButton` component that accepts any markup from its 
 
 ```angular-ts
 // ./base-button/base-button.ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'button[baseButton]',
-  template: `
-      <ng-content />
-  `,
+  template: ` <ng-content /> `,
 })
 export class BaseButton {}
 ```
 
 ```angular-ts
 // ./app.ts
-import { Component } from '@angular/core';
-import { BaseButton } from './base-button';
+import {Component} from '@angular/core';
+import {BaseButton} from './base-button';
 
 @Component({
   selector: 'app-root',
   imports: [BaseButton],
-  template: `
-    <button baseButton>
-      Next <span class="icon arrow-right"></span>
-    </button>
-  `,
+  template: ` <button baseButton>Next <span class="icon arrow-right"></span></button> `,
 })
 export class App {}
 ```

--- a/adev/src/content/guide/templates/ng-template.md
+++ b/adev/src/content/guide/templates/ng-template.md
@@ -111,7 +111,7 @@ A directive can inject a `TemplateRef` if that directive is applied directly to 
 
 ```angular-ts
 @Directive({
-  selector: '[myDirective]'
+  selector: '[myDirective]',
 })
 export class MyDirective {
   private fragment = inject(TemplateRef);
@@ -218,7 +218,7 @@ Each parameter is written as an attribute prefixed with `let-` with a value matc
 
 ```angular-html
 <ng-template let-pizzaTopping="topping">
-  <p>You selected: {{pizzaTopping}}</p>
+  <p>You selected: {{ pizzaTopping }}</p>
 </ng-template>
 ```
 
@@ -228,13 +228,10 @@ You can bind a context object to the `ngTemplateOutletContext` input:
 
 ```angular-html
 <ng-template #myFragment let-pizzaTopping="topping">
-  <p>You selected: {{pizzaTopping}}</p>
+  <p>You selected: {{ pizzaTopping }}</p>
 </ng-template>
 
-<ng-container
-  [ngTemplateOutlet]="myFragment"
-  [ngTemplateOutletContext]="{topping: 'onion'}"
-/>
+<ng-container [ngTemplateOutlet]="myFragment" [ngTemplateOutletContext]="{topping: 'onion'}" />
 ```
 
 ### Using `ViewContainerRef`

--- a/adev/src/content/guide/templates/pipes.md
+++ b/adev/src/content/guide/templates/pipes.md
@@ -9,19 +9,19 @@ NOTE: Angular's pipe syntax deviates from standard JavaScript, which uses the ve
 Here is an example using some built-in pipes that Angular provides:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { CurrencyPipe, DatePipe, TitleCasePipe } from '@angular/common';
+import {Component} from '@angular/core';
+import {CurrencyPipe, DatePipe, TitleCasePipe} from '@angular/common';
 
 @Component({
   selector: 'app-root',
   imports: [CurrencyPipe, DatePipe, TitleCasePipe],
   template: `
     <main>
-       <!-- Transform the company name to title-case and
+      <!-- Transform the company name to title-case and
        transform the purchasedOn date to a locale-formatted string -->
-<h1>Purchases from {{ company | titlecase }} on {{ purchasedOn | date }}</h1>
+      <h1>Purchases from {{ company | titlecase }} on {{ purchasedOn | date }}</h1>
 
-	    <!-- Transform the amount to a currency-formatted string -->
+      <!-- Transform the amount to a currency-formatted string -->
       <p>Total: {{ amount | currency }}</p>
     </main>
   `,
@@ -91,7 +91,7 @@ Some pipes accept parameters to configure the transformation. To specify a param
 For example, the `DatePipe` is able to take parameters to format the date in a specific way.
 
 ```angular-html
-<p>The event will occur at {{ scheduledOn | date:'hh:mm' }}.</p>
+<p>The event will occur at {{ scheduledOn | date: 'hh:mm' }}.</p>
 ```
 
 Some pipes may accept multiple parameters. You can specify additional parameter values separated by the colon character (`:`).
@@ -99,7 +99,7 @@ Some pipes may accept multiple parameters. You can specify additional parameter 
 For example, we can also pass a second optional parameter to control the timezone.
 
 ```angular-html
-<p>The event will occur at {{ scheduledOn | date:'hh:mm':'UTC' }}.</p>
+<p>The event will occur at {{ scheduledOn | date: 'hh:mm' : 'UTC' }}.</p>
 ```
 
 ## How pipes work
@@ -107,8 +107,8 @@ For example, we can also pass a second optional parameter to control the timezon
 Conceptually, pipes are functions that accept an input value and return a transformed value.
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { CurrencyPipe} from '@angular/common';
+import {Component} from '@angular/core';
+import {CurrencyPipe} from '@angular/common';
 
 @Component({
   selector: 'app-root',
@@ -148,7 +148,7 @@ The pipe operator has higher precedence than the conditional (ternary) operator.
 If the same expression were written without parentheses:
 
 ```angular-html
-{{ isAdmin ? 'Access granted' : 'Access denied' | uppercase }}
+{{ isAdmin ? 'Access granted' : ('Access denied' | uppercase) }}
 ```
 
 It will be parsed instead as:
@@ -178,7 +178,7 @@ Here is an example of a custom pipe that transforms strings to kebab case:
 
 ```angular-ts
 // kebab-case.pipe.ts
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'kebabCase',
@@ -195,7 +195,7 @@ export class KebabCasePipe implements PipeTransform {
 When creating a custom pipe, import `Pipe` from the `@angular/core` package and use it as a decorator for the TypeScript class.
 
 ```angular-ts
-import { Pipe } from '@angular/core';
+import {Pipe} from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
@@ -217,7 +217,7 @@ The naming convention for custom pipes consists of two conventions:
 In addition to the `@Pipe` decorator, custom pipes should always implement the `PipeTransform` interface from `@angular/core`.
 
 ```angular-ts
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
@@ -232,14 +232,14 @@ Implementing this interface ensures that your pipe class has the correct structu
 Every transformation is invoked by the `transform` method with the first parameter being the value being passed in and the return value being the transformed value.
 
 ```angular-ts
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
 })
 export class MyCustomTransformationPipe implements PipeTransform {
   transform(value: string): string {
-    return `My custom transformation of ${value}.`
+    return `My custom transformation of ${value}.`;
   }
 }
 ```
@@ -249,19 +249,19 @@ export class MyCustomTransformationPipe implements PipeTransform {
 You can add parameters to your transformation by adding additional parameters to the `transform` method:
 
 ```angular-ts
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'myCustomTransformation',
 })
 export class MyCustomTransformationPipe implements PipeTransform {
   transform(value: string, format: string): string {
-    let msg = `My custom transformation of ${value}.`
+    let msg = `My custom transformation of ${value}.`;
 
     if (format === 'uppercase') {
-      return msg.toUpperCase()
+      return msg.toUpperCase();
     } else {
-      return msg
+      return msg;
     }
   }
 }
@@ -274,7 +274,7 @@ When you want a pipe to detect changes within arrays or objects, it must be mark
 IMPORTANT: Avoid creating impure pipes unless absolutely necessary, as they can incur a significant performance penalty if used without care.
 
 ```angular-ts
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
 @Pipe({
   name: 'joinNamesImpure',

--- a/adev/src/content/guide/templates/two-way-binding.md
+++ b/adev/src/content/guide/templates/two-way-binding.md
@@ -13,8 +13,8 @@ Developers commonly use two-way binding to keep component data in sync with a fo
 The following example dynamically updates the `firstName` attribute on the page:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   imports: [FormsModule],
@@ -23,7 +23,7 @@ import { FormsModule } from '@angular/forms';
       <h2>Hello {{ firstName }}!</h2>
       <input type="text" [(ngModel)]="firstName" />
     </main>
-  `
+  `,
 })
 export class App {
   firstName = 'Ada';
@@ -48,8 +48,8 @@ Here is an example where the `App` is responsible for setting the initial count 
 
 ```angular-ts
 // ./app.ts
-import { Component } from '@angular/core';
-import { Counter } from './counter';
+import {Component} from '@angular/core';
+import {Counter} from './counter';
 
 @Component({
   selector: 'app-root',
@@ -68,7 +68,7 @@ export class App {
 
 ```angular-ts
 // './counter.ts';
-import { Component, model } from '@angular/core';
+import {Component, model} from '@angular/core';
 
 @Component({
   selector: 'app-counter',
@@ -82,7 +82,7 @@ export class Counter {
   count = model<number>(0);
 
   updateCount(amount: number): void {
-    this.count.update(currentCount => currentCount + amount);
+    this.count.update((currentCount) => currentCount + amount);
   }
 }
 ```
@@ -97,14 +97,16 @@ Here is a simplified example:
 
 ```angular-ts
 // './counter.ts';
-import { Component, model } from '@angular/core';
+import {Component, model} from '@angular/core';
 
-@Component({ /* Omitted for brevity */ })
+@Component({
+  /* Omitted for brevity */
+})
 export class Counter {
   count = model<number>(0);
 
   updateCount(amount: number): void {
-    this.count.update(currentCount => currentCount + amount);
+    this.count.update((currentCount) => currentCount + amount);
   }
 }
 ```
@@ -118,8 +120,8 @@ Here is a simplified example:
 
 ```angular-ts
 // ./app.ts
-import { Component } from '@angular/core';
-import { Counter } from './counter';
+import {Component} from '@angular/core';
+import {Counter} from './counter';
 
 @Component({
   selector: 'app-root',

--- a/adev/src/content/guide/templates/variables.md
+++ b/adev/src/content/guide/templates/variables.md
@@ -69,25 +69,25 @@ Since `@let` declarations are not hoisted, they **cannot** be accessed by parent
   @let insideDiv = value;
 </div>
 
+<!-- Valid -->
 {{ topLevel }}
 <!-- Valid -->
 {{ insideDiv }}
-<!-- Valid -->
 
 @if (condition) {
-  {{ topLevel + insideDiv }}
   <!-- Valid -->
+  {{ topLevel + insideDiv }}
 
   @let nested = value;
 
   @if (condition) {
-    {{ topLevel + insideDiv + nested }}
     <!-- Valid -->
+    {{ topLevel + insideDiv + nested }}
   }
 }
 
-{{ nested }}
 <!-- Error, not hoisted from @if -->
+{{ nested }}
 ```
 
 ### Full syntax

--- a/adev/src/content/guide/templates/variables.md
+++ b/adev/src/content/guide/templates/variables.md
@@ -16,9 +16,10 @@ Use `@let` to declare a variable whose value is based on the result of a templat
 @let data = data$ | async;
 @let pi = 3.14159;
 @let coordinates = {x: 50, y: 100};
-@let longExpression = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit ' +
-                      'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
-                      'Ut enim ad minim veniam...';
+@let longExpression =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit ' +
+  'sed do eiusmod tempor incididunt ut labore et dolore magna ' +
+  'Ut enim ad minim veniam...';
 ```
 
 Each `@let` block can declare exactly one variable. You cannot declare multiple variables in the same block with a comma.
@@ -31,12 +32,12 @@ Once you've declared a variable with `@let`, you can reuse it in the same templa
 @let user = user$ | async;
 
 @if (user) {
-  <h1>Hello, {{user.name}}</h1>
-  <user-avatar [photo]="user.photo"/>
+  <h1>Hello, {{ user.name }}</h1>
+  <user-avatar [photo]="user.photo" />
 
   <ul>
     @for (snack of user.favoriteSnacks; track snack.id) {
-      <li>{{snack.name}}</li>
+      <li>{{ snack.name }}</li>
     }
   </ul>
 
@@ -68,20 +69,25 @@ Since `@let` declarations are not hoisted, they **cannot** be accessed by parent
   @let insideDiv = value;
 </div>
 
-{{topLevel}} <!-- Valid -->
-{{insideDiv}} <!-- Valid -->
+{{ topLevel }}
+<!-- Valid -->
+{{ insideDiv }}
+<!-- Valid -->
 
 @if (condition) {
-  {{topLevel + insideDiv}} <!-- Valid -->
+  {{ topLevel + insideDiv }}
+  <!-- Valid -->
 
   @let nested = value;
 
   @if (condition) {
-    {{topLevel + insideDiv + nested}} <!-- Valid -->
+    {{ topLevel + insideDiv + nested }}
+    <!-- Valid -->
   }
 }
 
-{{nested}} <!-- Error, not hoisted from @if -->
+{{ nested }}
+<!-- Error, not hoisted from @if -->
 ```
 
 ### Full syntax
@@ -113,7 +119,7 @@ You can declare a variable on an element in a template by adding an attribute th
 
 ```angular-html
 <!-- Create a template reference variable named "taskInput", referring to the HTMLInputElement. -->
-<input #taskInput placeholder="Enter task name">
+<input #taskInput placeholder="Enter task name" />
 ```
 
 ### Assigning values to template reference variables
@@ -140,7 +146,7 @@ If you declare the variable on any other displayed element, the variable refers 
 
 ```angular-html
 <!-- The "taskInput" variable refers to the HTMLInputElement instance. -->
-<input #taskInput placeholder="Enter task name">
+<input #taskInput placeholder="Enter task name" />
 ```
 
 #### Assigning a reference to an Angular directive
@@ -152,14 +158,16 @@ Angular directives may have an `exportAs` property that defines a name by which 
   selector: '[dropZone]',
   exportAs: 'dropZone',
 })
-export class DropZone { /* ... */ }
+export class DropZone {
+  /* ... */
+}
 ```
 
 When you declare a template variable on an element, you can assign that variable a directive instance by specifying this `exportAs` name:
 
 ```angular-html
 <!-- The `firstZone` variable refers to the `DropZone` directive instance. -->
-<section dropZone #firstZone="dropZone"> ... </section>
+<section dropZone #firstZone="dropZone">...</section>
 ```
 
 You cannot refer to a directive that does not specify an `exportAs` name.
@@ -171,7 +179,7 @@ In addition to using template variables to read values from another part of the 
 When you want to query for a specific element in a template, you can declare a template variable on that element and then query for the element based on the variable name.
 
 ```angular-html
- <input #description value="Original description">
+<input #description value="Original description" />
 ```
 
 ```angular-ts

--- a/adev/src/content/guide/templates/whitespace.md
+++ b/adev/src/content/guide/templates/whitespace.md
@@ -11,7 +11,7 @@ Most developers prefer to format their templates with newlines and indentation t
   <h3>User profile</h3>
   <label>
     User name
-    <input>
+    <input />
   </label>
 </section>
 ```
@@ -20,7 +20,11 @@ This template contains whitespace between all of the elements. The following sni
 
 ```angular-html
 <!-- Total Whitespace: 20 -->
-<section>###<h3>User profile</h3>###<label>#####User name#####<input>###</label>#</section>
+<section>
+  ###
+  <h3>User profile</h3>
+  ###<label>#####User name#####<input />###</label>#
+</section>
 ```
 
 Preserving the whitespace as written in the template would result in many unnecessary [text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Text) and increase page rendering overhead. By ignoring this whitespace between elements, Angular performs less work when rendering the template on the page, improving overall performance.
@@ -31,7 +35,7 @@ When your web browser renders HTML on a page, it collapses multiple consecutive 
 
 ```angular-html
 <!-- What it looks like in the template -->
-<p>Hello         world</p>
+<p>Hello world</p>
 ```
 
 In this example, the browser displays only a single space between "Hello" and "world".

--- a/adev/src/content/guide/templates/whitespace.md
+++ b/adev/src/content/guide/templates/whitespace.md
@@ -6,7 +6,7 @@ By default, Angular templates do not preserve whitespace that the framework cons
 
 Most developers prefer to format their templates with newlines and indentation to make the template readable:
 
-```angular-html
+```html
 <section>
   <h3>User profile</h3>
   <label>
@@ -18,13 +18,10 @@ Most developers prefer to format their templates with newlines and indentation t
 
 This template contains whitespace between all of the elements. The following snippet shows the same HTML with each whitespace character replaced with the hash (`#`) character to highlight how much whitespace is present:
 
-```angular-html
+<!-- prettier-ignore>
+```html
 <!-- Total Whitespace: 20 -->
-<section>
-  ###
-  <h3>User profile</h3>
-  ###<label>#####User name#####<input />###</label>#
-</section>
+<section>###<h3>User profile</h3>###<label>#####User name#####<input>###</label>#</section>
 ```
 
 Preserving the whitespace as written in the template would result in many unnecessary [text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Text) and increase page rendering overhead. By ignoring this whitespace between elements, Angular performs less work when rendering the template on the page, improving overall performance.
@@ -33,9 +30,10 @@ Preserving the whitespace as written in the template would result in many unnece
 
 When your web browser renders HTML on a page, it collapses multiple consecutive whitespace characters to a single character:
 
-```angular-html
+<!-- prettier-ignore -->
+```html
 <!-- What it looks like in the template -->
-<p>Hello world</p>
+<p>Hello         world</p>
 ```
 
 In this example, the browser displays only a single space between "Hello" and "world".

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -464,7 +464,7 @@ The `DashboardHero` component is embedded in the `Dashboard` component template 
 
 ```angular-html
 @for (hero of heroes; track hero) {
-  <dashboard-hero class="col-1-4" [hero]="hero" (selected)="gotoDetail($event)"/>
+  <dashboard-hero class="col-1-4" [hero]="hero" (selected)="gotoDetail($event)" />
 }
 ```
 

--- a/adev/src/content/introduction/essentials/components.md
+++ b/adev/src/content/introduction/essentials/components.md
@@ -24,7 +24,9 @@ Here is a simplified example of a `UserProfile` component.
     <p>This is the user profile page</p>
   `,
 })
-export class UserProfile { /* Your component code goes here */ }
+export class UserProfile {
+  /* Your component code goes here */
+}
 ```
 
 The `@Component` decorator also optionally accepts a `styles` property for any CSS you want to apply to your template:
@@ -37,9 +39,15 @@ The `@Component` decorator also optionally accepts a `styles` property for any C
     <h1>User profile</h1>
     <p>This is the user profile page</p>
   `,
-  styles: `h1 { font-size: 3em; } `,
+  styles: `
+    h1 {
+      font-size: 3em;
+    }
+  `,
 })
-export class UserProfile { /* Your component code goes here */ }
+export class UserProfile {
+  /* Your component code goes here */
+}
 ```
 
 ### Separating HTML and CSS into separate files

--- a/adev/src/content/introduction/essentials/dependency-injection.md
+++ b/adev/src/content/introduction/essentials/dependency-injection.md
@@ -36,14 +36,13 @@ When you want to use a service in a component, you need to:
 Here’s what it might look like in the `Receipt` component:
 
 ```angular-ts
-import { Component, inject } from '@angular/core';
-import { Calculator } from './calculator';
+import {Component, inject} from '@angular/core';
+import {Calculator} from './calculator';
 
 @Component({
   selector: 'app-receipt',
   template: `<h1>The total is {{ totalCost }}</h1>`,
 })
-
 export class Receipt {
   private calculator = inject(Calculator);
   totalCost = this.calculator.add(50, 25);

--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -13,7 +13,7 @@ You can create a binding to show some dynamic text in a template by using double
 ```angular-ts
 @Component({
   selector: 'user-profile',
-  template: `<h1>Profile for {{userName()}}</h1>`,
+  template: `<h1>Profile for {{ userName() }}</h1>`,
 })
 export class UserProfile {
   userName = signal('pro_programmer_123');
@@ -58,7 +58,7 @@ You can also bind to HTML _attributes_ by prefixing the attribute name with `att
 
 ```angular-html
 <!-- Bind the `role` attribute on the `<ul>` element to value of `listRole`. -->
-<ul [attr.role]="listRole()">
+<ul [attr.role]="listRole()"></ul>
 ```
 
 Angular automatically updates DOM properties and attributes when the bound value changes.
@@ -76,7 +76,9 @@ Angular lets you add event listeners to an element in your template with parenth
 export class UserProfile {
   /* ... */
 
-  cancelSubscription() { /* Your event handling code goes here. */  }
+  cancelSubscription() {
+    /* Your event handling code goes here. */
+  }
 }
 ```
 
@@ -91,7 +93,9 @@ If you need to pass the [event](https://developer.mozilla.org/docs/Web/API/Event
 export class UserProfile {
   /* ... */
 
-  cancelSubscription(event: Event) { /* Your event handling code goes here. */  }
+  cancelSubscription(event: Event) {
+    /* Your event handling code goes here. */
+  }
 }
 ```
 
@@ -129,7 +133,7 @@ You can repeat part of a template multiple times with Angular's `@for` block:
 
 <ul class="user-badge-list">
   @for (badge of badges(); track badge.id) {
-    <li class="user-badge">{{badge.name}}</li>
+    <li class="user-badge">{{ badge.name }}</li>
   }
 </ul>
 ```

--- a/adev/src/content/reference/errors/NG0300.md
+++ b/adev/src/content/reference/errors/NG0300.md
@@ -24,11 +24,10 @@ export class RaisedBtnComponent {}
 @Component({
   selector: 'app-root',
   template: `
+    <!-- This node has 2 selectors: stroked-button and raised-button, and both match a different component: StrokedBtnComponent, and RaisedBtnComponent , so NG0300 will be raised  -->
 
-  <!-- This node has 2 selectors: stroked-button and raised-button, and both match a different component: StrokedBtnComponent, and RaisedBtnComponent , so NG0300 will be raised  -->
-
-<button stroked-button  raised-button></button>
-`,
+    <button stroked-button raised-button></button>
+  `,
 })
 export class AppComponent {}
 ```

--- a/adev/src/content/reference/errors/NG0500.md
+++ b/adev/src/content/reference/errors/NG0500.md
@@ -22,11 +22,11 @@ export class ExampleComponent {
     newNode.innerHTML = 'Hello';
 
     // Insert the <p> before the first element. Since Angular has no information
-   // about the <p> element, it will be looking for the <div> element at the first
-   // element position instead. As a result, a hydration mismatch error would be
-   // thrown. Instead, update component's template to create the <p> element.
-   this.hostElement.insertBefore(newNode, this.hostElement.firstChild);
- }
+    // about the <p> element, it will be looking for the <div> element at the first
+    // element position instead. As a result, a hydration mismatch error would be
+    // thrown. Instead, update component's template to create the <p> element.
+    this.hostElement.insertBefore(newNode, this.hostElement.firstChild);
+  }
 }
 ```
 

--- a/adev/src/content/reference/errors/NG0503.md
+++ b/adev/src/content/reference/errors/NG0503.md
@@ -9,7 +9,7 @@ The following examples will trigger the error.
 ```angular-ts
 @Component({
   selector: 'dynamic',
-  template: ` <ng-content /> `,
+  template: `<ng-content />`,
 })
 class DynamicComponent {}
 

--- a/adev/src/content/reference/errors/NG0503.md
+++ b/adev/src/content/reference/errors/NG0503.md
@@ -9,12 +9,9 @@ The following examples will trigger the error.
 ```angular-ts
 @Component({
   selector: 'dynamic',
-  template: `
-  <ng-content />
-`,
+  template: ` <ng-content /> `,
 })
-class DynamicComponent {
-}
+class DynamicComponent {}
 
 @Component({
   selector: 'app',
@@ -32,7 +29,7 @@ class SimpleComponent {
     // This is an unsupported pattern and an exception will be thrown.
     const compRef = createComponent(DynamicComponent, {
       environmentInjector: this.envInjector,
-      projectableNodes: [[div, p]]
+      projectableNodes: [[div, p]],
     });
   }
 }

--- a/adev/src/content/reference/errors/NG0504.md
+++ b/adev/src/content/reference/errors/NG0504.md
@@ -15,18 +15,14 @@ In this example, the `ngSkipHydration` attribute is applied to a `<div>` using h
   selector: '[dir]',
   host: {ngSkipHydration: 'true'},
 })
-class Dir {
-}
+class Dir {}
 
 @Component({
   selector: 'app',
   imports: [Dir],
-  template: `
-    <div dir></div>
-  `,
+  template: ` <div dir></div> `,
 })
-class SimpleComponent {
-}
+class SimpleComponent {}
 ```
 
 ## Example 2
@@ -37,12 +33,9 @@ Since the `<div>` doesn't act as a component host node, Angular will throw an er
 ```angular-ts
 @Component({
   selector: 'app',
-  template: `
-    <div ngSkipHydration></div>
-  `,
+  template: ` <div ngSkipHydration></div> `,
 })
-class SimpleComponent {
-}
+class SimpleComponent {}
 ```
 
 ## Debugging the error

--- a/adev/src/content/reference/errors/NG05104.md
+++ b/adev/src/content/reference/errors/NG05104.md
@@ -16,18 +16,18 @@ This issue occurs when the selector mismatches the tag
 export class AppComponent {}
 ```
 
-```angular-html
+<!-- prettier-ignore -->
+```html
 <html>
-  <app-root></app-root>
-  <!-- Doesn't match the selector -->
+  <app-root></app-root> <!-- Doesn't match the selector -->
 </html>
 ```
 
 Replace the tag with the correct one:
 
-```angular-html
+<!-- prettier-ignore -->
+```html
 <html>
-  <my-app></my-app>
-  <!-- OK -->
+  <my-app></my-app> <!-- OK -->
 </html>
 ```

--- a/adev/src/content/reference/errors/NG05104.md
+++ b/adev/src/content/reference/errors/NG05104.md
@@ -18,7 +18,8 @@ export class AppComponent {}
 
 ```angular-html
 <html>
-    <app-root></app-root> <!-- Doesn't match the selector -->
+  <app-root></app-root>
+  <!-- Doesn't match the selector -->
 </html>
 ```
 
@@ -26,6 +27,7 @@ Replace the tag with the correct one:
 
 ```angular-html
 <html>
-    <my-app></my-app> <!-- OK -->
+  <my-app></my-app>
+  <!-- OK -->
 </html>
 ```

--- a/adev/src/content/reference/errors/NG0955.md
+++ b/adev/src/content/reference/errors/NG0955.md
@@ -4,10 +4,16 @@ A track expression specified in the `@for` loop evaluated to duplicated keys for
 
 ```angular-ts
 @Component({
-    template: `@for (item of items; track item.value) {{{item.value}}}`,
+  template: `@for (item of items; track item.value) {
+    {{ item.value }}
+  }`,
 })
 class TestComponent {
-    items = [{key: 1, value: 'a'}, {key: 2, value: 'b'}, {key: 3, value: 'a'}];
+  items = [
+    {key: 1, value: 'a'},
+    {key: 2, value: 'b'},
+    {key: 3, value: 'a'},
+  ];
 }
 ```
 
@@ -23,9 +29,15 @@ Change the tracking expression such that it uniquely identifies an item in a col
 
 ```angular-ts
 @Component({
-    template: `@for (item of items; track item.key) {{{item.value}}}`,
+  template: `@for (item of items; track item.key) {
+    {{ item.value }}
+  }`,
 })
 class TestComponent {
-    items = [{key: 1, value: 'a'}, {key: 2, value: 'b'}, {key: 3, value: 'a'}];
+  items = [
+    {key: 1, value: 'a'},
+    {key: 2, value: 'b'},
+    {key: 3, value: 'a'},
+  ];
 }
 ```

--- a/adev/src/content/reference/errors/NG0956.md
+++ b/adev/src/content/reference/errors/NG0956.md
@@ -7,20 +7,20 @@ The identity track expression specified in the `@for` loop caused re-creation of
   template: `
     <button (click)="toggleAllDone()">All done!</button>
     <ul>
-    @for (todo of todos; track todo) {
-      <li>{{todo.task}}</li>
-    }
+      @for (todo of todos; track todo) {
+        <li>{{ todo.task }}</li>
+      }
     </ul>
   `,
 })
 export class App {
   todos = [
-    { id: 0, task: 'understand trackBy', done: false },
-    { id: 1, task: 'use proper tracking expression', done: false },
+    {id: 0, task: 'understand trackBy', done: false},
+    {id: 1, task: 'use proper tracking expression', done: false},
   ];
 
   toggleAllDone() {
-    this.todos = this.todos.map(todo => ({ ...todo, done: true }));
+    this.todos = this.todos.map((todo) => ({...todo, done: true}));
   }
 }
 ```
@@ -38,20 +38,20 @@ Change the tracking expression such that it uniquely identifies an item in a col
   template: `
     <button (click)="toggleAllDone()">All done!</button>
     <ul>
-    @for (todo of todos; track todo.id) {
-      <li>{{todo.task}}</li>
-    }
+      @for (todo of todos; track todo.id) {
+        <li>{{ todo.task }}</li>
+      }
     </ul>
   `,
 })
 export class App {
   todos = [
-    { id: 0, task: 'understand trackBy', done: false },
-    { id: 1, task: 'use proper tracking expression', done: false },
+    {id: 0, task: 'understand trackBy', done: false},
+    {id: 1, task: 'use proper tracking expression', done: false},
   ];
 
   toggleAllDone() {
-    this.todos = this.todos.map(todo => ({ ...todo, done: true }));
+    this.todos = this.todos.map((todo) => ({...todo, done: true}));
   }
 }
 ```

--- a/adev/src/content/reference/extended-diagnostics/NG8102.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8102.md
@@ -33,35 +33,31 @@ Double-check the type of the input and confirm whether it is actually expected t
 If the input should be nullable, add `null` or `undefined` to its type to indicate this.
 
 ```angular-ts
-
 import {Component} from '@angular/core';
 
 @Component({
-template: `<div>{{ username ?? 'root' }}</div>`,
+  template: `<div>{{ username ?? 'root' }}</div>`,
 })
 class MyComponent {
-// `username` is now nullable. If it is ever set to `null`, 'root' will be
-// displayed.
-username: string | null = 'Angelino';
+  // `username` is now nullable. If it is ever set to `null`, 'root' will be
+  // displayed.
+  username: string | null = 'Angelino';
 }
-
 ```
 
 If the input should _not_ be nullable, delete the `??` operator and its right operand, since the value is guaranteed by TypeScript to always be non-nullable.
 
 ```angular-ts
-
 import {Component} from '@angular/core';
 
 @Component({
-// Template always displays `username`, which is guaranteed to never be `null`
-// or `undefined`.
-template: `<div>{{ username }}</div>`,
+  // Template always displays `username`, which is guaranteed to never be `null`
+  // or `undefined`.
+  template: `<div>{{ username }}</div>`,
 })
 class MyComponent {
-username: string = 'Angelino';
+  username: string = 'Angelino';
 }
-
 ```
 
 ## Configuration requirements

--- a/adev/src/content/reference/extended-diagnostics/NG8105.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8105.md
@@ -3,7 +3,7 @@
 This diagnostic is emitted when an expression used in `*ngFor` is missing the `let` keyword.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // The `let` keyword is missing in the `*ngFor` expression.
@@ -23,7 +23,7 @@ A missing `let` is indicative of a syntax error in the `*ngFor` string. It also 
 Add the missing `let` keyword.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // The `let` keyword is now present in the `*ngFor` expression,

--- a/adev/src/content/reference/extended-diagnostics/NG8107.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8107.md
@@ -3,7 +3,7 @@
 This diagnostic detects when the left side of an optional chain operation (`.?`) does not include `null` or `undefined` in its type in Angular templates.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // Print the user's name safely, even if `user` is `null` or `undefined`.
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
 })
 class MyComponent {
   // `user` is declared as an object which _cannot_ be `null` or `undefined`.
-  user: { name: string } = { name: 'Angelino' };
+  user: {name: string} = {name: 'Angelino'};
 }
 ```
 
@@ -29,7 +29,7 @@ Double-check the type of the input and confirm whether it is actually expected t
 If the input should be nullable, add `null` or `undefined` to its type to indicate this.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // If `user` is nullish, `name` won't be evaluated and the expression will
@@ -37,14 +37,14 @@ import { Component } from '@angular/core';
   template: `<div>{{ user?.name }}</div>`,
 })
 class MyComponent {
-  user: { name: string } | null = { name: 'Angelino' };
+  user: {name: string} | null = {name: 'Angelino'};
 }
 ```
 
 If the input should not be nullable, delete the `?` operator.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // Template always displays `name` as `user` is guaranteed to never be `null`
@@ -52,7 +52,7 @@ import { Component } from '@angular/core';
   template: `<div>{{ foo.bar }}</div>`,
 })
 class MyComponent {
-  user: { name: string } = { name: 'Angelino' };
+  user: {name: string} = {name: 'Angelino'};
 }
 ```
 

--- a/adev/src/content/reference/extended-diagnostics/NG8108.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8108.md
@@ -4,7 +4,7 @@
 This diagnostic ensures that this attribute `ngSkipHydration` is set statically and the value is either set to `"true"` or an empty value.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `<user-viewer ngSkipHydration="hasUser" />`,
@@ -23,7 +23,7 @@ As a special attribute implemented by Angular, `ngSkipHydration` needs to be sta
 When using the `ngSkipHydration`, ensure that it's set as a static attribute (i.e. you do not use the Angular template binding syntax).
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `

--- a/adev/src/content/reference/extended-diagnostics/NG8109.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8109.md
@@ -3,7 +3,7 @@
 This diagnostic detects uninvoked signals in template interpolations.
 
 ```angular-ts
-import { Component, signal, Signal } from '@angular/core';
+import {Component, signal, Signal} from '@angular/core';
 
 @Component({
   template: `<div>{{ mySignal }}</div>`,
@@ -23,7 +23,7 @@ This means they are meant to be invoked when used in template interpolations to 
 Ensure to invoke the signal when you use it within a template interpolation to render its value.
 
 ```angular-ts
-import { Component, signal, Signal } from '@angular/core';
+import {Component, signal, Signal} from '@angular/core';
 
 @Component({
   template: `<div>{{ mySignal() }}</div>`,

--- a/adev/src/content/reference/extended-diagnostics/NG8111.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8111.md
@@ -3,7 +3,7 @@
 This diagnostic detects uninvoked functions in event bindings.
 
 ```angular-ts
-import { Component, signal, Signal } from '@angular/core';
+import {Component, signal, Signal} from '@angular/core';
 
 @Component({
   template: `<button (click)="(onClick)">Click me</button>`,
@@ -25,7 +25,7 @@ If the function is not invoked, it will not execute when the event is triggered.
 Ensure to invoke the function when you use it in an event binding to execute the function when the event is triggered.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `<button (click)="onClick()">Click me</button>`,

--- a/adev/src/content/reference/extended-diagnostics/NG8114.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8114.md
@@ -7,7 +7,7 @@ or (`||`) or logical and (`&&`) operators without parentheses to disambiguate pr
 import {Component, signal, Signal} from '@angular/core';
 
 @Component({
-  template: ` <button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button> `,
+  template: `<button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button>`,
 })
 class MyComponent {
   hasPermission = input(false);
@@ -31,7 +31,7 @@ operator.
 import {Component, signal, Signal} from '@angular/core';
 
 @Component({
-  template: ` <button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button> `,
+  template: `<button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button>`,
 })
 class MyComponent {
   hasPermission = input(false);

--- a/adev/src/content/reference/extended-diagnostics/NG8114.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8114.md
@@ -4,14 +4,10 @@ This diagnostic detects cases where the nullish coalescing operator (`??`) is mi
 or (`||`) or logical and (`&&`) operators without parentheses to disambiguate precedence.
 
 ```angular-ts
-import { Component, signal, Signal } from '@angular/core';
+import {Component, signal, Signal} from '@angular/core';
 
 @Component({
-  template: `
-    <button [disabled]="hasPermission() && (task()?.disabled ?? true)">
-      Run
-    </button>
-  `,
+  template: ` <button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button> `,
 })
 class MyComponent {
   hasPermission = input(false);
@@ -32,14 +28,10 @@ intent of the code was but want to keep the behavior the same, place the parenth
 operator.
 
 ```angular-ts
-import { Component, signal, Signal } from '@angular/core';
+import {Component, signal, Signal} from '@angular/core';
 
 @Component({
-  template: `
-    <button [disabled]="hasPermission() && (task()?.disabled ?? true)">
-      Run
-    </button>
-  `,
+  template: ` <button [disabled]="hasPermission() && (task()?.disabled ?? true)">Run</button> `,
 })
 class MyComponent {
   hasPermission = input(false);

--- a/adev/src/content/reference/extended-diagnostics/NG8115.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8115.md
@@ -3,7 +3,7 @@
 This diagnostic detects when a track function is not invoked in `@for` blocks.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `@for (item of items; track trackByName) {}`,
@@ -25,7 +25,7 @@ When you don't invoke the function, the reconcialiation algorithm will use the f
 Ensure to invoke the track function when you use it in a `@for` block to execute the function so the loop can uniquely identify items.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `@for (item of items; track trackByName(item)) {}`,

--- a/adev/src/content/reference/extended-diagnostics/NG8116.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8116.md
@@ -3,12 +3,12 @@
 This diagnostic ensures that a standalone component using custom structural directives (e.g., `*select` or `*featureFlag`) in a template has the necessary imports for those directives.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   // Template uses `*select`, but no corresponding directive imported.
   imports: [],
-  template: `<p *select="let data from source">{{ data }}</p>`,
+  template: `<p *select="let data; from: source">{{ data }}</p>`,
 })
 class MyComponent {}
 ```
@@ -22,16 +22,15 @@ Using a structural directive without importing it will fail at runtime, as Angul
 Make sure that the corresponding structural directive is imported into the component:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { SelectDirective } from 'my-directives';
+import {Component} from '@angular/core';
+import {SelectDirective} from 'my-directives';
 
 @Component({
   // Add `SelectDirective` to the `imports` array to make it available in the template.
   imports: [SelectDirective],
-  template: `<p *select="let data from source">{{ data }}</p>`,
+  template: `<p *select="let data; from: source">{{ data }}</p>`,
 })
 class MyComponent {}
-
 ```
 
 ## Configuration requirements

--- a/adev/src/content/reference/extended-diagnostics/NG8117.md
+++ b/adev/src/content/reference/extended-diagnostics/NG8117.md
@@ -3,7 +3,7 @@
 This diagnostic detects uninvoked functions in text interpolation.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `{{ getValue }}`,
@@ -25,7 +25,7 @@ If the function is not invoked, it will not return any value and the interpolati
 Ensure to invoke the function when you use it in text interpolation to return the value.
 
 ```angular-ts
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   template: `{{ getValue() }}`,

--- a/adev/src/content/reference/migrations/common-to-standalone.md
+++ b/adev/src/content/reference/migrations/common-to-standalone.md
@@ -19,8 +19,8 @@ ng generate @angular/core:common-to-standalone
 Before:
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-example',
@@ -29,19 +29,19 @@ import { CommonModule } from '@angular/common';
     <div *ngIf="show">
       {{ data | async | json }}
     </div>
-  `
+  `,
 })
 export class ExampleComponent {
   show = true;
-  data = Promise.resolve({ message: 'Hello' });
+  data = Promise.resolve({message: 'Hello'});
 }
 ```
 
 After running the migration (component imports added, CommonModule removed):
 
 ```angular-ts
-import { Component } from '@angular/core';
-import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
+import {Component} from '@angular/core';
+import {AsyncPipe, JsonPipe, NgIf} from '@angular/common';
 
 @Component({
   selector: 'app-example',
@@ -50,10 +50,10 @@ import { AsyncPipe, JsonPipe, NgIf } from '@angular/common';
     <div *ngIf="show">
       {{ data | async | json }}
     </div>
-  `
+  `,
 })
 export class ExampleComponent {
   show = true;
-  data = Promise.resolve({ message: 'Hello' });
+  data = Promise.resolve({message: 'Hello'});
 }
 ```

--- a/adev/src/content/reference/migrations/self-closing-tags.md
+++ b/adev/src/content/reference/migrations/self-closing-tags.md
@@ -13,15 +13,11 @@ ng generate @angular/core:self-closing-tag
 #### Before
 
 ```angular-html
-
 <hello-world></hello-world>
-
 ```
 
 #### After
 
 ```angular-html
-
 <hello-world />
-
 ```

--- a/adev/src/content/reference/migrations/signal-inputs.md
+++ b/adev/src/content/reference/migrations/signal-inputs.md
@@ -29,10 +29,10 @@ See more details in the section [below](#vscode-extension).
 import {Component, Input} from '@angular/core';
 
 @Component({
-  template: `Name: {{name ?? ''}}`
+  template: `Name: {{ name ?? '' }}`,
 })
 export class MyComponent {
-  @Input() name: string|undefined = undefined;
+  @Input() name: string | undefined = undefined;
 
   someMethod(): number {
     if (this.name) {
@@ -49,7 +49,7 @@ export class MyComponent {
 import {Component, input} from '@angular/core';
 
 @Component({
-  template: `Name: {{name() ?? ''}}`
+  template: `Name: {{ name() ?? '' }}`,
 })
 export class MyComponent {
   readonly name = input<string>();
@@ -61,7 +61,6 @@ export class MyComponent {
     }
     return -1;
   }
-
 }
 ```
 

--- a/adev/src/content/reference/migrations/signal-queries.md
+++ b/adev/src/content/reference/migrations/signal-queries.md
@@ -30,10 +30,10 @@ See more details in the section [below](#vscode-extension).
 import {Component, ContentChild} from '@angular/core';
 
 @Component({
-  template: `Has ref: {{someRef ? 'Yes' : 'No'}}`
+  template: `Has ref: {{ someRef ? 'Yes' : 'No' }}`,
 })
 export class MyComponent {
-  @ContentChild('someRef') ref: ElementRef|undefined = undefined;
+  @ContentChild('someRef') ref: ElementRef | undefined = undefined;
 
   someMethod(): void {
     if (this.ref) {
@@ -49,7 +49,7 @@ export class MyComponent {
 import {Component, contentChild} from '@angular/core';
 
 @Component({
-  template: `Has ref: {{someRef() ? 'Yes' : 'No'}}`
+  template: `Has ref: {{ someRef() ? 'Yes' : 'No' }}`,
 })
 export class MyComponent {
   readonly ref = contentChild<ElementRef>('someRef');

--- a/adev/src/content/reference/migrations/standalone.md
+++ b/adev/src/content/reference/migrations/standalone.md
@@ -105,7 +105,7 @@ export class SharedModule {}
 @Component({
   selector: 'greeter',
   template: '<div *ngIf="showGreeting">Hello</div>',
-  imports: [NgIf]
+  imports: [NgIf],
 })
 export class GreeterComponent {
   showGreeting = true;

--- a/adev/src/content/tools/cli/aot-compiler.md
+++ b/adev/src/content/tools/cli/aot-compiler.md
@@ -43,16 +43,14 @@ The metadata tells Angular how to construct instances of your application classe
 In the following example, the `@Component()` metadata object and the class constructor tell Angular how to create and display an instance of `TypicalComponent`.
 
 ```angular-ts
-
 @Component({
   selector: 'app-typical',
-  template: '<div>A typical component for {{data.name}}</div>'
+  template: '<div>A typical component for {{data.name}}</div>',
 })
 export class TypicalComponent {
   data = input.required<TypicalData>();
   private someService = inject(SomeService);
 }
-
 ```
 
 The Angular compiler extracts the metadata _once_ and generates a _factory_ for `TypicalComponent`.
@@ -188,17 +186,15 @@ The collector can evaluate references to module-local `const` declarations and i
 Consider the following component definition:
 
 ```angular-ts
-
 const template = '<div>{{hero().name}}</div>';
 
 @Component({
   selector: 'app-hero',
-  template: template
+  template: template,
 })
 export class HeroComponent {
   hero = input.required<Hero>();
 }
-
 ```
 
 The compiler could not refer to the `template` constant because it isn't exported.
@@ -206,15 +202,13 @@ The collector, however, can fold the `template` constant into the metadata defin
 The effect is the same as if you had written:
 
 ```angular-ts
-
 @Component({
   selector: 'app-hero',
-  template: '<div>{{hero().name}}</div>'
+  template: '<div>{{hero().name}}</div>',
 })
 export class HeroComponent {
   hero = input.required<Hero>();
 }
-
 ```
 
 There is no longer a reference to `template` and, therefore, nothing to trouble the compiler when it later interprets the _collector's_ output in `.metadata.json`.
@@ -222,25 +216,21 @@ There is no longer a reference to `template` and, therefore, nothing to trouble 
 You can take this example a step further by including the `template` constant in another expression:
 
 ```angular-ts
-
 const template = '<div>{{hero().name}}</div>';
 
 @Component({
   selector: 'app-hero',
-  template: template + '<div>{{hero().title}}</div>'
+  template: template + '<div>{{hero().title}}</div>',
 })
 export class HeroComponent {
   hero = input.required<Hero>();
 }
-
 ```
 
 The collector reduces this expression to its equivalent _folded_ string:
 
 ```angular-ts
-
-'<div>{{hero().name}}</div><div>{{hero().title}}</div>'
-
+'<div>{{hero().name}}</div><div>{{hero().title}}</div>';
 ```
 
 #### Foldable syntax
@@ -389,15 +379,13 @@ file.
 For example, consider the following component:
 
 ```angular-ts
-
 @Component({
   selector: 'my-component',
-  template: '{{person.addresss.street}}'
+  template: '{{person.addresss.street}}',
 })
 class MyComponent {
   person?: Person;
 }
-
 ```
 
 This produces the following error:
@@ -436,15 +424,13 @@ template compiler, the same way the `if` expression does in TypeScript.
 For example, to avoid `Object is possibly 'undefined'` error in the template above, modify it to only emit the interpolation if the value of `person` is initialized as shown below:
 
 ```angular-ts
-
 @Component({
   selector: 'my-component',
-  template: '<span *ngIf="person"> {{person.address.street}} </span>'
+  template: '<span *ngIf="person"> {{person.address.street}} </span>',
 })
 class MyComponent {
   person?: Person;
 }
-
 ```
 
 Using `*ngIf` allows the TypeScript compiler to infer that the `person` used in the binding expression will never be `undefined`.
@@ -459,10 +445,9 @@ In the following example, the `person` and `address` properties are always set t
 There is no convenient way to describe this constraint to TypeScript and the template compiler, but the error is suppressed in the example by using `address!.street`.
 
 ```angular-ts
-
 @Component({
   selector: 'my-component',
-  template: '<span *ngIf="person"> {{person.name}} lives on {{address!.street}} </span>'
+  template: '<span *ngIf="person"> {{person.name}} lives on {{address!.street}} </span>',
 })
 class MyComponent {
   person?: Person;
@@ -473,7 +458,6 @@ class MyComponent {
     this.address = address;
   }
 }
-
 ```
 
 The non-null assertion operator should be used sparingly as refactoring of the component might break this constraint.
@@ -481,10 +465,9 @@ The non-null assertion operator should be used sparingly as refactoring of the c
 In this example it is recommended to include the checking of `address` in the `*ngIf` as shown below:
 
 ```angular-ts
-
 @Component({
   selector: 'my-component',
-  template: '<span *ngIf="person && address"> {{person.name}} lives on {{address.street}} </span>'
+  template: '<span *ngIf="person && address"> {{person.name}} lives on {{address.street}} </span>',
 })
 class MyComponent {
   person?: Person;
@@ -495,5 +478,4 @@ class MyComponent {
     this.address = address;
   }
 }
-
 ```

--- a/adev/src/content/tools/cli/template-typecheck.md
+++ b/adev/src/content/tools/cli/template-typecheck.md
@@ -134,7 +134,6 @@ The template type checker checks whether a binding expression's type is compatib
 As an example, consider the following component:
 
 ```angular-ts
-
 export interface User {
   name: string;
 }
@@ -146,13 +145,11 @@ export interface User {
 export class UserDetailComponent {
   user = input.required<User>();
 }
-
 ```
 
 The `AppComponent` template uses this component as follows:
 
 ```angular-ts
-
 @Component({
   selector: 'app-root',
   template: '<user-detail [user]="selectedUser"></user-detail>',
@@ -160,7 +157,6 @@ The `AppComponent` template uses this component as follows:
 export class AppComponent {
   selectedUser: User | null = null;
 }
-
 ```
 
 Here, during type checking of the template for `AppComponent`, the `[user]="selectedUser"` binding corresponds with the `UserDetailComponent.user` input.
@@ -224,7 +220,6 @@ As an example, consider this custom button component:
 Consider the following directive:
 
 ```angular-ts
-
 @Component({
   selector: 'submit-button',
   template: `
@@ -234,9 +229,8 @@ Consider the following directive:
   `,
 })
 class SubmitButton {
-  disabled = input.required({transform: booleanAttribute });
+  disabled = input.required({transform: booleanAttribute});
 }
-
 ```
 
 Here, the `disabled` input of the component is being passed on to the `<button>` in the template.
@@ -306,13 +300,11 @@ The compiler treats it as a cast to the `any` type just like in TypeScript when 
 In the following example, casting `person` to the `any` type suppresses the error `Property address does not exist`.
 
 ```angular-ts
-
 @Component({
   selector: 'my-component',
-  template: '{{$any(person).address.street}}'
+  template: '{{$any(person).address.street}}',
 })
 class MyComponent {
   person?: Person;
 }
-
 ```

--- a/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/README.md
+++ b/adev/src/content/tutorials/deferrable-views/steps/3-defer-triggers/README.md
@@ -63,9 +63,8 @@ Next, update the template to include a button with the label "Show all comments"
 <button type="button" #showComments>Show all comments</button>
 
 @defer (on hover) {
-<article-comments />
+  <article-comments />
 } @placeholder (minimum 1s) {
-
   <p>Placeholder for comments</p>
 } @loading (minimum 1s; after 500ms) {
   <p>Loading comments...</p>
@@ -85,9 +84,8 @@ Update the `@defer` block in the template to use the `on interaction` trigger. P
 <button type="button" #showComments>Show all comments</button>
 
 @defer (on hover; on interaction(showComments)) {
-<article-comments />
+  <article-comments />
 } @placeholder (minimum 1s) {
-
   <p>Placeholder for comments</p>
 } @loading (minimum 1s; after 500ms) {
   <p>Loading comments...</p>

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -59,7 +59,8 @@ Note that in the above code example, each image has both `width` and `height` at
 In situations where you can't or don't want to specify a static `height` and `width` for images, you can use [the `fill` attribute](https://web.dev/articles/cls) to tell the image to act like a "background image", filling its containing element:
 
 ```angular-html
-<div class="image-container"> //Container div has 'position: "relative"'
+<div class="image-container">
+  //Container div has 'position: "relative"'
   <img ngSrc="www.example.com/image.png" fill />
 </div>
 ```

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -59,8 +59,8 @@ Note that in the above code example, each image has both `width` and `height` at
 In situations where you can't or don't want to specify a static `height` and `width` for images, you can use [the `fill` attribute](https://web.dev/articles/cls) to tell the image to act like a "background image", filling its containing element:
 
 ```angular-html
+// Container div has 'position: "relative"'
 <div class="image-container">
-  //Container div has 'position: "relative"'
   <img ngSrc="www.example.com/image.png" fill />
 </div>
 ```

--- a/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/17-reactive-forms/README.md
@@ -111,9 +111,7 @@ You have access to the form values, now it is time to handle the submission even
 Angular has an event handler for this specific purpose called `ngSubmit`. Update the form element to call the `handleSubmit` method when the form is submitted.
 
 ```angular-html {highlight:[3]}
-<form
-  [formGroup]="profileForm"
-  (ngSubmit)="handleSubmit()">
+<form [formGroup]="profileForm" (ngSubmit)="handleSubmit()"></form>
 ```
 
 </docs-step>

--- a/adev/src/content/tutorials/learn-angular/steps/22-pipes/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/22-pipes/README.md
@@ -52,7 +52,7 @@ Next, update `@Component()` decorator `imports` to include a reference to `Lower
 Finally, in `app.ts` update the template to include the `lowercase` pipe:
 
 ```angular-html
-template: `{{username | lowercase }}`
+template: `{{ username | lowercase }}`
 ```
 
 </docs-step>

--- a/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/README.md
@@ -11,7 +11,7 @@ In this activity, you will work with some pipes and pipe parameters.
 To pass parameters to a pipe, use the `:` syntax followed by the parameter value. Here's an example:
 
 ```angular-html
-template: `{{ date | date:'medium' }}`;
+template: `{{ date | date: 'medium' }}`;
 ```
 
 The output is `Jun 15, 2015, 9:43:11 PM`.
@@ -25,9 +25,8 @@ Time to customize some pipe output:
 In `app.ts`, update the template to include parameter for the `decimal` pipe.
 
 ```angular-html {highlight:[3]}
-template: `
-  ...
-  <li>Number with "decimal" {{ num | number:"3.2-2" }}</li>
+template: ` ...
+<li>Number with "decimal" {{ num | number: '3.2-2' }}</li>
 `
 ```
 
@@ -40,9 +39,8 @@ NOTE: What's that format? The parameter for the `DecimalPipe` is called `digitsI
 Now, update the template to use the `date` pipe.
 
 ```angular-html {highlight:[3]}
-template: `
-  ...
-  <li>Date with "date" {{ birthday | date: 'medium' }}</li>
+template: ` ...
+<li>Date with "date" {{ birthday | date: 'medium' }}</li>
 `
 ```
 
@@ -55,9 +53,8 @@ For extra fun, try some different parameters for `date`. More information can be
 For your last task, update the template to use the `currency` pipe.
 
 ```angular-html {highlight:[3]}
-template: `
-  ...
-  <li>Currency with "currency" {{ cost | currency }}</li>
+template: ` ...
+<li>Currency with "currency" {{ cost | currency }}</li>
 `
 ```
 

--- a/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/3-composing-components/README.md
@@ -18,8 +18,7 @@ In this example, there are two components `User` and `App`.
 Update the `App` template to include a reference to the `User` which uses the selector `app-user`. Be sure to add `User` to the imports array of `App`, this makes it available for use in the `App` template.
 
 ```angular-html
-template: `<app-user />`,
-imports: [User]
+template: `<app-user />`, imports: [User]
 ```
 
 The component now displays the message `Username: youngTech`. You can update the template code to include more markup.
@@ -29,7 +28,9 @@ The component now displays the message `Username: youngTech`. You can update the
 Because you can use any HTML markup that you want in a template, try updating the template for `App` to also include more HTML elements. This example will add a `<section>` element as the parent of the `<app-user>` element.
 
 ```angular-html
-template: `<section><app-user /></section>`,
+template: `
+<section><app-user /></section>
+`,
 ```
 
 </docs-step>

--- a/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/4-control-flow-if/README.md
@@ -51,8 +51,11 @@ Here's an example:
 
 ```angular-html
 template: `
-  @if (isServerRunning) { ... }
-  @else { ... }
+@if (isServerRunning) {
+  ...
+} @else {
+  ...
+}
 `;
 ```
 

--- a/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
@@ -13,7 +13,7 @@ In this activity, you'll learn how to use property binding in templates.
 To bind to an element's attribute, wrap the attribute name in square brackets. Here's an example:
 
 ```angular-html
-<img alt="photo" [src]="imageURL">
+<img alt="photo" [src]="imageURL" />
 ```
 
 In this example, the value of the `src` attribute will be bound to the class property `imageURL`. Whatever value `imageURL` has will be set as the `src` attribute of the `img` tag.

--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
@@ -43,7 +43,7 @@ showSecretMessage() {
 Update the template code in `app.ts` to bind to the `mouseover` event of the `section` element.
 
 ```angular-html
-<section (mouseover)="showSecretMessage()">
+<section (mouseover)="showSecretMessage()"></section>
 ```
 
 </docs-step>

--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
@@ -42,8 +42,9 @@ showSecretMessage() {
 <docs-step title="Bind to the template event">
 Update the template code in `app.ts` to bind to the `mouseover` event of the `section` element.
 
+<!-- prettier-ignore -->
 ```angular-html
-<section (mouseover)="showSecretMessage()"></section>
+<section (mouseover)="showSecretMessage()">
 ```
 
 </docs-step>

--- a/adev/src/content/tutorials/signals/steps/5-component-communication-with-signals/README.md
+++ b/adev/src/content/tutorials/signals/steps/5-component-communication-with-signals/README.md
@@ -31,7 +31,8 @@ Update the template in `product-card` to display the signal input values.
 <div class="product-card">
   <h3>{{ name() }}</h3>
   <p class="price">\${{ price() }}</p>
-  <p class="status">Status:
+  <p class="status">
+    Status:
     @if (available()) {
       Available
     } @else {

--- a/adev/src/content/tutorials/signals/steps/8-using-signals-with-directives/README.md
+++ b/adev/src/content/tutorials/signals/steps/8-using-signals-with-directives/README.md
@@ -78,21 +78,15 @@ Update the app template to demonstrate the reactive directive:
 
 ```angular-html
 template: `
-  <div>
-    <h1>Directive with Signals</h1>
+<div>
+  <h1>Directive with Signals</h1>
 
-    <div highlight color="yellow" [intensity]="0.2">
-      Hover me - Yellow highlight
-    </div>
+  <div highlight color="yellow" [intensity]="0.2">Hover me - Yellow highlight</div>
 
-    <div highlight color="blue" [intensity]="0.4">
-      Hover me - Blue highlight
-    </div>
+  <div highlight color="blue" [intensity]="0.4">Hover me - Blue highlight</div>
 
-    <div highlight color="green" [intensity]="0.6">
-      Hover me - Green highlight
-    </div>
-  </div>
+  <div highlight color="green" [intensity]="0.6">Hover me - Green highlight</div>
+</div>
 `,
 ```
 

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "karma-coverage": "^2.2.1",
     "karma-jasmine-html-reporter": "^2.1.0",
     "karma-sauce-launcher": "^4.3.6",
-    "prettier": "^3.0.0",
+    "prettier": "^3.8.0",
     "rollup-plugin-sourcemaps2": "^0.5.1",
     "semver": "^7.3.5",
     "tmp": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,8 +420,8 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       prettier:
-        specifier: ^3.0.0
-        version: 3.7.4
+        specifier: ^3.8.0
+        version: 3.8.0
       rollup-plugin-sourcemaps2:
         specifier: ^0.5.1
         version: 0.5.4(@types/node@20.19.30)(rollup@4.55.1)
@@ -663,8 +663,8 @@ importers:
         specifier: 6.6.5
         version: 6.6.5(preact@10.28.2)
       prettier:
-        specifier: 3.7.4
-        version: 3.7.4
+        specifier: 3.8.0
+        version: 3.8.0
       rxjs:
         specifier: 7.8.2
         version: 7.8.2
@@ -10466,8 +10466,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
+  prettier@3.8.0:
+    resolution: {integrity: sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -10594,7 +10594,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:
@@ -24262,7 +24261,7 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prettier@3.7.4: {}
+  prettier@3.8.0: {}
 
   pretty-bytes@5.6.0: {}
 


### PR DESCRIPTION
This version adds support for `angular-html` and `angular-ts` formatting in our markdown files.

(And also formatting for multiple `@case` and `spread` operators).
