### PR TITLE
docs(docs-infra): update the look of api items state labels

### DIFF
--- a/adev/src/app/features/references/api-items-section/api-items-section.component.html
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.html
@@ -29,13 +29,15 @@
         <span class="adev-item-title" [attr.title]="apiItem.title">{{ apiItem.title }}</span>
       </a>
       @if (apiItem.deprecated) {
-        <span class="adev-item-attribute" matTooltip="Deprecated"> &lt;!&gt; </span>
+        <span class="adev-item-attribute adev-deprecated" matTooltip="Deprecated"> DEPR </span>
       }
       @if (apiItem.experimental) {
-        <span class="adev-item-attribute" matTooltip="Experimental"> 🧪 </span>
+        <span class="adev-item-attribute adev-experimental" matTooltip="Experimental"> EXP </span>
       }
       @if (apiItem.developerPreview) {
-        <span class="adev-item-attribute" matTooltip="Developer Preview"> 🚧 </span>
+        <span class="adev-item-attribute adev-dev-preview" matTooltip="Developer Preview">
+          DEV
+        </span>
       }
     </li>
   }

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -88,16 +88,19 @@
   }
 }
 
+.docs-api-item-label {
+  pointer-events: none;
+}
+
 .adev-item-attribute {
   text-align: center;
-
-  border-radius: 1rem;
+  border-radius: 0.5rem;
   padding: 0rem 0.375rem;
-  margin-inline-start: 1.25rem;
+  margin-inline-start: 0.5rem;
   display: block;
   font-size: 0.625rem;
   line-height: 1rem;
-  cursor: pointer;
+  cursor: default;
   user-select: none;
   font-weight: bold;
 

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -47,6 +47,7 @@
     text-overflow: ellipsis;
     box-sizing: border-box;
     width: 100%;
+    justify-content: start;
 
     a {
       color: var(--quaternary-contrast);
@@ -73,19 +74,55 @@
 
 .adev-api-items-section-item {
   display: flex;
-  flex: 1;
   gap: 1em;
 }
 
+:host {
+  --item-attr-base-mix: 80%;
+
+  .docs-light-mode & {
+    --item-attr-base-mix: 20%;
+  }
+  @media screen and (prefers-color-scheme: light) {
+    --item-attr-base-mix: 20%;
+  }
+}
+
 .adev-item-attribute {
-  width: 24px;
   text-align: center;
-  font-family: var(--code-font);
-  background-color: var(--senary-contrast);
-  color: var(--tertiary-contrast);
-  border-radius: 0.25rem;
-  padding: 0.001rem 0.2rem 0.005rem;
-  margin-inline-start: 0.5rem;
+
+  border-radius: 1rem;
+  padding: 0rem 0.375rem;
+  margin-inline-start: 1.25rem;
+  display: block;
+  font-size: 0.625rem;
+  line-height: 1rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: bold;
+
+  &.adev-dev-preview {
+    background: color-mix(
+      in srgb,
+      var(--symbolic-yellow) var(--item-attr-base-mix),
+      var(--octonary-contrast)
+    );
+    color: var(--gray-1000);
+  }
+
+  &.adev-experimental {
+    background: color-mix(
+      in srgb,
+      var(--symbolic-green) var(--item-attr-base-mix),
+      var(--octonary-contrast)
+    );
+    color: var(--gray-1000);
+  }
+
+  &.adev-deprecated {
+    background-color: var(--senary-contrast);
+    color: var(--tertiary-contrast);
+  }
 }
 
 .adev-api-anchor {


### PR DESCRIPTION
This PR presents a new proposed look of the state icons of the API items. They are now labels.

### Motivation

With the current UI, and especially on larger screens, it's not immediately evident which item the state icon belongs to. If the items were bordered, that probably wouldn't be a problem.

<img width="2122" height="526" alt="Screenshot 2026-01-23 at 17 33 58" src="https://github.com/user-attachments/assets/78f9fd17-bcc5-45a1-aa94-0b61d1c60ee4" />

### New look

Since the icons are a bit bulky, which hadn't been really a problem when they were located at the rightmost side of the container, I converted them to labels:

<img width="1770" height="539" alt="Screenshot 2026-01-23 at 17 33 37" src="https://github.com/user-attachments/assets/aefb6fba-684b-4041-aca6-a2ce5b07a7c3" />
<img width="268" height="109" alt="Screenshot 2026-01-23 at 17 35 14" src="https://github.com/user-attachments/assets/c2c1e10d-b311-4021-9f5b-2a79d283f5c1" />
<img width="212" height="115" alt="Screenshot 2026-01-23 at 17 35 25" src="https://github.com/user-attachments/assets/738dc674-aa9e-431d-8d09-a97f34c18769" />

