### PR TITLE
fix(devtools): injector tree errors when inspecting null nodes

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.spec.ts
@@ -18,6 +18,8 @@ import {
   InjectorPath,
   InjectorTreeD3Node,
   InjectorTreeNode,
+  isElementTreeInjector,
+  isEnvironmentTreeInjector,
   splitInjectorPathsIntoElementAndEnvironmentPaths,
   transformInjectorResolutionPathsIntoTree,
 } from './injector-tree-fns';
@@ -11649,5 +11651,33 @@ describe('areInjectorTreesEqual', () => {
       children: [],
     });
     expect(areInjectorTreesEqual(a, d)).toEqual(false);
+  });
+});
+
+describe('isElementTreeInjector', () => {
+  it('should return true if the injector type is element', () => {
+    expect(isElementTreeInjector({type: 'element'} as SerializedInjector)).toEqual(true);
+  });
+
+  it('should return false if the injector type is NOT element', () => {
+    expect(isElementTreeInjector({type: 'environment'} as SerializedInjector)).toEqual(false);
+    expect(isElementTreeInjector({type: 'hidden'} as SerializedInjector)).toEqual(false);
+    expect(isElementTreeInjector({type: 'imported-module'} as SerializedInjector)).toEqual(false);
+    expect(isElementTreeInjector({type: 'null'} as SerializedInjector)).toEqual(false);
+  });
+});
+
+describe('isEnvironmentTreeInjector', () => {
+  it('should return true if the injector type is environment, null or imported-module', () => {
+    expect(isEnvironmentTreeInjector({type: 'environment'} as SerializedInjector)).toEqual(true);
+    expect(isEnvironmentTreeInjector({type: 'null'} as SerializedInjector)).toEqual(true);
+    expect(isEnvironmentTreeInjector({type: 'imported-module'} as SerializedInjector)).toEqual(
+      true,
+    );
+  });
+
+  it('should return false if the injector type is NOT environment, null or imported-module', () => {
+    expect(isEnvironmentTreeInjector({type: 'element'} as SerializedInjector)).toEqual(false);
+    expect(isEnvironmentTreeInjector({type: 'hidden'} as SerializedInjector)).toEqual(false);
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree-fns.ts
@@ -344,3 +344,15 @@ export function areInjectorTreesEqual(
 
   return true;
 }
+
+/** Checks whether an injector belongs to the element tree. */
+export function isElementTreeInjector(injector: SerializedInjector | undefined): boolean {
+  const type = injector?.type;
+  return type === 'element';
+}
+
+/** Checks whether an injector belongs to the environment tree. */
+export function isEnvironmentTreeInjector(injector: SerializedInjector | undefined): boolean {
+  const type = injector?.type;
+  return type === 'environment' || type === 'null' || type === 'imported-module';
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -42,6 +42,8 @@ import {
   InjectorTreeD3Node,
   InjectorTreeNode,
   InjectorTreeVisualizer,
+  isElementTreeInjector,
+  isEnvironmentTreeInjector,
   splitInjectorPathsIntoElementAndEnvironmentPaths,
   transformInjectorResolutionPathsIntoTree,
 } from './injector-tree-fns';
@@ -212,7 +214,7 @@ export class InjectorTreeComponent {
   private refreshVisualizer(): void {
     this.updateInjectorTreeVisualization(this.rawDirectiveForest);
 
-    if (this.selectedNode()?.data.injector.type === 'environment') {
+    if (isEnvironmentTreeInjector(this.selectedNode()?.data.injector)) {
       this.snapToRoot(this.environmentTree());
     }
 
@@ -282,11 +284,11 @@ export class InjectorTreeComponent {
 
     // wait for CD to run before snapping to root so that svg container can change size.
     setTimeout(() => {
-      const {type} = node.data.injector;
+      const {injector} = node.data;
 
-      if (type === 'element') {
+      if (isElementTreeInjector(injector)) {
         this.elementTree()?.snapToNode(node.data, SNAP_ZOOM_SCALE);
-      } else if (type === 'environment') {
+      } else if (isEnvironmentTreeInjector(injector)) {
         this.environmentTree()?.snapToNode(node.data, SNAP_ZOOM_SCALE);
       }
     });
@@ -301,9 +303,9 @@ export class InjectorTreeComponent {
     const injector = selectedNode.data.injector;
     let newNode: TreeD3Node<InjectorTreeNode> | null = null;
 
-    if (injector.type === 'element') {
+    if (isElementTreeInjector(injector)) {
       newNode = this.elementTree()?.getNodeById(injector.id) ?? null;
-    } else if (injector.type === 'environment') {
+    } else if (isEnvironmentTreeInjector(injector)) {
       newNode = this.environmentTree()?.getNodeById(injector.id) ?? null;
     }
 
@@ -351,7 +353,7 @@ export class InjectorTreeComponent {
       return;
     }
 
-    if (this.selectedNode()!.data.injector.type === 'element') {
+    if (isElementTreeInjector(this.selectedNode()!.data.injector)) {
       const idsToRoot = getInjectorIdsToRootFromNode(this.selectedNode()!);
       idsToRoot.forEach((id) => this.highlightNodeById(elementTree, id));
       const edgeIds = generateEdgeIdsFromNodeIds(idsToRoot);


### PR DESCRIPTION
Due to explicit injector type checks, inspecting nodes that have type !== `environment` but at the same time are rendered in the Environment Injector tree, opening their details used to break the app. This change fixes this.