### PR TITLE
fix(devtools): duplicated props in the properties panel

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/diffing/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/diffing/BUILD.bazel
@@ -1,6 +1,6 @@
-load("//devtools/tools:defaults.bzl", "ts_project")
+load("//devtools/tools:defaults.bzl", "ts_project", "ts_test_library", "zoneless_web_test_suite")
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//devtools:__subpackages__"])
 
 ts_project(
     name = "diffing",
@@ -10,5 +10,21 @@ ts_project(
     deps = [
         "//:node_modules/@angular/core",
         "//:node_modules/rxjs",
+    ],
+)
+
+ts_test_library(
+    name = "diffing_test",
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":diffing",
+        "//:node_modules/@angular/core",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "test",
+    deps = [
+        ":diffing_test",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/diffing/diffing.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/diffing/diffing.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DefaultIterableDiffer} from '@angular/core';
+import {diff} from './index';
+
+interface TestItem {
+  name: string;
+  value: number;
+}
+
+describe('diff', () => {
+  const trackBy = (_: number, item: TestItem) => `#${item.name}`;
+  const differ = new DefaultIterableDiffer<TestItem>(trackBy);
+
+  let host: TestItem[] = [];
+  let hostCopy: TestItem[] = [];
+
+  beforeEach(() => {
+    host = [
+      {name: 'foo', value: 1},
+      {name: 'bar', value: 2},
+      {name: 'baz', value: 3},
+    ];
+    hostCopy = structuredClone(host);
+  });
+
+  it('should remove all items from the host if the new array is empty', () => {
+    const output = diff(differ, host, []);
+
+    expect(output).toEqual({
+      newItems: [],
+      removedItems: [hostCopy[0], hostCopy[1], hostCopy[2]],
+      movedItems: [],
+      updatedItems: [],
+    });
+    expect(host).toEqual([]);
+  });
+
+  it('should add all items to the host if the host is empty', () => {
+    host = [];
+    const newArr = [{name: 'qux', value: 4}];
+    const output = diff(differ, host, newArr);
+
+    expect(output).toEqual({
+      newItems: [newArr[0]],
+      removedItems: [],
+      movedItems: [],
+      updatedItems: [],
+    });
+    expect(host).toEqual(newArr);
+  });
+
+  it('should add a new item', () => {
+    const newArr = [host[0], host[1], {name: 'qux', value: 2.5}, host[2]];
+    const output = diff(differ, host, newArr);
+
+    expect(output).toEqual({
+      newItems: [newArr[2]],
+      removedItems: [],
+      movedItems: [newArr[3]],
+      updatedItems: [],
+    });
+    expect(host).toEqual(newArr);
+  });
+
+  it('should add remove an item', () => {
+    const newArr = [host[0], host[2]];
+    const output = diff(differ, host, newArr);
+
+    expect(output).toEqual({
+      newItems: [],
+      removedItems: [hostCopy[1]],
+      movedItems: [newArr[1]],
+      updatedItems: [],
+    });
+    expect(host).toEqual(newArr);
+  });
+
+  it('should add remove an item', () => {
+    // Note that an item will be marked as
+    // updated only if its reference changes.
+    const newArr = [
+      host[0], // Same ref
+      hostCopy[1],
+      {
+        name: 'baz',
+        value: 4,
+      },
+    ];
+    const output = diff(differ, host, newArr);
+
+    expect(output).toEqual({
+      newItems: [],
+      removedItems: [],
+      movedItems: [],
+      updatedItems: [hostCopy[1], {name: 'baz', value: 4}],
+    });
+    expect(host).toEqual(newArr);
+  });
+});

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
@@ -26,7 +26,7 @@ import {arrayifyProps} from './arrayify-props';
 import {FlatNode, Property} from '../../../shared/object-tree-explorer/object-tree-types';
 
 const trackBy: TrackByFunction<FlatNode> = (_: number, item: FlatNode) =>
-  `#${item.prop.name}#${item.prop.descriptor.preview}#${item.level}`;
+  `#${item.prop.name}#${item.level}`;
 
 export class PropertyDataSource extends DataSource<FlatNode> {
   private _data = new BehaviorSubject<FlatNode[]>([]);


### PR DESCRIPTION
This fixes the issue mentioned in [this PR comment](https://github.com/angular/angular/pull/66601#issuecomment-3765893772).

### Bug & Steps To Reproduce

In essence, _sometimes*_ the children of a property in the Properties panel are duplicated. Often, this happens for a brief moment, making the issue a bit hard to catch and diagnose. Here are some steps to reproduce  (one example) in the demo app without having to modify the existing code:

1. Open the demo app.
2. Quickly select `app-sample-properties`.
3. Quickly expand the first prop – `computedObject` – in the Properties panel. This should happen before `app-heavy` is loaded.
4. Until `app-heavy` is loaded, the nested properties will be duplicated.

Obviously, there are minimal reproducible examples, but they require significant modifications to the app.

### Culprit

After an extensive investigation, it appears that the culprit is the `diff` function which is in charge of finding the difference between and modifying the existing `FlatNode` tree by a provided new one in the property data source. Here is the exact mechanism of the bug:

1. The top-level properties of a specific component are loaded.
2. A consecutive automatic call is loading the first level of nested properties.
3. Respectively, the new `FlatNode` tree is fed to the `diff` function along with the existing tree without nested props.
4. Since the tree is represented as an array in the data source, for example:
```javascript
{
  x: {
    x1: {
      x2: ...
    }
  },
  y: { y1 }
}
```
is `[x, x1, x2, y, y2]` where each property contains the level of nesting, all nodes except the first one are affected by the update (e.g. new nodes and moved nodes), meaning that in the given example only `x` remains unchanged.
5. However, `x` technically keeps (should keep) a reference to its children that is used to determine whether its children are loaded.
6. If the user expands `x`, the program determines that `x` doesn't have its nested properties loaded based on the reference.
7.  This results in another nested props request that technically leads to the duplication of these props.

### Fix

`diff` now performs an additional identity check and updates the items that haven't been moved or changed in any other way but their reference (respectively, internals).

Also, there are some unit tests to cover for the core `diff` operations.

@AleksanderBodurri, I think it's best that you review the PR since the code probably dates back to the very first versions of the DevTools. It seems that the bug is quite old.

---

\* While the culprit of the bug was found and it's evident that the affected nodes are the ones which internals were changed but retained their position in the array (usually, first nodes in the array), I haven't delved into why the properties resolve or stabilize by themselves, so to speak. I assume it has to do with component tree updates triggering some sort of a refresh.



