### PR TITLE
feat(forms): add form directive

### DIFF
--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -595,13 +595,13 @@ While field state typically updates through user interactions (typing, focusing,
 
 #### Form submission
 
-Signal Forms provides a `NgSignalForm` directive that simplifies form submission. It automatically prevents the default browser form submission behavior and sets the `novalidate` attribute on the `<form>` element.
+Signal Forms provides a `FormRoot` directive that simplifies form submission. It automatically prevents the default browser form submission behavior and sets the `novalidate` attribute on the `<form>` element.
 
 ```angular-ts
 @Component({
-  imports: [NgSignalForm, FormField],
+  imports: [FormRoot, FormField],
   template: `
-    <form [ngSignalForm]="registrationForm">
+    <form [formRoot]="registrationForm">
       <input [formField]="registrationForm.username" />
       <input type="email" [formField]="registrationForm.email" />
       <input type="password" [formField]="registrationForm.password" />
@@ -633,7 +633,7 @@ export class Registration {
 }
 ```
 
-When you use `NgSignalForm`, submitting the form automatically calls the `submit()` function, which marks all fields as touched (revealing validation errors) and executes your `action` callback if the form is valid.
+When you use `FormRoot`, submitting the form automatically calls the `submit()` function, which marks all fields as touched (revealing validation errors) and executes your `action` callback if the form is valid.
 
 You can also submit a form manually, without using the directive, by calling `submit(this.registrationForm)`. When explicitly calling the `submit` function like this, you can pass a `FormSubmitOptions` to override the default `submission` logic for the form: `submit(this.registrationForm, {action: () => /* ... */ })`.
 

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -214,6 +214,18 @@ export interface FormOptions<TModel> {
 }
 
 // @public
+export class FormRoot<T> {
+    // (undocumented)
+    readonly fieldTree: i0.InputSignal<FieldTree<T>>;
+    // (undocumented)
+    protected onSubmit(event: Event): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<FormRoot<any>, "form[formRoot]", never, { "fieldTree": { "alias": "formRoot"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<FormRoot<any>, never>;
+}
+
+// @public
 export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
     action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
@@ -402,18 +414,6 @@ export class MinValidationError extends BaseNgValidationError {
     readonly kind = "min";
     // (undocumented)
     readonly min: number;
-}
-
-// @public
-export class NgSignalForm<T> {
-    // (undocumented)
-    readonly fieldTree: i0.InputSignal<FieldTree<T>>;
-    // (undocumented)
-    protected onSubmit(event: Event): void;
-    // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgSignalForm<any>, "form[ngSignalForm]", never, { "fieldTree": { "alias": "ngSignalForm"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<NgSignalForm<any>, never>;
 }
 
 // @public

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -405,6 +405,18 @@ export class MinValidationError extends BaseNgValidationError {
 }
 
 // @public
+export class NgSignalForm<T> {
+    // (undocumented)
+    readonly fieldTree: i0.InputSignal<FieldTree<T>>;
+    // (undocumented)
+    protected onSubmit(event: Event): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgSignalForm<any>, "form[ngSignalForm]", never, { "fieldTree": { "alias": "ngSignalForm"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<NgSignalForm<any>, never>;
+}
+
+// @public
 export const NgValidationError: abstract new () => NgValidationError;
 
 // @public (undocumented)

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -21,3 +21,4 @@ export * from './src/api/structure';
 export * from './src/api/transformed_value';
 export * from './src/api/types';
 export * from './src/directive/form_field_directive';
+export * from './src/directive/ng_signal_form';

--- a/packages/forms/signals/src/directive/ng_signal_form.ts
+++ b/packages/forms/signals/src/directive/ng_signal_form.ts
@@ -22,7 +22,7 @@ import {FieldTree} from '../api/types';
  * @usageNotes
  *
  * ```html
- * <form [ngSignalForm]="myFieldTree">
+ * <form [formRoot]="myFieldTree">
  *   ...
  * </form>
  * ```
@@ -31,14 +31,14 @@ import {FieldTree} from '../api/types';
  * @experimental 21.0.0
  */
 @Directive({
-  selector: 'form[ngSignalForm]',
+  selector: 'form[formRoot]',
   host: {
     'novalidate': '',
     '(submit)': 'onSubmit($event)',
   },
 })
-export class NgSignalForm<T> {
-  readonly fieldTree = input.required<FieldTree<T>>({alias: 'ngSignalForm'});
+export class FormRoot<T> {
+  readonly fieldTree = input.required<FieldTree<T>>({alias: 'formRoot'});
 
   protected onSubmit(event: Event): void {
     event.preventDefault();

--- a/packages/forms/signals/src/directive/ng_signal_form.ts
+++ b/packages/forms/signals/src/directive/ng_signal_form.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Directive, input} from '@angular/core';
+
+import {submit} from '../api/structure';
+import {FieldTree} from '../api/types';
+
+/**
+ * A directive that binds a `FieldTree` to a `<form>` element.
+ *
+ * It automatically:
+ * 1. Sets `novalidate` on the form element to disable browser validation.
+ * 2. Listens for the `submit` event, prevents the default behavior, and calls `submit()` on the
+ * `FieldTree`.
+ *
+ * @usageNotes
+ *
+ * ```html
+ * <form [ngSignalForm]="myFieldTree">
+ *   ...
+ * </form>
+ * ```
+ *
+ * @publicApi
+ * @experimental 21.0.0
+ */
+@Directive({
+  selector: 'form[ngSignalForm]',
+  host: {
+    'novalidate': '',
+    '(submit)': 'onSubmit($event)',
+  },
+})
+export class NgSignalForm<T> {
+  readonly fieldTree = input.required<FieldTree<T>>({alias: 'ngSignalForm'});
+
+  protected onSubmit(event: Event): void {
+    event.preventDefault();
+    submit(this.fieldTree());
+  }
+}

--- a/packages/forms/signals/test/node/ng_signal_form.spec.ts
+++ b/packages/forms/signals/test/node/ng_signal_form.spec.ts
@@ -10,15 +10,15 @@ import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
-import {form, NgSignalForm} from '../../public_api';
+import {form, FormRoot} from '../../public_api';
 
 @Component({
   template: `
-    <form [ngSignalForm]="f">
+    <form [formRoot]="f">
       <button type="submit">Submit</button>
     </form>
   `,
-  imports: [NgSignalForm],
+  imports: [FormRoot],
 })
 class TestCmp {
   submitted = false;
@@ -31,7 +31,7 @@ class TestCmp {
   });
 }
 
-describe('NgSignalForm', () => {
+describe('FormRoot', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [provideZonelessChangeDetection()],
@@ -59,11 +59,11 @@ describe('NgSignalForm', () => {
   it('works when FormsModule is imported', () => {
     @Component({
       template: `
-        <form [ngSignalForm]="f">
+        <form [formRoot]="f">
           <button type="submit">Submit</button>
         </form>
       `,
-      imports: [NgSignalForm, FormsModule],
+      imports: [FormRoot, FormsModule],
     })
     class TestCmp {
       submitted = false;
@@ -90,11 +90,11 @@ describe('NgSignalForm', () => {
   it('works when ReactiveFormsModule is imported', () => {
     @Component({
       template: `
-        <form [ngSignalForm]="f">
+        <form [formRoot]="f">
           <button type="submit">Submit</button>
         </form>
       `,
-      imports: [NgSignalForm, ReactiveFormsModule],
+      imports: [FormRoot, ReactiveFormsModule],
     })
     class TestCmp {
       submitted = false;

--- a/packages/forms/signals/test/node/ng_signal_form.spec.ts
+++ b/packages/forms/signals/test/node/ng_signal_form.spec.ts
@@ -25,7 +25,6 @@ class TestCmp {
     submission: {
       action: async () => {
         this.submitted = true;
-        return undefined;
       },
     },
   });
@@ -50,13 +49,9 @@ describe('NgSignalForm', () => {
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
 
     const event = new Event('submit', {cancelable: true});
-    spyOn(event, 'preventDefault');
     act(() => formElement.dispatchEvent(event));
 
-    expect(event.preventDefault).toHaveBeenCalled();
-
-    await fixture.whenStable();
-
+    expect(event.defaultPrevented).toBe(true);
     expect(component.submitted).toBeTrue();
   });
 });

--- a/packages/forms/signals/test/node/ng_signal_form.spec.ts
+++ b/packages/forms/signals/test/node/ng_signal_form.spec.ts
@@ -8,6 +8,7 @@
 
 import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {form, NgSignalForm} from '../../public_api';
 
@@ -44,6 +45,68 @@ describe('NgSignalForm', () => {
   });
 
   it('should call submit on the field tree when form is submitted', async () => {
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+
+    const event = new Event('submit', {cancelable: true});
+    act(() => formElement.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(component.submitted).toBeTrue();
+  });
+
+  it('works when FormsModule is imported', () => {
+    @Component({
+      template: `
+        <form [ngSignalForm]="f">
+          <button type="submit">Submit</button>
+        </form>
+      `,
+      imports: [NgSignalForm, FormsModule],
+    })
+    class TestCmp {
+      submitted = false;
+      readonly f = form(signal({}), {
+        submission: {
+          action: async () => {
+            this.submitted = true;
+          },
+        },
+      });
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+
+    const event = new Event('submit', {cancelable: true});
+    act(() => formElement.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(component.submitted).toBeTrue();
+  });
+
+  it('works when ReactiveFormsModule is imported', () => {
+    @Component({
+      template: `
+        <form [ngSignalForm]="f">
+          <button type="submit">Submit</button>
+        </form>
+      `,
+      imports: [NgSignalForm, ReactiveFormsModule],
+    })
+    class TestCmp {
+      submitted = false;
+      readonly f = form(signal({}), {
+        submission: {
+          action: async () => {
+            this.submitted = true;
+          },
+        },
+      });
+    }
+
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const component = fixture.componentInstance;
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;

--- a/packages/forms/signals/test/web/ng_signal_form.spec.ts
+++ b/packages/forms/signals/test/web/ng_signal_form.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {form, NgSignalForm} from '../../public_api';
+
+@Component({
+  template: `
+    <form [ngSignalForm]="f">
+      <button type="submit">Submit</button>
+    </form>
+  `,
+  imports: [NgSignalForm],
+})
+class TestCmp {
+  submitted = false;
+  readonly f = form(signal({}), {
+    submission: {
+      action: async () => {
+        this.submitted = true;
+        return undefined;
+      },
+    },
+  });
+}
+
+describe('NgSignalForm', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+  });
+
+  it('should set novalidate on the form element', () => {
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    expect(formElement.hasAttribute('novalidate')).toBeTrue();
+  });
+
+  it('should call submit on the field tree when form is submitted', async () => {
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+
+    const event = new Event('submit', {cancelable: true});
+    spyOn(event, 'preventDefault');
+    act(() => formElement.dispatchEvent(event));
+
+    expect(event.preventDefault).toHaveBeenCalled();
+
+    await fixture.whenStable();
+
+    expect(component.submitted).toBeTrue();
+  });
+});
+
+function act<T>(fn: () => T): T {
+  try {
+    return fn();
+  } finally {
+    TestBed.tick();
+  }
+}


### PR DESCRIPTION
Adds a `ngSignalForm` directive to manage submitting the form in signal forms.
