### PR TITLE
refactor(http): Improves base64 encoding/decoding with feature detection

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -20,8 +20,8 @@ import {
   ɵtruncateMiddle as truncateMiddle,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
-import {Observable, of, from} from 'rxjs';
-import {tap, concatMap} from 'rxjs/operators';
+import {Observable, of} from 'rxjs';
+import {concatMap} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
@@ -266,41 +266,32 @@ export function transferCacheInterceptorFn(
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     // Request not found in cache. Make the request and cache it if on the server.
     return event$.pipe(
-      concatMap((event: HttpEvent<unknown>) => {
+      concatMap(async (event: HttpEvent<unknown>) => {
         // Only cache successful HTTP responses.
         if (event instanceof HttpResponse) {
-          const storeInCache = (body: unknown) => {
-            transferState.set<TransferHttpResponse>(storeKey, {
-              [BODY]: body,
-              [HEADERS]: getFilteredHeaders(event.headers, headersToInclude),
-              [STATUS]: event.status,
-              [STATUS_TEXT]: event.statusText,
-              [REQ_URL]: requestUrl,
-              [RESPONSE_TYPE]: req.responseType,
-            });
-          };
-
+          let body = event.body;
           if (req.responseType === 'blob') {
-            // Convert Blob to ArrayBuffer asynchronously before caching.
             // Note: Blob is converted to ArrayBuffer because Uint8Array constructor
             // doesn't accept Blob directly, which would result in an empty array.
             // Type assertion is safe here: when responseType is 'blob', the body is guaranteed to be a Blob
-            return from((event.body as Blob).arrayBuffer()).pipe(
-              tap((arrayBuffer) => storeInCache(toBase64(arrayBuffer))),
-              concatMap(() => of(event)),
-            );
+            const arrayBuffer = await (event.body as Blob).arrayBuffer();
+            body = toBase64(arrayBuffer);
+          } else if (req.responseType === 'arraybuffer') {
+            // For arraybuffer, convert to base64; for other types (json, text), store as-is.
+            // Type assertion is safe here: when responseType is 'arraybuffer', the body is
+            // guaranteed to be an ArrayBuffer
+            body = toBase64(event.body as ArrayBufferLike);
           }
-
-          // For arraybuffer, convert to base64; for other types (json, text), store as-is.
-          // Type assertion is safe here: when responseType is 'arraybuffer', the body is
-          // guaranteed to be an ArrayBuffer
-          const body =
-            req.responseType === 'arraybuffer'
-              ? toBase64(event.body as ArrayBufferLike)
-              : event.body;
-          storeInCache(body);
+          transferState.set<TransferHttpResponse>(storeKey, {
+            [BODY]: body,
+            [HEADERS]: getFilteredHeaders(event.headers, headersToInclude),
+            [STATUS]: event.status,
+            [STATUS_TEXT]: event.statusText,
+            [REQ_URL]: requestUrl,
+            [RESPONSE_TYPE]: req.responseType,
+          });
         }
-        return of(event);
+        return event;
       }),
     );
   }

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -20,8 +20,8 @@ import {
   ɵtruncateMiddle as truncateMiddle,
   ɵRuntimeError as RuntimeError,
 } from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {tap} from 'rxjs/operators';
+import {Observable, of, from} from 'rxjs';
+import {tap, concatMap} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
@@ -266,21 +266,41 @@ export function transferCacheInterceptorFn(
   if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     // Request not found in cache. Make the request and cache it if on the server.
     return event$.pipe(
-      tap((event: HttpEvent<unknown>) => {
+      concatMap((event: HttpEvent<unknown>) => {
         // Only cache successful HTTP responses.
         if (event instanceof HttpResponse) {
-          transferState.set<TransferHttpResponse>(storeKey, {
-            [BODY]:
-              req.responseType === 'arraybuffer' || req.responseType === 'blob'
-                ? toBase64(event.body)
-                : event.body,
-            [HEADERS]: getFilteredHeaders(event.headers, headersToInclude),
-            [STATUS]: event.status,
-            [STATUS_TEXT]: event.statusText,
-            [REQ_URL]: requestUrl,
-            [RESPONSE_TYPE]: req.responseType,
-          });
+          const storeInCache = (body: unknown) => {
+            transferState.set<TransferHttpResponse>(storeKey, {
+              [BODY]: body,
+              [HEADERS]: getFilteredHeaders(event.headers, headersToInclude),
+              [STATUS]: event.status,
+              [STATUS_TEXT]: event.statusText,
+              [REQ_URL]: requestUrl,
+              [RESPONSE_TYPE]: req.responseType,
+            });
+          };
+
+          if (req.responseType === 'blob') {
+            // Convert Blob to ArrayBuffer asynchronously before caching.
+            // Note: Blob is converted to ArrayBuffer because Uint8Array constructor
+            // doesn't accept Blob directly, which would result in an empty array.
+            // Type assertion is safe here: when responseType is 'blob', the body is guaranteed to be a Blob
+            return from((event.body as Blob).arrayBuffer()).pipe(
+              tap((arrayBuffer) => storeInCache(toBase64(arrayBuffer))),
+              concatMap(() => of(event)),
+            );
+          }
+
+          // For arraybuffer, convert to base64; for other types (json, text), store as-is.
+          // Type assertion is safe here: when responseType is 'arraybuffer', the body is
+          // guaranteed to be an ArrayBuffer
+          const body =
+            req.responseType === 'arraybuffer'
+              ? toBase64(event.body as ArrayBufferLike)
+              : event.body;
+          storeInCache(body);
         }
+        return of(event);
       }),
     );
   }

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -20,6 +20,7 @@ import {
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 import {withHttpTransferCache} from '../src/transfer_cache';
 import {HttpClient} from '../src/client';
+import {lastValueFrom} from 'rxjs';
 
 describe('httpResource', () => {
   beforeEach(() => {
@@ -424,15 +425,10 @@ describe('httpResource', () => {
 
     it('should synchronously resolve with a cached value from TransferState', async () => {
       globalThis['ngServerMode'] = true;
-      let requestResolved = false;
-      TestBed.inject(HttpClient)
-        .get('/data')
-        .subscribe(() => (requestResolved = true));
-      const req = TestBed.inject(HttpTestingController).expectOne('/data');
-      req.flush([1, 2, 3]);
 
-      expect(requestResolved).toBe(true);
-
+      const response = lastValueFrom(TestBed.inject(HttpClient).get('/data'));
+      TestBed.inject(HttpTestingController).expectOne('/data').flush([1, 2, 3]);
+      await response;
       // Now switch to client mode
       globalThis['ngServerMode'] = false;
 


### PR DESCRIPTION
Use feature detection for `Uint8Array.prototype.toBase64` and `Uint8Array.fromBase64`, falling back to the existing implementation when native support is not available
 

This is considerably faster when we have sizes like 50kb some like

https://github.com/SkyZeroZx/benchmark-encode-decode-64

```text
encode workaround x 3,732 ops/sec ±2.72% (92 runs sampled)
encode native x 232,185 ops/sec ±1.93% (91 runs sampled)
decode workaround x 258 ops/sec ±2.56% (88 runs sampled)
decode native x 39,383 ops/sec ±1.92% (89 runs sampled)
```

