### PR TITLE
docs(docs-infra): simplify external link rendering for pill

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-pill/docs-pill.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-pill/docs-pill.mts
@@ -7,7 +7,7 @@
  */
 
 import {Token, Tokens, RendererThis, TokenizerThis} from 'marked';
-import {anchorTarget, isExternalLink} from '../../helpers.mjs';
+import {anchorTarget} from '../../helpers.mjs';
 import {AdevDocsRenderer} from '../../renderer.mjs';
 
 interface DocsPillToken extends Tokens.Generic {
@@ -70,11 +70,7 @@ export const docsPillExtension = {
 
     return `
     <a class="docs-pill" href="${token.href}"${targetAttr}${downloadAttr}>
-      ${this.parser.parseInline(token.tokens)}${
-        isExternalLink(token.href)
-          ? '<docs-icon class="docs-icon-small">open_in_new</docs-icon>'
-          : ''
-      }
+      ${this.parser.parseInline(token.tokens)}
     </a>
     `;
   },

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-pill/docs-pill.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-pill/docs-pill.spec.mts
@@ -25,11 +25,10 @@ describe('markdown to html', () => {
     expect(samePageEl.textContent?.trim()).toBe('Same Page');
   });
 
-  it('should render external links with _blank target and iconography', () => {
+  it('should render external links with _blank target', () => {
     const samePageEl = markdownDocument.querySelectorAll('a.docs-pill')[1];
     expect(samePageEl.getAttribute('target')).toBe('_blank');
-    expect(samePageEl.textContent?.trim()).toContain('External Page');
-    expect(samePageEl.querySelector('docs-icon')?.textContent).toBe('open_in_new');
+    expect(samePageEl.textContent?.trim()).toBe('External Page');
   });
 
   it('should render internal links that are relative paths', () => {

--- a/adev/shared-docs/styles/docs/_pill.scss
+++ b/adev/shared-docs/styles/docs/_pill.scss
@@ -1,4 +1,5 @@
 // Pill
+@use './../links' as links;
 
 @mixin docs-pill() {
   .docs-pill {
@@ -27,8 +28,11 @@
       background: color-mix(in srgb, var(--pill-accent) 15%, transparent);
     }
 
-    .docs-icon-small {
-      margin-inline-start: 0.25rem;
+    // External link icon
+    &[href^='http:'],
+    &[href^='https:'] {
+      margin-left: 0rem;
+      @include links.external-link-with-icon();
     }
 
     .docs-dark-mode & {


### PR DESCRIPTION
Renders the external link icon for docs pills using CSS instead of a `docs-icon` component.

## Before 

 https://angular.dev/api/platform-browser/Meta

<img width="400" height="205" alt="image" src="https://github.com/user-attachments/assets/9b9340da-aeae-4713-8d49-b88a4a367896" />


## What is the new behavior?

 
<img width="434" height="204" alt="image" src="https://github.com/user-attachments/assets/66225b63-780d-4cf7-9a65-56a8b3fadb48" />

