### PR TITLE
docs: normalize spacing in animation example boxes

### DIFF
--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter-binding.css
@@ -6,9 +6,13 @@
 .enter-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
+}
+
+.enter-container p {
+  margin: 0;
 }
 
 .enter-animation {

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/enter.css
@@ -6,9 +6,13 @@
 .enter-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
+}
+
+.enter-container p {
+  margin: 0;
 }
 
 .enter-animation {

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-binding.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;
@@ -15,6 +15,10 @@
   @starting-style {
     opacity: 0;
   }
+}
+
+.leave-container p {
+  margin: 0;
 }
 
 .leaving {

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-event.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;
@@ -15,6 +15,10 @@
   @starting-style {
     opacity: 0;
   }
+}
+
+.leave-container p {
+  margin: 0;
 }
 
 .leaving {

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave-parent.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;
@@ -15,6 +15,10 @@
   @starting-style {
     opacity: 0;
   }
+}
+
+.leave-container p {
+  margin: 0;
 }
 
 .leaving {

--- a/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
+++ b/adev/src/content/examples/animations/src/app/enter-and-leave/leave.css
@@ -6,7 +6,7 @@
 .leave-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;
@@ -15,6 +15,10 @@
   @starting-style {
     opacity: 0;
   }
+}
+
+.leave-container p {
+  margin: 0;
 }
 
 .leaving {


### PR DESCRIPTION
Simplifies box padding and removes default paragraph margins to ensure consistent spacing and alignment in the animation examples.

## What is the current behavior?
<img width="1574" height="514" alt="image" src="https://github.com/user-attachments/assets/de52f496-dbb0-4c6b-8cd7-5af7469ce055" />

<img width="1578" height="574" alt="image" src="https://github.com/user-attachments/assets/cfd77729-b02b-4905-b7b7-3c0839e9225c" />


## What is the new behavior?
<img width="1552" height="276" alt="image" src="https://github.com/user-attachments/assets/6bb85325-9cd9-43d6-a41c-99fb553fac84" />
