### PR TITLE
refactor(core): guards stringify calls with ngDevMode

### DIFF
--- a/packages/core/src/di/create_injector.ts
+++ b/packages/core/src/di/create_injector.ts
@@ -47,7 +47,10 @@ export function createInjectorWithoutInjectorInstances(
   scopes = new Set<InjectorScope>(),
 ): R3Injector {
   const providers = [additionalProviders || EMPTY_ARRAY, importProvidersFrom(defType)];
-  name = name || (typeof defType === 'object' ? undefined : stringify(defType));
+  let source: string | undefined = undefined;
+  if (ngDevMode) {
+    source = name || (typeof defType === 'object' ? undefined : stringify(defType));
+  }
 
-  return new R3Injector(providers, parent || getNullInjector(), name || null, scopes);
+  return new R3Injector(providers, parent || getNullInjector(), source || null, scopes);
 }

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -69,7 +69,7 @@ const __forward_ref__ = getClosureSafeProperty({__forward_ref__: getClosureSafeP
 export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
   (<any>forwardRefFn).__forward_ref__ = forwardRef;
   (<any>forwardRefFn).toString = function () {
-    return stringify(this());
+    return ngDevMode ? stringify(this()) : '';
   };
   return <Type<any>>(<any>forwardRefFn);
 }

--- a/packages/core/src/di/forward_ref.ts
+++ b/packages/core/src/di/forward_ref.ts
@@ -68,9 +68,12 @@ const __forward_ref__ = getClosureSafeProperty({__forward_ref__: getClosureSafeP
  */
 export function forwardRef(forwardRefFn: ForwardRefFn): Type<any> {
   (<any>forwardRefFn).__forward_ref__ = forwardRef;
-  (<any>forwardRefFn).toString = function () {
-    return ngDevMode ? stringify(this()) : '';
-  };
+  if (ngDevMode) {
+    (<any>forwardRefFn).toString = function () {
+      return stringify(this());
+    };
+  }
+
   return <Type<any>>(<any>forwardRefFn);
 }
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -454,7 +454,6 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
     }
   }
 
-  //@ts-ignore
   override toString() {
     if (ngDevMode) {
       const tokens: string[] = [];
@@ -464,6 +463,8 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
       }
       return `R3Injector[${tokens.join(', ')}]`;
     }
+
+    return 'R3Injector[...]';
   }
 
   /**

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -455,12 +455,15 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
   }
 
   override toString() {
-    const tokens: string[] = [];
-    const records = this.records;
-    for (const token of records.keys()) {
-      tokens.push(stringify(token));
+    if (ngDevMode) {
+      const tokens: string[] = [];
+      const records = this.records;
+      for (const token of records.keys()) {
+        tokens.push(stringify(token));
+      }
+      return `R3Injector[${tokens.join(', ')}]`;
     }
-    return `R3Injector[${tokens.join(', ')}]`;
+    return '';
   }
 
   /**
@@ -521,7 +524,7 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
     const prevConsumer = setActiveConsumer(null);
     try {
       if (record.value === CIRCULAR) {
-        throw cyclicDependencyError(stringify(token));
+        throw cyclicDependencyError(ngDevMode ? stringify(token) : '');
       } else if (record.value === NOT_YET) {
         record.value = CIRCULAR;
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -454,6 +454,7 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
     }
   }
 
+  //@ts-ignore
   override toString() {
     if (ngDevMode) {
       const tokens: string[] = [];
@@ -463,7 +464,6 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
       }
       return `R3Injector[${tokens.join(', ')}]`;
     }
-    return '';
   }
 
   /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -830,7 +830,6 @@
       "shouldBeIgnoredByZone",
       "shouldSearchParent",
       "storeLViewOnDestroy",
-      "stringify",
       "stringifyCSSSelector",
       "stringifyCSSSelectorList",
       "style",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -686,7 +686,6 @@
       "stashEventListenerImpl",
       "storeLViewOnDestroy",
       "storeListenerCleanup",
-      "stringify",
       "stringifyCSSSelector",
       "stringifyCSSSelectorList",
       "syncViewWithBlueprint",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -725,7 +725,6 @@
       "shouldTriggerDeferBlock",
       "storeLViewOnDestroy",
       "storeTriggerCleanupFn",
-      "stringify",
       "stringifyCSSSelector",
       "stringifyCSSSelectorList",
       "syncViewWithBlueprint",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -775,7 +775,6 @@
       "skipTextNodes",
       "sortAndConcatParams",
       "storeLViewOnDestroy",
-      "stringify",
       "stringifyCSSSelector",
       "stringifyCSSSelectorList",
       "subscribeOn",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -612,7 +612,6 @@
       "shouldBeIgnoredByZone",
       "shouldSearchParent",
       "storeLViewOnDestroy",
-      "stringify",
       "stringifyCSSSelector",
       "stringifyCSSSelectorList",
       "syncViewWithBlueprint",


### PR DESCRIPTION
The `stringify` function is only needed for debugging purposes and should not be called in production mode.
 