### PR TITLE
fix(devtools): runtime error when a cluster preview node is missing

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
@@ -313,9 +313,11 @@ export class SignalsGraphVisualizer {
           this.updateDagreNode(n, existingNode, signalGraph);
           updatedNodes.push(n.id);
         } else if (isClusterNode(n) && !this.expandedClustersIds.has(n.id)) {
-          const previewNode = signalGraph.nodes[n.previewNode ?? -1] as DevtoolsSignalNode;
+          const previewNode = signalGraph.nodes[n.previewNode ?? -1] as
+            | DevtoolsSignalNode
+            | undefined;
 
-          if (previewNode.epoch !== existingNode.epoch) {
+          if (previewNode && previewNode.epoch !== existingNode.epoch) {
             this.updateDagreNode(previewNode, existingNode, signalGraph);
             updatedNodes.push(n.id);
           }


### PR DESCRIPTION
Fix the runtime error produced when a cluster preview node is missing triggered during a signal update.