### PR TITLE
feat(core): add ChangeDetectionStrategy.Eager alias for Default

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -209,7 +209,9 @@ export interface BootstrapOptions {
 
 // @public
 export enum ChangeDetectionStrategy {
+    // @deprecated
     Default = 1,
+    Eager = 1,
     OnPush = 0
 }
 

--- a/packages/compiler/src/core.ts
+++ b/packages/compiler/src/core.ts
@@ -29,6 +29,8 @@ export enum ViewEncapsulation {
 export enum ChangeDetectionStrategy {
   OnPush = 0,
   Default = 1,
+  // tslint:disable-next-line:no-duplicate-enum-values
+  Eager = 1,
 }
 
 export interface Input {

--- a/packages/core/src/change_detection/constants.ts
+++ b/packages/core/src/change_detection/constants.ts
@@ -27,6 +27,15 @@ export enum ChangeDetectionStrategy {
   /**
    * Use the default `CheckAlways` strategy, in which change detection is automatic until
    * explicitly deactivated.
+   * @deprecated Use `Eager` instead.
    */
   Default = 1,
+
+  /**
+   * Use the `Eager` strategy, meaning that the component is checked eagerly when the change
+   * detection traversal reaches it, rather than only checking under certain circumstances (e.g.
+   * `markForCheck`, a signal in the template changed, etc).
+   */
+  // tslint:disable-next-line:no-duplicate-enum-values
+  Eager = 1,
 }

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -145,6 +145,33 @@ describe('change detection', () => {
       expect(ref.instance.checks).toBe(2);
     });
 
+    it('should detect changes for Eager embedded views (alias for Default)', () => {
+      @Component({
+        selector: 'eager',
+        template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class EagerComponent {
+        checks = 0;
+        ngDoCheck() {
+          this.checks++;
+        }
+      }
+
+      @Component({template: '<ng-template #template></ng-template>'})
+      class Container {
+        @ViewChild('template', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
+      }
+      const fixture = TestBed.createComponent(Container);
+      const ref = fixture.componentInstance.vcr!.createComponent(EagerComponent);
+
+      fixture.detectChanges(false);
+      expect(ref.instance.checks).toBe(1);
+
+      fixture.detectChanges(false);
+      expect(ref.instance.checks).toBe(2);
+    });
+
     it('should not detect changes in child embedded views while they are detached', () => {
       const counters = {componentView: 0, embeddedView: 0};
 


### PR DESCRIPTION
Adds `ChangeDetectionStrategy.Eager` as an explicit alias for `ChangeDetectionStrategy.Default`. This improves readability when contrasting with `OnPush`, clarifying that the component will be checked eagerly when traversal reaches it.

Compiler findings:
- The compiler resolves `ChangeDetectionStrategy` enum members by value in `resolveEnumValue` (see `packages/compiler-cli/src/ngtsc/annotations/common/src/evaluation.ts`).
- Since `Eager` has usage value `1` (same as `Default`), it is correctly interpreted during static analysis.
- At runtime, `defineComponent` (in `packages/core/src/render3/definition.ts`) checks `changeDetection === ChangeDetectionStrategy.OnPush` (0). Any other value, including `1` (Eager/Default), results in eager checking behavior (`onPush: false`).
