### PR TITLE
refactor(compiler-cli): removes `reflector` parameter from wrapTypeRe…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
@@ -405,7 +405,7 @@ export function resolveProvidersRequiringFactory(
  * The `value` is the exported declaration of the class from its source file.
  * The `type` is an expression that would be used in the typings (.d.ts) files.
  */
-export function wrapTypeReference(reflector: ReflectionHost, clazz: ClassDeclaration): R3Reference {
+export function wrapTypeReference(clazz: ClassDeclaration): R3Reference {
   const value = new WrappedNodeExpr(clazz.name);
   const type = value;
   return {value, type};

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -394,7 +394,7 @@ export function extractDirectiveMetadata(
   // Detect if the component inherits from another class
   const usesInheritance = reflector.hasBaseClass(clazz);
   const sourceFile = clazz.getSourceFile();
-  const type = wrapTypeReference(reflector, clazz);
+  const type = wrapTypeReference(clazz);
 
   const rawHostDirectives = directive.get('hostDirectives') || null;
   const hostDirectives =

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -264,9 +264,12 @@ export class NgModuleSymbol extends SemanticSymbol {
 /**
  * Compiles @NgModule annotations to ngModuleDef fields.
  */
-export class NgModuleDecoratorHandler
-  implements DecoratorHandler<Decorator, NgModuleAnalysis, NgModuleSymbol, NgModuleResolution>
-{
+export class NgModuleDecoratorHandler implements DecoratorHandler<
+  Decorator,
+  NgModuleAnalysis,
+  NgModuleSymbol,
+  NgModuleResolution
+> {
   constructor(
     private reflector: ReflectionHost,
     private evaluator: PartialEvaluator,
@@ -546,7 +549,7 @@ export class NgModuleDecoratorHandler
       imports.some(isForwardReference) ||
       exports.some(isForwardReference);
 
-    const type = wrapTypeReference(this.reflector, node);
+    const type = wrapTypeReference(node);
 
     let ngModuleMetadata: R3NgModuleMetadata;
     if (allowUnresolvedReferences) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -66,9 +66,12 @@ export interface InjectableHandlerData {
 /**
  * Adapts the `compileInjectable` compiler for `@Injectable` decorators to the Ivy compiler.
  */
-export class InjectableDecoratorHandler
-  implements DecoratorHandler<Decorator, InjectableHandlerData, null, unknown>
-{
+export class InjectableDecoratorHandler implements DecoratorHandler<
+  Decorator,
+  InjectableHandlerData,
+  null,
+  unknown
+> {
   constructor(
     private reflector: ReflectionHost,
     private evaluator: PartialEvaluator,
@@ -272,7 +275,7 @@ function extractInjectableMetadata(
   reflector: ReflectionHost,
 ): R3InjectableMetadata {
   const name = clazz.name.text;
-  const type = wrapTypeReference(reflector, clazz);
+  const type = wrapTypeReference(clazz);
   const typeArgumentCount = reflector.getGenericArityOfClass(clazz) || 0;
   if (decorator.args === null) {
     throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -80,9 +80,12 @@ export class PipeSymbol extends SemanticSymbol {
   }
 }
 
-export class PipeDecoratorHandler
-  implements DecoratorHandler<Decorator, PipeHandlerData, PipeSymbol, unknown>
-{
+export class PipeDecoratorHandler implements DecoratorHandler<
+  Decorator,
+  PipeHandlerData,
+  PipeSymbol,
+  unknown
+> {
   constructor(
     private reflector: ReflectionHost,
     private evaluator: PartialEvaluator,
@@ -127,7 +130,7 @@ export class PipeDecoratorHandler
     this.perf.eventCount(PerfEvent.AnalyzePipe);
 
     const name = clazz.name.text;
-    const type = wrapTypeReference(this.reflector, clazz);
+    const type = wrapTypeReference(clazz);
 
     if (decorator.args === null) {
       throw new FatalDiagnosticError(


### PR DESCRIPTION
 The `wrapTypeReference` function no longer needs the `reflector` because it only uses the `clazz` parameter to create a `WrappedNodeExpr`.
 