### PR TITLE
feat(docs-infra): increase table-of-contents width for large screens

### DIFF
--- a/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
+++ b/adev/shared-docs/components/table-of-contents/table-of-contents.component.scss
@@ -8,10 +8,18 @@
   top: 0;
   height: fit-content;
   width: 14rem;
-  padding-right: 2rem;
+  padding-right: 1rem;
   max-height: 100vh;
   overflow-y: scroll;
   box-sizing: border-box;
+
+  @include mq.for-large-desktop-up {
+    width: 16rem;
+  }
+
+  @include mq.for-extra-large-desktop-up {
+    width: 25rem;
+  }
 
   aside {
     margin-bottom: 2rem;


### PR DESCRIPTION
Add media query overrides to expand the table-of-contents width on extra-large desktops.

fixes: #66823
