### PR TITLE
feat: change default decoding behavior for the image

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -327,7 +327,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
   @Input({transform: numberAttribute}) height: number | undefined;
 
   /**
-   * The desired decoding behavior for the image. Defaults to `auto`
+   * The desired decoding behavior for the image. Defaults to `async`
    * if not explicitly set, matching native browser behavior.
    *
    * Use `async` to decode the image off the main thread (non-blocking),
@@ -607,10 +607,9 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       // painted as early as possible.
       return 'sync';
     }
-    // Returns the value of the `decoding` attribute, defaulting to `auto`
-    // if not explicitly provided. This mimics native browser behavior and
-    // avoids breaking changes when no decoding strategy is specified.
-    return this.decoding ?? 'auto';
+    // Returns the value of the `decoding` attribute, defaulting to `async`
+    // if not explicitly provided.
+    return this.decoding ?? 'async';
   }
 
   private getRewrittenSrc(): string {

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -822,7 +822,7 @@ describe('Image directive', () => {
       );
     });
 
-    it('should set the decoding to "auto" by default', () => {
+    it('should set the decoding to "async" by default', () => {
       setupTestingModule();
 
       const template = '<img ngSrc="path/img.png" width="150" height="150">';
@@ -831,7 +831,7 @@ describe('Image directive', () => {
 
       const nativeElement = fixture.nativeElement as HTMLElement;
       const img = nativeElement.querySelector('img')!;
-      expect(img.getAttribute('decoding')).toEqual('auto');
+      expect(img.getAttribute('decoding')).toEqual('async');
     });
 
     it('should set the decoding to sync for priority images', () => {
@@ -846,16 +846,28 @@ describe('Image directive', () => {
       expect(img.getAttribute('decoding')).toEqual('sync');
     });
 
-    it('should override the default decoding behavior', () => {
+    it('should allow overriding the decoding behavior to "auto"', () => {
       setupTestingModule();
 
-      const template = '<img ngSrc="path/img.png" width="150" height="150" decoding="async">';
+      const template = '<img ngSrc="path/img.png" width="150" height="150" decoding="auto">';
       const fixture = createTestComponent(template);
       fixture.detectChanges();
 
       const nativeElement = fixture.nativeElement as HTMLElement;
       const img = nativeElement.querySelector('img')!;
-      expect(img.getAttribute('decoding')).toEqual('async');
+      expect(img.getAttribute('decoding')).toEqual('auto');
+    });
+
+    it('should override the default decoding behavior to "sync', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" width="150" height="150" decoding="sync">';
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('decoding')).toEqual('sync');
     });
   });
 


### PR DESCRIPTION
Replace default decoding from "auto" to "async"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Default decoding for image is "auto"

Issue Number: #61314

## What is the new behavior?

Replace default decoding for image from "auto" to "async"

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
