### PR TITLE
refactor(devtools): Add a new childSignalProp DebugSignalGraphNode kind t…

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/devtools-signal-graph.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph/devtools-signal-graph.spec.ts
@@ -219,12 +219,19 @@ describe('convertToDevtoolsSignalGraph', () => {
           debuggable: false,
           preview: dummyPreview,
         },
+        {
+          id: 'f',
+          kind: 'childSignalProp',
+          epoch: 1,
+          debuggable: false,
+          preview: dummyPreview,
+        },
       ],
       edges: [
         {producer: 0, consumer: 1},
         {producer: 2, consumer: 3},
         {producer: 1, consumer: 4},
-        {producer: 3, consumer: 4},
+        {producer: 3, consumer: 5},
       ],
     };
     const graph = convertToDevtoolsSignalGraph(debugGraph);
@@ -281,6 +288,15 @@ describe('convertToDevtoolsSignalGraph', () => {
           clusterId: undefined,
         },
         {
+          id: 'f',
+          kind: 'childSignalProp',
+          epoch: 1,
+          debuggable: false,
+          preview: dummyPreview,
+          nodeType: 'signal',
+          clusterId: undefined,
+        },
+        {
           id: 'cl_rsrc1',
           nodeType: 'cluster',
           clusterType: 'resource',
@@ -299,9 +315,9 @@ describe('convertToDevtoolsSignalGraph', () => {
         {producer: 0, consumer: 1},
         {producer: 2, consumer: 3},
         {producer: 1, consumer: 4},
-        {producer: 3, consumer: 4},
-        {producer: 5, consumer: 4},
+        {producer: 3, consumer: 5},
         {producer: 6, consumer: 4},
+        {producer: 7, consumer: 5},
       ],
       clusters: {
         'cl_rsrc1': {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.scss
@@ -87,6 +87,10 @@
           background-color: var(--red-03);
         }
 
+        &.type-child-signal-prop {
+          background-color: var(--orange-02);
+        }
+
         &.type-resource {
           background-color: var(--yellow-02);
           color: black;

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-details/signals-details.component.ts
@@ -30,6 +30,7 @@ const TYPE_CLASS_MAP: {[key in DebugSignalGraphNode['kind']]: string} = {
   'afterRenderEffectPhase': 'type-effect',
   'template': 'type-template',
   'linkedSignal': 'type-linked-signal',
+  'childSignalProp': 'type-child-signal-prop',
   'unknown': 'type-unknown',
 };
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.component.scss
@@ -232,6 +232,14 @@ $cluster-expand-anim-duration: 1s;
           background-color: var(--yellow-01);
         }
       }
+
+      .kind-child-signal-prop {
+        background-color: var(--orange-02);
+
+        .header {
+          background-color: var(--orange-01);
+        }
+      }
     }
   }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signals-view/signals-visualizer/signals-visualizer.ts
@@ -37,6 +37,7 @@ const KIND_CLASS_MAP: {[key in DebugSignalGraphNode['kind']]: string} = {
   'afterRenderEffectPhase': 'kind-effect',
   'template': 'kind-template',
   'linkedSignal': 'kind-linked-signal',
+  'childSignalProp': 'kind-child-signal-prop',
   'unknown': 'kind-unknown',
 };
 

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -25,6 +25,7 @@ export interface DebugSignalGraphNode {
     | 'template'
     | 'linkedSignal'
     | 'afterRenderEffectPhase'
+    | 'childSignalProp' // Represents a signal passed as a prop to a child component in a CoW app
     | 'unknown';
   epoch: number;
   label?: string;


### PR DESCRIPTION
…o represent a signal being passed to a child component as a prop.

The purpose for this change is to add nodes to the signal graph to make it clear when producer nodes, especially those that aren't consumed in the component being inspected, are passed to child components for consumption.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Various DebugSignalGraphNode kinds exist to represent signals, computeds, effects, and others in the signal graph.

Issue Number: N/A

## What is the new behavior?

A new childSignalProp DebugSignalGraphNode kind is being added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
