### PR TITLE
refactor(language-service): use type-only TypeScript imports in some files

### DIFF
--- a/packages/language-service/src/codefixes/code_fixes.ts
+++ b/packages/language-service/src/codefixes/code_fixes.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import tss from 'typescript';
+import type ts from 'typescript';
 
 import {TypeCheckInfo} from '../utils';
 
@@ -18,7 +18,7 @@ export class CodeFixes {
   private fixIdToRegistration = new Map<FixIdForCodeFixesAll, CodeActionMeta>();
 
   constructor(
-    private readonly tsLS: tss.LanguageService,
+    private readonly tsLS: ts.LanguageService,
     readonly codeActionMetas: CodeActionMeta[],
   ) {
     for (const meta of codeActionMetas) {
@@ -55,11 +55,11 @@ export class CodeFixes {
     start: number,
     end: number,
     errorCodes: readonly number[],
-    diagnostics: tss.Diagnostic[],
-    formatOptions: tss.FormatCodeSettings,
-    preferences: tss.UserPreferences,
-  ): readonly tss.CodeFixAction[] {
-    const codeActions: tss.CodeFixAction[] = [];
+    diagnostics: ts.Diagnostic[],
+    formatOptions: ts.FormatCodeSettings,
+    preferences: ts.UserPreferences,
+  ): readonly ts.CodeFixAction[] {
+    const codeActions: ts.CodeFixAction[] = [];
     for (const code of errorCodes) {
       const metas = this.errorCodeToFixes.get(code);
       if (metas === undefined) {
@@ -98,12 +98,12 @@ export class CodeFixes {
    */
   getAllCodeActions(
     compiler: NgCompiler,
-    diagnostics: tss.Diagnostic[],
-    scope: tss.CombinedCodeFixScope,
+    diagnostics: ts.Diagnostic[],
+    scope: ts.CombinedCodeFixScope,
     fixId: string,
-    formatOptions: tss.FormatCodeSettings,
-    preferences: tss.UserPreferences,
-  ): tss.CombinedCodeActions {
+    formatOptions: ts.FormatCodeSettings,
+    preferences: ts.UserPreferences,
+  ): ts.CombinedCodeActions {
     const meta = this.fixIdToRegistration.get(fixId as FixIdForCodeFixesAll);
     if (meta === undefined) {
       return {

--- a/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
+++ b/packages/language-service/src/codefixes/fix_invalid_banana_in_box.ts
@@ -8,7 +8,7 @@
 
 import {TmplAstBoundEvent} from '@angular/compiler';
 import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
-import tss from 'typescript';
+import type ts from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from '../template_target';
 import {getTypeCheckInfoAtPosition, TypeCheckInfo} from '../utils';
@@ -44,7 +44,7 @@ export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
   },
   fixIds: [FixIdForCodeFixesAll.FIX_INVALID_BANANA_IN_BOX],
   getAllCodeActions({diagnostics, compiler}) {
-    const fileNameToTextChangesMap = new Map<string, tss.TextChange[]>();
+    const fileNameToTextChangesMap = new Map<string, ts.TextChange[]>();
     for (const diag of diagnostics) {
       const fileName = diag.file?.fileName;
       if (fileName === undefined) {
@@ -77,7 +77,7 @@ export const fixInvalidBananaInBoxMeta: CodeActionMeta = {
       fileTextChanges.push(...textChanges);
     }
 
-    const fileTextChanges: tss.FileTextChanges[] = [];
+    const fileTextChanges: ts.FileTextChanges[] = [];
     for (const [fileName, textChanges] of fileNameToTextChangesMap) {
       fileTextChanges.push({
         fileName,
@@ -117,7 +117,7 @@ function getTheBoundEventAtPosition(
 /**
  * Flip the invalid "box in a banana" `([thing])` to the correct "banana in a box" `[(thing)]`.
  */
-function convertBoundEventToTsTextChange(node: TmplAstBoundEvent): readonly tss.TextChange[] {
+function convertBoundEventToTsTextChange(node: TmplAstBoundEvent): readonly ts.TextChange[] {
   const name = node.name;
   const boundSyntax = node.sourceSpan.toString();
   const expectedBoundSyntax = boundSyntax.replace(`(${name})`, `[(${name.slice(1, -1)})]`);

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -9,7 +9,7 @@
 import {ASTWithName, TmplAstElement} from '@angular/compiler';
 import {ErrorCode as NgCompilerErrorCode, ngErrorCode} from '@angular/compiler-cli';
 import {PotentialDirective, PotentialPipe} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
-import ts from 'typescript';
+import type ts from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from '../template_target';
 import {

--- a/packages/language-service/src/codefixes/fix_missing_member.ts
+++ b/packages/language-service/src/codefixes/fix_missing_member.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import tss from 'typescript';
+import type ts from 'typescript';
 
 import {getTcbNodesOfTemplateAtPosition} from '../template_target';
 import {getTypeCheckInfoAtPosition} from '../utils';
@@ -41,7 +41,7 @@ export const missingMemberMeta: CodeActionMeta = {
       return [];
     }
 
-    const codeActions: tss.CodeFixAction[] = [];
+    const codeActions: ts.CodeFixAction[] = [];
     const tcb = tcbNodesInfo.componentTcbNode;
     for (const tcbNode of tcbNodesInfo.nodes) {
       const tsLsCodeActions = tsLs.getCodeFixesAtPosition(
@@ -75,8 +75,8 @@ export const missingMemberMeta: CodeActionMeta = {
     compiler,
     diagnostics,
   }) {
-    const changes: tss.FileTextChanges[] = [];
-    const seen: Set<tss.ClassDeclaration> = new Set();
+    const changes: ts.FileTextChanges[] = [];
+    const seen: Set<ts.ClassDeclaration> = new Set();
     for (const diag of diagnostics) {
       if (!errorCodes.includes(diag.code)) {
         continue;

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -8,7 +8,7 @@
 
 import {absoluteFrom} from '@angular/compiler-cli';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import tss from 'typescript';
+import type ts from 'typescript';
 
 import {TypeCheckInfo} from '../utils';
 
@@ -26,9 +26,9 @@ export interface CodeActionContext {
   start: number;
   end: number;
   errorCode: number;
-  formatOptions: tss.FormatCodeSettings;
-  preferences: tss.UserPreferences;
-  tsLs: tss.LanguageService;
+  formatOptions: ts.FormatCodeSettings;
+  preferences: ts.UserPreferences;
+  tsLs: ts.LanguageService;
 }
 
 /**
@@ -39,38 +39,38 @@ export interface CodeActionContext {
  * `scope`, this context will be provided to the `CodeActionMeta` which could handle the `fixId`.
  */
 export interface CodeFixAllContext {
-  scope: tss.CombinedCodeFixScope;
+  scope: ts.CombinedCodeFixScope;
   compiler: NgCompiler;
   // https://github.com/microsoft/TypeScript/blob/5c4caafc2a2d0fceb03fce80fb14d3ee4407d918/src/services/types.ts#L781-L785
   fixId: string;
-  formatOptions: tss.FormatCodeSettings;
-  preferences: tss.UserPreferences;
-  tsLs: tss.LanguageService;
-  diagnostics: tss.Diagnostic[];
+  formatOptions: ts.FormatCodeSettings;
+  preferences: ts.UserPreferences;
+  tsLs: ts.LanguageService;
+  diagnostics: ts.Diagnostic[];
 }
 
 export interface CodeActionMeta {
   errorCodes: Array<number>;
-  getCodeActions: (context: CodeActionContext) => readonly tss.CodeFixAction[];
+  getCodeActions: (context: CodeActionContext) => readonly ts.CodeFixAction[];
   fixIds: FixIdForCodeFixesAll[];
-  getAllCodeActions: (context: CodeFixAllContext) => tss.CombinedCodeActions;
+  getAllCodeActions: (context: CodeFixAllContext) => ts.CombinedCodeActions;
 }
 
 /**
  * Convert the span of `textChange` in the TCB to the span of the template.
  */
 export function convertFileTextChangeInTcb(
-  changes: readonly tss.FileTextChanges[],
+  changes: readonly ts.FileTextChanges[],
   compiler: NgCompiler,
-): tss.FileTextChanges[] {
+): ts.FileTextChanges[] {
   const ttc = compiler.getTemplateTypeChecker();
-  const fileTextChanges: tss.FileTextChanges[] = [];
+  const fileTextChanges: ts.FileTextChanges[] = [];
   for (const fileTextChange of changes) {
     if (!ttc.isTrackedTypeCheckFile(absoluteFrom(fileTextChange.fileName))) {
       fileTextChanges.push(fileTextChange);
       continue;
     }
-    const textChanges: tss.TextChange[] = [];
+    const textChanges: ts.TextChange[] = [];
     let fileName: string | undefined;
     const seenTextChangeInTemplate = new Set<string>();
     for (const textChange of fileTextChange.textChanges) {
@@ -121,7 +121,7 @@ export function convertFileTextChangeInTcb(
  * 'fix all' is only available when there are multiple diagnostics that the code action meta
  * indicates it can fix.
  */
-export function isFixAllAvailable(meta: CodeActionMeta, diagnostics: tss.Diagnostic[]) {
+export function isFixAllAvailable(meta: CodeActionMeta, diagnostics: ts.Diagnostic[]) {
   const errorCodes = meta.errorCodes;
   let maybeFixableDiagnostics = 0;
   for (const diag of diagnostics) {

--- a/packages/language-service/src/quick_info_built_ins.ts
+++ b/packages/language-service/src/quick_info_built_ins.ts
@@ -21,7 +21,7 @@ import {
   TmplAstForLoopBlockEmpty,
   TmplAstNode,
 } from '@angular/compiler';
-import ts from 'typescript';
+import type ts from 'typescript';
 
 import {DisplayInfoKind, SYMBOL_TEXT} from './utils/display_parts';
 import {createQuickInfo, getTextSpanOfNode, isWithin, toTextSpan} from './utils';

--- a/packages/language-service/src/refactorings/convert_to_signal_input/apply_input_refactoring.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_input/apply_input_refactoring.ts
@@ -9,7 +9,7 @@
 import {CompilerOptions} from '@angular/compiler-cli';
 import {getFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import ts from 'typescript';
+import type ts from 'typescript';
 import {
   getMessageForClassIncompatibility,
   getMessageForFieldIncompatibility,

--- a/packages/language-service/src/refactorings/convert_to_signal_input/decorators.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_input/decorators.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import ts from 'typescript';
+import type ts from 'typescript';
 import {getAngularDecorators} from '@angular/compiler-cli/src/ngtsc/annotations';
 import {ReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {isDirectiveOrComponent} from '../../utils/decorators';

--- a/packages/language-service/src/refactorings/convert_to_signal_queries/decorators.ts
+++ b/packages/language-service/src/refactorings/convert_to_signal_queries/decorators.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import ts from 'typescript';
+import type ts from 'typescript';
 import {getAngularDecorators} from '@angular/compiler-cli/src/ngtsc/annotations';
 import {ReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {isDirectiveOrComponent} from '../../utils/decorators';

--- a/packages/language-service/src/refactorings/refactoring.ts
+++ b/packages/language-service/src/refactorings/refactoring.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import ts from 'typescript';
+import type ts from 'typescript';
 import {ApplyRefactoringProgressFn, ApplyRefactoringResult} from '../../api';
 import {CompilerOptions} from '@angular/compiler-cli';
 import {

--- a/packages/language-service/src/utils/decorators.ts
+++ b/packages/language-service/src/utils/decorators.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import ts from 'typescript';
+import type ts from 'typescript';
 import {ReflectionHost} from '@angular/compiler-cli/src/ngtsc/reflection';
 import {getAngularDecorators} from '@angular/compiler-cli/src/ngtsc/annotations';
 


### PR DESCRIPTION
Standardize on `import type ts from 'typescript'` across several files in the language-service package.

This ensures that these files do not have a runtime dependency on a specific version of the TypeScript module, instead relying on the instance provided by the host during initialization.

Note: This change is not comprehensive. Several files still require runtime access to the TypeScript module and will require further refactoring to fully decouple the dependency.