### PR TITLE
docs: remove legacy e2e configuration from i18n example

### DIFF
--- a/adev/src/content/examples/i18n/angular.json
+++ b/adev/src/content/examples/i18n/angular.json
@@ -119,18 +119,6 @@
             "styles": ["src/styles.css"],
             "scripts": []
           }
-        },
-        "e2e": {
-          "builder": "@angular-devkit/build-angular:private-protractor",
-          "options": {
-            "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "angular.io-example:serve:fr"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "angular.io-example:serve:production"
-            }
-          }
         }
         // #docregion locale-config, build-single-locale, build-production-french, i18n-subPath
       }


### PR DESCRIPTION
Removes the unused 'e2e' configuration block using '@angular-devkit/build-angular:private-protractor' from the i18n example configuration.
