### PR TITLE
refactor(forms): work around internal issue

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -12,7 +12,6 @@ import { FormControlState } from '@angular/forms';
 import { FormControlStatus } from '@angular/forms';
 import * as i0 from '@angular/core';
 import { Injector } from '@angular/core';
-import { NgControl } from '@angular/forms';
 import { Signal } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
 import { ValidatorFn } from '@angular/forms';

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -16,7 +16,6 @@ import { Injector } from '@angular/core';
 import { InputSignal } from '@angular/core';
 import { InputSignalWithTransform } from '@angular/core';
 import { ModelSignal } from '@angular/core';
-import { NgControl } from '@angular/forms';
 import { OutputRef } from '@angular/core';
 import { Provider } from '@angular/core';
 import { ResourceRef } from '@angular/core';


### PR DESCRIPTION
Works around an internal property renaming issue by changing how we declare the interface for `InteropNgControl`.
