### PR TITLE
fix(core): hold constructors weakly in DepsTracker cache

### DIFF
--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -31,10 +31,13 @@ import {
  * An implementation of DepsTrackerApi which will be used for JIT and local compilation.
  */
 class DepsTracker implements DepsTrackerApi {
-  private ownerNgModule = new Map<ComponentType<any>, NgModuleType<any>>();
+  private ownerNgModule = new WeakMap<ComponentType<any>, NgModuleType<any>>();
   private ngModulesWithSomeUnresolvedDecls = new Set<NgModuleType<any>>();
-  private ngModulesScopeCache = new Map<NgModuleType<any>, NgModuleScope>();
-  private standaloneComponentsScopeCache = new Map<ComponentType<any>, StandaloneComponentScope>();
+  private ngModulesScopeCache = new WeakMap<NgModuleType<any>, NgModuleScope>();
+  private standaloneComponentsScopeCache = new WeakMap<
+    ComponentType<any>,
+    StandaloneComponentScope
+  >();
 
   /**
    * Attempts to resolve ng module's forward ref declarations as much as possible and add them to


### PR DESCRIPTION
Otherwise a component can be held in memory longer than the component constructor is reachable from application code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the behavior?

When a component's constructor is no longer accessible it should not be held in memory by Angular
```typescript
it('is a test', async () => {
    const someDataIWantToBeCollected = generateData();

    @Component({template:''})
    class TestComponent {
        constructor() {
            console.log('I hold the data', someDataIWantToBeCollected);
        }
    }

     // Create an instance of TestComponent through a TestBed, do stuff that involves pulling data from the `DepsTracker`.
});
// PREVIOUSLY: The test has been completed, but `someDataIWantToBeCollected` is still being held in memory, because `standaloneComponentsScopeCache` is holding a reference to TestComponent's constructor.
// NOW: TestComponent is only held weakly by the cache, so when the test completes it is collected, as expected.
```
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

