### PR TITLE
refactor(compiler): use constants for parameter names

### DIFF
--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -9,6 +9,7 @@
 import * as o from '../../../../output/output_ast';
 import type {ParseSourceSpan} from '../../../../parse_util';
 
+import {CONTEXT_NAME} from '../../../../render3/view/util';
 import * as t from '../../../../render3/r3_ast';
 import {ExpressionKind, OpKind} from './enums';
 import {SlotHandle} from './handle';
@@ -1044,7 +1045,7 @@ export class ArrowFunctionExpr
   override readonly kind = ExpressionKind.ArrowFunction;
   readonly [ConsumesVarsTrait] = true;
   readonly [UsesVarOffset] = true;
-  readonly contextName = 'ctx';
+  readonly contextName = CONTEXT_NAME;
   readonly currentViewName = 'view';
 
   varOffset: number | null = null;

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -10,6 +10,7 @@
 import * as o from '../../../../src/output/output_ast';
 import {ConstantPool} from '../../../constant_pool';
 import * as ir from '../ir';
+import {CONTEXT_NAME, RENDER_FLAGS} from '../../../render3/view/util';
 
 import {
   CompilationJob,
@@ -244,7 +245,7 @@ function emitView(view: ViewCompilationUnit): o.FunctionExpr {
   const createCond = maybeGenerateRfBlock(1, createStatements);
   const updateCond = maybeGenerateRfBlock(2, updateStatements);
   return o.fn(
-    [new o.FnParam('rf'), new o.FnParam('ctx')],
+    [new o.FnParam(RENDER_FLAGS), new o.FnParam(CONTEXT_NAME)],
     [...createCond, ...updateCond],
     /* type */ undefined,
     /* sourceSpan */ undefined,
@@ -259,7 +260,11 @@ function maybeGenerateRfBlock(flag: number, statements: o.Statement[]): o.Statem
 
   return [
     o.ifStmt(
-      new o.BinaryOperatorExpr(o.BinaryOperator.BitwiseAnd, o.variable('rf'), o.literal(flag)),
+      new o.BinaryOperatorExpr(
+        o.BinaryOperator.BitwiseAnd,
+        o.variable(RENDER_FLAGS),
+        o.literal(flag),
+      ),
       statements,
     ),
   ];
@@ -300,7 +305,7 @@ export function emitHostBindingFunction(job: HostBindingCompilationJob): o.Funct
   const createCond = maybeGenerateRfBlock(1, createStatements);
   const updateCond = maybeGenerateRfBlock(2, updateStatements);
   return o.fn(
-    [new o.FnParam('rf'), new o.FnParam('ctx')],
+    [new o.FnParam(RENDER_FLAGS), new o.FnParam(CONTEXT_NAME)],
     [...createCond, ...updateCond],
     /* type */ undefined,
     /* sourceSpan */ undefined,

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -7,6 +7,7 @@
  */
 
 import {sanitizeIdentifier} from '../../../../parse_util';
+import {CONTEXT_NAME} from '../../../../render3/view/util';
 import * as ir from '../../ir';
 
 import {hyphenate} from './parse_extracted_styles';
@@ -214,7 +215,7 @@ function getVariableName(
           // TODO: Prefix increment and `_r` are for compatibility with the old naming scheme.
           // This has the potential to cause collisions when `ctx` is the identifier, so we need a
           // special check for that as well.
-          const compatPrefix = variable.identifier === 'ctx' ? 'i' : '';
+          const compatPrefix = variable.identifier === CONTEXT_NAME ? 'i' : '';
           variable.name = `${variable.identifier}_${compatPrefix}r${++state.index}`;
         } else {
           variable.name = `${variable.identifier}_i${state.index++}`;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -7,6 +7,7 @@
  */
 
 import * as o from '../../../../output/output_ast';
+import {CONTEXT_NAME} from '../../../../render3/view/util';
 import {Identifiers} from '../../../../render3/r3_identifiers';
 import * as ir from '../../ir';
 import {
@@ -818,7 +819,7 @@ function reifyIrExpression(unit: CompilationUnit, expr: o.Expression): o.Express
       return ng.arrowFunction(
         expr.varOffset,
         unit.job.pool.getSharedFunctionReference(getArrowFunctionFactory(unit, expr), 'arrowFn'),
-        o.variable('ctx'),
+        o.variable(CONTEXT_NAME),
       );
     default:
       throw new Error(

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
@@ -7,6 +7,7 @@
  */
 
 import * as o from '../../../../output/output_ast';
+import {CONTEXT_NAME} from '../../../../render3/view/util';
 import * as ir from '../../ir';
 import {CompilationJob, CompilationUnit} from '../compilation';
 
@@ -34,7 +35,7 @@ function processLexicalScope(
   const scope = new Map<ir.XrefId, o.Expression>();
 
   // The current view's context is accessible via the `ctx` parameter.
-  scope.set(view.xref, o.variable('ctx'));
+  scope.set(view.xref, o.variable(CONTEXT_NAME));
 
   for (const op of ops) {
     switch (op.kind) {
@@ -61,7 +62,7 @@ function processLexicalScope(
 
   if (view === view.job.root) {
     // Prefer `ctx` of the root view to any variables which happen to contain the root context.
-    scope.set(view.xref, o.variable('ctx'));
+    scope.set(view.xref, o.variable(CONTEXT_NAME));
   }
 
   for (const op of ops) {

--- a/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
@@ -7,6 +7,7 @@
  */
 
 import * as o from '../../../../output/output_ast';
+import {CONTEXT_NAME} from '../../../../render3/view/util';
 import * as ir from '../../ir';
 import {CompilationJob} from '../compilation';
 
@@ -550,7 +551,7 @@ function allowConservativeInlining(
   // that behavior here.
   switch (decl.variable.kind) {
     case ir.SemanticVariableKind.Identifier:
-      if (decl.initializer instanceof o.ReadVarExpr && decl.initializer.name === 'ctx') {
+      if (decl.initializer instanceof o.ReadVarExpr && decl.initializer.name === CONTEXT_NAME) {
         // Although TemplateDefinitionBuilder is cautious about inlining, we still want to do so
         // when the variable is the context, to imitate its behavior with aliases in control flow
         // blocks. This quirky behavior will become dead code once compatibility mode is no longer


### PR DESCRIPTION
Uses the existing constant for `ctx` and `rf`, instead of hardcoding the strings in a few places.
