### PR TITLE
refactor(platform-browser): update Meta and Title services to use inject

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -163,7 +163,6 @@ export enum HydrationFeatureKind {
 
 // @public
 export class Meta {
-    constructor(_doc: any);
     addTag(tag: MetaDefinition, forceCreation?: boolean): HTMLMetaElement | null;
     addTags(tags: MetaDefinition[], forceCreation?: boolean): HTMLMetaElement[];
     getTag(attrSelector: string): HTMLMetaElement | null;
@@ -230,7 +229,6 @@ export interface SafeValue {
 
 // @public
 export class Title {
-    constructor(_doc: any);
     getTitle(): string;
     setTitle(newTitle: string): void;
     // (undocumented)

--- a/packages/platform-browser/src/browser/meta.ts
+++ b/packages/platform-browser/src/browser/meta.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, ɵDomAdapter as DomAdapter, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 
 /**
  * Represents the attributes of an HTML `<meta>` element. The element itself is
@@ -57,10 +57,9 @@ export type MetaDefinition = {
  */
 @Injectable({providedIn: 'root'})
 export class Meta {
-  private _dom: DomAdapter;
-  constructor(@Inject(DOCUMENT) private _doc: any) {
-    this._dom = getDOM();
-  }
+  private _dom: DomAdapter = getDOM();
+  private readonly _doc = inject(DOCUMENT);
+
   /**
    * Retrieves or creates a specific `<meta>` tag element in the current HTML document.
    * In searching for an existing tag, Angular attempts to match the `name` or `property` attribute

--- a/packages/platform-browser/src/browser/title.ts
+++ b/packages/platform-browser/src/browser/title.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 
 /**
  * A service that can be used to get and set the title of a current HTML document.
@@ -21,7 +21,7 @@ import {Inject, Injectable} from '@angular/core';
  */
 @Injectable({providedIn: 'root'})
 export class Title {
-  constructor(@Inject(DOCUMENT) private _doc: any) {}
+  private readonly _doc = inject(DOCUMENT);
   /**
    * Get the title of the current HTML document.
    */

--- a/packages/platform-browser/test/browser/meta_spec.ts
+++ b/packages/platform-browser/test/browser/meta_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
-import {Injectable} from '@angular/core';
+import {DOCUMENT, Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserModule, Meta} from '../../index';
 import {expect} from '@angular/private/testing/matchers';
@@ -19,7 +19,15 @@ describe('Meta service', () => {
 
   beforeEach(() => {
     doc = getDOM().createHtmlDocument();
-    metaService = new Meta(doc);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: doc,
+        },
+      ],
+    });
+    metaService = TestBed.inject(Meta);
     defaultMeta = getDOM().createElement('meta', doc) as HTMLMetaElement;
     defaultMeta.setAttribute('property', 'fb:app_id');
     defaultMeta.setAttribute('content', '123456789');

--- a/packages/platform-browser/test/browser/title_spec.ts
+++ b/packages/platform-browser/test/browser/title_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
-import {Injectable} from '@angular/core';
+import {DOCUMENT, Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {BrowserModule, Title} from '../../index';
 import {expect} from '@angular/private/testing/matchers';
@@ -20,7 +20,15 @@ describe('title service', () => {
   beforeEach(() => {
     doc = getDOM().createHtmlDocument();
     initialTitle = doc.title;
-    titleService = new Title(doc);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: doc,
+        },
+      ],
+    });
+    titleService = TestBed.inject(Title);
   });
 
   afterEach(() => {

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -6,9 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {SharedStylesHost} from '../../src/dom/shared_styles_host';
 import {expect} from '@angular/private/testing/matchers';
+import {TestBed} from '@angular/core/testing';
+import {APP_ID} from '@angular/core';
 
 describe('SharedStylesHost', () => {
   let doc: Document;
@@ -17,7 +19,13 @@ describe('SharedStylesHost', () => {
   beforeEach(() => {
     doc = getDOM().createHtmlDocument();
     doc.title = '';
-    ssh = new SharedStylesHost(doc, 'app-id');
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: DOCUMENT, useValue: doc},
+        {provide: APP_ID, useValue: 'app-id'},
+      ],
+    });
+    ssh = TestBed.inject(SharedStylesHost);
     someHost = getDOM().createElement('div');
   });
 


### PR DESCRIPTION
Refactors the Meta and Title services to use the `inject` function for retrieving the `DOCUMENT` token.
Also update the SharedStylesHost test to use DI.

 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This shouldn't introduce any breaking changes since we consider them final classes, although I don't know their status within G3

Additionally, I updated the tests for using DI.