### PR TITLE
refactor(forms): guard unsupportedFeatureError with ngDevMode

### DIFF
--- a/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
+++ b/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
@@ -346,7 +346,7 @@ export class SignalFormControl<T> extends AbstractControl {
 
   override set dirty(_: boolean) {
     throw unsupportedFeatureError(
-      'Setting dirty directly is not supported. Instead use markAsDirty().',
+      ngDevMode && 'Setting dirty directly is not supported. Instead use markAsDirty().',
     );
   }
 
@@ -356,7 +356,7 @@ export class SignalFormControl<T> extends AbstractControl {
 
   override set pristine(_: boolean) {
     throw unsupportedFeatureError(
-      'Setting pristine directly is not supported. Instead use reset().',
+      ngDevMode && 'Setting pristine directly is not supported. Instead use reset().',
     );
   }
 
@@ -366,7 +366,8 @@ export class SignalFormControl<T> extends AbstractControl {
 
   override set touched(_: boolean) {
     throw unsupportedFeatureError(
-      'Setting touched directly is not supported. Instead use markAsTouched() or reset().',
+      ngDevMode &&
+        'Setting touched directly is not supported. Instead use markAsTouched() or reset().',
     );
   }
 
@@ -376,7 +377,7 @@ export class SignalFormControl<T> extends AbstractControl {
 
   override set untouched(_: boolean) {
     throw unsupportedFeatureError(
-      'Setting untouched directly is not supported. Instead use reset().',
+      ngDevMode && 'Setting untouched directly is not supported. Instead use reset().',
     );
   }
 


### PR DESCRIPTION
Move `unsupportedFeatureError` message behind `ngDevMode` to keep it dev only and allow proper tree-shaking.
 
