### PR TITLE
test(router): remove provider zoneless from tests

### DIFF
--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -24,7 +24,6 @@ import {
   inject,
   Injectable,
   NgModule,
-  provideZonelessChangeDetection,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {isNode} from '@angular/private/testing';
@@ -106,7 +105,6 @@ describe('bootstrap', () => {
     navigationEndPromise = promise;
     log = [];
     testProviders = [
-      provideZonelessChangeDetection(),
       {provide: DOCUMENT, useValue: doc},
       {provide: ViewportScroller, useClass: isNode ? NullViewportScroller : ViewportScroller},
       {provide: PlatformLocation, useClass: MockPlatformLocation},

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -7,15 +7,7 @@
  */
 
 import {CommonModule, NgForOf} from '@angular/common';
-import {
-  Component,
-  inject,
-  provideZonelessChangeDetection,
-  Input,
-  Type,
-  NgModule,
-  signal,
-} from '@angular/core';
+import {Component, inject, Input, Type, NgModule, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   provideRouter,
@@ -487,10 +479,7 @@ describe('router outlet data', () => {
     }
 
     TestBed.configureTestingModule({
-      providers: [
-        provideRouter([{path: '**', component: MyComponent}]),
-        provideZonelessChangeDetection(),
-      ],
+      providers: [provideRouter([{path: '**', component: MyComponent}])],
     });
 
     const harness = await RouterTestingHarness.create();

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -12,7 +12,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
-  ErrorHandler,
   Injectable,
   NgModule,
   TemplateRef,
@@ -20,7 +19,6 @@ import {
   ViewChild,
   ViewContainerRef,
   inject,
-  provideZonelessChangeDetection,
   signal,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -28,7 +26,6 @@ import {
   ChildrenOutletContexts,
   DefaultUrlSerializer,
   NavigationCancel,
-  NavigationEnd,
   NavigationError,
   Router,
   RouterModule,
@@ -36,7 +33,7 @@ import {
   UrlSerializer,
   UrlTree,
 } from '../index';
-import {firstValueFrom, of} from 'rxjs';
+import {of} from 'rxjs';
 import {switchMap, filter, mapTo, take} from 'rxjs/operators';
 
 import {
@@ -550,7 +547,6 @@ describe('Integration', () => {
 
         const appRef = await bootstrapApplication(App, {
           providers: [
-            provideZonelessChangeDetection(),
             provideRouter(
               [{path: 'simple', component: SimpleCmp}],
               withDisabledInitialNavigation(),

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, inject, signal, provideZonelessChangeDetection} from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Router, RouterLink, RouterModule, provideRouter} from '../index';

--- a/packages/router/test/view_transitions.spec.ts
+++ b/packages/router/test/view_transitions.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Component, destroyPlatform, provideZonelessChangeDetection} from '@angular/core';
+import {Component, destroyPlatform} from '@angular/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody, isNode} from '@angular/private/testing';
 import {
@@ -37,7 +37,6 @@ describe('view transitions', () => {
   it('should skip initial transition', async () => {
     const appRef = await bootstrapApplication(App, {
       providers: [
-        provideZonelessChangeDetection(),
         provideRouter(
           [{path: '**', component: App}],
           withDisabledInitialNavigation(),
@@ -66,10 +65,7 @@ describe('view transitions', () => {
     class ComponentB {}
 
     const res = await bootstrapApplication(App, {
-      providers: [
-        provideZonelessChangeDetection(),
-        provideRouter([{path: 'b', component: ComponentB}], withViewTransitions()),
-      ],
+      providers: [provideRouter([{path: 'b', component: ComponentB}], withViewTransitions())],
     });
     const router = res.injector.get(Router);
     const eventLog = [] as Event[];
@@ -97,7 +93,6 @@ describe('view transitions', () => {
       const transitionSpy = jasmine.createSpy();
       const appRef = await bootstrapApplication(App, {
         providers: [
-          provideZonelessChangeDetection(),
           provideRouter(
             [{path: '**', component: App}],
             withDisabledInitialNavigation(),


### PR DESCRIPTION
Removes the `provideZonelessChangeDetection` provider from router tests. It’s no longer needed and simplifies the test setup.
