### PR TITLE
refactor(compiler): remove zone-based testing utilities

### DIFF
--- a/packages/benchpress/test/BUILD.bazel
+++ b/packages/benchpress/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "test_lib",
@@ -13,7 +13,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/compiler/test/expression_parser/BUILD.bazel
+++ b/packages/compiler/test/expression_parser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "expression_parser_lib",
@@ -12,7 +12,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "expression_parser",
     data = [
         ":expression_parser_lib",

--- a/packages/compiler/test/ml_parser/BUILD.bazel
+++ b/packages/compiler/test/ml_parser/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "ml_parser_lib",
@@ -11,7 +11,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "ml_parser",
     data = [
         ":ml_parser_lib",

--- a/packages/compiler/test/render3/BUILD.bazel
+++ b/packages/compiler/test/render3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "test_lib",
@@ -14,7 +14,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/compiler/test/selector/BUILD.bazel
+++ b/packages/compiler/test/selector/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "selector_lib",
@@ -11,7 +11,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "selector",
     data = [
         ":selector_lib",

--- a/packages/core/test/compiler/BUILD.bazel
+++ b/packages/core/test/compiler/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -14,7 +14,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "compiler",
     data = [
         ":compiler_lib",

--- a/packages/service-worker/config/test/BUILD.bazel
+++ b/packages/service-worker/config/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "test_lib",
@@ -12,7 +12,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/service-worker/test/BUILD.bazel
+++ b/packages/service-worker/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "test_lib",
@@ -18,7 +18,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/service-worker/worker/test/BUILD.bazel
+++ b/packages/service-worker/worker/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
 
 ts_project(
     name = "test_lib",
@@ -14,7 +14,7 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1214,6 +1214,9 @@ import {envIsSupported} from '../testing/utils';
 
         const debuggerLogSpy = spyOn(driver.debugger, 'log');
 
+        // To drain the microtask queue (and process all rejections)
+        await new Promise((r) => setTimeout(r));
+
         scope.handleUnhandledRejection('Test rejection reason');
 
         expect(debuggerLogSpy).toHaveBeenCalledWith(

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -285,14 +285,10 @@ export class SwTestHarnessImpl
     if (!this.eventHandlers.has('unhandledrejection')) {
       throw new Error('No unhandledrejection handler registered');
     }
-    const promise = Promise.reject(reason);
-    // We want to simulate an unhandled rejection, but we don't want the test runner (Node)
-    // to actually see an unhandled rejection and fail the test. So we attach a dummy handler.
-    promise.catch(() => {});
     const event = {
       reason,
-      promise,
-    } as unknown as PromiseRejectionEvent;
+      promise: Promise.reject(reason),
+    } as PromiseRejectionEvent;
     this.eventHandlers.get('unhandledrejection')!.call(this, event);
   }
 

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -285,10 +285,14 @@ export class SwTestHarnessImpl
     if (!this.eventHandlers.has('unhandledrejection')) {
       throw new Error('No unhandledrejection handler registered');
     }
+    const promise = Promise.reject(reason);
+    // We want to simulate an unhandled rejection, but we don't want the test runner (Node)
+    // to actually see an unhandled rejection and fail the test. So we attach a dummy handler.
+    promise.catch(() => {});
     const event = {
       reason,
-      promise: Promise.reject(reason),
-    } as PromiseRejectionEvent;
+      promise,
+    } as unknown as PromiseRejectionEvent;
     this.eventHandlers.get('unhandledrejection')!.call(this, event);
   }
 


### PR DESCRIPTION
Having zone.js here already wasn't necessary.
