### PR TITLE
fix(compiler): add geolocation element to schema

### DIFF
--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -110,6 +110,7 @@ export const SCHEMA: string[] = [
   'form^[HTMLElement]|acceptCharset,action,autocomplete,encoding,enctype,method,name,!noValidate,target',
   'frame^[HTMLElement]|frameBorder,longDesc,marginHeight,marginWidth,name,!noResize,scrolling,src',
   'frameset^[HTMLElement]|cols,*afterprint,*beforeprint,*beforeunload,*blur,*error,*focus,*hashchange,*languagechange,*load,*message,*messageerror,*offline,*online,*pagehide,*pageshow,*popstate,*rejectionhandled,*resize,*scroll,*storage,*unhandledrejection,*unload,rows',
+  'geolocation^[HTMLElement]|accuracymode,!autolocate,*location,*promptaction,*promptdismiss,*validationstatuschange,!watch',
   'hr^[HTMLElement]|align,color,!noShade,size,width',
   'head^[HTMLElement]|',
   'h1,h2,h3,h4,h5,h6^[HTMLElement]|align',

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -187,17 +187,16 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     });
   });
 
-  if (!isNode) {
-    it('generate a new schema', () => {
-      let schema = '\n';
-      extractSchema()!.forEach((props, name) => {
-        schema += `'${name}|${props.join(',')}',\n`;
-      });
-      // Uncomment this line to see:
-      // the generated schema which can then be pasted to the DomElementSchemaRegistry
-      // console.log(schema);
-    });
-  }
+  // Uncomment to see the generated schema which can then be pasted to the DomElementSchemaRegistry
+  // if (!isNode) {
+  //   it('generate a new schema', () => {
+  //     let schema = '\n';
+  //     extractSchema()!.forEach((props, name) => {
+  //       schema += `'${name}|${props.join(',')}',\n`;
+  //     });
+  //     console.log(schema);
+  //   });
+  // }
 
   describe('normalizeAnimationStyleProperty', () => {
     it('should normalize the given CSS property to camelCase', () => {

--- a/packages/compiler/test/schema/schema_extractor.ts
+++ b/packages/compiler/test/schema/schema_extractor.ts
@@ -24,7 +24,7 @@ const ALL_HTML_TAGS =
   // https://www.w3.org/TR/html5/index.html
   'a,abbr,address,area,article,aside,audio,b,base,bdi,bdo,blockquote,body,br,button,canvas,caption,cite,code,col,colgroup,content,data,datalist,dd,del,dfn,div,dl,dt,em,embed,fieldset,figcaption,figure,footer,form,h1,h2,h3,h4,h5,h6,head,header,hgroup,hr,html,i,iframe,img,input,ins,kbd,keygen,label,legend,li,link,main,map,mark,meta,meter,nav,noscript,object,ol,optgroup,option,output,p,param,pre,progress,q,rb,rp,rt,rtc,ruby,s,samp,script,search,section,select,small,source,span,strong,style,sub,sup,table,tbody,td,template,textarea,tfoot,th,thead,time,title,tr,track,u,ul,var,video,wbr,' +
   // https://html.spec.whatwg.org/
-  'details,summary,menu,menuitem';
+  'details,summary,menu,menuitem,geolocation';
 
 // Via https://developer.mozilla.org/en-US/docs/Web/MathML
 const ALL_MATH_TAGS =


### PR DESCRIPTION
A new `geolocation` tag was recently added to Chrome. These changes update the schema to account for it.

See https://developer.chrome.com/blog/geolocation-html-element
