### PR TITLE
test(http): remove zone-based testing utilities

### DIFF
--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test", "zoneless_web_test_suite")
 
 ts_project(
     name = "test_lib",
@@ -21,14 +21,14 @@ ts_project(
     ],
 )
 
-angular_jasmine_test(
+zoneless_jasmine_test(
     name = "test",
     data = [
         ":test_lib",
     ],
 )
 
-ng_web_test_suite(
+zoneless_web_test_suite(
     name = "test_web",
     deps = [
         ":test_lib",

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -52,7 +52,7 @@ const TEST_POST_WITH_JSON_BODY = new HttpRequest(
 
 const XSSI_PREFIX = ")]}'\n";
 
-describe('FetchBackend', async () => {
+describe('FetchBackend', () => {
   let fetchMock: MockFetchFactory = null!;
   let backend: FetchBackend = null!;
   let fetchSpy: jasmine.Spy<typeof fetch>;
@@ -508,7 +508,7 @@ describe('FetchBackend', async () => {
       fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
     });
   });
-  describe('gets response URL', async () => {
+  describe('gets response URL', () => {
     it('from the response URL', (done) => {
       backend
         .handle(TEST_POST)
@@ -538,7 +538,7 @@ describe('FetchBackend', async () => {
       fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
     });
   });
-  describe('corrects for quirks', async () => {
+  describe('corrects for quirks', () => {
     it('by normalizing 0 status to 200 if a body is present', (done) => {
       backend
         .handle(TEST_POST)

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -15,8 +15,8 @@ import {
   TransferState,
   makeStateKey,
 } from '@angular/core';
-import {fakeAsync, flush, TestBed} from '@angular/core/testing';
-import {withBody} from '@angular/private/testing';
+import {TestBed} from '@angular/core/testing';
+import {useAutoTick, timeout, withBody} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
 import {HttpClient, HttpResponse, provideHttpClient} from '../public_api';
@@ -52,6 +52,7 @@ type RequestBody =
   | null;
 
 describe('TransferCache', () => {
+  useAutoTick();
   @Component({
     selector: 'test-app-http',
     template: 'hello',
@@ -169,13 +170,13 @@ describe('TransferCache', () => {
       expect(response.size).toBe(5);
     });
 
-    it('should stop storing HTTP calls in `TransferState` after application becomes stable', fakeAsync(() => {
+    it('should stop storing HTTP calls in `TransferState` after application becomes stable', async () => {
       makeRequestAndExpectOne('/test-1', 'foo');
       makeRequestAndExpectOne('/test-2', 'buzz');
 
       isStable.next(true);
 
-      flush();
+      await timeout();
 
       makeRequestAndExpectOne('/test-3', 'bar');
 
@@ -198,7 +199,7 @@ describe('TransferCache', () => {
           [RESPONSE_TYPE]: 'json',
         },
       });
-    }));
+    });
 
     it(`should use calls from cache when present and application is not stable`, () => {
       makeRequestAndExpectOne('/test-1', 'foo');
@@ -206,14 +207,14 @@ describe('TransferCache', () => {
       makeRequestAndExpectNone('/test-1');
     });
 
-    it(`should not use calls from cache when present and application is stable`, fakeAsync(() => {
+    it(`should not use calls from cache when present and application is stable`, async () => {
       makeRequestAndExpectOne('/test-1', 'foo');
 
       isStable.next(true);
-      flush();
+      await timeout();
       // Do the same call, this time it should go through as application is stable.
       makeRequestAndExpectOne('/test-1', 'foo');
-    }));
+    });
 
     it(`should differentiate calls with different parameters`, async () => {
       // make calls with different parameters. All of which should be saved in the state.

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -39,8 +39,8 @@ import {
 } from '../index';
 import {selectValueAccessor} from '../src/directives/shared';
 import {composeValidators} from '../src/validators';
-
-import {asyncValidator, timeout, useAutoTick} from './util';
+import {useAutoTick, timeout} from '@angular/private/testing';
+import {asyncValidator} from './util';
 
 class DummyControlValueAccessor implements ControlValueAccessor {
   writtenValue: any;

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -17,7 +17,8 @@ import {
 import {Validators} from '../src/validators';
 import {of} from 'rxjs';
 
-import {asyncValidator, timeout, useAutoTick} from './util';
+import {useAutoTick, timeout} from '@angular/private/testing';
+import {asyncValidator} from './util';
 
 (function () {
   describe('FormArray', () => {

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -15,7 +15,7 @@ import {
   Validators,
 } from '../index';
 import {of} from 'rxjs';
-import {timeout, useAutoTick} from './util';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 (function () {
   function syncValidator() {

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -8,7 +8,8 @@
 
 import {AsyncValidatorFn, FormArray, FormControl, FormGroup, Validators} from '../index';
 
-import {asyncValidator, asyncValidatorReturningObservable, timeout, useAutoTick} from './util';
+import {asyncValidator, asyncValidatorReturningObservable} from './util';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 (function () {
   function otherAsyncValidator() {

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -17,6 +17,7 @@ import {
   Validators,
   ValueChangeEvent,
 } from '../index';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 import {FormControlStatus, StatusChangeEvent} from '../src/model/abstract_model';
 import {
@@ -24,8 +25,6 @@ import {
   asyncValidatorReturningObservable,
   currentStateOf,
   simpleAsyncValidator,
-  timeout,
-  useAutoTick,
 } from './util';
 
 (function () {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -19,7 +19,13 @@ import {
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {dispatchEvent, isNode, sortedClassList} from '@angular/private/testing';
+import {
+  dispatchEvent,
+  isNode,
+  sortedClassList,
+  useAutoTick,
+  timeout,
+} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 import {merge, NEVER, Observable, of, Subject, Subscription, timer} from 'rxjs';
 import {map, tap} from 'rxjs/operators';
@@ -60,7 +66,6 @@ import {
 } from '../src/model/abstract_model';
 
 import {MyInput, MyInputForm} from './value_accessor_integration_spec';
-import {timeout, useAutoTick} from './util';
 
 // Produces a new @Directive (with a given selector) that represents a validator class.
 function createValidatorClass(selector: string) {

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -26,11 +26,10 @@ import {
   Validator,
 } from '../index';
 import {By} from '@angular/platform-browser';
-import {dispatchEvent, sortedClassList} from '@angular/private/testing';
+import {dispatchEvent, useAutoTick, timeout, sortedClassList} from '@angular/private/testing';
 import {merge} from 'rxjs';
 
 import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integration_spec';
-import {timeout, useAutoTick} from './util';
 
 describe('template-driven forms integration tests', () => {
   useAutoTick();

--- a/packages/forms/test/util.ts
+++ b/packages/forms/test/util.ts
@@ -91,19 +91,3 @@ export function asyncValidatorReturningObservable(c: AbstractControl): EventEmit
   });
   return e;
 }
-
-export async function timeout(ms?: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-export function useAutoTick() {
-  beforeEach(() => {
-    jasmine.clock().install();
-    jasmine.clock().autoTick();
-  });
-  afterEach(() => {
-    jasmine.clock().uninstall();
-  });
-}

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -20,7 +20,7 @@ import {
 } from '../index';
 
 import {normalizeValidators} from '../src/validators';
-import {timeout, useAutoTick} from './util';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 (function () {
   function validator(key: string, error: any): ValidatorFn {

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -39,9 +39,8 @@ import {
   Validators,
 } from '../index';
 import {By, ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
-import {dispatchEvent, isNode} from '@angular/private/testing';
+import {dispatchEvent, useAutoTick, timeout, isNode} from '@angular/private/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {timeout, useAutoTick} from './util';
 
 describe('value accessors', () => {
   useAutoTick();

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -167,3 +167,44 @@ if (typeof beforeEach == 'function') beforeEach(ensureDocument);
 if (typeof afterEach == 'function') afterEach(cleanupDocument);
 
 if (typeof afterEach === 'function') afterEach(resetJitOptions);
+
+/**
+ * Returns a promise that resolves after the specified time.
+ *
+ * @param ms - Time to wait in milliseconds. Defaults to 0.
+ *
+ * @example
+ * ```ts
+ * await timeout(100); // Wait 100ms
+ * ```
+ */
+export async function timeout(ms?: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Installs Jasmine's fake clock with auto-tick enabled for all tests in the describe block.
+ * Call at the top level of a describe block to automatically advance time for async operations.
+ *
+ * @example
+ * ```ts
+ * describe('MyComponent', () => {
+ *   useAutoTick();
+ *
+ *   it('should handle timers', () => {
+ *     // setTimeout, setInterval, etc. will execute synchronously
+ *   });
+ * });
+ * ```
+ */
+export function useAutoTick() {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().autoTick();
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+}

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -22,7 +22,7 @@ import {
   UrlTree,
 } from '../src/url_tree';
 import {getLoadedRoutes, getProvidersInjector} from '../src/utils/config';
-import {useAutoTick} from './helpers';
+import {useAutoTick} from '@angular/private/testing';
 
 describe('redirects', () => {
   useAutoTick();

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -26,7 +26,7 @@ import {
   NgModule,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {isNode} from '@angular/private/testing';
+import {isNode, useAutoTick} from '@angular/private/testing';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 import {
   NavigationEnd,
@@ -36,7 +36,6 @@ import {
   RouterOutlet,
   withEnabledBlockingInitialNavigation,
 } from '../index';
-import {useAutoTick} from './helpers';
 
 // This is needed, because all files under `packages/` are compiled together as part of the
 // [legacy-unit-tests-saucelabs][1] CI job, including the `lib.webworker.d.ts` typings brought in by

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -15,7 +15,7 @@ import {EMPTY, of} from 'rxjs';
 
 import {provideRouter, withExperimentalPlatformNavigation} from '../src/provide_router';
 import {isUrlTree} from '../src/url_tree';
-import {timeout, useAutoTick} from './helpers';
+import {useAutoTick, timeout} from '@angular/private/testing';
 import {afterNextNavigation} from '../src/utils/navigations';
 
 for (const browserAPI of ['navigation', 'history'] as const) {

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -18,7 +18,7 @@ import {ActivatedRoute, ActivatedRouteSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlSerializer, UrlTree} from '../src/url_tree';
 import {provideRouter, withRouterConfig} from '../src';
-import {timeout} from './helpers';
+import {timeout} from '@angular/private/testing';
 
 describe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '../../index';
 import {RouterTestingHarness} from '../../testing';
 import {InjectionToken} from '../../../core/src/di';
-import {timeout, useAutoTick} from '../helpers';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 describe('router outlet name', () => {
   useAutoTick();

--- a/packages/router/test/helpers.ts
+++ b/packages/router/test/helpers.ts
@@ -50,19 +50,3 @@ export function createActivatedRouteSnapshot(args: ARSArgs): ActivatedRouteSnaps
     TestBed.inject(EnvironmentInjector),
   );
 }
-
-export async function timeout(ms?: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-export function useAutoTick() {
-  beforeEach(() => {
-    jasmine.clock().install();
-    jasmine.clock().autoTick();
-  });
-  afterEach(() => {
-    jasmine.clock().uninstall();
-  });
-}

--- a/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
+++ b/packages/router/test/integration/duplicate_in_flight_navigations.spec.ts
@@ -24,7 +24,7 @@ import {
   BlankCmp,
   simulateLocationChange,
 } from './integration_helpers';
-import {timeout} from '../helpers';
+import {timeout} from '@angular/private/testing';
 
 export function duplicateInFlightNavigationsIntegrationSuite(browserAPI: 'history' | 'navigation') {
   describe('duplicate in-flight navigations', () => {

--- a/packages/router/test/integration/eager_url_update_strategy.spec.ts
+++ b/packages/router/test/integration/eager_url_update_strategy.spec.ts
@@ -22,16 +22,17 @@ import {
   provideRouter,
   withRouterConfig,
 } from '../../src';
-import {timeout} from '../helpers';
+
 import {
-  AbsoluteSimpleLinkCmp,
-  BlankCmp,
-  RootCmp,
-  SimpleCmp,
   TeamCmp,
-  advance,
+  RootCmp,
+  BlankCmp,
+  SimpleCmp,
+  AbsoluteSimpleLinkCmp,
   createRoot,
+  advance,
 } from './integration_helpers';
+import {timeout} from '@angular/private/testing';
 
 export function eagerUrlUpdateStrategyIntegrationSuite() {
   describe('"eager" urlUpdateStrategy', () => {

--- a/packages/router/test/integration/guards.spec.ts
+++ b/packages/router/test/integration/guards.spec.ts
@@ -73,7 +73,7 @@ import {
   createRoot,
   advance,
 } from './integration_helpers';
-import {timeout} from '../helpers';
+import {timeout} from '@angular/private/testing';
 
 export function guardsIntegrationSuite() {
   describe('guards', () => {

--- a/packages/router/test/integration/integration.spec.ts
+++ b/packages/router/test/integration/integration.spec.ts
@@ -72,7 +72,7 @@ import {navigationIntegrationTestSuite} from './navigation.spec';
 import {eagerUrlUpdateStrategyIntegrationSuite} from './eager_url_update_strategy.spec';
 import {duplicateInFlightNavigationsIntegrationSuite} from './duplicate_in_flight_navigations.spec';
 import {navigationErrorsIntegrationSuite} from './navigation_errors.spec';
-import {useAutoTick} from '../helpers';
+import {useAutoTick} from '@angular/private/testing';
 
 for (const browserAPI of ['navigation', 'history'] as const) {
   describe(`${browserAPI}-based routing`, () => {

--- a/packages/router/test/integration/integration_helpers.ts
+++ b/packages/router/test/integration/integration_helpers.ts
@@ -24,7 +24,7 @@ import {
 } from '../../index';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
-import {timeout} from '../helpers';
+import {timeout} from '@angular/private/testing';
 
 export const ROUTER_DIRECTIVES = [RouterLink, RouterLinkActive, RouterOutlet];
 

--- a/packages/router/test/integration/navigation.spec.ts
+++ b/packages/router/test/integration/navigation.spec.ts
@@ -10,6 +10,7 @@ import {Location, PlatformNavigation} from '@angular/common';
 import {ApplicationRef, Component, inject, NgModule} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {RouterTestingHarness} from '@angular/router/testing';
+import {timeout} from '@angular/private/testing';
 import {BehaviorSubject, filter, firstValueFrom} from 'rxjs';
 import {
   ActivatedRoute,
@@ -32,7 +33,6 @@ import {
   Routes,
   withRouterConfig,
 } from '../../src';
-import {timeout} from '../helpers';
 import {
   advance,
   createRoot,

--- a/packages/router/test/integration/navigation_errors.spec.ts
+++ b/packages/router/test/integration/navigation_errors.spec.ts
@@ -33,20 +33,20 @@ import {
   withRouterConfig,
 } from '../../src';
 import {RouterTestingHarness} from '../../testing';
-import {timeout} from '../helpers';
 import {
-  advance,
-  BlankCmp,
-  ConditionalThrowingCmp,
-  createRoot,
-  EmptyQueryParamsCmp,
-  expectEvents,
   RootCmp,
-  SimpleCmp,
-  simulateLocationChange,
-  ThrowingCmp,
+  BlankCmp,
   UserCmp,
+  expectEvents,
+  SimpleCmp,
+  ThrowingCmp,
+  ConditionalThrowingCmp,
+  EmptyQueryParamsCmp,
+  createRoot,
+  advance,
+  simulateLocationChange,
 } from './integration_helpers';
+import {timeout} from '@angular/private/testing';
 
 export function navigationErrorsIntegrationSuite(browserAPI: 'history' | 'navigation') {
   it('should handle failed navigations gracefully', async () => {

--- a/packages/router/test/integration/router_links.spec.ts
+++ b/packages/router/test/integration/router_links.spec.ts
@@ -27,7 +27,6 @@ import {
   createRoot,
   advance,
 } from './integration_helpers';
-import {timeout} from '../helpers';
 
 export function routerLinkIntegrationSpec() {
   describe('router links', () => {

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -11,7 +11,7 @@ import {TestBed} from '@angular/core/testing';
 import {ActivatedRouteSnapshot, provideRouter, Router} from '../../index';
 import {RouterTestingHarness} from '../../testing';
 import {EMPTY, interval, NEVER, of} from 'rxjs';
-import {useAutoTick} from '../helpers';
+import {useAutoTick} from '@angular/private/testing';
 
 describe('resolveData operator', () => {
   useAutoTick();

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -15,7 +15,7 @@ import {RouterConfigLoader} from '../src/router_config_loader';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
-import {useAutoTick} from './helpers';
+import {useAutoTick} from '@angular/private/testing';
 
 describe('recognize', () => {
   useAutoTick();

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -43,8 +43,7 @@ import {
   withViewTransitions,
 } from '../src/provide_router';
 import {afterNextNavigation} from '../src/utils/navigations';
-import {timeout} from './helpers';
-import {isBrowser, withBody} from '@angular/private/testing';
+import {isBrowser, withBody, timeout} from '@angular/private/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 
 describe('Integration', () => {

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -42,7 +42,7 @@ import {
   getLoadedRoutes,
   getProvidersInjector,
 } from '../src/utils/config';
-import {timeout, useAutoTick} from './helpers';
+import {useAutoTick, timeout} from '@angular/private/testing';
 
 describe('RouterPreloader', () => {
   useAutoTick();

--- a/packages/router/test/router_scroller.spec.ts
+++ b/packages/router/test/router_scroller.spec.ts
@@ -22,9 +22,9 @@ import {filter, switchMap, take} from 'rxjs/operators';
 import {PrivateRouterEvents, Scroll} from '../src/events';
 import {ROUTER_SCROLLER, RouterScroller} from '../src/router_scroller';
 import {ɵWritable as Writable} from '@angular/core';
-import {timeout} from './helpers';
 import {ViewportScroller} from '@angular/common';
 import {NavigationTransitions} from '../src/navigation_transition';
+import {timeout} from '@angular/private/testing';
 
 describe('RouterScroller', () => {
   it('defaults to disabled', () => {

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -10,7 +10,7 @@ import {Component, inject, Injectable, InjectionToken, NgModule} from '@angular/
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideRoutes, Router, RouterModule, ROUTES} from '../index';
-import {timeout} from './helpers';
+import {timeout} from '@angular/private/testing';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}

--- a/packages/router/test/with_platform_navigation.spec.ts
+++ b/packages/router/test/with_platform_navigation.spec.ts
@@ -9,7 +9,7 @@
 import {TestBed} from '@angular/core/testing';
 import {NavigationStart, provideRouter, Event, Router} from '../src';
 import {withExperimentalPlatformNavigation, withRouterConfig} from '../src/provide_router';
-import {withBody} from '@angular/private/testing';
+import {withBody, useAutoTick, timeout} from '@angular/private/testing';
 import {
   PlatformLocation,
   Location,
@@ -22,7 +22,6 @@ import {
   ɵFakeNavigationPlatformLocation as FakeNavigationPlatformLocation,
   provideLocationMocks,
 } from '@angular/common/testing';
-import {timeout, useAutoTick} from './helpers';
 import {inject} from '@angular/core';
 
 /// <reference types="dom-navigation" />


### PR DESCRIPTION
Removes usages of zone-based helpers as part of the migration to zoneless tests.

Completes the transition to zoneless.
