### PR TITLE
docs: fix syntax errors and improve grammar in navigation guide

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -15,7 +15,7 @@ import {RouterLink} from '@angular/router';
       <a routerLink="/user-profile">User profile</a>
       <a routerLink="/settings">Settings</a>
     </nav>
-  `
+  `,
   imports: [RouterLink],
   ...
 })
@@ -36,7 +36,7 @@ export class App {}
 
 In this example, the first example contains the full path with the protocol (i.e., `https://`) and the root domain (i.e., `angular.dev`) explicitly defined for the essentials page. In contrast, the second example assumes the user is already on the correct root domain for `/essentials`.
 
-Generally speaking, relative URLs are preferred because they are more maintainable across applications because they don’t need to know their absolute position within the routing hierarchy.
+Generally speaking, relative URLs are preferred as they are more maintainable across applications since they don’t need to know their absolute position within the routing hierarchy.
 
 ### How relative URLs work
 
@@ -56,7 +56,7 @@ When you need to define dynamic parameters in a relative URL, use the array synt
 <a [routerLink]="['user', currentUserId]">Current User</a>
 ```
 
-In addition, Angular routing allows you specify whether you want the path to be relative to the current URL or to the root domain based on whether the relative path is prefixed with a forward slash (`/`) or not.
+In addition, Angular routing allows you to specify whether you want the path to be relative to the current URL or to the root domain based on whether the relative path is prefixed with a forward slash (`/`) or not.
 
 For example, if the user is on `example.com/settings`, here is how different relative paths can be defined for various scenarios:
 
@@ -67,7 +67,7 @@ For example, if the user is on `example.com/settings`, here is how different rel
 
 <!-- Navigates to /team/:teamId/user/:userId -->
 <a routerLink="/team/123/user/456">User 456</a>
-<a [routerLink]="['/team', teamId, 'user', userId]">Current User</a>”
+<a [routerLink]="['/team', teamId, 'user', userId]">Current User</a>
 ```
 
 ## Programmatic navigation to routes
@@ -123,8 +123,6 @@ import {Router, ActivatedRoute} from '@angular/router';
 export class UserDetail {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-
-  constructor() {}
 
   // Navigate to a sibling route
   navigateToEdit() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `navigate-to-routes.md` page contains several small errors and grammatical issues:

* The `RouterLink` component example has a syntax error (a missing comma in the component metadata).
* There is a stray closing quote character (`"`) at the end of a code block in the relative URLs section.
* The `UserDetail` component example includes an unnecessary empty `constructor`.
* The explanation for relative links uses repetitive phrasing ("because... because").
* A sentence in the "How relative URLs work" section is missing the word "to" ("allows you specify").

Issue Number: N/A

## What is the new behavior?

The guide has been updated to correct these issues:

* Fixed the syntax error in the `RouterLink` example by adding the missing comma.
* Removed the stray character from the code block.
* Removed the unused empty `constructor` from `UserDetail` for cleaner code.
* Improved the flow of the relative links explanation to remove redundancy.
* Fixed the grammar error to read "allows you to specify".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->