### PR TITLE
fix(forms): simplify design of parse errors

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -203,7 +203,6 @@ export class FormField<T> {
 // @public (undocumented)
 export interface FormFieldBindingOptions {
     readonly focus?: (focusOptions?: FocusOptions) => void;
-    readonly parseErrors?: Signal<ValidationError.WithoutFieldTree[]>;
 }
 
 // @public
@@ -234,7 +233,6 @@ export interface FormUiControl<TValue> {
     readonly min?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
     readonly minLength?: InputSignal<number | undefined> | InputSignalWithTransform<number | undefined, unknown>;
     readonly name?: InputSignal<string> | InputSignalWithTransform<string, unknown>;
-    readonly parseErrors?: Signal<ValidationError.WithoutFieldTree[]>;
     readonly pattern?: InputSignal<readonly RegExp[]> | InputSignalWithTransform<readonly RegExp[], unknown>;
     readonly pending?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
     readonly readonly?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
@@ -563,6 +561,23 @@ export function submit<TModel>(form: FieldTree<TModel>, options?: FormSubmitOpti
 
 // @public (undocumented)
 export function submit<TModel>(form: FieldTree<TModel>, action: FormSubmitOptions<TModel>['action']): Promise<boolean>;
+
+// @public
+export function transformedValue<TValue, TRaw>(value: ModelSignal<TValue>, options: TransformedValueOptions<TValue, TRaw>): TransformedValueSignal<TRaw>;
+
+// @public
+export interface TransformedValueOptions<TValue, TRaw> {
+    format: (value: TValue) => TRaw;
+    parse: (rawValue: TRaw) => {
+        value?: TValue;
+        errors?: readonly ValidationError.WithoutFieldTree[];
+    };
+}
+
+// @public
+export interface TransformedValueSignal<TRaw> extends WritableSignal<TRaw> {
+    readonly parseErrors: Signal<readonly ValidationError.WithoutFieldTree[]>;
+}
 
 // @public
 export type TreeValidationResult<E extends ValidationError.WithOptionalFieldTree = ValidationError.WithOptionalFieldTree> = ValidationSuccess | OneOrMany<E>;

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -13,10 +13,11 @@
  */
 export * from './src/api/control';
 export * from './src/api/di';
-export * from './src/directive/form_field_directive';
 export * from './src/api/rules';
 export * from './src/api/rules/debounce';
 export * from './src/api/rules/metadata';
 export * from './src/api/rules/validation/validation_errors';
 export * from './src/api/structure';
+export * from './src/api/transformed_value';
 export * from './src/api/types';
+export * from './src/directive/form_field_directive';

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {InputSignal, InputSignalWithTransform, ModelSignal, OutputRef, Signal} from '@angular/core';
+import {InputSignal, InputSignalWithTransform, ModelSignal, OutputRef} from '@angular/core';
 import type {FormFieldBindingOptions} from '../directive/form_field_directive';
 import type {ValidationError, WithOptionalFieldTree} from './rules/validation/validation_errors';
 import type {DisabledReason} from './types';
@@ -117,12 +117,6 @@ export interface FormUiControl<TValue> {
   readonly pattern?:
     | InputSignal<readonly RegExp[]>
     | InputSignalWithTransform<readonly RegExp[], unknown>;
-  /**
-   * A signal containing the current parse errors for the control.
-   * This allows the control to communicate to the form that there are additional validation errors
-   * beyond those produced by the schema, due to being unable to parse the user's input.
-   */
-  readonly parseErrors?: Signal<ValidationError.WithoutFieldTree[]>;
   /**
    * Focuses the UI control.
    *

--- a/packages/forms/signals/src/api/transformed_value.ts
+++ b/packages/forms/signals/src/api/transformed_value.ts
@@ -97,7 +97,7 @@ export function transformedValue<TValue, TRaw>(
   const parseErrors = signal<readonly ValidationError.WithoutFieldTree[]>([]);
   const rawValue = linkedSignal(() => format(value()));
 
-  const formFieldParseErrors = inject(FORM_FIELD_PARSE_ERRORS, {optional: true});
+  const formFieldParseErrors = inject(FORM_FIELD_PARSE_ERRORS, {self: true, optional: true});
   if (formFieldParseErrors) {
     formFieldParseErrors.set(parseErrors);
   }

--- a/packages/forms/signals/src/api/transformed_value.ts
+++ b/packages/forms/signals/src/api/transformed_value.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  inject,
+  linkedSignal,
+  type ModelSignal,
+  type Signal,
+  signal,
+  type WritableSignal,
+} from '@angular/core';
+import {FORM_FIELD_PARSE_ERRORS} from '../directive/parse_errors';
+import type {ValidationError} from './rules';
+
+/**
+ * Options for `transformedValue`.
+ *
+ * @experimental 21.2.0
+ */
+export interface TransformedValueOptions<TValue, TRaw> {
+  /**
+   * Parse the raw value into the model value.
+   *
+   * Should return an object containing the parsed result, which may contain:
+   *   - `value`: The parsed model value. If `undefined`, the model will not be updated.
+   *   - `errors`: Any parse errors encountered. If `undefined`, no errors are reported.
+   */
+  parse: (rawValue: TRaw) => {value?: TValue; errors?: readonly ValidationError.WithoutFieldTree[]};
+
+  /**
+   * Format the model value into the raw value.
+   */
+  format: (value: TValue) => TRaw;
+}
+
+/**
+ * A writable signal representing a "raw" UI value that is synchronized with a model signal
+ * via parse/format transformations.
+ *
+ * @category control
+ * @experimental 21.2.0
+ */
+export interface TransformedValueSignal<TRaw> extends WritableSignal<TRaw> {
+  /**
+   * The current parse errors resulting from the last transformation.
+   */
+  readonly parseErrors: Signal<readonly ValidationError.WithoutFieldTree[]>;
+}
+
+/**
+ * Creates a writable signal representing a "raw" UI value that is transformed to/from a model
+ * value via `parse` and `format` functions.
+ *
+ * This utility simplifies the creation of custom form controls that parse a user-facing value
+ * representation into an underlying model value. For example, a numeric input that displays and
+ * accepts string values but stores a number.
+ *
+ * @param value The model signal to synchronize with.
+ * @param options Configuration including `parse` and `format` functions.
+ * @returns A `TransformedValueSignal` representing the raw value with parse error tracking.
+ * @experimental 21.2.0
+ *
+ * @example
+ * ```ts
+ * @Component({
+ *   selector: 'number-input',
+ *   template: `<input [value]="rawValue()" (input)="rawValue.set($event.target.value)" />`,
+ * })
+ * export class NumberInput implements FormValueControl<number | null> {
+ *   readonly value = model.required<number | null>();
+ *
+ *   protected readonly rawValue = transformedValue(this.value, {
+ *     parse: (val) => {
+ *       if (val === '') return {value: null};
+ *       const num = Number(val);
+ *       if (Number.isNaN(num)) {
+ *         return {errors: [{kind: 'parse', message: `${val} is not numeric`}]};
+ *       }
+ *       return {value: num};
+ *     },
+ *     format: (val) => val?.toString() ?? '',
+ *   });
+ * }
+ * ```
+ */
+export function transformedValue<TValue, TRaw>(
+  value: ModelSignal<TValue>,
+  options: TransformedValueOptions<TValue, TRaw>,
+): TransformedValueSignal<TRaw> {
+  const {parse, format} = options;
+
+  const parseErrors = signal<readonly ValidationError.WithoutFieldTree[]>([]);
+  const rawValue = linkedSignal(() => format(value()));
+
+  const formFieldParseErrors = inject(FORM_FIELD_PARSE_ERRORS, {optional: true});
+  if (formFieldParseErrors) {
+    formFieldParseErrors.set(parseErrors);
+  }
+
+  // Create the result signal with overridden set/update and a `parseErrors` property.
+  const result = rawValue as WritableSignal<TRaw> & {
+    parseErrors: Signal<readonly ValidationError.WithoutFieldTree[]>;
+  };
+  const originalSet = result.set.bind(result);
+
+  result.set = (newRawValue: TRaw) => {
+    const result = parse(newRawValue);
+    parseErrors.set(result.errors ?? []);
+    if (result.value !== undefined) {
+      value.set(result.value);
+    }
+    originalSet(newRawValue);
+  };
+
+  result.update = (updateFn: (value: TRaw) => TRaw) => {
+    result.set(updateFn(rawValue()));
+  };
+
+  result.parseErrors = parseErrors.asReadonly();
+
+  return result;
+}

--- a/packages/forms/signals/src/directive/parse_errors.ts
+++ b/packages/forms/signals/src/directive/parse_errors.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken, type Signal, type WritableSignal} from '@angular/core';
+import type {ValidationError} from '../api/rules';
+
+/**
+ * DI token that provides a writable signal that controls can use to set the signal of parse errors
+ * for the `FormField` directive. Used internally by `transformedValue`.
+ *
+ * @experimental 21.2.0
+ */
+export const FORM_FIELD_PARSE_ERRORS = new InjectionToken<
+  WritableSignal<Signal<readonly ValidationError.WithoutFieldTree[]> | undefined>
+>(typeof ngDevMode !== 'undefined' && ngDevMode ? 'FORM_FIELD_PARSE_ERRORS' : '');


### PR DESCRIPTION
Removes the `parseErrors` property on `FormUiControl` and instead introduces a new utility `transformedValue` that automatically handles synchronizing the raw value and model value using the given `parse` and `format` functions. It also automates the reporting of `parseErrors` to the `FormField`, simplifying the API surface

