### PR TITLE
test(forms): remove zoneless change detection from signals forms tests

### DIFF
--- a/packages/forms/signals/test/web/compat_form.spec.ts
+++ b/packages/forms/signals/test/web/compat_form.spec.ts
@@ -6,19 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {Component, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormControl} from '@angular/forms';
 import {compatForm} from '../../compat';
 import {FormField} from '../../public_api';
 
 describe('compatForm with [field] directive', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   it('should bind compat form to input with [field] directive', () => {
     @Component({
       imports: [FormField],

--- a/packages/forms/signals/test/web/field_proxy.spec.ts
+++ b/packages/forms/signals/test/web/field_proxy.spec.ts
@@ -6,23 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  input,
-  provideZonelessChangeDetection,
-  signal,
-} from '@angular/core';
+import {ChangeDetectionStrategy, Component, input, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form, type FieldTree} from '../../public_api';
 
 describe('field proxy', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   it('@for over array field should be reactive', () => {
     @Component({
       selector: 'iterate-field',

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -6,16 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Component,
-  Directive,
-  inject,
-  input,
-  provideZonelessChangeDetection,
-  resource,
-  signal,
-  viewChild,
-} from '@angular/core';
+import {Component, Directive, inject, input, resource, signal, viewChild} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
 import {
@@ -39,12 +30,6 @@ import {
 } from '@angular/forms/signals';
 
 describe('ControlValueAccessor', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-  });
-
   @Component({
     selector: 'custom-control',
     template: `


### PR DESCRIPTION
Removes the `provideZonelessChangeDetection` provider from signal-based forms tests. It’s no longer needed and simplifies the setup

