### PR TITLE
test(common): remove zone-based testing utilities

### DIFF
--- a/packages/common/test/BUILD.bazel
+++ b/packages/common/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
 
 ts_project(
     name = "test_lib",
@@ -23,14 +23,14 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test_web",
     deps = [
         ":test_lib",

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -8,7 +8,7 @@
 
 import {NgClass} from '../../index';
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 describe('binding to CSS class list', () => {
   let fixture: ComponentFixture<any> | null;
@@ -38,38 +38,38 @@ describe('binding to CSS class list', () => {
     });
   });
 
-  it('should clean up when the directive is destroyed', waitForAsync(() => {
+  it('should clean up when the directive is destroyed', () => {
     fixture = createTestComponent('<div *ngFor="let item of items" [ngClass]="item"></div>');
 
     getComponent().items = [['0']];
     fixture.detectChanges();
     getComponent().items = [['1']];
     detectChangesAndExpectClassName('1');
-  }));
+  });
 
   describe('expressions evaluating to objects', () => {
-    it('should add classes specified in an object literal', waitForAsync(() => {
+    it('should add classes specified in an object literal', () => {
       fixture = createTestComponent('<div [ngClass]="{foo: true, bar: false}"></div>');
 
       detectChangesAndExpectClassName('foo');
-    }));
+    });
 
-    it('should add classes specified in an object literal without change in class names', waitForAsync(() => {
+    it('should add classes specified in an object literal without change in class names', () => {
       fixture = createTestComponent(`<div [ngClass]="{'foo-bar': true, 'fooBar': true}"></div>`);
 
       detectChangesAndExpectClassName('foo-bar fooBar');
-    }));
+    });
 
-    it('should add and remove classes based on changes in object literal values', waitForAsync(() => {
+    it('should add and remove classes based on changes in object literal values', () => {
       fixture = createTestComponent('<div [ngClass]="{foo: condition, bar: !condition}"></div>');
 
       detectChangesAndExpectClassName('foo');
 
       getComponent().condition = false;
       detectChangesAndExpectClassName('bar');
-    }));
+    });
 
-    it('should add and remove classes based on changes to the expression object', waitForAsync(() => {
+    it('should add and remove classes based on changes to the expression object', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
       const objExpr = getComponent().objExpr;
 
@@ -83,9 +83,9 @@ describe('binding to CSS class list', () => {
 
       delete objExpr!['bar'];
       detectChangesAndExpectClassName('foo baz');
-    }));
+    });
 
-    it('should add and remove classes based on reference changes to the expression object', waitForAsync(() => {
+    it('should add and remove classes based on reference changes to the expression object', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
 
       detectChangesAndExpectClassName('foo');
@@ -95,9 +95,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = {baz: true};
       detectChangesAndExpectClassName('baz');
-    }));
+    });
 
-    it('should remove active classes when expression evaluates to null', waitForAsync(() => {
+    it('should remove active classes when expression evaluates to null', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
 
       detectChangesAndExpectClassName('foo');
@@ -107,9 +107,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = {'foo': false, 'bar': true};
       detectChangesAndExpectClassName('bar');
-    }));
+    });
 
-    it('should remove active classes when expression evaluates to undefined', waitForAsync(() => {
+    it('should remove active classes when expression evaluates to undefined', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
 
       detectChangesAndExpectClassName('foo');
@@ -119,9 +119,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = {'foo': false, 'bar': true};
       detectChangesAndExpectClassName('bar');
-    }));
+    });
 
-    it('should allow multiple classes per expression', waitForAsync(() => {
+    it('should allow multiple classes per expression', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
 
       getComponent().objExpr = {'bar baz': true, 'bar1 baz1': true};
@@ -129,24 +129,24 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = {'bar baz': false, 'bar1 baz1': true};
       detectChangesAndExpectClassName('bar1 baz1');
-    }));
+    });
 
-    it('should split by one or more spaces between classes', waitForAsync(() => {
+    it('should split by one or more spaces between classes', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
 
       getComponent().objExpr = {'foo bar     baz': true};
       detectChangesAndExpectClassName('foo bar baz');
-    }));
+    });
   });
 
   describe('expressions evaluating to lists', () => {
-    it('should add classes specified in a list literal', waitForAsync(() => {
+    it('should add classes specified in a list literal', () => {
       fixture = createTestComponent(`<div [ngClass]="['foo', 'bar', 'foo-bar', 'fooBar']"></div>`);
 
       detectChangesAndExpectClassName('foo bar foo-bar fooBar');
-    }));
+    });
 
-    it('should add and remove classes based on changes to the expression', waitForAsync(() => {
+    it('should add and remove classes based on changes to the expression', () => {
       fixture = createTestComponent('<div [ngClass]="arrExpr"></div>');
       const arrExpr = getComponent().arrExpr;
       detectChangesAndExpectClassName('foo');
@@ -159,38 +159,38 @@ describe('binding to CSS class list', () => {
 
       getComponent().arrExpr = arrExpr.filter((v: string) => v !== 'baz');
       detectChangesAndExpectClassName('foo');
-    }));
+    });
 
-    it('should add and remove classes when a reference changes', waitForAsync(() => {
+    it('should add and remove classes when a reference changes', () => {
       fixture = createTestComponent('<div [ngClass]="arrExpr"></div>');
       detectChangesAndExpectClassName('foo');
 
       getComponent().arrExpr = ['bar'];
       detectChangesAndExpectClassName('bar');
-    }));
+    });
 
-    it('should take initial classes into account when a reference changes', waitForAsync(() => {
+    it('should take initial classes into account when a reference changes', () => {
       fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
       detectChangesAndExpectClassName('foo');
 
       getComponent().arrExpr = ['bar'];
       detectChangesAndExpectClassName('foo bar');
-    }));
+    });
 
-    it('should ignore empty or blank class names', waitForAsync(() => {
+    it('should ignore empty or blank class names', () => {
       fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
       getComponent().arrExpr = ['', '  '];
       detectChangesAndExpectClassName('foo');
-    }));
+    });
 
-    it('should trim blanks from class names', waitForAsync(() => {
+    it('should trim blanks from class names', () => {
       fixture = createTestComponent('<div class="foo" [ngClass]="arrExpr"></div>');
 
       getComponent().arrExpr = [' bar  '];
       detectChangesAndExpectClassName('foo bar');
-    }));
+    });
 
-    it('should allow multiple classes per item in arrays', waitForAsync(() => {
+    it('should allow multiple classes per item in arrays', () => {
       fixture = createTestComponent('<div [ngClass]="arrExpr"></div>');
 
       getComponent().arrExpr = ['foo bar baz', 'foo1 bar1   baz1'];
@@ -198,7 +198,7 @@ describe('binding to CSS class list', () => {
 
       getComponent().arrExpr = ['foo bar   baz foobar'];
       detectChangesAndExpectClassName('foo bar baz foobar');
-    }));
+    });
 
     it('should throw with descriptive error message when CSS class is not a string', () => {
       fixture = createTestComponent(`<div [ngClass]="['foo', {}]"></div>`);
@@ -209,7 +209,7 @@ describe('binding to CSS class list', () => {
   });
 
   describe('expressions evaluating to sets', () => {
-    it('should add and remove classes if the set instance changed', waitForAsync(() => {
+    it('should add and remove classes if the set instance changed', () => {
       fixture = createTestComponent('<div [ngClass]="setExpr"></div>');
       let setExpr = new Set<string>();
       setExpr.add('bar');
@@ -220,16 +220,16 @@ describe('binding to CSS class list', () => {
       setExpr.add('baz');
       getComponent().setExpr = setExpr;
       detectChangesAndExpectClassName('baz');
-    }));
+    });
   });
 
   describe('expressions evaluating to string', () => {
-    it('should add classes specified in a string literal', waitForAsync(() => {
+    it('should add classes specified in a string literal', () => {
       fixture = createTestComponent(`<div [ngClass]="'foo bar foo-bar fooBar'"></div>`);
       detectChangesAndExpectClassName('foo bar foo-bar fooBar');
-    }));
+    });
 
-    it('should add and remove classes based on changes to the expression', waitForAsync(() => {
+    it('should add and remove classes based on changes to the expression', () => {
       fixture = createTestComponent('<div [ngClass]="strExpr"></div>');
       detectChangesAndExpectClassName('foo');
 
@@ -238,49 +238,49 @@ describe('binding to CSS class list', () => {
 
       getComponent().strExpr = 'baz';
       detectChangesAndExpectClassName('baz');
-    }));
+    });
 
-    it('should remove active classes when switching from string to null', waitForAsync(() => {
+    it('should remove active classes when switching from string to null', () => {
       fixture = createTestComponent(`<div [ngClass]="strExpr"></div>`);
       detectChangesAndExpectClassName('foo');
 
       getComponent().strExpr = null;
       detectChangesAndExpectClassName('');
-    }));
+    });
 
-    it('should remove active classes when switching from string to undefined', waitForAsync(() => {
+    it('should remove active classes when switching from string to undefined', () => {
       fixture = createTestComponent(`<div [ngClass]="strExpr"></div>`);
       detectChangesAndExpectClassName('foo');
 
       getComponent().strExpr = undefined;
       detectChangesAndExpectClassName('');
-    }));
+    });
 
-    it('should take initial classes into account when switching from string to null', waitForAsync(() => {
+    it('should take initial classes into account when switching from string to null', () => {
       fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
       detectChangesAndExpectClassName('foo');
 
       getComponent().strExpr = null;
       detectChangesAndExpectClassName('foo');
-    }));
+    });
 
-    it('should take initial classes into account when switching from string to undefined', waitForAsync(() => {
+    it('should take initial classes into account when switching from string to undefined', () => {
       fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
       detectChangesAndExpectClassName('foo');
 
       getComponent().strExpr = undefined;
       detectChangesAndExpectClassName('foo');
-    }));
+    });
 
-    it('should ignore empty and blank strings', waitForAsync(() => {
+    it('should ignore empty and blank strings', () => {
       fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
       getComponent().strExpr = '';
       detectChangesAndExpectClassName('foo');
-    }));
+    });
   });
 
   describe('cooperation with other class-changing constructs', () => {
-    it('should co-operate with the class attribute', waitForAsync(() => {
+    it('should co-operate with the class attribute', () => {
       fixture = createTestComponent('<div [ngClass]="objExpr" class="init foo"></div>');
       const objExpr = getComponent().objExpr;
 
@@ -295,9 +295,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = undefined;
       detectChangesAndExpectClassName('init foo');
-    }));
+    });
 
-    it('should co-operate with the interpolated class attribute', waitForAsync(() => {
+    it('should co-operate with the interpolated class attribute', () => {
       fixture = createTestComponent(`<div [ngClass]="objExpr" class="{{'init foo'}}"></div>`);
       const objExpr = getComponent().objExpr;
 
@@ -312,9 +312,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = undefined;
       detectChangesAndExpectClassName(`init foo`);
-    }));
+    });
 
-    it('should co-operate with the interpolated class attribute when interpolation changes', waitForAsync(() => {
+    it('should co-operate with the interpolated class attribute when interpolation changes', () => {
       fixture = createTestComponent(
         `<div [ngClass]="{large: false, small: true}" class="{{strExpr}}"></div>`,
       );
@@ -326,9 +326,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().strExpr = undefined;
       detectChangesAndExpectClassName(`small`);
-    }));
+    });
 
-    it('should co-operate with the class attribute and binding to it', waitForAsync(() => {
+    it('should co-operate with the class attribute and binding to it', () => {
       fixture = createTestComponent(`<div [ngClass]="objExpr" class="init" [class]="'foo'"></div>`);
       const objExpr = getComponent().objExpr;
 
@@ -343,9 +343,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().objExpr = undefined;
       detectChangesAndExpectClassName(`init foo`);
-    }));
+    });
 
-    it('should co-operate with the class attribute and class.name binding', waitForAsync(() => {
+    it('should co-operate with the class attribute and class.name binding', () => {
       const template = '<div class="init foo" [ngClass]="objExpr" [class.baz]="condition"></div>';
       fixture = createTestComponent(template);
       const objExpr = getComponent().objExpr;
@@ -360,9 +360,9 @@ describe('binding to CSS class list', () => {
 
       getComponent().condition = false;
       detectChangesAndExpectClassName('init bar');
-    }));
+    });
 
-    it('should co-operate with initial class and class attribute binding when binding changes', waitForAsync(() => {
+    it('should co-operate with initial class and class attribute binding when binding changes', () => {
       const template = '<div class="init" [ngClass]="objExpr" [class]="strExpr"></div>';
       fixture = createTestComponent(template);
       const cmp = getComponent();
@@ -380,7 +380,7 @@ describe('binding to CSS class list', () => {
 
       cmp.objExpr = undefined;
       detectChangesAndExpectClassName('init baz');
-    }));
+    });
   });
 
   describe('prevent regressions', () => {

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -27,7 +27,7 @@ import {
   ViewChildren,
   ViewContainerRef,
 } from '@angular/core';
-import {TestBed, waitForAsync} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('insert/remove', () => {
@@ -37,7 +37,7 @@ describe('insert/remove', () => {
     });
   });
 
-  it('should do nothing if component is null', waitForAsync(() => {
+  it('should do nothing if component is null', () => {
     const template = `<ng-template *ngComponentOutlet="currentComponent"></ng-template>`;
     TestBed.overrideComponent(TestComponent, {set: {template: template}});
     let fixture = TestBed.createComponent(TestComponent);
@@ -47,9 +47,9 @@ describe('insert/remove', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('');
-  }));
+  });
 
-  it('should insert content specified by a component', waitForAsync(() => {
+  it('should insert content specified by a component', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.detectChanges();
@@ -60,9 +60,9 @@ describe('insert/remove', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('foo');
-  }));
+  });
 
-  it('should emit a ComponentRef once a component was created', waitForAsync(() => {
+  it('should emit a ComponentRef once a component was created', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.detectChanges();
@@ -76,9 +76,9 @@ describe('insert/remove', () => {
     expect(fixture.nativeElement).toHaveText('foo');
     expect(fixture.componentInstance.cmpRef).toBeInstanceOf(ComponentRef);
     expect(fixture.componentInstance.cmpRef!.instance).toBeInstanceOf(InjectedComponent);
-  }));
+  });
 
-  it('should clear view if component becomes null', waitForAsync(() => {
+  it('should clear view if component becomes null', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.detectChanges();
@@ -95,9 +95,9 @@ describe('insert/remove', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('');
-  }));
+  });
 
-  it('should swap content if component changes', waitForAsync(() => {
+  it('should swap content if component changes', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.detectChanges();
@@ -114,9 +114,9 @@ describe('insert/remove', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('bar');
-  }));
+  });
 
-  it('should use the injector, if one supplied', waitForAsync(() => {
+  it('should use the injector, if one supplied', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     const uniqueValue = {};
@@ -132,9 +132,9 @@ describe('insert/remove', () => {
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBe(uniqueValue);
-  }));
+  });
 
-  it('should use the environmentInjector, if one supplied', waitForAsync(() => {
+  it('should use the environmentInjector, if one supplied', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     const uniqueValue = {};
@@ -156,9 +156,9 @@ describe('insert/remove', () => {
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBe(uniqueValue);
-  }));
+  });
 
-  it('should resolve with an injector', waitForAsync(() => {
+  it('should resolve with an injector', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     // We are accessing a ViewChild (ngComponentOutlet) before change detection has run
@@ -170,9 +170,9 @@ describe('insert/remove', () => {
     expect(cmpRef).toBeInstanceOf(ComponentRef);
     expect(cmpRef.instance).toBeInstanceOf(InjectedComponent);
     expect(cmpRef.instance.testToken).toBeNull();
-  }));
+  });
 
-  it('should render projectable nodes, if supplied', waitForAsync(() => {
+  it('should render projectable nodes, if supplied', () => {
     const template = `<ng-template>projected foo</ng-template>${TEST_CMP_TEMPLATE}`;
     TestBed.overrideComponent(TestComponent, {set: {template: template}}).configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
@@ -196,9 +196,9 @@ describe('insert/remove', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('projected foo');
-  }));
+  });
 
-  it('should resolve components from other modules, if supplied as an NgModule class reference', waitForAsync(() => {
+  it('should resolve components from other modules, if supplied as an NgModule class reference', () => {
     let fixture = TestBed.createComponent(TestComponent);
 
     fixture.detectChanges();
@@ -210,9 +210,9 @@ describe('insert/remove', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('baz');
-  }));
+  });
 
-  it('should clean up moduleRef, if supplied as an NgModule class reference', waitForAsync(() => {
+  it('should clean up moduleRef, if supplied as an NgModule class reference', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
@@ -224,9 +224,9 @@ describe('insert/remove', () => {
     expect(moduleRef.destroy).not.toHaveBeenCalled();
     fixture.destroy();
     expect(moduleRef.destroy).toHaveBeenCalled();
-  }));
+  });
 
-  it('should re-create moduleRef when changed (NgModule class reference)', waitForAsync(() => {
+  it('should re-create moduleRef when changed (NgModule class reference)', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.componentInstance.ngModule = TestModule2;
     fixture.componentInstance.currentComponent = Module2InjectedComponent;
@@ -241,9 +241,9 @@ describe('insert/remove', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('bat');
-  }));
+  });
 
-  it('should override providers from parent component using custom injector', waitForAsync(() => {
+  it('should override providers from parent component using custom injector', () => {
     TestBed.overrideComponent(InjectedComponent, {set: {template: 'Value: {{testToken}}'}});
     TestBed.overrideComponent(TestComponent, {
       set: {providers: [{provide: TEST_TOKEN, useValue: 'parent'}]},
@@ -258,7 +258,7 @@ describe('insert/remove', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement).toHaveText('Value: child');
-  }));
+  });
 
   it('should be available as a standalone directive', () => {
     @Component({

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, NgFor, NgForOf} from '../../index';
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 
@@ -38,35 +38,35 @@ describe('ngFor', () => {
     });
   });
 
-  it('should reflect initial elements', waitForAsync(() => {
+  it('should reflect initial elements', () => {
     fixture = createTestComponent();
 
     detectChangesAndExpectText('1;2;');
-  }));
+  });
 
-  it('should reflect added elements', waitForAsync(() => {
+  it('should reflect added elements', () => {
     fixture = createTestComponent();
     fixture.detectChanges();
     getComponent().items.push(3);
     detectChangesAndExpectText('1;2;3;');
-  }));
+  });
 
-  it('should reflect removed elements', waitForAsync(() => {
+  it('should reflect removed elements', () => {
     fixture = createTestComponent();
     fixture.detectChanges();
     getComponent().items.splice(1, 1);
     detectChangesAndExpectText('1;');
-  }));
+  });
 
-  it('should reflect moved elements', waitForAsync(() => {
+  it('should reflect moved elements', () => {
     fixture = createTestComponent();
     fixture.detectChanges();
     getComponent().items.splice(0, 1);
     getComponent().items.push(1);
     detectChangesAndExpectText('2;1;');
-  }));
+  });
 
-  it('should reflect a mix of all changes (additions/removals/moves)', waitForAsync(() => {
+  it('should reflect a mix of all changes (additions/removals/moves)', () => {
     fixture = createTestComponent();
 
     getComponent().items = [0, 1, 2, 3, 4, 5];
@@ -75,9 +75,9 @@ describe('ngFor', () => {
     getComponent().items = [6, 2, 7, 0, 4, 8];
 
     detectChangesAndExpectText('6;2;7;0;4;8;');
-  }));
+  });
 
-  it('should iterate over an array of objects', waitForAsync(() => {
+  it('should iterate over an array of objects', () => {
     const template = '<ul><li *ngFor="let item of items">{{item["name"]}};</li></ul>';
     fixture = createTestComponent(template);
 
@@ -93,16 +93,16 @@ describe('ngFor', () => {
     getComponent().items.splice(2, 1);
     getComponent().items.splice(0, 1);
     detectChangesAndExpectText('shyam;');
-  }));
+  });
 
-  it('should gracefully handle nulls', waitForAsync(() => {
+  it('should gracefully handle nulls', () => {
     const template = '<ul><li *ngFor="let item of null">{{item}};</li></ul>';
     fixture = createTestComponent(template);
 
     detectChangesAndExpectText('');
-  }));
+  });
 
-  it('should gracefully handle ref changing to null and back', waitForAsync(() => {
+  it('should gracefully handle ref changing to null and back', () => {
     fixture = createTestComponent();
 
     detectChangesAndExpectText('1;2;');
@@ -112,44 +112,44 @@ describe('ngFor', () => {
 
     getComponent().items = [1, 2, 3];
     detectChangesAndExpectText('1;2;3;');
-  }));
+  });
 
-  it('should throw on non-iterable ref', waitForAsync(() => {
+  it('should throw on non-iterable ref', () => {
     fixture = createTestComponent();
 
     getComponent().items = <any>'whaaa';
     expect(() => fixture.detectChanges()).toThrowError(
       /NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'\. NgFor only supports binding to Iterables, such as Arrays\. Find more at https:\/\/(?:next\.)?angular\.dev\/errors\/NG02200/,
     );
-  }));
+  });
 
-  it('should throw on non-iterable ref and suggest using an array ', waitForAsync(() => {
+  it('should throw on non-iterable ref and suggest using an array ', () => {
     fixture = createTestComponent();
 
     getComponent().items = <any>{'stuff': 'whaaa'};
     expect(() => fixture.detectChanges()).toThrowError(
       /NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'\. NgFor only supports binding to Iterables, such as Arrays\. Did you mean to use the keyvalue pipe\? Find more at https:\/\/(?:next\.)?angular\.dev\/errors\/NG02200/,
     );
-  }));
+  });
 
-  it('should throw on ref changing to string', waitForAsync(() => {
+  it('should throw on ref changing to string', () => {
     fixture = createTestComponent();
 
     detectChangesAndExpectText('1;2;');
 
     getComponent().items = <any>'whaaa';
     expect(() => fixture.detectChanges()).toThrowError();
-  }));
+  });
 
-  it('should works with duplicates', waitForAsync(() => {
+  it('should works with duplicates', () => {
     fixture = createTestComponent();
 
     const a = new Foo();
     getComponent().items = [a, a];
     detectChangesAndExpectText('foo;foo;');
-  }));
+  });
 
-  it('should repeat over nested arrays', waitForAsync(() => {
+  it('should repeat over nested arrays', () => {
     const template =
       '<div *ngFor="let item of items">' +
       '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>|' +
@@ -161,9 +161,9 @@ describe('ngFor', () => {
 
     getComponent().items = [['e'], ['f', 'g']];
     detectChangesAndExpectText('e-1;|f-2;g-2;|');
-  }));
+  });
 
-  it('should repeat over nested arrays with no intermediate element', waitForAsync(() => {
+  it('should repeat over nested arrays with no intermediate element', () => {
     const template =
       '<div *ngFor="let item of items">' +
       '<div *ngFor="let subitem of item">{{subitem}}-{{item.length}};</div>' +
@@ -175,9 +175,9 @@ describe('ngFor', () => {
 
     getComponent().items = [['e'], ['f', 'g']];
     detectChangesAndExpectText('e-1;f-2;g-2;');
-  }));
+  });
 
-  it('should repeat over nested ngIf that are the last node in the ngFor template', waitForAsync(() => {
+  it('should repeat over nested ngIf that are the last node in the ngFor template', () => {
     const template =
       `<div *ngFor="let item of items; let i=index">` +
       `<div>{{i}}|</div>` +
@@ -195,9 +195,9 @@ describe('ngFor', () => {
 
     items.push(1);
     detectChangesAndExpectText('0|even|1|2|even|');
-  }));
+  });
 
-  it('should allow of saving the collection', waitForAsync(() => {
+  it('should allow of saving the collection', () => {
     const template =
       '<ul><li *ngFor="let item of items as collection; index as i">{{i}}/{{collection.length}} - {{item}};</li></ul>';
     fixture = createTestComponent(template);
@@ -206,9 +206,9 @@ describe('ngFor', () => {
 
     getComponent().items = [1, 2, 3];
     detectChangesAndExpectText('0/3 - 1;1/3 - 2;2/3 - 3;');
-  }));
+  });
 
-  it('should display indices correctly', waitForAsync(() => {
+  it('should display indices correctly', () => {
     const template = '<span *ngFor ="let item of items; let i=index">{{i.toString()}}</span>';
     fixture = createTestComponent(template);
 
@@ -217,9 +217,9 @@ describe('ngFor', () => {
 
     getComponent().items = [1, 2, 6, 7, 4, 3, 5, 8, 9, 0];
     detectChangesAndExpectText('0123456789');
-  }));
+  });
 
-  it('should display count correctly', waitForAsync(() => {
+  it('should display count correctly', () => {
     const template = '<span *ngFor="let item of items; let len=count">{{len}}</span>';
     fixture = createTestComponent(template);
 
@@ -228,9 +228,9 @@ describe('ngFor', () => {
 
     getComponent().items = [4, 3, 2, 1, 0, -1];
     detectChangesAndExpectText('666666');
-  }));
+  });
 
-  it('should display first item correctly', waitForAsync(() => {
+  it('should display first item correctly', () => {
     const template =
       '<span *ngFor="let item of items; let isFirst=first">{{isFirst.toString()}}</span>';
     fixture = createTestComponent(template);
@@ -240,9 +240,9 @@ describe('ngFor', () => {
 
     getComponent().items = [2, 1];
     detectChangesAndExpectText('truefalse');
-  }));
+  });
 
-  it('should display last item correctly', waitForAsync(() => {
+  it('should display last item correctly', () => {
     const template =
       '<span *ngFor="let item of items; let isLast=last">{{isLast.toString()}}</span>';
     fixture = createTestComponent(template);
@@ -252,9 +252,9 @@ describe('ngFor', () => {
 
     getComponent().items = [2, 1];
     detectChangesAndExpectText('falsetrue');
-  }));
+  });
 
-  it('should display even items correctly', waitForAsync(() => {
+  it('should display even items correctly', () => {
     const template =
       '<span *ngFor="let item of items; let isEven=even">{{isEven.toString()}}</span>';
     fixture = createTestComponent(template);
@@ -264,9 +264,9 @@ describe('ngFor', () => {
 
     getComponent().items = [2, 1];
     detectChangesAndExpectText('truefalse');
-  }));
+  });
 
-  it('should display odd items correctly', waitForAsync(() => {
+  it('should display odd items correctly', () => {
     const template = '<span *ngFor="let item of items; let isOdd=odd">{{isOdd.toString()}}</span>';
     fixture = createTestComponent(template);
 
@@ -275,9 +275,9 @@ describe('ngFor', () => {
 
     getComponent().items = [2, 1];
     detectChangesAndExpectText('falsetrue');
-  }));
+  });
 
-  it('should allow to use a custom template', waitForAsync(() => {
+  it('should allow to use a custom template', () => {
     const template =
       '<ng-container *ngFor="let item of items; template: tpl"></ng-container>' +
       '<ng-template let-item let-i="index" #tpl><p>{{i}}: {{item}};</p></ng-template>';
@@ -285,17 +285,17 @@ describe('ngFor', () => {
     getComponent().items = ['a', 'b', 'c'];
     fixture.detectChanges();
     detectChangesAndExpectText('0: a;1: b;2: c;');
-  }));
+  });
 
-  it('should use a default template if a custom one is null', waitForAsync(() => {
+  it('should use a default template if a custom one is null', () => {
     const template = `<ul><ng-container *ngFor="let item of items; template: null; let i=index">{{i}}: {{item}};</ng-container></ul>`;
     fixture = createTestComponent(template);
     getComponent().items = ['a', 'b', 'c'];
     fixture.detectChanges();
     detectChangesAndExpectText('0: a;1: b;2: c;');
-  }));
+  });
 
-  it('should use a custom template when both default and a custom one are present', waitForAsync(() => {
+  it('should use a custom template when both default and a custom one are present', () => {
     const template =
       '<ng-container *ngFor="let item of items; template: tpl">{{i}};</ng-container>' +
       '<ng-template let-item let-i="index" #tpl>{{i}}: {{item}};</ng-template>';
@@ -304,19 +304,19 @@ describe('ngFor', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     detectChangesAndExpectText('0: a;1: b;2: c;');
-  }));
+  });
 
   describe('track by', () => {
-    it('should console.warn if trackBy is not a function', waitForAsync(() => {
+    it('should console.warn if trackBy is not a function', () => {
       // TODO(vicb): expect a warning message when we have a proper log service
       const template = `<p *ngFor="let item of items; trackBy: value"></p>`;
       fixture = createTestComponent(template);
       fixture.componentInstance.value = 0;
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
-    }));
+    });
 
-    it('should track by identity when trackBy is to `null` or `undefined`', waitForAsync(() => {
+    it('should track by identity when trackBy is to `null` or `undefined`', () => {
       // TODO(vicb): expect no warning message when we have a proper log service
       const template = `<p *ngFor="let item of items; trackBy: value">{{ item }}</p>`;
       fixture = createTestComponent(template);
@@ -325,9 +325,9 @@ describe('ngFor', () => {
       detectChangesAndExpectText('abc');
       fixture.componentInstance.value = undefined;
       detectChangesAndExpectText('abc');
-    }));
+    });
 
-    it('should set the context to the component instance', waitForAsync(() => {
+    it('should set the context to the component instance', () => {
       const template = `<p *ngFor="let item of items; trackBy: trackByContext.bind(this)"></p>`;
       fixture = createTestComponent(template);
 
@@ -335,9 +335,9 @@ describe('ngFor', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(thisArg).toBe(getComponent());
-    }));
+    });
 
-    it('should not replace tracked items', waitForAsync(() => {
+    it('should not replace tracked items', () => {
       const template = `<p *ngFor="let item of items; trackBy: trackById; let i=index">{{items[i]}}</p>`;
       fixture = createTestComponent(template);
 
@@ -351,9 +351,9 @@ describe('ngFor', () => {
       const firstP = buildItemList();
       const finalP = buildItemList();
       expect(finalP.nativeElement).toBe(firstP.nativeElement);
-    }));
+    });
 
-    it('should update implicit local variable on view', waitForAsync(() => {
+    it('should update implicit local variable on view', () => {
       const template = `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
       fixture = createTestComponent(template);
 
@@ -362,9 +362,9 @@ describe('ngFor', () => {
 
       getComponent().items = [{'id': 'a', 'color': 'red'}];
       detectChangesAndExpectText('red');
-    }));
+    });
 
-    it('should move items around and keep them updated ', waitForAsync(() => {
+    it('should move items around and keep them updated ', () => {
       const template = `<div *ngFor="let item of items; trackBy: trackById">{{item['color']}}</div>`;
       fixture = createTestComponent(template);
 
@@ -379,9 +379,9 @@ describe('ngFor', () => {
         {'id': 'a', 'color': 'red'},
       ];
       detectChangesAndExpectText('orangered');
-    }));
+    });
 
-    it('should handle added and removed items properly when tracking by index', waitForAsync(() => {
+    it('should handle added and removed items properly when tracking by index', () => {
       const template = `<div *ngFor="let item of items; trackBy: trackByIndex">{{item}}</div>`;
       fixture = createTestComponent(template);
 
@@ -393,7 +393,7 @@ describe('ngFor', () => {
       fixture.detectChanges();
       getComponent().items = ['e', 'f', 'h'];
       detectChangesAndExpectText('efh');
-    }));
+    });
   });
 
   it('should be available as a standalone directive', () => {

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -7,8 +7,8 @@
  */
 
 import {CommonModule, NgIf} from '../../index';
-import {Component, provideZoneChangeDetection} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 
@@ -27,77 +27,84 @@ describe('ngIf directive', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [CommonModule],
-      providers: [provideZoneChangeDetection()],
     });
   });
 
-  it('should work in a template attribute', waitForAsync(() => {
+  it('should work in a template attribute', () => {
     const template = '<span *ngIf="booleanCondition">hello</span>';
     fixture = createTestComponent(template);
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('hello');
-  }));
+  });
 
-  it('should work on a template element', waitForAsync(() => {
+  it('should work on a template element', () => {
     const template = '<ng-template [ngIf]="booleanCondition">hello2</ng-template>';
     fixture = createTestComponent(template);
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('hello2');
-  }));
+  });
 
-  it('should toggle node when condition changes', waitForAsync(() => {
+  it('should toggle node when condition changes', () => {
     const template = '<span *ngIf="booleanCondition">hello</span>';
     fixture = createTestComponent(template);
     getComponent().booleanCondition = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
     expect(fixture.nativeElement).toHaveText('');
 
     getComponent().booleanCondition = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('hello');
 
     getComponent().booleanCondition = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
     expect(fixture.nativeElement).toHaveText('');
-  }));
+  });
 
-  it('should handle nested if correctly', waitForAsync(() => {
+  it('should handle nested if correctly', () => {
     const template =
       '<div *ngIf="booleanCondition"><span *ngIf="nestedBooleanCondition">hello</span></div>';
 
     fixture = createTestComponent(template);
 
     getComponent().booleanCondition = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
     expect(fixture.nativeElement).toHaveText('');
 
     getComponent().booleanCondition = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('hello');
 
     getComponent().nestedBooleanCondition = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
     expect(fixture.nativeElement).toHaveText('');
 
     getComponent().nestedBooleanCondition = true;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('hello');
 
     getComponent().booleanCondition = false;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(0);
     expect(fixture.nativeElement).toHaveText('');
-  }));
+  });
 
-  it('should update several nodes with if', waitForAsync(() => {
+  it('should update several nodes with if', () => {
     const template =
       '<span *ngIf="numberCondition + 1 >= 2">helloNumber</span>' +
       '<span *ngIf="stringCondition == \'foo\'">helloString</span>' +
@@ -110,18 +117,20 @@ describe('ngIf directive', () => {
     expect(fixture.nativeElement.textContent).toEqual('helloNumberhelloStringhelloFunction');
 
     getComponent().numberCondition = 0;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('helloString');
 
     getComponent().numberCondition = 1;
+    fixture.changeDetectorRef.markForCheck();
     getComponent().stringCondition = 'bar';
     fixture.detectChanges();
     expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
     expect(fixture.nativeElement).toHaveText('helloNumber');
-  }));
+  });
 
-  it('should not add the element twice if the condition goes from truthy to truthy', waitForAsync(() => {
+  it('should not add the element twice if the condition goes from truthy to truthy', () => {
     const template = '<span *ngIf="numberCondition">hello</span>';
 
     fixture = createTestComponent(template);
@@ -133,16 +142,17 @@ describe('ngIf directive', () => {
     expect(fixture.nativeElement).toHaveText('hello');
 
     getComponent().numberCondition = 2;
+    fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     els = fixture.debugElement.queryAll(By.css('span'));
     expect(els.length).toEqual(1);
     expect(els[0].nativeElement.classList.contains('marker')).toBe(true);
 
     expect(fixture.nativeElement).toHaveText('hello');
-  }));
+  });
 
   describe('then/else templates', () => {
-    it('should support else', waitForAsync(() => {
+    it('should support else', () => {
       const template =
         '<span *ngIf="booleanCondition; else elseBlock">TRUE</span>' +
         '<ng-template #elseBlock>FALSE</ng-template>';
@@ -153,11 +163,12 @@ describe('ngIf directive', () => {
       expect(fixture.nativeElement).toHaveText('TRUE');
 
       getComponent().booleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('FALSE');
-    }));
+    });
 
-    it('should support then and else', waitForAsync(() => {
+    it('should support then and else', () => {
       const template =
         '<span *ngIf="booleanCondition; then thenBlock; else elseBlock">IGNORE</span>' +
         '<ng-template #thenBlock>THEN</ng-template>' +
@@ -169,9 +180,10 @@ describe('ngIf directive', () => {
       expect(fixture.nativeElement).toHaveText('THEN');
 
       getComponent().booleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('ELSE');
-    }));
+    });
 
     it('should support removing the then/else templates', () => {
       const template = `<span *ngIf="booleanCondition;
@@ -185,10 +197,12 @@ describe('ngIf directive', () => {
       comp.booleanCondition = true;
 
       comp.nestedBooleanCondition = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('Template');
 
       comp.nestedBooleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('');
 
@@ -196,15 +210,17 @@ describe('ngIf directive', () => {
       comp.booleanCondition = true;
 
       comp.nestedBooleanCondition = true;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('Template');
 
       comp.nestedBooleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('');
     });
 
-    it('should support dynamic else', waitForAsync(() => {
+    it('should support dynamic else', () => {
       const template =
         '<span *ngIf="booleanCondition; else nestedBooleanCondition ? b1 : b2">TRUE</span>' +
         '<ng-template #b1>FALSE1</ng-template>' +
@@ -216,15 +232,17 @@ describe('ngIf directive', () => {
       expect(fixture.nativeElement).toHaveText('TRUE');
 
       getComponent().booleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('FALSE1');
 
       getComponent().nestedBooleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('FALSE2');
-    }));
+    });
 
-    it('should support binding to variable using let', waitForAsync(() => {
+    it('should support binding to variable using let', () => {
       const template =
         '<span *ngIf="booleanCondition; else elseBlock; let v">{{v}}</span>' +
         '<ng-template #elseBlock let-v>{{v}}</ng-template>';
@@ -235,11 +253,12 @@ describe('ngIf directive', () => {
       expect(fixture.nativeElement).toHaveText('true');
 
       getComponent().booleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('false');
-    }));
+    });
 
-    it('should support binding to variable using as', waitForAsync(() => {
+    it('should support binding to variable using as', () => {
       const template =
         '<span *ngIf="booleanCondition as v; else elseBlock">{{v}}</span>' +
         '<ng-template #elseBlock let-v>{{v}}</ng-template>';
@@ -250,9 +269,10 @@ describe('ngIf directive', () => {
       expect(fixture.nativeElement).toHaveText('true');
 
       getComponent().booleanCondition = false;
+      fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('false');
-    }));
+    });
 
     it('should be available as a standalone directive', () => {
       @Component({
@@ -274,7 +294,7 @@ describe('ngIf directive', () => {
   });
 
   describe('Type guarding', () => {
-    it('should throw when then block is not template', waitForAsync(() => {
+    it('should throw when then block is not template', () => {
       const template =
         '<span *ngIf="booleanCondition; then thenBlock">IGNORE</span>' +
         '<div #thenBlock>THEN</div>';
@@ -284,9 +304,9 @@ describe('ngIf directive', () => {
       expect(() => fixture.detectChanges()).toThrowError(
         /ngIfThen must be a TemplateRef, but received/,
       );
-    }));
+    });
 
-    it('should throw when else block is not template', waitForAsync(() => {
+    it('should throw when else block is not template', () => {
       const template =
         '<span *ngIf="booleanCondition; else elseBlock">IGNORE</span>' +
         '<div #elseBlock>ELSE</div>';
@@ -296,7 +316,7 @@ describe('ngIf directive', () => {
       expect(() => fixture.detectChanges()).toThrowError(
         /ngIfElse must be a TemplateRef, but received/,
       );
-    }));
+    });
   });
 });
 

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -981,7 +981,7 @@ describe('Image directive', () => {
         await fixture.whenStable();
 
         // trick to wait for the whenStable() to fire in the directive
-        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve));
 
         if (isBrowser) {
           expect(consoleWarnSpy.calls.count()).toBe(1);

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '../../index';
 import {Component, Injectable} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('ngPlural', () => {
@@ -36,7 +36,7 @@ describe('ngPlural', () => {
     });
   });
 
-  it('should display the template according to the exact value', waitForAsync(() => {
+  it('should display the template according to the exact value', () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0"><li>you have no messages.</li></ng-template>' +
@@ -50,9 +50,9 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 1;
     detectChangesAndExpectText('you have one message.');
-  }));
+  });
 
-  it('should display the template according to the exact numeric value', waitForAsync(() => {
+  it('should display the template according to the exact numeric value', () => {
     const template =
       '<div>' +
       '<ul [ngPlural]="switchValue">' +
@@ -67,11 +67,11 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 1;
     detectChangesAndExpectText('you have one message.');
-  }));
+  });
 
   // https://github.com/angular/angular/issues/9868
   // https://github.com/angular/angular/issues/9882
-  it('should not throw when ngPluralCase contains expressions', waitForAsync(() => {
+  it('should not throw when ngPluralCase contains expressions', () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0"><li>{{ switchValue }}</li></ng-template>' +
@@ -81,9 +81,9 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 0;
     expect(() => fixture.detectChanges()).not.toThrow();
-  }));
+  });
 
-  it('should be applicable to <ng-container> elements', waitForAsync(() => {
+  it('should be applicable to <ng-container> elements', () => {
     const template =
       '<ng-container [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="=0">you have no messages.</ng-template>' +
@@ -97,9 +97,9 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 1;
     detectChangesAndExpectText('you have one message.');
-  }));
+  });
 
-  it('should display the template according to the category', waitForAsync(() => {
+  it('should display the template according to the category', () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -113,9 +113,9 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 8;
     detectChangesAndExpectText('you have many messages.');
-  }));
+  });
 
-  it('should default to other when no matches are found', waitForAsync(() => {
+  it('should default to other when no matches are found', () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -126,9 +126,9 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 100;
     detectChangesAndExpectText('default message.');
-  }));
+  });
 
-  it('should prioritize value matches over category matches', waitForAsync(() => {
+  it('should prioritize value matches over category matches', () => {
     const template =
       '<ul [ngPlural]="switchValue">' +
       '<ng-template ngPluralCase="few"><li>you have a few messages.</li></ng-template>' +
@@ -142,7 +142,7 @@ describe('ngPlural', () => {
 
     getComponent().switchValue = 3;
     detectChangesAndExpectText('you have a few messages.');
-  }));
+  });
 
   it('should be available as a standalone directive', () => {
     @Component({

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, NgStyle} from '../../index';
 import {Component} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 describe('NgStyle', () => {
   let fixture: ComponentFixture<TestComponent>;
@@ -35,14 +35,14 @@ describe('NgStyle', () => {
     TestBed.configureTestingModule({declarations: [TestComponent], imports: [CommonModule]});
   });
 
-  it('should add styles specified in an object literal', waitForAsync(() => {
+  it('should add styles specified in an object literal', () => {
     const template = `<div [ngStyle]="{'max-width': '40px'}"></div>`;
     fixture = createTestComponent(template);
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
-  }));
+  });
 
-  it('should add and change styles specified in an object expression', waitForAsync(() => {
+  it('should add and change styles specified in an object expression', () => {
     const template = `<div [ngStyle]="expr"></div>`;
     fixture = createTestComponent(template);
 
@@ -56,9 +56,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '30%'});
-  }));
+  });
 
-  it('should remove styles with a null expression', waitForAsync(() => {
+  it('should remove styles with a null expression', () => {
     const template = `<div [ngStyle]="expr"></div>`;
     fixture = createTestComponent(template);
 
@@ -71,9 +71,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-  }));
+  });
 
-  it('should remove styles with an undefined expression', waitForAsync(() => {
+  it('should remove styles with an undefined expression', () => {
     const template = `<div [ngStyle]="expr"></div>`;
     fixture = createTestComponent(template);
 
@@ -86,9 +86,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-  }));
+  });
 
-  it('should add and remove styles specified using style.unit notation', waitForAsync(() => {
+  it('should add and remove styles specified using style.unit notation', () => {
     const template = `<div [ngStyle]="{'max-width.px': expr}"></div>`;
 
     fixture = createTestComponent(template);
@@ -102,10 +102,10 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-  }));
+  });
 
   // https://github.com/angular/angular/issues/21064
-  it('should add and remove styles which names are not dash-cased', waitForAsync(() => {
+  it('should add and remove styles which names are not dash-cased', () => {
     fixture = createTestComponent(`<div [ngStyle]="{'color': expr}"></div>`);
 
     getComponent().expr = 'green';
@@ -117,9 +117,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('color');
-  }));
+  });
 
-  it('should update styles using style.unit notation when unit changes', waitForAsync(() => {
+  it('should update styles using style.unit notation when unit changes', () => {
     const template = `<div [ngStyle]="expr"></div>`;
 
     fixture = createTestComponent(template);
@@ -133,10 +133,10 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'max-width': '40em'});
-  }));
+  });
 
   // keyValueDiffer is sensitive to key order #9115
-  it('should change styles specified in an object expression', waitForAsync(() => {
+  it('should change styles specified in an object expression', () => {
     const template = `<div [ngStyle]="expr"></div>`;
 
     fixture = createTestComponent(template);
@@ -160,9 +160,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).toHaveCssStyle({'height': '5px', 'width': '5px'});
-  }));
+  });
 
-  it('should remove styles when deleting a key in an object expression', waitForAsync(() => {
+  it('should remove styles when deleting a key in an object expression', () => {
     const template = `<div [ngStyle]="expr"></div>`;
 
     fixture = createTestComponent(template);
@@ -176,9 +176,9 @@ describe('NgStyle', () => {
     fixture.changeDetectorRef.markForCheck();
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
-  }));
+  });
 
-  it('should co-operate with the style attribute', waitForAsync(() => {
+  it('should co-operate with the style attribute', () => {
     const template = `<div style="font-size: 12px" [ngStyle]="expr"></div>`;
 
     fixture = createTestComponent(template);
@@ -193,9 +193,9 @@ describe('NgStyle', () => {
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
     expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
-  }));
+  });
 
-  it('should co-operate with the style.[styleName]="expr" special-case in the compiler', waitForAsync(() => {
+  it('should co-operate with the style.[styleName]="expr" special-case in the compiler', () => {
     const template = `<div [style.font-size.px]="12" [ngStyle]="expr"></div>`;
 
     fixture = createTestComponent(template);
@@ -210,7 +210,7 @@ describe('NgStyle', () => {
     fixture.detectChanges();
     expectNativeEl(fixture).not.toHaveCssStyle('max-width');
     expectNativeEl(fixture).toHaveCssStyle({'font-size': '12px'});
-  }));
+  });
 
   it('should not write to the native node unless the bound expression has changed', () => {
     const template = `<div [ngStyle]="{'color': expr}"></div>`;

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, NgSwitch, NgSwitchCase, NgSwitchDefault} from '../../index';
 import {Attribute, Component, Directive, TemplateRef, ViewChild} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('NgSwitch', () => {
@@ -232,21 +232,21 @@ describe('NgSwitch', () => {
       detectChangesAndExpectText('when b1;when b2;');
     });
 
-    it('should throw error when ngSwitchCase is used outside of ngSwitch', waitForAsync(() => {
+    it('should throw error when ngSwitchCase is used outside of ngSwitch', () => {
       const template = '<div [ngSwitch]="switchValue"></div>' + '<div *ngSwitchCase="\'a\'"></div>';
 
       expect(() => createTestComponent(template)).toThrowError(
         'NG02000: An element with the "ngSwitchCase" attribute (matching the "NgSwitchCase" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)',
       );
-    }));
+    });
 
-    it('should throw error when ngSwitchDefault is used outside of ngSwitch', waitForAsync(() => {
+    it('should throw error when ngSwitchDefault is used outside of ngSwitch', () => {
       const template = '<div [ngSwitch]="switchValue"></div>' + '<div *ngSwitchDefault></div>';
 
       expect(() => createTestComponent(template)).toThrowError(
         'NG02000: An element with the "ngSwitchDefault" attribute (matching the "NgSwitchDefault" directive) must be located inside an element with the "ngSwitch" attribute (matching "NgSwitch" directive)',
       );
-    }));
+    });
 
     it('should support nested NgSwitch on ng-container with ngTemplateOutlet', () => {
       fixture = TestBed.createComponent(ComplexComponent);

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -21,7 +21,7 @@ import {
   QueryList,
   TemplateRef,
 } from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('NgTemplateOutlet', () => {
@@ -56,36 +56,36 @@ describe('NgTemplateOutlet', () => {
   });
 
   // https://github.com/angular/angular/issues/14778
-  it('should accept the component as the context', waitForAsync(() => {
+  it('should accept the component as the context', () => {
     const template =
       `<ng-container *ngTemplateOutlet="tpl; context: this"></ng-container>` +
       `<ng-template #tpl>{{context.foo}}</ng-template>`;
 
     fixture = createTestComponent(template);
     detectChangesAndExpectText('bar');
-  }));
+  });
 
-  it('should do nothing if templateRef is `null`', waitForAsync(() => {
+  it('should do nothing if templateRef is `null`', () => {
     const template = `<ng-container [ngTemplateOutlet]="null"></ng-container>`;
     fixture = createTestComponent(template);
     detectChangesAndExpectText('');
-  }));
+  });
 
-  it('should do nothing if templateRef is `undefined`', waitForAsync(() => {
+  it('should do nothing if templateRef is `undefined`', () => {
     const template = `<ng-container [ngTemplateOutlet]="undefined"></ng-container>`;
     fixture = createTestComponent(template);
     detectChangesAndExpectText('');
-  }));
+  });
 
-  it('should insert content specified by TemplateRef', waitForAsync(() => {
+  it('should insert content specified by TemplateRef', () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container [ngTemplateOutlet]="tpl"></ng-container>`;
     fixture = createTestComponent(template);
     detectChangesAndExpectText('foo');
-  }));
+  });
 
-  it('should clear content if TemplateRef becomes `null`', waitForAsync(() => {
+  it('should clear content if TemplateRef becomes `null`', () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
@@ -98,9 +98,9 @@ describe('NgTemplateOutlet', () => {
 
     setTplRef(null);
     detectChangesAndExpectText('');
-  }));
+  });
 
-  it('should clear content if TemplateRef becomes `undefined`', waitForAsync(() => {
+  it('should clear content if TemplateRef becomes `undefined`', () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
@@ -113,9 +113,9 @@ describe('NgTemplateOutlet', () => {
 
     setTplRef(undefined);
     detectChangesAndExpectText('');
-  }));
+  });
 
-  it('should swap content if TemplateRef changes', waitForAsync(() => {
+  it('should swap content if TemplateRef changes', () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template><ng-template>bar</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
@@ -129,25 +129,25 @@ describe('NgTemplateOutlet', () => {
 
     setTplRef(refs.tplRefs.last);
     detectChangesAndExpectText('bar');
-  }));
+  });
 
-  it('should display template if context is `null`', waitForAsync(() => {
+  it('should display template if context is `null`', () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: null"></ng-container>`;
     fixture = createTestComponent(template);
     detectChangesAndExpectText('foo');
-  }));
+  });
 
-  it('should display template if context is `undefined`', waitForAsync(() => {
+  it('should display template if context is `undefined`', () => {
     const template =
       `<ng-template #tpl>foo</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: undefined"></ng-container>`;
     fixture = createTestComponent(template);
     detectChangesAndExpectText('foo');
-  }));
+  });
 
-  it('should reflect initial context and changes', waitForAsync(() => {
+  it('should reflect initial context and changes', () => {
     const template =
       `<ng-template let-foo="foo" #tpl>{{foo}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
@@ -158,18 +158,18 @@ describe('NgTemplateOutlet', () => {
 
     fixture.componentInstance.context.foo = 'alter-bar';
     detectChangesAndExpectText('alter-bar');
-  }));
+  });
 
-  it('should reflect user defined `$implicit` property in the context', waitForAsync(() => {
+  it('should reflect user defined `$implicit` property in the context', () => {
     const template =
       `<ng-template let-ctx #tpl>{{ctx.foo}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
     fixture = createTestComponent(template);
     fixture.componentInstance.context = {$implicit: {foo: 'bra'}};
     detectChangesAndExpectText('bra');
-  }));
+  });
 
-  it('should reflect context re-binding', waitForAsync(() => {
+  it('should reflect context re-binding', () => {
     const template =
       `<ng-template let-shawshank="shawshank" #tpl>{{shawshank}}</ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; context: context"></ng-container>`;
@@ -180,7 +180,7 @@ describe('NgTemplateOutlet', () => {
 
     fixture.componentInstance.context = {shawshank: 'was here'};
     detectChangesAndExpectText('was here');
-  }));
+  });
 
   it('should update but not destroy embedded view when context values change', () => {
     const template =
@@ -280,7 +280,7 @@ describe('NgTemplateOutlet', () => {
     }).not.toThrow();
   });
 
-  it('should not throw when switching from template to null and back to template', waitForAsync(() => {
+  it('should not throw when switching from template to null and back to template', () => {
     const template =
       `<tpl-refs #refs="tplRefs"><ng-template>foo</ng-template></tpl-refs>` +
       `<ng-container [ngTemplateOutlet]="currentTplRef"></ng-container>`;
@@ -298,7 +298,7 @@ describe('NgTemplateOutlet', () => {
       setTplRef(refs.tplRefs.first);
       detectChangesAndExpectText('foo');
     }).not.toThrow();
-  }));
+  });
 
   it('should not mutate context object if two contexts with an identical shape are swapped', () => {
     fixture = TestBed.createComponent(MultiContextComponent);
@@ -322,7 +322,7 @@ describe('NgTemplateOutlet', () => {
     expect(componentInstance.context2).toEqual({name: 'one'});
   });
 
-  it('should be able to specify an injector', waitForAsync(() => {
+  it('should be able to specify an injector', () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -331,9 +331,9 @@ describe('NgTemplateOutlet', () => {
       providers: [{provide: templateToken, useValue: 'world'}],
     });
     detectChangesAndExpectText('Hello world');
-  }));
+  });
 
-  it('should re-render if the injector changes', waitForAsync(() => {
+  it('should re-render if the injector changes', () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -347,9 +347,9 @@ describe('NgTemplateOutlet', () => {
       providers: [{provide: templateToken, useValue: 'there'}],
     });
     detectChangesAndExpectText('Hello there');
-  }));
+  });
 
-  it('should override providers from parent component using custom injector', waitForAsync(() => {
+  it('should override providers from parent component using custom injector', () => {
     const template =
       `<ng-template #tpl><inject-value></inject-value></ng-template>` +
       `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
@@ -358,7 +358,7 @@ describe('NgTemplateOutlet', () => {
       providers: [{provide: templateToken, useValue: 'world'}],
     });
     detectChangesAndExpectText('Hello world');
-  }));
+  });
 
   it('should be available as a standalone directive', () => {
     @Component({

--- a/packages/common/test/directives/non_bindable_spec.ts
+++ b/packages/common/test/directives/non_bindable_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, ElementRef} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {hasClass} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 
@@ -18,15 +18,15 @@ describe('non-bindable', () => {
     });
   });
 
-  it('should not interpolate children', waitForAsync(() => {
+  it('should not interpolate children', () => {
     const template = '<div>{{text}}<span ngNonBindable>{{text}}</span></div>';
     const fixture = createTestComponent(template);
 
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveText('foo{{text}}');
-  }));
+  });
 
-  it('should ignore directives on child nodes', waitForAsync(() => {
+  it('should ignore directives on child nodes', () => {
     const template = '<div ngNonBindable><span id=child test-dec>{{text}}</span></div>';
     const fixture = createTestComponent(template);
     fixture.detectChanges();
@@ -35,15 +35,15 @@ describe('non-bindable', () => {
     // since the elements inside are not compiled.
     const span = fixture.nativeElement.querySelector('#child');
     expect(hasClass(span, 'compiled')).toBeFalsy();
-  }));
+  });
 
-  it('should trigger directives on the same node', waitForAsync(() => {
+  it('should trigger directives on the same node', () => {
     const template = '<div><span id=child ngNonBindable test-dec>{{text}}</span></div>';
     const fixture = createTestComponent(template);
     fixture.detectChanges();
     const span = fixture.nativeElement.querySelector('#child');
     expect(hasClass(span, 'compiled')).toBeTruthy();
-  }));
+  });
 });
 
 @Directive({

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -208,13 +208,17 @@ describe('AsyncPipe', () => {
       });
 
       it('should report rejections to error handler', async () => {
-        const spy = spyOn(TestBed.inject(ErrorHandler), 'handleError');
-        pipe.transform(promise);
-        reject(message);
-        try {
-          await promise;
-        } catch {}
-        expect(spy).toHaveBeenCalledWith(message);
+        // TestBed rethrows errors that are handled by ErrorHandler so they aren't swallowed/unnoticed
+        await jasmine.spyOnGlobalErrorsAsync(async function () {
+          const spy = spyOn(TestBed.inject(ErrorHandler), 'handleError');
+          pipe.transform(promise);
+          reject(message);
+          try {
+            // clear microtask queue (process all promise rejections)
+            await new Promise((r) => setTimeout(r));
+          } catch {}
+          expect(spy).toHaveBeenCalledWith(message);
+        });
       });
 
       it('should dispose of the existing subscription when subscribing to a new promise', async () => {

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -17,10 +17,12 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {Observable, of, Subscribable, Unsubscribable} from 'rxjs';
+import {useAutoTick} from './util';
 
 describe('AsyncPipe', () => {
   let pipe: AsyncPipe;
   let ref: ChangeDetectorRef & jasmine.SpyObj<ChangeDetectorRef>;
+  useAutoTick();
 
   function getChangeDetectorRefSpy() {
     return jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck', 'detectChanges']);

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, JsonPipe} from '../../index';
 import {Component} from '@angular/core';
-import {TestBed, waitForAsync} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('JsonPipe', () => {
@@ -67,7 +67,7 @@ describe('JsonPipe', () => {
       TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
     });
 
-    it('should work with mutable objects', waitForAsync(() => {
+    it('should work with mutable objects', () => {
       const fixture = TestBed.createComponent(TestComp);
       const mutable: number[] = [1];
       fixture.componentInstance.data = mutable;
@@ -79,7 +79,7 @@ describe('JsonPipe', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('[\n  1,\n  2\n]');
-    }));
+    });
   });
 
   it('should be available as a standalone pipe', () => {

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, SlicePipe} from '../../index';
 import {Component} from '@angular/core';
-import {TestBed, waitForAsync} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 describe('SlicePipe', () => {
@@ -103,7 +103,7 @@ describe('SlicePipe', () => {
       TestBed.configureTestingModule({declarations: [TestComp], imports: [CommonModule]});
     });
 
-    it('should work with mutable arrays', waitForAsync(() => {
+    it('should work with mutable arrays', () => {
       const fixture = TestBed.createComponent(TestComp);
       const mutable: number[] = [1, 2];
       fixture.componentInstance.data = mutable;
@@ -115,7 +115,7 @@ describe('SlicePipe', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveText('2,3');
-    }));
+    });
   });
 
   it('should be available as a standalone pipe', () => {

--- a/packages/common/test/pipes/util.ts
+++ b/packages/common/test/pipes/util.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export async function timeout(ms?: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function useAutoTick() {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().autoTick();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+}


### PR DESCRIPTION
Removes usages of zone-based helpers such as `fakeAsync` , `tick` `waitForAsync` as part of the migration to zoneless tests.

Completes the transition to zoneless.

