### PR TITLE
feat(forms): add field param to submit action and onInvalid

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -210,14 +210,20 @@ export interface FormFieldBindingOptions {
 export interface FormOptions<TModel> {
     injector?: Injector;
     name?: string;
-    submission?: FormSubmitOptions<TModel>;
+    submission?: FormSubmitOptions<TModel, unknown>;
 }
 
 // @public
-export interface FormSubmitOptions<TModel> {
-    action: (form: FieldTree<TModel>) => Promise<TreeValidationResult>;
+export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
+    action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
+        root: FieldTree<TRootModel>;
+        submitted: FieldTree<TSubmittedModel>;
+    }) => Promise<TreeValidationResult>;
     ignoreValidators?: 'pending' | 'none' | 'all';
-    onInvalid?: (form: FieldTree<TModel>) => void;
+    onInvalid?: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
+        root: FieldTree<TRootModel>;
+        submitted: FieldTree<TSubmittedModel>;
+    }) => void;
 }
 
 // @public
@@ -558,10 +564,10 @@ export type Subfields<TModel> = {
 };
 
 // @public
-export function submit<TModel>(form: FieldTree<TModel>, options?: FormSubmitOptions<TModel>): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, options?: NoInfer<FormSubmitOptions<unknown, TModel>>): Promise<boolean>;
 
 // @public (undocumented)
-export function submit<TModel>(form: FieldTree<TModel>, action: FormSubmitOptions<TModel>['action']): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>): Promise<boolean>;
 
 // @public
 export function transformedValue<TValue, TRaw>(value: ModelSignal<TValue>, options: TransformedValueOptions<TValue, TRaw>): TransformedValueSignal<TRaw>;

--- a/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
+++ b/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
@@ -108,7 +108,7 @@ export class SignalFormControl<T> extends AbstractControl {
     this.fieldTree = wrapFieldTreeForSyncUpdates(rawTree, () =>
       this.parent?.updateValueAndValidity({sourceControl: this} as any),
     );
-    this.fieldState = this.fieldTree();
+    this.fieldState = this.fieldTree() as FieldState<T>;
 
     this.defineCompatProperties();
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -17,6 +17,47 @@ import type {MetadataKey, ValidationError} from './rules';
 declare const ɵɵTYPE: unique symbol;
 
 /**
+ * Options that can be specified when submitting a form.
+ *
+ * @experimental 21.2.0
+ */
+export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
+  /**
+   * Function to run when submitting the form data (when form is valid).
+   *
+   * @param field The contextually relevant field for this action function (the root field when
+   *   specified during form creation, and the submitted field when specified as part of the
+   *   `submit()` call)
+   * @param detail An object containing the root field of the submitted form as well as the
+   *   submitted field itself
+   */
+  action: (
+    field: FieldTree<TRootModel & TSubmittedModel>,
+    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+  ) => Promise<TreeValidationResult>;
+  /**
+   * Function to run when attempting to submit the form data but validation is failing.
+   *
+   * @param field The contextually relevant field for this onInvalid function (the root field when
+   *   specified during form creation, and the submitted field when specified as part of the
+   *   `submit()` call)
+   * @param detail An object containing the root field of the submitted form as well as the
+   *   submitted field itself
+   */
+  onInvalid?: (
+    field: FieldTree<TRootModel & TSubmittedModel>,
+    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+  ) => void;
+  /**
+   * Whether to ignore any of the validators when submitting:
+   * - 'pending': Will submit if there are no invalid validators, pending validators do not block submission (default)
+   * - 'none': Will not submit unless all validators are passing, pending validators block submission
+   * - 'ignore': Will always submit regardless of invalid or pending validators
+   */
+  ignoreValidators?: 'pending' | 'none' | 'all';
+}
+
+/**
  * A type that represents either a single value of type `T` or a readonly array of `T`.
  * @template T The type of the value(s).
  *

--- a/packages/forms/signals/src/field/manager.ts
+++ b/packages/forms/signals/src/field/manager.ts
@@ -7,7 +7,7 @@
  */
 
 import {APP_ID, effect, Injector, untracked} from '@angular/core';
-import type {FormSubmitOptions} from '../api/structure';
+import type {FormSubmitOptions} from '../api/types';
 import type {FieldNodeStructure} from './structure';
 
 /**
@@ -20,12 +20,12 @@ import type {FieldNodeStructure} from './structure';
 export class FormFieldManager {
   readonly injector: Injector;
   readonly rootName: string;
-  readonly submitOptions: FormSubmitOptions<unknown> | undefined;
+  readonly submitOptions: FormSubmitOptions<unknown, unknown> | undefined;
 
   constructor(
     injector: Injector,
     rootName: string | undefined,
-    submitOptions: FormSubmitOptions<unknown> | undefined,
+    submitOptions: FormSubmitOptions<unknown, unknown> | undefined,
   ) {
     this.injector = injector;
     this.rootName = rootName ?? `${this.injector.get(APP_ID)}.form${nextFormId++}`;

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -7,7 +7,6 @@
  */
 
 import {computed, linkedSignal, type Signal, untracked, type WritableSignal} from '@angular/core';
-import type {FormField} from '../directive/form_field_directive';
 import {
   MAX,
   MAX_LENGTH,
@@ -19,6 +18,7 @@ import {
 } from '../api/rules/metadata';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
 import type {DisabledReason, FieldContext, FieldState, FieldTree} from '../api/types';
+import type {FormField} from '../directive/form_field_directive';
 import {DYNAMIC} from '../schema/logic';
 import {LogicNode} from '../schema/logic_node';
 import {FieldPathNode} from '../schema/path_node';

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -347,8 +347,10 @@ describe('Forms compat', () => {
 
       const {promise, resolve} = promiseWithResolvers<TreeValidationResult>();
 
-      const result = submit(f as unknown as FieldTree<void>, {
-        action: () => {
+      const result = submit(f, {
+        action: (field) => {
+          expect(field.name().value()).toBe('pirojok-the-cat');
+          expect(field.age().control()).toBe(control);
           return promise;
         },
       });


### PR DESCRIPTION
Add field param to submit action and onInvalid

The `action` and `onInvalid` handlers now recevie two pieces of
information:
1. The form that is being submitted
2. The specific field that the submit was triggered on