### PR TITLE
Update Signals Forms linking & docs

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -29,7 +29,6 @@ const LINK_EXEMPT = new Set([
   'input',
   'Event',
   'form',
-  'formatCurrency',
   'type',
 ]);
 

--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -28,6 +28,9 @@ const LINK_EXEMPT = new Set([
   '@keyframes',
   'input',
   'Event',
+  'form',
+  'formatCurrency',
+  'type',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {

--- a/adev/src/content/guide/forms/signals/custom-controls.md
+++ b/adev/src/content/guide/forms/signals/custom-controls.md
@@ -347,6 +347,7 @@ Controls sometimes display values differently than the form model stores them - 
 Use `linkedSignal()` (from `@angular/core`) to transform the model value for display, and handle input events to parse user input back to the storage format:
 
 ```angular-ts
+import {formatCurrency} from '@angular/common';
 import {ChangeDetectionStrategy, Component, linkedSignal, model} from '@angular/core';
 import {FormValueControl} from '@angular/forms/signals';
 
@@ -367,7 +368,7 @@ export class CurrencyInput implements FormValueControl<number> {
   readonly value = model.required<number>();
 
   // Stores display value ("1,234.56")
-  readonly displayValue = linkedSignal(() => formatCurrency(this.value()));
+  readonly displayValue = linkedSignal(() => formatCurrency(this.value(), 'en', 'USD'));
 
   // Update the model from the display value.
   updateModel() {
@@ -375,14 +376,9 @@ export class CurrencyInput implements FormValueControl<number> {
   }
 }
 
-// Converts a number to a currency string (e.g. 1234.56 -> "1,234.56").
-function formatCurrency(value: number) {
-  return value.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-}
-
-// Converts a currency string to a number (e.g. "1,234.56" -> 1234.56).
-function parseCurrency(value: string) {
-  return parseFloat(value.replace(/,/g, ''));
+// Converts a currency string to a number (e.g. "USD1,234.56" -> 1234.56).
+function parseCurrency(value: string): number {
+  return parseFloat(value.replace(/^[^\d-]+/, '').replace(/,/g, ''));
 }
 ```
 

--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -4,11 +4,11 @@ Signal Forms' field state allows you to react to user interactions by providing 
 
 ## Understanding field state
 
-When you create a form with the `form()` function, it returns a **field tree** - an object structure that mirrors your form model. Each field in the tree is accessible via dot notation (like `form.email`).
+When you create a form with the [`form()`](api/forms/signals/form) function, it returns a **field tree** - an object structure that mirrors your form model. Each field in the tree is accessible via dot notation (like [`form.email`](api/forms/signals/form#email)).
 
 ### Accessing field state
 
-When you call any field in the field tree as a function (like `form.email()`), it returns a `FieldState` object containing reactive signals that track the field's validation, interaction, and availability state. For example, the `invalid()` signal tells you whether the field has validation errors:
+When you call any field in the field tree as a function (like [`form.email()`](api/forms/signals/form#email)), it returns a `FieldState` object containing reactive signals that track the field's validation, interaction, and availability state. For example, the `invalid()` signal tells you whether the field has validation errors:
 
 ```angular-ts
 import {Component, signal} from '@angular/core';

--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -36,7 +36,7 @@ export class LoginComponent {
 }
 ```
 
-The `form()` function accepts the model signal and creates a **field tree** - a special object structure that mirrors your model's shape. The field tree is both navigable (access child fields with dot notation like `loginForm.email`) and callable (call a field as a function to access its state).
+The [`form()`](api/forms/signals/form) function accepts the model signal and creates a **field tree** - a special object structure that mirrors your model's shape. The field tree is both navigable (access child fields with dot notation like `loginForm.email`) and callable (call a field as a function to access its state).
 
 The `[formField]` directive binds each input element to its corresponding field in the field tree, enabling automatic two-way synchronization between the UI and model.
 

--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -603,12 +603,11 @@ Async validation handles validation that requires external data sources, like ch
 The `validateHttp()` function performs HTTP-based validation:
 
 ```angular-ts
-import {Component, signal, inject} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {Component, signal} from '@angular/core';
 import {form, FormField, required, validateHttp} from '@angular/forms/signals';
 
 @Component({
-  selector: 'app-username-form',
+  selector: 'app-username-form',|
   imports: [FormField],
   template: `
     <form>
@@ -624,8 +623,6 @@ import {form, FormField, required, validateHttp} from '@angular/forms/signals';
   `,
 })
 export class UsernameFormComponent {
-  http = inject(HttpClient);
-
   usernameModel = signal({username: ''});
 
   usernameForm = form(this.usernameModel, (schemaPath) => {


### PR DESCRIPTION
The Forms documentation is linking to native HTML elements and attributes in an inconsistent ways.

In the validation guide, `form` is linking:  

https://next.angular.dev/guide/forms/signals/validation#using-validatehttp

`formatCurrency` is linking in the next section:  

 https://next.angular.dev/guide/forms/signals/custom-controls#value-transformation

the same appears when referring to input types, for example:  
 ```html
  <input type="password" />