### PR TITLE
docs: remove non-existant method

### DIFF
--- a/adev/src/content/guide/aria/menu.md
+++ b/adev/src/content/guide/aria/menu.md
@@ -190,10 +190,9 @@ The container directive for menu items.
 
 #### Methods
 
-| Method           | Parameters | Description                        |
-| ---------------- | ---------- | ---------------------------------- |
-| `close`          | none       | Closes the menu                    |
-| `focusFirstItem` | none       | Moves focus to the first menu item |
+| Method  | Parameters | Description     |
+| ------- | ---------- | --------------- |
+| `close` | none       | Closes the menu |
 
 ### MenuBar
 


### PR DESCRIPTION
Removes the reference to the `focusFirstItem` method since it doesn't exist.

Fixes https://github.com/angular/components/issues/32741.
