### PR TITLE
feat(language-service): add Angular-specific Inlay Hints (LSP 3.17)

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -100,6 +100,265 @@ export interface LinkedEditingRanges {
 }
 
 /**
+ * A display part for interactive inlay hints.
+ * When clicked, can navigate to the definition of the type/parameter.
+ */
+export interface InlayHintDisplayPart {
+  /** The text to display */
+  text: string;
+  /** Optional navigation target span */
+  span?: {
+    /** Start offset in the target file */
+    start: number;
+    /** Length of the span */
+    length: number;
+  };
+  /** Optional target file path for navigation */
+  file?: string;
+}
+
+/**
+ * Represents an Angular-specific inlay hint to be displayed in the editor.
+ */
+export interface AngularInlayHint {
+  /** Offset position where the hint should appear */
+  position: number;
+  /**
+   * The text to display.
+   * For non-interactive hints, this contains the full hint text.
+   * For interactive hints, this may be empty and displayParts is used instead.
+   */
+  text: string;
+  /** Kind of hint: 'Type' for type annotations, 'Parameter' for parameter names */
+  kind: 'Type' | 'Parameter';
+  /** Whether to add padding before the hint */
+  paddingLeft?: boolean;
+  /** Whether to add padding after the hint */
+  paddingRight?: boolean;
+  /** Optional tooltip documentation */
+  tooltip?: string;
+  /**
+   * Display parts for interactive hints.
+   * When present, these parts can be clicked to navigate to type/parameter definitions.
+   * Used when interactiveInlayHints is enabled.
+   */
+  displayParts?: InlayHintDisplayPart[];
+}
+
+/**
+ * Configuration for which Angular inlay hints to show.
+ * These options are designed to align with TypeScript's inlay hints configuration
+ * where applicable to Angular templates.
+ */
+export interface InlayHintsConfig {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // VARIABLE TYPE HINTS - equivalent to TypeScript's includeInlayVariableTypeHints
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** Show type hints for @for loop variables: `@for (item: Item of items)` */
+  forLoopVariableTypes?: boolean;
+
+  /**
+   * Show type hints for @if alias variables: `@if (data; as result: Data)`
+   *
+   * Can be a boolean to enable/disable all @if alias hints, or an object for fine-grained control:
+   * - `simpleExpressions`: Show hints for simple variable references like `@if (data; as result)`
+   * - `complexExpressions`: Show hints for complex expressions like `@if (data == 2; as b)` or `@if (data.prop; as p)`
+   *
+   * When set to true, shows hints for all @if aliases.
+   * When set to 'complex', only shows hints for complex expressions (property access, comparisons, calls, etc.)
+   */
+  ifAliasTypes?:
+    | boolean
+    | 'complex'
+    | {
+        /** Show hints for simple variable references: @if (data; as result). Default: true */
+        simpleExpressions?: boolean;
+        /** Show hints for complex expressions: @if (data.prop; as p), @if (a == b; as c). Default: true */
+        complexExpressions?: boolean;
+      };
+
+  /** Show type hints for @let declarations: `@let count: number = items.length` */
+  letDeclarationTypes?: boolean;
+
+  /** Show type hints for template reference variables: `#ref: HTMLInputElement` */
+  referenceVariableTypes?: boolean;
+
+  /**
+   * Suppress hints when variable name matches the type name (case-insensitive).
+   * Equivalent to TypeScript's `includeInlayVariableTypeHintsWhenTypeMatchesName`.
+   * When false, skips hints like `@let user: User = getUser()` where name matches type.
+   * @default true
+   */
+  variableTypeHintsWhenTypeMatchesName?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ARROW FUNCTION TYPE HINTS - equivalent to TypeScript's function type hints
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show type hints for arrow function parameters in templates.
+   * Equivalent to TypeScript's `includeInlayFunctionParameterTypeHints`.
+   *
+   * When enabled, shows: `(a: number, b: string) => a + b` where types are inferred.
+   * @default true
+   */
+  arrowFunctionParameterTypes?: boolean;
+
+  /**
+   * Show return type hints for arrow functions in templates.
+   * Equivalent to TypeScript's `includeInlayFunctionLikeReturnTypeHints`.
+   *
+   * When enabled, shows: `(a, b): number => a + b` where return type is inferred.
+   * @default true
+   */
+  arrowFunctionReturnTypes?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PARAMETER NAME HINTS - equivalent to TypeScript's includeInlayParameterNameHints
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show parameter name hints for function/method arguments in expressions.
+   * Equivalent to TypeScript's `includeInlayParameterNameHints`.
+   *
+   * When enabled, shows: `handleClick(event: $event)` where 'event' is the parameter name.
+   * Options:
+   * - 'none': No parameter name hints
+   * - 'literals': Only for literal arguments (strings, numbers, booleans)
+   * - 'all': For all arguments
+   * @default 'all'
+   */
+  parameterNameHints?: 'none' | 'literals' | 'all';
+
+  /**
+   * Show parameter hints even when argument name matches parameter name.
+   * Equivalent to TypeScript's `includeInlayParameterNameHintsWhenArgumentMatchesName`.
+   * When false, skips hints like `onClick(event)` where arg name matches param name.
+   * @default false
+   */
+  parameterNameHintsWhenArgumentMatchesName?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // EVENT TYPE HINTS - Angular-specific for event bindings
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show type hints for event binding $event parameter.
+   * Works with @Output() EventEmitter<T>, output() OutputEmitterRef<T>, and model() changes.
+   * Example: `(click: MouseEvent)`, `(valueChange: string)`
+   *
+   * Can be a boolean to enable/disable all event hints, or an object for fine-grained control:
+   * - `nativeEvents`: Show hints for native HTML events (click, input, etc.)
+   * - `componentEvents`: Show hints for custom component/directive events
+   * - `animationEvents`: Show hints for animation events (@trigger.done)
+   */
+  eventParameterTypes?:
+    | boolean
+    | {
+        /** Show hints for native HTML events (click, input, keydown, etc.). Default: true */
+        nativeEvents?: boolean;
+        /** Show hints for custom component/directive output events. Default: true */
+        componentEvents?: boolean;
+        /** Show hints for animation events (@trigger.start, @trigger.done). Default: true */
+        animationEvents?: boolean;
+      };
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PIPE AND BINDING TYPE HINTS - Angular-specific
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** Show type hints for pipe output types: `{{ value | async: Observable<T> }}` */
+  pipeOutputTypes?: boolean;
+
+  /**
+   * Show type hints for property/input binding types.
+   * Works with @Input(), input(), input.required(), and model() inputs.
+   * Example: `[disabled: boolean]="isDisabled"`
+   *
+   * Can be a boolean to enable/disable all property hints, or an object for fine-grained control:
+   * - `nativeProperties`: Show hints for native DOM properties ([disabled], [hidden], etc.)
+   * - `componentInputs`: Show hints for component/directive @Input() and input() bindings
+   */
+  propertyBindingTypes?:
+    | boolean
+    | {
+        /** Show hints for native DOM properties. Default: true */
+        nativeProperties?: boolean;
+        /** Show hints for component/directive inputs. Default: true */
+        componentInputs?: boolean;
+      };
+
+  /**
+   * Show WritableSignal<T> type for two-way bindings with model() signals.
+   * When true: `[(checked: WritableSignal<boolean>)]="checkboxSignal"`
+   * When false: `[(checked: boolean)]="checkboxSignal"`
+   * @default true
+   */
+  twoWayBindingSignalTypes?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // VISUAL DIFFERENTIATION OPTIONS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Add visual indicator for input.required() bindings.
+   * Options:
+   * - 'none': No special indicator
+   * - 'asterisk': Add asterisk suffix `[user*: User]`
+   * - 'exclamation': Add exclamation suffix `[user: User!]`
+   * @default 'none'
+   */
+  requiredInputIndicator?: 'none' | 'asterisk' | 'exclamation';
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // INTERACTIVE HINTS - equivalent to TypeScript's interactiveInlayHints
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Enable clickable hints that navigate to type/parameter definitions.
+   * Equivalent to TypeScript's `interactiveInlayHints`.
+   * @default false
+   */
+  interactiveInlayHints?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // HOST LISTENER ARGUMENT TYPE HINTS - Angular-specific for @HostListener
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show type hints for @HostListener argument expressions.
+   * Example: `@HostListener('click', ['$event.target: EventTarget | null', '$event.clientX: number'])`
+   *
+   * When enabled, shows the inferred type for each expression passed in the decorator arguments.
+   * @default true
+   */
+  hostListenerArgumentTypes?: boolean;
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CONTROL FLOW BLOCK TYPE HINTS - Angular-specific for new control flow syntax
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Show type hints for @switch block expressions.
+   * Example: `@switch (status: Status) { @case (Status.Active) { ... } }`
+   *
+   * When enabled, shows the inferred type of the switch expression value.
+   * @default true
+   */
+  switchExpressionTypes?: boolean;
+
+  /**
+   * Show type hints for @defer block trigger expressions.
+   * Example: `@defer (when isVisible: boolean) { ... }`
+   *
+   * When enabled, shows the inferred type for 'when' trigger conditions.
+   * @default true
+   */
+  deferTriggerTypes?: boolean;
+}
+
+/**
  * `NgLanguageService` describes an instance of an Angular language service,
  * whose API surface is a strict superset of TypeScript's language service.
  */
@@ -135,6 +394,26 @@ export interface NgLanguageService extends ts.LanguageService {
     position: number,
   ): GetTemplateLocationForComponentResponse;
   getTypescriptLanguageService(): ts.LanguageService;
+
+  /**
+   * Provide Angular-specific inlay hints for templates.
+   *
+   * Returns hints for:
+   * - @for loop variable types: `@for (user: User of users)`
+   * - @if alias types: `@if (data; as result: ApiResult)`
+   * - Event parameter types: `(click)="onClick($event: MouseEvent)"`
+   * - Pipe output types
+   * - @let declaration types
+   *
+   * @param fileName The file to get inlay hints for
+   * @param span The text span to get hints within
+   * @param config Optional configuration for which hints to show
+   */
+  getAngularInlayHints(
+    fileName: string,
+    span: ts.TextSpan,
+    config?: InlayHintsConfig,
+  ): AngularInlayHint[];
 
   applyRefactoring(
     fileName: string,

--- a/packages/language-service/src/inlay_hints.ts
+++ b/packages/language-service/src/inlay_hints.ts
@@ -1,0 +1,2054 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  AST,
+  ASTWithSource,
+  ArrowFunction,
+  BindingPipe,
+  BindingType,
+  Call,
+  ImplicitReceiver,
+  LiteralArray,
+  LiteralMap,
+  LiteralPrimitive,
+  SafeCall,
+  ParsedEventType,
+  PropertyRead,
+  SpreadElement,
+  TemplateLiteral,
+  TmplAstBoundAttribute,
+  TmplAstBoundDeferredTrigger,
+  TmplAstBoundEvent,
+  TmplAstBoundText,
+  TmplAstDeferredBlock,
+  TmplAstForLoopBlock,
+  TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
+  TmplAstNode,
+  TmplAstSwitchBlock,
+  TmplAstTextAttribute,
+  TmplAstVariable,
+  TmplAstReference,
+  tmplAstVisitAll,
+  RecursiveAstVisitor,
+  TmplAstRecursiveVisitor,
+  Unary,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {
+  SymbolKind,
+  VariableSymbol,
+  PipeSymbol,
+  OutputBindingSymbol,
+  InputBindingSymbol,
+  LetDeclarationSymbol,
+  ReferenceSymbol,
+  DomBindingSymbol,
+  ElementSymbol,
+  ExpressionSymbol,
+} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api/checker';
+import {findFirstMatchingNode} from '@angular/compiler-cli/src/ngtsc/typecheck/src/comments';
+import ts from 'typescript';
+
+import {TypeCheckInfo} from './utils';
+
+// Re-export types from API for internal use
+export type {AngularInlayHint, InlayHintsConfig, InlayHintDisplayPart} from '../api';
+import type {AngularInlayHint, InlayHintsConfig, InlayHintDisplayPart} from '../api';
+
+/**
+ * Default configuration - aligned with TypeScript's defaults where applicable.
+ */
+const DEFAULT_CONFIG: Required<InlayHintsConfig> = {
+  // Variable type hints (like TS includeInlayVariableTypeHints)
+  forLoopVariableTypes: true,
+  ifAliasTypes: true,
+  letDeclarationTypes: true,
+  referenceVariableTypes: true,
+  variableTypeHintsWhenTypeMatchesName: true,
+
+  // Arrow function type hints (like TS function type hints)
+  arrowFunctionParameterTypes: true,
+  arrowFunctionReturnTypes: true,
+
+  // Parameter name hints (like TS includeInlayParameterNameHints)
+  parameterNameHints: 'all',
+  parameterNameHintsWhenArgumentMatchesName: false,
+
+  // Event type hints (Angular-specific)
+  eventParameterTypes: true,
+
+  // Pipe and binding hints (Angular-specific)
+  pipeOutputTypes: true,
+  propertyBindingTypes: true,
+  twoWayBindingSignalTypes: true,
+
+  // Visual differentiation
+  requiredInputIndicator: 'none',
+
+  // Interactive hints (like TS interactiveInlayHints)
+  interactiveInlayHints: false,
+
+  // Host listener argument types (Angular-specific)
+  hostListenerArgumentTypes: true,
+
+  // Control flow block hints (Angular-specific)
+  switchExpressionTypes: true,
+  deferTriggerTypes: true,
+};
+
+const globalDomTypeCacheByChecker = new WeakMap<ts.TypeChecker, Map<string, ts.Type | null>>();
+
+/**
+ * Normalize the eventParameterTypes config to a structured format.
+ */
+function normalizeEventConfig(
+  config:
+    | boolean
+    | {nativeEvents?: boolean; componentEvents?: boolean; animationEvents?: boolean}
+    | undefined,
+): {
+  enabled: boolean;
+  nativeEvents: boolean;
+  componentEvents: boolean;
+  animationEvents: boolean;
+} {
+  if (config === false) {
+    return {enabled: false, nativeEvents: false, componentEvents: false, animationEvents: false};
+  }
+  if (config === true || config === undefined) {
+    return {enabled: true, nativeEvents: true, componentEvents: true, animationEvents: true};
+  }
+  return {
+    enabled: true,
+    nativeEvents: config.nativeEvents ?? true,
+    componentEvents: config.componentEvents ?? true,
+    animationEvents: config.animationEvents ?? true,
+  };
+}
+
+/**
+ * Normalize the propertyBindingTypes config to a structured format.
+ */
+function normalizePropertyConfig(
+  config: boolean | {nativeProperties?: boolean; componentInputs?: boolean} | undefined,
+): {
+  enabled: boolean;
+  nativeProperties: boolean;
+  componentInputs: boolean;
+} {
+  if (config === false) {
+    return {enabled: false, nativeProperties: false, componentInputs: false};
+  }
+  if (config === true || config === undefined) {
+    return {enabled: true, nativeProperties: true, componentInputs: true};
+  }
+  return {
+    enabled: true,
+    nativeProperties: config.nativeProperties ?? true,
+    componentInputs: config.componentInputs ?? true,
+  };
+}
+
+/**
+ * Normalize the ifAliasTypes config to a structured format.
+ */
+function normalizeIfAliasConfig(config: InlayHintsConfig['ifAliasTypes']): {
+  enabled: boolean;
+  simpleExpressions: boolean;
+  complexExpressions: boolean;
+} {
+  if (config === false) {
+    return {enabled: false, simpleExpressions: false, complexExpressions: false};
+  }
+  if (config === true || config === undefined) {
+    return {enabled: true, simpleExpressions: true, complexExpressions: true};
+  }
+  if (config === 'complex') {
+    // Only show hints for complex expressions
+    return {enabled: true, simpleExpressions: false, complexExpressions: true};
+  }
+  return {
+    enabled: true,
+    simpleExpressions: config.simpleExpressions ?? true,
+    complexExpressions: config.complexExpressions ?? true,
+  };
+}
+
+/**
+ * Check if an @if expression is a "simple" expression.
+ * Simple: @if (variable; as alias) - just a property read from implicit receiver
+ * Complex: @if (var == 2; as alias), @if (var.prop; as alias), @if (fn(); as alias)
+ */
+function isSimpleIfExpression(expression: AST | null): boolean {
+  if (!expression) return true;
+
+  // Unwrap ASTWithSource
+  const expr = expression instanceof ASTWithSource ? expression.ast : expression;
+
+  // Simple case: PropertyRead with ImplicitReceiver (e.g., @if (data; as result))
+  if (expr instanceof PropertyRead && expr.receiver instanceof ImplicitReceiver) {
+    return true;
+  }
+
+  // Everything else is complex
+  return false;
+}
+
+/**
+ * Get Angular-specific inlay hints for a template.
+ */
+export function getInlayHintsForTemplate(
+  compiler: NgCompiler,
+  typeCheckInfo: TypeCheckInfo,
+  span: ts.TextSpan,
+  config: InlayHintsConfig = {},
+): AngularInlayHint[] {
+  const mergedConfig = {...DEFAULT_CONFIG, ...config};
+  const hints: AngularInlayHint[] = [];
+  const ttc = compiler.getTemplateTypeChecker();
+  const typeChecker = compiler.getCurrentProgram().getTypeChecker();
+
+  // Get the Type Check Block for accessing resolved types
+  // The TCB has TypeScript's resolved types for all expressions, including
+  // overloaded function calls and generic type inference
+  const tcb = ttc.getTypeCheckBlock(typeCheckInfo.declaration);
+
+  // Get the template AST (may be null for directives without templates)
+  const template = ttc.getTemplate(typeCheckInfo.declaration);
+
+  // Helper to check if a position is within our requested span
+  const isInSpan = (pos: number): boolean => {
+    return pos >= span.start && pos < span.start + span.length;
+  };
+
+  // Helper to format type string (remove unnecessary verbosity)
+  const formatType = (type: ts.Type): string => {
+    let typeStr = typeChecker.typeToString(
+      type,
+      undefined,
+      ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.OmitParameterModifiers,
+    );
+    // Simplify common patterns
+    typeStr = typeStr.replace(/import\([^)]+\)\./g, ''); // Remove import paths
+    return typeStr;
+  };
+
+  /**
+   * Try to get the declaration info from a type for interactive hints.
+   * Returns the first declaration's location if available.
+   */
+  const getTypeDeclarationInfo = (
+    type: ts.Type,
+  ): {file: string; start: number; length: number} | null => {
+    const symbol = type.getSymbol();
+    if (symbol) {
+      const declarations = symbol.getDeclarations();
+      if (declarations && declarations.length > 0) {
+        const decl = declarations[0];
+        const sourceFile = decl.getSourceFile();
+        return {
+          file: sourceFile.fileName,
+          start: decl.getStart(),
+          length: decl.getWidth(),
+        };
+      }
+    }
+    return null;
+  };
+
+  /**
+   * Create a type hint with optional interactivity.
+   * When interactiveInlayHints is enabled and the type has a declaration,
+   * clicking the hint navigates to the type definition.
+   *
+   * @param position - Position in the template where the hint should appear
+   * @param type - The ts.Type object (required for interactive navigation)
+   * @param typeStr - The formatted type string to display
+   * @param paddingLeft - Add padding before the hint
+   * @param paddingRight - Add padding after the hint
+   */
+  const createTypeHint = (
+    position: number,
+    type: ts.Type,
+    typeStr: string,
+    paddingLeft: boolean = false,
+    paddingRight: boolean = false,
+  ): AngularInlayHint => {
+    // Try to get the type's declaration for interactive hints
+    if (mergedConfig.interactiveInlayHints) {
+      const declInfo = getTypeDeclarationInfo(type);
+      if (declInfo) {
+        return {
+          position,
+          text: '',
+          kind: 'Type',
+          paddingLeft,
+          paddingRight,
+          displayParts: [
+            {
+              text: ': ',
+              span: {
+                start: declInfo.start,
+                length: declInfo.length,
+              },
+              file: declInfo.file,
+            },
+            {
+              text: typeStr,
+              span: {
+                start: declInfo.start,
+                length: declInfo.length,
+              },
+              file: declInfo.file,
+            },
+          ],
+        };
+      }
+    }
+
+    // Non-interactive hint
+    return {
+      position,
+      text: `: ${typeStr}`,
+      kind: 'Type',
+      paddingLeft,
+      paddingRight,
+    };
+  };
+
+  /**
+   * Create a type hint from a type string with optional suffix (like "!" for required).
+   * When interactiveInlayHints is enabled and the type has a declaration,
+   * clicking the hint navigates to the type definition.
+   *
+   * This is useful when we have a ts.Type but need to add extra text like
+   * required indicators or wrapper types.
+   *
+   * @param position - Position in the template where the hint should appear
+   * @param type - The ts.Type object (can be null if type not available)
+   * @param typeStr - The formatted type string to display
+   * @param suffix - Optional suffix to add after the type (e.g., "!" for required)
+   * @param prefix - Optional prefix before the colon (defaults to empty)
+   */
+  const createTypeHintWithSuffix = (
+    position: number,
+    type: ts.Type | null,
+    typeStr: string,
+    suffix: string = '',
+    prefix: string = '',
+  ): AngularInlayHint => {
+    // Try to get the type's declaration for interactive hints
+    if (mergedConfig.interactiveInlayHints && type) {
+      const declInfo = getTypeDeclarationInfo(type);
+      if (declInfo) {
+        const parts: InlayHintDisplayPart[] = [];
+        if (prefix) {
+          parts.push({text: prefix});
+        }
+        parts.push({
+          text: ': ',
+          span: {
+            start: declInfo.start,
+            length: declInfo.length,
+          },
+          file: declInfo.file,
+        });
+        parts.push({
+          text: typeStr,
+          span: {
+            start: declInfo.start,
+            length: declInfo.length,
+          },
+          file: declInfo.file,
+        });
+        if (suffix) {
+          parts.push({text: suffix});
+        }
+        return {
+          position,
+          text: '',
+          kind: 'Type',
+          paddingLeft: false,
+          paddingRight: false,
+          displayParts: parts,
+        };
+      }
+    }
+
+    // Non-interactive hint
+    return {
+      position,
+      text: `${prefix}: ${typeStr}${suffix}`,
+      kind: 'Type',
+      paddingLeft: false,
+      paddingRight: false,
+    };
+  };
+
+  /**
+   * Check if the type name matches the variable name (case-insensitive).
+   * TypeScript skips variable type hints when the type name matches the variable name.
+   * e.g., `const user: User` - hint is skipped because 'user' matches 'User'
+   */
+  const typeMatchesName = (typeName: string, variableName: string): boolean => {
+    // Handle generic types like User<T> - extract the base type name
+    const baseTypeName = typeName.split('<')[0].trim();
+    return baseTypeName.toLowerCase() === variableName.toLowerCase();
+  };
+
+  /**
+   * Check if a variable type hint should be shown based on config.
+   * Returns false if variableTypeHintsWhenTypeMatchesName is false and the names match.
+   */
+  const shouldShowVariableTypeHint = (typeStr: string, varName: string): boolean => {
+    if (!mergedConfig.variableTypeHintsWhenTypeMatchesName && typeMatchesName(typeStr, varName)) {
+      return false;
+    }
+    return true;
+  };
+
+  // Variables from @for/@if alias are visited both in specialized visitors
+  // and again through the generic variable visitor. Track these nodes to avoid
+  // emitting duplicates from the recursive traversal model.
+  const processedVariables = new Set<TmplAstVariable>();
+
+  // Visitor to collect inlay hints from template nodes
+  class InlayHintVisitor extends TmplAstRecursiveVisitor {
+    override visitForLoopBlock(block: TmplAstForLoopBlock): void {
+      if (mergedConfig.forLoopVariableTypes) {
+        // Get type hint for the main loop variable
+        const itemVar = block.item;
+        processedVariables.add(itemVar);
+        if (itemVar.keySpan && isInSpan(itemVar.keySpan.start.offset)) {
+          const symbol = ttc.getSymbolOfNode(itemVar, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Variable) {
+            const varSymbol = symbol as VariableSymbol;
+            const typeStr = formatType(varSymbol.tsType);
+            // Skip hint if type matches variable name (like TypeScript does)
+            if (shouldShowVariableTypeHint(typeStr, itemVar.name)) {
+              // Position after the variable name
+              hints.push(
+                createTypeHint(itemVar.keySpan.end.offset, varSymbol.tsType, typeStr, false, true),
+              );
+            }
+          }
+        }
+
+        // Get type hints for context variables ($index, $count, etc.)
+        // Only process context variables that have non-empty keySpans.
+        // The parser creates implicit context variables with empty spans for all
+        // allowed names ($index, $first, $last, $even, $odd, $count), but only
+        // explicitly aliased ones (e.g., `let idx = $index`) have meaningful spans.
+        for (const contextVar of block.contextVariables) {
+          processedVariables.add(contextVar);
+          // Skip implicit context variables with empty spans (start === end)
+          if (
+            !contextVar.keySpan ||
+            contextVar.keySpan.start.offset === contextVar.keySpan.end.offset
+          ) {
+            continue;
+          }
+
+          if (isInSpan(contextVar.keySpan.start.offset)) {
+            const symbol = ttc.getSymbolOfNode(contextVar, typeCheckInfo.declaration);
+            if (symbol && symbol.kind === SymbolKind.Variable) {
+              const varSymbol = symbol as VariableSymbol;
+              const typeStr = formatType(varSymbol.tsType);
+              // Skip hint if type matches variable name (like TypeScript does)
+              if (shouldShowVariableTypeHint(typeStr, contextVar.name)) {
+                hints.push(
+                  createTypeHint(
+                    contextVar.keySpan.end.offset,
+                    varSymbol.tsType,
+                    typeStr,
+                    false,
+                    true,
+                  ),
+                );
+              }
+            }
+          }
+        }
+      }
+
+      super.visitForLoopBlock(block);
+    }
+
+    override visitIfBlockBranch(branch: TmplAstIfBlockBranch): void {
+      if (branch.expressionAlias) {
+        processedVariables.add(branch.expressionAlias);
+      }
+
+      const ifAliasConfig = normalizeIfAliasConfig(mergedConfig.ifAliasTypes);
+      if (ifAliasConfig.enabled && branch.expressionAlias) {
+        // Get type for @if alias: @if (condition; as result)
+        const aliasVar = branch.expressionAlias;
+
+        // Check if this expression should show a hint based on config
+        const isSimple = isSimpleIfExpression(branch.expression);
+        const shouldShow = isSimple
+          ? ifAliasConfig.simpleExpressions
+          : ifAliasConfig.complexExpressions;
+
+        if (shouldShow && aliasVar.keySpan && isInSpan(aliasVar.keySpan.start.offset)) {
+          const symbol = ttc.getSymbolOfNode(aliasVar, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Variable) {
+            const varSymbol = symbol as VariableSymbol;
+            const typeStr = formatType(varSymbol.tsType);
+            // Skip hint if type matches variable name (like TypeScript does)
+            if (shouldShowVariableTypeHint(typeStr, aliasVar.name)) {
+              hints.push(
+                createTypeHint(aliasVar.keySpan.end.offset, varSymbol.tsType, typeStr, false, true),
+              );
+            }
+          }
+        }
+      }
+
+      super.visitIfBlockBranch(branch);
+    }
+
+    override visitBoundEvent(event: TmplAstBoundEvent): void {
+      // Show event type hint after event name: (click: MouseEvent)
+      const eventConfig = normalizeEventConfig(mergedConfig.eventParameterTypes);
+      if (eventConfig.enabled && event.keySpan) {
+        // Two-way bindings already have a property-side hint on visitBoundAttribute.
+        // Skip event-side type hint to avoid duplicate labels like `[(value: T: T)]`.
+        if (event.type === ParsedEventType.TwoWay) {
+          // Continue into handler for parameter-name hints below.
+        } else if (isInSpan(event.keySpan.start.offset)) {
+          // Determine the event source to apply fine-grained config
+          const symbol = ttc.getSymbolOfNode(event, typeCheckInfo.declaration);
+          const isComponentEvent = symbol?.kind === SymbolKind.Output;
+          const isAnimationEvent =
+            event.type === ParsedEventType.LegacyAnimation ||
+            event.type === ParsedEventType.Animation;
+          const isNativeEvent = !isComponentEvent && !isAnimationEvent;
+
+          // Check if this event type should show hints based on config
+          const shouldShow =
+            (isNativeEvent && eventConfig.nativeEvents) ||
+            (isComponentEvent && eventConfig.componentEvents) ||
+            (isAnimationEvent && eventConfig.animationEvents);
+
+          if (shouldShow) {
+            // Get the $event type from the template type checker
+            const eventTypeResult = getEventType(event, typeCheckInfo, ttc, typeChecker);
+            if (eventTypeResult) {
+              // Use createTypeHint for interactive hints if we have the ts.Type
+              if (eventTypeResult.tsType) {
+                hints.push(
+                  createTypeHint(
+                    event.keySpan.end.offset,
+                    eventTypeResult.tsType,
+                    eventTypeResult.typeStr,
+                  ),
+                );
+              } else {
+                // Fallback for types without ts.Type (like AnimationCallbackEvent)
+                hints.push({
+                  position: event.keySpan.end.offset,
+                  text: `: ${eventTypeResult.typeStr}`,
+                  kind: 'Type',
+                  paddingLeft: false,
+                  paddingRight: false,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // Show function argument parameter name hints for method calls in the handler
+      if (mergedConfig.parameterNameHints !== 'none') {
+        const visitor = new FunctionArgumentVisitor(
+          typeCheckInfo,
+          ttc,
+          typeChecker,
+          tcb,
+          hints,
+          isInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        event.handler.visit(visitor);
+      }
+    }
+
+    override visitVariable(variable: TmplAstVariable): void {
+      if (processedVariables.has(variable)) {
+        return;
+      }
+
+      // This handles template variables like `let-item` on ng-template
+      // and structural directive variables like `*ngFor="let item of items"`
+      if (
+        mergedConfig.forLoopVariableTypes &&
+        variable.keySpan &&
+        isInSpan(variable.keySpan.start.offset)
+      ) {
+        const symbol = ttc.getSymbolOfNode(variable, typeCheckInfo.declaration);
+        if (symbol && symbol.kind === SymbolKind.Variable) {
+          const varSymbol = symbol as VariableSymbol;
+          const typeStr = formatType(varSymbol.tsType);
+          // Skip hint if type matches variable name (like TypeScript does)
+          if (shouldShowVariableTypeHint(typeStr, variable.name)) {
+            hints.push(
+              createTypeHint(variable.keySpan.end.offset, varSymbol.tsType, typeStr, false, true),
+            );
+          }
+        }
+      }
+    }
+
+    override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+      // Handle @let declarations: @let result = expression
+      if (
+        mergedConfig.letDeclarationTypes &&
+        decl.nameSpan &&
+        isInSpan(decl.nameSpan.start.offset)
+      ) {
+        const symbol = ttc.getSymbolOfNode(decl, typeCheckInfo.declaration);
+        if (symbol && symbol.kind === SymbolKind.LetDeclaration) {
+          const letSymbol = symbol as LetDeclarationSymbol;
+          const typeStr = formatType(letSymbol.tsType);
+          // Skip hint if type matches variable name (like TypeScript does)
+          if (shouldShowVariableTypeHint(typeStr, decl.name)) {
+            hints.push(
+              createTypeHint(decl.nameSpan.end.offset, letSymbol.tsType, typeStr, false, true),
+            );
+          }
+        }
+      }
+    }
+
+    override visitReference(reference: TmplAstReference): void {
+      // Handle template reference variables: #ref, #myInput="matInput"
+      if (
+        mergedConfig.referenceVariableTypes &&
+        reference.keySpan &&
+        isInSpan(reference.keySpan.start.offset)
+      ) {
+        const symbol = ttc.getSymbolOfNode(reference, typeCheckInfo.declaration);
+        if (symbol && symbol.kind === SymbolKind.Reference) {
+          const refSymbol = symbol as ReferenceSymbol;
+          const typeStr = formatType(refSymbol.tsType);
+          // Skip hint if type matches variable name (like TypeScript does)
+          if (shouldShowVariableTypeHint(typeStr, reference.name)) {
+            hints.push(
+              createTypeHint(reference.keySpan.end.offset, refSymbol.tsType, typeStr, false, true),
+            );
+          }
+        }
+      }
+    }
+
+    override visitBoundText(text: TmplAstBoundText): void {
+      // Handle interpolations: {{ value | pipe }}
+      if (mergedConfig.pipeOutputTypes) {
+        const pipeVisitor = new PipeExpressionVisitor(
+          ttc,
+          typeChecker,
+          typeCheckInfo.declaration,
+          tcb,
+          hints,
+          isInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        text.value.visit(pipeVisitor);
+      }
+
+      // Show function argument parameter name hints for method calls in interpolations
+      if (mergedConfig.parameterNameHints !== 'none') {
+        const argVisitor = new FunctionArgumentVisitor(
+          typeCheckInfo,
+          ttc,
+          typeChecker,
+          tcb,
+          hints,
+          isInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        text.value.visit(argVisitor);
+      }
+    }
+
+    override visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
+      // Handle property bindings: [prop]="value | pipe"
+      if (mergedConfig.pipeOutputTypes) {
+        const pipeVisitor = new PipeExpressionVisitor(
+          ttc,
+          typeChecker,
+          typeCheckInfo.declaration,
+          tcb,
+          hints,
+          isInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        attribute.value.visit(pipeVisitor);
+      }
+
+      // Handle input binding type hints: [input: Type]="value" or [(model): WritableSignal<Type>]="signal"
+      // Works with @Input(), input(), input.required(), and model() bindings
+      const propertyConfig = normalizePropertyConfig(mergedConfig.propertyBindingTypes);
+      if (propertyConfig.enabled && attribute.keySpan) {
+        if (isInSpan(attribute.keySpan.start.offset)) {
+          if (attribute.type !== BindingType.Property && attribute.type !== BindingType.TwoWay) {
+            // Skip attr/style/class binding families for property type hints.
+            super.visitBoundAttribute(attribute);
+            return;
+          }
+
+          const symbol = ttc.getSymbolOfNode(attribute, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Input) {
+            // Component/directive input - check if we should show it
+            if (propertyConfig.componentInputs) {
+              const inputSymbol = symbol as InputBindingSymbol;
+              // Get the first binding's type (usually there's only one)
+              if (inputSymbol.bindings.length > 0) {
+                const binding = inputSymbol.bindings[0];
+                // Unwrap InputSignal<T>, InputSignalWithTransform<T, _>, or ModelSignal<T>
+                const unwrappedType = unwrapAngularType(binding.tsType);
+                const typeStr = formatType(unwrappedType);
+
+                // Check if this is a required input (for visual indicator)
+                const isRequired = isRequiredInput(binding.tsSymbol, typeChecker);
+                const requiredSuffix = getRequiredIndicator(
+                  isRequired,
+                  mergedConfig.requiredInputIndicator,
+                );
+
+                // For two-way bindings [(model)], optionally show that it expects WritableSignal<T>
+                if (
+                  attribute.type === BindingType.TwoWay &&
+                  mergedConfig.twoWayBindingSignalTypes
+                ) {
+                  // For two-way bindings, show WritableSignal<T>
+                  hints.push(
+                    createTypeHintWithSuffix(
+                      attribute.keySpan.end.offset,
+                      unwrappedType,
+                      `WritableSignal<${typeStr}>`,
+                      requiredSuffix,
+                    ),
+                  );
+                } else {
+                  hints.push(
+                    createTypeHintWithSuffix(
+                      attribute.keySpan.end.offset,
+                      unwrappedType,
+                      typeStr,
+                      requiredSuffix,
+                    ),
+                  );
+                }
+              }
+            }
+          } else if (symbol && symbol.kind === SymbolKind.DomBinding) {
+            // DOM property binding - check if we should show it
+            if (propertyConfig.nativeProperties) {
+              const domSymbol = symbol as DomBindingSymbol;
+              const propTypeResult = getDomPropertyType(attribute.name, domSymbol, typeChecker);
+              if (propTypeResult) {
+                hints.push(
+                  createTypeHint(
+                    attribute.keySpan.end.offset,
+                    propTypeResult.tsType,
+                    propTypeResult.typeStr,
+                  ),
+                );
+              }
+            }
+          }
+        }
+      }
+
+      // Show function argument parameter name hints for method calls in bindings
+      if (mergedConfig.parameterNameHints !== 'none') {
+        const argVisitor = new FunctionArgumentVisitor(
+          typeCheckInfo,
+          ttc,
+          typeChecker,
+          tcb,
+          hints,
+          isInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        attribute.value.visit(argVisitor);
+      }
+
+      super.visitBoundAttribute(attribute);
+    }
+
+    override visitTextAttribute(attribute: TmplAstTextAttribute): void {
+      // Handle text attribute input bindings: input="stringValue"
+      // These are inputs bound with plain string literals (no brackets)
+      const propertyConfig = normalizePropertyConfig(mergedConfig.propertyBindingTypes);
+      if (propertyConfig.enabled && propertyConfig.componentInputs && attribute.keySpan) {
+        if (isInSpan(attribute.keySpan.start.offset)) {
+          const symbol = ttc.getSymbolOfNode(attribute, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Input) {
+            const inputSymbol = symbol as InputBindingSymbol;
+            // Get the first binding's type (usually there's only one)
+            if (inputSymbol.bindings.length > 0) {
+              const binding = inputSymbol.bindings[0];
+              // Unwrap InputSignal<T>, InputSignalWithTransform<T, _>, or ModelSignal<T>
+              const unwrappedType = unwrapAngularType(binding.tsType);
+              const typeStr = formatType(unwrappedType);
+
+              // Check if this is a required input (for visual indicator)
+              const isRequired = isRequiredInput(binding.tsSymbol, typeChecker);
+              const requiredSuffix = getRequiredIndicator(
+                isRequired,
+                mergedConfig.requiredInputIndicator,
+              );
+
+              hints.push(
+                createTypeHintWithSuffix(
+                  attribute.keySpan.end.offset,
+                  unwrappedType,
+                  typeStr,
+                  requiredSuffix,
+                ),
+              );
+            }
+          }
+        }
+      }
+
+      super.visitTextAttribute(attribute);
+    }
+
+    override visitSwitchBlock(block: TmplAstSwitchBlock): void {
+      // Handle @switch expression type hints: @switch (status: Status) { ... }
+      if (mergedConfig.switchExpressionTypes && block.expression) {
+        // Get the expression's source span for positioning
+        const expr = block.expression;
+        const sourceSpan = expr instanceof ASTWithSource ? expr.sourceSpan : expr.span;
+
+        if (sourceSpan && isInSpan(sourceSpan.start)) {
+          // Get the type of the expression from the template type checker
+          const symbol = ttc.getSymbolOfNode(expr, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Expression) {
+            const exprSymbol =
+              symbol as import('@angular/compiler-cli/src/ngtsc/typecheck/api/symbols').ExpressionSymbol;
+            const typeStr = formatType(exprSymbol.tsType);
+            hints.push(createTypeHint(sourceSpan.end, exprSymbol.tsType, typeStr));
+          }
+        }
+      }
+
+      super.visitSwitchBlock(block);
+    }
+
+    override visitDeferredBlock(block: TmplAstDeferredBlock): void {
+      // Handle @defer trigger expression type hints: @defer (when isVisible: boolean) { ... }
+      if (mergedConfig.deferTriggerTypes) {
+        // Process 'when' trigger if it exists
+        const whenTrigger = block.triggers.when;
+        if (whenTrigger && whenTrigger instanceof TmplAstBoundDeferredTrigger) {
+          const expr = whenTrigger.value;
+          const sourceSpan = expr instanceof ASTWithSource ? expr.sourceSpan : expr.span;
+
+          if (sourceSpan && isInSpan(sourceSpan.start)) {
+            const symbol = ttc.getSymbolOfNode(expr, typeCheckInfo.declaration);
+            if (symbol && symbol.kind === SymbolKind.Expression) {
+              const exprSymbol =
+                symbol as import('@angular/compiler-cli/src/ngtsc/typecheck/api/symbols').ExpressionSymbol;
+              const typeStr = formatType(exprSymbol.tsType);
+              hints.push(createTypeHint(sourceSpan.end, exprSymbol.tsType, typeStr));
+            }
+          }
+        }
+
+        // Also check prefetch triggers (prefetch on ...)
+        const prefetchWhen = block.prefetchTriggers.when;
+        if (prefetchWhen && prefetchWhen instanceof TmplAstBoundDeferredTrigger) {
+          const expr = prefetchWhen.value;
+          const sourceSpan = expr instanceof ASTWithSource ? expr.sourceSpan : expr.span;
+
+          if (sourceSpan && isInSpan(sourceSpan.start)) {
+            const symbol = ttc.getSymbolOfNode(expr, typeCheckInfo.declaration);
+            if (symbol && symbol.kind === SymbolKind.Expression) {
+              const exprSymbol =
+                symbol as import('@angular/compiler-cli/src/ngtsc/typecheck/api/symbols').ExpressionSymbol;
+              const typeStr = formatType(exprSymbol.tsType);
+              hints.push(createTypeHint(sourceSpan.end, exprSymbol.tsType, typeStr));
+            }
+          }
+        }
+
+        // Also check hydrate triggers (hydrate when ...)
+        const hydrateWhen = block.hydrateTriggers.when;
+        if (hydrateWhen && hydrateWhen instanceof TmplAstBoundDeferredTrigger) {
+          const expr = hydrateWhen.value;
+          const sourceSpan = expr instanceof ASTWithSource ? expr.sourceSpan : expr.span;
+
+          if (sourceSpan && isInSpan(sourceSpan.start)) {
+            const symbol = ttc.getSymbolOfNode(expr, typeCheckInfo.declaration);
+            if (symbol && symbol.kind === SymbolKind.Expression) {
+              const exprSymbol =
+                symbol as import('@angular/compiler-cli/src/ngtsc/typecheck/api/symbols').ExpressionSymbol;
+              const typeStr = formatType(exprSymbol.tsType);
+              hints.push(createTypeHint(sourceSpan.end, exprSymbol.tsType, typeStr));
+            }
+          }
+        }
+      }
+
+      super.visitDeferredBlock(block);
+    }
+  }
+  // Type for the createTypeHint helper function
+  type CreateTypeHintFn = (
+    position: number,
+    type: ts.Type,
+    typeStr: string,
+    paddingLeft?: boolean,
+    paddingRight?: boolean,
+  ) => AngularInlayHint;
+
+  // Visitor for pipe expressions in interpolations and bindings
+  class PipeExpressionVisitor extends RecursiveAstVisitor {
+    constructor(
+      private readonly ttc: ReturnType<typeof compiler.getTemplateTypeChecker>,
+      private readonly typeChecker: ts.TypeChecker,
+      private readonly component: ts.ClassDeclaration,
+      private readonly tcb: ts.Node | null,
+      private readonly hints: AngularInlayHint[],
+      private readonly isInSpan: (pos: number) => boolean,
+      private readonly formatType: (type: ts.Type) => string,
+      private readonly config: InlayHintsConfig,
+      private readonly createTypeHintFn: CreateTypeHintFn,
+    ) {
+      super();
+    }
+
+    /**
+     * Get the resolved return type of a pipe call from the TCB.
+     * This uses TypeScript's actual overload resolution, which handles:
+     * - Overloaded method signatures (like DatePipe)
+     * - Generic type inference
+     * - Complex type relationships
+     */
+    private getResolvedPipeReturnType(ast: BindingPipe): ts.Type | null {
+      if (!this.tcb) return null;
+
+      // Find the call expression in the TCB using the pipe's source span
+      // The TCB has: _pipe.transform(value, arg1, arg2, ...)
+      const callExpr = findFirstMatchingNode(this.tcb, {
+        withSpan: ast.sourceSpan,
+        filter: ts.isCallExpression,
+      });
+
+      if (callExpr) {
+        // getTypeAtLocation on a call expression returns the resolved return type
+        // This automatically handles overload resolution and generics!
+        return this.typeChecker.getTypeAtLocation(callExpr);
+      }
+
+      return null;
+    }
+
+    override visitPipe(ast: BindingPipe, context: any): any {
+      // Pipe hints: {{ value | date : 'short' : 'pl' }}
+      // Goal: Show parameter names before pipe args and return type after the last argument
+      // Like function calls: {{ value | date(format: 'short', locale: 'pl'): string | null }}
+      if (ast.nameSpan && this.isInSpan(ast.nameSpan.start)) {
+        const symbol = this.ttc.getSymbolOfNode(ast, this.component);
+        if (symbol && symbol.kind === SymbolKind.Pipe) {
+          const pipeSymbol = symbol as PipeSymbol;
+
+          // Get the transform method's signature from the pipe class
+          const transformMethod = pipeSymbol.classSymbol.tsType.getProperty('transform');
+          if (transformMethod) {
+            const transformType = this.typeChecker.getTypeOfSymbolAtLocation(
+              transformMethod,
+              transformMethod.valueDeclaration!,
+            );
+            const signatures = this.typeChecker.getSignaturesOfType(
+              transformType,
+              ts.SignatureKind.Call,
+            );
+
+            if (signatures.length > 0) {
+              // For parameter name hints, we need to find a signature that matches the argument count
+              // We use the first signature that has enough parameters
+              const targetParamCount = ast.args.length + 1; // +1 for the piped value
+              let signatureForParams = signatures[0];
+              for (const sig of signatures) {
+                const params = sig.getParameters();
+                if (params.length >= targetParamCount) {
+                  signatureForParams = sig;
+                  break;
+                }
+              }
+
+              const parameters = signatureForParams.getParameters();
+
+              // Add parameter name hints for pipe arguments
+              // Parameters[0] is typically "value" (the piped input), so pipe args start at index 1
+              if (this.config.parameterNameHints !== 'none') {
+                for (let i = 0; i < ast.args.length; i++) {
+                  const arg = ast.args[i];
+                  const param = parameters[i + 1]; // +1 because first param is the piped value
+                  if (!param) continue;
+
+                  const paramName = param.getName();
+
+                  // Get the argument's source span
+                  const argSpan = arg.sourceSpan;
+                  if (!argSpan || !this.isInSpan(argSpan.start)) continue;
+
+                  // Create interactive hint if enabled
+                  if (this.config.interactiveInlayHints && param.valueDeclaration) {
+                    const paramDecl = param.valueDeclaration;
+                    const sourceFile = paramDecl.getSourceFile();
+                    this.hints.push({
+                      position: argSpan.start,
+                      text: '',
+                      kind: 'Parameter',
+                      paddingLeft: false,
+                      paddingRight: true,
+                      displayParts: [
+                        {
+                          text: paramName,
+                          span: {
+                            start: paramDecl.getStart(),
+                            length: paramDecl.getWidth(),
+                          },
+                          file: sourceFile.fileName,
+                        },
+                        {text: ':'},
+                      ],
+                    });
+                  } else {
+                    this.hints.push({
+                      position: argSpan.start,
+                      text: `${paramName}:`,
+                      kind: 'Parameter',
+                      paddingLeft: false,
+                      paddingRight: true,
+                    });
+                  }
+                }
+              }
+
+              // Get the return type using TypeScript's resolved type from the TCB call expression
+              // This automatically handles overload resolution and generics!
+              let returnType: ts.Type | null = this.getResolvedPipeReturnType(ast);
+
+              // Fallback: if we couldn't get the resolved type from TCB,
+              // use the first matching signature's return type
+              if (!returnType) {
+                returnType = signatureForParams.getReturnType();
+              }
+
+              const returnTypeStr = this.formatType(returnType);
+
+              // Position hint after the last pipe argument, or after pipe name if no args
+              let hintPosition: number;
+              if (ast.args.length > 0) {
+                const lastArg = ast.args[ast.args.length - 1];
+                hintPosition = lastArg.sourceSpan.end;
+              } else {
+                hintPosition = ast.nameSpan.end;
+              }
+
+              this.hints.push(
+                this.createTypeHintFn(hintPosition, returnType, returnTypeStr, false, true),
+              );
+            }
+          } else {
+            // Fallback: try to get return type from the TCB directly
+            const resolvedType = this.getResolvedPipeReturnType(ast);
+            if (resolvedType) {
+              const returnTypeStr = this.formatType(resolvedType);
+              this.hints.push(
+                this.createTypeHintFn(ast.nameSpan.end, resolvedType, returnTypeStr, false, true),
+              );
+            } else {
+              // Last resort fallback: use pipeSymbol.tsType's call signatures
+              const tsType = pipeSymbol.tsType;
+              const callSignatures = tsType.getCallSignatures();
+              if (callSignatures.length > 0) {
+                const returnType = callSignatures[0].getReturnType();
+                const returnTypeStr = this.formatType(returnType);
+                this.hints.push(
+                  this.createTypeHintFn(ast.nameSpan.end, returnType, returnTypeStr, false, true),
+                );
+              }
+            }
+          }
+        }
+      }
+      return super.visitPipe(ast, context);
+    }
+  }
+
+  /**
+   * Visitor for function/method call arguments to show parameter name hints.
+   * This follows TypeScript's inlay hints implementation for parameter names.
+   *
+   * Example: handleClick($event) -> handleClick(event: $event)
+   * where 'event' is the parameter name from the method signature.
+   */
+  class FunctionArgumentVisitor extends RecursiveAstVisitor {
+    constructor(
+      private readonly typeCheckInfo: TypeCheckInfo,
+      private readonly ttc: ReturnType<typeof compiler.getTemplateTypeChecker>,
+      private readonly typeChecker: ts.TypeChecker,
+      private readonly tcb: ts.Node | null,
+      private readonly hints: AngularInlayHint[],
+      private readonly isInSpan: (pos: number) => boolean,
+      private readonly formatType: (type: ts.Type) => string,
+      private readonly config: InlayHintsConfig,
+      private readonly createTypeHintFn?: CreateTypeHintFn,
+    ) {
+      super();
+    }
+
+    /**
+     * Get the resolved signature for a function call from the TCB.
+     * This uses TypeScript's actual overload resolution.
+     */
+    private getResolvedSignature(sourceSpan: {
+      start: number;
+      end: number;
+    }): ts.Signature | undefined {
+      if (!this.tcb) return undefined;
+
+      // Find the call expression in the TCB
+      const callExpr = findFirstMatchingNode(this.tcb, {
+        withSpan: sourceSpan,
+        filter: ts.isCallExpression,
+      });
+
+      if (callExpr) {
+        // getResolvedSignature returns the actual resolved overload
+        return this.typeChecker.getResolvedSignature(callExpr);
+      }
+
+      return undefined;
+    }
+
+    override visitCall(ast: Call, context: any): any {
+      this.processCallArguments(ast.receiver, ast.args, ast.sourceSpan);
+      return super.visitCall(ast, context);
+    }
+
+    override visitSafeCall(ast: SafeCall, context: any): any {
+      this.processCallArguments(ast.receiver, ast.args, ast.sourceSpan);
+      return super.visitSafeCall(ast, context);
+    }
+
+    private processCallArguments(
+      receiver: AST,
+      args: AST[],
+      sourceSpan: {start: number; end: number},
+    ): void {
+      if (args.length === 0) return;
+
+      // Try to get the resolved signature from the TCB first
+      // This handles overloads and generics correctly
+      let signature = this.getResolvedSignature(sourceSpan);
+
+      // Fallback to the first signature from the receiver type
+      if (!signature) {
+        const receiverSymbol = this.ttc.getSymbolOfNode(receiver, this.typeCheckInfo.declaration);
+        if (!receiverSymbol || receiverSymbol.kind !== SymbolKind.Expression) return;
+
+        const exprSymbol = receiverSymbol as ExpressionSymbol;
+        const receiverType = exprSymbol.tsType;
+
+        // Get call signatures from the receiver type
+        const signatures = this.typeChecker.getSignaturesOfType(
+          receiverType,
+          ts.SignatureKind.Call,
+        );
+        if (signatures.length === 0) return;
+
+        signature = signatures[0];
+      }
+
+      const parameters = signature.getParameters();
+
+      // Check if the last parameter is a rest parameter
+      let lastParamIsRest = false;
+      if (parameters.length > 0) {
+        const lastParam = parameters[parameters.length - 1];
+        const lastParamDecl = lastParam.valueDeclaration;
+        if (lastParamDecl && ts.isParameter(lastParamDecl) && lastParamDecl.dotDotDotToken) {
+          lastParamIsRest = true;
+        }
+      }
+
+      // Track current parameter position (may skip ahead for tuple spreads)
+      let signatureParamPos = 0;
+
+      // Add parameter name hints for each argument
+      for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        // Handle spread elements - TypeScript provides hints for tuple spreads
+        if (arg instanceof SpreadElement) {
+          // Get the type of the spread expression
+          const spreadSymbol = this.ttc.getSymbolOfNode(
+            arg.expression,
+            this.typeCheckInfo.declaration,
+          );
+          if (spreadSymbol && spreadSymbol.kind === SymbolKind.Expression) {
+            const spreadType = (spreadSymbol as ExpressionSymbol).tsType;
+            // Check if it's a tuple type
+            if (this.typeChecker.isTupleType(spreadType)) {
+              // Get the tuple's fixed length (number of required elements)
+              const tupleTypeRef = spreadType as ts.TypeReference;
+              const target = tupleTypeRef.target;
+              if (target && 'fixedLength' in target) {
+                const fixedLength = (target as any).fixedLength as number;
+                if (fixedLength > 0) {
+                  // Advance the parameter position by the tuple's fixed length
+                  signatureParamPos += fixedLength;
+                }
+              }
+            }
+          }
+          // Skip showing hint for the spread itself (no visual hint on ...arr)
+          continue;
+        }
+
+        // Handle rest parameters: if signatureParamPos >= params.length - 1 and last param is rest, use last param
+        let param: ts.Symbol | undefined;
+        let isFirstRestArg = false;
+        if (signatureParamPos < parameters.length - 1 || !lastParamIsRest) {
+          // Regular parameter or no rest param
+          param = parameters[signatureParamPos];
+        } else if (lastParamIsRest) {
+          // This argument maps to the rest parameter
+          param = parameters[parameters.length - 1];
+          // Mark as first rest arg only when this is the first argument mapping to rest
+          isFirstRestArg = signatureParamPos === parameters.length - 1;
+        }
+
+        // Advance to next parameter
+        signatureParamPos++;
+
+        if (!param) continue;
+
+        const paramName = param.getName();
+
+        // Skip if argument name matches parameter name (like TypeScript does)
+        // unless parameterNameHintsWhenArgumentMatchesName is true
+        if (
+          !this.config.parameterNameHintsWhenArgumentMatchesName &&
+          this.argumentMatchesParameterName(arg, paramName)
+        ) {
+          continue;
+        }
+
+        // In 'literals' mode, only show hints for literal arguments
+        if (this.config.parameterNameHints === 'literals' && !this.isHintableLiteral(arg)) {
+          continue;
+        }
+
+        // Get the argument's source span
+        const argSpan = arg.sourceSpan;
+        if (!argSpan || !this.isInSpan(argSpan.start)) continue;
+
+        // Add "..." prefix for the first rest argument only (like TypeScript does)
+        const prefix = isFirstRestArg ? '...' : '';
+
+        // Create interactive hint if enabled
+        if (this.config.interactiveInlayHints && param.valueDeclaration) {
+          const paramDecl = param.valueDeclaration;
+          const sourceFile = paramDecl.getSourceFile();
+          this.hints.push({
+            position: argSpan.start,
+            text: '', // Empty for interactive hints
+            kind: 'Parameter',
+            paddingLeft: false,
+            paddingRight: true,
+            displayParts: [
+              {
+                text: `${prefix}${paramName}`,
+                span: {
+                  start: paramDecl.getStart(),
+                  length: paramDecl.getWidth(),
+                },
+                file: sourceFile.fileName,
+              },
+              {text: ':'},
+            ],
+          });
+        } else {
+          this.hints.push({
+            position: argSpan.start,
+            text: `${prefix}${paramName}:`,
+            kind: 'Parameter',
+            paddingLeft: false,
+            paddingRight: true,
+          });
+        }
+      }
+    }
+
+    /**
+     * Check if the argument expression matches the parameter name.
+     * TypeScript skips parameter hints when the argument already conveys the parameter name.
+     * e.g., handleClick(event) where param is 'event' -> skip hint
+     */
+    private argumentMatchesParameterName(arg: AST, paramName: string): boolean {
+      if (arg instanceof PropertyRead) {
+        return arg.name === paramName;
+      }
+      return false;
+    }
+
+    /**
+     * Check if an argument is a "hintable literal" - used for 'literals' mode.
+     * TypeScript only shows parameter name hints for literal values in this mode.
+     * Includes: string/number/boolean literals, null, undefined, NaN, Infinity,
+     *           template literals, arrays, objects
+     *
+     * Aligned with TypeScript's isHintableLiteral function.
+     */
+    private isHintableLiteral(arg: AST): boolean {
+      // LiteralPrimitive covers strings, numbers, booleans, null
+      if (arg instanceof LiteralPrimitive) {
+        return true;
+      }
+      // LiteralArray covers array literals like [1, 2, 3]
+      if (arg instanceof LiteralArray) {
+        return true;
+      }
+      // LiteralMap covers object literals like { key: value }
+      if (arg instanceof LiteralMap) {
+        return true;
+      }
+      // Template literals like `hello ${name}` or `plain string`
+      if (arg instanceof TemplateLiteral) {
+        return true;
+      }
+      // Unary operations on literals (e.g., -1, +2, -Infinity)
+      if (arg instanceof Unary) {
+        if (arg.expr instanceof LiteralPrimitive) {
+          return true;
+        }
+        // -Infinity, +NaN etc.
+        if (arg.expr instanceof PropertyRead && this.isSpecialNumericIdentifier(arg.expr.name)) {
+          return true;
+        }
+      }
+      // Special identifiers: undefined, NaN, Infinity (from implicit receiver)
+      if (arg instanceof PropertyRead && arg.receiver instanceof ImplicitReceiver) {
+        if (this.isSpecialLiteralIdentifier(arg.name)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Check if an identifier name is a special literal-like value.
+     * TypeScript treats undefined, NaN, and Infinity as literals for hint purposes.
+     */
+    private isSpecialLiteralIdentifier(name: string): boolean {
+      return name === 'undefined' || name === 'NaN' || name === 'Infinity';
+    }
+
+    /**
+     * Check if an identifier name is a special numeric value (NaN, Infinity).
+     * Used for unary expressions like -Infinity.
+     */
+    private isSpecialNumericIdentifier(name: string): boolean {
+      return name === 'NaN' || name === 'Infinity';
+    }
+
+    /**
+     * Visit arrow functions in template expressions.
+     * Provides:
+     * 1. Parameter type hints - like TS includeInlayFunctionParameterTypeHints
+     * 2. Return type hints - like TS includeInlayFunctionLikeReturnTypeHints
+     *
+     * Example: `(a, b) => a + b` becomes `(a: number, b: number): number => a + b`
+     */
+    override visitArrowFunction(ast: ArrowFunction, context: any): any {
+      // Get the arrow function type from TCB
+      if (!this.tcb) {
+        return super.visitArrowFunction(ast, context);
+      }
+
+      // Find the arrow function expression in the TCB
+      const arrowExpr = findFirstMatchingNode(this.tcb, {
+        withSpan: ast.sourceSpan,
+        filter: ts.isArrowFunction,
+      });
+
+      if (!arrowExpr) {
+        return super.visitArrowFunction(ast, context);
+      }
+
+      const arrowType = this.typeChecker.getTypeAtLocation(arrowExpr);
+      const callSignatures = arrowType.getCallSignatures();
+      if (callSignatures.length === 0) {
+        return super.visitArrowFunction(ast, context);
+      }
+
+      const signature = callSignatures[0];
+      const parameters = signature.getParameters();
+
+      // Parameter type hints
+      if (this.config.arrowFunctionParameterTypes) {
+        for (let i = 0; i < ast.parameters.length && i < parameters.length; i++) {
+          const param = ast.parameters[i];
+          const tsParam = parameters[i];
+
+          // Get the parameter's source span
+          if (!param.sourceSpan || !this.isInSpan(param.sourceSpan.start)) continue;
+
+          // Get parameter type from TypeScript
+          const paramType = this.typeChecker.getTypeOfSymbolAtLocation(tsParam, arrowExpr);
+          const paramTypeStr = this.formatType(paramType);
+
+          // Skip if type is 'any' or parameter name matches type
+          if (paramTypeStr === 'any') continue;
+          if (param.name.toLowerCase() === paramTypeStr.toLowerCase()) continue;
+
+          // Position hint after the parameter name - use createTypeHint if available
+          if (this.createTypeHintFn) {
+            this.hints.push(this.createTypeHintFn(param.sourceSpan.end, paramType, paramTypeStr));
+          } else {
+            this.hints.push({
+              position: param.sourceSpan.end,
+              text: `: ${paramTypeStr}`,
+              kind: 'Type',
+              paddingLeft: false,
+              paddingRight: false,
+            });
+          }
+        }
+      }
+
+      // Return type hint
+      if (this.config.arrowFunctionReturnTypes) {
+        const returnType = signature.getReturnType();
+        const returnTypeStr = this.formatType(returnType);
+
+        // Skip if return type is 'any' or 'void'
+        if (returnTypeStr !== 'any' && returnTypeStr !== 'void') {
+          // Put the return hint just before the body expression.
+          // This renders close to the arrow and avoids overlapping parameter hints.
+          const hintPosition = ast.body.sourceSpan.start;
+          if (this.isInSpan(hintPosition)) {
+            if (this.createTypeHintFn) {
+              this.hints.push(this.createTypeHintFn(hintPosition, returnType, returnTypeStr));
+            } else {
+              this.hints.push({
+                position: hintPosition,
+                text: `: ${returnTypeStr}`,
+                kind: 'Type',
+                paddingLeft: false,
+                paddingRight: false,
+              });
+            }
+          }
+        }
+      }
+
+      // Continue visiting the body
+      return super.visitArrowFunction(ast, context);
+    }
+  }
+
+  /**
+   * Unwraps Angular wrapper types to get the underlying value type.
+   * Handles: EventEmitter<T>, OutputEmitterRef<T>, Observable<T>, Subject<T>,
+   *          InputSignal<T>, InputSignalWithTransform<T, _>, ModelSignal<T>
+   *
+   * @param type The type to unwrap
+   * @param typeChecker TypeScript type checker
+   * @returns The unwrapped type, or the original type if not a wrapper
+   */
+  function unwrapAngularType(type: ts.Type): ts.Type {
+    const typeRef = type as ts.TypeReference;
+    const typeArgs = typeRef.typeArguments ?? typeRef.aliasTypeArguments;
+    if (!typeArgs || typeArgs.length === 0) {
+      return type;
+    }
+    const symbolName = type.symbol?.name ?? type.aliasSymbol?.name;
+    if (
+      symbolName === 'EventEmitter' ||
+      symbolName === 'OutputEmitterRef' ||
+      symbolName === 'Observable' ||
+      symbolName === 'Subject' ||
+      symbolName === 'InputSignal' ||
+      symbolName === 'ModelSignal' ||
+      symbolName === 'InputSignalWithTransform'
+    ) {
+      return typeArgs[0];
+    }
+    return type;
+  }
+
+  /**
+   * Check if an input is required (input.required() or @Input with required: true).
+   *
+   * For signal inputs, we check the type signature:
+   * - Required: InputSignal<T> (no undefined in the type)
+   * - Optional: InputSignal<T | undefined>
+   *
+   * For decorator inputs, we check @Input({required: true}).
+   */
+  function isRequiredInput(symbol: ts.Symbol | undefined, typeChecker: ts.TypeChecker): boolean {
+    if (!symbol) return false;
+
+    const declarations = symbol.getDeclarations();
+    if (!declarations || declarations.length === 0) return false;
+
+    const decl = declarations[0];
+    if (!ts.isPropertyDeclaration(decl) && !ts.isPropertySignature(decl)) return false;
+
+    // Get the type at the declaration
+    const type = typeChecker.getTypeAtLocation(decl);
+    const typeName = typeChecker.typeToString(type);
+
+    // Check for signal-based inputs via type signature
+    // Required inputs have InputSignal<T> where T doesn't include undefined
+    // Optional inputs have InputSignal<T | undefined>
+    if (typeName.includes('InputSignal<')) {
+      // If the inner type includes undefined, it's optional
+      if (typeName.includes('undefined')) {
+        return false;
+      }
+      // Otherwise check if it's actually using input.required() via AST
+      // This handles edge cases where the type might look required but isn't
+      if (ts.isPropertyDeclaration(decl) && decl.initializer) {
+        if (ts.isCallExpression(decl.initializer)) {
+          const callExpr = decl.initializer;
+          if (ts.isPropertyAccessExpression(callExpr.expression)) {
+            const methodName = callExpr.expression.name.text;
+            if (methodName === 'required') {
+              return true;
+            }
+          }
+        }
+      }
+      // Even without AST check, if type doesn't have undefined, treat as required
+      return true;
+    }
+
+    // Check for decorator-based @Input({required: true})
+    if (ts.isPropertyDeclaration(decl)) {
+      const decorators = ts.getDecorators(decl);
+      if (decorators) {
+        for (const decorator of decorators) {
+          if (ts.isCallExpression(decorator.expression)) {
+            const decoratorExpr = decorator.expression.expression;
+            // Handle both `Input` and `namespace.Input` patterns
+            const decoratorName = ts.isIdentifier(decoratorExpr)
+              ? decoratorExpr.text
+              : ts.isPropertyAccessExpression(decoratorExpr)
+                ? decoratorExpr.name.text
+                : null;
+
+            if (decoratorName === 'Input') {
+              // Check if there's an options object with required: true
+              const args = decorator.expression.arguments;
+              if (args.length > 0) {
+                const firstArg = args[0];
+                if (ts.isObjectLiteralExpression(firstArg)) {
+                  for (const prop of firstArg.properties) {
+                    if (ts.isPropertyAssignment(prop)) {
+                      const propName = ts.isIdentifier(prop.name)
+                        ? prop.name.text
+                        : ts.isStringLiteral(prop.name)
+                          ? prop.name.text
+                          : null;
+                      if (
+                        propName === 'required' &&
+                        prop.initializer.kind === ts.SyntaxKind.TrueKeyword
+                      ) {
+                        return true;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the visual indicator suffix for required inputs.
+   */
+  function getRequiredIndicator(
+    isRequired: boolean,
+    indicator: 'none' | 'asterisk' | 'exclamation' | undefined,
+  ): string {
+    if (!isRequired || !indicator || indicator === 'none') {
+      return '';
+    }
+    if (indicator === 'asterisk') {
+      return '*';
+    }
+    if (indicator === 'exclamation') {
+      return '!';
+    }
+    return '';
+  }
+
+  /**
+   * Result type for getEventType - contains both the type string and optionally the ts.Type
+   * for interactive hint support.
+   */
+  interface EventTypeResult {
+    typeStr: string;
+    tsType: ts.Type | null;
+  }
+
+  /**
+   * Get the $event type for an event binding from TCB type inference.
+   * Returns null if the type cannot be determined.
+   *
+   * Handles:
+   * - @Output() EventEmitter<T>
+   * - output() OutputEmitterRef<T>
+   * - model() ModelSignal<T> - generates (nameChange) event
+   * - DOM events (click, input, etc.)
+   */
+  function getEventType(
+    event: TmplAstBoundEvent,
+    typeCheckInfo: TypeCheckInfo,
+    ttc: ReturnType<typeof compiler.getTemplateTypeChecker>,
+    typeChecker: ts.TypeChecker,
+  ): EventTypeResult | null {
+    // Get the event's output binding type from the template type checker
+    const symbol = ttc.getSymbolOfNode(event, typeCheckInfo.declaration);
+    if (symbol && symbol.kind === SymbolKind.Output) {
+      // Component/directive output event (@Output, output(), or model() change event)
+      const outputSymbol = symbol as OutputBindingSymbol;
+      const isDirectiveOrComponentOutput = outputSymbol.bindings.some(
+        (binding) => binding.target.kind === SymbolKind.Directive,
+      );
+      if (outputSymbol.bindings.length > 0) {
+        const bindingType = outputSymbol.bindings[0].tsType;
+        const resolvedType = isDirectiveOrComponentOutput
+          ? unwrapAngularType(bindingType)
+          : bindingType;
+        return {
+          typeStr: typeChecker.typeToString(resolvedType),
+          tsType: resolvedType,
+        };
+      }
+    }
+
+    // Animation events (check before DOM events)
+    if (event.type === ParsedEventType.LegacyAnimation) {
+      // Try to get AnimationEvent type from lib.dom
+      const animationEventType = getGlobalDomType('AnimationEvent', typeChecker);
+      return {
+        typeStr: 'AnimationEvent',
+        tsType: animationEventType,
+      };
+    }
+    if (event.type === ParsedEventType.Animation) {
+      // AnimationCallbackEvent is an Angular-specific type, no DOM equivalent
+      return {
+        typeStr: 'AnimationCallbackEvent',
+        tsType: null,
+      };
+    }
+
+    const eventTypeFromHandler = getEventTypeFromHandler(event, typeCheckInfo, ttc, typeChecker);
+    if (eventTypeFromHandler) {
+      return eventTypeFromHandler;
+    }
+
+    return null;
+  }
+
+  /**
+   * Try to get a global DOM type (like MouseEvent, KeyboardEvent) from the type checker.
+   * Returns null if the type is not found in the global scope.
+   */
+  function getGlobalDomType(typeName: string, typeChecker: ts.TypeChecker): ts.Type | null {
+    let globalDomTypeCache = globalDomTypeCacheByChecker.get(typeChecker);
+    if (!globalDomTypeCache) {
+      globalDomTypeCache = new Map<string, ts.Type | null>();
+      globalDomTypeCacheByChecker.set(typeChecker, globalDomTypeCache);
+    }
+
+    const cached = globalDomTypeCache.get(typeName);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    try {
+      // Try to resolve the type from the global scope
+      const symbol = typeChecker.resolveName(
+        typeName,
+        undefined,
+        ts.SymbolFlags.Type,
+        /* excludeGlobals */ false,
+      );
+      if (symbol) {
+        const declarations = symbol.getDeclarations();
+        if (declarations && declarations.length > 0) {
+          const resolvedType = typeChecker.getDeclaredTypeOfSymbol(symbol);
+          globalDomTypeCache.set(typeName, resolvedType);
+          return resolvedType;
+        }
+      }
+    } catch {
+      // Type not found in global scope
+    }
+    globalDomTypeCache.set(typeName, null);
+    return null;
+  }
+
+  /**
+   * Get the event type by finding the $event reference in the handler
+   * and using its inferred type from the TCB.
+   */
+  function getEventTypeFromHandler(
+    event: TmplAstBoundEvent,
+    typeCheckInfo: TypeCheckInfo,
+    ttc: ReturnType<typeof compiler.getTemplateTypeChecker>,
+    typeChecker: ts.TypeChecker,
+  ): EventTypeResult | null {
+    let eventResult: EventTypeResult | null = null;
+
+    class EventTypeVisitor extends RecursiveAstVisitor {
+      override visitPropertyRead(ast: PropertyRead, context: any): any {
+        if (ast.name === '$event' && !(ast.receiver instanceof PropertyRead)) {
+          const symbol = ttc.getSymbolOfNode(ast, typeCheckInfo.declaration);
+          if (symbol && symbol.kind === SymbolKind.Expression) {
+            const exprSymbol = symbol as ExpressionSymbol;
+            eventResult = {
+              typeStr: typeChecker.typeToString(exprSymbol.tsType),
+              tsType: exprSymbol.tsType,
+            };
+          }
+        }
+        return super.visitPropertyRead(ast, context);
+      }
+    }
+
+    const visitor = new EventTypeVisitor();
+    event.handler.visit(visitor);
+    return eventResult;
+  }
+
+  // Visit the template (if it exists - directives without templates will skip this)
+  if (template) {
+    const visitor = new InlayHintVisitor();
+    tmplAstVisitAll(visitor, template);
+  }
+
+  // Also process host element bindings (from component/directive host property and @HostBinding/@HostListener)
+  // NOTE: Host bindings have keySpan positions in the TypeScript file (not template), so we use
+  // a separate isInSpan check that accounts for the host binding positions being in TS source.
+  // When the span parameter covers only part of the file (e.g., visible area), host binding
+  // positions might be outside that range, but they should still be shown since they belong
+  // to this component. We create a helper function that checks if we're requesting the whole file.
+  const hostElement = ttc.getHostElement(typeCheckInfo.declaration);
+  if (hostElement) {
+    // For host bindings, check if the position is within the requested span.
+    // Host binding keySpan positions are absolute TypeScript file positions.
+    const isHostBindingInSpan = (pos: number): boolean => {
+      // If pos < 0, it's a dummy span, skip it
+      if (pos < 0) return false;
+      // Always show host binding hints (they're conceptually part of the component)
+      // The keySpan positions are in TypeScript source, but the span might only cover
+      // part of the file. Since host bindings are always associated with the component,
+      // we should show them regardless of whether they're in the visible range.
+      return pos >= span.start && pos < span.start + span.length;
+    };
+
+    // Process host property bindings for property type hints
+    // These come from @HostBinding('prop') or host: { '[prop]': 'expr' }
+    const propertyConfig = normalizePropertyConfig(mergedConfig.propertyBindingTypes);
+    if (propertyConfig.enabled && propertyConfig.nativeProperties) {
+      for (const binding of hostElement.bindings) {
+        // Only process bindings with valid keySpan (not dummy spans)
+        if (binding.keySpan && binding.keySpan.start.offset >= 0) {
+          if (isHostBindingInSpan(binding.keySpan.start.offset)) {
+            const rawHostBindingKey = typeCheckInfo.declaration
+              .getSourceFile()
+              .text.slice(binding.keySpan.start.offset, binding.keySpan.end.offset)
+              .replace(/["'`]/g, '')
+              .trim();
+
+            if (/^\[(attr\.|style\.|class\.)/i.test(rawHostBindingKey)) {
+              continue;
+            }
+
+            const symbol = ttc.getSymbolOfNode(binding, typeCheckInfo.declaration);
+            if (symbol && symbol.kind === SymbolKind.DomBinding) {
+              const domSymbol = symbol as DomBindingSymbol;
+              const propTypeResult = getDomPropertyType(binding.name, domSymbol, typeChecker);
+              if (propTypeResult) {
+                hints.push(
+                  createTypeHint(
+                    binding.keySpan.end.offset,
+                    propTypeResult.tsType,
+                    propTypeResult.typeStr,
+                  ),
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Process host event listeners for event type hints and function argument hints
+    const eventConfig = normalizeEventConfig(mergedConfig.eventParameterTypes);
+    for (const listener of hostElement.listeners) {
+      // Event type hint on the event name
+      if (eventConfig.enabled && listener.keySpan) {
+        if (isHostBindingInSpan(listener.keySpan.start.offset)) {
+          // For host listeners, determine the event source
+          const symbol = ttc.getSymbolOfNode(listener, typeCheckInfo.declaration);
+          const isComponentEvent = symbol?.kind === SymbolKind.Output;
+          const isAnimationEvent =
+            listener.type === ParsedEventType.LegacyAnimation ||
+            listener.type === ParsedEventType.Animation;
+          const isNativeEvent = !isComponentEvent && !isAnimationEvent;
+
+          const shouldShow =
+            (isNativeEvent && eventConfig.nativeEvents) ||
+            (isComponentEvent && eventConfig.componentEvents) ||
+            (isAnimationEvent && eventConfig.animationEvents);
+
+          if (shouldShow) {
+            const eventTypeResult = getEventType(listener, typeCheckInfo, ttc, typeChecker);
+            if (eventTypeResult) {
+              // Use createTypeHint for interactive hints if we have the ts.Type
+              if (eventTypeResult.tsType) {
+                hints.push(
+                  createTypeHint(
+                    listener.keySpan.end.offset,
+                    eventTypeResult.tsType,
+                    eventTypeResult.typeStr,
+                  ),
+                );
+              } else {
+                // Fallback for types without ts.Type
+                hints.push({
+                  position: listener.keySpan.end.offset,
+                  text: `: ${eventTypeResult.typeStr}`,
+                  kind: 'Type',
+                  paddingLeft: false,
+                  paddingRight: false,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // Function argument parameter name hints
+      if (mergedConfig.parameterNameHints !== 'none') {
+        const argVisitor = new FunctionArgumentVisitor(
+          typeCheckInfo,
+          ttc,
+          typeChecker,
+          tcb,
+          hints,
+          isHostBindingInSpan,
+          formatType,
+          mergedConfig,
+          createTypeHint,
+        );
+        listener.handler.visit(argVisitor);
+      }
+
+      // @HostListener argument type hints
+      // For @HostListener('click', ['$event.target', '$event.clientX']),
+      // we show the inferred type for each expression argument
+      if (mergedConfig.hostListenerArgumentTypes) {
+        processHostListenerArgumentTypes(
+          listener,
+          ttc,
+          typeChecker,
+          tcb,
+          typeCheckInfo,
+          hints,
+          isHostBindingInSpan,
+          formatType,
+          createTypeHint,
+        );
+      }
+    }
+  }
+
+  const dedupedHints: AngularInlayHint[] = [];
+  const seen = new Set<string>();
+  for (const hint of hints) {
+    const label = hint.displayParts?.map((part) => part.text).join('') ?? hint.text;
+    const key = `${hint.position}|${hint.kind}|${label}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    dedupedHints.push(hint);
+  }
+
+  return dedupedHints;
+}
+
+/**
+ * Process @HostListener argument expressions and add type hints.
+ *
+ * For decorators like `@HostListener('click', ['$event.target', '$event.clientX'])`,
+ * this shows the inferred type for each expression argument:
+ * `['$event.target: EventTarget | null', '$event.clientX: number']`
+ *
+ * The handler is a Call node where:
+ * - receiver is a PropertyRead of the method name
+ * - args are the parsed expressions from the decorator arguments
+ */
+function processHostListenerArgumentTypes(
+  listener: TmplAstBoundEvent,
+  ttc: TemplateTypeChecker,
+  typeChecker: ts.TypeChecker,
+  tcb: ts.Node | null,
+  typeCheckInfo: TypeCheckInfo,
+  hints: AngularInlayHint[],
+  isInSpan: (offset: number) => boolean,
+  formatType: (type: ts.Type) => string,
+  createTypeHintFn: (
+    position: number,
+    type: ts.Type,
+    typeStr: string,
+    paddingLeft?: boolean,
+    paddingRight?: boolean,
+  ) => AngularInlayHint,
+): void {
+  // The handler should be a Call node for @HostListener
+  if (!(listener.handler instanceof Call)) {
+    return;
+  }
+
+  const handlerCall = listener.handler as Call;
+
+  // Skip if no arguments or if the handler doesn't have the expected structure
+  if (handlerCall.args.length === 0) {
+    return;
+  }
+
+  // Process each argument expression
+  for (const arg of handlerCall.args) {
+    // Skip simple identifiers that are just variable references (method parameters)
+    // We only want to show hints for expressions like $event.target
+    if (arg instanceof PropertyRead && arg.receiver instanceof ImplicitReceiver) {
+      // This is a simple variable reference, might be $event itself
+      // Only skip if it's NOT $event (which would have type information)
+      if (arg.name !== '$event') {
+        continue;
+      }
+    }
+
+    // Get the source span for positioning the hint
+    const argSpan = arg.sourceSpan;
+    if (!argSpan || !isInSpan(argSpan.start)) {
+      continue;
+    }
+
+    // Try to find the corresponding TCB node and get its type
+    let hintType: ts.Type | null = null;
+
+    if (tcb) {
+      const tcbNode = findFirstMatchingNode(tcb, {
+        withSpan: argSpan,
+        filter: (node): node is ts.Expression => ts.isExpression(node),
+      });
+
+      if (tcbNode) {
+        hintType = typeChecker.getTypeAtLocation(tcbNode);
+      }
+    }
+
+    if (hintType) {
+      const typeStr = formatType(hintType);
+      hints.push(createTypeHintFn(argSpan.end, hintType, typeStr));
+    }
+  }
+}
+/**
+ * Get the type of a DOM property binding.
+ *
+ * For bindings like [value], [disabled], etc., looks up the property type
+ * on the element's DOM interface using TypeScript's type checker.
+ *
+ * Note: Style bindings ([style.width], [style.width.px]), class bindings ([class.active]),
+ * and attribute bindings ([attr.data-cy]) are NOT type-checked by Angular currently.
+ * See: packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
+ * "TODO: properly check class and style bindings."
+ *
+ * We intentionally don't show inlay hints for these bindings until Angular
+ * implements proper type checking for them, as any hint would be misleading
+ * (e.g., [style.width.px]="'2'" is valid at runtime).
+ */
+interface DomPropertyTypeResult {
+  typeStr: string;
+  tsType: ts.Type;
+}
+
+function getDomPropertyType(
+  bindingName: string,
+  domSymbol: DomBindingSymbol,
+  typeChecker: ts.TypeChecker,
+): DomPropertyTypeResult | null {
+  // Skip style/class/attr bindings - Angular doesn't type-check these yet
+  // See: packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
+  // "TODO: properly check class and style bindings."
+  if (
+    bindingName.startsWith('style.') ||
+    bindingName.startsWith('class.') ||
+    bindingName.startsWith('attr.')
+  ) {
+    return null;
+  }
+
+  // For regular DOM properties, look up the type on the element
+  if (domSymbol.host.kind === SymbolKind.Element) {
+    const elementSymbol = domSymbol.host as ElementSymbol;
+    const elementType = elementSymbol.tsType;
+
+    // Get the property from the element type
+    const property = elementType.getProperty(bindingName);
+    if (property) {
+      const propType = typeChecker.getTypeOfSymbol(property);
+      return {
+        typeStr: typeChecker.typeToString(propType),
+        tsType: propType,
+      };
+    }
+  }
+
+  return null;
+}

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -24,7 +24,9 @@ import ts from 'typescript';
 import {
   ApplyRefactoringProgressFn,
   ApplyRefactoringResult,
+  AngularInlayHint,
   GetComponentLocationsForTemplateResponse,
+  InlayHintsConfig,
   GetTcbResponse,
   GetTemplateLocationForComponentResponse,
   LinkedEditingRanges,
@@ -57,6 +59,7 @@ import {getTypeCheckInfoAtPosition, isTypeScriptFile, TypeCheckInfo} from './uti
 import {ActiveRefactoring, allRefactorings} from './refactorings/refactoring';
 import {getClassificationsForTemplate, TokenEncodingConsts} from './semantic_tokens';
 import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {getInlayHintsForTemplate} from './inlay_hints';
 
 type LanguageServiceConfig = Omit<PluginConfig, 'angularOnly'>;
 
@@ -214,6 +217,85 @@ export class LanguageService {
     return this.withCompilerAndPerfTracing(PerfPhase.LsQuickInfo, (compiler) => {
       return this.getQuickInfoAtPositionImpl(fileName, position, compiler);
     });
+  }
+
+  /**
+   * Provide Angular-specific inlay hints for templates.
+   *
+   * This returns hints for:
+   * - @for loop variable types: `@for (user: User of users)`
+   * - @if alias types: `@if (data; as result: ApiResult)`
+   * - Event parameter types: `(click)="onClick($event: MouseEvent)"`
+   * - Pipe output types: `{{ value | async: Observable<T> }}`
+   * - @let declaration types
+   *
+   * @param fileName The file to get inlay hints for
+   * @param span The text span to get hints within
+   * @param config Optional configuration for which hints to show
+   */
+  provideInlayHints(
+    fileName: string,
+    span: ts.TextSpan,
+    config?: InlayHintsConfig,
+  ): AngularInlayHint[] {
+    // Use LsQuickInfo phase since inlay hints are similar in cost
+    return (
+      this.withCompilerAndPerfTracing(PerfPhase.LsQuickInfo, (compiler) => {
+        const hints: AngularInlayHint[] = [];
+
+        if (isTypeScriptFile(fileName)) {
+          // For TypeScript files, find all components and process their templates
+          const program = compiler.getCurrentProgram();
+          const sourceFile = program.getSourceFile(fileName);
+          if (!sourceFile) {
+            return hints;
+          }
+
+          const ttc = compiler.getTemplateTypeChecker();
+
+          // Walk the source file to find component/directive classes
+          const visit = (node: ts.Node): void => {
+            if (ts.isClassDeclaration(node) && node.name) {
+              // Try to get the template for this class (component) or host element (directive)
+              try {
+                const template = ttc.getTemplate(node);
+                const hostElement = ttc.getHostElement(node);
+
+                // Process if we have either a template or host element
+                if (template || hostElement) {
+                  // This is a component with a template or a directive with host bindings
+                  const typeCheckInfo: TypeCheckInfo = {
+                    declaration: node,
+                    nodes: template ?? [],
+                  };
+                  const templateHints = getInlayHintsForTemplate(
+                    compiler,
+                    typeCheckInfo,
+                    span,
+                    config,
+                  );
+                  hints.push(...templateHints);
+                }
+              } catch {
+                // Not a component/directive or error getting template, skip
+              }
+            }
+            ts.forEachChild(node, visit);
+          };
+
+          visit(sourceFile);
+        } else {
+          // For external template files (HTML), find the associated component
+          const typeCheckInfo = getTypeCheckInfoAtPosition(fileName, span.start, compiler);
+          if (typeCheckInfo) {
+            const templateHints = getInlayHintsForTemplate(compiler, typeCheckInfo, span, config);
+            hints.push(...templateHints);
+          }
+        }
+
+        return hints;
+      }) ?? []
+    );
   }
 
   private getQuickInfoAtPositionImpl(

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -17,6 +17,8 @@ import {
   isNgLanguageService,
   LinkedEditingRanges,
   NgLanguageService,
+  AngularInlayHint,
+  InlayHintsConfig,
 } from '../api';
 
 import {LanguageService} from './language_service';
@@ -350,6 +352,14 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     ngLS.ensureProjectAnalyzed();
   }
 
+  function getAngularInlayHints(
+    fileName: string,
+    span: ts.TextSpan,
+    config?: InlayHintsConfig,
+  ): AngularInlayHint[] {
+    return ngLS.provideInlayHints(fileName, span, config);
+  }
+
   return {
     ...tsLS,
     ensureProjectAnalyzed,
@@ -382,6 +392,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getApplicableRefactors,
     applyRefactoring,
     getLinkedEditingRangeAtPosition,
+    getAngularInlayHints,
   };
 }
 

--- a/packages/language-service/test/inlay_hints_spec.ts
+++ b/packages/language-service/test/inlay_hints_spec.ts
@@ -1,0 +1,3727 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+
+import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv, Project} from '../testing';
+
+describe('inlay hints', () => {
+  let env: LanguageServiceTestEnv;
+  let project: Project;
+
+  beforeEach(() => {
+    initMockFileSystem('Native');
+    env = LanguageServiceTestEnv.setup();
+  });
+
+  describe('@for loop variables', () => {
+    it('should provide type hints for @for loop item variable', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          interface User {
+            id: number;
+            name: string;
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`@for (user of users; track user.id) { {{ user.name }} }\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            users: User[] = [];
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      const userHint = hints.find((h) => h.text === ': User');
+      expect(userHint).toBeDefined();
+    });
+
+    it('should provide type hints for @for context variables', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`@for (item of items; track $index; let i = $index, c = $count) {
+              {{ item }} #{{ i }} of {{ c }}
+            }\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            items = ['a', 'b', 'c'];
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have `: string` for item, `: number` for i and c
+      const stringHints = hints.filter((h) => h.text === ': string');
+      const numberHints = hints.filter((h) => h.text === ': number');
+
+      expect(stringHints.length).toBeGreaterThanOrEqual(1); // item: string
+      expect(numberHints.length).toBeGreaterThanOrEqual(2); // i: number, c: number
+    });
+  });
+
+  describe('@if alias', () => {
+    it('should provide type hints for @if alias', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          interface User {
+            name: string;
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`@if (currentUser; as u) { {{ u.name }} }\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            currentUser: User | null = null;
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have a type hint for the alias (narrowed from User | null)
+      // The narrowed type should be User (not User | null)
+      expect(hints.length).toBeGreaterThan(0);
+      const userHint = hints.find((h) => h.text.includes('User'));
+      expect(userHint).toBeDefined();
+    });
+
+    it('should provide type hints for @else if alias', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`
+              @if (condition1; as a) {
+                {{ a }}
+              } @else if (condition2; as b) {
+                {{ b }}
+              }
+            \`,
+            standalone: false,
+          })
+          export class AppCmp {
+            condition1: string | null = null;
+            condition2: number | null = null;
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have hints for both aliases
+      const stringHint = hints.find((h) => h.text.includes('string'));
+      const numberHint = hints.find((h) => h.text.includes('number'));
+
+      expect(stringHint).toBeDefined();
+      expect(numberHint).toBeDefined();
+    });
+  });
+
+  describe('@let declarations', () => {
+    it('should provide type hints for @let declarations', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`
+              @let count = items.length;
+              @let doubled = count * 2;
+              {{ count }} {{ doubled }}
+            \`,
+            standalone: false,
+          })
+          export class AppCmp {
+            items = [1, 2, 3];
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Both should be `: number`
+      const numberHints = hints.filter((h) => h.text === ': number');
+      expect(numberHints.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('event parameters', () => {
+    // Note: Native DOM event hints (MouseEvent, KeyboardEvent) may not work in unit tests
+    // due to the mock file system lacking proper DOM type definitions.
+    // These are tested in the LSP integration tests instead.
+
+    it('should not throw when processing event bindings', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="onClick($event)">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            onClick(e: any) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+  });
+
+  describe('pipes', () => {
+    // Note: Pipe output hints work but may need proper pipe registration.
+    // Fully tested in LSP integration tests.
+    it('should not throw when processing pipes', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'double', standalone: false})
+          export class DoublePipe implements PipeTransform {
+            transform(value: number): number {
+              return value * 2;
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ count | double }}\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            count = 5;
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+
+    it('should show parameter names for pipe arguments', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'format', standalone: true})
+          export class FormatPipe implements PipeTransform {
+            transform(value: string, prefix?: string, suffix?: string): string {
+              return (prefix ?? '') + value + (suffix ?? '');
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ name | format : '[' : ']' }}\`,
+            standalone: true,
+            imports: [FormatPipe],
+          })
+          export class AppCmp {
+            name = 'hello';
+          }
+        `,
+      };
+      project = env.addProject('test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have parameter name hints for the pipe arguments
+      const prefixHint = hints.find((h) => h.text === 'prefix:');
+      const suffixHint = hints.find((h) => h.text === 'suffix:');
+      const returnTypeHint = hints.find((h) => h.text === ': string');
+
+      expect(prefixHint).toBeDefined();
+      expect(prefixHint?.kind).toBe('Parameter');
+      expect(suffixHint).toBeDefined();
+      expect(suffixHint?.kind).toBe('Parameter');
+      expect(returnTypeHint).toBeDefined();
+      expect(returnTypeHint?.kind).toBe('Type');
+    });
+
+    it('should show return type hint after pipe name when no arguments', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'upper', standalone: true})
+          export class UpperPipe implements PipeTransform {
+            transform(value: string): string {
+              return value.toUpperCase();
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ name | upper }}\`,
+            standalone: true,
+            imports: [UpperPipe],
+          })
+          export class AppCmp {
+            name = 'hello';
+          }
+        `,
+      };
+      project = env.addProject('test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have return type hint
+      const returnTypeHint = hints.find((h) => h.text === ': string');
+      expect(returnTypeHint).toBeDefined();
+      expect(returnTypeHint?.kind).toBe('Type');
+    });
+
+    it('should respect parameterNameHints: none for pipes', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'format', standalone: true})
+          export class FormatPipe implements PipeTransform {
+            transform(value: string, prefix?: string, suffix?: string): string {
+              return (prefix ?? '') + value + (suffix ?? '');
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ name | format : '[' : ']' }}\`,
+            standalone: true,
+            imports: [FormatPipe],
+          })
+          export class AppCmp {
+            name = 'hello';
+          }
+        `,
+      };
+      project = env.addProject('test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'none'});
+
+      // Should NOT have parameter name hints
+      const prefixHint = hints.find((h) => h.text === 'prefix:');
+      const suffixHint = hints.find((h) => h.text === 'suffix:');
+      expect(prefixHint).toBeUndefined();
+      expect(suffixHint).toBeUndefined();
+
+      // Should still have return type hint (controlled by pipeOutputTypes)
+      const returnTypeHint = hints.find((h) => h.text === ': string');
+      expect(returnTypeHint).toBeDefined();
+    });
+
+    it('should show correct return type for overloaded pipe signatures', () => {
+      // This tests that the inlay hints correctly resolve overloaded signatures
+      // based on the input value type, not just argument count
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'nullable', standalone: true})
+          export class NullablePipe implements PipeTransform {
+            // Overload 1: When value is null/undefined, return null
+            transform(value: null | undefined): null;
+            // Overload 2: When value is a string, return string | null
+            transform(value: string): string | null;
+            // Overload 3: Implementation signature
+            transform(value: string | null | undefined): string | null;
+            transform(value: string | null | undefined): string | null {
+              return value ?? null;
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ name | nullable }}\`,
+            standalone: true,
+            imports: [NullablePipe],
+          })
+          export class AppCmp {
+            name: string = 'hello';
+          }
+        `,
+      };
+      project = env.addProject('test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // When input is `string`, should match the second overload and show `: string | null`
+      const returnTypeHint = hints.find((h) => h.text === ': string | null');
+      expect(returnTypeHint).toBeDefined();
+      expect(returnTypeHint?.kind).toBe('Type');
+    });
+
+    it('should show correct return type for DatePipe from @angular/common', () => {
+      // DatePipe has overloaded signatures that depend on input type
+      // When input is Date|string|number: returns string | null
+      // This test uses createModuleAndProjectWithDeclarations which includes CommonModule
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ today | date : 'short' }}\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            today = new Date();
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // DatePipe.transform returns string | null when input is Date
+      // Should show parameter name hint for 'format'
+      const formatHint = hints.find((h) => h.text === 'format:');
+      expect(formatHint).toBeDefined();
+      expect(formatHint?.kind).toBe('Parameter');
+
+      // Should show return type hint `: string | null`
+      const returnTypeHint = hints.find((h) => h.text === ': string | null');
+      expect(returnTypeHint).toBeDefined();
+      expect(returnTypeHint?.kind).toBe('Type');
+    });
+  });
+
+  describe('template references', () => {
+    // Note: HTMLInputElement hint may not work in unit tests due to mock DOM types.
+    // Fully tested in LSP integration tests.
+    it('should not throw when processing references', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<input #myInput />\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+
+    it('should provide type hints for directive exportAs references', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[tooltip]',
+            exportAs: 'tooltip',
+            standalone: false,
+          })
+          export class TooltipDirective {
+            text = '';
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div tooltip #tip="tooltip"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw - directive exportAs may not be fully resolved in mock
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+  });
+
+  describe('structural directives', () => {
+    it('should provide type hints for *ngFor variables', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+          import {NgForOf} from '@angular/common';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<li *ngFor="let item of items; let idx = index">{{ item }}</li>\`,
+            standalone: false,
+            imports: [NgForOf],
+          })
+          export class AppCmp {
+            items = ['a', 'b', 'c'];
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have `: string` for item, `: number` for idx
+      const stringHint = hints.find((h) => h.text === ': string');
+      const numberHint = hints.find((h) => h.text === ': number');
+
+      expect(stringHint).toBeDefined();
+      expect(numberHint).toBeDefined();
+    });
+  });
+
+  describe('host event bindings', () => {
+    // Note: DOM event type hints (MouseEvent, KeyboardEvent) may not work in unit tests
+    // due to the mock file system lacking proper DOM type definitions.
+    // These are fully tested in the LSP integration tests instead.
+
+    it('should not throw when processing host event bindings', () => {
+      const files = {
+        'app.ts': `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[highlight]',
+            standalone: false,
+            host: {
+              '(click)': 'handleClick($event)',
+              '(mouseenter)': 'handleMouseEnter($event)',
+            },
+          })
+          export class HighlightDirective {
+            handleClick(event: MouseEvent) {}
+            handleMouseEnter(event: MouseEvent) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+
+    it('should work for directives without templates', () => {
+      const files = {
+        'app.ts': `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[myDirective]',
+            standalone: false,
+            host: {
+              '(keydown)': 'onKeydown($event)',
+            },
+          })
+          export class MyDirective {
+            onKeydown(event: KeyboardEvent) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw
+      expect(() => appFile.getInlayHints()).not.toThrow();
+    });
+
+    describe('@HostListener argument types', () => {
+      it('should provide type hints for @HostListener argument expressions', () => {
+        const files = {
+          'app.ts': `
+            import {Component, HostListener} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+            })
+            export class AppCmp {
+              @HostListener('click', ['$event.target', '$event.clientX'])
+              handleClick(target: EventTarget | null, x: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw
+        const hints = appFile.getInlayHints();
+        expect(hints).toBeDefined();
+      });
+
+      it('should work for @HostListener with $event directly', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDirective]',
+              standalone: false,
+            })
+            export class MyDirective {
+              @HostListener('keydown', ['$event'])
+              onKeydown(event: KeyboardEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle nested property access on $event', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('click', ['$event.target.nodeName'])
+              onClick(nodeName: string) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw for deeply nested property access
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener with no arguments', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('focus')
+              onFocus() {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work when there are no arguments
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener with window events', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('window:resize', ['$event.target.innerWidth'])
+              onResize(width: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw for window events
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener with document events', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('document:keydown', ['$event.key', '$event.ctrlKey'])
+              onKeydown(key: string, ctrl: boolean) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work with document events and multiple arguments
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener with safe navigation on $event', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('click', ['$event.target?.nodeName'])
+              onClick(nodeName: string | undefined) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle safe navigation operator
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should respect hostListenerArgumentTypes config when disabled', () => {
+        const files = {
+          'app.ts': `
+            import {Component, HostListener} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+            })
+            export class AppCmp {
+              @HostListener('click', ['$event.target', '$event.clientX'])
+              handleClick(target: EventTarget | null, x: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With hostListenerArgumentTypes disabled, should return no hints for @HostListener
+        const hintsDisabled = appFile.getInlayHints({hostListenerArgumentTypes: false});
+        // With hostListenerArgumentTypes enabled (default), should potentially show hints
+        const hintsEnabled = appFile.getInlayHints({hostListenerArgumentTypes: true});
+
+        // Both should work without errors
+        expect(hintsDisabled).toBeDefined();
+        expect(hintsEnabled).toBeDefined();
+      });
+
+      it('should handle @HostListener with method calls as arguments', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('click', ['$event.target.getAttribute("data-id")'])
+              onClick(dataId: string | null) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle method call expressions
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener with arithmetic expressions', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('mousemove', ['$event.clientX + $event.clientY'])
+              onMouseMove(sum: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle binary expressions
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should provide parameter name hints for all @HostListener mapped arguments', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('click', ['$event', '$event.target'])
+              onClick2(tedt: PointerEvent, targets: EventTarget | null) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          parameterNameHints: 'all',
+          hostListenerArgumentTypes: true,
+        });
+
+        const firstArgHint = hints.find((h) => h.kind === 'Parameter' && h.text === 'tedt:');
+        const secondArgHint = hints.find((h) => h.kind === 'Parameter' && h.text === 'targets:');
+
+        expect(firstArgHint).toBeDefined();
+        expect(secondArgHint).toBeDefined();
+      });
+
+      it('should handle host metadata style events', () => {
+        const files = {
+          'app.ts': `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+              host: {
+                '(click)': 'onClick($event.target)',
+                '(mouseenter)': 'onMouseEnter($event.clientX, $event.clientY)',
+              }
+            })
+            export class MyDir {
+              onClick(target: EventTarget | null) {}
+              onMouseEnter(x: number, y: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work with host metadata style events too
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle @HostListener on components', () => {
+        const files = {
+          'app.ts': `
+            import {Component, HostListener} from '@angular/core';
+
+            @Component({
+              selector: 'app-button',
+              template: '<button><ng-content></ng-content></button>',
+              standalone: false,
+            })
+            export class AppButton {
+              @HostListener('click', ['$event.button', '$event.shiftKey', '$event.altKey'])
+              onClick(button: number, shift: boolean, alt: boolean) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work on components, not just directives
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+    });
+
+    describe('@HostBinding property types', () => {
+      it('should work for @HostBinding with DOM property', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostBinding('disabled')
+              isDisabled = false;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should work for @HostBinding with class binding', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostBinding('class.active')
+              isActive = true;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle class bindings (even though they're not fully type-checked)
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should work for @HostBinding with style binding', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostBinding('style.width.px')
+              width = 100;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle style bindings (even though they're not fully type-checked)
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should work for @HostBinding without explicit property name', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostBinding()
+              title = 'My Title';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work when property name is inferred from the class member name
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should work for @HostBinding with attr prefix', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostBinding} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostBinding('attr.aria-label')
+              ariaLabel = 'Accessible label';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should handle attribute bindings
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should work for host metadata style bindings', () => {
+        const files = {
+          'app.ts': `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+              host: {
+                '[disabled]': 'isDisabled',
+                '[class.active]': 'isActive',
+                '[style.width.px]': 'width',
+              }
+            })
+            export class MyDir {
+              isDisabled = false;
+              isActive = true;
+              width = 100;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should work with host metadata style bindings
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+    });
+
+    describe('host metadata event type hints', () => {
+      it('should provide event type hints for host metadata events', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '(click)': 'onClick($event)',
+                '(keydown)': 'onKeydown($event)',
+                '(mouseenter)': 'onMouseEnter($event)',
+                '(focus)': 'onFocus($event)',
+              }
+            })
+            export class AppCmp {
+              onClick(event: PointerEvent) {}
+              onKeydown(event: KeyboardEvent) {}
+              onMouseEnter(event: MouseEvent) {}
+              onFocus(event: FocusEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should produce event type hints for host events
+        expect(hints).toBeDefined();
+        expect(hints.length).toBeGreaterThan(0);
+      });
+
+      it('should provide event type hints for global target events in host metadata', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '(window:resize)': 'onResize($event)',
+                '(document:click)': 'onDocClick($event)',
+                '(body:scroll)': 'onBodyScroll($event)',
+              }
+            })
+            export class AppCmp {
+              onResize(event: UIEvent) {}
+              onDocClick(event: PointerEvent) {}
+              onBodyScroll(event: Event) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should handle global target events (window:, document:, body:)
+        expect(hints).toBeDefined();
+      });
+
+      it('should provide event type hints for keyboard modifier events in host metadata', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '(keydown.enter)': 'onEnter($event)',
+                '(keydown.shift.enter)': 'onShiftEnter($event)',
+                '(keydown.escape)': 'onEscape($event)',
+              }
+            })
+            export class AppCmp {
+              onEnter(event: Event) {}
+              onShiftEnter(event: Event) {}
+              onEscape(event: Event) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should handle keyboard modifier events (keydown.enter, etc.)
+        expect(hints).toBeDefined();
+      });
+
+      it('should provide binding type hints for host metadata property bindings', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '[disabled]': 'isDisabled',
+                '[hidden]': 'isHidden',
+                '[title]': 'tooltipText',
+              }
+            })
+            export class AppCmp {
+              isDisabled = false;
+              isHidden = true;
+              tooltipText = 'Some tooltip';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should process host property bindings without throwing.
+        expect(hints).toBeDefined();
+      });
+
+      it('should not emit type hints for host metadata attr/style/class bindings', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '[attr.aria-label]': 'label',
+                '[style.width.px]': 'width',
+                '[class.active]': 'active',
+              }
+            })
+            export class AppCmp {
+              label = 'hello';
+              width = 120;
+              active = true;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        const attrLikeHint = hints.find(
+          (h) => h.text === ': string' || h.text === ': number' || h.text === ': boolean',
+        );
+        expect(attrLikeHint).toBeUndefined();
+      });
+
+      it('should handle mixed host metadata with events and bindings', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              host: {
+                '(click)': 'onClick($event)',
+                '(mouseenter)': 'onMouseEnter($event)',
+                '[disabled]': 'isDisabled',
+                '[class.active]': 'isActive',
+                '[style.backgroundColor]': 'bgColor',
+                '[attr.aria-label]': 'ariaLabel',
+              }
+            })
+            export class AppCmp {
+              onClick(event: PointerEvent) {}
+              onMouseEnter(event: MouseEvent) {}
+              isDisabled = false;
+              isActive = true;
+              bgColor = 'blue';
+              ariaLabel = 'My label';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should handle mixed host metadata (events + bindings)
+        expect(hints).toBeDefined();
+      });
+
+      it('should handle @HostListener with $event property access and verify hints', () => {
+        const files = {
+          'app.ts': `
+            import {Directive, HostListener} from '@angular/core';
+
+            @Directive({
+              selector: '[myDir]',
+              standalone: false,
+            })
+            export class MyDir {
+              @HostListener('click', ['$event.target', '$event.clientX', '$event.clientY'])
+              onClick(target: EventTarget | null, x: number, y: number) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({hostListenerArgumentTypes: true});
+
+        // Assert all mapped argument types are present, including the second argument.
+        const labels = hints
+          .filter((h) => h.kind === 'Type')
+          .map((h) => h.displayParts?.map((p) => p.text).join('') ?? h.text);
+
+        expect(labels.some((l) => l.includes('EventTarget | null'))).toBeTrue();
+        expect(labels.some((l) => l.includes('number'))).toBeTrue();
+      });
+
+      it('should handle animation events in host metadata', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+            import {trigger, state, style, animate, transition} from '@angular/animations';
+
+            @Component({
+              selector: 'app-cmp',
+              template: '',
+              standalone: false,
+              animations: [
+                trigger('fade', [
+                  state('void', style({ opacity: 0 })),
+                  state('*', style({ opacity: 1 })),
+                  transition(':enter', animate('300ms')),
+                  transition(':leave', animate('300ms')),
+                ])
+              ],
+              host: {
+                '[@fade]': 'state',
+                '(@fade.start)': 'onAnimationStart($event)',
+                '(@fade.done)': 'onAnimationDone($event)',
+              }
+            })
+            export class AppCmp {
+              state = 'active';
+              onAnimationStart(event: any) {}
+              onAnimationDone(event: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Animation events should not throw
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+    });
+
+    describe('@switch block expression types', () => {
+      it('should provide type hints for @switch expression', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            enum Status {
+              Active = 'active',
+              Inactive = 'inactive',
+              Pending = 'pending',
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @switch (status) {
+                  @case (Status.Active) { Active }
+                  @case (Status.Inactive) { Inactive }
+                  @default { Unknown }
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              status: Status = Status.Active;
+              Status = Status;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should have Status hint for @switch (status)
+        const statusHint = hints.find((h) => h.text === ': Status');
+        expect(statusHint).toBeDefined();
+      });
+
+      it('should include undefined for optional chaining in @switch expression', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User {
+              id: number;
+              name: string;
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @switch (user?.id) {
+                  @case (1) { First }
+                  @default { Other }
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              user: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should include undefined since optional chaining can return undefined
+        // when user is null, user?.id evaluates to undefined
+        const typeHint = hints.find(
+          (h) => h.text.includes('number') && h.text.includes('undefined'),
+        );
+        expect(typeHint).toBeDefined();
+        expect(typeHint?.text).toMatch(/number\s*\|\s*undefined/);
+      });
+
+      it('should work with primitive switch expressions', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @switch (count) {
+                  @case (1) { One }
+                  @case (2) { Two }
+                  @default { Other }
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              count = 1;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should have number hint for @switch (count)
+        const numberHint = hints.find((h) => h.text === ': number');
+        expect(numberHint).toBeDefined();
+      });
+
+      it('should respect switchExpressionTypes config option', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @switch (value) {
+                  @case ('a') { A }
+                  @default { Other }
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              value = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With switchExpressionTypes disabled, should not show hints
+        const hintsDisabled = appFile.getInlayHints({switchExpressionTypes: false});
+        const stringHintDisabled = hintsDisabled.find((h) => h.text === ': string');
+        expect(stringHintDisabled).toBeUndefined();
+
+        // With switchExpressionTypes enabled (default), should show hints
+        const hintsEnabled = appFile.getInlayHints({switchExpressionTypes: true});
+        const stringHintEnabled = hintsEnabled.find((h) => h.text === ': string');
+        expect(stringHintEnabled).toBeDefined();
+      });
+    });
+
+    describe('@defer block trigger types', () => {
+      it('should provide type hints for @defer when trigger', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @defer (when isVisible) {
+                  <div>Deferred content</div>
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              isVisible = true;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+
+        // Should have boolean hint for when isVisible
+        const booleanHint = hints.find((h) => h.text === ': boolean');
+        expect(booleanHint).toBeDefined();
+      });
+
+      it('should respect deferTriggerTypes config option', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @defer (when loaded) {
+                  <div>Content</div>
+                }
+              \`,
+              standalone: true,
+            })
+            export class AppCmp {
+              loaded = false;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With deferTriggerTypes disabled, should not show hints
+        const hintsDisabled = appFile.getInlayHints({deferTriggerTypes: false});
+        const boolHintDisabled = hintsDisabled.find((h) => h.text === ': boolean');
+        expect(boolHintDisabled).toBeUndefined();
+
+        // With deferTriggerTypes enabled (default), should show hints
+        const hintsEnabled = appFile.getInlayHints({deferTriggerTypes: true});
+        const boolHintEnabled = hintsEnabled.find((h) => h.text === ': boolean');
+        expect(boolHintEnabled).toBeDefined();
+      });
+    });
+
+    describe('ng-template context variables', () => {
+      it('should provide type hints for let- variables on ng-template', () => {
+        const files = {
+          'app.ts': `
+            import {Component, TemplateRef, ViewChild} from '@angular/core';
+            import {NgTemplateOutlet} from '@angular/common';
+
+            interface User {
+              name: string;
+              age: number;
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                <ng-template #userTpl let-user let-extra="extra">
+                  {{ user.name }} - {{ extra }}
+                </ng-template>
+                <ng-container *ngTemplateOutlet="userTpl; context: ctx"></ng-container>
+              \`,
+              standalone: true,
+              imports: [NgTemplateOutlet],
+            })
+            export class AppCmp {
+              ctx = { $implicit: { name: 'John', age: 30 } as User, extra: 'info' };
+              @ViewChild('userTpl') userTpl!: TemplateRef<any>;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw
+        const hints = appFile.getInlayHints();
+        expect(hints).toBeDefined();
+      });
+    });
+
+    describe('structural directive context exports', () => {
+      it('should provide type hints for *ngIf exported context', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+            import {NgIf} from '@angular/common';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div *ngIf="data as result">{{ result }}</div>\`,
+              standalone: true,
+              imports: [NgIf],
+            })
+            export class AppCmp {
+              data = 'hello';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw (structural directive context is handled via visitVariable)
+        const hints = appFile.getInlayHints();
+        expect(hints).toBeDefined();
+      });
+    });
+  });
+
+  describe('property binding types', () => {
+    it('should provide type hints for input bindings', () => {
+      const files = {
+        'user-display.directive.ts': `
+          import {Directive, Input} from '@angular/core';
+
+          export interface User {
+            name: string;
+          }
+
+          @Directive({
+            selector: '[userDisplay]',
+            standalone: false,
+          })
+          export class UserDisplayDirective {
+            @Input() user!: User;
+            @Input() count!: number;
+          }
+        `,
+        'app.ts': `
+          import {Component} from '@angular/core';
+          import {User} from './user-display.directive';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div userDisplay [user]="currentUser" [count]="5"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            currentUser: User = { name: 'Test' };
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have User hint for [user] and number hint for [count]
+      const userHint = hints.find((h) => h.text === ': User');
+      const numberHint = hints.find((h) => h.text === ': number');
+
+      expect(userHint).toBeDefined();
+      expect(numberHint).toBeDefined();
+    });
+  });
+
+  describe('signal-based inputs and outputs', () => {
+    // Note: Signal-based API tests (input(), output(), model()) may produce different results
+    // in unit tests due to the mock file system lacking full @angular/core type definitions.
+    // The actual type unwrapping is tested in LSP integration tests.
+
+    it('should not throw when processing signal-based inputs', () => {
+      const files = {
+        'signal-input.directive.ts': `
+          import {Directive, input} from '@angular/core';
+
+          export interface User {
+            name: string;
+          }
+
+          @Directive({
+            selector: '[signalInput]',
+            standalone: false,
+          })
+          export class SignalInputDirective {
+            user = input<User>();
+            count = input.required<number>();
+          }
+        `,
+        'app.ts': `
+          import {Component} from '@angular/core';
+          import {User} from './signal-input.directive';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div signalInput [user]="currentUser" [count]="5"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            currentUser: User = { name: 'Test' };
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw when processing signal-based inputs
+      expect(() => appFile.getInlayHints({propertyBindingTypes: true})).not.toThrow();
+    });
+
+    it('should not throw when processing signal-based outputs', () => {
+      const files = {
+        'signal-output.directive.ts': `
+          import {Directive, output} from '@angular/core';
+
+          @Directive({
+            selector: '[signalOutput]',
+            standalone: false,
+          })
+          export class SignalOutputDirective {
+            clicked = output<MouseEvent>();
+            changed = output<string>();
+          }
+        `,
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div signalOutput (clicked)="handleClick($event)" (changed)="handleChange($event)"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            handleClick(event: MouseEvent) {}
+            handleChange(value: string) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw when processing signal-based outputs
+      expect(() => appFile.getInlayHints({eventParameterTypes: true})).not.toThrow();
+    });
+
+    it('should unwrap EventEmitter types for legacy output hints', () => {
+      const files = {
+        'legacy-output.directive.ts': `
+          import {Directive, Output, EventEmitter} from '@angular/core';
+
+          @Directive({
+            selector: '[legacyOutput]',
+            standalone: false,
+          })
+          export class LegacyOutputDirective {
+            @Output() clicked = new EventEmitter<MouseEvent>();
+            @Output() changed = new EventEmitter<string>();
+          }
+        `,
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div legacyOutput (clicked)="handleClick($event)" (changed)="handleChange($event)"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            handleClick(event: MouseEvent) {}
+            handleChange(value: string) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw when processing legacy EventEmitter outputs
+      expect(() => appFile.getInlayHints({eventParameterTypes: true})).not.toThrow();
+    });
+  });
+
+  describe('animation events', () => {
+    it('should provide AnimationEvent type hint for legacy animation events', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<div [@myAnimation]="state" (@myAnimation.done)="onDone($event)"></div>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            state = 'start';
+            onDone(event: any) {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints();
+
+      // Should have AnimationEvent hint for $event
+      const animationHint = hints.find((h) => h.text === ': AnimationEvent');
+      expect(animationHint).toBeDefined();
+    });
+  });
+
+  describe('config options', () => {
+    describe('variableTypeHintsWhenTypeMatchesName', () => {
+      it('should skip variable hints when type matches name (default true)', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User {
+              name: string;
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@for (user of users; track user.name) { {{ user.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              users: User[] = [];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With default config (variableTypeHintsWhenTypeMatchesName: true), should show hint
+        const hintsWithDefault = appFile.getInlayHints();
+        const userHint = hintsWithDefault.find((h) => h.text === ': User');
+        expect(userHint).toBeDefined();
+
+        // With variableTypeHintsWhenTypeMatchesName: false, should skip hint
+        const hintsSkipped = appFile.getInlayHints({variableTypeHintsWhenTypeMatchesName: false});
+        const skippedUserHint = hintsSkipped.find((h) => h.text === ': User');
+        expect(skippedUserHint).toBeUndefined();
+      });
+
+      it('should not skip hints when names do not match', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface Person {
+              name: string;
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@for (item of people; track item.name) { {{ item.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              people: Person[] = [];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // item doesn't match Person, so hint should always show
+        const hints = appFile.getInlayHints({variableTypeHintsWhenTypeMatchesName: false});
+        const personHint = hints.find((h) => h.text === ': Person');
+        expect(personHint).toBeDefined();
+      });
+    });
+
+    describe('parameterNameHints', () => {
+      it('should show parameter name hints when set to "all"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick($event)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleClick(event: MouseEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+        // Should have parameter name hint for event
+        const paramHint = hints.find((h) => h.kind === 'Parameter' && h.text.includes('event'));
+        expect(paramHint).toBeDefined();
+      });
+
+      it('should hide parameter name hints when set to "none"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick($event)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleClick(event: MouseEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'none'});
+        // Should have NO parameter name hints
+        const paramHints = hints.filter((h) => h.kind === 'Parameter');
+        expect(paramHints.length).toBe(0);
+      });
+
+      it('should only show hints for literals when set to "literals"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ formatValue(42, name) }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+              formatValue(num: number, str: string) { return num + str; }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'literals'});
+        // Should have hint for literal 42, but not for variable name
+        const numHint = hints.find((h) => h.kind === 'Parameter' && h.text.includes('num'));
+        expect(numHint).toBeDefined();
+        const strHint = hints.find((h) => h.kind === 'Parameter' && h.text.includes('str'));
+        expect(strHint).toBeUndefined(); // 'name' is not a literal
+      });
+    });
+
+    describe('parameterNameHintsWhenArgumentMatchesName', () => {
+      it('should skip hints when argument matches parameter name (default false)', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick(event)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              event: MouseEvent | undefined;
+              handleClick(event: MouseEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Default: skip hints when argument name matches parameter name
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+        const paramHint = hints.find((h) => h.kind === 'Parameter');
+        expect(paramHint).toBeUndefined();
+      });
+
+      it('should show hints when enabled even if argument matches parameter name', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick(event)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              event: MouseEvent | undefined;
+              handleClick(event: MouseEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With parameterNameHintsWhenArgumentMatchesName: true, should show hint
+        const hints = appFile.getInlayHints({
+          parameterNameHints: 'all',
+          parameterNameHintsWhenArgumentMatchesName: true,
+        });
+        const paramHint = hints.find((h) => h.kind === 'Parameter' && h.text.includes('event'));
+        expect(paramHint).toBeDefined();
+      });
+
+      it('should use TypeScript resolved signature for overloaded methods', () => {
+        // This tests that the inlay hints correctly use TypeScript's overload resolution
+        // for method calls with overloaded signatures
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ format('hello', 42) }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              // Overloaded method signatures
+              format(value: string, count: number): string;
+              format(value: number, prefix: string): string;
+              format(value: string | number, extra: string | number): string {
+                return String(value) + String(extra);
+              }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+
+        // Should show 'value:' and 'count:' based on the first overload
+        // because the first argument is a string literal
+        const valueHint = hints.find((h) => h.text === 'value:');
+        const countHint = hints.find((h) => h.text === 'count:');
+        expect(valueHint).toBeDefined();
+        expect(countHint).toBeDefined();
+      });
+
+      it('should show ... prefix for rest parameters', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ sum(1, 2, 3, 4) }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              sum(first: number, ...rest: number[]): number {
+                return first + rest.reduce((a, b) => a + b, 0);
+              }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+
+        // First argument should have 'first:' hint
+        const firstHint = hints.find((h) => h.text === 'first:');
+        expect(firstHint).toBeDefined();
+
+        // First rest argument (second overall) should have '...rest:' hint
+        const restHint = hints.find((h) => h.text === '...rest:');
+        expect(restHint).toBeDefined();
+      });
+    });
+
+    describe('disabling specific hint categories', () => {
+      it('should respect forLoopVariableTypes: false', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@for (item of items; track $index) { {{ item }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              items = ['a', 'b', 'c'];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({forLoopVariableTypes: false});
+        // Should have no hints for @for variable
+        const stringHint = hints.find((h) => h.text === ': string');
+        expect(stringHint).toBeUndefined();
+      });
+
+      it('should respect letDeclarationTypes: false', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@let count = items.length; {{ count }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              items = [1, 2, 3];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({letDeclarationTypes: false});
+        const numberHint = hints.find((h) => h.text === ': number');
+        expect(numberHint).toBeUndefined();
+      });
+
+      it('should respect eventParameterTypes: false', () => {
+        const files = {
+          'app.ts': `
+            import {Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[myDirective]',
+              standalone: false,
+              host: {
+                '(click)': 'onClick($event)',
+              },
+            })
+            export class MyDirective {
+              onClick(event: MouseEvent) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: false});
+        const mouseHint = hints.find((h) => h.text === ': MouseEvent');
+        expect(mouseHint).toBeUndefined();
+      });
+    });
+
+    describe('fine-grained event source configuration', () => {
+      it('should respect eventParameterTypes.componentEvents: false', () => {
+        const files = {
+          'output.directive.ts': `
+            import {Directive, Output, EventEmitter} from '@angular/core';
+
+            @Directive({
+              selector: '[outputDirective]',
+              standalone: false,
+            })
+            export class OutputDirective {
+              @Output() customEvent = new EventEmitter<string>();
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div outputDirective (customEvent)="handleCustom($event)"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleCustom(value: string) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With componentEvents: false, should not show component event hints
+        const hints = appFile.getInlayHints({
+          eventParameterTypes: {componentEvents: false, nativeEvents: true, animationEvents: true},
+        });
+        const stringHint = hints.find((h) => h.text === ': string');
+        expect(stringHint).toBeUndefined();
+      });
+
+      it('should show component events when componentEvents: true', () => {
+        const files = {
+          'output.directive.ts': `
+            import {Directive, Output, EventEmitter} from '@angular/core';
+
+            @Directive({
+              selector: '[outputDirective]',
+              standalone: false,
+            })
+            export class OutputDirective {
+              @Output() customEvent = new EventEmitter<string>();
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div outputDirective (customEvent)="handleCustom($event)"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleCustom(value: string) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With componentEvents: true, should show component event hints
+        const hints = appFile.getInlayHints({
+          eventParameterTypes: {componentEvents: true, nativeEvents: false, animationEvents: false},
+        });
+        const stringHint = hints.find((h) => h.text === ': string');
+        expect(stringHint).toBeDefined();
+      });
+    });
+
+    describe('DOM event type mapping', () => {
+      // Note: The DOM_EVENT_TYPE_MAP provides correct event types for various DOM events.
+      // However, in unit tests the mock file system may not have DOM type definitions,
+      // so we verify the implementation handles events correctly without testing exact types.
+      // Full type verification is done in LSP integration tests with real TypeScript libs.
+
+      it('should handle click events with DOM event type map', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="onClick($event)">Click</button>\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onClick(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw and should return hints
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        // Should have at least one type hint for the event
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+
+        // DOM event hints should be concise concrete types, not verbose generic signatures.
+        const labels = typeHints.map((h) => h.text);
+        expect(labels.some((label) => label.includes('PointerEvent'))).toBe(true);
+        expect(labels.some((label) => label.includes('<K extends keyof HTMLElementEventMap'))).toBe(
+          false,
+        );
+      });
+
+      it('should handle dblclick events with DOM event type map', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div (dblclick)="onDblClick($event)">Double click</div>\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onDblClick(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle keydown events with DOM event type map', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<input (keydown)="onKeydown($event)" />\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onKeydown(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle keydown with modifiers', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<input (keydown.enter)="onEnter($event)" />\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onEnter(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        // keydown.enter should still be mapped to KeyboardEvent
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle focus and blur events', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<input (focus)="onFocus($event)" (blur)="onBlur($event)" />\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onFocus(e: any) {}
+              onBlur(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        // Should have hints for both focus and blur
+        expect(typeHints.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('should handle input events', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<input (input)="onInput($event)" />\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onInput(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle drag events', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div (dragover)="onDragOver($event)" (drop)="onDrop($event)">Drop</div>\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onDragOver(e: any) {}
+              onDrop(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('should handle mouseenter and mouseleave events', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div (mouseenter)="onEnter($event)" (mouseleave)="onLeave($event)">Hover</div>\`,
+              standalone: true,
+            })
+            export class AppCmp {
+              onEnter(e: any) {}
+              onLeave(e: any) {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({eventParameterTypes: true});
+        expect(hints).toBeDefined();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+
+    describe('fine-grained @if alias configuration', () => {
+      it('should show hints for simple @if expressions by default', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (currentUser; as u) { {{ u.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              currentUser: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({ifAliasTypes: true});
+        const userHint = hints.find((h) => h.text.includes('User'));
+        expect(userHint).toBeDefined();
+      });
+
+      it('should hide hints for simple @if expressions when ifAliasTypes is "complex"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (currentUser; as u) { {{ u.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              currentUser: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With 'complex', simple property reads should not show hints
+        const hints = appFile.getInlayHints({ifAliasTypes: 'complex'});
+        const userHint = hints.find((h) => h.text.includes('User'));
+        expect(userHint).toBeUndefined();
+      });
+
+      it('should show hints for complex @if expressions when ifAliasTypes is "complex"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (items.length > 0; as hasItems) { has items }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              items = ['a', 'b'];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With 'complex', comparison expressions should show hints
+        const hints = appFile.getInlayHints({ifAliasTypes: 'complex'});
+        const booleanHint = hints.find((h) => h.text.includes('boolean'));
+        expect(booleanHint).toBeDefined();
+      });
+
+      it('should show hints for property access @if expressions when ifAliasTypes is "complex"', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (currentUser?.name; as name) { {{ name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              currentUser: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Property access is complex, should show hints
+        const hints = appFile.getInlayHints({ifAliasTypes: 'complex'});
+        const stringHint = hints.find((h) => h.text.includes('string'));
+        expect(stringHint).toBeDefined();
+      });
+
+      it('should respect ifAliasTypes: { simpleExpressions: false, complexExpressions: true }', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @if (currentUser; as u) { simple }
+                @if (currentUser?.name; as n) { complex }
+              \`,
+              standalone: false,
+            })
+            export class AppCmp {
+              currentUser: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          ifAliasTypes: {simpleExpressions: false, complexExpressions: true},
+        });
+        // Should not have User hint (simple expression)
+        const userHint = hints.find((h) => h.text.includes('User'));
+        expect(userHint).toBeUndefined();
+        // Should have string hint (complex expression)
+        const stringHint = hints.find((h) => h.text.includes('string'));
+        expect(stringHint).toBeDefined();
+      });
+
+      it('should hide all @if hints when ifAliasTypes is false', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface User { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (currentUser; as u) { {{ u.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              currentUser: User | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({ifAliasTypes: false});
+        const userHint = hints.find((h) => h.text.includes('User'));
+        expect(userHint).toBeUndefined();
+      });
+    });
+
+    describe('fine-grained property binding configuration', () => {
+      it('should respect propertyBindingTypes.componentInputs: false', () => {
+        const files = {
+          'input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[inputDirective]',
+              standalone: false,
+            })
+            export class InputDirective {
+              @Input() value!: string;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div inputDirective [value]="name"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With componentInputs: false, should not show component input hints
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: {componentInputs: false, nativeProperties: true},
+        });
+        const stringHint = hints.find((h) => h.text === ': string');
+        expect(stringHint).toBeUndefined();
+      });
+
+      it('should show component inputs when componentInputs: true', () => {
+        const files = {
+          'input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[inputDirective]',
+              standalone: false,
+            })
+            export class InputDirective {
+              @Input() value!: string;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div inputDirective [value]="name"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With componentInputs: true, should show component input hints
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: {componentInputs: true, nativeProperties: false},
+        });
+        const stringHint = hints.find((h) => h.text === ': string');
+        expect(stringHint).toBeDefined();
+      });
+
+      it('should not duplicate boolean hints when directive and DOM property overlap', () => {
+        const files = {
+          'my-directive-a.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[myDirectiveA]',
+              standalone: false,
+            })
+            export class MyDirectiveA {
+              @Input() disabled = false;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<input myDirectiveA [disabled]="'true'" [style.backgroundColor]="'rgb(0, 0, 255)'" />\`,
+              standalone: false,
+            })
+            export class AppCmp {}
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({propertyBindingTypes: true});
+        const booleanHints = hints.filter((h) => h.text === ': boolean');
+        expect(booleanHints.length).toBe(1);
+      });
+
+      it('should not emit property type hints for attr/style/class template bindings', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \
+                \
+                  '<div [attr.aria-label]="label" [style.width.px]="width" [class.active]="active"></div>',
+              standalone: false,
+            })
+            export class AppCmp {
+              label = 'hello';
+              width = 120;
+              active = true;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({propertyBindingTypes: true});
+        const primitiveHint = hints.find(
+          (h) => h.text === ': string' || h.text === ': number' || h.text === ': boolean',
+        );
+
+        expect(primitiveHint).toBeUndefined();
+      });
+    });
+
+    describe('requiredInputIndicator', () => {
+      it('should not add indicator when requiredInputIndicator: none', () => {
+        const files = {
+          'input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[inputDirective]',
+              standalone: false,
+            })
+            export class InputDirective {
+              @Input({required: true}) value!: string;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div inputDirective [value]="name"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: true,
+          requiredInputIndicator: 'none',
+        });
+        // Should have `: string` without any indicator
+        const hint = hints.find((h) => h.text.includes('string'));
+        expect(hint?.text).toBe(': string');
+      });
+
+      it('should add asterisk indicator for @Input({required: true})', () => {
+        const files = {
+          'input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[inputDirective]',
+              standalone: false,
+            })
+            export class InputDirective {
+              @Input({required: true}) value!: string;
+              @Input() optional?: number;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div inputDirective [value]="name" [optional]="count"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+              count = 42;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: true,
+          requiredInputIndicator: 'asterisk',
+        });
+        // Required input should have asterisk
+        const requiredHint = hints.find((h) => h.text.includes('string'));
+        expect(requiredHint?.text).toBe(': string*');
+        // Optional input should NOT have asterisk
+        const optionalHint = hints.find((h) => h.text.includes('number'));
+        expect(optionalHint?.text).toBe(': number | undefined');
+      });
+
+      it('should add exclamation indicator for @Input({required: true})', () => {
+        const files = {
+          'input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[inputDirective]',
+              standalone: false,
+            })
+            export class InputDirective {
+              @Input({required: true}) value!: string;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div inputDirective [value]="name"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: true,
+          requiredInputIndicator: 'exclamation',
+        });
+        const hint = hints.find((h) => h.text.includes('string'));
+        expect(hint?.text).toBe(': string!');
+      });
+
+      it('should add asterisk indicator for input.required() signal inputs', () => {
+        const files = {
+          'signal-input.directive.ts': `
+            import {Directive, input} from '@angular/core';
+
+            @Directive({
+              selector: '[signalInput]',
+              standalone: false,
+            })
+            export class SignalInputDirective {
+              requiredValue = input.required<string>();
+              optionalValue = input<number>();
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div signalInput [requiredValue]="name" [optionalValue]="count"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              name = 'test';
+              count = 42;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: true,
+          requiredInputIndicator: 'asterisk',
+        });
+        // Required signal input should have asterisk
+        const requiredHint = hints.find((h) => h.text.includes('string'));
+        expect(requiredHint?.text).toBe(': string*');
+        // Optional signal input should NOT have asterisk (type includes undefined)
+        const optionalHint = hints.find((h) => h.text.includes('number'));
+        expect(optionalHint?.text).toBe(': number | undefined');
+      });
+    });
+
+    describe('text attribute input bindings', () => {
+      it('should show type hints for text attribute inputs (input="value" syntax)', () => {
+        const files = {
+          'text-input.directive.ts': `
+            import {Directive, Input} from '@angular/core';
+
+            @Directive({
+              selector: '[textInput]',
+              standalone: false,
+            })
+            export class TextInputDirective {
+              @Input() text!: string;
+              @Input() label!: string;
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div textInput text="hello" label="greeting"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {}
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({propertyBindingTypes: true});
+        // Should show : string for both text attributes bound to inputs
+        const textHint = hints.find((h) => h.position > 75 && h.text === ': string');
+        expect(textHint).toBeDefined();
+        // Should have hints for both text attribute inputs
+        const stringHints = hints.filter((h) => h.text === ': string');
+        expect(stringHints.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it('should show required indicator for required text attribute inputs', () => {
+        const files = {
+          'text-input.directive.ts': `
+            import {Directive, input} from '@angular/core';
+
+            @Directive({
+              selector: '[textInput]',
+              standalone: false,
+            })
+            export class TextInputDirective {
+              text = input.required<string>();
+              optional = input<string>();
+            }
+          `,
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div textInput text="required" optional="maybe"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {}
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          propertyBindingTypes: true,
+          requiredInputIndicator: 'exclamation',
+        });
+        // Required signal input should have exclamation
+        const requiredHint = hints.find((h) => h.text === ': string!');
+        expect(requiredHint).toBeDefined();
+        // Optional signal input should show undefined in type (no indicator)
+        const optionalHint = hints.find((h) => h.text.includes('undefined'));
+        expect(optionalHint).toBeDefined();
+      });
+
+      it('should not show hints for regular HTML attributes', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<div id="myDiv" class="container"></div>\`,
+              standalone: false,
+            })
+            export class AppCmp {}
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({propertyBindingTypes: true});
+        // Should not have type hints for regular HTML attributes like id and class
+        // (they are not Angular input bindings)
+        const idHint = hints.find((h) => h.text.includes('id'));
+        const classHint = hints.find((h) => h.text.includes('class'));
+        expect(idHint).toBeUndefined();
+        expect(classHint).toBeUndefined();
+      });
+    });
+  });
+
+  describe('arrow functions in templates', () => {
+    it('should not throw when processing arrow functions in templates', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'apply', standalone: false})
+          export class ApplyPipe implements PipeTransform {
+            transform(value: number, fn: (v: number) => number): number {
+              return fn(value);
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ 5 | apply : x => x * 2 }}\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Arrow functions may not always produce type hints depending on TCB inference
+      // The key is that it should not throw
+      expect(() => appFile.getInlayHints({arrowFunctionParameterTypes: true})).not.toThrow();
+    });
+
+    it('should disable arrow function parameter hints when configured', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'apply', standalone: false})
+          export class ApplyPipe implements PipeTransform {
+            transform(value: number, fn: (v: number) => number): number {
+              return fn(value);
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ 5 | apply : x => x * 2 }}\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hintsWithout = appFile.getInlayHints({
+        arrowFunctionParameterTypes: false,
+        pipeOutputTypes: false,
+      });
+      // Should not have parameter type hints for arrow function params
+      const paramHint = hintsWithout.find((h) => h.text === ': number' && h.kind === 'Type');
+      // The hint might still appear from pipe parameter hints, so just check it doesn't throw
+      expect(() => appFile.getInlayHints({arrowFunctionParameterTypes: false})).not.toThrow();
+    });
+
+    it('should provide arrow function return hints when enabled', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'apply', standalone: false})
+          export class ApplyPipe implements PipeTransform {
+            transform<T, R>(value: T, fn: (v: T) => R): R {
+              return fn(value);
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ 5 | apply : x => x * 2 }}\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      expect(() =>
+        appFile.getInlayHints({
+          arrowFunctionReturnTypes: true,
+          arrowFunctionParameterTypes: false,
+          pipeOutputTypes: false,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should disable arrow function return hints when configured', () => {
+      const files = {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({name: 'apply', standalone: false})
+          export class ApplyPipe implements PipeTransform {
+            transform<T, R>(value: T, fn: (v: T) => R): R {
+              return fn(value);
+            }
+          }
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`{{ 5 | apply : x => x * 2 }}\`,
+            standalone: false,
+          })
+          export class AppCmp {}
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      expect(() =>
+        appFile.getInlayHints({
+          arrowFunctionReturnTypes: false,
+          arrowFunctionParameterTypes: false,
+          pipeOutputTypes: false,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('isHintableLiteral - TypeScript parity', () => {
+    it('should show parameter hints for template literals', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="log(\\\`hello\\\`)">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            log(message: string): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'literals'});
+      // Should show hint for template literal in 'literals' mode
+      const paramHint = hints.find((h) => h.text === 'message:' && h.kind === 'Parameter');
+      expect(paramHint).toBeDefined();
+    });
+
+    it('should show parameter hints for undefined, NaN, Infinity', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="setValue(undefined)">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            setValue(val: undefined): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      // Should not throw when processing undefined as a hintable literal
+      expect(() => appFile.getInlayHints({parameterNameHints: 'literals'})).not.toThrow();
+    });
+
+    it('should show parameter hints for negative literals like -1', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="setIndex(-1)">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            setIndex(idx: number): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'literals'});
+      // Should show hint for -1 in 'literals' mode (unary expression with literal)
+      const paramHint = hints.find((h) => h.text === 'idx:' && h.kind === 'Parameter');
+      expect(paramHint).toBeDefined();
+    });
+
+    it('should show parameter hints for array literals', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="setItems([1, 2, 3])">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            setItems(items: number[]): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'literals'});
+      // Should show hint for array literal in 'literals' mode
+      const paramHint = hints.find((h) => h.text === 'items:' && h.kind === 'Parameter');
+      expect(paramHint).toBeDefined();
+    });
+
+    it('should show parameter hints for object literals', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="setConfig({key: 'value'})">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            setConfig(config: {key: string}): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'literals'});
+      // Should show hint for object literal in 'literals' mode
+      const paramHint = hints.find((h) => h.text === 'config:' && h.kind === 'Parameter');
+      expect(paramHint).toBeDefined();
+    });
+  });
+
+  describe('tuple spread in function calls', () => {
+    it('should handle tuple spread arguments correctly', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="setCoords(1, 2, 3)">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            setCoords(x: number, y: number, z: number): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+      // Should show parameter name hints for all three arguments
+      const xHint = hints.find((h) => h.text === 'x:' && h.kind === 'Parameter');
+      const yHint = hints.find((h) => h.text === 'y:' && h.kind === 'Parameter');
+      const zHint = hints.find((h) => h.text === 'z:' && h.kind === 'Parameter');
+      expect(xHint).toBeDefined();
+      expect(yHint).toBeDefined();
+      expect(zHint).toBeDefined();
+    });
+  });
+
+  describe('rest parameters', () => {
+    it('should show ... prefix for first rest argument', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="log('prefix', 'a', 'b', 'c')">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            log(prefix: string, ...items: string[]): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+      // Should show 'prefix:' for first arg and '...items:' for rest args
+      const prefixHint = hints.find((h) => h.text === 'prefix:' && h.kind === 'Parameter');
+      const restHint = hints.find((h) => h.text === '...items:' && h.kind === 'Parameter');
+      expect(prefixHint).toBeDefined();
+      expect(restHint).toBeDefined();
+    });
+
+    it('should handle function with only rest parameters', () => {
+      const files = {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'app-cmp',
+            template: \`<button (click)="logAll('a', 'b', 'c')">Click</button>\`,
+            standalone: false,
+          })
+          export class AppCmp {
+            logAll(...items: string[]): void {}
+          }
+        `,
+      };
+      project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+
+      const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+      // First argument should have '...items:' prefix
+      const restHint = hints.find((h) => h.text === '...items:' && h.kind === 'Parameter');
+      expect(restHint).toBeDefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    describe('empty and edge case expressions', () => {
+      it('should handle function calls with no arguments', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="doSomething()">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              doSomething(): void {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw and produce no parameter hints
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+        const paramHints = hints.filter((h) => h.kind === 'Parameter');
+        expect(paramHints.length).toBe(0);
+      });
+
+      it('should handle nested function calls', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="outer(inner(42))">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              inner(num: number): string { return String(num); }
+              outer(str: string): void {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({parameterNameHints: 'all'});
+        // Should have hints for both inner and outer calls
+        const numHint = hints.find((h) => h.text === 'num:');
+        const strHint = hints.find((h) => h.text === 'str:');
+        expect(numHint).toBeDefined();
+        expect(strHint).toBeDefined();
+      });
+
+      it('should handle chained pipe calls', () => {
+        const files = {
+          'app.ts': `
+            import {Component, Pipe, PipeTransform} from '@angular/core';
+
+            @Pipe({name: 'prefix', standalone: true})
+            export class PrefixPipe implements PipeTransform {
+              transform(value: string, prefix: string): string {
+                return prefix + value;
+              }
+            }
+
+            @Pipe({name: 'suffix', standalone: true})
+            export class SuffixPipe implements PipeTransform {
+              transform(value: string, suffix: string): string {
+                return value + suffix;
+              }
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ name | prefix : '[' | suffix : ']' }}\`,
+              standalone: true,
+              imports: [PrefixPipe, SuffixPipe],
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = env.addProject('test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+        // Should have parameter hints for both pipes
+        const prefixHint = hints.find((h) => h.text === 'prefix:');
+        const suffixHint = hints.find((h) => h.text === 'suffix:');
+        expect(prefixHint).toBeDefined();
+        expect(suffixHint).toBeDefined();
+      });
+
+      it('should handle safe call operator ?.', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="obj?.method?.(42)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              obj: { method?: (val: number) => void } | null = null;
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw when processing safe call
+        expect(() => appFile.getInlayHints({parameterNameHints: 'all'})).not.toThrow();
+      });
+    });
+
+    describe('generic type inference', () => {
+      it('should handle generic functions without throwing', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@let result = identity('hello'); {{ result }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              identity<T>(value: T): T { return value; }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw when processing generics
+        expect(() => appFile.getInlayHints()).not.toThrow();
+        // Should produce some hints (at minimum for @let declaration)
+        const hints = appFile.getInlayHints();
+        expect(hints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle complex generic types', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface Box<T> { value: T; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@let box = makeBox(123); {{ box.value }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              makeBox<T>(value: T): Box<T> { return { value }; }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+        // Box should be Box<number>
+        const boxHint = hints.find((h) => h.text.includes('Box'));
+        expect(boxHint).toBeDefined();
+        expect(boxHint?.text).toContain('number');
+      });
+    });
+
+    describe('union and intersection types', () => {
+      it('should display union types correctly', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@let value = getValue(); {{ value }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              getValue(): string | number { return 'test'; }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+        // Should produce hint with union type
+        expect(hints.length).toBeGreaterThan(0);
+        // The hint should contain some type info (exact format may vary)
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+
+      it('should handle narrowed types in @if blocks', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@if (value !== null; as v) { {{ v }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              value: string | null = 'test';
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw when processing narrowed types
+        expect(() => appFile.getInlayHints()).not.toThrow();
+        // Should produce hints
+        const hints = appFile.getInlayHints();
+        const typeHints = hints.filter((h) => h.kind === 'Type');
+        expect(typeHints.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('interactive hints', () => {
+      it('should create displayParts when interactiveInlayHints is true', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick(42)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleClick(value: number): void {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          parameterNameHints: 'all',
+          interactiveInlayHints: true,
+        });
+        // Should have interactive hint with displayParts
+        const paramHint = hints.find((h) => h.kind === 'Parameter' && h.displayParts);
+        expect(paramHint).toBeDefined();
+        expect(paramHint?.displayParts?.length).toBeGreaterThan(0);
+        // First part should have span and file for navigation
+        expect(paramHint?.displayParts?.[0].span).toBeDefined();
+        expect(paramHint?.displayParts?.[0].file).toBeDefined();
+      });
+
+      it('should NOT create displayParts when interactiveInlayHints is false', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`<button (click)="handleClick(42)">Click</button>\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              handleClick(value: number): void {}
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints({
+          parameterNameHints: 'all',
+          interactiveInlayHints: false,
+        });
+        // Should have non-interactive hints (no displayParts)
+        const paramHints = hints.filter((h) => h.kind === 'Parameter');
+        expect(paramHints.length).toBeGreaterThan(0);
+        expect(paramHints.every((h) => !h.displayParts)).toBe(true);
+      });
+    });
+
+    describe('special cases for @for loops', () => {
+      it('should not duplicate hints for @for context variables', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`
+                @for (item of items; track $index; let i = $index, f = $first, l = $last) {
+                  {{ item }} #{{ i }} first:{{ f }} last:{{ l }}
+                }
+              \`,
+              standalone: false,
+            })
+            export class AppCmp {
+              items = ['a', 'b', 'c'];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        const hints = appFile.getInlayHints();
+        // Count hints - each variable should appear only once
+        const stringHints = hints.filter((h) => h.text === ': string');
+        const numberHints = hints.filter((h) => h.text === ': number');
+        const booleanHints = hints.filter((h) => h.text === ': boolean');
+
+        expect(stringHints.length).toBe(1); // item: string
+        expect(numberHints.length).toBe(1); // i: number
+        expect(booleanHints.length).toBe(2); // f: boolean, l: boolean
+      });
+
+      it('should handle empty @for loop', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@for (item of []; track $index) { {{ item }} } @empty { no items }\`,
+              standalone: false,
+            })
+            export class AppCmp {}
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+    });
+
+    describe('special cases for pipes', () => {
+      it('should handle pipe with no transform method gracefully', () => {
+        const files = {
+          'app.ts': `
+            import {Component, Pipe, PipeTransform} from '@angular/core';
+
+            // Technically invalid pipe, but should not crash
+            @Pipe({name: 'invalid', standalone: true})
+            export class InvalidPipe {
+              // Missing transform method
+            }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ name | invalid }}\`,
+              standalone: true,
+              imports: [InvalidPipe],
+            })
+            export class AppCmp {
+              name = 'test';
+            }
+          `,
+        };
+        project = env.addProject('test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Should not throw even with invalid pipe
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+
+      it('should handle async pipe without throwing', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`{{ data$ | async }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              data$ = Promise.resolve('hello');
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // Async pipe may not be fully available in mock environment
+        // The key is it should not throw
+        expect(() => appFile.getInlayHints()).not.toThrow();
+      });
+    });
+
+    describe('type matching name edge cases', () => {
+      it('should be case-insensitive when matching type to name', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface USER { name: string; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@for (user of users; track user.name) { {{ user.name }} }\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              users: USER[] = [];
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With variableTypeHintsWhenTypeMatchesName: false, should skip hint
+        // even though 'user' and 'USER' have different cases
+        const hints = appFile.getInlayHints({variableTypeHintsWhenTypeMatchesName: false});
+        const userHint = hints.find((h) => h.text === ': USER');
+        expect(userHint).toBeUndefined();
+      });
+
+      it('should handle generic types when matching name', () => {
+        const files = {
+          'app.ts': `
+            import {Component} from '@angular/core';
+
+            interface Box<T> { value: T; }
+
+            @Component({
+              selector: 'app-cmp',
+              template: \`@let box = getBox(); {{ box.value }}\`,
+              standalone: false,
+            })
+            export class AppCmp {
+              getBox(): Box<string> { return { value: 'test' }; }
+            }
+          `,
+        };
+        project = createModuleAndProjectWithDeclarations(env, 'test', files);
+        const appFile = project.openFile('app.ts');
+
+        // With variableTypeHintsWhenTypeMatchesName: false, should skip hint
+        // for Box<string> when variable is named 'box'
+        const hints = appFile.getInlayHints({variableTypeHintsWhenTypeMatchesName: false});
+        const boxHint = hints.find((h) => h.text.includes('Box'));
+        expect(boxHint).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -140,6 +140,24 @@ export class OpenBuffer {
   getSignatureHelpItems() {
     return this.ngLS.getSignatureHelpItems(this.scriptInfo.fileName, this._cursor);
   }
+
+  getInlayHints(
+    spanOrConfig?: ts.TextSpan | Record<string, unknown>,
+    config?: Record<string, unknown>,
+  ) {
+    let span: ts.TextSpan;
+    let inlayConfig: Record<string, unknown> | undefined;
+
+    if (spanOrConfig && typeof spanOrConfig === 'object' && 'start' in spanOrConfig) {
+      span = spanOrConfig as ts.TextSpan;
+      inlayConfig = config;
+    } else {
+      span = {start: 0, length: this.scriptInfo.getSnapshot().getLength()};
+      inlayConfig = spanOrConfig as Record<string, unknown> | undefined;
+    }
+
+    return this.ngLS.provideInlayHints(this.scriptInfo.fileName, span, inlayConfig);
+  }
 }
 
 /**

--- a/vscode-ng-language-service/README.md
+++ b/vscode-ng-language-service/README.md
@@ -67,3 +67,57 @@ code --install-extension /path/to/ngls.vsix
 - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#angularls) for [Neovim](https://neovim.io)
 - [Wild Web Developer](https://github.com/eclipse/wildwebdeveloper) for Eclipse
 - [lsp-mode](https://github.com/emacs-lsp/lsp-mode) for Emacs
+
+## Inlay Hints
+
+The Angular Language Service provides inlay hints for templates, showing inline type annotations directly in your code. This feature helps you understand types without hovering over variables.
+
+### Examples
+
+```html
+<!-- @for loop variables -->
+@for (user /* : User */ of users; track user.id) { {{ user.name }} }
+
+<!-- @if aliases (simple and complex) -->
+@if (currentUser; as user) { {{ user.name }} }
+@if (currentUser.profile; as profile /* : Profile */) { {{ profile.name }} }
+
+<!-- @let declarations -->
+@let count /* : number */ = items.length;
+
+<!-- Template references -->
+<input #emailInput /* : HTMLInputElement */ />
+
+<!-- Event bindings -->
+<button (click)="handleClick($event /* : MouseEvent */)">
+  <!-- Property bindings -->
+  <app-child [data /* : Data */]="myData"></app-child>
+</button>
+```
+
+### Configuration
+
+All inlay hints settings are under `angular.inlayHints.*`:
+
+| Setting                           | Default  | Description                                                                   |
+| --------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `eventParameterTypes`             | `false`  | Show `$event` types for event bindings                                        |
+| `forLoopVariableTypes`            | `false`  | Show types for `@for` loop variables                                          |
+| `ifAliasTypes`                    | `false`  | Show types for `@if` aliases. Set to `'complex'` for complex expressions only |
+| `letDeclarationTypes`             | `false`  | Show types for `@let` declarations                                            |
+| `referenceVariableTypes`          | `false`  | Show types for template reference variables                                   |
+| `suppressWhenTypeMatchesName`     | `false`  | Suppress variable type hints when variable name matches type                  |
+| `arrowFunctionParameterTypes`     | `false`  | Show parameter types for arrow functions                                      |
+| `arrowFunctionReturnTypes`        | `false`  | Show return types for arrow functions                                         |
+| `parameterNameHints`              | `'all'`  | Show parameter names: `'none'`, `'literals'`, or `'all'`                      |
+| `suppressWhenArgumentMatchesName` | `true`   | Suppress parameter hints when argument matches parameter name                 |
+| `propertyBindingTypes`            | `false`  | Show types for property/input bindings                                        |
+| `pipeOutputTypes`                 | `false`  | Show pipe output types                                                        |
+| `twoWayBindingSignalTypes`        | `false`  | Show signal types for two-way bindings                                        |
+| `requiredInputIndicator`          | `'none'` | Required input indicator: `'none'`, `'asterisk'`, `'exclamation'`             |
+| `interactiveInlayHints`           | `false`  | Enable click-to-navigate type definitions                                     |
+| `hostListenerArgumentTypes`       | `false`  | Show `@HostListener` argument types                                           |
+| `switchExpressionTypes`           | `false`  | Show `@switch` expression types                                               |
+| `deferTriggerTypes`               | `false`  | Show `@defer` trigger types                                                   |
+
+To disable all Angular inlay hints, you can set `editor.inlayHints.enabled` to `"off"` in your VS Code settings.

--- a/vscode-ng-language-service/client/src/config_change.ts
+++ b/vscode-ng-language-service/client/src/config_change.ts
@@ -1,0 +1,39 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export interface ConfigurationChangeLike {
+  affectsConfiguration(section: string): boolean;
+}
+
+export function shouldRestartOnConfigurationChange(e: ConfigurationChangeLike): boolean {
+  if (e.affectsConfiguration('typescript.tsdk')) {
+    return true;
+  }
+
+  if (!e.affectsConfiguration('angular')) {
+    return false;
+  }
+
+  const affectsInlayHints =
+    e.affectsConfiguration('angular.inlayHints') || e.affectsConfiguration('editor.inlayHints');
+
+  if (!affectsInlayHints) {
+    return true;
+  }
+
+  const affectsNonInlayAngularSettings =
+    e.affectsConfiguration('angular.log') ||
+    e.affectsConfiguration('angular.trace.server') ||
+    e.affectsConfiguration('angular.enable-strict-mode-prompt') ||
+    e.affectsConfiguration('angular.suggest') ||
+    e.affectsConfiguration('angular.forceStrictTemplates') ||
+    e.affectsConfiguration('angular.suppressAngularDiagnosticCodes') ||
+    e.affectsConfiguration('angular.server');
+
+  return affectsNonInlayAngularSettings;
+}

--- a/vscode-ng-language-service/client/src/embedded_support.ts
+++ b/vscode-ng-language-service/client/src/embedded_support.ts
@@ -35,6 +35,25 @@ export function isNotTypescriptOrSupportedDecoratorField(
 }
 
 /**
+ * Determines if a range is eligible for Angular language-service requests.
+ *
+ * For TypeScript files this is true when either range endpoint is within a
+ * supported decorator field. Non-TypeScript documents are always eligible.
+ */
+export function isNotTypescriptOrSupportedDecoratorRange(
+  document: vscode.TextDocument,
+  range: vscode.Range,
+): boolean {
+  if (document.languageId !== 'typescript') {
+    return true;
+  }
+  return (
+    isNotTypescriptOrSupportedDecoratorField(document, range.start) ||
+    isNotTypescriptOrSupportedDecoratorField(document, range.end)
+  );
+}
+
+/**
  * Determines if the position is inside a string literal. Returns `true` if the document language is
  * not TypeScript.
  */

--- a/vscode-ng-language-service/client/src/extension.ts
+++ b/vscode-ng-language-service/client/src/extension.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 
 import {AngularLanguageClient} from './client';
 import {registerCommands} from './commands';
+import {shouldRestartOnConfigurationChange} from './config_change';
 
 export function activate(context: vscode.ExtensionContext) {
   const client = new AngularLanguageClient(context);
@@ -18,10 +19,10 @@ export function activate(context: vscode.ExtensionContext) {
   // client can be deactivated on extension deactivation
   registerCommands(client, context);
 
-  // Restart the server on configuration change.
+  // Restart the server on configuration changes that affect startup/session state.
   const disposable = vscode.workspace.onDidChangeConfiguration(
     async (e: vscode.ConfigurationChangeEvent) => {
-      if (!e.affectsConfiguration('angular')) {
+      if (!shouldRestartOnConfigurationChange(e)) {
         return;
       }
       await client.stop();

--- a/vscode-ng-language-service/client/src/tests/embedded_support_spec.ts
+++ b/vscode-ng-language-service/client/src/tests/embedded_support_spec.ts
@@ -5,10 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import {DocumentUri, TextDocument} from 'vscode-languageserver-textdocument';
 
-import {isNotTypescriptOrSupportedDecoratorField} from '../embedded_support';
+import {
+  isNotTypescriptOrSupportedDecoratorField,
+  isNotTypescriptOrSupportedDecoratorRange,
+} from '../embedded_support';
 
 describe('embedded language support', () => {
   describe('isInsideAngularContext', () => {
@@ -88,7 +91,60 @@ describe('embedded language support', () => {
       );
     });
   });
+
+  describe('isNotTypescriptOrSupportedDecoratorRange', () => {
+    it('returns true for non-TypeScript documents', () => {
+      const vdoc = TextDocument.create(
+        'test.html' as DocumentUri,
+        'html',
+        0,
+        '<div></div>',
+      ) as {} as vscode.TextDocument;
+      (vdoc as any).fileName = 'test.html';
+      const range = makeRange(vdoc, 0, 5);
+      expect(isNotTypescriptOrSupportedDecoratorRange(vdoc, range)).toBeTrue();
+    });
+
+    it('returns true when range start is in supported decorator field', () => {
+      const source = `const cmp = {template: '<div>foo</div>'};`;
+      const vdoc = TextDocument.create(
+        'test.ts' as DocumentUri,
+        'typescript',
+        0,
+        source,
+      ) as {} as vscode.TextDocument;
+      (vdoc as any).fileName = 'test.ts';
+
+      const start = source.indexOf('foo');
+      const end = source.indexOf('const');
+      const range = makeRange(vdoc, start, end);
+      expect(isNotTypescriptOrSupportedDecoratorRange(vdoc, range)).toBeTrue();
+    });
+
+    it('returns false when both endpoints are outside supported decorator fields', () => {
+      const source = `const cmp = {template: '<div>foo</div>'};\nconst x = 1;`;
+      const vdoc = TextDocument.create(
+        'test.ts' as DocumentUri,
+        'typescript',
+        0,
+        source,
+      ) as {} as vscode.TextDocument;
+      (vdoc as any).fileName = 'test.ts';
+
+      const start = source.indexOf('const x');
+      const end = source.indexOf('= 1') + 3;
+      const range = makeRange(vdoc, start, end);
+      expect(isNotTypescriptOrSupportedDecoratorRange(vdoc, range)).toBeFalse();
+    });
+  });
 });
+
+function makeRange(document: vscode.TextDocument, start: number, end: number): vscode.Range {
+  return {
+    start: document.positionAt(start),
+    end: document.positionAt(end),
+  } as vscode.Range;
+}
 
 function test(
   fileWithCursor: string,

--- a/vscode-ng-language-service/client/src/tests/extension_spec.ts
+++ b/vscode-ng-language-service/client/src/tests/extension_spec.ts
@@ -1,0 +1,59 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type * as vscode from 'vscode';
+
+import {shouldRestartOnConfigurationChange} from '../config_change';
+
+describe('extension config restart policy', () => {
+  it('does not restart for inlay-only angular settings', () => {
+    expect(
+      shouldRestartOnConfigurationChange(
+        createConfigChangeEvent(['angular', 'angular.inlayHints']),
+      ),
+    ).toBeFalse();
+  });
+
+  it('does not restart for editor inlay hints only', () => {
+    expect(
+      shouldRestartOnConfigurationChange(createConfigChangeEvent(['editor.inlayHints'])),
+    ).toBeFalse();
+  });
+
+  it('restarts for non-inlay angular settings', () => {
+    expect(shouldRestartOnConfigurationChange(createConfigChangeEvent(['angular.log']))).toBeTrue();
+  });
+
+  it('restarts for mixed inlay and non-inlay angular settings', () => {
+    expect(
+      shouldRestartOnConfigurationChange(
+        createConfigChangeEvent(['angular', 'angular.inlayHints', 'angular.suggest']),
+      ),
+    ).toBeTrue();
+  });
+
+  it('restarts for typescript.tsdk changes', () => {
+    expect(
+      shouldRestartOnConfigurationChange(createConfigChangeEvent(['typescript.tsdk'])),
+    ).toBeTrue();
+  });
+
+  it('does not restart for unrelated settings', () => {
+    expect(
+      shouldRestartOnConfigurationChange(createConfigChangeEvent(['editor.fontSize'])),
+    ).toBeFalse();
+  });
+});
+
+function createConfigChangeEvent(affected: string[]): vscode.ConfigurationChangeEvent {
+  return {
+    affectsConfiguration: (section: string): boolean => {
+      return affected.some((entry) => entry === section || entry.startsWith(`${section}.`));
+    },
+  } as vscode.ConfigurationChangeEvent;
+}

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -112,6 +112,37 @@ describe('Angular language server', () => {
     expect(diagnostics[0].relatedInformation![0].location.uri).toBe(FOO_COMPONENT_URI);
   });
 
+  it('should not publish duplicate diagnostics for the same @let warning', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @let a = 100;
+    <div [style]="{'padding': '20px'}"></div>
+  \`,
+})
+export class AppComponent {}`,
+    );
+
+    const diagnostics = await getDiagnosticsForFile(client, APP_COMPONENT);
+    const letDiagnostics = diagnostics.filter((d) => d.message.includes('@let a is declared'));
+
+    expect(letDiagnostics.length).toBeGreaterThan(0);
+
+    const uniqueKeys = new Set(
+      letDiagnostics.map(
+        (d) =>
+          `${d.message}|${d.code}|${d.range.start.line}:${d.range.start.character}-${d.range.end.line}:${d.range.end.character}`,
+      ),
+    );
+    expect(uniqueKeys.size).toBe(letDiagnostics.length);
+  });
+
   it('should support request cancellation', async () => {
     openTextDocument(client, APP_COMPONENT);
     // Send a request and immediately cancel it
@@ -631,6 +662,833 @@ export class AppComponent {
     expect(codeLensResolveResponse?.command?.title).toEqual('Go to component');
   });
 
+  describe('inlay hints', () => {
+    it('should provide TypeScript inlay hints for component class', async () => {
+      openTextDocument(client, APP_COMPONENT);
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 20, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // The server should respond (may be empty if TS inlay hints are disabled,
+      // but the request itself should succeed)
+      expect(response).toBeDefined();
+      // response can be null or empty array if TS has no hints to show
+      // The important thing is that the request doesn't fail
+    });
+
+    it('should handle inlay hints for external template', async () => {
+      openTextDocument(client, FOO_TEMPLATE);
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 10, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // For HTML templates, we currently don't provide Angular-specific hints
+      // (that's a future enhancement), but the request should succeed
+      expect(response).toBeDefined();
+    });
+
+    it('should provide parameter name hints for all @HostListener mapped arguments', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+          languageId: 'typescript',
+          version: 1,
+          text: `
+import {Component, HostListener} from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: '',
+  standalone: false,
+})
+export class AppComponent {
+  @HostListener('click', ['$event', '$event.target'])
+  onClick2(tedt: PointerEvent, targets: EventTarget | null) {}
+}
+`,
+        },
+      });
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 30, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      const labels = (response ?? []).map((h) =>
+        typeof h.label === 'string' ? h.label : h.label.map((part) => part.value).join(''),
+      );
+      expect(labels).toContain('tedt:');
+      expect(labels).toContain('targets:');
+    });
+
+    it('should provide HostListener type hints for all mapped arguments including second arg', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+          languageId: 'typescript',
+          version: 1,
+          text: `
+import {Directive, HostListener} from '@angular/core';
+
+@Directive({
+  selector: '[myDir]',
+  standalone: false,
+})
+export class MyDir {
+  @HostListener('keydown', ['$event', '$event.target'])
+  onHostKey(event: KeyboardEvent, target: EventTarget | null) {}
+}
+`,
+        },
+      });
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 30, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      const labels = (response ?? []).map((h) =>
+        typeof h.label === 'string' ? h.label : h.label.map((part) => part.value).join(''),
+      );
+      expect(labels.some((l) => l.includes('KeyboardEvent'))).toBeTrue();
+
+      const targetHint = (response ?? []).find((h) => {
+        const label =
+          typeof h.label === 'string' ? h.label : h.label.map((part) => part.value).join('');
+        return label.includes('EventTarget | null');
+      });
+      expect(targetHint).toBeDefined();
+
+      // Ensure the EventTarget hint is attached to the second mapped argument (`$event.target`).
+      const hostListenerLine = "  @HostListener('keydown', ['$event', '$event.target'])";
+      const secondArgStart = hostListenerLine.indexOf('$event.target');
+      expect(targetHint!.position.line).toBe(8);
+      expect(targetHint!.position.character).toBeGreaterThanOrEqual(secondArgStart);
+    });
+
+    it('should provide array literal parameter name hints in TypeScript templates', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+          languageId: 'typescript',
+          version: 1,
+          text: `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: '{{ sum([1, 2, 3]) }}',
+  standalone: false,
+})
+export class AppComponent {
+  sum(values: number[]): number {
+    return values.reduce((acc, n) => acc + n, 0);
+  }
+}
+`,
+        },
+      });
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 30, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      const labels = (response ?? []).map((h) =>
+        typeof h.label === 'string' ? h.label : h.label.map((part) => part.value).join(''),
+      );
+      expect(labels).toContain('values:');
+    });
+
+    it('should resolve inlay hints', async () => {
+      openTextDocument(client, APP_COMPONENT);
+
+      // First get some hints
+      const hints = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: APP_COMPONENT_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 20, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // If we have any hints, try to resolve one
+      if (hints && hints.length > 0) {
+        const resolved = await client.sendRequest(lsp.InlayHintResolveRequest.type, hints[0]);
+        expect(resolved).toBeDefined();
+        // Resolved hint should have at least the same position
+        expect(resolved.position).toEqual(hints[0].position);
+      }
+    });
+
+    it('should return inlay hints response for external template', async () => {
+      // Use existing foo.component.html which has a simple template
+      openTextDocument(client, FOO_TEMPLATE);
+
+      // First verify diagnostics work (confirms Angular LS is working)
+      const diagnostics = await getDiagnosticsForFile(client, FOO_TEMPLATE);
+      expect(diagnostics).toBeDefined();
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 10, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // The InlayHint request should succeed (response is null or array)
+      // For external templates, we may not have hints yet if the feature
+      // isn't fully implemented, but the request shouldn't fail
+      // Check that response is either null or an array (not undefined)
+      expect(response === null || Array.isArray(response)).toBe(true);
+    });
+
+    it('should provide Angular inlay hints for @if alias', async () => {
+      // Create a component with @if and alias
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@if (title; as result) {
+  <div>{{ result }}</div>
+}`,
+        },
+      });
+
+      // Wait for diagnostics to ensure the file is processed
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have at least one hint for the @if alias
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      expect(response!.length).toBeGreaterThan(0);
+
+      // Find the alias hint - should show the type (string for title)
+      const aliasHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('string');
+      });
+      expect(aliasHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for pipe output types in template expressions', async () => {
+      // Use existing foo.component.html which has a pipe: {{title | uppercase}}
+      openTextDocument(client, FOO_TEMPLATE);
+
+      // Wait for diagnostics to ensure the file is processed
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      // Now try inlay hints
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 10, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have at least one hint for the pipe
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      expect(response!.length).toBeGreaterThan(0);
+
+      // Find the pipe hint - should show the output type of uppercase pipe
+      const pipeHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('string');
+      });
+      expect(pipeHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for @for loop variables', async () => {
+      // Create a template with @for loop
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@for (item of [1, 2, 3]; track item; let idx = $index) {
+  <div>{{ item }} at {{ idx }}</div>
+}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have hints for the loop variable and possibly context variables
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      expect(response!.length).toBeGreaterThan(0);
+
+      // Find hint for the loop item (should be number)
+      const itemHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('number');
+      });
+      expect(itemHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for multiple @let declarations', async () => {
+      // Create a template with @let declaration
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@let doubled = 2 * 2;
+<div>{{ doubled }}</div>`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have a hint for the @let declaration
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      expect(response!.length).toBeGreaterThan(0);
+
+      // The hint should show number type for the multiplication result
+      const letHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('number');
+      });
+      expect(letHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for event parameter types', async () => {
+      // Create a template with event binding using $event
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `<button (click)="onClick($event)">Click me</button>`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // The hint might be present if the implementation supports it
+      expect(response === null || Array.isArray(response)).toBe(true);
+
+      // If hints are returned, check for MouseEvent or Event type
+      if (response && response.length > 0) {
+        const eventHint = response.find((h) => {
+          const label =
+            typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+          return label.includes('MouseEvent') || label.includes('Event');
+        });
+        // Event hint is optional - some configurations might not enable it
+        if (eventHint) {
+          expect(eventHint.position).toBeDefined();
+        }
+      }
+    });
+
+    it('should provide inlay hints for structural directive let variables', async () => {
+      // Create a template with ngFor structural directive (let-item pattern)
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `<ng-template ngFor let-item [ngForOf]="[1, 2, 3]" let-i="index">
+  <div>{{ item }} at {{ i }}</div>
+</ng-template>`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Hints should be returned for let variables
+      expect(response === null || Array.isArray(response)).toBe(true);
+
+      // If hints are returned, check for number type hints
+      if (response && response.length > 0) {
+        const numberHint = response.find((h) => {
+          const label =
+            typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+          return label.includes('number');
+        });
+        // Number hint expected for the item and index
+        expect(numberHint).toBeDefined();
+      }
+    });
+
+    it('should provide inlay hints for pipes in property bindings', async () => {
+      // Create a template with pipe in property binding
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `<div [title]="title | uppercase">Hover me</div>`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have a hint for the pipe output
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      expect(response!.length).toBeGreaterThan(0);
+
+      // Find the pipe hint - should show string type
+      const pipeHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('string');
+      });
+      expect(pipeHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for chained pipes', async () => {
+      // Create a template with chained pipes
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `{{ title | uppercase | lowercase }}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      // Should have hints for each pipe in the chain
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+      // At least 2 hints for 2 pipes
+      expect(response!.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should not produce duplicate inlay hints for @for loop variables', async () => {
+      // Regression test: TmplAstRecursiveVisitor visits variables twice
+      // (once in visitForLoopBlock, once via visitVariable) which caused duplicates
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@for (item of [1, 2, 3]; track item; let idx = $index) {
+  {{ item }}
+}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Count hints with ': number' - there should be exactly 2:
+      // one for 'item' and one for 'idx'
+      const numberHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': number';
+      });
+
+      // Should have exactly 2 number hints, not 4+ (which would happen with duplicates)
+      expect(numberHints.length).toBe(2);
+    });
+
+    it('should not produce duplicate inlay hints for @if alias', async () => {
+      // Regression test: @if alias was being visited twice causing duplicate hints
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@if (title; as myTitle) {
+  {{ myTitle }}
+}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Count hints with ': string' - there should be exactly 1 for 'myTitle'
+      const stringHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': string';
+      });
+
+      // Should have exactly 1 string hint, not 2 (which would happen with duplicates)
+      expect(stringHints.length).toBe(1);
+    });
+
+    it('should provide inlay hints for @else if alias', async () => {
+      // @else if also supports the 'as' alias syntax
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@if (false) {
+  never
+} @else if (title; as elseIfAlias) {
+  {{ elseIfAlias }}
+}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 10, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have a hint for the @else if alias
+      const stringHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': string';
+      });
+
+      // Should have exactly 1 string hint for 'elseIfAlias'
+      expect(stringHints.length).toBe(1);
+    });
+
+    it('should provide inlay hints for @let declarations', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `@let greeting = title;
+@let doubled = 2 * 2;
+{{ greeting }} {{ doubled }}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have hints for both @let declarations
+      const stringHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': string';
+      });
+      const numberHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': number';
+      });
+
+      expect(stringHints.length).toBe(1); // greeting: string
+      expect(numberHints.length).toBe(1); // doubled: number
+    });
+
+    it('should provide inlay hints for pipe output types', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `{{ title | uppercase }}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 1, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have a hint for the pipe output type
+      const pipeHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('string');
+      });
+
+      expect(pipeHints.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should provide inlay hints for template reference variables', async () => {
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `<input #myInput>
+<div #myDiv>content</div>
+{{ myInput.value }} {{ myDiv.textContent }}`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 5, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have hints for #myInput (HTMLInputElement) and #myDiv (HTMLDivElement)
+      const inputHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('HTMLInputElement');
+      });
+      const divHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('HTMLDivElement');
+      });
+
+      expect(inputHint).toBeDefined();
+      expect(divHint).toBeDefined();
+
+      // Interactive hints should carry location metadata for type label parts.
+      expect(inputHint).toBeDefined();
+      if (inputHint && Array.isArray(inputHint.label)) {
+        const typePart = inputHint.label.find((part) => part.value.includes('HTMLInputElement'));
+        expect(typePart?.location).toBeDefined();
+        expect(typePart?.location?.uri).toContain('lib.dom');
+      }
+    });
+
+    it('should provide inlay hints for structural directive variables (*ngFor)', async () => {
+      // Use a template with *ngFor that uses a simple string array
+      client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+          languageId: 'html',
+          version: 1,
+          text: `<div *ngFor="let char of title; let idx = index">{{ char }} {{ idx }}</div>`,
+        },
+      });
+
+      await getDiagnosticsForFile(client, FOO_TEMPLATE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: FOO_TEMPLATE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 2, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).toBeDefined();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have hints for 'char' (string) and 'idx' (number)
+      const charHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': string';
+      });
+      const idxHint = response!.find((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label === ': number';
+      });
+
+      expect(charHint).toBeDefined();
+      expect(idxHint).toBeDefined();
+    });
+
+    it('should provide inlay hints for host event bindings', async () => {
+      const HIGHLIGHT_DIRECTIVE = join(PROJECT_PATH, 'app', 'highlight.directive.ts');
+      const HIGHLIGHT_DIRECTIVE_URI = pathToFileURL(HIGHLIGHT_DIRECTIVE).toString();
+
+      openTextDocument(client, HIGHLIGHT_DIRECTIVE);
+      await getDiagnosticsForFile(client, HIGHLIGHT_DIRECTIVE);
+
+      const response = (await client.sendRequest(lsp.InlayHintRequest.type, {
+        textDocument: {
+          uri: HIGHLIGHT_DIRECTIVE_URI,
+        },
+        range: {
+          start: {line: 0, character: 0},
+          end: {line: 30, character: 0},
+        },
+      })) as lsp.InlayHint[] | null;
+
+      expect(response).not.toBeNull();
+      expect(Array.isArray(response)).toBe(true);
+
+      // Should have event type hints for the $event parameter in host event handlers
+      // Note: click events are PointerEvent in modern browsers, mouseenter is MouseEvent
+      const eventHints = response!.filter((h) => {
+        const label = typeof h.label === 'string' ? h.label : h.label.map((l) => l.value).join('');
+        return label.includes('MouseEvent') || label.includes('PointerEvent');
+      });
+
+      // Should have at least 2 event type hints (one for click=PointerEvent, one for mouseenter=MouseEvent)
+      expect(eventHints.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   it('detects an Angular project', async () => {
     openTextDocument(client, FOO_TEMPLATE);
     const templateResponse = await client.sendRequest(IsInAngularProject, {
@@ -666,15 +1524,17 @@ export class AppComponent {
               {
                 'newText': '\nimport { BarComponent } from "./bar.component";',
                 'range': {
-                  'start': {'line': 5, 'character': 45},
-                  'end': {'line': 5, 'character': 45},
+                  // Line numbers adjusted for HighlightDirective import
+                  'start': {'line': 6, 'character': 57},
+                  'end': {'line': 6, 'character': 57},
                 },
               },
               {
                 'newText': 'imports: [CommonModule, PostModule, BarComponent]',
                 'range': {
-                  'start': {'line': 8, 'character': 2},
-                  'end': {'line': 8, 'character': 37},
+                  // Line numbers adjusted for HighlightDirective import
+                  'start': {'line': 9, 'character': 2},
+                  'end': {'line': 9, 'character': 37},
                 },
               },
             ],

--- a/vscode-ng-language-service/integration/project/app/app.module.ts
+++ b/vscode-ng-language-service/integration/project/app/app.module.ts
@@ -4,10 +4,11 @@ import {PostModule} from 'post';
 
 import {AppComponent} from './app.component';
 import {FooComponent} from './foo.component';
+import {HighlightDirective} from './highlight.directive';
 
 @NgModule({
   imports: [CommonModule, PostModule],
-  declarations: [AppComponent, FooComponent],
+  declarations: [AppComponent, FooComponent, HighlightDirective],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/vscode-ng-language-service/integration/project/app/highlight.directive.ts
+++ b/vscode-ng-language-service/integration/project/app/highlight.directive.ts
@@ -1,0 +1,27 @@
+import {Directive, HostListener} from '@angular/core';
+
+@Directive({
+  selector: '[appHighlight]',
+  standalone: false,
+  host: {
+    '(click)': 'handleClick($event)',
+    '(mouseenter)': 'handleMouseEnter($event)',
+    '[class.highlighted]': 'isHighlighted',
+    '[style.backgroundColor]': 'bgColor',
+    '[attr.data-highlight]': 'highlightId',
+  },
+})
+export class HighlightDirective {
+  isHighlighted = false;
+  bgColor = 'yellow';
+  highlightId = 'highlight-1';
+
+  handleClick(event: MouseEvent) {
+    console.log('clicked', event);
+    this.isHighlighted = !this.isHighlighted;
+  }
+
+  handleMouseEnter(event: MouseEvent) {
+    console.log('mouse entered', event);
+  }
+}

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -161,6 +161,119 @@
             "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
           }
         }
+      },
+      {
+        "title": "Inlay Hints",
+        "properties": {
+          "angular.inlayHints.bindingHints.pipeOutputTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for pipe output types.\n\nExample:\n\n```html\n{{ value | async /* : User | null */ }}\n```"
+          },
+          "angular.inlayHints.bindingHints.propertyBindingTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for property/input bindings.\n\nExample:\n\n```html\n<cmp [disabled /* : boolean */]=\"flag\" />\n```"
+          },
+          "angular.inlayHints.bindingHints.requiredInputIndicator": {
+            "type": "string",
+            "enum": [
+              "none",
+              "asterisk",
+              "exclamation"
+            ],
+            "default": "none",
+            "markdownDescription": "Visual indicator for required inputs. `'asterisk'` shows `*`, `'exclamation'` shows `!` after the type.\n\nExample:\n\n```html\n<cmp [requiredInput /* : string* */]=\"value\" />\n```"
+          },
+          "angular.inlayHints.bindingHints.twoWayBindingSignalTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show signal type hints for two-way bindings.\n\nExample:\n\n```html\n<cmp [(value /* : WritableSignal<string> */)]=\"model\" />\n```"
+          },
+          "angular.inlayHints.controlFlowHints.deferTriggerTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for `@defer` `when` trigger expressions. The expression is evaluated by truthiness, so its type is not always `boolean`.\n\nExample:\n\n```html\n@defer (when user /* : User | null */) { ... }\n```"
+          },
+          "angular.inlayHints.controlFlowHints.switchExpressionTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for `@switch` expression types.\n\nExample:\n\n```html\n@switch (status /* : Status */) { ... }\n```"
+          },
+          "angular.inlayHints.eventHints.hostListenerArgumentTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for host listener handler arguments.\n\nExamples:\n\n```ts\n@HostListener('keydown', ['$event', '$event.target'])\nonHostKey(event /* : KeyboardEvent */, target /* : EventTarget | null */) {}\n```\n\n```ts\nhost: {\n  '(keydown)': 'onHostKey($event /* : KeyboardEvent */, $event.target /* : EventTarget | null */)',\n}\n```"
+          },
+          "angular.inlayHints.eventHints.parameterTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for event binding `$event` parameter.\n\nExample:\n\n```html\n<button (click)=\"onClick($event /* : MouseEvent */)\"></button>\n```"
+          },
+          "angular.inlayHints.functionTypes.arrowFunctionParameterTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for arrow function parameters in templates.\n\nExample:\n\n```html\n{{ value | apply : (x /* : number */) => x * 2 }}\n```"
+          },
+          "angular.inlayHints.functionTypes.arrowFunctionReturnTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show return type hints for arrow functions in templates.\n\nExample:\n\n```html\n{{ value | apply : (x) /* : number */ => x * 2 }}\n```"
+          },
+          "angular.inlayHints.interaction.interactiveInlayHints": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable interactive inlay hints that navigate to definitions when clicked.\n\nExample:\n\n```html\n{{ formatAmount(/* precision: */ 2) }}\n```\n\nWith this enabled, hint parts can be navigated."
+          },
+          "angular.inlayHints.parameterHints.nameHints": {
+            "type": "string",
+            "enum": [
+              "none",
+              "literals",
+              "all"
+            ],
+            "default": "all",
+            "markdownDescription": "Show parameter name hints for function/method calls. `'literals'` shows hints only for literal arguments.\n\nExample:\n\n```html\n{{ formatAmount(/* value: */ amount, /* precision: */ 2) }}\n```"
+          },
+          "angular.inlayHints.variableTypes.forLoopVariableTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for `@for` loop variables.\n\nExample:\n\n```html\n@for (user /* : User */ of users) { ... }\n```"
+          },
+          "angular.inlayHints.variableTypes.ifAliasTypes": {
+            "type": [
+              "boolean",
+              "string"
+            ],
+            "enum": [
+              true,
+              false,
+              "complex"
+            ],
+            "default": false,
+            "markdownDescription": "Show type hints for `@if` alias variables. Set to `'complex'` to only show hints for complex expressions.\n\nExamples:\n\n```html\n@if (user; as u) { {{ u.name }} } // simple expression\n@if (user.profile; as profile /* : Profile */) { {{ profile.name }} } // complex expression\n```"
+          },
+          "angular.inlayHints.variableTypes.letDeclarationTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for `@let` declarations.\n\nExample:\n\n```html\n@let count /* : number */ = items.length\n```"
+          },
+          "angular.inlayHints.variableTypes.referenceVariableTypes": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show type hints for template reference variables.\n\nExample:\n\n```html\n<input #input /* : HTMLInputElement */ />\n```"
+          },
+          "angular.inlayHints.parameterHints.suppressWhenArgumentMatchesName": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Suppress parameter name hints when argument name matches parameter name.\n\nExample:\n\n```html\n{{ onClick(user) }}\n```\n\nWhen enabled, suppresses hints where argument text already conveys the same name."
+          },
+          "angular.inlayHints.variableTypes.suppressWhenTypeMatchesName": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Suppress variable type hints when variable name matches type name (case-insensitive).\n\nExample:\n\n```html\n@let user = getUser()\n```\n\nWhen enabled, suppresses `/* : User */` for names like `user: User`."
+          }
+        }
       }
     ],
     "grammars": [

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -99,68 +99,70 @@
         }
       ]
     },
-    "configuration": {
-      "title": "Angular Language Service",
-      "properties": {
-        "angular.log": {
-          "type": "string",
-          "enum": [
-            "off",
-            "terse",
-            "normal",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
-        },
-        "angular.enable-strict-mode-prompt": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.dev/reference/configs/angular-compiler-options)."
-        },
-        "angular.trace.server": {
-          "type": "string",
-          "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the Angular language server."
-        },
-        "angular.suggest.includeAutomaticOptionalChainCompletions": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled."
-        },
-        "angular.suggest.includeCompletionsWithSnippetText": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace."
-        },
-        "angular.suggest.autoImports": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable/disable auto import suggestions for the exported Angular components from the current project."
-        },
-        "angular.forceStrictTemplates": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
-        },
-        "angular.suppressAngularDiagnosticCodes": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "A comma-separated list of error codes in templates whose diagnostics should be ignored."
-        },
-        "angular.server.useClientSideFileWatcher": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+    "configuration": [
+      {
+        "title": "Preferences",
+        "properties": {
+          "angular.log": {
+            "type": "string",
+            "enum": [
+              "off",
+              "terse",
+              "normal",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
+          },
+          "angular.trace.server": {
+            "type": "string",
+            "scope": "window",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Traces the communication between VS Code and the Angular language server."
+          },
+          "angular.enable-strict-mode-prompt": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.dev/reference/configs/angular-compiler-options)."
+          },
+          "angular.forceStrictTemplates": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
+          },
+          "angular.suppressAngularDiagnosticCodes": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "A comma-separated list of error codes in templates whose diagnostics should be ignored."
+          },
+          "angular.suggest.includeAutomaticOptionalChainCompletions": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled."
+          },
+          "angular.suggest.includeCompletionsWithSnippetText": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace."
+          },
+          "angular.suggest.autoImports": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable/disable auto import suggestions for the exported Angular components from the current project."
+          },
+          "angular.server.useClientSideFileWatcher": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+          }
         }
       }
-    },
+    ],
     "grammars": [
       {
         "path": "./syntaxes/inline-template.json",

--- a/vscode-ng-language-service/server/src/config.ts
+++ b/vscode-ng-language-service/server/src/config.ts
@@ -1,0 +1,148 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as lsp from 'vscode-languageserver/node';
+
+const workspaceConfigCache = new WeakMap<lsp.Connection, Map<string, unknown[]>>();
+
+/**
+ * A single configuration item to request from the client.
+ *
+ * See LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration
+ */
+export interface ConfigurationItem {
+  /**
+   * The scope to get the configuration section for.
+   * This is typically a file URI (e.g., file:///path/to/file.ts).
+   * When provided, VS Code returns workspace folder-specific settings
+   * that apply to that file's workspace folder.
+   */
+  scopeUri?: string;
+
+  /**
+   * The configuration section asked for.
+   * For example: 'typescript.inlayHints' or 'angular.inlayHints'
+   * This corresponds to the key prefix in settings.json.
+   */
+  section?: string;
+}
+
+/**
+ * Request workspace configuration from the client.
+ *
+ * This uses the LSP workspace/configuration request which allows the server
+ * to pull configuration from the client on-demand. This is the preferred
+ * approach over CLI arguments because:
+ *
+ * 1. Configuration changes take effect immediately without restarting
+ * 2. Supports per-workspace and per-folder configuration
+ * 3. VS Code automatically merges settings from different scopes:
+ *    - Default settings
+ *    - User settings (global)
+ *    - Workspace settings
+ *    - Workspace folder settings
+ *    - Language-specific settings
+ *
+ * The client returns the effective (merged) configuration value for each item.
+ *
+ * @param connection The LSP connection to the client
+ * @param items Array of configuration items to request
+ * @returns Array of configuration values, one for each requested item
+ *
+ * @example
+ * ```typescript
+ * const [tsConfig, angularConfig] = await getWorkspaceConfiguration(
+ *   session.connection,
+ *   [
+ *     { section: 'typescript.inlayHints', scopeUri: documentUri },
+ *     { section: 'angular.inlayHints', scopeUri: documentUri },
+ *   ]
+ * );
+ * ```
+ */
+export async function getWorkspaceConfiguration<T = unknown>(
+  connection: lsp.Connection,
+  items: ConfigurationItem[],
+): Promise<T[]> {
+  try {
+    return await connection.workspace.getConfiguration(items);
+  } catch (error) {
+    // Return empty objects if the client doesn't support workspace/configuration
+    // This provides graceful degradation for older clients
+    return items.map(() => ({}) as T);
+  }
+}
+
+/**
+ * Request workspace configuration with simple per-connection memoization.
+ *
+ * Cache entries are invalidated when the server receives workspace/didChangeConfiguration.
+ */
+export async function getWorkspaceConfigurationCached<T = unknown>(
+  connection: lsp.Connection,
+  items: ConfigurationItem[],
+): Promise<T[]> {
+  const key = JSON.stringify(items);
+  let cache = workspaceConfigCache.get(connection);
+  if (!cache) {
+    cache = new Map();
+    workspaceConfigCache.set(connection, cache);
+  }
+
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached as T[];
+  }
+
+  const value = await getWorkspaceConfiguration<T>(connection, items);
+  cache.set(key, value as unknown[]);
+  return value;
+}
+
+export function clearWorkspaceConfigurationCache(connection: lsp.Connection): void {
+  workspaceConfigCache.delete(connection);
+}
+
+/**
+ * Flatten a nested configuration object into a flat object with dot-notation keys.
+ *
+ * VS Code returns configuration as nested objects based on the section hierarchy.
+ * This utility flattens them into a format that's easier to work with when
+ * mapping to internal configuration formats.
+ *
+ * @param config The nested configuration object
+ * @param prefix The prefix to use for the keys (typically the section name)
+ * @returns A flat object with dot-notation keys
+ *
+ * @example
+ * ```typescript
+ * // Input: { parameterNames: { enabled: 'all' } }
+ * // Output: { 'typescript.inlayHints.parameterNames.enabled': 'all' }
+ * const flat = flattenConfiguration(tsConfig, 'typescript.inlayHints');
+ * ```
+ */
+export function flattenConfiguration(
+  config: Record<string, unknown>,
+  prefix: string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  function flatten(obj: Record<string, unknown>, currentPrefix: string): void {
+    for (const [key, value] of Object.entries(obj)) {
+      const newKey = `${currentPrefix}.${key}`;
+      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        flatten(value as Record<string, unknown>, newKey);
+      } else {
+        result[newKey] = value;
+      }
+    }
+  }
+
+  flatten(config, prefix);
+  return result;
+}

--- a/vscode-ng-language-service/server/src/handlers/initialization.ts
+++ b/vscode-ng-language-service/server/src/handlers/initialization.ts
@@ -52,6 +52,11 @@ export function onInitialize(session: Session, params: lsp.InitializeParams): ls
         // [here](https://github.com/angular/vscode-ng-language-service/issues/1828)
         codeActionKinds: [lsp.CodeActionKind.QuickFix],
       },
+      // Inlay hints provider (LSP 3.17)
+      // Provides type annotations for template variables, $event types, etc.
+      inlayHintProvider: {
+        resolveProvider: true,
+      },
     },
     serverOptions,
   };

--- a/vscode-ng-language-service/server/src/handlers/inlay_hints.ts
+++ b/vscode-ng-language-service/server/src/handlers/inlay_hints.ts
@@ -1,0 +1,343 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as lsp from 'vscode-languageserver/node';
+import * as ts from 'typescript/lib/tsserverlibrary';
+import {Session} from '../session';
+import {lspRangeToTsPositions} from '../utils';
+import {filePathToUri} from '../utils';
+import {getWorkspaceConfigurationCached, flattenConfiguration} from '../config';
+import {
+  isNgLanguageService,
+  AngularInlayHint,
+  InlayHintsConfig,
+} from '@angular/language-service/api';
+
+function isEditorInlayHintsEnabled(vsCodeConfig: Record<string, unknown>): boolean {
+  const editorEnabled = vsCodeConfig['editor.inlayHints.enabled'];
+  return !(editorEnabled === 'off' || editorEnabled === false);
+}
+
+/**
+ * Map VS Code's Angular inlay hints configuration to InlayHintsConfig.
+ */
+function mapAngularInlayHintsConfig(vsCodeConfig: Record<string, unknown>): InlayHintsConfig {
+  const config: InlayHintsConfig = {};
+
+  const getConfigValue = <T>(...keys: string[]): T | undefined => {
+    for (const key of keys) {
+      if (vsCodeConfig[key] !== undefined && vsCodeConfig[key] !== null) {
+        return vsCodeConfig[key] as T;
+      }
+    }
+    return undefined;
+  };
+
+  const forLoopVariableTypes = getConfigValue<boolean>(
+    'angular.inlayHints.variableTypes.forLoopVariableTypes',
+  );
+  if (forLoopVariableTypes !== undefined) config.forLoopVariableTypes = forLoopVariableTypes;
+
+  const ifAliasTypes = getConfigValue<boolean | 'complex'>(
+    'angular.inlayHints.variableTypes.ifAliasTypes',
+  );
+  if (ifAliasTypes !== undefined) config.ifAliasTypes = ifAliasTypes;
+
+  const letDeclarationTypes = getConfigValue<boolean>(
+    'angular.inlayHints.variableTypes.letDeclarationTypes',
+  );
+  if (letDeclarationTypes !== undefined) config.letDeclarationTypes = letDeclarationTypes;
+
+  const referenceVariableTypes = getConfigValue<boolean>(
+    'angular.inlayHints.variableTypes.referenceVariableTypes',
+  );
+  if (referenceVariableTypes !== undefined) config.referenceVariableTypes = referenceVariableTypes;
+
+  const suppressWhenTypeMatchesName = getConfigValue<boolean>(
+    'angular.inlayHints.variableTypes.suppressWhenTypeMatchesName',
+  );
+  if (suppressWhenTypeMatchesName !== undefined) {
+    config.variableTypeHintsWhenTypeMatchesName = !suppressWhenTypeMatchesName;
+  }
+
+  const arrowFunctionParameterTypes = getConfigValue<boolean>(
+    'angular.inlayHints.functionTypes.arrowFunctionParameterTypes',
+  );
+  if (arrowFunctionParameterTypes !== undefined) {
+    config.arrowFunctionParameterTypes = arrowFunctionParameterTypes;
+  }
+
+  const arrowFunctionReturnTypes = getConfigValue<boolean>(
+    'angular.inlayHints.functionTypes.arrowFunctionReturnTypes',
+  );
+  if (arrowFunctionReturnTypes !== undefined) {
+    config.arrowFunctionReturnTypes = arrowFunctionReturnTypes;
+  }
+
+  const parameterNameHints = getConfigValue<'none' | 'literals' | 'all'>(
+    'angular.inlayHints.parameterHints.nameHints',
+  );
+  if (parameterNameHints !== undefined) config.parameterNameHints = parameterNameHints;
+
+  const suppressWhenArgumentMatchesName = getConfigValue<boolean>(
+    'angular.inlayHints.parameterHints.suppressWhenArgumentMatchesName',
+  );
+  if (suppressWhenArgumentMatchesName !== undefined) {
+    config.parameterNameHintsWhenArgumentMatchesName = !suppressWhenArgumentMatchesName;
+  }
+
+  const eventParameterTypes = getConfigValue<boolean>(
+    'angular.inlayHints.eventHints.parameterTypes',
+  );
+  if (eventParameterTypes !== undefined) config.eventParameterTypes = eventParameterTypes;
+
+  const propertyBindingTypes = getConfigValue<boolean>(
+    'angular.inlayHints.bindingHints.propertyBindingTypes',
+  );
+  if (propertyBindingTypes !== undefined) config.propertyBindingTypes = propertyBindingTypes;
+
+  const pipeOutputTypes = getConfigValue<boolean>(
+    'angular.inlayHints.bindingHints.pipeOutputTypes',
+  );
+  if (pipeOutputTypes !== undefined) config.pipeOutputTypes = pipeOutputTypes;
+
+  const twoWayBindingSignalTypes = getConfigValue<boolean>(
+    'angular.inlayHints.bindingHints.twoWayBindingSignalTypes',
+  );
+  if (twoWayBindingSignalTypes !== undefined) {
+    config.twoWayBindingSignalTypes = twoWayBindingSignalTypes;
+  }
+
+  const requiredInputIndicator = getConfigValue<'none' | 'asterisk' | 'exclamation'>(
+    'angular.inlayHints.bindingHints.requiredInputIndicator',
+  );
+  if (requiredInputIndicator !== undefined) {
+    config.requiredInputIndicator = requiredInputIndicator;
+  }
+
+  const interactiveInlayHints = getConfigValue<boolean>(
+    'angular.inlayHints.interaction.interactiveInlayHints',
+  );
+  if (interactiveInlayHints !== undefined) config.interactiveInlayHints = interactiveInlayHints;
+
+  const hostListenerArgumentTypes = getConfigValue<boolean>(
+    'angular.inlayHints.eventHints.hostListenerArgumentTypes',
+  );
+  if (hostListenerArgumentTypes !== undefined) {
+    config.hostListenerArgumentTypes = hostListenerArgumentTypes;
+  }
+
+  const switchExpressionTypes = getConfigValue<boolean>(
+    'angular.inlayHints.controlFlowHints.switchExpressionTypes',
+  );
+  if (switchExpressionTypes !== undefined) config.switchExpressionTypes = switchExpressionTypes;
+
+  const deferTriggerTypes = getConfigValue<boolean>(
+    'angular.inlayHints.controlFlowHints.deferTriggerTypes',
+  );
+  if (deferTriggerTypes !== undefined) config.deferTriggerTypes = deferTriggerTypes;
+
+  return config;
+}
+
+/**
+ * Handle the textDocument/inlayHint request (LSP 3.17).
+ *
+ * This handler provides inlay hints for Angular templates, showing:
+ * - Types of template variables (from *ngFor, @for, @if aliases)
+ * - Event parameter types ($event)
+ * - Pipe output types
+ * - Signal types
+ *
+ * This handler returns Angular-specific template inlay hints.
+ * TypeScript inlay hints are provided by TypeScript's own provider in VS Code.
+ */
+export async function onInlayHint(
+  session: Session,
+  params: lsp.InlayHintParams,
+): Promise<lsp.InlayHint[] | null> {
+  const lsInfo = session.getLSAndScriptInfo(params.textDocument);
+  if (!lsInfo) {
+    return null;
+  }
+
+  const {languageService, scriptInfo} = lsInfo;
+  const hints: lsp.InlayHint[] = [];
+
+  // Get the text span for the requested range
+  const [startOffset, endOffset] = lspRangeToTsPositions(scriptInfo, params.range);
+  const span = {start: startOffset, length: endOffset - startOffset};
+
+  // Request workspace configuration from the client for Angular inlay hints.
+  let angularConfig: InlayHintsConfig = {};
+
+  try {
+    // Request configuration from the client using shared config infrastructure
+    const configResult = await getWorkspaceConfigurationCached<Record<string, unknown>>(
+      session.connection,
+      [
+        {section: 'angular.inlayHints', scopeUri: params.textDocument.uri},
+        {section: 'editor.inlayHints', scopeUri: params.textDocument.uri},
+      ],
+    );
+
+    if (configResult && configResult.length >= 2) {
+      // Flatten each config section using the shared utility
+      const flatConfig: Record<string, unknown> = {
+        ...flattenConfiguration(configResult[0] ?? {}, 'angular.inlayHints'),
+        ...flattenConfiguration(configResult[1] ?? {}, 'editor.inlayHints'),
+      };
+
+      if (!isEditorInlayHintsEnabled(flatConfig)) {
+        return null;
+      }
+      angularConfig = mapAngularInlayHintsConfig(flatConfig);
+    }
+  } catch {
+    // If configuration request fails, use defaults
+  }
+
+  // Get Angular-specific inlay hints for templates
+  //    - @for item variable types: @for (user: User of users)
+  //    - @if alias types: @if (data; as result: ApiResult)
+  //    - $event parameter types: (click)="onClick($event: MouseEvent)"
+  //    - Pipe output types: {{ value | async }}
+  //    - @let declaration types
+  if (isNgLanguageService(languageService)) {
+    try {
+      const angularHints = languageService.getAngularInlayHints(
+        scriptInfo.fileName,
+        span,
+        angularConfig,
+      );
+      for (const angularHint of angularHints) {
+        const position = scriptInfo.positionToLineOffset(angularHint.position);
+        hints.push(convertAngularInlayHint(session, angularHint, position));
+      }
+    } catch (e) {
+      // Silently ignore - Angular hints are optional
+    }
+  }
+
+  return hints.length > 0 ? hints : null;
+}
+
+/**
+ * Handle the inlayHint/resolve request.
+ *
+ * This is called when the user requests lazy resolution for an inlay hint.
+ * For now, we just return the hint as-is since we don't have expensive data to defer.
+ */
+export function onInlayHintResolve(session: Session, hint: lsp.InlayHint): lsp.InlayHint {
+  // Currently, all our hints are fully computed upfront.
+  // In the future, we could defer tooltip computation here.
+  return hint;
+}
+
+/**
+ * Convert an Angular InlayHint to an LSP InlayHint.
+ */
+function convertAngularInlayHint(
+  session: Session,
+  angularHint: AngularInlayHint,
+  position: {line: number; offset: number},
+): lsp.InlayHint {
+  // Convert to LSP's 0-based line/character
+  const lspPosition: lsp.Position = {
+    line: position.line - 1,
+    character: position.offset - 1,
+  };
+
+  // Map Angular hint kind to LSP InlayHintKind
+  const kind = angularHint.kind === 'Type' ? lsp.InlayHintKind.Type : lsp.InlayHintKind.Parameter;
+
+  // Build the label - can be string or InlayHintLabelPart[] for interactive hints
+  let label: string | lsp.InlayHintLabelPart[];
+  if (angularHint.displayParts && angularHint.displayParts.length > 0) {
+    // Interactive hints with navigation support
+    label = angularHint.displayParts.map((part) => {
+      const labelPart: lsp.InlayHintLabelPart = {
+        value: part.text,
+      };
+      const location = getDisplayPartLocation(session, part);
+      if (location) {
+        labelPart.location = location;
+      }
+      return labelPart;
+    });
+  } else {
+    // Non-interactive hints
+    label = angularHint.text;
+  }
+
+  const hint: lsp.InlayHint = {
+    position: lspPosition,
+    label,
+    kind,
+    paddingLeft: angularHint.paddingLeft,
+    paddingRight: angularHint.paddingRight,
+  };
+
+  if (angularHint.tooltip) {
+    hint.tooltip = angularHint.tooltip;
+  }
+
+  return hint;
+}
+
+function getDisplayPartLocation(
+  session: Session,
+  part: {
+    span?: {start: number; length: number};
+    file?: string;
+  },
+): lsp.Location | undefined {
+  if (!part.span || !part.file) {
+    return undefined;
+  }
+
+  const scriptInfo = session.projectService.getScriptInfo(part.file);
+  if (scriptInfo) {
+    const start = scriptInfo.positionToLineOffset(part.span.start);
+    const end = scriptInfo.positionToLineOffset(part.span.start + part.span.length);
+
+    return {
+      uri: filePathToUri(part.file),
+      range: {
+        start: {line: start.line - 1, character: start.offset - 1},
+        end: {line: end.line - 1, character: end.offset - 1},
+      },
+    };
+  }
+
+  const text = readFileText(session, part.file);
+  if (text === undefined) {
+    return undefined;
+  }
+
+  const sourceFile = ts.createSourceFile(part.file, text, ts.ScriptTarget.Latest, true);
+  const start = ts.getLineAndCharacterOfPosition(sourceFile, part.span.start);
+  const end = ts.getLineAndCharacterOfPosition(sourceFile, part.span.start + part.span.length);
+
+  return {
+    uri: filePathToUri(part.file),
+    range: {
+      start: {line: start.line, character: start.character},
+      end: {line: end.line, character: end.character},
+    },
+  };
+}
+
+function readFileText(session: Session, fileName: string): string | undefined {
+  const scriptInfo = session.projectService.getScriptInfo(fileName);
+  if (scriptInfo) {
+    const snapshot = scriptInfo.getSnapshot();
+    return snapshot.getText(0, snapshot.getLength());
+  }
+  return ts.sys.readFile(fileName);
+}

--- a/vscode-ng-language-service/server/src/tests/config_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/config_spec.ts
@@ -1,0 +1,120 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  clearWorkspaceConfigurationCache,
+  flattenConfiguration,
+  getWorkspaceConfigurationCached,
+} from '../config';
+
+describe('flattenConfiguration', () => {
+  it('should flatten a simple nested object', () => {
+    const config = {
+      enabled: 'all',
+      suppressWhenArgumentMatchesName: true,
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints.parameterNames');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+    });
+  });
+
+  it('should flatten deeply nested objects', () => {
+    const config = {
+      parameterNames: {
+        enabled: 'all',
+        suppressWhenArgumentMatchesName: true,
+      },
+      variableTypes: {
+        enabled: true,
+      },
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+      'typescript.inlayHints.variableTypes.enabled': true,
+    });
+  });
+
+  it('should handle arrays as leaf values', () => {
+    const config = {
+      items: ['a', 'b', 'c'],
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.items': ['a', 'b', 'c'],
+    });
+  });
+
+  it('should handle null values', () => {
+    const config = {
+      value: null,
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.value': null,
+    });
+  });
+
+  it('should handle empty objects', () => {
+    const config = {};
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({});
+  });
+
+  it('should handle mixed value types', () => {
+    const config = {
+      stringVal: 'test',
+      numberVal: 42,
+      boolVal: false,
+      nested: {
+        deep: 'value',
+      },
+    };
+    const result = flattenConfiguration(config, 'config');
+    expect(result).toEqual({
+      'config.stringVal': 'test',
+      'config.numberVal': 42,
+      'config.boolVal': false,
+      'config.nested.deep': 'value',
+    });
+  });
+
+  it('should memoize workspace configuration requests for identical items', async () => {
+    const getConfiguration = jasmine.createSpy().and.resolveTo([{}, {}]);
+    const connection = {
+      workspace: {
+        getConfiguration,
+      },
+    } as any;
+
+    const items = [{section: 'angular.inlayHints'}, {section: 'editor.inlayHints'}];
+    await getWorkspaceConfigurationCached(connection, items);
+    await getWorkspaceConfigurationCached(connection, items);
+
+    expect(getConfiguration).toHaveBeenCalledTimes(1);
+  });
+
+  it('should invalidate cached workspace configuration entries', async () => {
+    const getConfiguration = jasmine.createSpy().and.resolveTo([{}]);
+    const connection = {
+      workspace: {
+        getConfiguration,
+      },
+    } as any;
+
+    const items = [{section: 'angular.inlayHints', scopeUri: 'file:///workspace/app.component.ts'}];
+    await getWorkspaceConfigurationCached(connection, items);
+    clearWorkspaceConfigurationCache(connection);
+    await getWorkspaceConfigurationCached(connection, items);
+
+    expect(getConfiguration).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

## PR Type

- [x] Feature
- [x] Refactoring (small infrastructure extraction to simplify review)

## What is the current behavior?

Issue Number: #66730

## What is the new behavior?

This PR adds Angular-specific template inlay hints end-to-end across the language service and VS Code extension.

It also includes a small server-side workspace configuration helper refactor so inlay hint settings can be pulled and refreshed cleanly.

Highlights:

- Angular template inlay hints for variables, bindings, events, pipes, and control flow.
- LSP `textDocument/inlayHint` and `inlayHint/resolve` support in the extension server.
- Angular inlay hint settings in the VS Code extension with runtime refresh behavior.
- Request guards to avoid Angular inlay hint requests on unsupported TypeScript regions.
- Unit and integration regression coverage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- This PR no longer has an external dependency on a separate workspace-configuration PR.

## Screenshots
<img width="909" height="587" alt="image" src="https://github.com/user-attachments/assets/1a35283d-e299-4e7f-98b6-0aa1547f73c0" />

<img width="762" height="363" alt="image" src="https://github.com/user-attachments/assets/e0ee5747-35e5-4230-9543-12f2f2f39ccb" />

<img width="464" height="156" alt="image" src="https://github.com/user-attachments/assets/0ed22ea9-23f8-4dbc-8f31-e4ac018c4891" />

<img width="663" height="259" alt="image" src="https://github.com/user-attachments/assets/0e520d04-4c2f-4af9-8447-760dd38bb1f7" />

