### PR TITLE
fix(docs): fix wrong line highlight in lightweight injection token fo…

### DIFF
--- a/adev/src/content/guide/di/lightweight-injection-tokens.md
+++ b/adev/src/content/guide/di/lightweight-injection-tokens.md
@@ -144,7 +144,7 @@ This lets the parent communicate with the child, if it is present, in a type-saf
 For example, the `LibCard` now queries `LibHeaderToken` rather than `LibHeader`.
 The following example shows how the pattern lets `LibCard` communicate with the `LibHeader` without actually referring to `LibHeader`:
 
-```ts {highlight: [[2],[9],[11],[19]]}
+```ts {highlight: [[2],[7],[11],[19]]}
 abstract class LibHeaderToken {
   abstract doSomething(): void;
 }


### PR DESCRIPTION

## What is the current behavior?

<img width="1120" height="538" alt="image" src="https://github.com/user-attachments/assets/8b752985-6006-4535-b5c8-bcddcde3564d" />
