### PR TITLE
fix(router): Do not intercept reload events with Navigation integration

### DIFF
--- a/packages/router/src/statemanager/navigation_state_manager.ts
+++ b/packages/router/src/statemanager/navigation_state_manager.ts
@@ -191,8 +191,7 @@ export class NavigationStateManager extends StateManager {
     // to add the router-specific state.
     if (
       navigationEvent &&
-      (navigationEvent.navigationType === 'traverse' ||
-        navigationEvent.navigationType === 'reload') &&
+      navigationEvent.navigationType === 'traverse' &&
       this.eventAndRouterDestinationsMatch(navigationEvent, transition)
     ) {
       return;
@@ -339,7 +338,10 @@ export class NavigationStateManager extends StateManager {
   private handleNavigate(event: NavigateEvent) {
     // If the event cannot be intercepted (e.g., cross-origin, or some browser-internal
     // navigations), let the browser handle it.
-    if (!event.canIntercept) {
+    // We also do not convert reload navigation events to SPA navigations. Intercepting
+    // would prevent the generally expected hard refresh. If an application wants special
+    // handling for reloads, they can implement it in their own `navigate` event listener.
+    if (!event.canIntercept || event.navigationType === 'reload') {
       return;
     }
 

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed} from '@angular/core/testing';
-import {provideRouter, Router} from '../src';
+import {provideRouter, Event, Router} from '../src';
 import {withExperimentalPlatformNavigation, withRouterConfig} from '../src/provide_router';
 import {withBody} from '@angular/private/testing';
 import {
@@ -241,5 +241,29 @@ if (typeof window !== 'undefined' && 'navigation' in window) {
         expect(router.url).toBe('/somewhere');
       }),
     );
+
+    it('should not convert reload events to SPA navigations', async () => {
+      const navigation = TestBed.inject(PlatformNavigation);
+      navigation.addEventListener(
+        'navigate',
+        (e: NavigateEvent) => {
+          e.intercept({
+            handler: () => new Promise((_, reject) => setTimeout(reject, 2)),
+          });
+        },
+        {once: true},
+      );
+      const routerEvents: Event[] = [];
+      router.events.subscribe((e) => routerEvents.push(e));
+      router.resetConfig([
+        {
+          path: '**',
+          children: [],
+        },
+      ]);
+      navigation.reload();
+      await timeout(3);
+      expect(routerEvents).toEqual([]);
+    });
   });
 }


### PR DESCRIPTION
This commit prevents the Router from intercepting reload navigations in the navigate event listener. This would convert hard page reloads to SPA navigations.

fixes #66746
