### PR TITLE
docs: fix spelling errors in documentation

### DIFF
--- a/adev/src/content/guide/animations/enter-and-leave.md
+++ b/adev/src/content/guide/animations/enter-and-leave.md
@@ -45,7 +45,7 @@ You can use `animate.leave` to animate elements as they _leave_ the DOM. You can
 
 When the animation completes, Angular automatically removes the animated element from the DOM.
 
-NOTE: When using multiple keyframe animations or transition properties on a an element, Angular waits to remove the element only _after_ the longest of those animations has completed.
+NOTE: When using multiple keyframe animations or transition properties on an element, Angular waits to remove the element only _after_ the longest of those animations has completed.
 
 `animate.leave` can also be used with signals, and other bindings. You can use `animate.leave` with a single class or multiple classes. Either specify it as a simple string with spaces or a string array.
 

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -188,7 +188,7 @@ effect(() => {
 
 ## Advanced derivations
 
-While `computed` handles simple readonly derivations, you might find yourself needing a writable state that is dependant on other signals.
+While `computed` handles simple readonly derivations, you might find yourself needing a writable state that is dependent on other signals.
 For more information see the [Dependent state with linkedSignal](/guide/signals/linked-signal) guide.
 
 All signal APIs are synchronous— `signal`, `computed`, `input`, etc. However, applications often need to deal with data that is available asynchronously. A `Resource` gives you a way to incorporate async data into your application's signal-based code and still allow you to access its data synchronously. For more information see the [Async reactivity with resources](/guide/signals/resource) guide.

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -357,7 +357,7 @@ Unlike the real `getQuote()` method, this spy bypasses the server and returns a 
 
 ### Async test with a Vitest fake timers
 
-To mock async functions like `setTimeout` or `Promise`s, you can leverage Vitest fake timers to controle whenever the fire.
+To mock async functions like `setTimeout` or `Promise`s, you can leverage Vitest fake timers to control whenever they fire.
 
 ```ts
 it('should display error when TwainQuotes service fails', async () => {
@@ -392,7 +392,7 @@ it('should display error when TwainQuotes service fails', async () => {
 
 ### More async tests
 
-With the stubbe service returning async observables, most of your tests will have to be async as well.
+With the stubbed service returning async observables, most of your tests will have to be async as well.
 
 Here's a test that demonstrates the data flow you'd expect in the real world.
 
@@ -419,7 +419,7 @@ it('should show quote after getQuote', async () => {
 
     const fixture = TestBed.createComponent(TwainComponent);
     const twainQuotes = TestBed.inject(TwainQuotes) as MockTwainQuotes;
-    await vi.runAllTimersAsync(); // render before the quote is recieved
+    await vi.runAllTimersAsync(); // render before the quote is received
 
     const quoteEl = fixture.nativeElement.querySelector('.twain');
     expect(quoteEl.textContent).toBe('...');

--- a/adev/src/content/tools/libraries/creating-libraries.md
+++ b/adev/src/content/tools/libraries/creating-libraries.md
@@ -289,7 +289,7 @@ To use linked libraries, you need to configure your application's `angular.json`
 
 **Configuration options explained:**
 
-- `preserveSymlinks: true`: Instructs the build system to follow the symlinks created by your package manager's linking command instead of resolving to the symlink's original location. This is essential to to avoid multiple copies of the dependent node packages.
+- `preserveSymlinks: true`: Instructs the build system to follow the symlinks created by your package manager's linking command instead of resolving to the symlink's original location. This is essential to avoid multiple copies of the dependent node packages.
 - `sourceMap.vendor`: Enabling vendor source maps (especially `vendor: true`) for easier debugging of linked library code.
 - `prebundle.exclude`: By default, the Angular CLI can pre-bundle all node dependencies. Excluding your library ensures that the linked source code is properly watched and rebuilt when changes occur.
 


### PR DESCRIPTION
Fix 6 spelling errors across documentation files:
- components-scenarios.md: 'recieved' → 'received', 'stubbe' → 'stubbed', 'controle' → 'control'
- overview.md: 'dependant' → 'dependent'
- creating-libraries.md: 'to to' → 'to'
- enter-and-leave.md: 'a an' → 'an'

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
