### PR TITLE
refactor(language-service): initial use of type-only imports and standard server types

### DIFF
--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -12,7 +12,7 @@
  * Entry point for all public APIs of the language service package.
  */
 
-import ts from 'typescript';
+import type ts from 'typescript';
 
 export interface PluginConfig {
   /**

--- a/packages/language-service/plugin-factory.ts
+++ b/packages/language-service/plugin-factory.ts
@@ -9,25 +9,19 @@
 // Note: use a type-only import to prevent TypeScript from being bundled in.
 import type ts from 'typescript';
 
-import {NgLanguageService, PluginConfig} from './api';
-
-interface PluginModule extends ts.server.PluginModule {
-  create(createInfo: ts.server.PluginCreateInfo): NgLanguageService;
-  onConfigurationChanged?(config: PluginConfig): void;
-}
-
-export const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
-  let plugin: PluginModule;
+export const factory: ts.server.PluginModuleFactory = (tsModule) => {
+  let plugin: ts.server.PluginModule;
 
   return {
-    create(info: ts.server.PluginCreateInfo): NgLanguageService {
+    create(info: ts.server.PluginCreateInfo): ts.LanguageService {
       plugin ??= require(`@angular/language-service/bundles/language-service.js`)(tsModule);
+
       return plugin.create(info);
     },
     getExternalFiles(project: ts.server.Project): string[] {
       return plugin?.getExternalFiles?.(project, tsModule.typescript.ProgramUpdateLevel.Full) ?? [];
     },
-    onConfigurationChanged(config: PluginConfig): void {
+    onConfigurationChanged(config: unknown): void {
       plugin?.onConfigurationChanged?.(config);
     },
   };


### PR DESCRIPTION
This commit converts the typescript import in api.ts to a type-only import and updates the plugin factory to utilize standard TypeScript server types. Internal interfaces and specific service types are replaced with general types to decouple the factory wrapper from internal implementations.