### PR TITLE
docs(docs-infra): improve accessibility of search dialog trigger

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -190,6 +190,7 @@
           type="button"
           (click)="toggleSearchDialog($event)"
           title="Search docs"
+          [aria-label]="'Open search dialog with ' + searchTitle"
         >
           <svg
             aria-hidden="true"
@@ -202,10 +203,7 @@
               d="M14.583 15.48 9.104 10a4.591 4.591 0 0 1-1.458.844 5.156 5.156 0 0 1-1.771.302c-1.5 0-2.77-.52-3.813-1.563C1.022 8.542.5 7.285.5 5.813c0-1.473.52-2.73 1.563-3.771C3.103 1 4.367.479 5.854.479 7.326.48 8.58 1 9.614 2.042c1.035 1.041 1.553 2.298 1.553 3.77 0 .598-.098 1.174-.292 1.73A5.287 5.287 0 0 1 10 9.104l5.5 5.459-.917.916ZM5.854 9.895c1.125 0 2.083-.4 2.875-1.198a3.95 3.95 0 0 0 1.188-2.885 3.95 3.95 0 0 0-1.188-2.886C7.938 2.13 6.98 1.73 5.854 1.73c-1.139 0-2.107.4-2.906 1.198-.799.799-1.198 1.76-1.198 2.886 0 1.125.4 2.086 1.198 2.885.799.799 1.767 1.198 2.906 1.198Z"
             />
           </svg>
-          <span
-            class="adev-nav-item__label adev-search-desktop"
-            [aria-label]="'Open search dialog with ' + searchTitle"
-          >
+          <span class="adev-nav-item__label adev-search-desktop">
             <kbd>{{ searchLabel }}</kbd>
             <kbd>K</kbd>
           </span>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [x] Other... Please describe: Accessibility Violation

## What is the current behavior?

This PR addresses an accessibility violation in the navigation component where an aria-label was incorrectly applied to a `<span>` element. As shown in this screenshot, [IBM Accessibility Checker](https://github.com/IBMa/equal-access) reported a violation on the website homepage [angular.dev](https://angular.dev/):
<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/a0a56fc8-1b5c-4986-bcb1-3d6f9f2e5c9c" />

- The `aria-label` attribute was placed on a `<span>` with an implicit `generic` role.
- According to ARIA specifications, browsers and assistive technologies (like screen readers) often ignore `aria-label` on non-interactive elements that lack an explicit landmark or widget role.
- Consequently, screen reader users might not receive the intended "Open search dialog (`Open search dialog with Control K`)" context when navigating the search trigger.

## What is the new behavior?

- Removed the `aria-label` from the inner `<span>` element.
- Replaced the generic `title="Search docs"` on the parent `<button>` with a more descriptive `[aria-label]`.
- This ensures the label is correctly associated with the interactive element, making it perceivable by assistive technologies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

### Verification Results

**Fix Before**
`aria-label` on `<span>` (Ignored by screen readers)
IBM Checker warns: "ARIA attributes should be valid for the element"

<img width="1295" height="335" alt="image" src="https://github.com/user-attachments/assets/ebeef56e-1469-4050-b688-fd62877517b0" />

**Fix After:**
`aria-label` on `<button>` (Correctly announced)
IBM Checker passes for this element

<img width="1290" height="261" alt="image" src="https://github.com/user-attachments/assets/dc79a4a6-6a6f-475b-8092-f788041ac119" />

### A11YRepair
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.