### PR TITLE
docs: apply prefer/avoid blocks in UI with comments

### DIFF
--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -416,7 +416,7 @@ When you add `min()` and `max()` validation rules to the schema, the FormField d
 
 IMPORTANT: Don't implement validation logic in your control. Define validation rules in the form schema and let your control display the results:
 
-```typescript
+```ts {avoid}
 // Avoid: Validation in control
 export class BadControl implements FormValueControl<string> {
   value = model<string>('');
@@ -424,7 +424,9 @@ export class BadControl implements FormValueControl<string> {
     return this.value().length >= 8;
   } // Don't do this!
 }
+```
 
+```ts {prefer}
 // Good: Validation in schema, control displays results
 accountForm = form(this.accountModel, (schemaPath) => {
   minLength(schemaPath.password, 8, {message: 'Password must be at least 8 characters'});

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -74,14 +74,16 @@ const usernameField = loginForm.username;
 
 Form models should provide initial values for all fields you want to include in the field tree.
 
-```ts
+```ts {prefer}
 // Good: All fields initialized
 const userModel = signal({
   name: '',
   email: '',
   age: 0,
 });
+```
 
+```ts {avoid}
 // Avoid: Missing initial value
 const userModel = signal({
   name: '',


### PR DESCRIPTION
Apply inline comments with proper Prefer and Avoid UI blocks so guidance is more visible and consistent across the documentation.

## PR Checklist


## What is the current behavior?
<img width="1600" height="844" alt="image" src="https://github.com/user-attachments/assets/13f2a6c7-f2b2-4544-87c4-61c7fe873876" />


## What is the new behavior?
<img width="1648" height="1080" alt="image" src="https://github.com/user-attachments/assets/8bdfce90-991e-49ea-9c95-a4acd8862e51" />

