### PR TITLE
docs: generalize wording for CSP nonce configuration options

### DIFF
--- a/adev/src/content/guide/security.md
+++ b/adev/src/content/guide/security.md
@@ -148,7 +148,7 @@ default-src 'self'; style-src 'self' 'nonce-randomNonceGoesHere'; script-src 'se
 
 When serving your Angular application, the server should include a randomly-generated nonce in the HTTP header for each request.
 You must provide this nonce to Angular so that the framework can render `<style>` elements.
-You can set the nonce for Angular in one of two ways:
+You can set the nonce for Angular in one of the following ways:
 
 1. Set the `autoCsp` option to `true` the [workspace configuration](reference/configs/workspace-config#extra-build-and-test-options).
 1. Set the `ngCspNonce` attribute on the root application element as `<app ngCspNonce="randomNonceGoesHere"></app>`. Use this approach if you have access to server-side templating that can add the nonce both to the header and the `index.html` when constructing the response.


### PR DESCRIPTION
Replaces “one of two ways” with “one of the following ways” to avoid hardcoding the number of supported approaches and keep the documentation accurate if options change.

fixes: #66861
