### PR TITLE
refactor(core): remove `index` from text node creation

### DIFF
--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -31,7 +31,7 @@ import {getOrCreateTNode} from '../tnode_manipulation';
  *
  * @codeGenApi
  */
-export function ɵɵtext(index: number, value: string = ''): void {
+export function ɵɵtext(index: number, value = ''): void {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
@@ -42,7 +42,7 @@ export function ɵɵtext(index: number, value: string = ''): void {
     ? getOrCreateTNode(tView, adjustedIndex, TNodeType.Text, value, null)
     : (tView.data[adjustedIndex] as TElementNode);
 
-  const textNative = _locateOrCreateTextNode(tView, lView, tNode, value, index);
+  const textNative = _locateOrCreateTextNode(tView, lView, tNode, value);
   lView[adjustedIndex] = textNative;
 
   if (wasLastNodeCreated()) {
@@ -58,7 +58,6 @@ let _locateOrCreateTextNode: typeof locateOrCreateTextNodeImpl = (
   lView: LView,
   tNode: TNode,
   value: string,
-  index: number,
 ) => {
   lastNodeWasCreated(true);
   return createTextNode(lView[RENDERER], value);
@@ -73,7 +72,6 @@ function locateOrCreateTextNodeImpl(
   lView: LView,
   tNode: TNode,
   value: string,
-  index: number,
 ): RText {
   const isNodeCreationMode = !canHydrateNode(lView, tNode);
   lastNodeWasCreated(isNodeCreationMode);


### PR DESCRIPTION
Removes unnecessary `index` parameter from `_locateOrCreateTextNode` and `locateOrCreateTextNodeImpl` functions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
