### PR TITLE
fix(core): export DirectiveWithBindings

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -640,6 +640,12 @@ export interface DirectiveDecorator {
 }
 
 // @public
+export interface DirectiveWithBindings<T> {
+    bindings: Binding[];
+    type: Type<T>;
+}
+
+// @public
 export interface DoBootstrap {
     // (undocumented)
     ngDoBootstrap(appRef: ApplicationRef): void;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -113,7 +113,13 @@ export {
   afterNextRender,
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
-export {Binding, inputBinding, outputBinding, twoWayBinding} from './render3/dynamic_bindings';
+export {
+  Binding,
+  DirectiveWithBindings,
+  inputBinding,
+  outputBinding,
+  twoWayBinding,
+} from './render3/dynamic_bindings';
 export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';


### PR DESCRIPTION
Exports the `DirectiveWithBindings` interface since it's part of the public API of `createComponent`.

Fixes #66851.
