### PR TITLE
fix(language-service): Detect local project version on creation

### DIFF
--- a/packages/language-service/test/version_detection_spec.ts
+++ b/packages/language-service/test/version_detection_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {LanguageServiceTestEnv} from '../testing';
+
+describe('Angular version detection', () => {
+  let env: LanguageServiceTestEnv;
+
+  beforeEach(() => {
+    initMockFileSystem('Native');
+    env = LanguageServiceTestEnv.setup();
+  });
+
+  it('should detect Angular version per project', () => {
+    // Project 1: Angular v16
+    const project1 = env.addProject('project1', {
+      'tsconfig.json': '{}',
+      'app.ts': 'export class App {}',
+      'node_modules/@angular/core/package.json': JSON.stringify({
+        name: '@angular/core',
+        version: '16.0.0',
+      }),
+    });
+
+    // Project 2: Angular v17
+    const project2 = env.addProject('project2', {
+      'tsconfig.json': '{}',
+      'app.ts': 'export class App {}',
+      'node_modules/@angular/core/package.json': JSON.stringify({
+        name: '@angular/core',
+        version: '17.0.0',
+      }),
+    });
+
+    // We need to access the internal options to verify detection
+    // Project wrapper in testing exposes ngLS
+    const options1 = project1.ngLS.getCompilerOptions();
+    expect(options1['_angularCoreVersion']).toBe('16.0.0');
+
+    const options2 = project2.ngLS.getCompilerOptions();
+    expect(options2['_angularCoreVersion']).toBe('17.0.0');
+  });
+
+  it('should fallback to default if detection fails', () => {
+    const project = env.addProject('project-no-core', {
+      'tsconfig.json': '{}',
+      'app.ts': 'export class App {}',
+    });
+    const options = project.ngLS.getCompilerOptions();
+    expect(options['_angularCoreVersion']).toBeUndefined();
+  });
+});

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -669,6 +669,7 @@ async function getAngularVersionsInWorkspace(
   return Array.from(angularCoreModules);
 }
 
+// TODO(atscott): Now that language service resolves the version of Angular local to the project, do we need this?
 function setAngularVersionAndShowMultipleVersionsWarning(
   angularVersions: NodeModule[],
   args: string[],
@@ -685,7 +686,10 @@ function setAngularVersionAndShowMultipleVersionsWarning(
   // For example, if we tell the v21 compiler that we're using v21 but there's a v13 project,
   // the compiler may attempt to import and use APIs from angular core that don't exist in v13.
   args.push('--angularCoreVersion', angularVersions[0].version.toString());
-  outputChannel.appendLine(`Using Angular version ${angularVersions[0].version.toString()}.`);
+  outputChannel.appendLine(
+    `Using Angular version ${angularVersions[0].version.toString()} by default. If ` +
+      `the project-specific version cannot be resolved, this version will be used.`,
+  );
 
   let minorVersions = new Map<string, NodeModule>();
   for (const v of angularVersions) {

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -612,36 +612,6 @@ export class AppComponent {
     expect(response).toBeNull();
   });
 
-  it('should handle apps where standalone is not enabled by default (pre v19)', async () => {
-    await initServer({angularCoreVersion: '18.0.0'});
-    const moduleFile = join(PROJECT_PATH, 'app/app.module.ts');
-
-    // Update component to not specify standalone explicitly. This should be interpreted as
-    // false in pre-v19 projects. The component is already declared in AppModule, and there should
-    // be no diagnostics.
-    openTextDocument(
-      client,
-      APP_COMPONENT,
-      `
-      import {Component, EventEmitter, Input, Output} from '@angular/core';
-
-      @Component({
-        selector: 'my-app',
-        template: '<h1>Hello {{name}}</h1>',
-        // standalone: false, // standalone is implicitly false
-      })
-      export class AppComponent {
-        name = 'Angular';
-        @Input() appInput = '';
-        @Output() appOutput = new EventEmitter<string>();
-      }
-      `,
-    );
-    openTextDocument(client, APP_COMPONENT_MODULE);
-    const diagnostics = await getDiagnosticsForFile(client, moduleFile);
-    expect(diagnostics.length).toBe(0);
-  });
-
   it('should provide a "go to component" codelens', async () => {
     openTextDocument(client, FOO_TEMPLATE);
     const codeLensResponse = await client.sendRequest(lsp.CodeLensRequest.type, {


### PR DESCRIPTION
This updates the language service to use the detected version of angular core in the given project on load rather than the minimum detected version in the workspace
