### PR TITLE
docs: Add missing link in HostListener documentation

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -1020,7 +1020,7 @@ export interface HostListenerDecorator {
    *
    * @usageNotes
    *
-   * NOTE:  **Always** prefer using the `host` property over `@HostListener`.
+   * NOTE:  **Always** prefer using the [`host` property](guide/components/host-elements#binding-to-the-host-element) over `@HostListener`.
    * This decorator exist exclusively for backwards compatibility.
    *
    * The following example declares a directive


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The documentation for `HostListener` is missing a link to the `host` property while the doucmnetation of `HostBinding` has that link at the exact same place.

Issue Number: N/A

## What is the new behavior?

The documentation for `HostListener` now has an link.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
