### PR TITLE
feat(language-service): add Document Symbols support for Angular templates

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -90,6 +90,60 @@ export interface ApplyRefactoringResult extends Omit<ts.RefactorEditInfo, 'notAp
 }
 
 /**
+ * Angular-specific LSP SymbolKind values for template symbols.
+ * These are used for symbols that don't have a direct TypeScript ScriptElementKind mapping.
+ * Values match LSP SymbolKind enum: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind
+ */
+export enum AngularSymbolKind {
+  Namespace = 3,
+  Class = 5,
+  Array = 18,
+  Object = 19,
+  Struct = 23,
+  Event = 24,
+}
+
+/**
+ * A document symbol representing an Angular template element.
+ * This uses TypeScript's NavigationTree structure so it can be merged with TS symbols.
+ */
+export interface TemplateDocumentSymbol {
+  /** Display name for the symbol */
+  text: string;
+  /** Kind of symbol (using TypeScript's ScriptElementKind for compatibility) */
+  kind: ts.ScriptElementKind;
+  /**
+   * Optional LSP SymbolKind override for Angular-specific symbol types.
+   * When set, this takes precedence over the default ScriptElementKind mapping.
+   */
+  lspKind?: AngularSymbolKind;
+  /** Span covering the entire symbol */
+  spans: ts.TextSpan[];
+  /** Span for just the name (used for selection) */
+  nameSpan?: ts.TextSpan;
+  /** Child symbols */
+  childItems?: TemplateDocumentSymbol[];
+  /**
+   * The name of the class this template belongs to.
+   * Only set for root-level symbols in TypeScript files with inline templates.
+   * Used to merge template symbols into the correct component class when
+   * multiple components exist in the same file.
+   */
+  className?: string;
+}
+
+/**
+ * Options for customizing document symbols behavior.
+ */
+export interface DocumentSymbolsOptions {
+  /**
+   * Show all implicit @for loop variables ($index, $count, $first, $last, $even, $odd).
+   * When false (default), only explicitly aliased variables like `let i = $index` are shown.
+   */
+  showImplicitForVariables?: boolean;
+}
+
+/**
  * Result for linked editing ranges containing the ranges and optional word pattern.
  */
 export interface LinkedEditingRanges {
@@ -414,6 +468,19 @@ export interface NgLanguageService extends ts.LanguageService {
     span: ts.TextSpan,
     config?: InlayHintsConfig,
   ): AngularInlayHint[];
+
+  /**
+   * Gets document symbols for Angular templates, including control flow blocks,
+   * elements, components, template references, and @let declarations.
+   * Returns symbols in NavigationTree format for compatibility with TypeScript.
+   *
+   * @param fileName The file path to get template symbols for
+   * @param options Optional configuration for document symbols behavior
+   */
+  getTemplateDocumentSymbols(
+    fileName: string,
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[];
 
   applyRefactoring(
     fileName: string,

--- a/packages/language-service/src/document_symbols.ts
+++ b/packages/language-service/src/document_symbols.ts
@@ -1,0 +1,760 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  AST,
+  ASTWithSource,
+  TmplAstBoundAttribute,
+  TmplAstBoundDeferredTrigger,
+  TmplAstComponent,
+  TmplAstContent,
+  TmplAstDeferredBlock,
+  TmplAstDeferredBlockError,
+  TmplAstDeferredBlockLoading,
+  TmplAstDeferredBlockPlaceholder,
+  TmplAstElement,
+  TmplAstForLoopBlock,
+  TmplAstForLoopBlockEmpty,
+  TmplAstHoverDeferredTrigger,
+  TmplAstIfBlock,
+  TmplAstIfBlockBranch,
+  TmplAstInteractionDeferredTrigger,
+  TmplAstLetDeclaration,
+  TmplAstNode,
+  TmplAstRecursiveVisitor,
+  TmplAstReference,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
+  TmplAstTemplate,
+  TmplAstTextAttribute,
+  TmplAstTimerDeferredTrigger,
+  TmplAstVariable,
+  TmplAstViewportDeferredTrigger,
+  tmplAstVisitAll,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import ts from 'typescript';
+
+import {AngularSymbolKind, DocumentSymbolsOptions, TemplateDocumentSymbol} from '../api';
+
+import {getFirstComponentForTemplateFile, isTypeScriptFile, toTextSpan} from './utils';
+
+// Re-export for consumers that import from this file
+export type {AngularSymbolKind, DocumentSymbolsOptions, TemplateDocumentSymbol};
+
+/** Maximum length for expression text in symbol names */
+const MAX_EXPRESSION_LENGTH = 30;
+
+/**
+ * Gets the source text for an expression, truncated if too long.
+ */
+function getExpressionText(expr: AST | null): string {
+  if (expr === null) {
+    return '';
+  }
+  // ASTWithSource contains the original source text
+  if (expr instanceof ASTWithSource && expr.source !== null) {
+    const source = expr.source.trim();
+    if (source.length > MAX_EXPRESSION_LENGTH) {
+      return source.substring(0, MAX_EXPRESSION_LENGTH) + '…';
+    }
+    return source;
+  }
+  // Fallback for other AST types - just use ellipsis
+  return '…';
+}
+
+/**
+ * Gets document symbols for Angular templates in the given file.
+ * For TypeScript files with inline templates, returns symbols for each template.
+ * For external template files (.html), returns symbols for the template content.
+ *
+ * @param compiler The Angular compiler instance
+ * @param fileName The file path to get template symbols for
+ * @param options Optional configuration for document symbols behavior
+ */
+export function getTemplateDocumentSymbols(
+  compiler: NgCompiler,
+  fileName: string,
+  options?: DocumentSymbolsOptions,
+): TemplateDocumentSymbol[] {
+  if (isTypeScriptFile(fileName)) {
+    const sf = compiler.getCurrentProgram().getSourceFile(fileName);
+    if (sf === undefined) {
+      return [];
+    }
+
+    const symbols: TemplateDocumentSymbol[] = [];
+    for (const stmt of sf.statements) {
+      if (isNamedClassDeclaration(stmt)) {
+        const resources = compiler.getDirectiveResources(stmt);
+        if (
+          resources === null ||
+          resources.template === null ||
+          isExternalResource(resources.template)
+        ) {
+          continue;
+        }
+        const template = compiler.getTemplateTypeChecker().getTemplate(stmt);
+        if (template === null) {
+          continue;
+        }
+        // For inline templates, create symbols with className for proper merging
+        const className = stmt.name.text;
+        const templateSymbols = TemplateSymbolVisitor.getSymbols(template, options);
+        // Set className on root-level symbols for multi-component file support
+        for (const symbol of templateSymbols) {
+          symbol.className = className;
+        }
+        if (templateSymbols.length > 0) {
+          symbols.push(...templateSymbols);
+        }
+      }
+    }
+    return symbols;
+  } else {
+    // External template file
+    const typeCheckInfo = getFirstComponentForTemplateFile(fileName, compiler);
+    if (typeCheckInfo === undefined) {
+      return [];
+    }
+    return TemplateSymbolVisitor.getSymbols(typeCheckInfo.nodes, options);
+  }
+}
+
+/**
+ * Visitor that walks the template AST and creates document symbols.
+ */
+class TemplateSymbolVisitor extends TmplAstRecursiveVisitor {
+  private readonly symbols: TemplateDocumentSymbol[] = [];
+  private readonly symbolStack: TemplateDocumentSymbol[][] = [];
+  /**
+   * Set of variables that have already been processed explicitly.
+   * Used to prevent duplicates when visitVariable is called via tmplAstVisitAll.
+   */
+  private readonly processedVariables = new Set<TmplAstVariable>();
+  /**
+   * Options for customizing symbol generation behavior.
+   */
+  private readonly options: DocumentSymbolsOptions;
+
+  constructor(options?: DocumentSymbolsOptions) {
+    super();
+    this.options = options ?? {};
+  }
+
+  static getSymbols(
+    templateNodes: TmplAstNode[],
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    const visitor = new TemplateSymbolVisitor(options);
+    visitor.symbolStack.push(visitor.symbols);
+    tmplAstVisitAll(visitor, templateNodes);
+    return visitor.symbols;
+  }
+
+  private addSymbol(symbol: TemplateDocumentSymbol): void {
+    const current = this.symbolStack[this.symbolStack.length - 1];
+    current.push(symbol);
+  }
+
+  private pushChildren(symbol: TemplateDocumentSymbol): void {
+    symbol.childItems = [];
+    this.symbolStack.push(symbol.childItems);
+  }
+
+  private popChildren(): void {
+    this.symbolStack.pop();
+  }
+
+  // Control flow blocks
+  override visitIfBlock(block: TmplAstIfBlock): void {
+    // Visit branches with index to differentiate @if from @else if
+    for (let i = 0; i < block.branches.length; i++) {
+      this.visitIfBlockBranchWithIndex(block.branches[i], i);
+    }
+  }
+
+  private visitIfBlockBranchWithIndex(branch: TmplAstIfBlockBranch, index: number): void {
+    let name: string;
+    if (branch.expression === null) {
+      // No expression means @else
+      name = '@else';
+    } else if (index === 0) {
+      // First branch with expression is @if
+      const exprText = getExpressionText(branch.expression);
+      const aliasText = branch.expressionAlias ? `; as ${branch.expressionAlias.name}` : '';
+      name = `@if (${exprText}${aliasText})`;
+    } else {
+      // Subsequent branches with expression are @else if
+      const exprText = getExpressionText(branch.expression);
+      const aliasText = branch.expressionAlias ? `; as ${branch.expressionAlias.name}` : '';
+      name = `@else if (${exprText}${aliasText})`;
+    }
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // Control flow → Struct 🔶
+      spans: [toTextSpan(branch.sourceSpan)],
+      nameSpan: toTextSpan(branch.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add expression alias as a child variable if present
+    if (branch.expressionAlias) {
+      this.processedVariables.add(branch.expressionAlias);
+      const aliasSymbol: TemplateDocumentSymbol = {
+        text: `as ${branch.expressionAlias.name}`,
+        kind: ts.ScriptElementKind.localVariableElement,
+        spans: [toTextSpan(branch.expressionAlias.keySpan)],
+        nameSpan: toTextSpan(branch.expressionAlias.keySpan),
+      };
+      this.addSymbol(aliasSymbol);
+    }
+
+    tmplAstVisitAll(this, branch.children);
+    this.popChildren();
+  }
+
+  // Keep the base class method as a no-op since we handle branches in visitIfBlock
+  override visitIfBlockBranch(_branch: TmplAstIfBlockBranch): void {
+    // Handled by visitIfBlockBranchWithIndex
+  }
+
+  override visitForLoopBlock(block: TmplAstForLoopBlock): void {
+    // Get expression text for the collection being iterated
+    const exprText = getExpressionText(block.expression);
+    const name = `@for (${block.item.name} of ${exprText})`;
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Array, // @for loop → Array 📦
+      spans: [toTextSpan(block.mainBlockSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add the loop item variable (mark as processed to avoid duplicates)
+    this.processedVariables.add(block.item);
+    const itemSymbol: TemplateDocumentSymbol = {
+      text: `let ${block.item.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(block.item.keySpan)],
+      nameSpan: toTextSpan(block.item.keySpan),
+    };
+    this.addSymbol(itemSymbol);
+
+    // Add context variables ($index, $count, $first, $last, $even, $odd)
+    // By default, only show explicitly aliased ones (e.g., `let i = $index`)
+    // If showImplicitForVariables is true, show all including implicit ones
+    for (const contextVar of block.contextVariables) {
+      this.processedVariables.add(contextVar);
+      // Show if explicitly aliased (name differs from value) OR if showImplicitForVariables is enabled
+      const isExplicitlyAliased = contextVar.name !== contextVar.value;
+      if (isExplicitlyAliased || this.options.showImplicitForVariables) {
+        const contextSymbol: TemplateDocumentSymbol = {
+          text: `let ${contextVar.name}`,
+          kind: ts.ScriptElementKind.localVariableElement,
+          spans: [toTextSpan(contextVar.keySpan)],
+          nameSpan: toTextSpan(contextVar.keySpan),
+        };
+        this.addSymbol(contextSymbol);
+      }
+    }
+
+    tmplAstVisitAll(this, block.children);
+    if (block.empty) {
+      block.empty.visit(this);
+    }
+    this.popChildren();
+  }
+
+  override visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: '@empty',
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Array, // @empty is part of @for → Array
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitSwitchBlock(block: TmplAstSwitchBlock): void {
+    // Get expression text for the switch condition
+    const exprText = getExpressionText(block.expression);
+    const name = `@switch (${exprText})`;
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // @switch → Struct 🔶
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.groups);
+    this.popChildren();
+  }
+
+  override visitSwitchBlockCaseGroup(group: TmplAstSwitchBlockCaseGroup): void {
+    // A case group represents multiple cases that share the same body (fall-through)
+    // Create a single symbol for the group with all case labels
+    if (group.cases.length === 0) {
+      return;
+    }
+
+    // Build the name by combining all case labels
+    const caseLabels: string[] = [];
+    let hasDefault = false;
+    for (const caseBlock of group.cases) {
+      if (caseBlock.expression === null) {
+        hasDefault = true;
+        caseLabels.push('@default');
+      } else {
+        const exprText = getExpressionText(caseBlock.expression);
+        caseLabels.push(`@case (${exprText})`);
+      }
+    }
+
+    // For a single case, just use the case name
+    // For multiple cases (fall-through), join with " | " to indicate grouping
+    const name = caseLabels.length === 1 ? caseLabels[0] : caseLabels.join(' | ');
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: hasDefault ? ts.ScriptElementKind.label : ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // @case/@default → Struct 🔶
+      spans: [toTextSpan(group.sourceSpan)],
+      nameSpan: toTextSpan(group.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, group.children);
+    this.popChildren();
+  }
+
+  // Keep the base class method as a no-op since we handle cases in visitSwitchBlockCaseGroup
+  override visitSwitchBlockCase(_block: TmplAstSwitchBlockCase): void {
+    // Handled by visitSwitchBlockCaseGroup
+  }
+
+  override visitDeferredBlock(block: TmplAstDeferredBlock): void {
+    // Build defer name with trigger information
+    const triggers = this.getDeferTriggerInfo(block);
+    const name = triggers.length > 0 ? `@defer (${triggers.join('; ')})` : '@defer';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @defer → Event ⚡
+      spans: [toTextSpan(block.mainBlockSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add prefetch trigger info as child if present
+    const prefetchTriggers = this.getPrefetchTriggerInfo(block);
+    if (prefetchTriggers.length > 0) {
+      const prefetchSymbol: TemplateDocumentSymbol = {
+        text: `prefetch ${prefetchTriggers.join('; ')}`,
+        kind: ts.ScriptElementKind.keyword,
+        spans: [toTextSpan(block.startSourceSpan)],
+        nameSpan: toTextSpan(block.startSourceSpan),
+      };
+      this.addSymbol(prefetchSymbol);
+    }
+
+    tmplAstVisitAll(this, block.children);
+    if (block.placeholder) {
+      block.placeholder.visit(this);
+    }
+    if (block.loading) {
+      block.loading.visit(this);
+    }
+    if (block.error) {
+      block.error.visit(this);
+    }
+    this.popChildren();
+  }
+
+  /**
+   * Gets human-readable trigger information for a @defer block.
+   */
+  private getDeferTriggerInfo(block: TmplAstDeferredBlock): string[] {
+    const triggers: string[] = [];
+    const t = block.triggers;
+
+    if (t.when) {
+      const exprText = getExpressionText((t.when as TmplAstBoundDeferredTrigger).value);
+      triggers.push(`when ${exprText}`);
+    }
+    if (t.idle) {
+      triggers.push('on idle');
+    }
+    if (t.immediate) {
+      triggers.push('on immediate');
+    }
+    if (t.timer) {
+      const delay = (t.timer as TmplAstTimerDeferredTrigger).delay;
+      triggers.push(`on timer(${delay}ms)`);
+    }
+    if (t.viewport) {
+      const ref = (t.viewport as TmplAstViewportDeferredTrigger).reference;
+      triggers.push(ref ? `on viewport(${ref})` : 'on viewport');
+    }
+    if (t.interaction) {
+      const ref = (t.interaction as TmplAstInteractionDeferredTrigger).reference;
+      triggers.push(ref ? `on interaction(${ref})` : 'on interaction');
+    }
+    if (t.hover) {
+      const ref = (t.hover as TmplAstHoverDeferredTrigger).reference;
+      triggers.push(ref ? `on hover(${ref})` : 'on hover');
+    }
+    if (t.never) {
+      triggers.push('on never');
+    }
+
+    return triggers;
+  }
+
+  /**
+   * Gets human-readable prefetch trigger information for a @defer block.
+   */
+  private getPrefetchTriggerInfo(block: TmplAstDeferredBlock): string[] {
+    const triggers: string[] = [];
+    const t = block.prefetchTriggers;
+
+    if (t.when) {
+      const exprText = getExpressionText((t.when as TmplAstBoundDeferredTrigger).value);
+      triggers.push(`when ${exprText}`);
+    }
+    if (t.idle) {
+      triggers.push('on idle');
+    }
+    if (t.immediate) {
+      triggers.push('on immediate');
+    }
+    if (t.timer) {
+      const delay = (t.timer as TmplAstTimerDeferredTrigger).delay;
+      triggers.push(`on timer(${delay}ms)`);
+    }
+    if (t.viewport) {
+      const ref = (t.viewport as TmplAstViewportDeferredTrigger).reference;
+      triggers.push(ref ? `on viewport(${ref})` : 'on viewport');
+    }
+    if (t.interaction) {
+      const ref = (t.interaction as TmplAstInteractionDeferredTrigger).reference;
+      triggers.push(ref ? `on interaction(${ref})` : 'on interaction');
+    }
+    if (t.hover) {
+      const ref = (t.hover as TmplAstHoverDeferredTrigger).reference;
+      triggers.push(ref ? `on hover(${ref})` : 'on hover');
+    }
+
+    return triggers;
+  }
+
+  override visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder): void {
+    // Include minimum time parameter if present
+    const minTime = block.minimumTime;
+    const name = minTime !== null ? `@placeholder (minimum ${minTime}ms)` : '@placeholder';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @placeholder → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitDeferredBlockLoading(block: TmplAstDeferredBlockLoading): void {
+    // Include timing parameters if present
+    const timings: string[] = [];
+    if (block.afterTime !== null) {
+      timings.push(`after ${block.afterTime}ms`);
+    }
+    if (block.minimumTime !== null) {
+      timings.push(`minimum ${block.minimumTime}ms`);
+    }
+    const name = timings.length > 0 ? `@loading (${timings.join('; ')})` : '@loading';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @loading → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitDeferredBlockError(block: TmplAstDeferredBlockError): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: '@error',
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @error → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  // Elements and components
+  override visitElement(element: TmplAstElement): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `<${element.name}>`,
+      kind: ts.ScriptElementKind.memberVariableElement,
+      // Use Object for elements 🟡
+      lspKind: AngularSymbolKind.Object,
+      spans: [toTextSpan(element.sourceSpan)],
+      nameSpan: toTextSpan(element.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references as children
+    for (const ref of element.references) {
+      ref.visit(this);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, element.children);
+    this.popChildren();
+  }
+
+  override visitComponent(component: TmplAstComponent): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `<${component.tagName || component.componentName}>`,
+      kind: ts.ScriptElementKind.classElement,
+      lspKind: AngularSymbolKind.Class,
+      spans: [toTextSpan(component.sourceSpan)],
+      nameSpan: toTextSpan(component.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references as children
+    for (const ref of component.references) {
+      ref.visit(this);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, component.children);
+    this.popChildren();
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    // Check if this template is from a structural directive (has directives and tagName)
+    const structuralDirective = this.getStructuralDirectiveInfo(template);
+
+    let name: string;
+    let kind: ts.ScriptElementKind;
+    let lspKind: AngularSymbolKind;
+
+    if (structuralDirective) {
+      // Display structural directive like control flow: *ngIf (expr), *ngFor (let item of items)
+      name = structuralDirective.displayName;
+      // Use Class icon for all structural directives (like components)
+      kind = ts.ScriptElementKind.classElement;
+      lspKind = AngularSymbolKind.Class;
+    } else {
+      // Regular ng-template or template element → keep as Field to match HTML elements
+      name = template.tagName ? `<${template.tagName}>` : '<ng-template>';
+      kind = ts.ScriptElementKind.memberVariableElement;
+      lspKind = AngularSymbolKind.Object;
+    }
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind,
+      lspKind,
+      spans: [toTextSpan(template.sourceSpan)],
+      nameSpan: toTextSpan(template.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references and variables as children
+    for (const ref of template.references) {
+      ref.visit(this);
+    }
+    for (const variable of template.variables) {
+      this.addTemplateVariableSymbol(variable, structuralDirective !== null);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, template.children);
+    this.popChildren();
+  }
+
+  private addTemplateVariableSymbol(
+    variable: TmplAstVariable,
+    isStructuralDirectiveTemplate: boolean,
+  ): void {
+    // Compiler microsyntax parser preserves key/value spans for variables.
+    // For `export as local`, `valueSpan` appears before `keySpan`.
+    // For `let local = export`, `keySpan` appears before `valueSpan`.
+    const isAsSyntax =
+      variable.valueSpan !== undefined && variable.value !== '$implicit'
+        ? variable.valueSpan.start.offset < variable.keySpan.start.offset
+        : false;
+    const isMicrosyntaxAlias =
+      isStructuralDirectiveTemplate && variable.value !== '$implicit' && isAsSyntax;
+    const text = isMicrosyntaxAlias ? `as ${variable.name}` : `let ${variable.name}`;
+
+    const symbol: TemplateDocumentSymbol = {
+      text,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(variable.keySpan)],
+      nameSpan: toTextSpan(variable.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  /**
+   * Detects structural directives and returns generic display information based
+   * on microsyntax/template bindings (without directive-specific hardcoding).
+   */
+  private getStructuralDirectiveInfo(
+    template: TmplAstTemplate,
+  ): {displayName: string; directiveName: string} | null {
+    // If no templateAttrs, not a structural directive template
+    if (template.templateAttrs.length === 0) {
+      return null;
+    }
+
+    const textAttrs = template.templateAttrs.filter(
+      (attr): attr is TmplAstTextAttribute => attr instanceof TmplAstTextAttribute,
+    );
+    const boundAttrs = template.templateAttrs.filter(
+      (attr): attr is TmplAstBoundAttribute => attr instanceof TmplAstBoundAttribute,
+    );
+
+    // For inline structural syntax (`*prefix="..."`), this text attribute is
+    // the directive prefix (`prefix`).
+    const prefixAttr = textAttrs[0];
+    if (prefixAttr) {
+      const directiveName = prefixAttr.name;
+      const directiveNameLower = directiveName.toLowerCase();
+
+      const primaryBound = boundAttrs.find(
+        (attr) => attr.name.toLowerCase() === directiveNameLower,
+      );
+      if (primaryBound) {
+        const expr = getExpressionText(primaryBound.value);
+        return {displayName: `*${directiveName} (${expr})`, directiveName};
+      }
+
+      const keyedBound = boundAttrs.find((attr) => {
+        if (!attr.name.toLowerCase().startsWith(directiveNameLower)) {
+          return false;
+        }
+        if (attr.name.length <= directiveName.length) {
+          return false;
+        }
+        const keySuffix = attr.name.slice(directiveName.length);
+        return /^[A-Z][A-Za-z0-9]*$/.test(keySuffix);
+      });
+      if (keyedBound) {
+        const itemVar = template.variables.find((v) => v.value === '$implicit');
+        const itemName = itemVar?.name || 'item';
+        const expr = getExpressionText(keyedBound.value);
+        const rawKeyword = keyedBound.name.slice(directiveName.length);
+        const keyword = rawKeyword[0].toLowerCase() + rawKeyword.slice(1);
+        return {
+          displayName: `*${directiveName} (let ${itemName} ${keyword} ${expr})`,
+          directiveName,
+        };
+      }
+
+      const firstBound = boundAttrs[0];
+      if (firstBound) {
+        const expr = getExpressionText(firstBound.value);
+        return {displayName: `*${directiveName} (${expr})`, directiveName};
+      }
+
+      return {displayName: `*${directiveName}`, directiveName};
+    }
+
+    if (boundAttrs.length > 0) {
+      const firstBound = boundAttrs[0];
+      const expr = getExpressionText(firstBound.value);
+      return {displayName: `*${firstBound.name} (${expr})`, directiveName: firstBound.name};
+    }
+
+    return null;
+  }
+
+  override visitContent(content: TmplAstContent): void {
+    const selector = content.selector ? ` select="${content.selector}"` : '';
+    const symbol: TemplateDocumentSymbol = {
+      text: `<ng-content${selector}>`,
+      kind: ts.ScriptElementKind.interfaceElement,
+      spans: [toTextSpan(content.sourceSpan)],
+      nameSpan: toTextSpan(content.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  // Template variables and references
+  override visitReference(reference: TmplAstReference): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `#${reference.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(reference.sourceSpan)],
+      nameSpan: toTextSpan(reference.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  override visitVariable(variable: TmplAstVariable): void {
+    // Skip variables that were already processed explicitly (e.g., @for item, @if alias)
+    if (this.processedVariables.has(variable)) {
+      return;
+    }
+    const symbol: TemplateDocumentSymbol = {
+      text: `let ${variable.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(variable.sourceSpan)],
+      nameSpan: toTextSpan(variable.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `@let ${decl.name}`,
+      kind: ts.ScriptElementKind.letElement,
+      spans: [toTextSpan(decl.sourceSpan)],
+      nameSpan: toTextSpan(decl.nameSpan),
+    };
+    this.addSymbol(symbol);
+  }
+}

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -39,6 +39,11 @@ import {CompilerFactory} from './compiler_factory';
 import {CompletionBuilder} from './completions';
 import {DefinitionBuilder} from './definitions';
 import {getLinkedEditingRangeAtPosition} from './linked_editing_range';
+import {
+  DocumentSymbolsOptions,
+  getTemplateDocumentSymbols,
+  TemplateDocumentSymbol,
+} from './document_symbols';
 import {getOutliningSpans} from './outlining_spans';
 import {QuickInfoBuilder} from './quick_info';
 import {ReferencesBuilder, RenameBuilder} from './references_and_rename';
@@ -570,6 +575,23 @@ export class LanguageService {
   getOutliningSpans(fileName: string): ts.OutliningSpan[] {
     return this.withCompilerAndPerfTracing(PerfPhase.OutliningSpans, (compiler) => {
       return getOutliningSpans(compiler, fileName);
+    });
+  }
+
+  /**
+   * Gets document symbols for Angular templates, including control flow blocks,
+   * elements, components, template references, and @let declarations.
+   * Returns symbols in NavigationTree format for compatibility with TypeScript.
+   *
+   * @param fileName The file path to get template symbols for
+   * @param options Optional configuration for document symbols behavior
+   */
+  getTemplateDocumentSymbols(
+    fileName: string,
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    return this.withCompilerAndPerfTracing(PerfPhase.LsComponentLocations, (compiler) => {
+      return getTemplateDocumentSymbols(compiler, fileName, options);
     });
   }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -11,6 +11,7 @@ import type ts from 'typescript';
 import {
   ApplyRefactoringProgressFn,
   ApplyRefactoringResult,
+  DocumentSymbolsOptions,
   GetComponentLocationsForTemplateResponse,
   GetTcbResponse,
   GetTemplateLocationForComponentResponse,
@@ -19,6 +20,7 @@ import {
   NgLanguageService,
   AngularInlayHint,
   InlayHintsConfig,
+  TemplateDocumentSymbol,
 } from '../api';
 
 import {LanguageService} from './language_service';
@@ -360,6 +362,13 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return ngLS.provideInlayHints(fileName, span, config);
   }
 
+  function getTemplateDocumentSymbols(
+    fileName: string,
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    return ngLS.getTemplateDocumentSymbols(fileName, options);
+  }
+
   return {
     ...tsLS,
     ensureProjectAnalyzed,
@@ -385,6 +394,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getSignatureHelpItems,
     getOutliningSpans,
     getTemplateLocationForComponent,
+    getTemplateDocumentSymbols,
     hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),
     getCodeFixesAtPosition,
     getCombinedCodeFix,

--- a/vscode-ng-language-service/README.md
+++ b/vscode-ng-language-service/README.md
@@ -11,6 +11,7 @@ and external templates including:
 - AOT Diagnostic messages
 - Quick info
 - Go to definition
+- Document Symbols for Outline panel, breadcrumbs, and "Go to Symbol"
 
 ## Download
 
@@ -29,6 +30,35 @@ as shown in the following example:
 ```
 
 For more information, see the [Angular compiler options](https://angular.io/guide/angular-compiler-options) guide.
+
+## Extension Settings
+
+### Document Symbols
+
+Document Symbols enable the Outline panel, breadcrumbs navigation, and "Go to Symbol" (Cmd+Shift+O / Ctrl+Shift+O) to show Angular template elements like `@if`, `@for`, structural directives, and template references.
+
+| Setting                                            | Default | Description                                                                                  |
+| -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `angular.documentSymbols.enabled`                  | `true`  | Enable Angular-specific document symbols                                                     |
+| `angular.documentSymbols.showImplicitForVariables` | `false` | Show implicit `@for` loop variables (`$index`, `$count`, `$first`, `$last`, `$even`, `$odd`) |
+
+For TypeScript files with inline templates, the Outline shows only the component class with template symbols nested inside:
+
+```
+MyComponent (class)
+└── (template)
+    ├── @if (condition)
+    └── <button>
+```
+
+Example configuration:
+
+```json
+{
+  "angular.documentSymbols.enabled": true,
+  "angular.documentSymbols.showImplicitForVariables": false
+}
+```
 
 ## Versioning
 

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -244,6 +244,15 @@ export class AngularLanguageClient implements vscode.Disposable {
 
           return angularCompletionsPromise;
         },
+        provideDocumentSymbols: async (
+          document: vscode.TextDocument,
+          token: vscode.CancellationToken,
+          next: lsp.ProvideDocumentSymbolsSignature,
+        ) => {
+          if (await this.isInAngularProject(document)) {
+            return next(document, token);
+          }
+        },
         provideFoldingRanges: async (
           document: vscode.TextDocument,
           context: vscode.FoldingContext,
@@ -495,6 +504,11 @@ export class AngularLanguageClient implements vscode.Disposable {
     if (suppressAngularDiagnosticCodes) {
       args.push('--suppressAngularDiagnosticCodes', suppressAngularDiagnosticCodes);
     }
+
+    // Note: Document symbols settings (angular.documentSymbols.enabled,
+    // angular.documentSymbols.showImplicitForVariables) are now fetched
+    // dynamically via workspace/configuration request by the server.
+    // This allows users to change these settings without restarting.
 
     const tsdk = config.get('typescript.tsdk', '');
     if (tsdk.trim().length > 0) {

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -318,6 +318,904 @@ export class AppComponent {
     expect(response).toContain({startLine: 32, endLine: 33}); // empty
   });
 
+  it('provides document symbols for TypeScript files (default: filtered to components)', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component, Input, Output, EventEmitter} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: '<div>{{name}}</div>',
+})
+export class AppComponent {
+  name = 'Angular';
+
+  constructor() {}
+
+  greet(): string {
+    return 'Hello, ' + this.name;
+  }
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // Only component classes with templates are shown, without TypeScript children (methods, properties)
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+    expect(appComponentSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    // Class should only have template children, not TypeScript symbols
+    expect(appComponentSymbol!.children).toBeDefined();
+    // Should have (template) container with template symbols
+    const templateSymbol = appComponentSymbol!.children!.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+    // Should NOT have TypeScript method/property children
+    const nameSymbol = appComponentSymbol!.children!.find((c) => c.name === 'name');
+    expect(nameSymbol).toBeUndefined();
+    const constructorSymbol = appComponentSymbol!.children!.find((c) => c.name === 'constructor');
+    expect(constructorSymbol).toBeUndefined();
+    const greetSymbol = appComponentSymbol!.children!.find((c) => c.name === 'greet');
+    expect(greetSymbol).toBeUndefined();
+  });
+
+  it('handles multiple components in a single file', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'first-comp',
+  template: '<h1>First</h1>',
+})
+export class FirstComponent {
+  value = 1;
+}
+
+@Component({
+  selector: 'second-comp',
+  template: '<h2>Second</h2>',
+})
+export class SecondComponent {
+  value = 2;
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // Both components should be present
+    const firstSymbol = response.find((s) => s.name === 'FirstComponent');
+    expect(firstSymbol).toBeDefined();
+    expect(firstSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    const firstTemplateSymbol = firstSymbol!.children!.find((c) => c.name === '(template)');
+    expect(firstTemplateSymbol).toBeDefined();
+
+    const secondSymbol = response.find((s) => s.name === 'SecondComponent');
+    expect(secondSymbol).toBeDefined();
+    expect(secondSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    const secondTemplateSymbol = secondSymbol!.children!.find((c) => c.name === '(template)');
+    expect(secondTemplateSymbol).toBeDefined();
+
+    // Neither should have TypeScript property children by default
+    const firstValue = firstSymbol!.children!.find((c) => c.name === 'value');
+    expect(firstValue).toBeUndefined();
+    const secondValue = secondSymbol!.children!.find((c) => c.name === 'value');
+    expect(secondValue).toBeUndefined();
+  });
+
+  it('returns empty symbols for TypeScript files without Angular templates', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+// A regular TypeScript file with no Angular components
+export interface User {
+  name: string;
+  age: number;
+}
+
+export function greet(user: User): string {
+  return 'Hello, ' + user.name;
+}
+
+export class UserService {
+  private users: User[] = [];
+
+  addUser(user: User): void {
+    this.users.push(user);
+  }
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // With default filtering, no symbols should be returned for non-Angular files
+    // (TypeScript LS handles these files instead)
+    expect(response.length).toBe(0);
+  });
+
+  it('provides document symbols for Angular templates with control flow', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (showContent) {
+      <div class="container">
+        <router-outlet></router-outlet>
+      </div>
+    } @else {
+      <p>No content</p>
+    }
+
+    @for (item of items; track item) {
+      <span #itemRef>{{ item }}</span>
+    } @empty {
+      <p>No items</p>
+    }
+
+    @let message = 'Hello';
+    <ng-content select="header"></ng-content>
+  \`,
+})
+export class AppComponent {
+  showContent = true;
+  items = [1, 2, 3];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    expect(Array.isArray(response)).toBe(true);
+
+    // Should contain the class symbol
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+    expect(appComponentSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // The class should have a (template) child containing Angular template symbols
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+    expect(templateSymbol!.children).toBeDefined();
+
+    // Check for @if block (now shows actual expression)
+    const ifSymbol = templateSymbol!.children!.find((c) => c.name === '@if (showContent)');
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.kind).toBe(lsp.SymbolKind.Struct); // Control flow → Struct
+
+    // Check for @else block
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+
+    // Check for @for block (now shows actual expression)
+    const forSymbol = templateSymbol!.children!.find((c) => c.name === '@for (item of items)');
+    expect(forSymbol).toBeDefined();
+    expect(forSymbol!.kind).toBe(lsp.SymbolKind.Array); // @for loop → Array
+
+    // Check for @let declaration
+    const letSymbol = templateSymbol!.children!.find((c) => c.name === '@let message');
+    expect(letSymbol).toBeDefined();
+    expect(letSymbol!.kind).toBe(lsp.SymbolKind.Variable);
+
+    // Check for ng-content
+    const ngContentSymbol = templateSymbol!.children!.find((c) => c.name.includes('ng-content'));
+    expect(ngContentSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for external HTML template files', async () => {
+    openTextDocument(
+      client,
+      FOO_TEMPLATE,
+      `
+@if (condition) {
+  <div>
+    <router-outlet name="primary"></router-outlet>
+  </div>
+}
+
+@for (item of items; track item) {
+  <span #ref>{{ item }}</span>
+} @empty {
+  <p>Empty</p>
+}
+
+@defer {
+  <heavy-component></heavy-component>
+} @placeholder {
+  <p>Loading...</p>
+}
+`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: FOO_TEMPLATE_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    expect(Array.isArray(response)).toBe(true);
+
+    // External templates should have template symbols at the root level
+    // Check for @if block (now shows actual expression)
+    const ifSymbol = response.find((s) => s.name === '@if (condition)');
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.kind).toBe(lsp.SymbolKind.Struct); // Control flow → Struct
+
+    // Check for @for block (now shows actual expression)
+    const forSymbol = response.find((s) => s.name === '@for (item of items)');
+    expect(forSymbol).toBeDefined();
+
+    // Check for @defer block
+    const deferSymbol = response.find((s) => s.name === '@defer');
+    expect(deferSymbol).toBeDefined();
+    expect(deferSymbol!.children).toBeDefined();
+
+    // @defer should have @placeholder as a child
+    const placeholderSymbol = deferSymbol!.children!.find((c) => c.name === '@placeholder');
+    expect(placeholderSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @else if branches', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (status === 'active') {
+      <p>Active</p>
+    } @else if (status === 'pending') {
+      <p>Pending</p>
+    } @else if (status === 'error') {
+      <p>Error</p>
+    } @else {
+      <p>Unknown</p>
+    }
+  \`,
+})
+export class AppComponent {
+  status = 'active';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block
+    const ifSymbol = templateSymbol!.children!.find((c) =>
+      c.name.startsWith("@if (status === 'active')"),
+    );
+    expect(ifSymbol).toBeDefined();
+
+    // Check for @else if blocks (should show actual condition)
+    const elseIfPending = templateSymbol!.children!.find((c) =>
+      c.name.includes("@else if (status === 'pending')"),
+    );
+    expect(elseIfPending).toBeDefined();
+
+    const elseIfError = templateSymbol!.children!.find((c) =>
+      c.name.includes("@else if (status === 'error')"),
+    );
+    expect(elseIfError).toBeDefined();
+
+    // Check for @else block
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @switch with case fall-through', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @switch (color) {
+      @case ('red') {
+        <p>Red color</p>
+      }
+      @case ('green') {
+        <p>Green color</p>
+      }
+      @default {
+        <p>Unknown color</p>
+      }
+    }
+  \`,
+})
+export class AppComponent {
+  color = 'red';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @switch block (should show actual expression)
+    const switchSymbol = templateSymbol!.children!.find((c) => c.name === '@switch (color)');
+    expect(switchSymbol).toBeDefined();
+    expect(switchSymbol!.children).toBeDefined();
+
+    // Check for @case blocks (should show actual case values)
+    const caseRed = switchSymbol!.children!.find((c) => c.name.includes("@case ('red')"));
+    expect(caseRed).toBeDefined();
+
+    const caseGreen = switchSymbol!.children!.find((c) => c.name.includes("@case ('green')"));
+    expect(caseGreen).toBeDefined();
+
+    // Check for @default
+    const defaultCase = switchSymbol!.children!.find((c) => c.name === '@default');
+    expect(defaultCase).toBeDefined();
+  });
+
+  it('provides document symbols for @for with context variables', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @for (item of items; track item.id; let i = $index; let first = $first; let last = $last) {
+      <div>{{ i }}: {{ item.name }}</div>
+    } @empty {
+      <div>No items</div>
+    }
+  \`,
+})
+export class AppComponent {
+  items = [{id: 1, name: 'A'}, {id: 2, name: 'B'}];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @for block (shows loop variable and collection)
+    const forSymbol = templateSymbol!.children!.find((c) => c.name.includes('@for (item of'));
+    expect(forSymbol).toBeDefined();
+    expect(forSymbol!.children).toBeDefined();
+
+    // Check for loop item variable
+    const itemVar = forSymbol!.children!.find((c) => c.name === 'let item');
+    expect(itemVar).toBeDefined();
+
+    // Check for context variables (aliased)
+    const indexVar = forSymbol!.children!.find((c) => c.name === 'let i');
+    expect(indexVar).toBeDefined();
+
+    const firstVar = forSymbol!.children!.find((c) => c.name === 'let first');
+    expect(firstVar).toBeDefined();
+
+    const lastVar = forSymbol!.children!.find((c) => c.name === 'let last');
+    expect(lastVar).toBeDefined();
+
+    // Check for @empty block
+    const emptySymbol = forSymbol!.children!.find((c) => c.name === '@empty');
+    expect(emptySymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @if/@else-if expression aliases', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (user$ | async; as user) {
+      <p>Welcome, {{ user.name }}</p>
+    }
+  \`,
+})
+export class AppComponent {
+  user$ = of({name: 'Test'});
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block with alias (shows expression and alias)
+    const ifSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@if') && c.name.includes('as user'),
+    );
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.children).toBeDefined();
+
+    // Check for alias variable
+    const aliasVar = ifSymbol!.children!.find((c) => c.name === 'as user');
+    expect(aliasVar).toBeDefined();
+  });
+
+  it('provides document symbols for @defer with triggers', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @defer (on viewport) {
+      <p>Loaded</p>
+    } @placeholder {
+      <p>Placeholder</p>
+    } @loading {
+      <p>Loading...</p>
+    } @error {
+      <p>Error!</p>
+    }
+  \`,
+})
+export class AppComponent {
+  value = 'test';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @defer block with trigger info
+    const deferSymbol = templateSymbol!.children!.find((c) => c.name.includes('@defer'));
+    expect(deferSymbol).toBeDefined();
+    expect(deferSymbol!.name).toContain('on viewport');
+    expect(deferSymbol!.children).toBeDefined();
+
+    // Check for @placeholder
+    const placeholderSymbol = deferSymbol!.children!.find((c) => c.name.includes('@placeholder'));
+    expect(placeholderSymbol).toBeDefined();
+
+    // Check for @loading
+    const loadingSymbol = deferSymbol!.children!.find((c) => c.name.includes('@loading'));
+    expect(loadingSymbol).toBeDefined();
+
+    // Check for @error
+    const errorSymbol = deferSymbol!.children!.find((c) => c.name === '@error');
+    expect(errorSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for *ngFor structural directive', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  imports: [CommonModule],
+  template: \`
+    <ul>
+      <li *ngFor="let item of items; let i = index; let isFirst = first">
+        {{ i }}: {{ item }}
+      </li>
+    </ul>
+  \`,
+})
+export class AppComponent {
+  items = ['a', 'b', 'c'];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Find the <ul> element
+    const ulSymbol = templateSymbol!.children!.find((c) => c.name === '<ul>');
+    expect(ulSymbol).toBeDefined();
+
+    // Check for *ngFor directive (should show like control flow)
+    const ngForSymbol = ulSymbol!.children!.find((c) => c.name.includes('*ngFor'));
+    expect(ngForSymbol).toBeDefined();
+    expect(ngForSymbol!.name).toContain('let item of');
+
+    // Check for let- variables as children
+    expect(ngForSymbol!.children).toBeDefined();
+    const itemVar = ngForSymbol!.children!.find((c) => c.name === 'let item');
+    expect(itemVar).toBeDefined();
+
+    const indexVar = ngForSymbol!.children!.find((c) => c.name === 'let i');
+    expect(indexVar).toBeDefined();
+
+    const firstVar = ngForSymbol!.children!.find((c) => c.name === 'let isFirst');
+    expect(firstVar).toBeDefined();
+  });
+
+  it('provides document symbols for *ngIf structural directive', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  imports: [CommonModule],
+  template: \`
+    <div *ngIf="isVisible; else notVisible">
+      Visible content
+    </div>
+    <ng-template #notVisible>
+      <p>Not visible</p>
+    </ng-template>
+  \`,
+})
+export class AppComponent {
+  isVisible = true;
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for *ngIf directive (should show the condition)
+    const ngIfSymbol = templateSymbol!.children!.find((c) => c.name.includes('*ngIf'));
+    expect(ngIfSymbol).toBeDefined();
+    expect(ngIfSymbol!.name).toContain('isVisible');
+
+    // Check for ng-template with reference
+    const ngTemplateSymbol = templateSymbol!.children!.find((c) => c.name === '<ng-template>');
+    expect(ngTemplateSymbol).toBeDefined();
+
+    // Check for the #notVisible reference
+    const notVisibleRef = ngTemplateSymbol!.children!.find((c) => c.name === '#notVisible');
+    expect(notVisibleRef).toBeDefined();
+  });
+
+  it('provides document symbols for custom structural directive let/as microsyntax', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component, Directive, Input} from '@angular/core';
+
+@Directive({
+  selector: '[myDir]',
+  standalone: true,
+})
+export class MyDir<T = unknown> {
+  @Input() myDir: T | null = null;
+  @Input() myDirOf: readonly T[] | null = null;
+  @Input() myDirTrackBy: ((index: number, value: T) => unknown) | null = null;
+}
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  imports: [MyDir],
+  template: \
+    '<ng-container *myDir="let item of [1,2,3] as items; trackBy: track; index as i">{{ item }}{{ items.length }}{{ i }}</ng-container>',
+})
+export class AppComponent {
+  track = (index: number) => index;
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    const myDirSymbol = templateSymbol!.children!.find((c) => c.name.includes('*myDir'));
+    expect(myDirSymbol).toBeDefined();
+
+    const childNames = myDirSymbol!.children?.map((c) => c.name) ?? [];
+    expect(childNames).toContain('let item');
+    expect(childNames).toContain('as items');
+    expect(childNames).toContain('as i');
+  });
+
+  it('provides document symbols for @if with expression alias', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  template: \`
+    @if (user; as currentUser) {
+      <div>Hello, {{ currentUser.name }}!</div>
+    } @else if (guestName; as name) {
+      <div>Welcome, {{ name }}!</div>
+    } @else {
+      <div>Anonymous</div>
+    }
+  \`,
+})
+export class AppComponent {
+  user = { name: 'John' };
+  guestName = '';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block with alias
+    const ifSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@if') && c.name.includes('currentUser'),
+    );
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.name).toContain('as currentUser');
+
+    // The alias should appear exactly once as a child
+    const currentUserAliases = ifSymbol!.children!.filter((c) => c.name === 'as currentUser');
+    expect(currentUserAliases.length).toBe(1);
+
+    // Check for @else if block with alias
+    const elseIfSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@else if') && c.name.includes('name'),
+    );
+    expect(elseIfSymbol).toBeDefined();
+    expect(elseIfSymbol!.name).toContain('as name');
+
+    // The alias should appear exactly once
+    const nameAliases = elseIfSymbol!.children!.filter((c) => c.name === 'as name');
+    expect(nameAliases.length).toBe(1);
+
+    // Check for @else block (no alias)
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for nested @if with alias inside @for', async () => {
+    // Test case similar to user's template structure
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  template: \`
+    @for (category of categories; track category.name) {
+      <div class="category">
+        @for (test of category.tests; track test.name; let i = $index) {
+          @if (!test.passed; as tr) {
+            <div class="failed">{{ tr }}</div>
+          }
+        }
+      </div>
+    }
+  \`,
+})
+export class AppComponent {
+  categories = [
+    { name: 'Category 1', tests: [{ name: 'Test 1', passed: true }, { name: 'Test 2', passed: false }] }
+  ];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Find the outer @for - name is "@for (category of categories)"
+    const outerForSymbol = templateSymbol!.children!.find(
+      (c) => c.name.startsWith('@for') && c.name.includes('category'),
+    );
+    expect(outerForSymbol).toBeDefined();
+
+    // Find the <div> inside outer @for
+    const divSymbol = outerForSymbol!.children!.find((c) => c.name === '<div>');
+    expect(divSymbol).toBeDefined();
+
+    // Find nested @for inside <div> - name is "@for (test of category.tests)"
+    const nestedForSymbol = divSymbol!.children!.find(
+      (c) => c.name.startsWith('@for') && c.name.includes('test of'),
+    );
+    expect(nestedForSymbol).toBeDefined();
+
+    // Check for 'let test' and 'let i' (explicit alias for $index)
+    const testVar = nestedForSymbol!.children!.filter((c) => c.name === 'let test');
+    expect(testVar.length).toBe(1);
+    const indexVar = nestedForSymbol!.children!.filter((c) => c.name === 'let i');
+    expect(indexVar.length).toBe(1);
+
+    // Find @if with alias inside nested @for - name is "@if (!test.passed; as tr)"
+    const ifSymbol = nestedForSymbol!.children!.find(
+      (c) => c.name.startsWith('@if') && c.name.includes('as tr'),
+    );
+    expect(ifSymbol).toBeDefined();
+
+    // The 'tr' alias should appear exactly once
+    const trAliases = ifSymbol!.children!.filter((c) => c.name === 'as tr');
+    expect(trAliases.length).toBe(1);
+  });
+
+  it('provides document symbols for component without "Component" suffix', async () => {
+    // Test that components like "NxWelcome" (without "Component" suffix) still get template symbols
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-welcome',
+  template: \`
+    @if (title) {
+      <span>{{ title }}</span>
+    }
+  \`,
+})
+export class Welcome {
+  title = 'Hello';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    // Should contain the class symbol
+    const welcomeSymbol = response.find((s) => s.name === 'Welcome');
+    expect(welcomeSymbol).toBeDefined();
+    expect(welcomeSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // The class should have a (template) child containing Angular template symbols
+    const templateSymbol = welcomeSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+
+    // Check for @if block
+    const ifSymbol = templateSymbol!.children!.find((c) => c.name === '@if (title)');
+    expect(ifSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for multiple components in one file', async () => {
+    // Test that files with multiple components (common in tests/storybooks) work correctly
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  template: \`<button>{{ label }}</button>\`,
+})
+export class ButtonComponent {
+  label = 'Click me';
+}
+
+@Component({
+  selector: 'app-input',
+  template: \`<input [placeholder]="hint" />\`,
+})
+export class InputComponent {
+  hint = 'Type here';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    // Should contain both class symbols
+    const buttonSymbol = response.find((s) => s.name === 'ButtonComponent');
+    expect(buttonSymbol).toBeDefined();
+    expect(buttonSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    const inputSymbol = response.find((s) => s.name === 'InputComponent');
+    expect(inputSymbol).toBeDefined();
+    expect(inputSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // ButtonComponent should have its own (template) with <button>
+    const buttonTemplate = buttonSymbol!.children?.find((c) => c.name === '(template)');
+    expect(buttonTemplate).toBeDefined();
+    const buttonElement = buttonTemplate!.children!.find((c) => c.name === '<button>');
+    expect(buttonElement).toBeDefined();
+
+    // InputComponent should have its own (template) with <input>
+    const inputTemplate = inputSymbol!.children?.find((c) => c.name === '(template)');
+    expect(inputTemplate).toBeDefined();
+    const inputElement = inputTemplate!.children!.find((c) => c.name === '<input>');
+    expect(inputElement).toBeDefined();
+  });
+
   describe('signature help', () => {
     it('should show signature help for an empty call', async () => {
       client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -159,6 +159,16 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+          },
+          "angular.documentSymbols.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable Angular-specific document symbols in the Outline view and breadcrumbs. Shows control flow blocks (`@if`, `@for`, `@defer`), elements, variables, and structural directives."
+          },
+          "angular.documentSymbols.showImplicitForVariables": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show all implicit `@for` loop variables (`$index`, `$count`, `$first`, `$last`, `$even`, `$odd`) in document symbols. When disabled (default), only explicitly aliased variables like `let i = $index` are shown."
           }
         }
       },

--- a/vscode-ng-language-service/server/src/handlers/document_symbols.ts
+++ b/vscode-ng-language-service/server/src/handlers/document_symbols.ts
@@ -1,0 +1,440 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+import * as lsp from 'vscode-languageserver';
+import * as ts from 'typescript/lib/tsserverlibrary';
+import {isNgLanguageService, TemplateDocumentSymbol} from '@angular/language-service/api';
+
+import {getWorkspaceConfiguration} from '../config';
+import {Session} from '../session';
+import {tsTextSpanToLspRange} from '../utils';
+
+/**
+ * Configuration for document symbols feature.
+ * These settings control how document symbols are generated for Angular templates.
+ */
+interface DocumentSymbolsConfig {
+  /**
+   * Whether to enable document symbols for Angular templates.
+   * When enabled (default), shows control flow blocks, elements, variables, etc.
+   * When disabled, only TypeScript symbols are shown in the outline.
+   */
+  enabled: boolean;
+  /**
+   * Whether to show 'implicit' annotation for template variables
+   * that are implicitly typed by Angular (e.g., `let item` in `@for`).
+   */
+  showImplicitForVariables: boolean;
+}
+
+/**
+ * Handles textDocument/documentSymbol requests.
+ *
+ * Returns a hierarchical list of symbols in the document that appears in:
+ * - The Outline view in VS Code
+ * - The breadcrumbs navigation bar
+ * - The "Go to Symbol" picker (Ctrl+Shift+O / Cmd+Shift+O)
+ */
+export async function onDocumentSymbol(
+  session: Session,
+  params: lsp.DocumentSymbolParams,
+): Promise<lsp.DocumentSymbol[] | null> {
+  const lsInfo = session.getLSAndScriptInfo(params.textDocument);
+  if (lsInfo === null) {
+    return null;
+  }
+  const {scriptInfo, languageService} = lsInfo;
+  const isHtmlFile = params.textDocument.uri.endsWith('.html');
+
+  // Fetch document symbols configuration from the client using workspace/configuration.
+  // This allows users to change settings without restarting the language server.
+  const [config] = await getWorkspaceConfiguration<DocumentSymbolsConfig>(session.connection, [
+    {scopeUri: params.textDocument.uri, section: 'angular.documentSymbols'},
+  ]);
+
+  // Check if document symbols are enabled (default: true)
+  const isEnabled = config?.enabled !== false;
+
+  // When disabled, do not return Angular symbols. This lets other providers
+  // (e.g. TypeScript/HTML) remain visible.
+  if (!isEnabled) {
+    return null;
+  }
+
+  // For HTML template files, we only need Angular template symbols (no TS symbols)
+  if (isHtmlFile) {
+    if (isEnabled && isNgLanguageService(languageService)) {
+      const templateSymbols = languageService.getTemplateDocumentSymbols(scriptInfo.fileName, {
+        showImplicitForVariables: config?.showImplicitForVariables ?? false,
+      });
+      if (templateSymbols.length > 0) {
+        return convertTemplateSymbols(templateSymbols, scriptInfo);
+      }
+    }
+    return null;
+  }
+
+  // Get template symbols for Angular files
+  let templateSymbols: TemplateDocumentSymbol[] = [];
+  if (isNgLanguageService(languageService)) {
+    templateSymbols = languageService.getTemplateDocumentSymbols(scriptInfo.fileName, {
+      showImplicitForVariables: config?.showImplicitForVariables ?? false,
+    });
+  }
+
+  // For TypeScript files, get the navigation tree which includes
+  // classes, functions, variables, imports, etc.
+  const navigationTree = languageService.getNavigationTree(scriptInfo.fileName);
+  if (!navigationTree) {
+    return null;
+  }
+
+  // Get the set of class names that have templates
+  const classNamesWithTemplates = new Set<string>();
+  for (const symbol of templateSymbols) {
+    if (symbol.className) {
+      classNamesWithTemplates.add(symbol.className);
+    }
+  }
+
+  // Filter TypeScript symbols to only show classes with templates (no methods/properties)
+  // This implements the hybrid approach where component classes are shown as containers
+  // with template symbols nested inside
+  const tsSymbols = filterNavigationTreeToTemplateClasses(
+    navigationTree,
+    scriptInfo,
+    classNamesWithTemplates,
+  );
+
+  // For Angular TypeScript files, merge template symbols into component classes
+  if (templateSymbols.length > 0) {
+    mergeTemplateSymbolsIntoClass(tsSymbols, templateSymbols, scriptInfo);
+  }
+
+  return tsSymbols;
+}
+
+/**
+ * Merges Angular template symbols into the component class in the TypeScript symbol tree.
+ * This places control flow blocks, elements, etc. under the component class they belong to.
+ * Supports multiple components in the same file by matching on className.
+ */
+function mergeTemplateSymbolsIntoClass(
+  tsSymbols: lsp.DocumentSymbol[],
+  templateSymbols: TemplateDocumentSymbol[],
+  scriptInfo: ts.server.ScriptInfo,
+): void {
+  if (templateSymbols.length === 0) {
+    return;
+  }
+
+  // Group template symbols by their className
+  const symbolsByClass = new Map<string, TemplateDocumentSymbol[]>();
+  const symbolsWithoutClass: TemplateDocumentSymbol[] = [];
+
+  for (const symbol of templateSymbols) {
+    if (symbol.className) {
+      const existing = symbolsByClass.get(symbol.className) ?? [];
+      existing.push(symbol);
+      symbolsByClass.set(symbol.className, existing);
+    } else {
+      symbolsWithoutClass.push(symbol);
+    }
+  }
+
+  // For each class in the TypeScript symbols, try to find matching template symbols
+  for (const tsSymbol of tsSymbols) {
+    if (tsSymbol.kind === lsp.SymbolKind.Class) {
+      const classTemplateSymbols = symbolsByClass.get(tsSymbol.name);
+      if (classTemplateSymbols && classTemplateSymbols.length > 0) {
+        const converted = convertTemplateSymbols(classTemplateSymbols, scriptInfo);
+        addTemplateSymbolsToClass(tsSymbol, converted);
+        symbolsByClass.delete(tsSymbol.name);
+      }
+    }
+  }
+
+  // Handle any remaining symbols without className (fallback for older API or edge cases)
+  if (symbolsWithoutClass.length > 0) {
+    const converted = convertTemplateSymbols(symbolsWithoutClass, scriptInfo);
+    // Find first class to merge into
+    for (const tsSymbol of tsSymbols) {
+      if (tsSymbol.kind === lsp.SymbolKind.Class) {
+        addTemplateSymbolsToClass(tsSymbol, converted);
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Adds template symbols as children of a component class symbol.
+ */
+function addTemplateSymbolsToClass(
+  classSymbol: lsp.DocumentSymbol,
+  templateSymbols: lsp.DocumentSymbol[],
+): void {
+  if (!classSymbol.children) {
+    classSymbol.children = [];
+  }
+  // Create a "(template)" container to group template symbols
+  const templateContainer: lsp.DocumentSymbol = {
+    name: '(template)',
+    kind: lsp.SymbolKind.Namespace,
+    range: templateSymbols[0].range,
+    selectionRange: templateSymbols[0].selectionRange,
+    children: templateSymbols,
+  };
+  classSymbol.children.push(templateContainer);
+}
+
+/**
+ * Filters the TypeScript NavigationTree to only include classes that have Angular templates.
+ * This implements the hybrid approach where:
+ * - Classes with templates are shown (without their methods/properties)
+ * - Classes without templates are filtered out
+ * - Non-class symbols (functions, variables, etc.) are filtered out
+ *
+ * This provides a cleaner outline for Angular files, showing only the component
+ * structure with template symbols nested inside.
+ */
+function filterNavigationTreeToTemplateClasses(
+  tree: ts.NavigationTree,
+  scriptInfo: ts.server.ScriptInfo,
+  classNamesWithTemplates: Set<string>,
+): lsp.DocumentSymbol[] {
+  const result: lsp.DocumentSymbol[] = [];
+
+  // If no classes have templates, return empty array
+  // This means we show nothing for non-Angular files (TypeScript handles those)
+  if (classNamesWithTemplates.size === 0) {
+    return result;
+  }
+
+  // The root node is the file itself, process its children
+  if (tree.kind === ts.ScriptElementKind.moduleElement && tree.childItems) {
+    for (const child of tree.childItems) {
+      const filtered = filterNavigationItem(child, scriptInfo, classNamesWithTemplates);
+      if (filtered) {
+        result.push(filtered);
+      }
+    }
+  } else {
+    // For non-module roots, filter the node itself
+    const filtered = filterNavigationItem(tree, scriptInfo, classNamesWithTemplates);
+    if (filtered) {
+      result.push(filtered);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Filters a single NavigationTree item.
+ * - If it's a class with a template, return the class node (without children - no methods/properties)
+ * - If it's a container (module, namespace), recurse and keep if any children match
+ * - Otherwise, return null (filter out)
+ */
+function filterNavigationItem(
+  item: ts.NavigationTree,
+  scriptInfo: ts.server.ScriptInfo,
+  classNamesWithTemplates: Set<string>,
+): lsp.DocumentSymbol | null {
+  // Check if this is a class with a template
+  if (
+    (item.kind === ts.ScriptElementKind.classElement ||
+      item.kind === ts.ScriptElementKind.localClassElement) &&
+    item.text &&
+    classNamesWithTemplates.has(item.text)
+  ) {
+    // Return the class node WITHOUT its children (methods, properties)
+    // The template symbols will be added later by mergeTemplateSymbolsIntoClass
+    const spans = item.spans;
+    if (!spans || spans.length === 0) {
+      return null;
+    }
+
+    const range = tsTextSpanToLspRange(scriptInfo, spans[0]);
+    const selectionRange =
+      item.nameSpan !== undefined ? tsTextSpanToLspRange(scriptInfo, item.nameSpan) : range;
+
+    return {
+      name: item.text,
+      kind: lsp.SymbolKind.Class,
+      range,
+      selectionRange,
+      // No children - template symbols will be added later
+    };
+  }
+
+  // For container types (module, namespace), recurse into children
+  // and keep the container if any children match
+  if (
+    item.kind === ts.ScriptElementKind.moduleElement ||
+    item.kind === ts.ScriptElementKind.directory
+  ) {
+    if (item.childItems && item.childItems.length > 0) {
+      const filteredChildren: lsp.DocumentSymbol[] = [];
+      for (const child of item.childItems) {
+        const filtered = filterNavigationItem(child, scriptInfo, classNamesWithTemplates);
+        if (filtered) {
+          filteredChildren.push(filtered);
+        }
+      }
+
+      // If any children matched, return this container with filtered children
+      if (filteredChildren.length > 0) {
+        const spans = item.spans;
+        if (!spans || spans.length === 0) {
+          // Keep the container instead of dropping the subtree when span info is missing.
+          const childRange = filteredChildren[0].range;
+          return {
+            name: item.text || '',
+            kind: scriptElementKindToSymbolKind(item.kind),
+            range: childRange,
+            selectionRange: childRange,
+            children: filteredChildren,
+          };
+        }
+
+        const range = tsTextSpanToLspRange(scriptInfo, spans[0]);
+        const selectionRange =
+          item.nameSpan !== undefined ? tsTextSpanToLspRange(scriptInfo, item.nameSpan) : range;
+
+        return {
+          name: item.text || '',
+          kind: scriptElementKindToSymbolKind(item.kind),
+          range,
+          selectionRange,
+          children: filteredChildren,
+        };
+      }
+    }
+  }
+
+  // Filter out everything else (functions, variables, interfaces, etc.)
+  return null;
+}
+
+/**
+ * Maps TypeScript's ScriptElementKind to LSP SymbolKind.
+ */
+function scriptElementKindToSymbolKind(kind: ts.ScriptElementKind): lsp.SymbolKind {
+  switch (kind) {
+    case ts.ScriptElementKind.moduleElement:
+      return lsp.SymbolKind.Module;
+    case ts.ScriptElementKind.classElement:
+      return lsp.SymbolKind.Class;
+    case ts.ScriptElementKind.localClassElement:
+      return lsp.SymbolKind.Class;
+    case ts.ScriptElementKind.interfaceElement:
+      return lsp.SymbolKind.Interface;
+    case ts.ScriptElementKind.typeElement:
+      return lsp.SymbolKind.TypeParameter;
+    case ts.ScriptElementKind.enumElement:
+      return lsp.SymbolKind.Enum;
+    case ts.ScriptElementKind.enumMemberElement:
+      return lsp.SymbolKind.EnumMember;
+    case ts.ScriptElementKind.variableElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.localVariableElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.functionElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.localFunctionElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.memberFunctionElement:
+      return lsp.SymbolKind.Method;
+    case ts.ScriptElementKind.memberGetAccessorElement:
+      return lsp.SymbolKind.Property;
+    case ts.ScriptElementKind.memberSetAccessorElement:
+      return lsp.SymbolKind.Property;
+    case ts.ScriptElementKind.memberVariableElement:
+      return lsp.SymbolKind.Field;
+    case ts.ScriptElementKind.constructorImplementationElement:
+      return lsp.SymbolKind.Constructor;
+    case ts.ScriptElementKind.callSignatureElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.indexSignatureElement:
+      return lsp.SymbolKind.Key;
+    case ts.ScriptElementKind.constructSignatureElement:
+      return lsp.SymbolKind.Constructor;
+    case ts.ScriptElementKind.parameterElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.typeParameterElement:
+      return lsp.SymbolKind.TypeParameter;
+    case ts.ScriptElementKind.constElement:
+      return lsp.SymbolKind.Constant;
+    case ts.ScriptElementKind.letElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.alias:
+      return lsp.SymbolKind.Variable;
+    default:
+      return lsp.SymbolKind.Variable;
+  }
+}
+
+/**
+ * Converts Angular template symbols to LSP DocumentSymbol[].
+ */
+function convertTemplateSymbols(
+  symbols: TemplateDocumentSymbol[],
+  scriptInfo: ts.server.ScriptInfo,
+): lsp.DocumentSymbol[] {
+  const result: lsp.DocumentSymbol[] = [];
+
+  for (const symbol of symbols) {
+    const converted = convertTemplateSymbol(symbol, scriptInfo);
+    if (converted) {
+      result.push(converted);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Converts a single Angular template symbol to an LSP DocumentSymbol.
+ */
+function convertTemplateSymbol(
+  symbol: TemplateDocumentSymbol,
+  scriptInfo: ts.server.ScriptInfo,
+): lsp.DocumentSymbol | null {
+  if (!symbol.spans || symbol.spans.length === 0) {
+    return null;
+  }
+
+  const range = tsTextSpanToLspRange(scriptInfo, symbol.spans[0]);
+  const selectionRange = symbol.nameSpan
+    ? tsTextSpanToLspRange(scriptInfo, symbol.nameSpan)
+    : range;
+
+  const children: lsp.DocumentSymbol[] = [];
+  if (symbol.childItems) {
+    for (const child of symbol.childItems) {
+      const childSymbol = convertTemplateSymbol(child, scriptInfo);
+      if (childSymbol) {
+        children.push(childSymbol);
+      }
+    }
+  }
+
+  // Use lspKind if available, otherwise fall back to ScriptElementKind mapping
+  const kind =
+    symbol.lspKind !== undefined
+      ? (symbol.lspKind as lsp.SymbolKind)
+      : scriptElementKindToSymbolKind(symbol.kind);
+
+  return {
+    name: symbol.text,
+    kind,
+    range,
+    selectionRange,
+    children: children.length > 0 ? children : undefined,
+  };
+}

--- a/vscode-ng-language-service/server/src/handlers/initialization.ts
+++ b/vscode-ng-language-service/server/src/handlers/initialization.ts
@@ -19,6 +19,7 @@ export function onInitialize(session: Session, params: lsp.InitializeParams): ls
   return {
     capabilities: {
       foldingRangeProvider: true,
+      documentSymbolProvider: true,
       codeLensProvider: {resolveProvider: true},
       textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
       completionProvider: {

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -29,6 +29,7 @@ import {
   IsInAngularProject,
 } from '../../common/requests';
 
+import {clearWorkspaceConfigurationCache} from './config';
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
 import {ServerHost} from './server_host';
 import {
@@ -47,13 +48,13 @@ import {onFoldingRanges} from './handlers/folding';
 import {onHover} from './handlers/hover';
 import {onInitialize} from './handlers/initialization';
 import {onLinkedEditingRange} from './handlers/linked_editing_range';
+import {onDocumentSymbol} from './handlers/document_symbols';
 import {onRenameRequest, onPrepareRename} from './handlers/rename';
 import {onSignatureHelp} from './handlers/signature';
 import {onGetTcb} from './handlers/tcb';
 import {onGetTemplateLocationForComponent, isInAngularProject} from './handlers/template_info';
 import {onDidChangeWatchedFiles} from './handlers/did_change_watched_files';
 import {onInlayHint, onInlayHintResolve} from './handlers/inlay_hints';
-import {clearWorkspaceConfigurationCache} from './config';
 
 export interface SessionOptions {
   host: ServerHost;
@@ -257,6 +258,7 @@ export class Session {
     conn.onHover((p) => onHover(this, p));
     conn.onFoldingRanges((p) => onFoldingRanges(this, p));
     conn.languages.onLinkedEditingRange((p) => onLinkedEditingRange(this, p));
+    conn.onDocumentSymbol(async (p) => await onDocumentSymbol(this, p));
     conn.onCompletion((p) => onCompletion(this, p));
     conn.onCompletionResolve((p) => onCompletionResolve(this, p));
     conn.onRequest(GetComponentsWithTemplateFile, (p) => getComponentsWithTemplateFile(this, p));


### PR DESCRIPTION
# PR: feat(language-service): add Document Symbols support for Angular templates

## Description

Adds comprehensive Document Symbols support for Angular templates, enabling the Outline panel, breadcrumbs navigation, and "Go to Symbol" (Cmd+Shift+O / Ctrl+Shift+O) features to work with Angular template syntax.

## Features

### Block Syntax Support
- `@if`, `@else`, `@else if` with expression and alias display
- `@for` with track expression and context variables
- `@switch`, `@case`, `@default` blocks
- `@defer`, `@placeholder`, `@loading`, `@error` blocks with triggers
- `@let` declarations

### Structural Directive Support
- `*ngIf`, `*ngFor`, `*ngSwitch`, `*ngSwitchCase`, `*ngSwitchDefault`
- `*ngTemplateOutlet`, `*ngComponentOutlet`, `*ngPlural`, `*ngPluralCase`
- Custom structural directives (shown with Class icon)

### Template File Support
- **TypeScript files**: Template symbols nested under `(template)` node in component class
- **External HTML templates**: Template symbols at root level (works with `templateUrl`)


### Multi-Component Support
- **Multiple components per file**: Correctly merges template symbols into each component class
- **Non-standard naming**: Works with components without "Component" suffix

### Variables and References
- Loop item variables (`let item`)
- Template reference variables (`#ref`)
- Context variable aliases (`let i = $index`)
- Expression aliases (`as alias`)

### SymbolKind Mappings

| Template Element | SymbolKind | Icon |
|-----------------|------------|------|
| `@if`, `@else`, `@switch`, `@case` | Struct | 🔶 |
| `@for`, `@empty` | Array | 📦 |
| `@defer`, `@placeholder`, `@loading`, `@error` | Event | ⚡ |
| HTML elements | Object | 🟡 |
| Variables | Variable | |
| Structural directives | Class | |

## Configuration

### `angular.documentSymbols.enabled` (default: `true`)
Enables Angular-specific document symbols.

### `angular.documentSymbols.showImplicitForVariables` (default: `false`)
Shows all implicit `@for` loop variables (`$index`, `$count`, `$first`, `$last`, `$even`, `$odd`).

## Example

Template:
```html
@for (item of items; track item.id; let i = $index) {
  @if (item.visible; as isVisible) {
    <div #container (click)="onClick()">
      {{ item.name }}
    </div>
  }
}
```

Outline:
```
@for (item of items)  📦
├── let item
├── let i
├── @if (item.visible; as isVisible)  🔶
│   ├── as isVisible
│   └── <div>  🟡
│       └── #container
```

## Breaking Changes

None

## Related Issues

Closes #66691

---

## AI Disclosure

This PR was developed using Claude Opus 4.6 and GPT 5.3 Max AI assistants under human orchestration and review by @kbrilla.
