### PR TITLE
ci: exclude standard_schema from sync.

### DIFF
--- a/.ng-dev/google-sync-config.json
+++ b/.ng-dev/google-sync-config.json
@@ -16,6 +16,7 @@
     "packages/docs/**",
     "packages/elements/schematics/**",
     "packages/examples/**",
+    "packages/forms/signals/src/api/rules/validation/standard_schema.ts",
     "packages/localize/**",
     "packages/private/**",
     "packages/service-worker/**",


### PR DESCRIPTION
This file isn't sync into G3 and this should prevent the CI from requiring a presubmit when the file is modified.

#66871, for example required a presubmit when there isn't anything that is synced into G3. 