### PR TITLE
test(forms): remove zone-based testing utilities

### DIFF
--- a/packages/forms/test/BUILD.bazel
+++ b/packages/forms/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
 
 ts_project(
     name = "test_lib",
@@ -20,14 +20,14 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test_web",
     tags = [
         # disabled on 2020-04-14 due to failure on saucelabs monitor job

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ChangeDetectorRef, SimpleChange, ɵWritable as Writable} from '@angular/core';
-import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {
   AbstractControl,
   CheckboxControlValueAccessor,
@@ -40,7 +40,7 @@ import {
 import {selectValueAccessor} from '../src/directives/shared';
 import {composeValidators} from '../src/validators';
 
-import {asyncValidator} from './util';
+import {asyncValidator, timeout, useAutoTick} from './util';
 
 class DummyControlValueAccessor implements ControlValueAccessor {
   writtenValue: any;
@@ -61,6 +61,7 @@ class CustomValidatorDirective implements Validator {
 
 describe('Form Directives', () => {
   let defaultAccessor: DefaultValueAccessor;
+  useAutoTick();
 
   beforeEach(() => {
     defaultAccessor = new DefaultValueAccessor(null!, null!, null!);
@@ -244,7 +245,7 @@ describe('Form Directives', () => {
         );
       });
 
-      it('should set up validators', fakeAsync(() => {
+      it('should set up validators', async () => {
         form.addControl(loginControlDir);
 
         // sync validators are set
@@ -256,11 +257,11 @@ describe('Form Directives', () => {
         // sync validator passes, running async validators
         expect(formModel.pending).toBe(true);
 
-        tick();
+        await timeout();
 
         expect(formModel.hasError('required', ['login'])).toBe(false);
         expect(formModel.hasError('async', ['login'])).toBe(true);
-      }));
+      });
 
       it('should write value to the DOM', () => {
         (<FormControl>formModel.get(['login'])).setValue('initValue');
@@ -286,7 +287,7 @@ describe('Form Directives', () => {
         }
       };
 
-      it('should set up validator', fakeAsync(() => {
+      it('should set up validator', async () => {
         const group = new FormGroupName(
           form,
           [matchingPasswordsValidator],
@@ -308,10 +309,10 @@ describe('Form Directives', () => {
         // sync validators pass, running async validators
         expect(formModel.pending).toBe(true);
 
-        tick();
+        await timeout();
 
         expect(formModel.hasError('async', ['passwords'])).toBe(true);
-      }));
+      });
     });
 
     describe('removeControl', () => {
@@ -342,15 +343,15 @@ describe('Form Directives', () => {
         expect(formModel.errors).toEqual({'custom': true});
       });
 
-      it('should set up an async validator', fakeAsync(() => {
+      it('should set up an async validator', async () => {
         const f = new FormGroupDirective([], [asyncValidator('expected')]);
         f.form = formModel;
         f.ngOnChanges({'form': new SimpleChange(null, null, false)});
 
-        tick();
+        await timeout();
 
         expect(formModel.errors).toEqual({'async': true});
-      }));
+      });
     });
   });
 
@@ -400,51 +401,51 @@ describe('Form Directives', () => {
     });
 
     describe('addControl & addFormGroup', () => {
-      it('should create a control with the given name', fakeAsync(() => {
+      it('should create a control with the given name', async () => {
         form.addFormGroup(personControlGroupDir);
         form.addControl(loginControlDir);
 
-        flushMicrotasks();
+        await timeout();
 
         expect(formModel.get(['person', 'login'])).not.toBeNull();
-      }));
+      });
 
       // should update the form's value and validity
     });
 
     describe('removeControl & removeFormGroup', () => {
-      it('should remove control', fakeAsync(() => {
+      it('should remove control', async () => {
         form.addFormGroup(personControlGroupDir);
         form.addControl(loginControlDir);
 
         form.removeFormGroup(personControlGroupDir);
         form.removeControl(loginControlDir);
 
-        flushMicrotasks();
+        await timeout();
 
         expect(formModel.get(['person'])).toBeNull();
         expect(formModel.get(['person', 'login'])).toBeNull();
-      }));
+      });
 
       // should update the form's value and validity
     });
 
-    it('should set up sync validator', fakeAsync(() => {
+    it('should set up sync validator', async () => {
       const formValidator = () => ({'custom': true});
       const f = new NgForm([formValidator], []);
 
-      tick();
+      await timeout();
 
       expect(f.form.errors).toEqual({'custom': true});
-    }));
+    });
 
-    it('should set up async validator', fakeAsync(() => {
+    it('should set up async validator', async () => {
       const f = new NgForm([], [asyncValidator('expected')]);
 
-      tick();
+      await timeout();
 
       expect(f.form.errors).toEqual({'async': true});
-    }));
+    });
 
     describe('events emissions', () => {
       it('formControl should emit an event when resetting a form', () => {
@@ -676,56 +677,56 @@ describe('Form Directives', () => {
       );
     });
 
-    it('should set up validator', fakeAsync(() => {
+    it('should set up validator', async () => {
       // this will add the required validator and recalculate the validity
       ngModel.ngOnChanges({});
-      tick();
+      await timeout();
 
       expect(ngModel.control.errors).toEqual({'required': true});
 
       ngModel.control.setValue('someValue');
-      tick();
+      await timeout();
 
       expect(ngModel.control.errors).toEqual({'async': true});
-    }));
+    });
 
-    it('should mark as disabled properly', fakeAsync(() => {
+    it('should mark as disabled properly', async () => {
       ngModel.ngOnChanges({isDisabled: new SimpleChange('', undefined, false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(false);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange('', null, false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(false);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange('' as any, false, false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(false);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange('', 'false', false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(false);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange('' as any, 0, false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(false);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange(null, '', false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(true);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'true', false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(true);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange(null, true, false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(true);
 
       ngModel.ngOnChanges({isDisabled: new SimpleChange(null, 'anything else', false)});
-      tick();
+      await timeout();
       expect(ngModel.control.disabled).toEqual(true);
-    }));
+    });
   });
 
   describe('FormControlName', () => {

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {fakeAsync, tick} from '@angular/core/testing';
 import {
   AbstractControl,
   FormArray,
@@ -18,10 +17,12 @@ import {
 import {Validators} from '../src/validators';
 import {of} from 'rxjs';
 
-import {asyncValidator} from './util';
+import {asyncValidator, timeout, useAutoTick} from './util';
 
 (function () {
   describe('FormArray', () => {
+    useAutoTick();
+
     describe('adding/removing', () => {
       let a: FormArray;
       let c1: FormControl, c2: FormControl, c3: FormControl;
@@ -1087,32 +1088,32 @@ import {asyncValidator} from './util';
         return of({'other': true});
       }
 
-      it('should run the async validator', fakeAsync(() => {
+      it('should run the async validator', async () => {
         const c = new FormControl('value');
         const g = new FormArray([c], null!, asyncValidator('expected'));
 
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
 
         expect(g.errors).toEqual({'async': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set a single async validator from options obj', fakeAsync(() => {
+      it('should set a single async validator from options obj', async () => {
         const g = new FormArray([new FormControl('value')], {
           asyncValidators: asyncValidator('expected'),
         });
 
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
 
         expect(g.errors).toEqual({'async': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set multiple async validators from an array', fakeAsync(() => {
+      it('should set multiple async validators from an array', async () => {
         const g = new FormArray([new FormControl('value')], null!, [
           asyncValidator('expected'),
           otherObservableValidator,
@@ -1120,26 +1121,26 @@ import {asyncValidator} from './util';
 
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
 
         expect(g.errors).toEqual({'async': true, 'other': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set multiple async validators from options obj', fakeAsync(() => {
+      it('should set multiple async validators from options obj', async () => {
         const g = new FormArray([new FormControl('value')], {
           asyncValidators: [asyncValidator('expected'), otherObservableValidator],
         });
 
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
 
         expect(g.errors).toEqual({'async': true, 'other': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should fire statusChanges events when async validators are added via options object', fakeAsync(() => {
+      it('should fire statusChanges events when async validators are added via options object', async () => {
         // The behavior is tested (in other spec files) for each of the model types (`FormControl`,
         // `FormGroup` and `FormArray`).
         let statuses: string[] = [];
@@ -1151,9 +1152,9 @@ import {asyncValidator} from './util';
         asc.statusChanges.subscribe((status: any) => statuses.push(status));
 
         // After a tick, the async validator should change status PENDING -> VALID.
-        tick();
+        await timeout();
         expect(statuses).toEqual(['VALID']);
-      }));
+      });
     });
 
     describe('disable() & enable()', () => {
@@ -1319,31 +1320,31 @@ import {asyncValidator} from './util';
           expect(arr.errors).toEqual({'expected': true});
         });
 
-        it('should clear out async array errors when disabled', fakeAsync(() => {
+        it('should clear out async array errors when disabled', async () => {
           const arr = new FormArray([new FormControl()], null!, asyncValidator('expected'));
-          tick();
+          await timeout();
           expect(arr.errors).toEqual({'async': true});
 
           arr.disable();
           expect(arr.errors).toEqual(null);
 
           arr.enable();
-          tick();
+          await timeout();
           expect(arr.errors).toEqual({'async': true});
-        }));
+        });
 
-        it('should re-populate async array errors when enabled from a child', fakeAsync(() => {
+        it('should re-populate async array errors when enabled from a child', async () => {
           const arr = new FormArray([new FormControl()], null!, asyncValidator('expected'));
-          tick();
+          await timeout();
           expect(arr.errors).toEqual({'async': true});
 
           arr.disable();
           expect(arr.errors).toEqual(null);
 
           arr.push(new FormControl());
-          tick();
+          await timeout();
           expect(arr.errors).toEqual({'async': true});
-        }));
+        });
       });
 
       describe('disabled events', () => {

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {Component} from '@angular/core';
-import {fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {
   FormBuilder,
   NonNullableFormBuilder,
@@ -15,6 +15,7 @@ import {
   Validators,
 } from '../index';
 import {of} from 'rxjs';
+import {timeout, useAutoTick} from './util';
 
 (function () {
   function syncValidator() {
@@ -26,6 +27,8 @@ import {of} from 'rxjs';
 
   describe('Form Builder', () => {
     let b: FormBuilder;
+
+    useAutoTick();
 
     beforeEach(() => {
       b = new FormBuilder();
@@ -233,7 +236,7 @@ import {of} from 'rxjs';
       expect(a.asyncValidator).toBe(asyncValidator);
     });
 
-    it('should create control arrays with multiple async validators', fakeAsync(() => {
+    it('should create control arrays with multiple async validators', async () => {
       function asyncValidator1() {
         return of({'async1': true});
       }
@@ -244,10 +247,10 @@ import {of} from 'rxjs';
       const a = b.array(['one', 'two'], null, [asyncValidator1, asyncValidator2]);
       expect(a.value).toEqual(['one', 'two']);
 
-      tick();
+      await timeout();
 
       expect(a.errors).toEqual({'async1': true, 'async2': true});
-    }));
+    });
 
     it('should create control arrays with multiple sync validators', () => {
       function syncValidator1() {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {
   AbstractControl,
   ControlEvent,
@@ -24,6 +23,8 @@ import {
   asyncValidatorReturningObservable,
   currentStateOf,
   simpleAsyncValidator,
+  timeout,
+  useAutoTick,
 } from './util';
 import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model';
 
@@ -37,6 +38,8 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
   }
 
   describe('FormGroup', () => {
+    useAutoTick();
+
     describe('value', () => {
       it('should be the reduced value of the child controls', () => {
         const g = new FormGroup({'one': new FormControl('111'), 'two': new FormControl('222')});
@@ -947,12 +950,12 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
       let control: FormControl;
       let group: FormGroup;
 
-      beforeEach(waitForAsync(() => {
+      beforeEach(async () => {
         control = new FormControl('', null, asyncValidatorReturningObservable);
         group = new FormGroup({'one': control});
-      }));
+      });
 
-      it('should fire statusChanges events for async validators added via options object', fakeAsync(() => {
+      it('should fire statusChanges events for async validators added via options object', async () => {
         // The behavior can be tested for each of the model types.
         let statuses: string[] = [];
 
@@ -963,18 +966,18 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
         asc.statusChanges.subscribe((status: any) => statuses.push(status));
 
         // After a tick, the async validator should change status PENDING -> VALID.
-        tick();
+        await timeout();
         expect(statuses).toEqual(['VALID']);
-      }));
+      });
 
-      it('should fire a statusChange if child has async validation change', fakeAsync(() => {
+      it('should fire a statusChange if child has async validation change', async () => {
         const loggedValues: string[] = [];
         group.statusChanges.subscribe((status) => loggedValues.push(status));
 
         control.setValue('');
-        tick();
+        await timeout();
         expect(loggedValues).toEqual(['PENDING', 'INVALID']);
-      }));
+      });
     });
 
     describe('getError', () => {
@@ -1120,76 +1123,76 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
     });
 
     describe('asyncValidator', () => {
-      it('should run the async validator', fakeAsync(() => {
+      it('should run the async validator', async () => {
         const c = new FormControl('value');
         const g = new FormGroup({'one': c}, null!, asyncValidator('expected'));
 
         expect(g.pending).toEqual(true);
 
-        tick(1);
+        await timeout(1);
 
         expect(g.errors).toEqual({'async': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set multiple async validators from array', fakeAsync(() => {
+      it('should set multiple async validators from array', async () => {
         const g = new FormGroup({'one': new FormControl('value')}, null!, [
           asyncValidator('expected'),
           otherObservableValidator,
         ]);
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
         expect(g.errors).toEqual({'async': true, 'other': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set single async validator from options obj', fakeAsync(() => {
+      it('should set single async validator from options obj', async () => {
         const g = new FormGroup(
           {'one': new FormControl('value')},
           {asyncValidators: asyncValidator('expected')},
         );
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
         expect(g.errors).toEqual({'async': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it('should set multiple async validators from options obj', fakeAsync(() => {
+      it('should set multiple async validators from options obj', async () => {
         const g = new FormGroup(
           {'one': new FormControl('value')},
           {asyncValidators: [asyncValidator('expected'), otherObservableValidator]},
         );
         expect(g.pending).toEqual(true);
 
-        tick();
+        await timeout();
         expect(g.errors).toEqual({'async': true, 'other': true});
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it("should set the parent group's status to pending", fakeAsync(() => {
+      it("should set the parent group's status to pending", async () => {
         const c = new FormControl('value', null!, asyncValidator('expected'));
         const g = new FormGroup({'one': c});
 
         expect(g.pending).toEqual(true);
 
-        tick(1);
+        await timeout(1);
 
         expect(g.pending).toEqual(false);
-      }));
+      });
 
-      it("should run the parent group's async validator when children are pending", fakeAsync(() => {
+      it("should run the parent group's async validator when children are pending", async () => {
         const c = new FormControl('value', null!, asyncValidator('expected'));
         const g = new FormGroup({'one': c}, null!, asyncValidator('expected'));
 
-        tick(1);
+        await timeout(1);
 
         expect(g.errors).toEqual({'async': true});
         expect(g.get('one')!.errors).toEqual({'async': true});
-      }));
+      });
 
-      it('should handle successful async FormGroup resolving synchronously before a successful async child validator', fakeAsync(() => {
+      it('should handle successful async FormGroup resolving synchronously before a successful async child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1208,16 +1211,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: false, status: 'VALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle successful async FormGroup resolving after a synchronously and successfully resolving child validator', fakeAsync(() => {
+      it('should handle successful async FormGroup resolving after a synchronously and successfully resolving child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1236,16 +1239,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form group validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: false, status: 'VALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle successful async FormGroup and child control validators resolving synchronously', fakeAsync(() => {
+      it('should handle successful async FormGroup and child control validators resolving synchronously', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1262,9 +1265,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle failing async FormGroup and failing child control validators resolving synchronously', fakeAsync(() => {
+      it('should handle failing async FormGroup and failing child control validators resolving synchronously', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1286,9 +1289,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'INVALID'}, // Group
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle failing async FormGroup and successful child control validators resolving synchronously', fakeAsync(() => {
+      it('should handle failing async FormGroup and successful child control validators resolving synchronously', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1304,9 +1307,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle failing async FormArray and successful children validators resolving synchronously', fakeAsync(() => {
+      it('should handle failing async FormArray and successful children validators resolving synchronously', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1335,9 +1338,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Group p
           {errors: null, pending: false, status: 'VALID'}, // Control c2
         ]);
-      }));
+      });
 
-      it('should handle failing FormGroup validator resolving after successful child validator', fakeAsync(() => {
+      it('should handle failing FormGroup validator resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1355,7 +1358,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1363,16 +1366,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form group validation fails
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle failing FormArray validator resolving after successful child validator', fakeAsync(() => {
+      it('should handle failing FormArray validator resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1386,7 +1389,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([a, a.at(0)!])).toEqual([
@@ -1394,16 +1397,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form array validation fails
         expect(currentStateOf([a, a.at(0)!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // FormArray
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle successful FormGroup validator resolving after successful child validator', fakeAsync(() => {
+      it('should handle successful FormGroup validator resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1421,7 +1424,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1429,16 +1432,15 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
-
+        await timeout(1);
         // After 1ms, the form group validation resolves
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: false, status: 'VALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle successful FormArray validator resolving after successful child validators', fakeAsync(() => {
+      it('should handle successful FormArray validator resolving after successful child validators', async () => {
         const c1 = new FormControl(
           'fcValue',
           null!,
@@ -1469,7 +1471,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // c2
         ]);
 
-        tick(2);
+        await timeout(2);
 
         // After 2ms, g validation has resolved
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1478,7 +1480,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // c2
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, c2 validation has resolved
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1487,7 +1489,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // c2
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, FormArray own validation has resolved
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1495,9 +1497,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // g
           {errors: null, pending: false, status: 'VALID'}, // c2
         ]);
-      }));
+      });
 
-      it('should handle failing FormArray validator resolving after successful child validators', fakeAsync(() => {
+      it('should handle failing FormArray validator resolving after successful child validators', async () => {
         const c1 = new FormControl(
           'fcValue',
           null!,
@@ -1528,7 +1530,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // c2
         ]);
 
-        tick(2);
+        await timeout(2);
 
         // After 2ms, g validation has resolved
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1537,7 +1539,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // c2
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, c2 validation has resolved
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1546,7 +1548,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // c2
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, FormArray own validation has failed
         expect(currentStateOf([a, a.at(0)!, a.at(1)!])).toEqual([
@@ -1554,9 +1556,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // g
           {errors: null, pending: false, status: 'VALID'}, // c2
         ]);
-      }));
+      });
 
-      it('should handle multiple successful FormGroup validators resolving after successful child validator', fakeAsync(() => {
+      it('should handle multiple successful FormGroup validators resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1573,7 +1575,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1581,7 +1583,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, one form async validator has resolved but not the second
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1589,16 +1591,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form group validation resolves
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: false, status: 'VALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle multiple FormGroup validators (success then failure) resolving after successful child validator', fakeAsync(() => {
+      it('should handle multiple FormGroup validators (success then failure) resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1615,32 +1617,30 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
-
+        await timeout(1);
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: true, status: 'PENDING'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, one form async validator has resolved but not the second
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: null, pending: true, status: 'PENDING'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form group validation fails
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle multiple FormGroup validators (failure then success) resolving after successful child validator', fakeAsync(() => {
+      it('should handle multiple FormGroup validators (failure then success) resolving after successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1656,8 +1656,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Group
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
-
-        tick(1);
+        await timeout(1);
 
         // After 1ms, only form control validation has resolved
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1665,7 +1664,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // All async validators are composed into one function. So, after 2ms, the FormGroup g is
         // still in pending state without errors
@@ -1674,16 +1673,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, the form group validation fails
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle async validators in nested form groups / arrays', fakeAsync(() => {
+      it('should handle async validators in nested form groups / arrays', async () => {
         const c1 = new FormControl(
           'fcValue',
           null!,
@@ -1721,7 +1720,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Group g2
         ]);
 
-        tick(2);
+        await timeout(2);
 
         // After 2ms, g1 validation fails
         expect(currentStateOf([g, g.get('g1')!, g.get('g2')!])).toEqual([
@@ -1730,7 +1729,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Group g2
         ]);
 
-        tick(2);
+        await timeout(2);
 
         // After 2ms, g2 validation resolves
         expect(currentStateOf([g, g.get('g1')!, g.get('g2')!])).toEqual([
@@ -1739,7 +1738,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: false, status: 'VALID'}, // Group g2
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, g validation fails because g1 is invalid, but since errors do not cascade, so
         // we still have null errors for g
@@ -1748,9 +1747,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group g1
           {errors: null, pending: false, status: 'VALID'}, // Group g2
         ]);
-      }));
+      });
 
-      it('should handle failing FormGroup validator resolving before successful child validator', fakeAsync(() => {
+      it('should handle failing FormGroup validator resolving before successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1768,7 +1767,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, form group validation fails
         expect(currentStateOf([g, g.get('one')!])).toEqual([
@@ -1776,16 +1775,16 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, child validation resolves
         expect(currentStateOf([g, g.get('one')!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
 
-      it('should handle failing FormArray validator resolving before successful child validator', fakeAsync(() => {
+      it('should handle failing FormArray validator resolving before successful child validator', async () => {
         const c = new FormControl(
           'fcValue',
           null!,
@@ -1798,8 +1797,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // FormArray
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
-
-        tick(1);
+        await timeout(1);
 
         // After 1ms, form array validation fails
         expect(currentStateOf([a, a.at(0)!])).toEqual([
@@ -1807,14 +1805,14 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           {errors: null, pending: true, status: 'PENDING'}, // Control
         ]);
 
-        tick(1);
+        await timeout(1);
 
         // After 1ms, child validation resolves
         expect(currentStateOf([a, a.at(0)!])).toEqual([
           {errors: {async: true}, pending: false, status: 'INVALID'}, // FormArray
           {errors: null, pending: false, status: 'VALID'}, // Control
         ]);
-      }));
+      });
     });
 
     describe('disable() & enable()', () => {
@@ -2010,35 +2008,35 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           expect(g.errors).toEqual({'expected': true});
         });
 
-        it('should clear out async group errors when disabled', fakeAsync(() => {
+        it('should clear out async group errors when disabled', async () => {
           const g = new FormGroup({'one': new FormControl()}, null!, asyncValidator('expected'));
-          tick();
+          await timeout();
           expect(g.errors).toEqual({'async': true});
 
           g.disable();
           expect(g.errors).toEqual(null);
 
           g.enable();
-          tick();
+          await timeout();
           expect(g.errors).toEqual({'async': true});
-        }));
+        });
 
-        it('should re-populate async group errors when enabled from a child', fakeAsync(() => {
+        it('should re-populate async group errors when enabled from a child', async () => {
           const g: FormGroup = new FormGroup(
             {'one': new FormControl()},
             null!,
             asyncValidator('expected'),
           );
-          tick();
+          await timeout();
           expect(g.errors).toEqual({'async': true});
 
           g.disable();
           expect(g.errors).toEqual(null);
 
           g.addControl('two', new FormControl());
-          tick();
+          await timeout();
           expect(g.errors).toEqual({'async': true});
-        }));
+        });
       });
 
       describe('disabled events', () => {
@@ -2192,7 +2190,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
       };
 
       describe('stand alone controls', () => {
-        it('should run the async validator on stand alone controls and set status to `INVALID`', fakeAsync(() => {
+        it('should run the async validator on stand alone controls and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', null, simpleAsyncValidator({timeout: 0, shouldFail: true}));
 
@@ -2200,11 +2198,11 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           expect(logs.length).toBe(0);
 
-          tick(1);
+          await timeout(1);
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           // Note that above `simpleAsyncValidator` is called with `timeout:0`.  When the timeout
           // is set to `0`, the function returns `of(error)`, and the function behaves in a
@@ -2215,9 +2213,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             'value: "new!"', // value change emitted by `setValue`
             'status: INVALID', // async validator run after `setValue` call
           ]);
-        }));
+        });
 
-        it('should run the async validator on stand alone controls and set status to `VALID`', fakeAsync(() => {
+        it('should run the async validator on stand alone controls and set status to `VALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', null, asyncValidator('new!'));
 
@@ -2225,11 +2223,11 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           expect(logs.length).toBe(0);
 
-          tick(1);
+          await timeout(1);
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'status: INVALID', // status change emitted as a result of initial async validator run
@@ -2237,9 +2235,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             'status: PENDING', // status change emitted by `setValue`
             'status: VALID', // async validator run after `setValue` call
           ]);
-        }));
+        });
 
-        it('should run the async validator on stand alone controls, include `PENDING` and set status to `INVALID`', fakeAsync(() => {
+        it('should run the async validator on stand alone controls, include `PENDING` and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
@@ -2247,11 +2245,11 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           expect(logs.length).toBe(0);
 
-          tick(1);
+          await timeout(1);
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'status: INVALID', // status change emitted as a result of initial async validator run
@@ -2259,9 +2257,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             'status: PENDING', // status change emitted by `setValue`
             'status: INVALID', // async validator run after `setValue` call
           ]);
-        }));
+        });
 
-        it('should run setValue before the initial async validator and set status to `VALID`', fakeAsync(() => {
+        it('should run setValue before the initial async validator and set status to `VALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', null, asyncValidator('new!'));
 
@@ -2271,7 +2269,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           // The `setValue` call invoked synchronously cancels the initial run of the
           // `asyncValidator` (which would cause the control status to be changed to `INVALID`), so
@@ -2281,9 +2279,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             'status: PENDING', // status change emitted by `setValue`
             'status: VALID', // async validator run after `setValue` call
           ]);
-        }));
+        });
 
-        it('should run setValue before the initial async validator and set status to `INVALID`', fakeAsync(() => {
+        it('should run setValue before the initial async validator and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
@@ -2293,7 +2291,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           // The `setValue` call invoked synchronously cancels the initial run of the
           // `asyncValidator` (which would cause the control status to be changed to `INVALID`), so
@@ -2303,9 +2301,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             'status: PENDING', // status change emitted by `setValue`
             'status: INVALID', // async validator run after `setValue` call
           ]);
-        }));
+        });
 
-        it('should cancel initial run of the async validator and not emit anything', fakeAsync(() => {
+        it('should cancel initial run of the async validator and not emit anything', async () => {
           const logger: string[] = [];
           const c = new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
@@ -2315,14 +2313,14 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           c.setValue('new!', {emitEvent: false});
 
-          tick(1);
+          await timeout(1);
 
           // Because we are calling `setValue` with `emitEvent: false`, nothing is emitted
           // and our logger remains empty
           expect(logger).toEqual([]);
-        }));
+        });
 
-        it('should emit status change despite updating the value with emitEvent: false multiple times', fakeAsync(() => {
+        it('should emit status change despite updating the value with emitEvent: false multiple times', async () => {
           const c = new FormControl(
             '',
             null,
@@ -2340,7 +2338,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           const events: FormControlStatus[] = [];
           statusChange$.subscribe((e) => events.push(e));
-          tick(1);
+          await timeout(1);
 
           expect(c.status).toBe('VALID');
           expect(events.length).toBe(1);
@@ -2348,15 +2346,15 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           c.setValue('foo', {emitEvent: false});
           c.setValue('foo', {emitEvent: false});
-          tick(1);
+          await timeout(1);
 
           // We make sure that we're still not emitting if none of the updates requested an emit
           expect(c.status).toBe('VALID');
           expect(events.length).toBe(1);
           expect(events.at(-1)).toBe('VALID');
-        }));
+        });
 
-        it('should cancel initial run of the async validator and emit on the event Observable', fakeAsync(() => {
+        it('should cancel initial run of the async validator and emit on the event Observable', async () => {
           const c = new FormControl('', null, simpleAsyncValidator({timeout: 1, shouldFail: true}));
 
           const events: ControlEvent[] = [];
@@ -2366,7 +2364,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           c.setValue('new!');
 
-          tick(1);
+          await timeout(1);
 
           // validator was invoked twice (init + setValue)
           // but since we cancel pending validators we only get 1 status update cycle
@@ -2375,9 +2373,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
           expect((events[1] as StatusChangeEvent).status).toBe('PENDING');
           expect(events[2]).toBeInstanceOf(StatusChangeEvent);
           expect((events[2] as StatusChangeEvent).status).toBe('INVALID');
-        }));
+        });
 
-        it('should run the sync validator on stand alone controls and set status to `INVALID`', fakeAsync(() => {
+        it('should run the sync validator on stand alone controls and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('new!', Validators.required);
 
@@ -2385,19 +2383,19 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           expect(logs.length).toBe(0);
 
-          tick(1);
+          await timeout(1);
 
           c.setValue('', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value: ""', // value change emitted by `setValue`
             'status: INVALID', // status change emitted by `setValue`
           ]);
-        }));
+        });
 
-        it('should run the sync validator on stand alone controls and set status to `VALID`', fakeAsync(() => {
+        it('should run the sync validator on stand alone controls and set status to `VALID`', async () => {
           const logs: string[] = [];
           const c = new FormControl('', Validators.required);
 
@@ -2405,21 +2403,21 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           expect(logs.length).toBe(0);
 
-          tick(1);
+          await timeout(1);
 
           c.setValue('new!', {emitEvent: true});
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value: "new!"', // value change emitted by `setValue`
             'status: VALID', // status change emitted by `setValue`
           ]);
-        }));
+        });
       });
 
       describe('combination of multiple form controls', () => {
-        it('should run the async validator on the FormControl added to the FormGroup and set status to `VALID`', fakeAsync(() => {
+        it('should run the async validator on the FormControl added to the FormGroup and set status to `VALID`', async () => {
           const logs: string[] = [];
           const c1 = new FormControl('one');
           const g1 = new FormGroup({'one': c1});
@@ -2445,7 +2443,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           g1.setControl('one', c2);
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value (g1): {"one":"new!"}', // value change emitted by `setControl`
@@ -2459,9 +2457,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             {errors: null, pending: false, status: 'VALID'}, // Group
             {errors: null, pending: false, status: 'VALID'}, // Control 2
           ]);
-        }));
+        });
 
-        it('should run the async validator on the FormControl added to the FormGroup and set status to `INVALID`', fakeAsync(() => {
+        it('should run the async validator on the FormControl added to the FormGroup and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c1 = new FormControl('one');
           const g1 = new FormGroup({'one': c1});
@@ -2491,7 +2489,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           g1.setControl('one', c2);
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value (g1): {"one":"new!"}',
@@ -2506,9 +2504,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             {errors: null, pending: false, status: 'INVALID'}, // Group
             {errors: {async: true}, pending: false, status: 'INVALID'}, // Control 2
           ]);
-        }));
+        });
 
-        it('should run the async validator at `FormControl` and `FormGroup` level and set status to `INVALID`', fakeAsync(() => {
+        it('should run the async validator at `FormControl` and `FormGroup` level and set status to `INVALID`', async () => {
           const logs: string[] = [];
           const c1 = new FormControl('one');
           const g1 = new FormGroup(
@@ -2542,7 +2540,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           g1.setControl('one', c2);
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value (g1): {"one":"new!"}',
@@ -2558,9 +2556,9 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             {errors: {async: true}, pending: false, status: 'INVALID'}, // Group
             {errors: {async: true}, pending: false, status: 'INVALID'}, // Control 2
           ]);
-        }));
+        });
 
-        it('should run the async validator on a `FormArray` and a `FormControl` and status to `INVALID`', fakeAsync(() => {
+        it('should run the async validator on a `FormArray` and a `FormControl` and status to `INVALID`', async () => {
           const logs: string[] = [];
           const c1 = new FormControl('one');
           const g1 = new FormGroup(
@@ -2602,7 +2600,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
 
           g1.setControl('one', c2);
 
-          tick(1);
+          await timeout(1);
 
           expect(logs).toEqual([
             'value (g1): {"one":"new!"}', // g1's call to `setControl` triggered value update
@@ -2623,7 +2621,7 @@ import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model'
             {errors: {async: true}, pending: false, status: 'INVALID'}, // FormArray
             {errors: {async: true}, pending: false, status: 'INVALID'}, // Control 2
           ]);
-        }));
+        });
       });
     });
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -17,7 +17,7 @@ import {
   Type,
   ViewChild,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchEvent, isNode, sortedClassList} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
@@ -60,6 +60,7 @@ import {
 } from '../src/model/abstract_model';
 
 import {MyInput, MyInputForm} from './value_accessor_integration_spec';
+import {timeout, useAutoTick} from './util';
 
 // Produces a new @Directive (with a given selector) that represents a validator class.
 function createValidatorClass(selector: string) {
@@ -139,6 +140,8 @@ const ValueAccessorA = createControlValueAccessor('[cva-a]');
 const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
 describe('reactive forms integration tests', () => {
+  useAutoTick();
+
   function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
@@ -1712,7 +1715,7 @@ describe('reactive forms integration tests', () => {
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
     });
 
-    it('should work with single fields and async validators', fakeAsync(() => {
+    it('should work with single fields and async validators', async () => {
       const fixture = initTest(FormControlComp);
       const control = new FormControl('', null!, uniqLoginAsyncValidator('good'));
       fixture.debugElement.componentInstance.control = control;
@@ -1727,13 +1730,13 @@ describe('reactive forms integration tests', () => {
 
       input.value = 'good';
       dispatchEvent(input, 'input');
-      tick();
+      await timeout();
       fixture.detectChanges();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-    }));
+    });
 
-    it('should work with single fields that combines async and sync validators', fakeAsync(() => {
+    it('should work with single fields that combines async and sync validators', async () => {
       const fixture = initTest(FormControlComp);
       const control = new FormControl('', Validators.required, uniqLoginAsyncValidator('good'));
       fixture.debugElement.componentInstance.control = control;
@@ -1752,18 +1755,18 @@ describe('reactive forms integration tests', () => {
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-pending', 'ng-touched']);
 
-      tick();
+      await timeout();
       fixture.detectChanges();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-invalid', 'ng-touched']);
 
       input.value = 'good';
       dispatchEvent(input, 'input');
-      tick();
+      await timeout();
       fixture.detectChanges();
 
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
-    }));
+    });
 
     it('should work with single fields in parent forms', () => {
       const fixture = initTest(FormGroupComp);
@@ -2916,19 +2919,19 @@ describe('reactive forms integration tests', () => {
           .toBe(true);
       });
 
-      it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
+      it('should not prevent the default action on forms with method="dialog"', async () => {
         if (typeof HTMLDialogElement === 'undefined') {
           return;
         }
 
         const fixture = initTest(NativeDialogForm);
         fixture.detectChanges();
-        tick();
+        await timeout();
         const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
         fixture.detectChanges();
 
         expect(event.defaultPrevented).toBe(false);
-      }));
+      });
     });
   });
 
@@ -2944,14 +2947,14 @@ describe('reactive forms integration tests', () => {
     });
 
     describe('deprecation warnings', () => {
-      it('should warn once by default when using ngModel with formControlName', fakeAsync(() => {
+      it('should warn once by default when using ngModel with formControlName', async () => {
         const fixture = initTest(FormGroupNgModel);
         fixture.componentInstance.form = new FormGroup({
           'login': new FormControl(''),
           'password': new FormControl(''),
         });
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
         expect(warnSpy.calls.mostRecent().args[0]).toMatch(
@@ -2961,17 +2964,17 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.login = 'some value';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
-      }));
+      });
 
-      it('should warn once by default when using ngModel with formControl', fakeAsync(() => {
+      it('should warn once by default when using ngModel with formControl', async () => {
         const fixture = initTest(FormControlNgModel);
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
         expect(warnSpy.calls.mostRecent().args[0]).toMatch(
@@ -2981,12 +2984,12 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.login = 'some value';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy.calls.count()).toEqual(1);
-      }));
+      });
 
-      it('should warn once for each instance when global provider is provided with "always"', fakeAsync(() => {
+      it('should warn once for each instance when global provider is provided with "always"', async () => {
         TestBed.configureTestingModule({
           declarations: [FormControlNgModel],
           imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'always'})],
@@ -2996,15 +2999,15 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy.calls.count()).toEqual(2);
         expect(warnSpy.calls.mostRecent().args[0]).toMatch(
           /It looks like you're using ngModel on the same form field as formControl/gi,
         );
-      }));
+      });
 
-      it('should silence warnings when global provider is provided with "never"', fakeAsync(() => {
+      it('should silence warnings when global provider is provided with "never"', async () => {
         TestBed.configureTestingModule({
           declarations: [FormControlNgModel],
           imports: [ReactiveFormsModule.withConfig({warnOnNgModelWithFormControl: 'never'})],
@@ -3014,13 +3017,13 @@ describe('reactive forms integration tests', () => {
         fixture.componentInstance.control = new FormControl('');
         fixture.componentInstance.passwordControl = new FormControl('');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(warnSpy).not.toHaveBeenCalled();
-      }));
+      });
     });
 
-    it('should support ngModel for complex forms', fakeAsync(() => {
+    it('should support ngModel for complex forms', async () => {
       const fixture = initTest(FormGroupNgModel);
       fixture.componentInstance.form = new FormGroup({
         'login': new FormControl(''),
@@ -3028,7 +3031,7 @@ describe('reactive forms integration tests', () => {
       });
       fixture.componentInstance.login = 'oldValue';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(input.value).toEqual('oldValue');
@@ -3036,35 +3039,35 @@ describe('reactive forms integration tests', () => {
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
 
-      tick();
+      await timeout();
       expect(fixture.componentInstance.login).toEqual('updatedValue');
-    }));
+    });
 
-    it('should support ngModel for single fields', fakeAsync(() => {
+    it('should support ngModel for single fields', async () => {
       const fixture = initTest(FormControlNgModel);
       fixture.componentInstance.control = new FormControl('');
       fixture.componentInstance.passwordControl = new FormControl('');
       fixture.componentInstance.login = 'oldValue';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       expect(input.value).toEqual('oldValue');
 
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
-      tick();
+      await timeout();
 
       expect(fixture.componentInstance.login).toEqual('updatedValue');
-    }));
+    });
 
-    it('should not update the view when the value initially came from the view', fakeAsync(() => {
+    it('should not update the view when the value initially came from the view', async () => {
       if (isNode) return;
       const fixture = initTest(FormControlNgModel);
       fixture.componentInstance.control = new FormControl('');
       fixture.componentInstance.passwordControl = new FormControl('');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       input.value = 'aa';
@@ -3072,13 +3075,13 @@ describe('reactive forms integration tests', () => {
       dispatchEvent(input, 'input');
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       // selection start has not changed because we did not reset the value
       expect(input.selectionStart).toEqual(1);
-    }));
+    });
 
-    it('should work with updateOn submit', fakeAsync(() => {
+    it('should work with updateOn submit', async () => {
       const fixture = initTest(FormGroupNgModel);
       const formGroup = new FormGroup({
         login: new FormControl('', {updateOn: 'submit'}),
@@ -3087,13 +3090,13 @@ describe('reactive forms integration tests', () => {
       fixture.componentInstance.form = formGroup;
       fixture.componentInstance.login = 'initial';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       input.value = 'Nancy';
       dispatchEvent(input, 'input');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(fixture.componentInstance.login)
         .withContext('Expected ngModel value to remain unchanged on input.')
@@ -3102,12 +3105,12 @@ describe('reactive forms integration tests', () => {
       const form = fixture.debugElement.query(By.css('form')).nativeElement;
       dispatchEvent(form, 'submit');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(fixture.componentInstance.login)
         .withContext('Expected ngModel value to update on submit.')
         .toEqual('Nancy');
-    }));
+    });
   });
 
   describe('validations', () => {
@@ -3381,14 +3384,14 @@ describe('reactive forms integration tests', () => {
 
       expect(form.pending).toEqual(true);
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await timeout(100);
 
       expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
       const input = fixture.debugElement.query(By.css('input'));
       input.nativeElement.value = 'expected';
       dispatchEvent(input.nativeElement, 'input');
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await timeout(100);
 
       expect(form.valid).toEqual(true);
     });
@@ -3407,13 +3410,13 @@ describe('reactive forms integration tests', () => {
       expect(form.valid).toEqual(false);
     });
 
-    it('should use async validators defined in the model', fakeAsync(() => {
+    it('should use async validators defined in the model', async () => {
       const fixture = initTest(FormGroupComp);
       const control = new FormControl('', Validators.required, uniqLoginAsyncValidator('expected'));
       const form = new FormGroup({'login': control});
       fixture.componentInstance.form = form;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(form.hasError('required', ['login'])).toEqual(true);
 
@@ -3422,18 +3425,18 @@ describe('reactive forms integration tests', () => {
       dispatchEvent(input.nativeElement, 'input');
 
       expect(form.pending).toEqual(true);
-      tick();
+      await timeout();
 
       expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
       input.nativeElement.value = 'expected';
       dispatchEvent(input.nativeElement, 'input');
-      tick();
+      await timeout();
 
       expect(form.valid).toEqual(true);
-    }));
+    });
 
-    it('async validator should not override result of sync validator', fakeAsync(() => {
+    it('async validator should not override result of sync validator', async () => {
       const fixture = initTest(FormGroupComp);
       const control = new FormControl(
         '',
@@ -3442,7 +3445,7 @@ describe('reactive forms integration tests', () => {
       );
       fixture.componentInstance.form = new FormGroup({'login': control});
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(control.hasError('required')).toEqual(true);
 
@@ -3454,12 +3457,12 @@ describe('reactive forms integration tests', () => {
 
       input.nativeElement.value = '';
       dispatchEvent(input.nativeElement, 'input');
-      tick(110);
+      await timeout(110);
 
       expect(control.valid).toEqual(false);
-    }));
+    });
 
-    it('should handle async validation changes in parent and child controls', fakeAsync(() => {
+    it('should handle async validation changes in parent and child controls', async () => {
       const fixture = initTest(FormGroupComp);
       const control = new FormControl(
         '',
@@ -3473,7 +3476,7 @@ describe('reactive forms integration tests', () => {
       );
       fixture.componentInstance.form = form;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       // Initially, the form is invalid because the nested mandatory control is empty
       expect(control.hasError('required')).toEqual(true);
@@ -3489,7 +3492,7 @@ describe('reactive forms integration tests', () => {
       // The form control asynchronous validation is in progress (for 100 ms)
       expect(control.pending).toEqual(true);
 
-      tick(100);
+      await timeout(100);
 
       // Now the asynchronous validation has resolved, and since the form control value
       // (`angul`) has a length > 3, the validation is successful
@@ -3499,7 +3502,7 @@ describe('reactive forms integration tests', () => {
       // waiting for its own validation
       expect(form.pending).toEqual(true);
 
-      tick(100);
+      await timeout(100);
 
       // Login form control is valid. However, the form control is invalid because `angul` does
       // not include `angular`
@@ -3514,23 +3517,23 @@ describe('reactive forms integration tests', () => {
       // Since the form control value changed, its asynchronous validation runs for 100ms
       expect(control.pending).toEqual(true);
 
-      tick(100);
+      await timeout(100);
 
       // Even if the child control is valid, the form control is pending because it is still
       // waiting for its own validation
       expect(control.invalid).toEqual(false);
       expect(form.pending).toEqual(true);
 
-      tick(100);
+      await timeout(100);
 
       // Now, the form is valid because its own asynchronous validation has resolved
       // successfully, because the form control value `angular` includes the `angular` string
       expect(control.invalid).toEqual(false);
       expect(form.pending).toEqual(false);
       expect(form.invalid).toEqual(false);
-    }));
+    });
 
-    it('should cancel observable properly between validation runs', fakeAsync(() => {
+    it('should cancel observable properly between validation runs', async () => {
       const fixture = initTest(FormControlComp);
       const resultArr: number[] = [];
       fixture.componentInstance.control = new FormControl(
@@ -3539,7 +3542,7 @@ describe('reactive forms integration tests', () => {
         observableValidator(resultArr),
       );
       fixture.detectChanges();
-      tick(100);
+      await timeout(100);
 
       expect(resultArr.length)
         .withContext(`Expected source observable to emit once on init.`)
@@ -3554,11 +3557,11 @@ describe('reactive forms integration tests', () => {
       dispatchEvent(input.nativeElement, 'input');
       fixture.detectChanges();
 
-      tick(100);
+      await timeout(100);
       expect(resultArr.length)
         .withContext(`Expected original observable to be canceled on the next value change.`)
         .toEqual(2);
-    }));
+    });
 
     describe('enabling validators conditionally', () => {
       it('should not activate minlength and maxlength validators if input is null', () => {
@@ -4719,7 +4722,7 @@ describe('reactive forms integration tests', () => {
       expectValidatorsToBeCalled(validatorSpy, asyncValidatorSpy, {ctx: newControl, count: 1});
     });
 
-    it('should keep control in pending state if async validator never emits', fakeAsync(() => {
+    it('should keep control in pending state if async validator never emits', async () => {
       const fixture = initTest(FormControlWithAsyncValidatorFn);
       fixture.detectChanges();
 
@@ -4727,12 +4730,12 @@ describe('reactive forms integration tests', () => {
       expect(control.status).toBe('PENDING');
 
       control.setValue('SOME-NEW-VALUE');
-      tick();
+      await timeout();
 
       // Since validator never emits, we expect a control to be retained in a pending state.
       expect(control.status).toBe('PENDING');
       expect(control.errors).toBe(null);
-    }));
+    });
 
     it('should call validators defined via `set[Async]Validators` after view init', () => {
       const fixture = initTest(FormControlWithValidators, ViewValidatorA, AsyncViewValidatorA);

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, ɵgetDOM as getDOM} from '@angular/common';
 import {Component, Directive, ElementRef, forwardRef, Input, Type, ViewChild} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   AbstractControl,
   AsyncValidator,
@@ -30,8 +30,11 @@ import {dispatchEvent, sortedClassList} from '@angular/private/testing';
 import {merge} from 'rxjs';
 
 import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integration_spec';
+import {timeout, useAutoTick} from './util';
 
 describe('template-driven forms integration tests', () => {
+  useAutoTick();
+
   function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
@@ -41,12 +44,12 @@ describe('template-driven forms integration tests', () => {
   }
 
   describe('basic functionality', () => {
-    it('should support ngModel for standalone fields', fakeAsync(() => {
+    it('should support ngModel for standalone fields', async () => {
       const fixture = initTest(StandaloneNgModel);
       fixture.componentInstance.name = 'oldValue';
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       // model -> view
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -54,23 +57,23 @@ describe('template-driven forms integration tests', () => {
 
       input.value = 'updatedValue';
       dispatchEvent(input, 'input');
-      tick();
+      await timeout();
 
       // view -> model
       expect(fixture.componentInstance.name).toEqual('updatedValue');
-    }));
+    });
 
-    it('should support ngModel registration with a parent form', fakeAsync(() => {
+    it('should support ngModel registration with a parent form', async () => {
       const fixture = initTest(NgModelForm);
       fixture.componentInstance.name = 'Nancy';
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.value).toEqual({name: 'Nancy'});
       expect(form.valid).toBe(false);
-    }));
+    });
 
     it('should report properties which are written outside of template bindings', async () => {
       // For example ngModel writes to `checked` property programmatically
@@ -93,34 +96,34 @@ describe('template-driven forms integration tests', () => {
       expect(input.nativeElement.checked).toBe(true);
     });
 
-    it('should add novalidate by default to form element', fakeAsync(() => {
+    it('should add novalidate by default to form element', async () => {
       const fixture = initTest(NgModelForm);
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.query(By.css('form'));
       expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
-    }));
+    });
 
-    it('should be possible to use native validation and angular forms', fakeAsync(() => {
+    it('should be possible to use native validation and angular forms', async () => {
       const fixture = initTest(NgModelNativeValidateForm);
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.query(By.css('form'));
       expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
-    }));
+    });
 
-    it('should support ngModelGroup', fakeAsync(() => {
+    it('should support ngModelGroup', async () => {
       const fixture = initTest(NgModelGroupForm);
       fixture.componentInstance.first = 'Nancy';
       fixture.componentInstance.last = 'Drew';
       fixture.componentInstance.email = 'some email';
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       // model -> view
       const inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -129,36 +132,36 @@ describe('template-driven forms integration tests', () => {
 
       inputs[0].nativeElement.value = 'Carson';
       dispatchEvent(inputs[0].nativeElement, 'input');
-      tick();
+      await timeout();
 
       // view -> model
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.value).toEqual({name: {first: 'Carson', last: 'Drew'}, email: 'some email'});
-    }));
+    });
 
-    it('should add controls and control groups to form control model', fakeAsync(() => {
+    it('should add controls and control groups to form control model', async () => {
       const fixture = initTest(NgModelGroupForm);
       fixture.componentInstance.first = 'Nancy';
       fixture.componentInstance.last = 'Drew';
       fixture.componentInstance.email = 'some email';
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.control.get('name')!.value).toEqual({first: 'Nancy', last: 'Drew'});
       expect(form.control.get('name.first')!.value).toEqual('Nancy');
       expect(form.control.get('email')!.value).toEqual('some email');
-    }));
+    });
 
-    it('should remove controls and control groups from form control model', fakeAsync(() => {
+    it('should remove controls and control groups from form control model', async () => {
       const fixture = initTest(NgModelNgIfForm);
       fixture.componentInstance.emailShowing = true;
       fixture.componentInstance.first = 'Nancy';
       fixture.componentInstance.email = 'some email';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.control.get('email')!.value).toEqual('some email');
@@ -168,7 +171,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.emailShowing = false;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(form.control.get('email')).toBe(null);
       expect(form.value).toEqual({name: {first: 'Nancy'}});
@@ -180,14 +183,14 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.groupShowing = false;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(form.control.get('name')).toBe(null);
       expect(form.control.get('name.first')).toBe(null);
       expect(form.value).toEqual({});
-    }));
+    });
 
-    it('should set status classes with ngModel', waitForAsync(() => {
+    it('should set status classes with ngModel', async () => {
       const fixture = initTest(NgModelForm);
       fixture.componentInstance.name = 'aa';
       fixture.detectChanges();
@@ -225,7 +228,7 @@ describe('template-driven forms integration tests', () => {
         expect(sortedClassList(formEl)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
         expect(sortedClassList(input)).not.toContain('ng-submitted');
       });
-    }));
+    });
 
     it('should set status classes with ngModel and async validators', async () => {
       const fixture = initTest(NgModelAsyncValidation, NgAsyncValidator);
@@ -247,7 +250,7 @@ describe('template-driven forms integration tests', () => {
       expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
     });
 
-    it('should set status classes with ngModelGroup and ngForm', waitForAsync(() => {
+    it('should set status classes with ngModelGroup and ngForm', async () => {
       const fixture = initTest(NgModelGroupForm);
       fixture.componentInstance.first = '';
       fixture.detectChanges();
@@ -287,7 +290,7 @@ describe('template-driven forms integration tests', () => {
           'ng-valid',
         ]);
       });
-    }));
+    });
 
     it('should set status classes involving nested FormGroups', async () => {
       const fixture = initTest(NgModelNestedForm);
@@ -339,7 +342,7 @@ describe('template-driven forms integration tests', () => {
       expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
     });
 
-    it('should keep track of the ngModel value when together used with an ngFor inside a form', fakeAsync(() => {
+    it('should keep track of the ngModel value when together used with an ngFor inside a form', async () => {
       @Component({
         template: `
           <form>
@@ -371,35 +374,35 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.add(3);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '2']);
 
       fixture.componentInstance.remove(1);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '2']);
 
       fixture.componentInstance.add(1);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '2', '3']);
 
       fixture.componentInstance.items[1].value = '1';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '3']);
 
       fixture.componentInstance.items[2].value = '2';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '2']);
-    }));
+    });
 
-    it('should keep track of the ngModel value when together used with an ngFor inside an ngModelGroup', fakeAsync(() => {
+    it('should keep track of the ngModel value when together used with an ngFor inside an ngModelGroup', async () => {
       @Component({
         template: `
           <form>
@@ -434,33 +437,33 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.add(3);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '2']);
 
       fixture.componentInstance.remove(1);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '2']);
 
       fixture.componentInstance.add(1);
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '2', '3']);
 
       fixture.componentInstance.items[1].value = '1';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '3']);
 
       fixture.componentInstance.items[2].value = '2';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(getValues()).toEqual(['0', '1', '2']);
-    }));
+    });
   });
 
   describe('name and ngModelOptions', () => {
@@ -474,67 +477,67 @@ describe('template-driven forms integration tests', () => {
       expect(() => fixture.detectChanges()).not.toThrow();
     });
 
-    it('should not register standalone ngModels with parent form', fakeAsync(() => {
+    it('should not register standalone ngModels with parent form', async () => {
       const fixture = initTest(NgModelOptionsStandalone);
       fixture.componentInstance.one = 'some data';
       fixture.componentInstance.two = 'should not show';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const inputs = fixture.debugElement.queryAll(By.css('input'));
-      tick();
+      await timeout();
 
       expect(form.value).toEqual({one: 'some data'});
       expect(inputs[1].nativeElement.value).toEqual('should not show');
-    }));
+    });
 
-    it('should override name attribute with ngModelOptions name if provided', fakeAsync(() => {
+    it('should override name attribute with ngModelOptions name if provided', async () => {
       const fixture = initTest(NgModelForm);
       fixture.componentInstance.options = {name: 'override'};
       fixture.componentInstance.name = 'some data';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.value).toEqual({override: 'some data'});
-    }));
+    });
   });
 
   describe('updateOn', () => {
     describe('blur', () => {
-      it('should default updateOn to change', fakeAsync(() => {
+      it('should default updateOn to change', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         const name = form.control.get('name') as FormControl;
         expect((name as any)._updateOn).toBeUndefined();
         expect(name.updateOn).toEqual('change');
-      }));
+      });
 
-      it('should set control updateOn to blur properly', fakeAsync(() => {
+      it('should set control updateOn to blur properly', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         const name = form.control.get('name') as FormControl;
         expect((name as any)._updateOn).toEqual('blur');
         expect(name.updateOn).toEqual('blur');
-      }));
+      });
 
-      it('should always set value and validity on init', fakeAsync(() => {
+      it('should always set value and validity on init', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -545,20 +548,20 @@ describe('template-driven forms integration tests', () => {
           name: 'Nancy Drew',
         });
         expect(form.valid).withContext('Expected validation to run on initial value.').toBe(true);
-      }));
+      });
 
-      it('should always set value programmatically right away', fakeAsync(() => {
+      it('should always set value programmatically right away', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         fixture.componentInstance.name = 'Carson';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -572,20 +575,20 @@ describe('template-driven forms integration tests', () => {
         expect(form.valid)
           .withContext('Expected validation to run immediately on programmatic change.')
           .toBe(false);
-      }));
+      });
 
-      it('should update value/validity on blur', fakeAsync(() => {
+      it('should update value/validity on blur', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(fixture.componentInstance.name)
@@ -600,14 +603,14 @@ describe('template-driven forms integration tests', () => {
           .withContext('Expected value to update on blur.')
           .toEqual('Nancy Drew');
         expect(form.valid).withContext('Expected validation to run on blur.').toBe(true);
-      }));
+      });
 
-      it('should wait for second blur to update value/validity again', fakeAsync(() => {
+      it('should wait for second blur to update value/validity again', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
@@ -620,7 +623,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Carson';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(fixture.componentInstance.name)
@@ -637,20 +640,20 @@ describe('template-driven forms integration tests', () => {
           .withContext('Expected value to update on second blur.')
           .toEqual('Carson');
         expect(form.valid).withContext('Expected validation to run on second blur.').toBe(false);
-      }));
+      });
 
-      it('should not update dirtiness until blur', fakeAsync(() => {
+      it('should not update dirtiness until blur', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(form.dirty).withContext('Expected dirtiness not to update on input.').toBe(false);
@@ -659,20 +662,20 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
 
         expect(form.dirty).withContext('Expected dirtiness to update on blur.').toBe(true);
-      }));
+      });
 
-      it('should not update touched until blur', fakeAsync(() => {
+      it('should not update touched until blur', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(form.touched).withContext('Expected touched not to update on input.').toBe(false);
@@ -681,14 +684,14 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
 
         expect(form.touched).withContext('Expected touched to update on blur.').toBe(true);
-      }));
+      });
 
-      it('should not emit valueChanges or statusChanges until blur', fakeAsync(() => {
+      it('should not emit valueChanges or statusChanges until blur', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const values: any[] = [];
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -701,7 +704,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input.')
@@ -716,14 +719,14 @@ describe('template-driven forms integration tests', () => {
         );
 
         sub.unsubscribe();
-      }));
+      });
 
-      it('should not fire ngModelChange event on blur unless value has changed', fakeAsync(() => {
+      it('should not fire ngModelChange event on blur unless value has changed', async () => {
         const fixture = initTest(NgModelChangesForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.events)
           .withContext('Expected ngModelChanges not to fire.')
@@ -740,7 +743,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Carson';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.events)
           .withContext('Expected ngModelChanges not to fire on input.')
@@ -764,7 +767,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Bess';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.events)
           .withContext('Expected ngModelChanges not to fire on input after blur.')
@@ -777,29 +780,29 @@ describe('template-driven forms integration tests', () => {
           ['fired', 'fired'],
           'Expected ngModelChanges to fire again on blur if value changed.',
         );
-      }));
+      });
     });
 
     describe('submit', () => {
-      it('should set control updateOn to submit properly', fakeAsync(() => {
+      it('should set control updateOn to submit properly', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         const name = form.control.get('name') as FormControl;
         expect((name as any)._updateOn).toEqual('submit');
         expect(name.updateOn).toEqual('submit');
-      }));
+      });
 
-      it('should always set value and validity on init', fakeAsync(() => {
+      it('should always set value and validity on init', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -810,20 +813,20 @@ describe('template-driven forms integration tests', () => {
           .withContext('Expected initial control value be set.')
           .toEqual({name: 'Nancy Drew'});
         expect(form.valid).withContext('Expected validation to run on initial value.').toBe(true);
-      }));
+      });
 
-      it('should always set value programmatically right away', fakeAsync(() => {
+      it('should always set value programmatically right away', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy Drew';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         fixture.componentInstance.name = 'Carson';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -836,20 +839,20 @@ describe('template-driven forms integration tests', () => {
         expect(form.valid)
           .withContext('Expected validation to run immediately on programmatic change.')
           .toBe(false);
-      }));
+      });
 
-      it('should update on submit', fakeAsync(() => {
+      it('should update on submit', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(fixture.componentInstance.name)
@@ -859,7 +862,7 @@ describe('template-driven forms integration tests', () => {
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.name)
           .withContext('Expected value not to update on blur.')
@@ -874,30 +877,30 @@ describe('template-driven forms integration tests', () => {
           .withContext('Expected value to update on submit.')
           .toEqual('Nancy Drew');
         expect(form.valid).withContext('Expected validation to run on submit.').toBe(true);
-      }));
+      });
 
-      it('should wait until second submit to update again', fakeAsync(() => {
+      it('should wait until second submit to update again', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(formEl, 'submit');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         input.value = 'Carson';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(fixture.componentInstance.name)
@@ -909,22 +912,22 @@ describe('template-driven forms integration tests', () => {
 
         dispatchEvent(formEl, 'submit');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.name)
           .withContext('Expected value to update on second submit.')
           .toEqual('Carson');
         expect(form.valid).withContext('Expected validation to run on second submit.').toBe(false);
-      }));
+      });
 
-      it('should not run validation for onChange controls on submit', fakeAsync(() => {
+      it('should not run validation for onChange controls on submit', async () => {
         const validatorSpy = jasmine.createSpy('validator');
         const groupValidatorSpy = jasmine.createSpy('groupValidatorSpy');
 
         const fixture = initTest(NgModelGroupForm);
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         form.control.get('name')!.setValidators(groupValidatorSpy);
@@ -936,27 +939,27 @@ describe('template-driven forms integration tests', () => {
 
         expect(validatorSpy).not.toHaveBeenCalled();
         expect(groupValidatorSpy).not.toHaveBeenCalled();
-      }));
+      });
 
-      it('should not update dirtiness until submit', fakeAsync(() => {
+      it('should not update dirtiness until submit', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(form.dirty).withContext('Expected dirtiness not to update on input.').toBe(false);
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(form.dirty).withContext('Expected dirtiness not to update on blur.').toBe(false);
 
@@ -965,24 +968,24 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
 
         expect(form.dirty).withContext('Expected dirtiness to update on submit.').toBe(true);
-      }));
+      });
 
-      it('should not update touched until submit', fakeAsync(() => {
+      it('should not update touched until submit', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(form.touched).withContext('Expected touched not to update on blur.').toBe(false);
@@ -992,14 +995,14 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
 
         expect(form.touched).withContext('Expected touched to update on submit.').toBe(true);
-      }));
+      });
 
-      it('should reset properly', fakeAsync(() => {
+      it('should reset properly', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = 'Nancy' as string | null;
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
@@ -1012,7 +1015,7 @@ describe('template-driven forms integration tests', () => {
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         form.resetForm();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(input.value).withContext('Expected view value to reset.').toEqual('');
         expect(form.value).withContext('Expected form value to reset.').toEqual({name: null});
@@ -1034,14 +1037,14 @@ describe('template-driven forms integration tests', () => {
           .toEqual(null);
         expect(form.dirty).withContext('Expected dirty to stay false on submit.').toBe(false);
         expect(form.touched).withContext('Expected touched to stay false on submit.').toBe(false);
-      }));
+      });
 
-      it('should not emit valueChanges or statusChanges until submit', fakeAsync(() => {
+      it('should not emit valueChanges or statusChanges until submit', async () => {
         const fixture = initTest(NgModelForm);
         fixture.componentInstance.name = '';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const values: any[] = [];
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1054,7 +1057,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on input.')
@@ -1062,7 +1065,7 @@ describe('template-driven forms integration tests', () => {
 
         dispatchEvent(input, 'blur');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(values)
           .withContext('Expected no valueChanges or statusChanges on blur.')
@@ -1077,14 +1080,14 @@ describe('template-driven forms integration tests', () => {
           'Expected valueChanges and statusChanges on submit.',
         );
         sub.unsubscribe();
-      }));
+      });
 
-      it('should not fire ngModelChange event on submit unless value has changed', fakeAsync(() => {
+      it('should not fire ngModelChange event on submit unless value has changed', async () => {
         const fixture = initTest(NgModelChangesForm);
         fixture.componentInstance.name = 'Carson';
         fixture.componentInstance.options = {updateOn: 'submit'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
         dispatchEvent(formEl, 'submit');
@@ -1098,7 +1101,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Carson';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.events)
           .withContext('Expected ngModelChanges not to fire on input.')
@@ -1122,7 +1125,7 @@ describe('template-driven forms integration tests', () => {
         input.value = 'Bess';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.events)
           .withContext('Expected ngModelChanges not to fire on input after submit.')
@@ -1135,30 +1138,30 @@ describe('template-driven forms integration tests', () => {
           ['fired', 'fired'],
           'Expected ngModelChanges to fire again on submit if value changed.',
         );
-      }));
+      });
 
-      it('should not prevent the default action on forms with method="dialog"', fakeAsync(() => {
+      it('should not prevent the default action on forms with method="dialog"', async () => {
         if (typeof HTMLDialogElement === 'undefined') {
           return;
         }
 
         const fixture = initTest(NativeDialogForm);
         fixture.detectChanges();
-        tick();
+        await timeout();
         const event = dispatchEvent(fixture.componentInstance.form.nativeElement, 'submit');
         fixture.detectChanges();
 
         expect(event.defaultPrevented).toBe(false);
-      }));
+      });
     });
 
     describe('ngFormOptions', () => {
-      it('should use ngFormOptions value when ngModelOptions are not set', fakeAsync(() => {
+      it('should use ngFormOptions value when ngModelOptions are not set', async () => {
         const fixture = initTest(NgModelOptionsStandalone);
         fixture.componentInstance.options = {name: 'two'};
         fixture.componentInstance.formOptions = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         const controlOne = form.control.get('one')! as FormControl;
@@ -1172,20 +1175,20 @@ describe('template-driven forms integration tests', () => {
         expect(controlTwo.updateOn)
           .withContext('Expected last control to inherit updateOn from parent form.')
           .toEqual('blur');
-      }));
+      });
 
-      it('should actually update using ngFormOptions value', fakeAsync(() => {
+      it('should actually update using ngFormOptions value', async () => {
         const fixture = initTest(NgModelOptionsStandalone);
         fixture.componentInstance.one = '';
         fixture.componentInstance.formOptions = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         input.value = 'Nancy Drew';
         dispatchEvent(input, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         expect(form.value).withContext('Expected value not to update on input.').toEqual({
@@ -1198,14 +1201,14 @@ describe('template-driven forms integration tests', () => {
         expect(form.value).withContext('Expected value to update on blur.').toEqual({
           one: 'Nancy Drew',
         });
-      }));
+      });
 
-      it('should allow ngModelOptions updateOn to override ngFormOptions', fakeAsync(() => {
+      it('should allow ngModelOptions updateOn to override ngFormOptions', async () => {
         const fixture = initTest(NgModelOptionsStandalone);
         fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
         fixture.componentInstance.formOptions = {updateOn: 'change'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         const controlOne = form.control.get('one')! as FormControl;
@@ -1221,16 +1224,16 @@ describe('template-driven forms integration tests', () => {
         expect(controlTwo.updateOn)
           .withContext('Expected control updateOn to override form updateOn.')
           .toEqual('blur');
-      }));
+      });
 
-      it('should update using ngModelOptions override', fakeAsync(() => {
+      it('should update using ngModelOptions override', async () => {
         const fixture = initTest(NgModelOptionsStandalone);
         fixture.componentInstance.one = '';
         fixture.componentInstance.two = '';
         fixture.componentInstance.options = {updateOn: 'blur', name: 'two'};
         fixture.componentInstance.formOptions = {updateOn: 'change'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const [inputOne, inputTwo] = fixture.debugElement.queryAll(By.css('input'));
         inputOne.nativeElement.value = 'Nancy Drew';
@@ -1246,7 +1249,7 @@ describe('template-driven forms integration tests', () => {
         inputTwo.nativeElement.value = 'Carson Drew';
         dispatchEvent(inputTwo.nativeElement, 'input');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(form.value).withContext('Expected second value not to update on input.').toEqual({
           one: 'Nancy Drew',
@@ -1260,15 +1263,15 @@ describe('template-driven forms integration tests', () => {
           {one: 'Nancy Drew', two: 'Carson Drew'},
           'Expected second value to update on blur.',
         );
-      }));
+      });
 
-      it('should not use ngFormOptions for standalone ngModels', fakeAsync(() => {
+      it('should not use ngFormOptions for standalone ngModels', async () => {
         const fixture = initTest(NgModelOptionsStandalone);
         fixture.componentInstance.two = '';
         fixture.componentInstance.options = {standalone: true};
         fixture.componentInstance.formOptions = {updateOn: 'blur'};
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const inputTwo = fixture.debugElement.queryAll(By.css('input'))[1].nativeElement;
         inputTwo.value = 'Nancy Drew';
@@ -1278,41 +1281,41 @@ describe('template-driven forms integration tests', () => {
         expect(fixture.componentInstance.two)
           .withContext('Expected standalone ngModel not to inherit blur update.')
           .toEqual('Nancy Drew');
-      }));
+      });
     });
   });
 
   describe('submit and reset events', () => {
-    it('should emit ngSubmit event with the original submit event on submit', fakeAsync(() => {
+    it('should emit ngSubmit event with the original submit event on submit', async () => {
       const fixture = initTest(NgModelForm);
       fixture.componentInstance.event = null!;
 
       const form = fixture.debugElement.query(By.css('form'));
       dispatchEvent(form.nativeElement, 'submit');
-      tick();
+      await timeout();
 
       expect(fixture.componentInstance.event.type).toEqual('submit');
-    }));
+    });
 
-    it('should mark NgForm as submitted on submit event', fakeAsync(() => {
+    it('should mark NgForm as submitted on submit event', async () => {
       const fixture = initTest(NgModelForm);
 
-      tick();
+      await timeout();
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.submitted).toBe(false);
 
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
       dispatchEvent(formEl, 'submit');
-      tick();
+      await timeout();
 
       expect(form.submitted).toBe(true);
-    }));
+    });
 
-    it('should reset the form to empty when reset event is fired', fakeAsync(() => {
+    it('should reset the form to empty when reset event is fired', async () => {
       const fixture = initTest(NgModelForm);
       fixture.componentInstance.name = 'should be cleared' as string | null;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const formEl = fixture.debugElement.query(By.css('form'));
@@ -1324,32 +1327,32 @@ describe('template-driven forms integration tests', () => {
 
       dispatchEvent(formEl.nativeElement, 'reset');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.value).toBe(''); // view value
       expect(fixture.componentInstance.name).toBe(null); // ngModel value
       expect(form.value.name).toEqual(null); // control value
-    }));
+    });
 
-    it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
+    it('should reset the form submit state when reset button is clicked', async () => {
       const fixture = initTest(NgModelForm);
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const formEl = fixture.debugElement.query(By.css('form'));
 
       dispatchEvent(formEl.nativeElement, 'submit');
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(form.submitted).toBe(true);
 
       dispatchEvent(formEl.nativeElement, 'reset');
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(form.submitted).toBe(false);
-    }));
+    });
   });
 
   describe('valueChange and statusChange events', () => {
-    it('should emit valueChanges and statusChanges on init', fakeAsync(() => {
+    it('should emit valueChanges and statusChanges on init', async () => {
       const fixture = initTest(NgModelForm);
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       fixture.componentInstance.name = 'aa';
@@ -1364,18 +1367,18 @@ describe('template-driven forms integration tests', () => {
       form.statusChanges!.subscribe((status: string) => (formValidity = status));
       form.valueChanges!.subscribe((value: string) => (formValue = value));
 
-      tick();
+      await timeout();
 
       expect(formValidity).toEqual('INVALID');
       expect(formValue).toEqual({name: 'aa'});
-    }));
+    });
 
-    it('should mark controls dirty before emitting the value change event', fakeAsync(() => {
+    it('should mark controls dirty before emitting the value change event', async () => {
       const fixture = initTest(NgModelForm);
       const form = fixture.debugElement.children[0].injector.get(NgForm).form;
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       form.get('name')!.valueChanges.subscribe(() => {
         expect(form.get('name')!.dirty).toBe(true);
@@ -1385,12 +1388,12 @@ describe('template-driven forms integration tests', () => {
       inputEl.value = 'newValue';
 
       dispatchEvent(inputEl, 'input');
-    }));
+    });
 
-    it('should mark controls pristine before emitting the value change event when resetting ', fakeAsync(() => {
+    it('should mark controls pristine before emitting the value change event when resetting ', async () => {
       const fixture = initTest(NgModelForm);
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm).form;
       const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
@@ -1406,11 +1409,11 @@ describe('template-driven forms integration tests', () => {
       });
 
       dispatchEvent(formEl, 'reset');
-    }));
+    });
   });
 
   describe('disabled controls', () => {
-    it('should not consider disabled controls in value or validation', fakeAsync(() => {
+    it('should not consider disabled controls in value or validation', async () => {
       const fixture = initTest(NgModelGroupForm);
       fixture.componentInstance.isDisabled = false;
       fixture.componentInstance.first = '';
@@ -1418,7 +1421,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.email = 'some email';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.value).toEqual({name: {first: '', last: 'Drew'}, email: 'some email'});
@@ -1428,47 +1431,46 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.isDisabled = true;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(form.value).toEqual({name: {last: 'Drew'}, email: 'some email'});
       expect(form.valid).toBe(true);
       expect(form.control.get('name.first')!.disabled).toBe(true);
-    }));
+    });
 
-    it('should add disabled attribute in the UI if disable() is called programmatically', fakeAsync(() => {
+    it('should add disabled attribute in the UI if disable() is called programmatically', async () => {
       const fixture = initTest(NgModelGroupForm);
       fixture.componentInstance.isDisabled = false;
       fixture.componentInstance.first = 'Nancy';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       form.control.get('name.first')!.disable();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css(`[name="first"]`));
       expect(input.nativeElement.disabled).toBe(true);
-    }));
+    });
 
-    it('should disable a custom control if disabled attr is added', waitForAsync(() => {
+    it('should disable a custom control if disabled attr is added', async () => {
       const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
       fixture.componentInstance.name = 'Nancy';
       fixture.componentInstance.isDisabled = true;
       fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          const form = fixture.debugElement.children[0].injector.get(NgForm);
-          expect(form.control.get('name')!.disabled).toBe(true);
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
 
-          const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-          expect(customInput.nativeElement.disabled).toEqual(true);
-        });
-      });
-    }));
+      const form = fixture.debugElement.children[0].injector.get(NgForm);
+      expect(form.control.get('name')!.disabled).toBe(true);
 
-    it('should disable a control with unbound disabled attr', fakeAsync(() => {
+      const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+      expect(customInput.nativeElement.disabled).toEqual(true);
+    });
+
+    it('should disable a control with unbound disabled attr', async () => {
       TestBed.overrideComponent(NgModelForm, {
         set: {
           template: `
@@ -1480,7 +1482,7 @@ describe('template-driven forms integration tests', () => {
       });
       const fixture = initTest(NgModelForm);
       fixture.detectChanges();
-      tick();
+      await timeout();
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       expect(form.control.get('name')!.disabled).toBe(true);
 
@@ -1489,16 +1491,16 @@ describe('template-driven forms integration tests', () => {
 
       form.control.enable();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(input.nativeElement.disabled).toEqual(false);
-    }));
+    });
   });
 
   describe('validation directives', () => {
-    it('required validator should validate checkbox', fakeAsync(() => {
+    it('required validator should validate checkbox', async () => {
       const fixture = initTest(NgModelCheckboxRequiredValidator);
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const control = fixture.debugElement.children[0].injector
         .get(NgForm)
@@ -1511,7 +1513,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.required = true;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.checked).toBe(false);
       expect(control.hasError('required')).toBe(true);
@@ -1519,7 +1521,7 @@ describe('template-driven forms integration tests', () => {
       input.nativeElement.checked = true;
       dispatchEvent(input.nativeElement, 'change');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.checked).toBe(true);
       expect(control.hasError('required')).toBe(false);
@@ -1527,7 +1529,7 @@ describe('template-driven forms integration tests', () => {
       input.nativeElement.checked = false;
       dispatchEvent(input.nativeElement, 'change');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.checked).toBe(false);
       expect(control.hasError('required')).toBe(true);
@@ -1535,16 +1537,16 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.required = false;
       dispatchEvent(input.nativeElement, 'change');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.checked).toBe(false);
       expect(control.hasError('required')).toBe(false);
-    }));
+    });
 
-    it('should validate email', fakeAsync(() => {
+    it('should validate email', async () => {
       const fixture = initTest(NgModelEmailValidator);
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const control = fixture.debugElement.children[0].injector.get(NgForm).control.get('email')!;
 
@@ -1554,14 +1556,14 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.validatorEnabled = true;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.value).toEqual('');
       expect(control.hasError('email')).toBe(false);
 
       input.nativeElement.value = '@';
       dispatchEvent(input.nativeElement, 'input');
-      tick();
+      await timeout();
 
       expect(input.nativeElement.value).toEqual('@');
       expect(control.hasError('email')).toBe(true);
@@ -1569,7 +1571,7 @@ describe('template-driven forms integration tests', () => {
       input.nativeElement.value = 'test@gmail.com';
       dispatchEvent(input.nativeElement, 'input');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.value).toEqual('test@gmail.com');
       expect(control.hasError('email')).toBe(false);
@@ -1577,20 +1579,20 @@ describe('template-driven forms integration tests', () => {
       input.nativeElement.value = 'text';
       dispatchEvent(input.nativeElement, 'input');
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(input.nativeElement.value).toEqual('text');
       expect(control.hasError('email')).toBe(true);
-    }));
+    });
 
-    it('should support dir validators using bindings', fakeAsync(() => {
+    it('should support dir validators using bindings', async () => {
       const fixture = initTest(NgModelValidationBindings);
       fixture.componentInstance.required = true;
       fixture.componentInstance.minLen = 3;
       fixture.componentInstance.maxLen = 3;
       fixture.componentInstance.pattern = '.{3,}';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const required = fixture.debugElement.query(By.css('[name=required]'));
       const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
@@ -1625,14 +1627,14 @@ describe('template-driven forms integration tests', () => {
       dispatchEvent(pattern.nativeElement, 'input');
 
       expect(form.valid).toEqual(true);
-    }));
+    });
 
-    it('should support optional fields with string pattern validator', fakeAsync(() => {
+    it('should support optional fields with string pattern validator', async () => {
       const fixture = initTest(NgModelMultipleValidators);
       fixture.componentInstance.required = false;
       fixture.componentInstance.pattern = '[a-z]+';
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const input = fixture.debugElement.query(By.css('input'));
@@ -1647,14 +1649,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toBeFalsy();
       expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
-    }));
+    });
 
-    it('should support optional fields with RegExp pattern validator', fakeAsync(() => {
+    it('should support optional fields with RegExp pattern validator', async () => {
       const fixture = initTest(NgModelMultipleValidators);
       fixture.componentInstance.required = false;
       fixture.componentInstance.pattern = /^[a-z]+$/;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const input = fixture.debugElement.query(By.css('input'));
@@ -1669,14 +1671,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toBeFalsy();
       expect(form.control.hasError('pattern', ['tovalidate'])).toBeTruthy();
-    }));
+    });
 
-    it('should support optional fields with minlength validator', fakeAsync(() => {
+    it('should support optional fields with minlength validator', async () => {
       const fixture = initTest(NgModelMultipleValidators);
       fixture.componentInstance.required = false;
       fixture.componentInstance.minLen = 2;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const form = fixture.debugElement.children[0].injector.get(NgForm);
       const input = fixture.debugElement.query(By.css('input'));
@@ -1691,12 +1693,12 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toBeFalsy();
       expect(form.control.hasError('minlength', ['tovalidate'])).toBeTruthy();
-    }));
+    });
 
-    it('changes on bound properties should change the validation state of the form', fakeAsync(() => {
+    it('changes on bound properties should change the validation state of the form', async () => {
       const fixture = initTest(NgModelValidationBindings);
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const required = fixture.debugElement.query(By.css('[name=required]'));
       const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
@@ -1764,16 +1766,16 @@ describe('template-driven forms integration tests', () => {
       expect(required.nativeElement.getAttribute('minlength')).toEqual(null);
       expect(required.nativeElement.getAttribute('maxlength')).toEqual(null);
       expect(required.nativeElement.getAttribute('pattern')).toEqual(null);
-    }));
+    });
 
-    it('should update control status', fakeAsync(() => {
+    it('should update control status', async () => {
       const fixture = initTest(NgModelChangeState);
       const inputEl = fixture.debugElement.query(By.css('input'));
       const inputNativeEl = inputEl.nativeElement;
       const onNgModelChange = jasmine.createSpy('onNgModelChange');
       fixture.componentInstance.onNgModelChange = onNgModelChange;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(onNgModelChange).not.toHaveBeenCalled();
 
@@ -1784,7 +1786,7 @@ describe('template-driven forms integration tests', () => {
       });
       dispatchEvent(inputNativeEl, 'input');
       expect(onNgModelChange).toHaveBeenCalled();
-      tick();
+      await timeout();
 
       inputNativeEl.value = '333';
       onNgModelChange.and.callFake((ngModel: NgModel) => {
@@ -1793,15 +1795,15 @@ describe('template-driven forms integration tests', () => {
       });
       dispatchEvent(inputNativeEl, 'input');
       expect(onNgModelChange).toHaveBeenCalledTimes(2);
-      tick();
-    }));
+      await timeout();
+    });
 
-    it('should validate max', fakeAsync(() => {
+    it('should validate max', async () => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1828,7 +1830,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.max = 0;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       dispatchEvent(input, 'input');
       fixture.detectChanges();
       expect(input.getAttribute('max')).toEqual('0');
@@ -1840,13 +1842,13 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['max'].errors).toBeNull();
-    }));
+    });
 
-    it('should validate max for float number', fakeAsync(() => {
+    it('should validate max for float number', async () => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10.25;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1875,13 +1877,13 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(false);
       expect(form.controls['max'].errors).toEqual({max: {max: 10.25, actual: 10.35}});
-    }));
+    });
 
-    it('should apply max validation when control value is defined as a string', fakeAsync(() => {
+    it('should apply max validation when control value is defined as a string', async () => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1898,14 +1900,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['max'].errors).toBeNull();
-    }));
+    });
 
-    it('should re-validate if max changes', fakeAsync(() => {
+    it('should re-validate if max changes', async () => {
       const fixture = initTest(NgModelMaxValidator);
       fixture.componentInstance.max = 10;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1927,14 +1929,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(false);
       expect(form.controls['max'].errors).toEqual({max: {max: 5, actual: 9}});
-    }));
+    });
 
-    it('should validate min', fakeAsync(() => {
+    it('should validate min', async () => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -1961,7 +1963,7 @@ describe('template-driven forms integration tests', () => {
       fixture.componentInstance.min = 0;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       input.value = -5;
       dispatchEvent(input, 'input');
       fixture.detectChanges();
@@ -1974,13 +1976,13 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min'].errors).toBeNull();
-    }));
+    });
 
-    it('should validate min for float number', fakeAsync(() => {
+    it('should validate min for float number', async () => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10.25;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2009,12 +2011,12 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(false);
       expect(form.controls['min'].errors).toEqual({min: {min: 10.25, actual: 10.15}});
-    }));
-    it('should apply min validation when control value is defined as a string', fakeAsync(() => {
+    });
+    it('should apply min validation when control value is defined as a string', async () => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2031,14 +2033,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(false);
       expect(form.controls['min'].errors).toEqual({min: {min: 10, actual: 9}});
-    }));
+    });
 
-    it('should re-validate if min changes', fakeAsync(() => {
+    it('should re-validate if min changes', async () => {
       const fixture = initTest(NgModelMinValidator);
       fixture.componentInstance.min = 10;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2060,16 +2062,16 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min'].errors).toBeNull();
-    }));
+    });
 
-    it('should not include the min and max validators when using another directive with the same properties', fakeAsync(() => {
+    it('should not include the min and max validators when using another directive with the same properties', async () => {
       const fixture = initTest(NgModelNoMinMaxValidator);
       const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
 
       fixture.componentInstance.min = 10;
       fixture.componentInstance.max = 20;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const min = fixture.debugElement.query(By.directive(MinValidator));
       expect(min).toBeNull();
@@ -2081,9 +2083,9 @@ describe('template-driven forms integration tests', () => {
       expect(cd).toBeDefined();
 
       expect(validateFnSpy).not.toHaveBeenCalled();
-    }));
+    });
 
-    it('should not include the min and max validators when using a custom component with the same properties', fakeAsync(() => {
+    it('should not include the min and max validators when using a custom component with the same properties', async () => {
       @Directive({
         selector: 'my-custom-component',
         providers: [
@@ -2118,7 +2120,7 @@ describe('template-driven forms integration tests', () => {
       const validateFnSpy = spyOn(MaxValidator.prototype, 'validate');
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const mv = fixture.debugElement.query(By.directive(MaxValidator));
       expect(mv).toBeNull();
@@ -2127,9 +2129,9 @@ describe('template-driven forms integration tests', () => {
       expect(cd).toBeDefined();
 
       expect(validateFnSpy).not.toHaveBeenCalled();
-    }));
+    });
 
-    it('should not include the min and max validators for inputs with type range', fakeAsync(() => {
+    it('should not include the min and max validators for inputs with type range', async () => {
       @Component({
         template: '<input type="range" min="10" max="20">',
         standalone: false,
@@ -2141,7 +2143,7 @@ describe('template-driven forms integration tests', () => {
       const minValidateFnSpy = spyOn(MinValidator.prototype, 'validate');
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const maxValidator = fixture.debugElement.query(By.directive(MaxValidator));
       expect(maxValidator).toBeNull();
@@ -2151,10 +2153,10 @@ describe('template-driven forms integration tests', () => {
 
       expect(maxValidateFnSpy).not.toHaveBeenCalled();
       expect(minValidateFnSpy).not.toHaveBeenCalled();
-    }));
+    });
 
     describe('enabling validators conditionally', () => {
-      it('should not include the minLength and maxLength validators for null', fakeAsync(() => {
+      it('should not include the minLength and maxLength validators for null', async () => {
         @Component({
           template:
             '<form><input name="amount" ngModel [minlength]="minlen" [maxlength]="maxlen"></form>',
@@ -2168,7 +2170,7 @@ describe('template-driven forms integration tests', () => {
 
         const fixture = initTest(MinLengthMaxLengthComponent);
         fixture.detectChanges();
-        tick();
+        await timeout();
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2241,9 +2243,9 @@ describe('template-driven forms integration tests', () => {
         setValidatorValues({minlength: null, maxlength: null});
         verifyValidatorAttrValues({minlength: null, maxlength: null});
         verifyFormState({isValid: true});
-      }));
+      });
 
-      it('should not include the min and max validators for null', fakeAsync(() => {
+      it('should not include the min and max validators for null', async () => {
         @Component({
           template:
             '<form><input type="number" name="minmaxinput" ngModel [min]="minlen" [max]="maxlen"></form>',
@@ -2257,7 +2259,7 @@ describe('template-driven forms integration tests', () => {
 
         const fixture = initTest(MinLengthMaxLengthComponent);
         fixture.detectChanges();
-        tick();
+        await timeout();
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2330,18 +2332,18 @@ describe('template-driven forms integration tests', () => {
         setValidatorValues({min: null, max: null});
         verifyValidatorAttrValues({min: null, max: null});
         verifyFormState({isValid: true});
-      }));
+      });
     });
 
     ['number', 'string'].forEach((inputType: string) => {
-      it(`should validate min and max when constraints are represented using a ${inputType}`, fakeAsync(() => {
+      it(`should validate min and max when constraints are represented using a ${inputType}`, async () => {
         const fixture = initTest(NgModelMinMaxValidator);
 
         fixture.componentInstance.min = inputType === 'string' ? '5' : 5;
         fixture.componentInstance.max = inputType === 'string' ? '10' : 10;
 
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const input = fixture.debugElement.query(By.css('input')).nativeElement;
         const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2369,14 +2371,14 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
         expect(form.valid).toEqual(true);
         expect(form.controls['min_max'].errors).toBeNull();
-      }));
+      });
     });
-    it('should validate min and max', fakeAsync(() => {
+    it('should validate min and max', async () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = 5;
       fixture.componentInstance.max = 10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2404,14 +2406,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min_max'].errors).toBeNull();
-    }));
+    });
 
-    it('should apply min and max validation when control value is defined as a string', fakeAsync(() => {
+    it('should apply min and max validation when control value is defined as a string', async () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = 5;
       fixture.componentInstance.max = 10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2439,15 +2441,15 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min_max'].errors).toBeNull();
-    }));
+    });
 
-    it('should re-validate if min/max changes', fakeAsync(() => {
+    it('should re-validate if min/max changes', async () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = 5;
       fixture.componentInstance.max = 10;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2487,14 +2489,14 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toEqual(true);
       expect(form.controls['min_max'].errors).toBeNull();
-    }));
+    });
 
-    it('should run min/max validation for empty values ', fakeAsync(() => {
+    it('should run min/max validation for empty values ', async () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = 5;
       fixture.componentInstance.max = 10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2510,14 +2512,14 @@ describe('template-driven forms integration tests', () => {
 
       expect(maxValidateFnSpy).toHaveBeenCalled();
       expect(minValidateFnSpy).toHaveBeenCalled();
-    }));
+    });
 
-    it('should run min/max validation for negative values', fakeAsync(() => {
+    it('should run min/max validation for negative values', async () => {
       const fixture = initTest(NgModelMinMaxValidator);
       fixture.componentInstance.min = -20;
       fixture.componentInstance.max = -10;
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       const form = fixture.debugElement.children[0].injector.get(NgForm);
@@ -2545,9 +2547,9 @@ describe('template-driven forms integration tests', () => {
       fixture.detectChanges();
       expect(form.valid).toBeFalse();
       expect(form.controls['min_max'].errors).toEqual({max: {max: -10, actual: 0}});
-    }));
+    });
 
-    it('should call registerOnValidatorChange as a part of a formGroup setup', fakeAsync(() => {
+    it('should call registerOnValidatorChange as a part of a formGroup setup', async () => {
       let registerOnValidatorChangeFired = 0;
       let registerOnAsyncValidatorChangeFired = 0;
 
@@ -2616,7 +2618,7 @@ describe('template-driven forms integration tests', () => {
 
       const fixture = initTest(NgModelNoOpValidation, NoOpValidator, NoOpAsyncValidator);
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       expect(registerOnValidatorChangeFired).toBe(1);
       expect(registerOnAsyncValidatorChangeFired).toBe(1);
@@ -2629,24 +2631,24 @@ describe('template-driven forms integration tests', () => {
       // since it's invoked just once during the setup phase.
       expect(registerOnValidatorChangeFired).toBe(1);
       expect(registerOnAsyncValidatorChangeFired).toBe(1);
-    }));
+    });
   });
 
   describe('IME events', () => {
-    it('should determine IME event handling depending on platform by default', fakeAsync(() => {
+    it('should determine IME event handling depending on platform by default', async () => {
       const fixture = initTest(StandaloneNgModel);
       const inputEl = fixture.debugElement.query(By.css('input'));
       const inputNativeEl = inputEl.nativeElement;
       fixture.componentInstance.name = 'oldValue';
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(inputNativeEl.value).toEqual('oldValue');
 
       inputEl.triggerEventHandler('compositionstart');
 
       inputNativeEl.value = 'updatedValue';
       dispatchEvent(inputNativeEl, 'input');
-      tick();
+      await timeout();
 
       const isAndroid = /android (\d+)/.test(getDOM().getUserAgent().toLowerCase());
       if (isAndroid) {
@@ -2659,13 +2661,13 @@ describe('template-driven forms integration tests', () => {
         inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
 
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.name).toEqual('updatedValue');
       }
-    }));
+    });
 
-    it('should hold IME events until compositionend if composition mode', fakeAsync(() => {
+    it('should hold IME events until compositionend if composition mode', async () => {
       TestBed.overrideComponent(StandaloneNgModel, {
         set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]},
       });
@@ -2674,14 +2676,14 @@ describe('template-driven forms integration tests', () => {
       const inputNativeEl = inputEl.nativeElement;
       fixture.componentInstance.name = 'oldValue';
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(inputNativeEl.value).toEqual('oldValue');
 
       inputEl.triggerEventHandler('compositionstart');
 
       inputNativeEl.value = 'updatedValue';
       dispatchEvent(inputNativeEl, 'input');
-      tick();
+      await timeout();
 
       // ngModel should not update when compositionstart
       expect(fixture.componentInstance.name).toEqual('oldValue');
@@ -2689,13 +2691,13 @@ describe('template-driven forms integration tests', () => {
       inputEl.triggerEventHandler('compositionend', {target: {value: 'updatedValue'}});
 
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       // ngModel should update when compositionend
       expect(fixture.componentInstance.name).toEqual('updatedValue');
-    }));
+    });
 
-    it('should work normally with composition events if composition mode is off', fakeAsync(() => {
+    it('should work normally with composition events if composition mode is off', async () => {
       TestBed.overrideComponent(StandaloneNgModel, {
         set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]},
       });
@@ -2705,27 +2707,27 @@ describe('template-driven forms integration tests', () => {
       const inputNativeEl = inputEl.nativeElement;
       fixture.componentInstance.name = 'oldValue';
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(inputNativeEl.value).toEqual('oldValue');
 
       inputEl.triggerEventHandler('compositionstart');
 
       inputNativeEl.value = 'updatedValue';
       dispatchEvent(inputNativeEl, 'input');
-      tick();
+      await timeout();
 
       // ngModel should update normally
       expect(fixture.componentInstance.name).toEqual('updatedValue');
-    }));
+    });
   });
 
   describe('ngModel corner cases', () => {
-    it('should update the view when the model is set back to what used to be in the view', fakeAsync(() => {
+    it('should update the view when the model is set back to what used to be in the view', async () => {
       const fixture = initTest(StandaloneNgModel);
       fixture.componentInstance.name = '';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const input = fixture.debugElement.query(By.css('input')).nativeElement;
       input.value = 'aa';
@@ -2733,29 +2735,29 @@ describe('template-driven forms integration tests', () => {
       dispatchEvent(input, 'input');
 
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(fixture.componentInstance.name).toEqual('aa');
 
       // Programmatically update the input value to be "bb".
       fixture.componentInstance.name = 'bb';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(input.value).toEqual('bb');
 
       // Programatically set it back to "aa".
       fixture.componentInstance.name = 'aa';
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-      tick();
+      await timeout();
       expect(input.value).toEqual('aa');
-    }));
+    });
 
-    it('should not crash when validity is checked from a binding', fakeAsync(() => {
+    it('should not crash when validity is checked from a binding', async () => {
       const fixture = initTest(NgModelValidBinding);
-      tick();
+      await timeout();
       expect(() => fixture.detectChanges()).not.toThrowError();
-    }));
+    });
   });
 });
 

--- a/packages/forms/test/util.ts
+++ b/packages/forms/test/util.ts
@@ -91,3 +91,19 @@ export function asyncValidatorReturningObservable(c: AbstractControl): EventEmit
   });
   return e;
 }
+
+export async function timeout(ms?: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function useAutoTick() {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().autoTick();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+}

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -23,7 +23,7 @@ import {
   Type,
   ViewChild,
 } from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -41,8 +41,11 @@ import {
 import {By, ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {dispatchEvent, isNode} from '@angular/private/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {timeout, useAutoTick} from './util';
 
 describe('value accessors', () => {
+  useAutoTick();
+
   function initTest<T>(component: Type<T>, ...directives: Type<any>[]): ComponentFixture<T> {
     TestBed.configureTestingModule({
       declarations: [component, ...directives],
@@ -298,14 +301,14 @@ describe('value accessors', () => {
     });
 
     describe('in template-driven forms', () => {
-      it('with option values that are objects', fakeAsync(() => {
+      it('with option values that are objects', async () => {
         if (isNode) return;
         const fixture = initTest(NgModelSelectForm);
         const comp = fixture.componentInstance;
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
         comp.selectedCity = comp.cities[1];
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
@@ -317,13 +320,13 @@ describe('value accessors', () => {
         select.nativeElement.value = '2: Object';
         dispatchEvent(select.nativeElement, 'change');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         // view -> model
         expect(comp.selectedCity['name']).toEqual('Buffalo');
-      }));
+      });
 
-      it('when new options are added', fakeAsync(() => {
+      it('when new options are added', async () => {
         if (isNode) return;
         const fixture = initTest(NgModelSelectForm);
         const comp = fixture.componentInstance;
@@ -331,27 +334,28 @@ describe('value accessors', () => {
         comp.selectedCity = comp.cities[1];
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         comp.cities.push({'name': 'Buffalo'});
         comp.selectedCity = comp.cities[2];
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
         expect(select.nativeElement.value).toEqual('2: Object');
         expect(buffalo.nativeElement.selected).toBe(true);
-      }));
+      });
 
-      it('when options are removed', fakeAsync(() => {
+      it('when options are removed', async () => {
         const fixture = initTest(NgModelSelectForm);
         const comp = fixture.componentInstance;
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
         comp.selectedCity = comp.cities[1];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         expect(select.nativeElement.value).toEqual('1: Object');
@@ -359,50 +363,52 @@ describe('value accessors', () => {
         comp.cities.pop();
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         expect(select.nativeElement.value).not.toEqual('1: Object');
-      }));
+      });
 
-      it('when option values have same content, but different identities', fakeAsync(() => {
+      it('when option values have same content, but different identities', async () => {
         if (isNode) return;
         const fixture = initTest(NgModelSelectForm);
         const comp = fixture.componentInstance;
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'NYC'}];
         comp.selectedCity = comp.cities[0];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
 
         comp.selectedCity = comp.cities[2];
+        fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
         expect(select.nativeElement.value).toEqual('2: Object');
         expect(secondNYC.nativeElement.selected).toBe(true);
-      }));
+      });
 
-      it('should work with null option', fakeAsync(() => {
+      it('should work with null option', async () => {
         const fixture = initTest(NgModelSelectWithNullForm);
         const comp = fixture.componentInstance;
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
         comp.selectedCity = null;
-        fixture.detectChanges();
+        await fixture.whenStable();
 
         const select = fixture.debugElement.query(By.css('select'));
 
         select.nativeElement.value = '2: Object';
         dispatchEvent(select.nativeElement, 'change');
-        fixture.detectChanges();
-        tick();
+        await fixture.whenStable();
+        await timeout();
         expect(comp.selectedCity!['name']).toEqual('NYC');
 
         select.nativeElement.value = '0: null';
         dispatchEvent(select.nativeElement, 'change');
-        fixture.detectChanges();
-        tick();
+        await fixture.whenStable();
+        await timeout();
         expect(comp.selectedCity).toEqual(null);
-      }));
+      });
 
       it('should throw an error when compareWith is not a function', () => {
         const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
@@ -413,7 +419,7 @@ describe('value accessors', () => {
         );
       });
 
-      it('should compare options using provided compareWith function', fakeAsync(() => {
+      it('should compare options using provided compareWith function', async () => {
         if (isNode) return;
         const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
         const comp = fixture.componentInstance;
@@ -423,15 +429,15 @@ describe('value accessors', () => {
           {id: 2, name: 'LA'},
         ];
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         const sfOption = fixture.debugElement.query(By.css('option'));
         expect(select.nativeElement.value).toEqual('0: Object');
         expect(sfOption.nativeElement.selected).toBe(true);
-      }));
+      });
 
-      it('should support re-assigning the options array with compareWith', fakeAsync(() => {
+      it('should support re-assigning the options array with compareWith', async () => {
         if (isNode) return;
         const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
         fixture.componentInstance.selectedCity = {id: 1, name: 'SF'};
@@ -441,7 +447,7 @@ describe('value accessors', () => {
         ];
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
         // will select the second option (NY).
@@ -459,7 +465,7 @@ describe('value accessors', () => {
         ];
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         // Now that the options array has been re-assigned, new option instances will
         // be created by ngFor. These instances will have different option IDs, subsequent
@@ -468,7 +474,7 @@ describe('value accessors', () => {
         const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
         expect(select.nativeElement.value).toEqual('3: Object');
         expect(nyOption.nativeElement.selected).toBe(true);
-      }));
+      });
     });
   });
 
@@ -504,17 +510,17 @@ describe('value accessors', () => {
         );
       });
 
-      it('should compare options using provided compareWith function', fakeAsync(() => {
+      it('should compare options using provided compareWith function', async () => {
         if (isNode) return;
         const fixture = initTest(FormControlSelectMultipleWithCompareFn);
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const select = fixture.debugElement.query(By.css('select'));
         const sfOption = fixture.debugElement.query(By.css('option'));
         expect(select.nativeElement.value).toEqual('0: Object');
         expect(sfOption.nativeElement.selected).toBe(true);
-      }));
+      });
     });
 
     describe('in template-driven forms', () => {
@@ -527,15 +533,15 @@ describe('value accessors', () => {
         comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
       });
 
-      const detectChangesAndTick = (): void => {
+      const detectChangesAndTick = async (): Promise<void> => {
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
       };
 
-      const setSelectedCities = (selectedCities: any): void => {
+      const setSelectedCities = async (selectedCities: any): Promise<void> => {
         comp.selectedCities = selectedCities;
-        detectChangesAndTick();
+        await detectChangesAndTick();
       };
 
       const selectOptionViaUI = (valueString: string): void => {
@@ -555,45 +561,45 @@ describe('value accessors', () => {
         }
       };
 
-      it('verify that native `selectedOptions` field is used while detecting the list of selected options', fakeAsync(() => {
+      it('verify that native `selectedOptions` field is used while detecting the list of selected options', async () => {
         if (isNode || !HTMLSelectElement.prototype.hasOwnProperty('selectedOptions')) return;
         const spy = spyOnProperty(
           HTMLSelectElement.prototype,
           'selectedOptions',
           'get',
         ).and.callThrough();
-        setSelectedCities([]);
+        await setSelectedCities([]);
 
         selectOptionViaUI('1: Object');
         assertOptionElementSelectedState([false, true, false]);
         expect(spy).toHaveBeenCalled();
-      }));
+      });
 
-      it('should reflect state of model after option selected and new options subsequently added', fakeAsync(() => {
+      it('should reflect state of model after option selected and new options subsequently added', async () => {
         if (isNode) return;
-        setSelectedCities([]);
+        await setSelectedCities([]);
 
         selectOptionViaUI('1: Object');
         assertOptionElementSelectedState([false, true, false]);
 
         comp.cities.push({'name': 'Chicago'});
-        detectChangesAndTick();
+        await detectChangesAndTick();
 
         assertOptionElementSelectedState([false, true, false, false]);
-      }));
+      });
 
-      it('should reflect state of model after option selected and then other options removed', fakeAsync(() => {
+      it('should reflect state of model after option selected and then other options removed', async () => {
         if (isNode) return;
-        setSelectedCities([]);
+        await setSelectedCities([]);
 
         selectOptionViaUI('1: Object');
         assertOptionElementSelectedState([false, true, false]);
 
         comp.cities.pop();
-        detectChangesAndTick();
+        await detectChangesAndTick();
 
         assertOptionElementSelectedState([false, true]);
-      }));
+      });
     });
 
     it('should throw an error when compareWith is not a function', () => {
@@ -605,7 +611,7 @@ describe('value accessors', () => {
       );
     });
 
-    it('should compare options using provided compareWith function', fakeAsync(() => {
+    it('should compare options using provided compareWith function', async () => {
       if (isNode) return;
       const fixture = initTest(NgModelSelectMultipleWithCustomCompareFnForm);
       const comp = fixture.componentInstance;
@@ -615,13 +621,13 @@ describe('value accessors', () => {
       ];
       comp.selectedCities = [comp.cities[0]];
       fixture.detectChanges();
-      tick();
+      await timeout();
 
       const select = fixture.debugElement.query(By.css('select'));
       const sfOption = fixture.debugElement.query(By.css('option'));
       expect(select.nativeElement.value).toEqual('0: Object');
       expect(sfOption.nativeElement.selected).toBe(true);
-    }));
+    });
   });
 
   describe('should support <type=radio>', () => {
@@ -872,11 +878,11 @@ describe('value accessors', () => {
     });
 
     describe('in template-driven forms', () => {
-      it('should support basic functionality', fakeAsync(() => {
+      it('should support basic functionality', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'fish';
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         // model -> view
         const inputs = fixture.debugElement.queryAll(By.css('input'));
@@ -884,19 +890,19 @@ describe('value accessors', () => {
         expect(inputs[1].nativeElement.checked).toEqual(true);
 
         dispatchEvent(inputs[0].nativeElement, 'change');
-        tick();
+        await timeout();
 
         // view -> model
         expect(fixture.componentInstance.food).toEqual('chicken');
         expect(inputs[1].nativeElement.checked).toEqual(false);
-      }));
+      });
 
-      it('should support multiple named <type=radio> groups', fakeAsync(() => {
+      it('should support multiple named <type=radio> groups', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'fish';
         fixture.componentInstance.drink = 'sprite';
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.checked).toEqual(false);
@@ -905,54 +911,54 @@ describe('value accessors', () => {
         expect(inputs[3].nativeElement.checked).toEqual(true);
 
         dispatchEvent(inputs[0].nativeElement, 'change');
-        tick();
+        await timeout();
 
         expect(fixture.componentInstance.food).toEqual('chicken');
         expect(fixture.componentInstance.drink).toEqual('sprite');
         expect(inputs[1].nativeElement.checked).toEqual(false);
         expect(inputs[2].nativeElement.checked).toEqual(false);
         expect(inputs[3].nativeElement.checked).toEqual(true);
-      }));
+      });
 
-      it('should support initial undefined value', fakeAsync(() => {
+      it('should support initial undefined value', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.checked).toEqual(false);
         expect(inputs[1].nativeElement.checked).toEqual(false);
         expect(inputs[2].nativeElement.checked).toEqual(false);
         expect(inputs[3].nativeElement.checked).toEqual(false);
-      }));
+      });
 
-      it('should support resetting properly', fakeAsync(() => {
+      it('should support resetting properly', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'chicken';
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.query(By.css('form'));
         dispatchEvent(form.nativeElement, 'reset');
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.checked).toEqual(false);
         expect(inputs[1].nativeElement.checked).toEqual(false);
-      }));
+      });
 
-      it('should support setting value to null and undefined', fakeAsync(() => {
+      it('should support setting value to null and undefined', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'chicken';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         fixture.componentInstance.food = null!;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.checked).toEqual(false);
@@ -961,25 +967,25 @@ describe('value accessors', () => {
         fixture.componentInstance.food = 'chicken';
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         fixture.componentInstance.food = undefined!;
         fixture.changeDetectorRef.markForCheck();
         fixture.detectChanges();
-        tick();
+        await timeout();
         expect(inputs[0].nativeElement.checked).toEqual(false);
         expect(inputs[1].nativeElement.checked).toEqual(false);
-      }));
+      });
 
-      it('should disable radio controls properly with programmatic call', fakeAsync(() => {
+      it('should disable radio controls properly with programmatic call', async () => {
         const fixture = initTest(NgModelRadioForm);
         fixture.componentInstance.food = 'fish';
         fixture.detectChanges();
-        tick();
+        await timeout();
 
         const form = fixture.debugElement.children[0].injector.get(NgForm);
         form.control.get('food')!.disable();
-        tick();
+        await timeout();
 
         const inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[0].nativeElement.disabled).toBe(true);
@@ -988,7 +994,7 @@ describe('value accessors', () => {
         expect(inputs[3].nativeElement.disabled).toBe(false);
 
         form.control.disable();
-        tick();
+        await timeout();
 
         expect(inputs[0].nativeElement.disabled).toBe(true);
         expect(inputs[1].nativeElement.disabled).toBe(true);
@@ -996,13 +1002,13 @@ describe('value accessors', () => {
         expect(inputs[3].nativeElement.disabled).toBe(true);
 
         form.control.enable();
-        tick();
+        await timeout();
 
         expect(inputs[0].nativeElement.disabled).toBe(false);
         expect(inputs[1].nativeElement.disabled).toBe(false);
         expect(inputs[2].nativeElement.disabled).toBe(false);
         expect(inputs[3].nativeElement.disabled).toBe(false);
-      }));
+      });
     });
   });
 
@@ -1247,14 +1253,14 @@ describe('value accessors', () => {
       });
 
       describe('in template-driven forms', () => {
-        it('with option values that are objects', fakeAsync(() => {
+        it('with option values that are objects', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectForm);
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'Buffalo'}];
           comp.selectedCity = comp.cities[1];
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
@@ -1266,13 +1272,13 @@ describe('value accessors', () => {
           select.nativeElement.value = '2: Object';
           dispatchEvent(select.nativeElement, 'change');
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           // view -> model
           expect(comp.selectedCity['name']).toEqual('Buffalo');
-        }));
+        });
 
-        it('when new options are added', fakeAsync(() => {
+        it('when new options are added', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectForm);
           const comp = fixture.componentInstance;
@@ -1280,52 +1286,52 @@ describe('value accessors', () => {
           comp.selectedCity = comp.cities[1];
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           comp.cities.push({'name': 'Buffalo'});
           comp.selectedCity = comp.cities[2];
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
           expect(select.nativeElement.value).toEqual('2: Object');
           expect(buffalo.nativeElement.selected).toBe(true);
-        }));
+        });
 
-        it('should not select options added after the select renders', fakeAsync(() => {
+        it('should not select options added after the select renders', async () => {
           // see issue #14505
           if (isNode) return;
           const fixture = initTest(NgModelSelectForm);
           const comp = fixture.componentInstance;
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           comp.cities.push({name: 'Minneapolis'});
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           expect(select.nativeElement.selectedIndex).toEqual(-1);
           const minneapolis = fixture.debugElement.queryAll(By.css('option'))[0];
           expect(minneapolis.nativeElement.selected).toBe(false);
-        }));
+        });
 
-        it('when there is a placeholder option', fakeAsync(() => {
+        it('when there is a placeholder option', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectWithPlaceholderForm);
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const placeholder = fixture.debugElement.queryAll(By.css('option'))[0];
           expect(placeholder.nativeElement.selected).toBe(true);
-        }));
+        });
 
-        it('when options are removed', fakeAsync(() => {
+        it('when options are removed', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectForm);
           const comp = fixture.componentInstance;
@@ -1333,7 +1339,7 @@ describe('value accessors', () => {
           comp.selectedCity = comp.cities[1];
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           expect(select.nativeElement.value).toEqual('1: Object');
@@ -1341,12 +1347,12 @@ describe('value accessors', () => {
           comp.cities.pop();
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           // no option should be selected, since ngModel doesn't match anything in cities array
           expect(select.nativeElement.value).not.toEqual('1: Object');
           expect(select.nativeElement.value).not.toEqual('0: Object');
-        }));
+        });
 
         it('should not select first option when options are removed and animations module is used', async () => {
           // this test is the same as the one above, but tested with BrowserAnimationsModule
@@ -1383,45 +1389,50 @@ describe('value accessors', () => {
           expect(select.nativeElement.value).not.toEqual('0: Object');
         });
 
-        it('when option values have same content, but different identities', fakeAsync(() => {
+        it('when option values have same content, but different identities', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectForm);
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}, {'name': 'NYC'}];
           comp.selectedCity = comp.cities[0];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           comp.selectedCity = comp.cities[2];
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
           expect(select.nativeElement.value).toEqual('2: Object');
           expect(secondNYC.nativeElement.selected).toBe(true);
-        }));
+        });
 
-        it('should work with null option', fakeAsync(() => {
+        it('should work with null option', async () => {
           const fixture = initTest(NgModelSelectWithNullForm);
           const comp = fixture.componentInstance;
           comp.cities = [{'name': 'SF'}, {'name': 'NYC'}];
           comp.selectedCity = null;
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
 
           const select = fixture.debugElement.query(By.css('select'));
 
           select.nativeElement.value = '2: Object';
           dispatchEvent(select.nativeElement, 'change');
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
           expect(comp.selectedCity!['name']).toEqual('NYC');
 
           select.nativeElement.value = '0: null';
           dispatchEvent(select.nativeElement, 'change');
+          fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
           expect(comp.selectedCity).toEqual(null);
-        }));
+        });
 
         it('should throw an error when compareWith is not a function', () => {
           const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
@@ -1432,7 +1443,7 @@ describe('value accessors', () => {
           );
         });
 
-        it('should compare options using provided compareWith function', fakeAsync(() => {
+        it('should compare options using provided compareWith function', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
           const comp = fixture.componentInstance;
@@ -1442,15 +1453,15 @@ describe('value accessors', () => {
             {id: 2, name: 'LA'},
           ];
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           const select = fixture.debugElement.query(By.css('select'));
           const sfOption = fixture.debugElement.query(By.css('option'));
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
-        }));
+        });
 
-        it('should support re-assigning the options array with compareWith', fakeAsync(() => {
+        it('should support re-assigning the options array with compareWith', async () => {
           if (isNode) return;
           const fixture = initTest(NgModelSelectWithCustomCompareFnForm);
           fixture.componentInstance.selectedCity = {id: 1, name: 'SF'};
@@ -1460,7 +1471,7 @@ describe('value accessors', () => {
           ];
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
           // will select the second option (NY).
@@ -1478,7 +1489,7 @@ describe('value accessors', () => {
           ];
           fixture.changeDetectorRef.markForCheck();
           fixture.detectChanges();
-          tick();
+          await timeout();
 
           // Now that the options array has been re-assigned, new option instances will
           // be created by ngFor. These instances will have different option IDs, subsequent
@@ -1487,7 +1498,7 @@ describe('value accessors', () => {
           const nyOption = fixture.debugElement.queryAll(By.css('option'))[1];
           expect(select.nativeElement.value).toEqual('3: Object');
           expect(nyOption.nativeElement.selected).toBe(true);
-        }));
+        });
       });
     });
   });
@@ -1600,30 +1611,29 @@ describe('value accessors', () => {
     });
 
     describe('in template-driven forms', () => {
-      it('should support standard writing to view and model', waitForAsync(() => {
+      it('should support standard writing to view and model', async () => {
         const fixture = initTest(NgModelCustomWrapper, NgModelCustomComp);
         fixture.componentInstance.name = 'Nancy';
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          fixture.detectChanges();
-          fixture.whenStable().then(() => {
-            // model -> view
-            const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
-            expect(customInput.nativeElement.value).toEqual('Nancy');
+        await fixture.whenStable();
+        fixture.detectChanges();
+        await fixture.whenStable();
 
-            customInput.nativeElement.value = 'Carson';
-            dispatchEvent(customInput.nativeElement, 'input');
-            fixture.detectChanges();
+        // model -> view
+        const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+        expect(customInput.nativeElement.value).toEqual('Nancy');
 
-            // view -> model
-            expect(fixture.componentInstance.name).toEqual('Carson');
-          });
-        });
-      }));
+        customInput.nativeElement.value = 'Carson';
+        dispatchEvent(customInput.nativeElement, 'input');
+        fixture.detectChanges();
+
+        // view -> model
+        expect(fixture.componentInstance.name).toEqual('Carson');
+      });
     });
 
     describe('`ngModel` value accessor inside an OnPush component', () => {
-      it('should run change detection and update the value', () => {
+      it('should run change detection and update the value', async () => {
         @Component({
           selector: 'parent',
           template: '<child [ngModel]="value"></child>',
@@ -1661,29 +1671,27 @@ describe('value accessors', () => {
           registerOnTouched(): void {}
         }
 
-        fakeAsync(async () => {
-          const fixture = initTest(Parent, Child);
-          fixture.componentInstance.value = 'Nancy';
-          fixture.detectChanges();
+        const fixture = initTest(Parent, Child);
+        fixture.componentInstance.value = 'Nancy';
+        fixture.detectChanges();
 
-          await fixture.whenStable();
-          fixture.detectChanges();
-          await fixture.whenStable();
+        await fixture.whenStable();
+        fixture.detectChanges();
+        await fixture.whenStable();
 
-          const child = fixture.debugElement.query(By.css('child'));
-          // Let's ensure that the initial value has been set, because previously
-          // it wasn't set inside an `OnPush` component.
-          expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
+        const child = fixture.debugElement.query(By.css('child'));
+        // Let's ensure that the initial value has been set, because previously
+        // it wasn't set inside an `OnPush` component.
+        expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
 
-          fixture.componentInstance.setTimeoutAndChangeValue();
+        fixture.componentInstance.setTimeoutAndChangeValue();
 
-          tick(50);
+        await timeout(50);
 
-          fixture.detectChanges();
-          await fixture.whenStable();
+        fixture.detectChanges();
+        await fixture.whenStable();
 
-          expect(child.nativeElement.innerHTML).toEqual('Value: Carson');
-        });
+        expect(child.nativeElement.innerHTML).toEqual('Value: Carson');
       });
     });
   });


### PR DESCRIPTION
Removes usages of zone-based helpers such as `fakeAsync` , `tick` `waitForAsync` as part of the migration to zoneless tests.

Completes the transition to zoneless.
 

## Other information

I tried to keep the changes as minimal as possible. I don’t think we have a way to progressively migrate tests if we enable `zoneless_jasmine_test` and `zoneless_web_test_suite`, unless we explicitly specify which files should remain Zone based.

However, that would likely lead to the same outcome anyway, since , as I understand it , the overall intention is to completely remove Zone.js.
