### PR TITLE
fix(core): capture animation dependencies eagerly to avoid destroyed injector

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -71,8 +71,13 @@ export function ɵɵanimateEnter(value: string | AnimationClassBindingFn): typeo
   const tNode = getCurrentTNode()!;
   cancelLeavingNodes(tNode, lView);
 
+  // Capture NgZone eagerly while the injector is still valid. The animation
+  // function runs later from the queue, at which point the lView injector
+  // may have been destroyed.
+  const ngZone = lView[INJECTOR]!.get(NgZone);
+
   addAnimationToLView(getLViewEnterAnimations(lView), tNode, () =>
-    runEnterAnimation(lView, tNode, value),
+    runEnterAnimation(lView, tNode, value, ngZone),
   );
 
   initializeAnimationQueueScheduler(lView[INJECTOR]);
@@ -91,13 +96,13 @@ export function runEnterAnimation(
   lView: LView,
   tNode: TNode,
   value: string | AnimationClassBindingFn,
+  ngZone: NgZone,
 ): void {
   const nativeElement = getNativeByTNode(tNode, lView) as HTMLElement;
 
   ngDevMode && assertElementNodes(nativeElement, 'animate.enter');
 
   const renderer = lView[RENDERER];
-  const ngZone = lView[INJECTOR]!.get(NgZone);
 
   // Retrieve the actual class list from the value. This will resolve any resolver functions from
   // bindings.
@@ -256,8 +261,13 @@ export function ɵɵanimateLeave(value: string | AnimationClassBindingFn): typeo
   const tNode = getCurrentTNode()!;
   cancelLeavingNodes(tNode, lView);
 
+  // Capture NgZone eagerly while the injector is still valid. The animation
+  // function runs later from the queue, at which point the lView injector
+  // may have been destroyed.
+  const ngZone = lView[INJECTOR]!.get(NgZone);
+
   addAnimationToLView(getLViewLeaveAnimations(lView), tNode, () =>
-    runLeaveAnimations(lView, tNode, value),
+    runLeaveAnimations(lView, tNode, value, ngZone),
   );
 
   initializeAnimationQueueScheduler(lView[INJECTOR]);
@@ -269,6 +279,7 @@ function runLeaveAnimations(
   lView: LView,
   tNode: TNode,
   value: string | AnimationClassBindingFn,
+  ngZone: NgZone,
 ): {promise: Promise<void>; resolve: VoidFunction} {
   const {promise, resolve} = promiseWithResolvers<void>();
   const nativeElement = getNativeByTNode(tNode, lView) as Element;
@@ -276,7 +287,6 @@ function runLeaveAnimations(
   ngDevMode && assertElementNodes(nativeElement, 'animate.leave');
 
   const renderer = lView[RENDERER];
-  const ngZone = lView[INJECTOR].get(NgZone);
   allLeavingAnimations.add(lView[ID]);
   (getLViewLeaveAnimations(lView).get(tNode.index)!.resolvers ??= []).push(resolve);
 
@@ -391,8 +401,14 @@ export function ɵɵanimateLeaveListener(value: AnimationFunction): typeof ɵɵa
 
   allLeavingAnimations.add(lView[ID]);
 
+  // Capture NgZone and MAX_ANIMATION_TIMEOUT eagerly while the injector is
+  // still valid. The animation function runs later from the queue, at which
+  // point the lView injector may have been destroyed.
+  const ngZone = lView[INJECTOR]!.get(NgZone);
+  const maxAnimationTimeout = lView[INJECTOR]!.get(MAX_ANIMATION_TIMEOUT);
+
   addAnimationToLView(getLViewLeaveAnimations(lView), tNode, () =>
-    runLeaveAnimationFunction(lView, tNode, value),
+    runLeaveAnimationFunction(lView, tNode, value, ngZone, maxAnimationTimeout),
   );
 
   initializeAnimationQueueScheduler(lView[INJECTOR]);
@@ -407,6 +423,8 @@ function runLeaveAnimationFunction(
   lView: LView,
   tNode: TNode,
   value: AnimationFunction,
+  ngZone: NgZone,
+  maxAnimationTimeout: number,
 ): {promise: Promise<void>; resolve: VoidFunction} {
   const {promise, resolve} = promiseWithResolvers<void>();
   const nativeElement = getNativeByTNode(tNode, lView) as Element;
@@ -416,8 +434,6 @@ function runLeaveAnimationFunction(
   const cleanupFns: VoidFunction[] = [];
   const renderer = lView[RENDERER];
   const animationsDisabled = areAnimationsDisabled(lView);
-  const ngZone = lView[INJECTOR]!.get(NgZone);
-  const maxAnimationTimeout = lView[INJECTOR]!.get(MAX_ANIMATION_TIMEOUT);
 
   (getLViewLeaveAnimations(lView).get(tNode.index)!.resolvers ??= []).push(resolve);
   const resolvers = getLViewLeaveAnimations(lView).get(tNode.index)?.resolvers;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We've had several bug reports of animations causing DOM nodes to be retained. When this occurs a `NG0205` error is thrown, and I was able to find a stack trace in our error logs: 

<img width="1782" height="1884" alt="CleanShot 2026-02-10 at 18 39 29@2x" src="https://github.com/user-attachments/assets/2e2b4e32-0dfb-44cc-9e36-8451c86d193a" />

I was struggling to find steps to create a minimal reproduction in stackblitz, but Claude was able to use the stack trace to create a test case and fix the issue (the explanation it provided makes sense to me)

## What is the new behavior?

Animations no longer crash and cause DOM nodes to be retained

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
