### PR TITLE
docs(docs-infra): fix heading ID generation and display

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/test/heading/heading.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/heading/heading.spec.mts
@@ -104,6 +104,10 @@ describe('markdown to html', () => {
 
     expect(h2HeaderId).toBe('my-custom-id');
     expect(h2AnchorHref).toBe(`#${h2HeaderId}`);
+
+    // Verify that the custom ID syntax is removed from the displayed text
+    expect(h2Anchor?.textContent?.trim()).toBe('My heading');
+    expect(h2Anchor?.textContent).not.toContain('{#');
   });
 
   it('should be able to parse heading with a valid tag in a code block', () => {

--- a/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
@@ -34,7 +34,9 @@ export function headingRender(
 
   const link = customId ?? getIdFromHeading(headingText);
 
-  const label = parsedText.replace(/`(.*?)`/g, '<code>$1</code>');
+  // Replace code backticks and remove custom ID syntax from the displayed label
+  let label = parsedText.replace(/`(.*?)`/g, '<code>$1</code>');
+  label = label.replace(/{#\s*[\w-]+\s*}/g, '').trim();
   const normalizedLabel = label.replace(/<\/?code>/g, '');
 
   return `

--- a/adev/src/content/guide/templates/ng-template.md
+++ b/adev/src/content/guide/templates/ng-template.md
@@ -222,7 +222,7 @@ Each parameter is written as an attribute prefixed with `let-` with a value matc
 </ng-template>
 ```
 
-### Using `NgTemplateOutlet`
+### Using `NgTemplateOutlet` {#using-ngtemplateoutlet-with-parameters}
 
 You can bind a context object to the `ngTemplateOutletContext` input:
 
@@ -234,11 +234,11 @@ You can bind a context object to the `ngTemplateOutletContext` input:
 <ng-container [ngTemplateOutlet]="myFragment" [ngTemplateOutletContext]="{topping: 'onion'}" />
 ```
 
-### Using `ViewContainerRef`
+### Using `ViewContainerRef` {#using-viewcontainerref-with-parameters}
 
 You can pass a context object as the second argument to `createEmbeddedView`:
 
-```angular-ts
+```ts
 this.viewContainer.createEmbeddedView(this.myFragment, {topping: 'onion'});
 ```
 


### PR DESCRIPTION
Ensures that custom heading IDs are properly handled
 
## What is the current behavior?
 
<img width="1283" height="692" alt="image" src="https://github.com/user-attachments/assets/8444b2c8-4c1a-420e-9075-a34257b2c404" />


## What is the new behavior?
 
<img width="1144" height="688" alt="image" src="https://github.com/user-attachments/assets/58fad1b3-df8c-40d7-acdb-ad4fc6fc7d0c" />
