### PR TITLE
feat(devtools): add dependencies highlighting to the signal graph

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/utils.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/utils.spec.ts
@@ -8,7 +8,7 @@
 
 import {PropType} from '../../../../../../protocol';
 import {DevtoolsSignalGraphNode} from './signal-graph-types';
-import {checkClusterMatch, getNodeNames, isClusterNode, isSignalNode} from './utils';
+import {checkClusterMatch, getNodeLabel, getNodeNames, isClusterNode, isSignalNode} from './utils';
 
 const syntheticClusterNode: DevtoolsSignalGraphNode = {
   nodeType: 'cluster',
@@ -154,5 +154,34 @@ describe('checkClusterMatch', () => {
       clusterName: 'baz',
       signalName: 'qux',
     });
+  });
+});
+
+describe('getNodeLabel', () => {
+  it('should handle regular signal nodes', () => {
+    expect(getNodeLabel(regularSignalNode)).toEqual('bar');
+  });
+
+  it('should handle synthetic cluster nodes', () => {
+    expect(getNodeLabel(syntheticClusterNode)).toEqual('foo');
+  });
+
+  it('should handle compound nodes', () => {
+    expect(getNodeLabel(compoundNode)).toEqual('qux');
+  });
+
+  it('should handle unnamed signal nodes', () => {
+    const node = structuredClone(regularSignalNode);
+    node.label = '';
+
+    expect(getNodeLabel(node)).toEqual('Unnamed');
+  });
+
+  it('should handle effect nodes', () => {
+    const node = structuredClone(regularSignalNode);
+    node.label = '';
+    node.kind = 'effect';
+
+    expect(getNodeLabel(node)).toEqual('Effect');
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/utils.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/utils.ts
@@ -82,3 +82,11 @@ export function checkClusterMatch(n: DebugSignalGraphNode): {
     signalName,
   };
 }
+
+/** Returns the actual name/label of the signal node. */
+export function getNodeLabel(n: DevtoolsSignalGraphNode): string {
+  if (!n.label && isSignalNode(n)) {
+    return n.kind === 'effect' ? 'Effect' : 'Unnamed';
+  }
+  return getNodeNames(n).signalName;
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.html
@@ -3,24 +3,52 @@
 @let isClusterNode = this.isClusterNode(node);
 
 <div class="header">
-  @if (isSignalNode) {
+  <div class="controls">
+    @if (isSignalNode) {
+      <button
+        ng-button
+        size="compact"
+        class="action-btn"
+        btnType="secondary"
+        (click)="gotoSource.emit(node)"
+        [disabled]="!node.debuggable"
+        matTooltip="View source"
+      >
+        <mat-icon> code </mat-icon>
+      </button>
+    } @else if (isClusterNode) {
+      <button
+        ng-button
+        size="compact"
+        class="action-btn"
+        btnType="secondary"
+        (click)="expandCluster.emit(node.id)"
+        matTooltip="Expand"
+      >
+        <mat-icon> expand_content </mat-icon>
+      </button>
+    }
     <button
       ng-button
       size="compact"
       class="action-btn"
-      (click)="gotoSource.emit(node)"
-      [disabled]="!node.debuggable"
+      btnType="secondary"
+      (click)="highlightDeps.emit({node, direction: 'down'})"
+      matTooltip="Highlight downstream dependents path"
     >
-      <mat-icon> arrow_outward </mat-icon>
-      View Source
+      <mat-icon> swipe_down_alt </mat-icon>
     </button>
-  }
-  @if (isClusterNode) {
-    <button ng-button size="compact" class="action-btn" (click)="expandCluster.emit(node.id)">
-      <mat-icon> expand_content </mat-icon>
-      Expand
+    <button
+      ng-button
+      size="compact"
+      class="action-btn"
+      btnType="secondary"
+      (click)="highlightDeps.emit({node, direction: 'up'})"
+      matTooltip="Highlight upstream dependencies path"
+    >
+      <mat-icon> swipe_up_alt </mat-icon>
     </button>
-  }
+  </div>
   <button
     ng-button
     btnType="icon"

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
@@ -21,15 +21,20 @@
     justify-content: space-between;
     gap: 0.75rem;
 
-    .action-btn {
+    .controls {
       display: flex;
-      align-items: center;
-      gap: 0.25rem;
+      gap: 0.5rem;
 
-      mat-icon {
-        width: 16px;
-        height: 16px;
-        font-size: 16px;
+      .action-btn {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+
+        mat-icon {
+          width: 16px;
+          height: 16px;
+          font-size: 16px;
+        }
       }
     }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
@@ -21,6 +21,7 @@ import {
   DevtoolsSignalNode,
   DevtoolsClusterNode,
 } from '../../signal-graph';
+import {MatTooltip} from '@angular/material/tooltip';
 
 const TYPE_CLASS_MAP: {[key in DebugSignalGraphNode['kind']]: string} = {
   'signal': 'type-signal',
@@ -47,7 +48,7 @@ interface ResourceCluster {
   templateUrl: './signals-details.component.html',
   styleUrl: './signals-details.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [SignalsValueTreeComponent, MatIcon, ButtonComponent],
+  imports: [SignalsValueTreeComponent, MatIcon, ButtonComponent, MatTooltip],
 })
 export class SignalsDetailsComponent {
   private readonly signalGraph = inject(SignalGraphManager);
@@ -56,6 +57,10 @@ export class SignalsDetailsComponent {
 
   protected readonly gotoSource = output<DevtoolsSignalGraphNode>();
   protected readonly expandCluster = output<string>();
+  protected readonly highlightDeps = output<{
+    node: DevtoolsSignalGraphNode;
+    direction: 'up' | 'down';
+  }>();
   protected readonly close = output<void>();
 
   protected readonly TYPE_CLASS_MAP = TYPE_CLASS_MAP;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.html
@@ -14,6 +14,7 @@
     [node]="node"
     (gotoSource)="gotoSource($event)"
     (expandCluster)="expandCluster($event)"
+    (highlightDeps)="highlightDeps($event)"
     (close)="detailsVisible.set(false)"
   />
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-tab.component.ts
@@ -110,4 +110,8 @@ export class SignalsTabComponent {
   expandCluster(clusterId: string) {
     this.visualizer().expandCluster(clusterId);
   }
+
+  highlightDeps({node, direction}: {node: DevtoolsSignalGraphNode; direction: 'up' | 'down'}) {
+    this.visualizer().highlightDependencies(node, direction);
+  }
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.html
@@ -1,17 +1,35 @@
 <svg #host></svg>
 
-@if (expandedClusters().length) {
-  <div class="visible-clusters">
-    <p>Expanded nodes</p>
-    @for (cluster of expandedClusters(); track cluster.id) {
+@let hasExpandedClusters = expandedClusters().length;
+
+@if (hasExpandedClusters || highlightedNodeLabel()) {
+  <div class="menu">
+    @if (hasExpandedClusters) {
+      <p>Expanded nodes</p>
+      @for (cluster of expandedClusters(); track cluster.id) {
+        <button
+          ng-button
+          size="compact"
+          class="collapse"
+          (click)="collapseCluster(cluster.id)"
+          [attr.title]="'Collapse ' + cluster.name"
+        >
+          <mat-icon>close</mat-icon>
+          <span>{{ cluster.name }}</span>
+        </button>
+      }
+    }
+    @if (highlightedNodeLabel(); as nodeLabel) {
+      <p>Highlighted dependencies</p>
       <button
         ng-button
         size="compact"
-        (click)="collapseCluster(cluster.id)"
-        [attr.title]="'Collapse ' + cluster.name"
+        class="unhighlight"
+        (click)="unhighlightDependencies()"
+        [attr.title]="'Unhighlight ' + nodeLabel"
       >
         <mat-icon>close</mat-icon>
-        <span>{{ cluster.name }}</span>
+        <span>{{ nodeLabel }}</span>
       </button>
     }
   </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.scss
@@ -61,6 +61,17 @@ $cluster-expand-anim-duration: 1s;
       }
 
       .edge {
+        &.highlighted {
+          .path {
+            stroke: var(--purple-03);
+            stroke-width: 1.75px;
+          }
+
+          marker > path {
+            fill: var(--purple-03);
+          }
+        }
+
         .path {
           stroke: var(--gray-500);
           fill: none;
@@ -79,7 +90,7 @@ $cluster-expand-anim-duration: 1s;
         }
       }
 
-      .node-label {
+      .node-cont {
         position: relative;
         box-sizing: border-box;
         contain: paint;
@@ -142,11 +153,33 @@ $cluster-expand-anim-duration: 1s;
         }
       }
 
-      .selected rect {
-        stroke: var(--dynamic-blue-02);
-        stroke-width: 3px;
+      .selected rect,
+      .highlighted-origin rect,
+      .highlighted rect {
         ry: 8px;
         rx: 8px;
+      }
+
+      .selected rect {
+        stroke-width: 3px;
+      }
+
+      .highlighted-origin rect,
+      .highlighted rect {
+        stroke-width: 6px;
+      }
+
+      .highlighted rect {
+        stroke: var(--purple-03);
+      }
+
+      .highlighted-origin rect {
+        stroke: var(--purple-02);
+      }
+
+      /* Note: It's important to keep the following `<class> rect` order to achieve the intended coloring. */
+      .selected rect {
+        stroke: var(--blue-03);
       }
 
       .kind-signal {
@@ -202,7 +235,7 @@ $cluster-expand-anim-duration: 1s;
     }
   }
 
-  .visible-clusters {
+  .menu {
     position: absolute;
     top: 0.2rem;
     left: 0.2rem;
@@ -216,6 +249,10 @@ $cluster-expand-anim-duration: 1s;
       margin: 0;
       padding: 0;
       margin-bottom: 0.5rem;
+
+      &:not(:first-child) {
+        margin-top: 0.5rem;
+      }
     }
 
     button {
@@ -223,8 +260,16 @@ $cluster-expand-anim-duration: 1s;
       align-items: center;
       gap: 0.1rem;
       margin-bottom: 0.375rem;
-      background-color: var(--yellow-02);
       max-width: 100px;
+      color: var(--gray-800);
+
+      &.collapse {
+        background-color: var(--yellow-02);
+      }
+
+      &.unhighlight {
+        background-color: var(--purple-03);
+      }
 
       mat-icon {
         width: 16px;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
@@ -227,7 +227,11 @@ export class SignalsGraphVisualizer {
   }
 
   highlightDependencies(node: DevtoolsSignalGraphNode, direction: 'down' | 'up') {
-    const nodeIdx = this.inputGraph?.nodes.findIndex((n) => node === n);
+    if (!this.inputGraph) {
+      return;
+    }
+
+    const nodeIdx = this.inputGraph.nodes.findIndex((n) => node === n);
     if (nodeIdx === -1) {
       return;
     }
@@ -237,12 +241,12 @@ export class SignalsGraphVisualizer {
     const pathNodesIds = new Set<string>();
     const edges = new Set<string>();
     const stack = [nodeIdx];
-    const nodes = this.inputGraph!.nodes;
+    const nodes = this.inputGraph.nodes;
 
     while (stack.length) {
       const currentIdx = stack.pop()!;
 
-      for (const edge of this.inputGraph!.edges) {
+      for (const edge of this.inputGraph.edges) {
         const currNodeIdx = direction === 'down' ? edge.producer : edge.consumer;
 
         if (currNodeIdx === currentIdx) {


### PR DESCRIPTION
Add ability to highlight the upstream and downstream dependencies path via the node details.


https://github.com/user-attachments/assets/ed53cede-c973-42d9-b2a5-dfc949f452b6

