### PR TITLE
fix(router): Do not intercept reload events with Navigation integration

### DIFF
--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -239,8 +239,7 @@ export class NavigationStateManager extends StateManager {
       // initiated outside the router, we do need to replace it with a router-triggered navigation
       // to add the router-specific state.
       (navigationEvent &&
-        (navigationEvent.navigationType === 'traverse' ||
-          navigationEvent.navigationType === 'reload') &&
+        navigationEvent.navigationType === 'traverse' &&
         this.eventAndRouterDestinationsMatch(navigationEvent, transition))
     ) {
       return;
@@ -388,7 +387,10 @@ export class NavigationStateManager extends StateManager {
   private handleNavigate(event: NavigateEvent) {
     // If the event cannot be intercepted (e.g., cross-origin, or some browser-internal
     // navigations), let the browser handle it.
-    if (!event.canIntercept) {
+    // We also do not convert reload navigation events to SPA navigations. Intercepting
+    // would prevent the generally expected hard refresh. If an application wants special
+    // handling for reloads, they can implement it in their own `navigate` event listener.
+    if (!event.canIntercept || event.navigationType === 'reload') {
       return;
     }
 


### PR DESCRIPTION
This commit prevents the Router from intercepting reload navigations in the navigate event listener. This would convert hard page reloads to SPA navigations.

fixes #66746
