### PR TITLE
test(common): enables zoneless change detection in tests

### DIFF
--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -20,7 +20,6 @@ import {
   NgModule,
   NO_ERRORS_SCHEMA,
   Optional,
-  provideZonelessChangeDetection,
   QueryList,
   TemplateRef,
   Type,
@@ -35,7 +34,6 @@ describe('insert/remove', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TestModule],
-      providers: [provideZonelessChangeDetection()],
     });
   });
 

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -9,7 +9,6 @@
 import {CommonModule} from '../../index';
 import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
 import {
-  Compiler,
   Component,
   ComponentRef,
   createEnvironmentInjector,
@@ -19,9 +18,9 @@ import {
   Injector,
   Input,
   NgModule,
-  NgModuleFactory,
   NO_ERRORS_SCHEMA,
   Optional,
+  provideZonelessChangeDetection,
   QueryList,
   TemplateRef,
   Type,
@@ -34,7 +33,10 @@ import {expect} from '@angular/private/testing/matchers';
 
 describe('insert/remove', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [TestModule]});
+    TestBed.configureTestingModule({
+      imports: [TestModule],
+      providers: [provideZonelessChangeDetection()],
+    });
   });
 
   it('should do nothing if component is null', waitForAsync(() => {

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -11,7 +11,7 @@ import {
   Component,
   PLATFORM_ID,
   Provider,
-  provideZoneChangeDetection,
+  provideZonelessChangeDetection,
   Type,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -43,7 +43,7 @@ import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_imag
 describe('Image directive', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideZoneChangeDetection()],
+      providers: [provideZonelessChangeDetection()],
     });
   });
 
@@ -734,6 +734,7 @@ describe('Image directive', () => {
           // Update input (expect to throw)
           (fixture.componentInstance as unknown as {[key: string]: unknown})[inputName as string] =
             value;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
         }).toThrowError(new RegExp(expectedErrorMessage));
       });
@@ -1872,6 +1873,7 @@ describe('Image directive', () => {
       expect(imgs[0].src).toBe(`${IMG_BASE_URL}/img.png`);
 
       fixture.componentInstance.ngSrc = 'updatedImg.png';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(imgs[0].src).toBe(`${IMG_BASE_URL}/updatedImg.png`);
     });
@@ -1900,6 +1902,7 @@ describe('Image directive', () => {
       );
 
       fixture.componentInstance.ngSrc = 'updatedImg.png';
+      fixture.changeDetectorRef.markForCheck();
       nativeElement = fixture.nativeElement as HTMLElement;
       imgs = nativeElement.querySelectorAll('img')!;
       fixture.detectChanges();

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  PLATFORM_ID,
-  Provider,
-  provideZonelessChangeDetection,
-  Type,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, PLATFORM_ID, Provider, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {isBrowser, isNode, withHead} from '@angular/private/testing';
@@ -41,12 +34,6 @@ import {
 import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_image/preconnect_link_checker';
 
 describe('Image directive', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   const PLACEHOLDER_BLUR_AMOUNT = 15;
 
   describe('preload <link> element on a server', () => {

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -18,7 +18,7 @@ describe('ngPlural', () => {
     return fixture.componentInstance;
   }
 
-  function detectChangesAndExpectText<T>(text: string): void {
+  function detectChangesAndExpectText(text: string): void {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText(text);

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -18,7 +18,6 @@ import {
   NO_ERRORS_SCHEMA,
   OnDestroy,
   Provider,
-  provideZonelessChangeDetection,
   QueryList,
   TemplateRef,
 } from '@angular/core';
@@ -52,7 +51,7 @@ describe('NgTemplateOutlet', () => {
         InjectValueComponent,
       ],
       imports: [CommonModule],
-      providers: [provideZonelessChangeDetection(), DestroyedSpyService],
+      providers: [DestroyedSpyService],
     });
   });
 

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -18,6 +18,7 @@ import {
   NO_ERRORS_SCHEMA,
   OnDestroy,
   Provider,
+  provideZonelessChangeDetection,
   QueryList,
   TemplateRef,
 } from '@angular/core';
@@ -51,7 +52,7 @@ describe('NgTemplateOutlet', () => {
         InjectValueComponent,
       ],
       imports: [CommonModule],
-      providers: [DestroyedSpyService],
+      providers: [provideZonelessChangeDetection(), DestroyedSpyService],
     });
   });
 


### PR DESCRIPTION
Adds `provideZonelessChangeDetection` to TestBed configurations in  `ngComponentOutlet` , `ngOptimizedImage` , `ngTemplateOutlet` and `ngPlural`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: Enable Zoneless Test

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
