### PR TITLE
test(forms): migrate reactive forms and value accessors to zoneless

### DIFF
--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -14,7 +14,6 @@ import {
   forwardRef,
   Input,
   OnDestroy,
-  provideZoneChangeDetection,
   Type,
   ViewChild,
 } from '@angular/core';
@@ -144,7 +143,6 @@ describe('reactive forms integration tests', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, ReactiveFormsModule],
-      providers: [provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }
@@ -222,6 +220,7 @@ describe('reactive forms integration tests', () => {
       fixture.detectChanges();
 
       fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const input = fixture.debugElement.query(By.css('input'));
@@ -235,6 +234,7 @@ describe('reactive forms integration tests', () => {
 
       const newForm = new FormGroup({'login': new FormControl('newValue')});
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const input = fixture.debugElement.query(By.css('input'));
@@ -263,6 +263,7 @@ describe('reactive forms integration tests', () => {
         }),
       });
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -299,6 +300,7 @@ describe('reactive forms integration tests', () => {
         'pattern': new FormControl(''),
       });
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(newForm.get('login')!.errors).toEqual({required: true});
@@ -317,6 +319,7 @@ describe('reactive forms integration tests', () => {
         'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')}),
       });
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(form.get('signin')!.valid).toBe(false);
@@ -331,6 +334,7 @@ describe('reactive forms integration tests', () => {
       fixture.detectChanges();
 
       form.addControl('email', new FormControl('email'));
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
@@ -340,6 +344,7 @@ describe('reactive forms integration tests', () => {
         'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')}),
       });
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
@@ -357,6 +362,7 @@ describe('reactive forms integration tests', () => {
       let inputs = fixture.debugElement.queryAll(By.css('input'));
       expect(inputs[2]).not.toBeDefined();
       cityArray.push(new FormControl('LA'));
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -366,6 +372,7 @@ describe('reactive forms integration tests', () => {
       const newForm = new FormGroup({cities: newArr});
       fixture.componentInstance.form = newForm;
       fixture.componentInstance.cityArray = newArr;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -405,6 +412,7 @@ describe('reactive forms integration tests', () => {
       expect(input.disabled).toBe(false);
 
       fixture.componentInstance.recreateAndDisable();
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(input.disabled).toBe(true);
     });
@@ -516,9 +524,11 @@ describe('reactive forms integration tests', () => {
         ]);
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         newArr.removeAt(0);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         let inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -533,6 +543,7 @@ describe('reactive forms integration tests', () => {
         expect(newArr.value).toEqual(['new value', 'LA']);
 
         newArr.removeAt(0);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -568,9 +579,11 @@ describe('reactive forms integration tests', () => {
         ]);
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         newArr.removeAt(0);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         const formEl = fixture.debugElement.query(By.css('form'));
@@ -588,9 +601,11 @@ describe('reactive forms integration tests', () => {
         const newArr = new FormArray([new FormControl('SF'), new FormControl('NY')]);
         fixture.componentInstance.cityArray = newArr;
         form.setControl('cities', newArr);
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         newArr.insert(1, new FormControl('LA'));
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         let inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -646,6 +661,7 @@ describe('reactive forms integration tests', () => {
       fixture.detectChanges();
 
       cityArray.push(new FormControl('LA'));
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -818,6 +834,7 @@ describe('reactive forms integration tests', () => {
 
         const fixture = initTest(App);
         fixture.componentInstance.useStandaloneControl();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         let input = fixture.nativeElement.querySelector('input');
@@ -827,6 +844,7 @@ describe('reactive forms integration tests', () => {
         // Replace `FormControl` with `FormGroup` at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideGroup();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -836,6 +854,7 @@ describe('reactive forms integration tests', () => {
         // Swap `FormGroup` with `FormControl` back at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useStandaloneControl();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -878,6 +897,7 @@ describe('reactive forms integration tests', () => {
 
         const fixture = initTest(App);
         fixture.componentInstance.useStandaloneControl();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         let input = fixture.nativeElement.querySelector('input');
@@ -887,6 +907,7 @@ describe('reactive forms integration tests', () => {
         // Replace `FormControl` with `FormArray` at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideArray();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -896,6 +917,7 @@ describe('reactive forms integration tests', () => {
         // Swap `FormArray` with `FormControl` back at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useStandaloneControl();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -942,6 +964,7 @@ describe('reactive forms integration tests', () => {
 
         const fixture = initTest(App);
         fixture.componentInstance.useControlInsideGroup();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         let input = fixture.nativeElement.querySelector('input');
@@ -951,6 +974,7 @@ describe('reactive forms integration tests', () => {
         // Replace `FormGroup` with `FormArray` at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideArray();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -960,6 +984,7 @@ describe('reactive forms integration tests', () => {
         // Swap `FormArray` with `FormGroup` back at the same location
         // in data model and trigger change detection.
         fixture.componentInstance.useControlInsideGroup();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         input = fixture.nativeElement.querySelector('input');
@@ -2934,6 +2959,7 @@ describe('reactive forms integration tests', () => {
         );
 
         fixture.componentInstance.login = 'some value';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -2953,6 +2979,7 @@ describe('reactive forms integration tests', () => {
         );
 
         fixture.componentInstance.login = 'some value';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -3327,12 +3354,14 @@ describe('reactive forms integration tests', () => {
         'pattern': new FormControl(''),
       });
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       fixture.componentInstance.required = false;
       fixture.componentInstance.minLen = null!;
       fixture.componentInstance.maxLen = null!;
       fixture.componentInstance.pattern = null!;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       expect(newForm.hasError('required', ['login'])).toEqual(false);
@@ -3342,25 +3371,27 @@ describe('reactive forms integration tests', () => {
       expect(newForm.valid).toEqual(true);
     });
 
-    it('should use async validators defined in the html', fakeAsync(() => {
+    it('should use async validators defined in the html', async () => {
       const fixture = initTest(UniqLoginWrapper, UniqLoginValidator);
       const form = new FormGroup({'login': new FormControl('')});
-      tick();
       fixture.componentInstance.form = form;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(form.pending).toEqual(true);
-      tick(100);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
       const input = fixture.debugElement.query(By.css('input'));
       input.nativeElement.value = 'expected';
       dispatchEvent(input.nativeElement, 'input');
-      tick(100);
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(form.valid).toEqual(true);
-    }));
+    });
 
     it('should use sync validators defined in the model', () => {
       const fixture = initTest(FormGroupComp);
@@ -3577,6 +3608,7 @@ describe('reactive forms integration tests', () => {
         const setValidatorValues = (values: minmax) => {
           fixture.componentInstance.minlen = values.minlength;
           fixture.componentInstance.maxlen = values.maxlength;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
         };
         const verifyValidatorAttrValues = (values: {minlength: any; maxlength: any}) => {
@@ -3674,6 +3706,7 @@ describe('reactive forms integration tests', () => {
         const setValidatorValues = (values: minmax) => {
           fixture.componentInstance.minlen = values.min;
           fixture.componentInstance.maxlen = values.max;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
         };
         const verifyValidatorAttrValues = (values: {min: any; max: any}) => {
@@ -3751,6 +3784,7 @@ describe('reactive forms integration tests', () => {
           expect(form.controls['pin'].errors).toBeNull();
 
           fixture.componentInstance.max = 1;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           expect(input.getAttribute('max')).toEqual('1');
@@ -3759,6 +3793,7 @@ describe('reactive forms integration tests', () => {
 
           fixture.componentInstance.min = 0;
           fixture.componentInstance.max = 0;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           expect(input.getAttribute('min')).toEqual('0');
           expect(input.getAttribute('max')).toEqual('0');
@@ -4108,6 +4143,7 @@ describe('reactive forms integration tests', () => {
         expect(registerOnAsyncValidatorChangeFired).toBe(1);
 
         fixture.componentInstance.validatorInput = 'baz';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         // Changing the validator input should not cause the onValidatorChange to be called
@@ -4639,6 +4675,7 @@ describe('reactive forms integration tests', () => {
 
       // Update `form` input with a new value.
       fixture.componentInstance.form = newForm;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       const validatorSpy = validatorSpyOn(ViewValidatorA);
@@ -4808,6 +4845,7 @@ describe('reactive forms integration tests', () => {
       // `formControlName` directive that is bound to the `control` FormControl instance.
       const newFormA = new FormGroup({login: new FormControl('new-a')});
       fixture.componentInstance.formA = newFormA;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       validatorSpy.calls.reset();
@@ -4863,6 +4901,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form control and verify no directive-related callbacks
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -4883,6 +4922,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: make the form control visible again and verify all callbacks are correctly
       // attached.
       fixture.componentInstance.visible = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -4947,6 +4987,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form control and verify no directive-related callbacks
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5023,6 +5064,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form control and verify no directive-related callbacks
       // (validators, value accessors) were invoked.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5104,6 +5146,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5130,6 +5173,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: make the form control visible again and verify all callbacks are correctly
       // attached and invoked.
       fixture.componentInstance.visible = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5205,6 +5249,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5291,6 +5336,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: update the list of logins which would result in cleanups for no longer needed
       // (thus destroyed) directives.
       fixture.componentInstance.logins = ['c', 'd'];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5316,6 +5362,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5403,6 +5450,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5501,6 +5549,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5532,6 +5581,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: make the form array control available again and verify all callbacks are
       // correctly attached and invoked.
       fixture.componentInstance.visible = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5624,6 +5674,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5655,6 +5706,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: make the form group available again and verify all callbacks are correctly
       // attached and invoked.
       fixture.componentInstance.visible = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5763,6 +5815,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: remove ControlA from the view by updating the list of ids.
       // Verify that ControlA is detached from the view, but ControlB still works.
       fixture.componentInstance.ids = [1];
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5796,6 +5849,7 @@ describe('reactive forms integration tests', () => {
       // Case 3: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5898,6 +5952,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -5994,6 +6049,7 @@ describe('reactive forms integration tests', () => {
       // Case 2: hide form group and verify that no directive-related callbacks
       // (validators, value accessors) are invoked when we set control value later.
       fixture.componentInstance.visible = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Reset all spies again, prepare for next check.
@@ -6096,7 +6152,6 @@ describe('reactive forms integration tests', () => {
 
       it('should mark formArray as submitted on submit event', () => {
         const fixture = initTest(FormArrayComp);
-        const controls = [new FormControl('fish'), new FormControl('cat'), new FormControl('dog')];
         fixture.detectChanges();
 
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormArrayDirective);
@@ -6143,12 +6198,14 @@ describe('reactive forms integration tests', () => {
         expect(inputs.length).toBe(3);
 
         controls.push(new FormControl('pineapple'));
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs.length).toBe(4);
 
         controls.pop();
         controls.pop();
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs.length).toBe(2);

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -7,16 +7,7 @@
  */
 
 import {CommonModule, ɵgetDOM as getDOM} from '@angular/common';
-import {
-  Component,
-  Directive,
-  ElementRef,
-  forwardRef,
-  Input,
-  provideZoneChangeDetection,
-  Type,
-  ViewChild,
-} from '@angular/core';
+import {Component, Directive, ElementRef, forwardRef, Input, Type, ViewChild} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {
   AbstractControl,
@@ -45,7 +36,6 @@ describe('template-driven forms integration tests', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, CommonModule],
-      providers: [provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }
@@ -166,6 +156,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.emailShowing = true;
       fixture.componentInstance.first = 'Nancy';
       fixture.componentInstance.email = 'some email';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -175,6 +166,7 @@ describe('template-driven forms integration tests', () => {
 
       // should remove individual control successfully
       fixture.componentInstance.emailShowing = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -186,6 +178,7 @@ describe('template-driven forms integration tests', () => {
 
       // should remove form group successfully
       fixture.componentInstance.groupShowing = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -234,27 +227,25 @@ describe('template-driven forms integration tests', () => {
       });
     }));
 
-    it('should set status classes with ngModel and async validators', fakeAsync(() => {
+    it('should set status classes with ngModel and async validators', async () => {
       const fixture = initTest(NgModelAsyncValidation, NgAsyncValidator);
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
+      const input = fixture.debugElement.query(By.css('input')).nativeElement;
+      expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
-        dispatchEvent(input, 'blur');
-        fixture.detectChanges();
+      dispatchEvent(input, 'blur');
+      fixture.detectChanges();
 
-        expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
+      expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-touched']);
 
-        input.value = 'updatedValue';
-        dispatchEvent(input, 'input');
-        tick();
-        fixture.detectChanges();
+      input.value = 'updatedValue';
+      dispatchEvent(input, 'input');
+      await fixture.whenStable();
 
-        expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-      });
-    }));
+      expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
+    });
 
     it('should set status classes with ngModelGroup and ngForm', waitForAsync(() => {
       const fixture = initTest(NgModelGroupForm);
@@ -378,26 +369,31 @@ describe('template-driven forms integration tests', () => {
         fixture.debugElement.queryAll(By.css('input')).map((el) => el.nativeElement.value);
       const fixture = initTest(App);
       fixture.componentInstance.add(3);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '2']);
 
       fixture.componentInstance.remove(1);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '2']);
 
       fixture.componentInstance.add(1);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '2', '3']);
 
       fixture.componentInstance.items[1].value = '1';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '3']);
 
       fixture.componentInstance.items[2].value = '2';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '2']);
@@ -436,26 +432,31 @@ describe('template-driven forms integration tests', () => {
         fixture.debugElement.queryAll(By.css('input')).map((el) => el.nativeElement.value);
       const fixture = initTest(App);
       fixture.componentInstance.add(3);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '2']);
 
       fixture.componentInstance.remove(1);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '2']);
 
       fixture.componentInstance.add(1);
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '2', '3']);
 
       fixture.componentInstance.items[1].value = '1';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '3']);
 
       fixture.componentInstance.items[2].value = '2';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(getValues()).toEqual(['0', '1', '2']);
@@ -550,10 +551,12 @@ describe('template-driven forms integration tests', () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'blur'};
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
         fixture.componentInstance.name = 'Carson';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -813,10 +816,12 @@ describe('template-driven forms integration tests', () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'submit'};
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
         fixture.componentInstance.name = 'Carson';
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -1411,6 +1416,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.first = '';
       fixture.componentInstance.last = 'Drew';
       fixture.componentInstance.email = 'some email';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1420,6 +1426,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.control.get('name.first')!.disabled).toBe(false);
 
       fixture.componentInstance.isDisabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1502,6 +1509,7 @@ describe('template-driven forms integration tests', () => {
       expect(control.hasError('required')).toBe(false);
 
       fixture.componentInstance.required = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1544,6 +1552,7 @@ describe('template-driven forms integration tests', () => {
       expect(control.hasError('email')).toBe(false);
 
       fixture.componentInstance.validatorEnabled = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1790,6 +1799,7 @@ describe('template-driven forms integration tests', () => {
     it('should validate max', fakeAsync(() => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1816,6 +1826,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['max'].errors).toBeNull();
 
       fixture.componentInstance.max = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       dispatchEvent(input, 'input');
@@ -1892,6 +1903,7 @@ describe('template-driven forms integration tests', () => {
     it('should re-validate if max changes', fakeAsync(() => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1911,6 +1923,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['max'].errors).toBeNull();
 
       fixture.componentInstance.max = 5;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(form.valid).toEqual(false);
       expect(form.controls['max'].errors).toEqual({max: {max: 5, actual: 9}});
@@ -1919,6 +1932,7 @@ describe('template-driven forms integration tests', () => {
     it('should validate min', fakeAsync(() => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -1945,6 +1959,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
 
       fixture.componentInstance.min = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       input.value = -5;
@@ -2021,6 +2036,7 @@ describe('template-driven forms integration tests', () => {
     it('should re-validate if min changes', fakeAsync(() => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -2040,6 +2056,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
 
       fixture.componentInstance.min = 9;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min'].errors).toBeNull();
@@ -2181,6 +2198,7 @@ describe('template-driven forms integration tests', () => {
         const setValidatorValues = (values: minmax) => {
           fixture.componentInstance.minlen = values.minlength;
           fixture.componentInstance.maxlen = values.maxlength;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
         };
         const verifyFormState = (state: state) => {
@@ -2269,6 +2287,7 @@ describe('template-driven forms integration tests', () => {
         const setValidatorValues = (values: minmax) => {
           fixture.componentInstance.minlen = values.min;
           fixture.componentInstance.maxlen = values.max;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
         };
         const verifyFormState = (state: state) => {
@@ -2426,6 +2445,7 @@ describe('template-driven forms integration tests', () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = 5;
       fixture.componentInstance.max = 10;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -2445,6 +2465,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['min_max'].errors).toEqual({max: {max: 10, actual: 12}});
 
       fixture.componentInstance.max = 12;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min_max'].errors).toBeNull();
@@ -2462,6 +2483,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.controls['min_max'].errors).toEqual({min: {min: 5, actual: 0}});
 
       fixture.componentInstance.min = 0;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min_max'].errors).toBeNull();
@@ -2600,6 +2622,7 @@ describe('template-driven forms integration tests', () => {
       expect(registerOnAsyncValidatorChangeFired).toBe(1);
 
       fixture.componentInstance.validatorInput = 'bar';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 
       // Changing validator inputs should not cause `registerOnValidatorChange` to be invoked,
@@ -2700,6 +2723,7 @@ describe('template-driven forms integration tests', () => {
     it('should update the view when the model is set back to what used to be in the view', fakeAsync(() => {
       const fixture = initTest(StandaloneNgModel);
       fixture.componentInstance.name = '';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
 
@@ -2714,12 +2738,14 @@ describe('template-driven forms integration tests', () => {
 
       // Programmatically update the input value to be "bb".
       fixture.componentInstance.name = 'bb';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(input.value).toEqual('bb');
 
       // Programatically set it back to "aa".
       fixture.componentInstance.name = 'aa';
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       tick();
       expect(input.value).toEqual('aa');

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -19,8 +19,6 @@ import {
   Input,
   NgZone,
   Output,
-  PLATFORM_ID,
-  provideZoneChangeDetection,
   RendererFactory2,
   Type,
   ViewChild,
@@ -49,7 +47,6 @@ describe('value accessors', () => {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
       imports: [FormsModule, ReactiveFormsModule],
-      providers: [{provide: PLATFORM_ID, useValue: 'browser'}, provideZoneChangeDetection()],
     });
     return TestBed.createComponent(component);
   }
@@ -287,6 +284,7 @@ describe('value accessors', () => {
           {id: 1, name: 'SF'},
           {id: 2, name: 'NY'},
         ];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         // Now that the options array has been re-assigned, new option instances will
@@ -331,11 +329,13 @@ describe('value accessors', () => {
         const comp = fixture.componentInstance;
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
         comp.selectedCity = comp.cities[1];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
         comp.cities.push({'name': 'Buffalo'});
         comp.selectedCity = comp.cities[2];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -439,6 +439,7 @@ describe('value accessors', () => {
           {id: 1, name: 'SF'},
           {id: 2, name: 'NY'},
         ];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -456,6 +457,7 @@ describe('value accessors', () => {
           {id: 1, name: 'SF'},
           {id: 2, name: 'NY'},
         ];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
 
@@ -526,6 +528,7 @@ describe('value accessors', () => {
       });
 
       const detectChangesAndTick = (): void => {
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
         tick();
       };
@@ -1128,6 +1131,7 @@ describe('value accessors', () => {
             {id: 1, name: 'SF'},
             {id: 2, name: 'NY'},
           ];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           // Now that the options array has been re-assigned, new option instances will
@@ -1159,6 +1163,7 @@ describe('value accessors', () => {
             {id: 3, name: 'LA'},
             {id: 4, name: 'BXL'},
           ];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           // using trackBy, instances can be re-used, the option IDs stays the same but their
@@ -1195,6 +1200,7 @@ describe('value accessors', () => {
             {id: 1, name: 'SF'},
             {id: 3, name: 'LA'},
           ];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           // Now that the options array has been re-assigned, new option instances will
@@ -1232,6 +1238,7 @@ describe('value accessors', () => {
 
           fixture.componentInstance.compareFnCalls = 0;
           fixture.componentInstance.cities.splice(2, 2);
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           // compareWith should only be called once since first city is still selected
@@ -1271,11 +1278,13 @@ describe('value accessors', () => {
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
           comp.selectedCity = comp.cities[1];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 
           comp.cities.push({'name': 'Buffalo'});
           comp.selectedCity = comp.cities[2];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 
@@ -1294,6 +1303,7 @@ describe('value accessors', () => {
           tick();
 
           comp.cities.push({name: 'Minneapolis'});
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 
@@ -1448,6 +1458,7 @@ describe('value accessors', () => {
             {id: 1, name: 'SF'},
             {id: 2, name: 'NY'},
           ];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 
@@ -1465,6 +1476,7 @@ describe('value accessors', () => {
             {id: 1, name: 'SF'},
             {id: 2, name: 'NY'},
           ];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
           tick();
 


### PR DESCRIPTION
Migrates reactive forms, template-driven forms, and value accessors to zoneless tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
