### PR TITLE
fix(language-service): show narrowed type for @let declarations in hover

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -179,6 +179,13 @@ export interface TemplateTypeChecker {
   getSymbolOfNode(node: AST | TmplAstNode, component: ts.ClassDeclaration): Symbol | null;
 
   /**
+   * Retrieves the `TcbLocation` for the node in a component's template.
+   *
+   * This method can return `null` if a valid `TcbLocation` cannot be determined for the node.
+   */
+  getTcbLocationOfNode(node: AST | TmplAstNode, component: ts.ClassDeclaration): TcbLocation | null;
+
+  /**
    * Get "global" `Completion`s in the given context.
    *
    * Global completions are completions in the global context, as opposed to completions within an

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -799,6 +799,17 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return this.perf.inPhase(PerfPhase.TtcSymbol, () => builder.getSymbol(node));
   }
 
+  getTcbLocationOfNode(
+    node: AST | TmplAstNode,
+    component: ts.ClassDeclaration,
+  ): TcbLocation | null {
+    const builder = this.getOrCreateSymbolBuilder(component);
+    if (builder === null) {
+      return null;
+    }
+    return this.perf.inPhase(PerfPhase.TtcSymbol, () => builder.getTcbLocation(node));
+  }
+
   private getOrCreateSymbolBuilder(component: ts.ClassDeclaration): SymbolBuilder | null {
     if (this.symbolBuilderCache.has(component)) {
       return this.symbolBuilderCache.get(component)!;

--- a/packages/language-service/test/let_narrowing_spec.ts
+++ b/packages/language-service/test/let_narrowing_spec.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import ts from 'typescript';
+
+import {LanguageServiceTestEnv, Project} from '../testing';
+
+describe('let declarations narrowing', () => {
+  let env: LanguageServiceTestEnv;
+  let project: Project;
+
+  beforeEach(() => {
+    initMockFileSystem('Native');
+    env = LanguageServiceTestEnv.setup();
+  });
+
+  function expectQuickInfo({
+    templateOverride,
+    expectedSpanText,
+    expectedDisplayString,
+  }: {
+    templateOverride: string;
+    expectedSpanText: string;
+    expectedDisplayString: string;
+  }): ts.QuickInfo {
+    const text = templateOverride.replace('¦', '');
+    const template = project.openFile('app.html');
+    template.contents = text;
+    env.expectNoSourceDiagnostics();
+
+    template.moveCursorToText(templateOverride);
+    const quickInfo = template.getQuickInfoAtPosition();
+    expect(quickInfo).toBeTruthy();
+    const {textSpan, displayParts} = quickInfo!;
+    expect(text.substring(textSpan.start, textSpan.start + textSpan.length)).toEqual(
+      expectedSpanText,
+    );
+    expect(toText(displayParts)).toEqual(expectedDisplayString);
+    return quickInfo!;
+  }
+
+  function toText(displayParts?: ts.SymbolDisplayPart[]): string {
+    return (displayParts || []).map((p) => p.text).join('');
+  }
+
+  it('should show narrowed type for @let declaration in hover', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'app-cmp',
+          templateUrl: './app.html',
+          standalone: true,
+        })
+        export class AppCmp {
+          val: {data: number} | null = {data: 1};
+        }
+      `,
+      'app.html': 'Will be overridden',
+    };
+    project = env.addProject('test', files);
+
+    expectQuickInfo({
+      templateOverride: `
+        @let obj = val;
+        @if (obj !== null) {
+          <div [id]="ob¦j.data"></div>
+        }
+      `,
+      expectedSpanText: 'obj',
+      // Current incorrect behavior: (variable) obj: { data: number; } | null
+      // Expected behavior: (variable) obj: { data: number; }
+      expectedDisplayString: '(let) const obj: {\n    data: number;\n}',
+    });
+  });
+});


### PR DESCRIPTION
When hovering over a `@let` declaration variable inside a control flow block (e.g., `@if`), the Language Service now shows the flow-narrowed type instead of the original declaration type.

The fix retrieves type information from the TCB at the usage location where TypeScript has applied flow narrowing, rather than from the declaration location.

Fixes #65491

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When hovering over a @let variable inside a narrowed scope (e.g., @if (obj !== null)), the Language Service shows the original declaration type including null.

Issue Number: #65491

## What is the new behavior?
The hover tooltip now shows the flow-narrowed type, matching what the Angular compiler uses for type checking.



## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Issue reported on: Angular v19.2.5 with Language Service Extension v20.1.1
Validated on: Angular main branch (21.1.0-next.1)

Root cause: getQuickInfoForLetDeclarationSymbol() queried TypeScript at the declaration location in the TCB, not the usage location where flow narrowing applies.

Fix: Added getTcbLocationOfNode() to TemplateTypeChecker to find the TCB node at the usage site. Updated QuickInfoBuilder to use this method for @let declarations, with graceful fallback to the original behavior. This follows the same pattern used by getQuickInfoForBindingSymbol and  getQuickInfoForPipeSymbol.