### PR TITLE
fix(docs-infra): use components directly

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -8,7 +8,7 @@
 
 import {NgTemplateOutlet} from '@angular/common';
 import {ChangeDetectionStrategy, Component, inject, input, output} from '@angular/core';
-import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatTooltip} from '@angular/material/tooltip';
 import {RouterLink, RouterLinkActive} from '@angular/router';
 import {NavigationItem} from '../../interfaces/index';
 import {IsActiveNavigationItem} from '../../pipes';
@@ -23,7 +23,7 @@ import {IconComponent} from '../icon/icon.component';
     IconComponent,
     IsActiveNavigationItem,
     NgTemplateOutlet,
-    MatTooltipModule,
+    MatTooltip,
   ],
   templateUrl: './navigation-list.component.html',
   styleUrls: ['./navigation-list.component.scss'],

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.ts
@@ -9,7 +9,6 @@
 import {
   afterNextRender,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   computed,
   ElementRef,
@@ -20,13 +19,13 @@ import {
   Type,
 } from '@angular/core';
 import {DOCUMENT, NgComponentOutlet, NgTemplateOutlet} from '@angular/common';
-import {MatTabsModule} from '@angular/material/tabs';
+import {MatTab, MatTabGroup} from '@angular/material/tabs';
 import {Clipboard} from '@angular/cdk/clipboard';
 import {CopySourceCodeButton} from '../../copy-source-code-button/copy-source-code-button.component';
 import {IconComponent} from '../../icon/icon.component';
 import {ExampleMetadata, Snippet} from '../../../interfaces/index';
 import {EXAMPLE_VIEWER_CONTENT_LOADER} from '../../../providers/index';
-import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatTooltip} from '@angular/material/tooltip';
 
 export const CODE_LINE_NUMBER_CLASS_NAME = 'shiki-ln-number';
 export const CODE_LINE_CLASS_NAME = 'line';
@@ -37,8 +36,9 @@ export const HIDDEN_CLASS_NAME = 'hidden';
   selector: 'docs-example-viewer',
   imports: [
     CopySourceCodeButton,
-    MatTabsModule,
-    MatTooltipModule,
+    MatTabGroup,
+    MatTab,
+    MatTooltip,
     IconComponent,
     NgTemplateOutlet,
     NgComponentOutlet,

--- a/adev/src/app/editor/code-editor/code-editor.component.ts
+++ b/adev/src/app/editor/code-editor/code-editor.component.ts
@@ -22,7 +22,7 @@ import {
   viewChild,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {MatTabGroup, MatTabsModule} from '@angular/material/tabs';
+import {MatTabGroup, MatTab, MatTabLabel} from '@angular/material/tabs';
 import {Title} from '@angular/platform-browser';
 import {debounceTime, from, map, switchMap} from 'rxjs';
 
@@ -53,7 +53,16 @@ const ANGULAR_DEV = 'https://angular.dev';
   templateUrl: './code-editor.component.html',
   styleUrls: ['./code-editor.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatTabsModule, MatTooltip, IconComponent, CdkMenu, CdkMenuItem, CdkMenuTrigger],
+  imports: [
+    MatTabGroup,
+    MatTab,
+    MatTabLabel,
+    MatTooltip,
+    IconComponent,
+    CdkMenu,
+    CdkMenuItem,
+    CdkMenuTrigger,
+  ],
 })
 export class CodeEditor {
   readonly restrictedMode = input(false);

--- a/adev/src/app/editor/embedded-editor.component.ts
+++ b/adev/src/app/editor/embedded-editor.component.ts
@@ -23,7 +23,7 @@ import {
 } from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {IconComponent, TutorialType} from '@angular/docs';
-import {MatTabGroup, MatTabsModule} from '@angular/material/tabs';
+import {MatTabGroup, MatTab} from '@angular/material/tabs';
 import {map} from 'rxjs';
 
 import {MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES} from './alert-manager.service';
@@ -46,7 +46,7 @@ export const LARGE_EDITOR_HEIGHT_BREAKPOINT = 550;
 @Component({
   selector: EMBEDDED_EDITOR_SELECTOR,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AngularSplitModule, CodeEditor, Preview, Terminal, MatTabsModule, IconComponent],
+  imports: [AngularSplitModule, CodeEditor, Preview, Terminal, MatTab, MatTabGroup, IconComponent],
   templateUrl: './embedded-editor.component.html',
   styleUrls: ['./embedded-editor.component.scss'],
   providers: [EditorUiState],

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.ts
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.ts
@@ -10,11 +10,11 @@ import {ChangeDetectionStrategy, Component, input} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {ApiItemsGroup} from '../interfaces/api-items-group';
 import ApiItemLabel from '../api-item-label/api-item-label.component';
-import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'adev-api-items-section',
-  imports: [ApiItemLabel, RouterLink, MatTooltipModule],
+  imports: [ApiItemLabel, RouterLink, MatTooltip],
   templateUrl: './api-items-section.component.html',
   styleUrls: ['./api-items-section.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/core';
 import {Select, SelectOption, TextField} from '@angular/docs';
 import {FormField, form} from '@angular/forms/signals';
-import {MatChipsModule} from '@angular/material/chips';
+import {MatChipListbox, MatChipOption} from '@angular/material/chips';
 import {Params, Router} from '@angular/router';
 import ApiItemLabel from '../api-item-label/api-item-label.component';
 import ApiItemsSection from '../api-items-section/api-items-section.component';
@@ -48,7 +48,8 @@ export const DEFAULT_STATUS = STATUSES.stable | STATUSES.developerPreview | STAT
     TextField,
     ApiLabel,
     CdkMenuModule,
-    MatChipsModule,
+    MatChipListbox,
+    MatChipOption,
     KeyValuePipe,
     Select,
     FormField,

--- a/adev/src/app/features/update/update.component.ts
+++ b/adev/src/app/features/update/update.component.ts
@@ -9,12 +9,9 @@
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
 import {Step, RECOMMENDATIONS, ApplicationComplexity} from './recommendations';
 import {Clipboard} from '@angular/cdk/clipboard';
-import {CdkMenuModule} from '@angular/cdk/menu';
-import {MatCheckboxModule} from '@angular/material/checkbox';
-import {MatInputModule} from '@angular/material/input';
-import {MatCardModule} from '@angular/material/card';
-import {MatGridListModule} from '@angular/material/grid-list';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
+import {MatCheckbox} from '@angular/material/checkbox';
+import {MatButtonToggleGroup, MatButtonToggle} from '@angular/material/button-toggle';
 import {IconComponent} from '@angular/docs';
 import {ActivatedRoute, Router} from '@angular/router';
 import {marked} from 'marked';
@@ -33,12 +30,12 @@ const isWindows = typeof window !== 'undefined' && window.navigator.userAgent.in
   templateUrl: './update.component.html',
   styleUrl: './update.component.scss',
   imports: [
-    MatCheckboxModule,
-    MatInputModule,
-    MatCardModule,
-    MatGridListModule,
-    MatButtonToggleModule,
-    CdkMenuModule,
+    MatCheckbox,
+    MatButtonToggleGroup,
+    MatButtonToggle,
+    CdkMenuTrigger,
+    CdkMenu,
+    CdkMenuItem,
     IconComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Switches the Material and CDK components to be used directly, instead of using the modules. This allows better diagnostics for unused directives.
