### PR TITLE
feat(common): support height in `ImageLoaderConfig` and built-i…

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -334,6 +334,7 @@ export type ImageLoader = (config: ImageLoaderConfig) => string;
 
 // @public
 export interface ImageLoaderConfig {
+    height?: number;
     isPlaceholder?: boolean;
     loaderParams?: {
         [key: string]: any;

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
@@ -34,6 +34,10 @@ function createCloudflareUrl(path: string, config: ImageLoaderConfig) {
     params += `,width=${config.width}`;
   }
 
+  if (config.height) {
+    params += `,height=${config.height}`;
+  }
+
   // When requesting a placeholder image we ask for a low quality image to reduce the load time.
   if (config.isPlaceholder) {
     params += `,quality=${PLACEHOLDER_QUALITY}`;

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
@@ -65,6 +65,10 @@ function createCloudinaryUrl(path: string, config: ImageLoaderConfig) {
     params += `,w_${config.width}`;
   }
 
+  if (config.height) {
+    params += `,h_${config.height}`;
+  }
+
   if (config.loaderParams?.['rounded']) {
     params += `,r_max`;
   }

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -28,6 +28,10 @@ export interface ImageLoaderConfig {
    */
   width?: number;
   /**
+   * Height of the requested image (to be used when generating srcset).
+   */
+  height?: number;
+  /**
    * Whether the loader should generate a URL for a small image placeholder instead of a full-sized
    * image.
    */

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
@@ -54,6 +54,10 @@ export function createImagekitUrl(path: string, config: ImageLoaderConfig): stri
     params.push(`w-${width}`);
   }
 
+  if (config.height) {
+    params.push(`h-${config.height}`);
+  }
+
   // When requesting a placeholder image we ask for a low quality image to reduce the load time.
   if (config.isPlaceholder) {
     params.push(`q-${PLACEHOLDER_QUALITY}`);

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
@@ -52,6 +52,10 @@ function createImgixUrl(path: string, config: ImageLoaderConfig) {
     params.push(`w=${config.width}`);
   }
 
+  if (config.height) {
+    params.push(`h=${config.height}`);
+  }
+
   // When requesting a placeholder image we ask a low quality image to reduce the load time.
   if (config.isPlaceholder) {
     params.push(`q=${PLACEHOLDER_QUALITY}`);

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/netlify_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/netlify_loader.ts
@@ -91,6 +91,10 @@ function createNetlifyUrl(config: ImageLoaderConfig, path?: string) {
     url.searchParams.set('w', config.width.toString());
   }
 
+  if (config.height) {
+    url.searchParams.set('h', config.height.toString());
+  }
+
   // When requesting a placeholder image we ask for a low quality image to reduce the load time.
   // If the quality is specified in the loader config - always use provided value.
   const configQuality = config.loaderParams?.['quality'] ?? config.loaderParams?.['q'];

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -573,12 +573,28 @@ export class NgOptimizedImage implements OnInit, OnChanges {
     }
   }
 
+  /**
+   * Calculates the aspect ratio of the image based on width and height.
+   * Returns null if the aspect ratio cannot be calculated (missing dimensions or height is 0).
+   */
+  private getAspectRatio(): number | null {
+    if (this.width && this.height && this.height !== 0) {
+      return this.width / this.height;
+    }
+    return null;
+  }
+
   private callImageLoader(
     configWithoutCustomParams: Omit<ImageLoaderConfig, 'loaderParams'>,
   ): string {
     let augmentedConfig: ImageLoaderConfig = configWithoutCustomParams;
     if (this.loaderParams) {
       augmentedConfig.loaderParams = this.loaderParams;
+    }
+    // Calculate height if width is provided and aspect ratio is available
+    const ratio = this.getAspectRatio();
+    if (ratio !== null && augmentedConfig.width) {
+      augmentedConfig.height = Math.round(augmentedConfig.width / ratio);
     }
     return this.imageLoader(augmentedConfig);
   }


### PR DESCRIPTION
…n loaders

Introduces an optional `height` property in `ImageLoaderConfig`, allowing built-in image loaders to generate URLs with explicit height parameters. This improves layout control and enables better support for loaders that require height-based transformations.

Closes #51723

 
## What is the current behavior?
We can take the following example, in which a transformation will not work correctly unless we have an explicit `height`

 https://stackblitz.com/edit/stackblitz-starters-tupnmbnu?file=src%2Fmain.ts

## What is the new behavior?

 To be able to have an explicit height

 