### PR TITLE
fix(devtools): signal node value preview for afterRenderEffect

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
@@ -589,7 +589,7 @@ function getBodyText(node: DevtoolsSignalGraphNode, graph: DevtoolsSignalGraph):
     return '</>';
   }
 
-  if (node.kind === 'effect') {
+  if (node.kind === 'effect' || node.kind === 'afterRenderEffectPhase') {
     return '() => {}';
   }
 


### PR DESCRIPTION
Render an arrow function (`() => {}`) in the signal nodes in the graph that represent `afterRenderEffect`s.
