### PR TITLE
fix(compiler): handle whitespace in control flow attribute bubbling

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -170,6 +170,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should support ngProjectAs in control flow blocks",
+      "inputFiles": [
+        "ng_project_as_control_flow.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Incorrect MyApp definition",
+          "files": [
+            "ng_project_as_control_flow.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -3,9 +3,7 @@
   "cases": [
     {
       "description": "should support content projection in root template",
-      "inputFiles": [
-        "root_template.ts"
-      ],
+      "inputFiles": ["root_template.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SimpleComponent definition",
@@ -29,29 +27,21 @@
     },
     {
       "description": "should support multi-slot content projection with multiple wildcard slots",
-      "inputFiles": [
-        "multiple_wildcards.ts"
-      ],
+      "inputFiles": ["multiple_wildcards.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid content projection instructions generated",
-          "files": [
-            "multiple_wildcards.js"
-          ]
+          "files": ["multiple_wildcards.js"]
         }
       ]
     },
     {
       "description": "should support content projection in nested templates",
-      "inputFiles": [
-        "nested_template.ts"
-      ],
+      "inputFiles": ["nested_template.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid content projection instructions generated",
-          "files": [
-            "nested_template.js"
-          ]
+          "files": ["nested_template.js"]
         },
         {
           "failureMessage": "Invalid content projection instructions generated",
@@ -66,15 +56,11 @@
     },
     {
       "description": "should support content projection in both the root and nested templates",
-      "inputFiles": [
-        "root_and_nested.ts"
-      ],
+      "inputFiles": ["root_and_nested.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid content projection instructions generated",
-          "files": [
-            "root_and_nested.js"
-          ]
+          "files": ["root_and_nested.js"]
         },
         {
           "failureMessage": "Invalid content projection instructions generated",
@@ -89,99 +75,71 @@
     },
     {
       "description": "should parse the selector that is passed into ngProjectAs",
-      "inputFiles": [
-        "ng_project_as_selector.ts"
-      ],
+      "inputFiles": ["ng_project_as_selector.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SimpleComponent definition",
-          "files": [
-            "ng_project_as_selector.js"
-          ]
+          "files": ["ng_project_as_selector.js"]
         }
       ]
     },
     {
       "description": "should take the first selector if multiple values are passed into ngProjectAs",
-      "inputFiles": [
-        "ng_project_as_compound_selector.ts"
-      ],
+      "inputFiles": ["ng_project_as_compound_selector.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SimpleComponent definition",
-          "files": [
-            "ng_project_as_compound_selector.js"
-          ]
+          "files": ["ng_project_as_compound_selector.js"]
         }
       ]
     },
     {
       "description": "should include parsed ngProjectAs selectors into template attrs",
-      "inputFiles": [
-        "ng_project_as_attribute.ts"
-      ],
+      "inputFiles": ["ng_project_as_attribute.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect MyApp definition",
-          "files": [
-            "ng_project_as_attribute.js"
-          ]
+          "files": ["ng_project_as_attribute.js"]
         }
       ]
     },
     {
       "description": "should capture the node name of ng-content with a structural directive",
-      "inputFiles": [
-        "ng_content_with_structural_dir.ts"
-      ],
+      "inputFiles": ["ng_content_with_structural_dir.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect SimpleComponent definition",
-          "files": [
-            "ng_content_with_structural_dir.js"
-          ]
+          "files": ["ng_content_with_structural_dir.js"]
         }
       ]
     },
     {
       "description": "support projectAs on ng-content",
-      "inputFiles": [
-        "project_as_ng_content.ts"
-      ],
+      "inputFiles": ["project_as_ng_content.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect projection",
-          "files": [
-            "project_as_ng_content.js"
-          ]
+          "files": ["project_as_ng_content.js"]
         }
       ]
     },
     {
       "description": "should support fallback content in ng-content",
-      "inputFiles": [
-        "ng_content_fallback.ts"
-      ],
+      "inputFiles": ["ng_content_fallback.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect projection",
-          "files": [
-            "ng_content_fallback.js"
-          ]
+          "files": ["ng_content_fallback.js"]
         }
       ]
     },
     {
       "description": "should support ngProjectAs in control flow blocks",
-      "inputFiles": [
-        "ng_project_as_control_flow.ts"
-      ],
+      "inputFiles": ["ng_project_as_control_flow.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect MyApp definition",
-          "files": [
-            "ng_project_as_control_flow.js"
-          ]
+          "files": ["ng_project_as_control_flow.js"]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_attribute.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_attribute.js
@@ -1,25 +1,25 @@
 export class MyApp {
-  // ...
-  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
-    type: MyApp,
-    selectors: [
-        ["my-app"]
-    ],
-    standalone: false,
-    decls: 1,
-    vars: 1,
-    consts: [
-        ["ngProjectAs", ".someclass", __AttributeMarker.ProjectAs__, ["", 8, "someclass"], __AttributeMarker.Template__, "ngIf"],
-        ["ngProjectAs", ".someclass", __AttributeMarker.ProjectAs__, ["", 8, "someclass"]]
-    ],
-    template: function MyApp_Template(rf, ctx) {
-        if (rf & 1) {
-            i0.ɵɵtemplate(0, MyApp_div_0_Template, 1, 0, "div", 0);
-        }
-        if (rf & 2) {
-            i0.ɵɵproperty("ngIf", ctx.show);
-        }
-    },
-    encapsulation: 2
-  });
+    // ...
+    static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+        type: MyApp,
+        selectors: [
+            ["my-app"]
+        ],
+        standalone: false,
+        decls: 1,
+        vars: 1,
+        consts: [
+            [__AttributeMarker.ProjectAs__, ["", 8, "someclass"], __AttributeMarker.Template__, "ngIf"],
+            [__AttributeMarker.ProjectAs__, ["", 8, "someclass"]]
+        ],
+        template: function MyApp_Template(rf, ctx) {
+            if (rf & 1) {
+                i0.ɵɵtemplate(0, MyApp_div_0_Template, 1, 0, "div", 0);
+            }
+            if (rf & 2) {
+                i0.ɵɵproperty("ngIf", ctx.show);
+            }
+        },
+        encapsulation: 2
+    });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_compound_selector.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_compound_selector.js
@@ -11,7 +11,7 @@ export class MyApp {
     standalone: false,
     decls: 2,
     vars: 0,
-    consts: [["ngProjectAs", "[title],[header]", 5, ["", "title", ""]]],
+    consts: [[__AttributeMarker.ProjectAs__, ["", "title", ""]]],
     template: function MyApp_Template(rf, ctx) {
       if (rf & 1) {
         $r3$.ɵɵelementStart(0, "simple");

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.js
@@ -1,0 +1,53 @@
+function MyApp_Conditional_1_Template(rf, ctx) {
+    if (rf & 1) {
+        i0.ɵɵelement(0, "h1");
+    }
+}
+
+function MyApp_For_3_Template(rf, ctx) {
+    if (rf & 1) {
+        i0.ɵɵelement(0, "h2");
+    }
+}
+
+function MyApp_Case_6_Template(rf, ctx) {
+    if (rf & 1) {
+        i0.ɵɵelement(0, "h3");
+    }
+}
+
+export class MyApp {
+    static ɵcmp = i0.ɵɵdefineComponent({
+        type: MyApp,
+        selectors: [["my-app"]],
+        standalone: false,
+        decls: 8,
+        vars: 2,
+        consts: [[__AttributeMarker.ProjectAs__, ["", "title", ""]]],
+        template: function MyApp_Template(rf, ctx) {
+            if (rf & 1) {
+                i0.ɵɵelementStart(0, "simple");
+                i0.ɵɵtemplate(1, MyApp_Conditional_1_Template, 1, 0, "h1", 0);
+                i0.ɵɵelementEnd();
+                i0.ɵɵelementStart(2, "simple");
+                i0.ɵɵrepeater(3, MyApp_For_3_Template, 1, 0, "h2", 0, i0.ɵɵrepeaterTrackByIdentity);
+                i0.ɵɵelementEnd();
+                i0.ɵɵelementStart(4, "simple");
+                i0.ɵɵelementStart(5, "Conditional");
+                i0.ɵɵtemplate(6, MyApp_Case_6_Template, 1, 0, "h3", 0);
+                i0.ɵɵelementEnd();
+                i0.ɵɵelementEnd();
+            }
+            if (rf & 2) {
+                i0.ɵɵadvance(1);
+                i0.ɵɵconditional(true ? 1 : -1);
+                i0.ɵɵadvance(2);
+                i0.ɵɵrepeater([1]);
+                i0.ɵɵadvance(3);
+                i0.ɵɵconditional(true ? 6 : -1);
+            }
+        },
+        dependencies: [SimpleComponent],
+        encapsulation: 2
+    });
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.ts
@@ -1,0 +1,28 @@
+import { Component, NgModule } from '@angular/core';
+
+@Component({
+    selector: 'simple', template: '<div><ng-content select="[title]"></ng-content></div>',
+    standalone: false
+})
+export class SimpleComponent {
+}
+
+@Component({
+    selector: 'my-app',
+    template: `
+    <simple>@if (true) { <h1 ngProjectAs="[title]"></h1> }</simple>
+    <simple>@for (item of [1]; track item) { <h2 ngProjectAs="[title]"></h2> }</simple>
+    <simple>
+      @switch (true) {
+        @case (true) { <h3 ngProjectAs="[title]"></h3> }
+      }
+    </simple>
+  `,
+    imports: [SimpleComponent],
+})
+export class MyApp {
+}
+
+@NgModule({ declarations: [MyApp, SimpleComponent] })
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_control_flow.ts
@@ -18,7 +18,7 @@ export class SimpleComponent {
       }
     </simple>
   `,
-    imports: [SimpleComponent],
+    standalone: false
 })
 export class MyApp {
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_selector.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_project_as_selector.js
@@ -9,13 +9,13 @@ export class MyApp {
     standalone: false,
     decls: 2,
     vars: 0,
-    consts: [["ngProjectAs", "[title]", 5, ["", "title", ""]]],
+    consts: [[__AttributeMarker.ProjectAs__, ["", "title", ""]]],
     template: function MyApp_Template(rf, ctx) {
-        if (rf & 1) {
-            $r3$.ɵɵelementStart(0, "simple");
-            $r3$.ɵɵelement(1, "h1", 0);
-            $r3$.ɵɵelementEnd();
-        }
+      if (rf & 1) {
+        $r3$.ɵɵelementStart(0, "simple");
+        $r3$.ɵɵelement(1, "h1", 0);
+        $r3$.ɵɵelementEnd();
+      }
     },
     dependencies: [SimpleComponent],
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/project_as_ng_content.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/project_as_ng_content.js
@@ -4,44 +4,44 @@ const _c1 = ["[card-title]", "[card-content]"];
 const _c2 = ["*"];
 // ...
 selectors: [["card"]],
-standalone: false,
-ngContentSelectors: _c1,
-decls: 3,
-vars: 0,
-template: function Card_Template(rf, ctx) {
-	if (rf & 1) {
-		i0.ɵɵprojectionDef(_c0);
-		i0.ɵɵprojection(0);
-		i0.ɵɵtext(1, " --- ");
-		i0.ɵɵprojection(2, 1);
-	}
-}
+	standalone: false,
+		ngContentSelectors: _c1,
+			decls: 3,
+				vars: 0,
+					template: function Card_Template(rf, ctx) {
+						if (rf & 1) {
+							i0.ɵɵprojectionDef(_c0);
+							i0.ɵɵprojection(0);
+							i0.ɵɵtext(1, " --- ");
+							i0.ɵɵprojection(2, 1);
+						}
+					}
 // ...
 selectors: [["card-with-title"]],
-standalone: false,
-ngContentSelectors: _c2,
-decls: 4,
-vars: 0,
-consts: [["ngProjectAs", "[card-title]", 5, ["", "card-title", ""]]],
-template: function CardWithTitle_Template(rf, ctx) {
-	if (rf & 1) {
-		i0.ɵɵprojectionDef();
-		i0.ɵɵelementStart(0, "card")(1, "h1", 0);
-		i0.ɵɵtext(2, "Title");
-		i0.ɵɵelementEnd();
-		i0.ɵɵprojection(3, 0, ["ngProjectAs", "[card-content]", 5, ["", "card-content", ""]]);
-		i0.ɵɵelementEnd();
-	}
-}
+	standalone: false,
+		ngContentSelectors: _c2,
+			decls: 4,
+				vars: 0,
+					consts: [[__AttributeMarker.ProjectAs__, ["", "card-title", ""]]],
+						template: function CardWithTitle_Template(rf, ctx) {
+							if (rf & 1) {
+								i0.ɵɵprojectionDef();
+								i0.ɵɵelementStart(0, "card")(1, "h1", 0);
+								i0.ɵɵtext(2, "Title");
+								i0.ɵɵelementEnd();
+								i0.ɵɵprojection(3, 0, [__AttributeMarker.ProjectAs__, ["", "card-content", ""]]);
+								i0.ɵɵelementEnd();
+							}
+						}
 // ...
 selectors: [["app"]],
-standalone: false,
-decls: 2,
-vars: 0,
-template: function App_Template(rf, ctx) {
-	if (rf & 1) {
-		i0.ɵɵelementStart(0, "card-with-title");
-		i0.ɵɵtext(1, "content");
-		i0.ɵɵelementEnd();
-	}
-}
+	standalone: false,
+		decls: 2,
+			vars: 0,
+				template: function App_Template(rf, ctx) {
+					if (rf & 1) {
+						i0.ɵɵelementStart(0, "card-with-title");
+						i0.ɵɵtext(1, "content");
+						i0.ɵɵelementEnd();
+					}
+				}

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -1853,7 +1853,12 @@ function ingestControlFlowInsertionPoint(
   for (const child of node.children) {
     // Skip over comment nodes and @let declarations since
     // it doesn't matter where they end up in the DOM.
-    if (child instanceof t.Comment || child instanceof t.LetDeclaration) {
+    // Also skip over whitespace-only text nodes.
+    if (
+      child instanceof t.Comment ||
+      child instanceof t.LetDeclaration ||
+      (child instanceof t.Text && child.value.trim().length === 0)
+    ) {
       continue;
     }
 

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -180,6 +180,7 @@ class ElementAttributes {
         throw Error('ngProjectAs must have a string literal value');
       }
       this.projectAs = value.value.toString();
+      return;
       // TODO: TemplateDefinitionBuilder allows `ngProjectAs` to also be assigned as a literal
       // attribute. Is this sane?
     }


### PR DESCRIPTION
# Description
This PR fixes a bug where `ngProjectAs` (and other attributes) are ignored when used on an element directly inside a control flow block like `@if`, `@for`, or `@switch` if there is any whitespace around the element.

## Root Cause
1. **Whitespace Sensitivity:** The `ingestControlFlowInsertionPoint` function in the template pipeline was overly strict, returning `null` if it encountered any node that wasn't a comment or an `@let` declaration before the root element. This included whitespace nodes used for formatting.
2. **Redundant Attribute:** `ngProjectAs` was being added to both the special `projectAs` field (serialized as `AttributeMarker.ProjectAs`) and the standard attributes list, causing a redundant `ngprojectas` attribute at runtime.

## Changes
- Updated `ingestControlFlowInsertionPoint` in `ingest.ts` to skip whitespace-only text nodes.
- Modified `ConstCollection` in `const_collection.ts` to prevent adding `ngProjectAs` to the standard attributes list.
- Added a new compliance test case covering `@if`, `@for`, and `@switch`.

## Verification Results
- Verified that attributes (including `ngProjectAs`) now correctly bubble up to the control flow block's create instruction even with whitespace in the template.
- Verified that `ngProjectAs` is correctly serialized in the constant pool without being duplicated as a literal attribute.
- Compliance test case `ng_project_as_control_flow.ts` successfully demonstrates the fix.

Fixes #59398
