### PR TITLE
test(forms): cancel pending async validators on submission

### DIFF
--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -379,6 +379,7 @@ export async function submit<TModel>(
   node.submitState.selfSubmitting.set(true);
   try {
     const errors = await action(form);
+    node.cancelPendingValidation();
     errors && setSubmissionErrors(node, errors);
   } finally {
     node.submitState.selfSubmitting.set(false);

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -6,12 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Signal, ɵWritable} from '@angular/core';
+import {computed, Signal, WritableSignal, ɵWritable} from '@angular/core';
+import {createMetadataKey, MetadataKey, MetadataReducer} from '../api/rules/metadata';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
 import type {FieldTree, TreeValidationResult, ValidationResult} from '../api/types';
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
 import {shortCircuitFalse} from './util';
+
+/**
+ * A private {@link MetadataKey} used to accumulate `validateAsync()` parameters.
+ *
+ * This is used to cancel all pending validations when the field is submitted.
+ */
+export const PENDING_VALIDATION_PARAMS: MetadataKey<
+  Signal<WritableSignal<unknown | undefined>[]>,
+  WritableSignal<unknown | undefined> | undefined,
+  WritableSignal<unknown | undefined>[]
+> = createMetadataKey(MetadataReducer.list());
 
 /**
  * Helper function taking validation state, and returning own state of the node.


### PR DESCRIPTION
Prevent a validation that is pending at the time of submission from overriding submission errors when it resolves.