### PR TITLE
fix(core): prevent destroyed views from being detached

### DIFF
--- a/packages/core/src/render3/view/container.ts
+++ b/packages/core/src/render3/view/container.ts
@@ -18,7 +18,7 @@ import {
 } from '../interfaces/container';
 import {TNode} from '../interfaces/node';
 import {RComment, RElement} from '../interfaces/renderer_dom';
-import {isLView} from '../interfaces/type_checks';
+import {isDestroyed, isLView} from '../interfaces/type_checks';
 import {
   DECLARATION_COMPONENT_VIEW,
   DECLARATION_LCONTAINER,
@@ -153,6 +153,9 @@ export function detachView(lContainer: LContainer, removeIndex: number): LView |
   const viewToDetach = lContainer[indexInContainer];
 
   if (viewToDetach) {
+    if (isDestroyed(viewToDetach)) {
+      return;
+    }
     const declarationLContainer = viewToDetach[DECLARATION_LCONTAINER];
     if (declarationLContainer !== null && declarationLContainer !== lContainer) {
       detachMovedView(declarationLContainer, viewToDetach);


### PR DESCRIPTION
A destroyed view will always remove itself after destruction, so it should never be allowed to be detached before that as doing so will break the destroy chain

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When destroying a component, one might inadvertently try to remove the element from its ViewContainerRef. Doing so will break the destroy lifecycle hook as angular is unable to go back up the destroy tree. 

Issue Number: N/A

## What is the new behavior?

Attempting to detach/remove a node that's destroyed will fail to do so.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I hit this when playing with CDK portals and doing:
```ts
const ref = portalOutlet.attach(portal);
ref.onDestroy(() => {
  portalOutlet.dispose();
});
```

portalOutlet will remove the item from the ViewContainerRef, which would stop destroying components with no error.

Maybe we could instead throw an error with a ngDevMode check instead?