### PR TITLE
build: don't substitute binary files

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "yq.bzl", version = "0.3.4")
 bazel_dep(name = "rules_angular")
 git_override(
     module_name = "rules_angular",
-    commit = "7133b97252508f8528e5c5818a9a73cacc2e2a0e",
+    commit = "7f607d44d74fd1470e51f3d55363f1684548d008",
     remote = "https://github.com/devversion/rules_angular.git",
 )
 

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -32,6 +32,8 @@ ng_examples_db(
 ng_package(
     srcs = [
         "package.json",
+    ],
+    data = [
         "resources/code-examples.db",
     ],
     package = "@angular/forms",


### PR DESCRIPTION
Previously, ng_package applied version stamping to all source files, which corrupted binary files like SQLite databases.

This change ignores text substitution for files passed to the `data` attribute, ensuring binary assets are preserved intact in the final package.

fixes #66637
