### PR TITLE
docs: remove outdated components guide link

### DIFF
--- a/adev/src/app/routing/redirections.ts
+++ b/adev/src/app/routing/redirections.ts
@@ -32,10 +32,6 @@ export const REDIRECT_ROUTES: Route[] = [
     redirectTo: '/guide/templates/defer',
   },
   {
-    path: 'guide/components/importing',
-    redirectTo: '/guide/components/anatomy-of-components#using-components',
-  },
-  {
     path: 'guide/templates/attribute-binding',
     redirectTo: '/guide/templates/binding#binding-dynamic-properties-and-attributes',
   },

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -63,9 +63,9 @@ export interface BootstrapContext {
 }
 
 /**
- * Bootstraps an instance of an Angular application and renders a standalone component as the
- * application's root component. More information about standalone components can be found in [this
- * guide](guide/components/importing).
+ * Bootstraps an instance of an Angular application and renders component as the
+ * application's root component. More information about components can be found in [this
+ * guide](guide/components).
  *
  * @usageNotes
  * The root component passed into this function **must** be a standalone one


### PR DESCRIPTION
Removes the unreferenced `guide/components/importing` link, redirection and updates the reference to point to the correct `guide/components` page.