### PR TITLE
docs: update `bootstrapApplication` docs

### DIFF
--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -68,24 +68,22 @@ export interface BootstrapContext {
  * guide](guide/components/importing).
  *
  * @usageNotes
- * The root component passed into this function *must* be a standalone one (should have the
- * `standalone: true` flag in the `@Component` decorator config).
+ * The root component passed into this function **must** be a standalone one
  *
  * ```angular-ts
  * @Component({
- *   standalone: true,
  *   template: 'Hello world!'
  * })
- * class RootComponent {}
+ * class Root {}
  *
- * const appRef: ApplicationRef = await bootstrapApplication(RootComponent);
+ * const appRef: ApplicationRef = await bootstrapApplication(Root);
  * ```
  *
  * You can add the list of providers that should be available in the application injector by
  * specifying the `providers` field in an object passed as the second argument:
  *
  * ```ts
- * await bootstrapApplication(RootComponent, {
+ * await bootstrapApplication(Root, {
  *   providers: [
  *     {provide: BACKEND_URL, useValue: 'https://yourdomain.com/api'}
  *   ]
@@ -96,7 +94,7 @@ export interface BootstrapContext {
  * existing NgModule (and transitively from all NgModules that it imports):
  *
  * ```ts
- * await bootstrapApplication(RootComponent, {
+ * await bootstrapApplication(Root, {
  *   providers: [
  *     importProvidersFrom(SomeNgModule)
  *   ]
@@ -111,7 +109,7 @@ export interface BootstrapContext {
  * ```ts
  * import {provideProtractorTestingSupport} from '@angular/platform-browser';
  *
- * await bootstrapApplication(RootComponent, {providers: [provideProtractorTestingSupport()]});
+ * await bootstrapApplication(Root, {providers: [provideProtractorTestingSupport()]});
  * ```
  *
  * @param rootComponent A reference to a standalone component that should be rendered.


### PR DESCRIPTION
Explicit mention of the flag standalone:true is removed, since it is the default behavior