### PR TITLE
Revert "refactor(service-worker): remove zone-based testing utilities"

### DIFF
--- a/packages/service-worker/config/test/BUILD.bazel
+++ b/packages/service-worker/config/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
+load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
 
 ts_project(
     name = "test_lib",
@@ -12,7 +12,7 @@ ts_project(
     ],
 )
 
-zoneless_jasmine_test(
+angular_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/service-worker/test/BUILD.bazel
+++ b/packages/service-worker/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ng_web_test_suite", "ts_project", "zoneless_jasmine_test")
+load("//tools:defaults.bzl", "angular_jasmine_test", "ng_web_test_suite", "ts_project")
 
 ts_project(
     name = "test_lib",
@@ -18,7 +18,7 @@ ts_project(
     ],
 )
 
-zoneless_jasmine_test(
+angular_jasmine_test(
     name = "test",
     data = [
         ":test_lib",

--- a/packages/service-worker/worker/test/BUILD.bazel
+++ b/packages/service-worker/worker/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
+load("//tools:defaults.bzl", "angular_jasmine_test", "ts_project")
 
 ts_project(
     name = "test_lib",
@@ -14,7 +14,7 @@ ts_project(
     ],
 )
 
-zoneless_jasmine_test(
+angular_jasmine_test(
     name = "test",
     data = [
         ":test_lib",


### PR DESCRIPTION
This reverts commit 12b770dd3ef293fcf18c0c97a4215b2f5d676172 due to CI failures ([link](https://github.com/angular/angular/actions/runs/21832148928/job/62999748478)).