### PR TITLE
feat(forms): Adds support for numeric inputmode

### DIFF
--- a/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/signal_forms_spec.ts
@@ -128,6 +128,120 @@ runInEachFileSystem(() => {
       expect(extractMessage(diags[0])).toBe(`Type 'number' is not assignable to type 'string'.`);
     });
 
+    it('should allow string or number for inputs with numeric inputmode', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({
+            template: '<input inputmode="numeric" [formField]="f"/>',
+            imports: [FormField]
+          })
+          export class Comp {
+            f = form(signal(0));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should reject invalid types for inputs with numeric inputmode', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({
+            template: '<input inputmode="numeric" [formField]="f"/>',
+            imports: [FormField]
+          })
+          export class Comp {
+            f = form(signal({}));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(extractMessage(diags[0])).toBe(
+        `Type '{}' is not assignable to type 'string | number'.`,
+      );
+    });
+
+    it('should allow string or number for inputs with dynamically bound inputmode', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({
+            template: '<input [inputMode]="mode" [formField]="f"/>',
+            imports: [FormField]
+          })
+          export class Comp {
+            mode = 'numeric';
+            f = form(signal(0));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should allow string or number for inputs with bound inputmode attribute', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({
+            template: '<input [attr.inputmode]="mode" [formField]="f"/>',
+            imports: [FormField]
+          })
+          export class Comp {
+            mode = 'numeric';
+            f = form(signal(0));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(0);
+    });
+
+    it('should reject invalid types for inputs with dynamically bound inputmode', () => {
+      env.write(
+        'test.ts',
+        `
+          import {Component, signal} from '@angular/core';
+          import {FormField, form} from '@angular/forms/signals';
+
+          @Component({
+            template: '<input [inputMode]="mode" [formField]="f"/>',
+            imports: [FormField]
+          })
+          export class Comp {
+            mode = 'numeric';
+            f = form(signal({}));
+          }
+        `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect(extractMessage(diags[0])).toBe(
+        `Type '{}' is not assignable to type 'string | number'.`,
+      );
+    });
+
     it('should infer the type of the field from the input `type`', () => {
       env.write(
         'test.ts',

--- a/packages/forms/signals/src/directive/native.ts
+++ b/packages/forms/signals/src/directive/native.ts
@@ -90,6 +90,17 @@ export function getNativeControlValue(
         return element.valueAsNumber;
       }
       break;
+    case 'text':
+      if (element.inputMode === 'numeric' && typeof untracked(currentValue) === 'number') {
+        // For text-based inputs with `inputmode="numeric"`, parse the value as a number.
+        // This supports `<input type="text" inputmode="numeric">
+        if (element.value === '') {
+          return NaN;
+        }
+
+        return Number(element.value);
+      }
+      break;
   }
 
   // Default to reading the value as a string.
@@ -134,6 +145,13 @@ export function setNativeControlValue(element: NativeFormControl, value: unknown
         setNativeNumberControlValue(element, value);
         return;
       }
+      break;
+    case 'text':
+      if (element.inputMode === 'numeric' && typeof value === 'number') {
+        element.value = isNaN(value) ? '' : String(value);
+        return;
+      }
+      break;
   }
 
   // Default to setting the value as a string.

--- a/packages/forms/signals/test/web/form_field_directive.spec.ts
+++ b/packages/forms/signals/test/web/form_field_directive.spec.ts
@@ -3883,6 +3883,123 @@ describe('field directive', () => {
       });
       expect(cmp.f().value()).toBe('abc');
     });
+
+    it('should sync number field with text type input (inputmode="numeric")', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="text" inputmode="numeric" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(123));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('123');
+      expect(input.type).toBe('text');
+
+      // Model -> View
+      act(() => cmp.f().value.set(456));
+      expect(input.value).toBe('456');
+
+      // View -> Model
+      act(() => {
+        input.value = '789';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe(789);
+
+      // Clearing the input should produce NaN
+      act(() => {
+        input.value = '';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBeNaN();
+
+      // Setting NaN should clear the input
+      act(() => cmp.f().value.set(NaN));
+      expect(input.value).toBe('');
+    });
+
+    it('should sync string field with text type input (inputmode="numeric")', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="text" inputmode="numeric" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('123'));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state - should work as string
+      expect(input.value).toBe('123');
+
+      // Model -> View
+      act(() => cmp.f().value.set('456'));
+      expect(input.value).toBe('456');
+
+      // View -> Model (should remain as string)
+      act(() => {
+        input.value = '789';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe('789');
+    });
+
+    it('should handle non-numeric input with inputmode="numeric"', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="text" inputmode="numeric" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(123));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+
+      // Non-numeric input should parse to NaN
+      act(() => {
+        input.value = 'abc';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(fix.componentInstance.f().value()).toBeNaN();
+      expect(input.value).toBe('');
+    });
+
+    it('should handle negative numbers with inputmode="numeric"', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="text" inputmode="numeric" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal(-123));
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial negative value
+      expect(input.value).toBe('-123');
+
+      // Model -> View with negative
+      act(() => cmp.f().value.set(-456));
+      expect(input.value).toBe('-456');
+
+      // View -> Model with negative
+      act(() => {
+        input.value = '-789';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe(-789);
+    });
   });
 
   describe('should be marked dirty by user interaction', () => {


### PR DESCRIPTION
Currently, type="text" inputs are treated strictly as string values. When used with inputmode="numeric" and bound to a numeric signal field, this results in a next error : 

```text
 TS2322 error number is not assignable to string
```

Allows inputs configured with `inputmode="numeric"` to properly synchronize with signal-based form fields by accepting and normalizing both string and number values. This aligns with [accessibility practices](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers) ( due to assistive technology issues e.g., problematic spinner controls and screen reader behavior) while still preserving the numeric keyboard on mobile


```ts
@Component({
  template: `
      <input
        type="text"
        inputmode="numeric"
        [formField]="f.documentNumber"    
      />
  `,
})
class InputModeExample {
  readonly data = signal({
    documentNumber: 4,
  });

  readonly f = form(this.data);
}
```
 
## Other information

This addresses part of #66903 by enabling proper support for `inputmode="numeric"` with numeric form fields.

However, on iOS, `pattern="[0-9]*"` is often required to consistently trigger the numeric keypad. Since pattern is currently disallowed with `[formField]`, that aspect remains unresolved and would need to be considered separately. ( Although we can currently use modifying the DOM directly as a workaround to add it at runtime   ) 
