### PR TITLE
perf(router): Use .bind to avoid holding other closures in memory

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -697,9 +697,8 @@ export class Router {
 
     // Make sure that the error is propagated even though `processNavigations` catch
     // handler does not rethrow
-    return promise.catch((e: any) => {
-      return Promise.reject(e);
-    });
+    // perf: Use `.bind` to avoid holding the other closures in this scope while this promise is unsettled.
+    return promise.catch(Promise.reject.bind(Promise));
   }
 }
 


### PR DESCRIPTION
In many JS runtimes all closures created in the same scope share a context this means that data held in one of the closures is not collected until all of the closures are collected. This change prevents the returned promise from holding a reaction that holds the entire `Router` object in memory.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Other... Please describe:

Memory performance improvement to the router package.
