### PR TITLE
refactor(forms): convert `FieldNode.controlValue` to a `WritableSignal`

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -128,7 +128,7 @@ export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = T
 
 // @public
 export interface FieldState<TValue, TKey extends string | number = string | number> {
-    readonly controlValue: Signal<TValue>;
+    readonly controlValue: WritableSignal<TValue>;
     readonly dirty: Signal<boolean>;
     readonly disabled: Signal<boolean>;
     // (undocumented)
@@ -154,7 +154,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     readonly readonly: Signal<boolean>;
     readonly required: Signal<boolean>;
     reset(value?: TValue): void;
-    setControlValue(value: TValue): void;
     readonly submitting: Signal<boolean>;
     readonly touched: Signal<boolean>;
     readonly valid: Signal<boolean>;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -362,12 +362,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * buffer debounced updates from the control to the field. This will also not take into account
    * the {@link controlValue} of children.
    */
-  readonly controlValue: Signal<TValue>;
-
-  /**
-   * Sets {@link controlValue} immediately and triggers synchronization to {@link value}.
-   */
-  setControlValue(value: TValue): void;
+  readonly controlValue: WritableSignal<TValue>;
 
   /**
    * Sets the dirty status of the field to `true`.

--- a/packages/forms/signals/src/directive/control_custom.ts
+++ b/packages/forms/signals/src/directive/control_custom.ts
@@ -22,7 +22,7 @@ export function customControlCreate(
   host: ControlDirectiveHost,
   parent: FormField<unknown>,
 ): () => void {
-  host.listenToCustomControlModel((value) => parent.state().setControlValue(value));
+  host.listenToCustomControlModel((value) => parent.state().controlValue.set(value));
   host.listenToCustomControlOutput('touchedChange', () => parent.state().markAsTouched());
 
   parent.registerAsBinding(host.customControl as FormUiControl<unknown>);

--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -22,7 +22,7 @@ export function cvaControlCreate(
   parent: FormField<unknown>,
 ): () => void {
   parent.controlValueAccessor!.registerOnChange((value: unknown) =>
-    parent.state().setControlValue(value as any),
+    parent.state().controlValue.set(value as any),
   );
   parent.controlValueAccessor!.registerOnTouched(() => parent.state().markAsTouched());
   parent.registerAsBinding();

--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -26,7 +26,7 @@ export function nativeControlCreate(
 
   host.listenToDom('input', () => {
     const state = parent.state();
-    state.setControlValue(getNativeControlValue(input, state.value));
+    state.controlValue.set(getNativeControlValue(input, state.value));
   });
 
   host.listenToDom('blur', () => parent.state().markAsTouched());

--- a/packages/forms/signals/test/node/api/debounce.spec.ts
+++ b/packages/forms/signals/test/node/api/debounce.spec.ts
@@ -23,7 +23,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
     });
@@ -39,7 +39,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -58,7 +58,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -79,7 +79,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
     });
@@ -95,7 +95,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -115,7 +115,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -142,10 +142,10 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
-      street.setControlValue('2000 N Shoreline Blvd');
+      street.controlValue.set('2000 N Shoreline Blvd');
       expect(street.value()).toBe('');
 
       first.resolve();
@@ -172,7 +172,7 @@ describe('debounce', () => {
       const street = addressForm.street();
 
       // Set `controlValue` which will trigger a debounce update.
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -204,10 +204,10 @@ describe('debounce', () => {
         );
         const street = addressForm.street();
 
-        street.setControlValue('1600 Amphitheatre Pkwy');
+        street.controlValue.set('1600 Amphitheatre Pkwy');
         expect(abortSpy).not.toHaveBeenCalled();
 
-        street.setControlValue('2000 N Shoreline Blvd');
+        street.controlValue.set('2000 N Shoreline Blvd');
         expect(abortSpy).toHaveBeenCalledTimes(1);
 
         resolve();
@@ -230,7 +230,7 @@ describe('debounce', () => {
         );
         const street = addressForm.street();
 
-        street.setControlValue('1600 Amphitheatre Pkwy');
+        street.controlValue.set('1600 Amphitheatre Pkwy');
         expect(abortSpy).not.toHaveBeenCalled();
 
         street.markAsTouched();
@@ -255,7 +255,7 @@ describe('debounce', () => {
         );
         const street = addressForm.street();
 
-        street.setControlValue('1600 Amphitheatre Pkwy');
+        street.controlValue.set('1600 Amphitheatre Pkwy');
         expect(addListenerSpy).toHaveBeenCalledOnceWith('abort', jasmine.any(Function), {
           once: true,
         });
@@ -280,7 +280,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -300,7 +300,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
     });
@@ -316,7 +316,7 @@ describe('debounce', () => {
         options(),
       );
 
-      addressForm().setControlValue({street: '1600 Amphitheatre Pkwy'});
+      addressForm().controlValue.set({street: '1600 Amphitheatre Pkwy'});
       expect(addressForm().controlValue()).toEqual({street: '1600 Amphitheatre Pkwy'});
       expect(addressForm().value()).toEqual({street: ''});
 
@@ -334,10 +334,10 @@ describe('debounce', () => {
         options(),
       );
 
-      addressForm.street().setControlValue('1600 Amphitheatre Pkwy');
+      addressForm.street().controlValue.set('1600 Amphitheatre Pkwy');
       expect(addressForm().value()).toEqual({street: '', city: ''});
 
-      addressForm.city().setControlValue('Mountain View');
+      addressForm.city().controlValue.set('Mountain View');
       expect(addressForm().value()).toEqual({street: '', city: 'Mountain View'});
 
       await timeout(0);
@@ -361,7 +361,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
     });
@@ -384,7 +384,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -417,12 +417,12 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
 
       debounced.set(true);
-      street.setControlValue('2000 N Shoreline Blvd');
+      street.controlValue.set('2000 N Shoreline Blvd');
       expect(street.controlValue()).toBe('2000 N Shoreline Blvd');
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
 
@@ -448,7 +448,7 @@ describe('debounce', () => {
       );
       const street = addressForm.street();
 
-      street.setControlValue('1600 Amphitheatre Pkwy');
+      street.controlValue.set('1600 Amphitheatre Pkwy');
       expect(street.controlValue()).toBe('1600 Amphitheatre Pkwy');
       expect(street.value()).toBe('');
 
@@ -456,7 +456,7 @@ describe('debounce', () => {
       expect(street.value()).toBe('1600 Amphitheatre Pkwy');
 
       debounced.set(false);
-      street.setControlValue('2000 N Shoreline Blvd');
+      street.controlValue.set('2000 N Shoreline Blvd');
       expect(street.value()).toBe('2000 N Shoreline Blvd');
     });
   });

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -616,7 +616,7 @@ describe('FieldNode', () => {
       // Same object identity because there was no change to flush to the name.
       expect(myForm().value()).toBe(product);
 
-      myForm.name().setControlValue('b');
+      myForm.name().controlValue.set('b');
       // Same object identity because the name change is still pending.
       expect(myForm().value()).toBe(product);
 


### PR DESCRIPTION
Remove `setControlValue()` from `Field` and convert `controlValue` to a `WritableSignal` whose setter implements the debounced syncing behavior of `setControlValue()`.

Also make sure that all signal reads during a sync are untracked.