### PR TITLE
docs(docs-infra): Exempts more symbols from automatic linking

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -26,6 +26,8 @@ const LINK_EXEMPT = new Set([
   'group()',
   'keyframes',
   '@keyframes',
+  'input',
+  'Event',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {


### PR DESCRIPTION
## What is the current behavior?

Links are generated for `Event` and `input`, which we can consider generic words.
See https://angular.dev/guide/testing/pipes
<img width="775" height="525" alt="image" src="https://github.com/user-attachments/assets/5dbdb36b-5adc-4240-84ea-b6e96fdf25d3" />

 

## What is the new behavior?

Extends the list of symbols that should not be automatically link 
 
