### PR TITLE
refactor(language-service): decouple TypeScript dependency in ts_plugin

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import ts from 'typescript';
+import type ts from 'typescript';
 
 import {
   ApplyRefactoringProgressFn,
@@ -352,20 +352,20 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
   };
 }
 
-export function getExternalFiles(project: ts.server.Project): string[] {
+function getExternalFiles(tsModule: typeof ts, project: ts.server.Project): string[] {
   if (!project.hasRoots()) {
     return []; // project has not been initialized
   }
   const typecheckFiles: string[] = [];
   const resourceFiles: string[] = [];
   for (const scriptInfo of project.getScriptInfos()) {
-    if (scriptInfo.scriptKind === ts.ScriptKind.External) {
+    if (scriptInfo.scriptKind === tsModule.ScriptKind.External) {
       // script info for typecheck file is marked as external, see
       // getOrCreateTypeCheckScriptInfo() in
       // packages/language-service/src/language_service.ts
       typecheckFiles.push(scriptInfo.fileName);
     }
-    if (scriptInfo.scriptKind === ts.ScriptKind.Unknown) {
+    if (scriptInfo.scriptKind === tsModule.ScriptKind.Unknown) {
       // script info for resource file is marked as unknown.
       // Including these as external files is necessary because otherwise they will get removed from
       // the project when `updateNonInferredProjectFiles` is called as part of the
@@ -381,6 +381,6 @@ export function getExternalFiles(project: ts.server.Project): string[] {
 export function initialize(mod: {typescript: typeof ts}): ts.server.PluginModule {
   return {
     create,
-    getExternalFiles,
+    getExternalFiles: getExternalFiles.bind(undefined, mod.typescript),
   };
 }

--- a/packages/language-service/test/legacy/ts_plugin_spec.ts
+++ b/packages/language-service/test/legacy/ts_plugin_spec.ts
@@ -6,15 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import ts from 'typescript';
+
 import {LanguageService} from '../../src/language_service';
-import {getExternalFiles} from '../../src/ts_plugin';
+import {initialize} from '../../src/ts_plugin';
 
 import {APP_COMPONENT, setup} from './mock_host';
 
 describe('getExternalFiles()', () => {
   it('should return all typecheck files', () => {
     const {project, tsLS} = setup();
-    let externalFiles = getExternalFiles(project);
+    const plugin = initialize({typescript: ts});
+
+    let externalFiles = plugin.getExternalFiles?.(project, ts.ProgramUpdateLevel.Full);
     // Initially there are no external files because Ivy compiler hasn't done
     // a global analysis
     expect(externalFiles).toEqual([]);
@@ -22,9 +26,9 @@ describe('getExternalFiles()', () => {
     const ngLS = new LanguageService(project, tsLS, {});
     ngLS.getSemanticDiagnostics(APP_COMPONENT);
     // Now that global analysis is run, we should have all the typecheck files
-    externalFiles = getExternalFiles(project);
+    externalFiles = plugin.getExternalFiles?.(project, ts.ProgramUpdateLevel.Full);
     // Includes 1 typecheck file, 1 template, and 1 css files
-    expect(externalFiles.length).toBe(3);
-    expect(externalFiles[0].endsWith('app.component.ngtypecheck.ts')).toBeTrue();
+    expect(externalFiles?.length).toBe(3);
+    expect(externalFiles?.[0].endsWith('app.component.ngtypecheck.ts')).toBeTrue();
   });
 });


### PR DESCRIPTION
Update `ts_plugin.ts` to use the TypeScript instance provided by the editor during initialization instead of a local import. This prevents potential issues caused by version mismatches between the plugin's internal TypeScript dependency and the version used by the host.