### PR TITLE
fix(core): prevent element duplication with dynamic components

### DIFF
--- a/packages/core/src/animation/queue.ts
+++ b/packages/core/src/animation/queue.ts
@@ -100,3 +100,17 @@ export function queueEnterAnimations(
     addToAnimationQueue(injector, nodeAnimations.animateFns);
   }
 }
+
+export function removeAnimationsFromQueue(
+  injector: Injector,
+  animationFns: VoidFunction | VoidFunction[],
+) {
+  const animationQueue = injector.get(ANIMATION_QUEUE);
+  if (Array.isArray(animationFns)) {
+    for (const animateFn of animationFns) {
+      animationQueue.queue.delete(animateFn);
+    }
+  } else {
+    animationQueue.queue.delete(animationFns);
+  }
+}

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -84,7 +84,11 @@ import {ProfilerEvent} from '../../primitives/devtools';
 import {getLViewParent, getNativeByTNode, unwrapRNode} from './util/view_utils';
 import {allLeavingAnimations} from '../animation/longest_animation';
 import {Injector} from '../di';
-import {addToAnimationQueue, queueEnterAnimations} from '../animation/queue';
+import {
+  addToAnimationQueue,
+  queueEnterAnimations,
+  removeAnimationsFromQueue,
+} from '../animation/queue';
 import {RunLeaveAnimationFn} from '../animation/interfaces';
 
 const enum WalkTNodeTreeAction {
@@ -385,6 +389,10 @@ function runLeaveAnimationsWithCallback(
   callback: Function,
 ) {
   const animations = lView?.[ANIMATIONS];
+  if (animations?.enter?.has(tNode.index)) {
+    removeAnimationsFromQueue(injector, animations.enter.get(tNode.index)!.animateFns);
+  }
+
   if (animations == null || animations.leave == undefined || !animations.leave.has(tNode.index))
     return callback(false);
 

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -756,6 +756,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeClass",
       "removeElements",
       "removeFromArray",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -604,6 +604,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeElements",
       "removeFromArray",
       "removeLViewOnDestroy",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -656,6 +656,7 @@
       "registerPreOrderHooks",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeFromArray",
       "removeLViewFromLContainer",
       "removeLViewOnDestroy",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -875,6 +875,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeElements",
       "removeFromArray",
       "removeLViewOnDestroy",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -873,6 +873,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeElements",
       "removeFromArray",
       "removeLViewOnDestroy",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -697,6 +697,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeDehydratedView",
       "removeDehydratedViews",
       "removeElements",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1003,6 +1003,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeElements",
       "removeFromArray",
       "removeLViewOnDestroy",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -552,6 +552,7 @@
       "relativePath",
       "rememberChangeHistoryAndInvokeOnChangesHook",
       "remove",
+      "removeAnimationsFromQueue",
       "removeElements",
       "removeFromArray",
       "removeLViewOnDestroy",


### PR DESCRIPTION
When dynamic components are rapidly added and removed with animate.leave and animate.enter, a leave animation might fire before the enter animation could, causing an element to be retained. This fix prevents that from occuring by clearing the enter animations in this case.

fixes: #66794