### PR TITLE
feat(language-server): add shared workspace/configuration utilities

### DIFF
--- a/vscode-ng-language-service/server/src/config.ts
+++ b/vscode-ng-language-service/server/src/config.ts
@@ -1,0 +1,145 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as lsp from 'vscode-languageserver/node';
+
+/**
+ * A single configuration item to request from the client.
+ *
+ * See LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration
+ */
+export interface ConfigurationItem {
+  /**
+   * The scope to get the configuration section for.
+   * This is typically a file URI (e.g., file:///path/to/file.ts).
+   * When provided, VS Code returns workspace folder-specific settings
+   * that apply to that file's workspace folder.
+   */
+  scopeUri?: string;
+
+  /**
+   * The configuration section asked for.
+   * For example: 'typescript.inlayHints' or 'angular.inlayHints'
+   * This corresponds to the key prefix in settings.json.
+   */
+  section?: string;
+}
+
+/**
+ * Request workspace configuration from the client.
+ *
+ * This uses the LSP workspace/configuration request which allows the server
+ * to pull configuration from the client on-demand. This is the preferred
+ * approach over CLI arguments because:
+ *
+ * 1. Configuration changes take effect immediately without restarting
+ * 2. Supports per-workspace and per-folder configuration
+ * 3. VS Code automatically merges settings from different scopes:
+ *    - Default settings
+ *    - User settings (global)
+ *    - Workspace settings
+ *    - Workspace folder settings
+ *    - Language-specific settings
+ *
+ * The client returns the effective (merged) configuration value for each item.
+ *
+ * @param connection The LSP connection to the client
+ * @param items Array of configuration items to request
+ * @returns Array of configuration values, one for each requested item
+ *
+ * @example
+ * ```typescript
+ * const [tsConfig, angularConfig] = await getWorkspaceConfiguration(
+ *   session.connection,
+ *   [
+ *     { section: 'typescript.inlayHints', scopeUri: documentUri },
+ *     { section: 'angular.inlayHints', scopeUri: documentUri },
+ *   ]
+ * );
+ * ```
+ */
+export async function getWorkspaceConfiguration<T = unknown>(
+  connection: lsp.Connection,
+  items: ConfigurationItem[],
+): Promise<T[]> {
+  try {
+    return await connection.workspace.getConfiguration(items);
+  } catch (error) {
+    // Return empty objects if the client doesn't support workspace/configuration
+    // This provides graceful degradation for older clients
+    return items.map(() => ({}) as T);
+  }
+}
+
+/**
+ * Request a single configuration section from the client.
+ *
+ * This is a convenience wrapper around getWorkspaceConfiguration for
+ * requesting a single section.
+ *
+ * @param connection The LSP connection to the client
+ * @param section The configuration section to request
+ * @param scopeUri Optional URI to scope the configuration to a specific file/folder
+ * @returns The configuration value for the requested section
+ *
+ * @example
+ * ```typescript
+ * const config = await getConfigurationSection(
+ *   session.connection,
+ *   'angular.inlayHints',
+ *   documentUri
+ * );
+ * ```
+ */
+export async function getConfigurationSection<T = unknown>(
+  connection: lsp.Connection,
+  section: string,
+  scopeUri?: string,
+): Promise<T> {
+  const [result] = await getWorkspaceConfiguration<T>(connection, [{section, scopeUri}]);
+  return result;
+}
+
+/**
+ * Flatten a nested configuration object into a flat object with dot-notation keys.
+ *
+ * VS Code returns configuration as nested objects based on the section hierarchy.
+ * This utility flattens them into a format that's easier to work with when
+ * mapping to internal configuration formats.
+ *
+ * @param config The nested configuration object
+ * @param prefix The prefix to use for the keys (typically the section name)
+ * @returns A flat object with dot-notation keys
+ *
+ * @example
+ * ```typescript
+ * // Input: { parameterNames: { enabled: 'all' } }
+ * // Output: { 'typescript.inlayHints.parameterNames.enabled': 'all' }
+ * const flat = flattenConfiguration(tsConfig, 'typescript.inlayHints');
+ * ```
+ */
+export function flattenConfiguration(
+  config: Record<string, unknown>,
+  prefix: string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  function flatten(obj: Record<string, unknown>, currentPrefix: string): void {
+    for (const [key, value] of Object.entries(obj)) {
+      const newKey = `${currentPrefix}.${key}`;
+      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        flatten(value as Record<string, unknown>, newKey);
+      } else {
+        result[newKey] = value;
+      }
+    }
+  }
+
+  flatten(config, prefix);
+  return result;
+}

--- a/vscode-ng-language-service/server/src/tests/config_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/config_spec.ts
@@ -1,0 +1,85 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {flattenConfiguration} from '../config';
+
+describe('flattenConfiguration', () => {
+  it('should flatten a simple nested object', () => {
+    const config = {
+      enabled: 'all',
+      suppressWhenArgumentMatchesName: true,
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints.parameterNames');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+    });
+  });
+
+  it('should flatten deeply nested objects', () => {
+    const config = {
+      parameterNames: {
+        enabled: 'all',
+        suppressWhenArgumentMatchesName: true,
+      },
+      variableTypes: {
+        enabled: true,
+      },
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+      'typescript.inlayHints.variableTypes.enabled': true,
+    });
+  });
+
+  it('should handle arrays as leaf values', () => {
+    const config = {
+      items: ['a', 'b', 'c'],
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.items': ['a', 'b', 'c'],
+    });
+  });
+
+  it('should handle null values', () => {
+    const config = {
+      value: null,
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.value': null,
+    });
+  });
+
+  it('should handle empty objects', () => {
+    const config = {};
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({});
+  });
+
+  it('should handle mixed value types', () => {
+    const config = {
+      stringVal: 'test',
+      numberVal: 42,
+      boolVal: false,
+      nested: {
+        deep: 'value',
+      },
+    };
+    const result = flattenConfiguration(config, 'config');
+    expect(result).toEqual({
+      'config.stringVal': 'test',
+      'config.numberVal': 42,
+      'config.boolVal': false,
+      'config.nested.deep': 'value',
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds shared infrastructure for features to request configuration from the VS Code client using the LSP `workspace/configuration` protocol. This is the preferred approach over CLI arguments because:

1. **Configuration changes take effect immediately** without restarting the extension
2. **Supports per-workspace and per-folder configuration** via VS Code's settings hierarchy
3. **VS Code automatically merges settings** from different scopes:
   - Default settings
   - User settings (global)
   - Workspace settings
   - Workspace folder settings
   - Language-specific settings

## New Utilities

| Utility | Purpose |
|---------|---------|
| `getWorkspaceConfiguration` | Request multiple config sections at once |
| `getConfigurationSection` | Convenience wrapper for single sections |
| `flattenConfiguration` | Flatten nested config to dot-notation keys |

## Usage Example

```typescript
// Request multiple sections
const [tsConfig, angularConfig] = await getWorkspaceConfiguration(
  session.connection,
  [
    { section: 'typescript.inlayHints', scopeUri: documentUri },
    { section: 'angular.inlayHints', scopeUri: documentUri },
  ]
);

// Flatten for easier mapping
const flat = flattenConfiguration(tsConfig, 'typescript.inlayHints');
// { 'typescript.inlayHints.parameterNames.enabled': 'all', ... }
```

## LSP Reference

See [workspace/configuration](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration) in the LSP 3.17 specification.

## Dependents

This infrastructure will be used by:
- #66731 (Inlay Hints)
- #66690 (Document Symbols)

## Breaking Changes

None

## 🤖 AI Disclosure

This PR was developed using Claude Opus 4.5 AI assistant under human orchestration and review by @kbrilla.
