### PR TITLE
docs(docs-infra): ensure code preview copy preserves spaces

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/entities/renderables.mts
@@ -167,11 +167,9 @@ export type CliCommandRenderable = CliCommand & {
   htmlDescription: string;
   cards: CliCardRenderable[];
   argumentsLabel: string;
-  hasOptions: boolean;
+  optionsLabel: string;
   subcommands?: CliCommandRenderable[];
 };
 
 export interface InitializerApiFunctionRenderable
-  extends Omit<InitializerApiFunctionEntry, 'jsdocTags'>,
-    DocEntryRenderable,
-    HasRenderableToc {}
+  extends Omit<InitializerApiFunctionEntry, 'jsdocTags'>, DocEntryRenderable, HasRenderableToc {}

--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
@@ -26,19 +26,15 @@ export function CliCommandReference(entry: CliCommandRenderable) {
               <code>
                 <div className={'shiki line cli'}>
                   ng {commandName(entry, command)}
-                  {entry.argumentsLabel ? (
+                  {entry.argumentsLabel && (
                     <button member-id={'Arguments'} className="shiki-ln-line-argument">
                       {entry.argumentsLabel}
                     </button>
-                  ) : (
-                    <></>
                   )}
-                  {entry.hasOptions ? (
+                  {entry.optionsLabel && (
                     <button member-id={'Options'} className="shiki-ln-line-option">
-                      [options]
+                      {entry.optionsLabel}
                     </button>
-                  ) : (
-                    <></>
                   )}
                 </div>
               </code>

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/cli.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/cli.spec.mts
@@ -40,7 +40,7 @@ describe('CLI docs to html', () => {
     const cliTocs = fragment.querySelectorAll('.docs-reference-cli-toc')!;
     expect(cliTocs.length).toBe(2);
 
-    expect(cliTocs[0].textContent).toContain('ng component[name][options]');
-    expect(cliTocs[1].textContent).toContain('ng c[name][options]');
+    expect(cliTocs[0].textContent).toContain('ng component [name] [options]');
+    expect(cliTocs[1].textContent).toContain('ng c [name] [options]');
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/cli-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/cli-transforms.mts
@@ -27,7 +27,7 @@ export function getCliRenderable(command: CliCommand): CliCommandRenderable {
     }),
     cards: getCliCardsRenderable(command),
     argumentsLabel: getArgumentsLabel(command),
-    hasOptions: getOptions(command).length > 0,
+    optionsLabel: getOptionsLabel(command),
   };
 }
 
@@ -66,7 +66,12 @@ function getArgumentsLabel(command: CliCommand): string {
   if (args.length === 0) {
     return '';
   }
-  return command.command.replace(`${command.name} `, '');
+  const label = command.command.replace(/^ng\s+/, '').replace(`${command.name} `, '');
+  return ` ${label}`;
+}
+
+function getOptionsLabel(command: CliCommand): string {
+  return getOptions(command).length > 0 ? ' [options]' : '';
 }
 
 function getArgs(command: CliCommand): CliOption[] {


### PR DESCRIPTION
Preserve whitespace when copying code examples from the docs. Fixes the copy handler so copied snippets keep original spacing.

Fixes #66790

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
