### PR TITLE
test(compiler): remove zone-based testing utilities

### DIFF
--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
 
 # Uses separate test rules to allow the tests to run in parallel
 
@@ -39,7 +39,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "extract_i18n",
     data = [
         ":extract_i18n_lib",
@@ -66,7 +66,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "perform_watch",
     data = [
         ":perform_watch_lib",
@@ -90,7 +90,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "perform_compile",
     data = [
         ":perform_compile_lib",
@@ -110,7 +110,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "typescript_support",
     data = [
         ":typescript_support_lib",
@@ -127,7 +127,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "version_helpers",
     data = [
         ":version_helpers_lib",

--- a/packages/compiler/test/BUILD.bazel
+++ b/packages/compiler/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
 
 # Test that should only be run in node
 NODE_ONLY = [
@@ -43,7 +43,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",
@@ -52,7 +52,7 @@ angular_jasmine_test(
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test_web",
     deps = [
         ":test_lib",

--- a/packages/compiler/test/i18n/integration_xliff2_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff2_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {Xliff2} from '../../src/i18n/serializers/xliff2';
-import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 import {
@@ -21,8 +20,7 @@ import {
 // TODO(alxhub): figure out if this test is still relevant.
 xdescribe('i18n XLIFF integration spec', () => {
   describe('(with LF line endings)', () => {
-    beforeEach(waitForAsync(() =>
-      configureCompiler(XLIFF2_TOMERGE + LF_LINE_ENDING_XLIFF2_TOMERGE, 'xlf2')));
+    beforeEach(() => configureCompiler(XLIFF2_TOMERGE + LF_LINE_ENDING_XLIFF2_TOMERGE, 'xlf2'));
 
     it('should extract from templates', () => {
       const serializer = new Xliff2();
@@ -41,8 +39,7 @@ xdescribe('i18n XLIFF integration spec', () => {
   });
 
   describe('(with CRLF line endings', () => {
-    beforeEach(waitForAsync(() =>
-      configureCompiler(XLIFF2_TOMERGE + CRLF_LINE_ENDING_XLIFF2_TOMERGE, 'xlf2')));
+    beforeEach(() => configureCompiler(XLIFF2_TOMERGE + CRLF_LINE_ENDING_XLIFF2_TOMERGE, 'xlf2'));
 
     it('should extract from templates (with CRLF line endings)', () => {
       const serializer = new Xliff2();

--- a/packages/compiler/test/i18n/integration_xliff_spec.ts
+++ b/packages/compiler/test/i18n/integration_xliff_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {Xliff} from '../../src/i18n/serializers/xliff';
-import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 import {
@@ -21,8 +20,7 @@ import {
 // TODO(alxhub): figure out if this test is still relevant.
 xdescribe('i18n XLIFF integration spec', () => {
   describe('(with LF line endings)', () => {
-    beforeEach(waitForAsync(() =>
-      configureCompiler(XLIFF_TOMERGE + LF_LINE_ENDING_XLIFF_TOMERGE, 'xlf')));
+    beforeEach(() => configureCompiler(XLIFF_TOMERGE + LF_LINE_ENDING_XLIFF_TOMERGE, 'xlf'));
 
     it('should extract from templates', () => {
       const serializer = new Xliff();
@@ -41,8 +39,7 @@ xdescribe('i18n XLIFF integration spec', () => {
   });
 
   describe('(with CRLF line endings', () => {
-    beforeEach(waitForAsync(() =>
-      configureCompiler(XLIFF_TOMERGE + CRLF_LINE_ENDING_XLIFF_TOMERGE, 'xlf')));
+    beforeEach(() => configureCompiler(XLIFF_TOMERGE + CRLF_LINE_ENDING_XLIFF_TOMERGE, 'xlf'));
 
     it('should extract from templates (with CRLF line endings)', () => {
       const serializer = new Xliff();

--- a/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
+++ b/packages/compiler/test/i18n/integration_xmb_xtb_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {Xmb} from '../../src/i18n/serializers/xmb';
-import {waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
 
 import {
@@ -21,7 +20,7 @@ import {
 // TODO(alxhub): figure out if this test is still relevant.
 xdescribe('i18n XMB/XTB integration spec', () => {
   describe('(with LF line endings)', () => {
-    beforeEach(waitForAsync(() => configureCompiler(XTB + LF_LINE_ENDING_XTB, 'xtb')));
+    beforeEach(() => configureCompiler(XTB + LF_LINE_ENDING_XTB, 'xtb'));
 
     it('should extract from templates', () => {
       const serializer = new Xmb();
@@ -40,7 +39,7 @@ xdescribe('i18n XMB/XTB integration spec', () => {
   });
 
   describe('(with CRLF line endings', () => {
-    beforeEach(waitForAsync(() => configureCompiler(XTB + CRLF_LINE_ENDING_XTB, 'xtb')));
+    beforeEach(() => configureCompiler(XTB + CRLF_LINE_ENDING_XTB, 'xtb'));
 
     it('should extract from templates (with CRLF line endings)', () => {
       const serializer = new Xmb();

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {Component, Directive, Input} from '@angular/core';
-import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 
@@ -15,7 +15,7 @@ describe('integration tests', () => {
   let fixture: ComponentFixture<TestComponent>;
 
   describe('directives', () => {
-    it('should support dotted selectors', waitForAsync(() => {
+    it('should support dotted selectors', () => {
       @Directive({
         selector: '[dot.name]',
         standalone: false,
@@ -33,11 +33,11 @@ describe('integration tests', () => {
       fixture.detectChanges();
       const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
       expect(myDir.value).toEqual('foo');
-    }));
+    });
   });
 
   describe('ng-container', () => {
-    it('should work regardless the namespace', waitForAsync(() => {
+    it('should work regardless the namespace', () => {
       @Component({
         selector: 'comp',
         template:
@@ -50,7 +50,7 @@ describe('integration tests', () => {
       f.detectChanges();
 
       expect(f.nativeElement.children[0].children[0].tagName).toEqual('rect');
-    }));
+    });
   });
 });
 


### PR DESCRIPTION
Removes usages of zone-based helpers such as `waitForAsync` as part of the migration to zoneless tests.

Completes the transition to zoneless.