### PR TITLE
docs: remove dead guide link

### DIFF
--- a/adev/src/app/routing/redirections.ts
+++ b/adev/src/app/routing/redirections.ts
@@ -32,10 +32,6 @@ export const REDIRECT_ROUTES: Route[] = [
     redirectTo: '/guide/templates/defer',
   },
   {
-    path: 'guide/components/importing',
-    redirectTo: '/guide/components/anatomy-of-components#using-components',
-  },
-  {
     path: 'guide/templates/attribute-binding',
     redirectTo: '/guide/templates/binding#binding-dynamic-properties-and-attributes',
   },

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -15,7 +15,7 @@ import {containsElement, getParentElement, invokeQuery, validateStyleProperty} f
  *
  * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  *
- * `AnimationDriver` implentation for Noop animations
+ * `AnimationDriver` implementation for Noop animations
  */
 @Injectable()
 export class NoopAnimationDriver implements AnimationDriver {

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -183,7 +183,7 @@ export interface ImagePlaceholderConfig {
  * - Warns if the image will be visually distorted when rendered
  *
  * @usageNotes
- * The `NgOptimizedImage` directive is marked as [standalone](guide/components/importing) and can
+ * The `NgOptimizedImage` directive is marked as [standalone](guide/components) and can
  * be imported directly.
  *
  * Follow the steps below to enable and use the directive:

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -112,7 +112,7 @@ type WalkProviderTreeVisitor = (
  * providers.
  *
  * More information about standalone components can be found in [this
- * guide](guide/components/importing).
+ * guide](guide/components).
  *
  * @usageNotes
  * The results of the `importProvidersFrom` call can be used in the `bootstrapApplication` call:

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -49,7 +49,7 @@ export interface DirectiveDecorator {
    *
    * ### Declaring directives
    *
-   * By default, directives are marked as [standalone](guide/components/importing), which makes
+   * By default, directives are marked as [standalone](guide/components), which makes
    * them available to other components in your application.
    *
    * ```ts
@@ -336,7 +336,7 @@ export interface Directive {
    * providers).
    *
    * More information about standalone components, directives, and pipes can be found in [this
-   * guide](guide/components/importing).
+   * guide](guide/components).
    */
   standalone?: boolean;
 
@@ -631,7 +631,7 @@ export interface Component extends Directive {
    * used in a template) via the imports property.
    *
    * More information about standalone components, directives, and pipes can be found in [this
-   * guide](guide/components/importing).
+   * guide](guide/components).
    */
   standalone?: boolean;
 
@@ -644,7 +644,7 @@ export interface Component extends Directive {
    * declared in an NgModule generates a compilation error.
    *
    * More information about standalone components, directives, and pipes can be found in [this
-   * guide](guide/components/importing).
+   * guide](guide/components).
    */
   imports?: (Type<any> | ReadonlyArray<any>)[];
 
@@ -667,7 +667,7 @@ export interface Component extends Directive {
    * declared in an NgModule generates a compilation error.
    *
    * More information about standalone components, directives, and pipes can be found in [this
-   * guide](guide/components/importing).
+   * guide](guide/components).
    */
   schemas?: SchemaMetadata[];
 }
@@ -751,7 +751,7 @@ export interface Pipe {
    * pipes don't depend on any "intermediate context" of an NgModule (ex. configured providers).
    *
    * More information about standalone components, directives, and pipes can be found in [this
-   * guide](guide/components/importing).
+   * guide](guide/components).
    */
   standalone?: boolean;
 }

--- a/packages/core/src/render3/def_getters.ts
+++ b/packages/core/src/render3/def_getters.ts
@@ -77,7 +77,7 @@ function assertTypeDefined(type: any, symbolType: string): void {
 /**
  * Checks whether a given Component, Directive or Pipe is marked as standalone.
  * This will return false if passed anything other than a Component, Directive, or Pipe class
- * See [this guide](guide/components/importing) for additional information:
+ * See [this guide](guide/components) for additional information:
  *
  * @param type A reference to a Component, Directive or Pipe.
  * @publicApi

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -65,7 +65,7 @@ export interface BootstrapContext {
 /**
  * Bootstraps an instance of an Angular application and renders a standalone component as the
  * application's root component. More information about standalone components can be found in [this
- * guide](guide/components/importing).
+ * guide](guide/components).
  *
  * @usageNotes
  * The root component passed into this function **must** be a standalone one


### PR DESCRIPTION
Updates the components guide reference by removing the outdated `guide/components/importing` link and pointing to the correct `guide/components` page.
