### PR TITLE
fix(forms): sync native input validators when type changes

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -67,11 +67,28 @@ export function nativeControlCreate(
 
     for (const name of CONTROL_BINDING_NAMES) {
       const value = readFieldStateBindingValue(state, name);
-      if (bindingUpdated(bindings, name, value)) {
+      const acceptsNative = parent.elementAcceptsNativeProperty(name);
+      const changed = bindingUpdated(bindings, name, value);
+
+      if (changed) {
         host.setInputOnDirectives(name, value);
-        if (parent.elementAcceptsNativeProperty(name)) {
+
+        if (acceptsNative) {
           setNativeDomProperty(parent.renderer, input, name, value as string | number | undefined);
         }
+        continue;
+      }
+
+      // unchanged
+      if (!acceptsNative) {
+        if (input.hasAttribute(name)) {
+          parent.renderer.removeAttribute(input, name);
+        }
+        continue;
+      }
+
+      if (value !== undefined && !input.hasAttribute(name)) {
+        setNativeDomProperty(parent.renderer, input, name, value as string | number | undefined);
       }
     }
 

--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -122,8 +122,22 @@ export class FormField<T> {
 
   // Compute some helper booleans about the type of element we're sitting on.
   private readonly elementIsNativeFormElement = isNativeFormElement(this.element);
-  private readonly elementAcceptsNumericValues = isNumericFormElement(this.element);
-  private readonly elementAcceptsTextualValues = isTextualFormElement(this.element);
+
+  /**
+   * Dynamically checks if the native element accepts numeric values based on its current type.
+   * This is a getter to support dynamic type bindings (e.g., `<input [type]="myType()">`).
+   */
+  private get elementAcceptsNumericValues(): boolean {
+    return isNumericFormElement(this.element);
+  }
+
+  /**
+   * Dynamically checks if the native element accepts textual values based on its current type.
+   * This is a getter to support dynamic type bindings (e.g., `<input [type]="myType()">`).
+   */
+  private get elementAcceptsTextualValues(): boolean {
+    return isTextualFormElement(this.element);
+  }
 
   /**
    * Utility that casts `this.element` to `NativeFormControl` to avoid repeated type guards. Only

--- a/packages/forms/signals/test/web/form_field_directive.spec.ts
+++ b/packages/forms/signals/test/web/form_field_directive.spec.ts
@@ -1587,6 +1587,41 @@ describe('field directive', () => {
         expect(element.max).toBe('5');
       });
 
+      it('should bind to native control with dynamic type', () => {
+        @Component({
+          imports: [FormField],
+          template: `<input [type]="inputType()" [formField]="f" />`,
+        })
+        class TestCmp {
+          readonly inputType = signal<string>('text');
+          readonly max = signal(100);
+          readonly f = form(signal(50), (p) => {
+            max(p, this.max);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+
+        // When type is 'text', max attribute should not be applied
+        expect(element.max).toBe('');
+        expect(element.type).toBe('text');
+
+        // Change type to 'number' - max should now be applied
+        act(() => fixture.componentInstance.inputType.set('number'));
+        expect(element.type).toBe('number');
+        expect(element.max).toBe('100');
+
+        // Update max value
+        act(() => fixture.componentInstance.max.set(200));
+        expect(element.max).toBe('200');
+
+        // Change type back to 'text' - max should be removed
+        act(() => fixture.componentInstance.inputType.set('text'));
+        expect(element.type).toBe('text');
+        expect(element.max).toBe('');
+      });
+
       it('should bind to custom control', () => {
         @Component({selector: 'custom-control', template: ``})
         class CustomControl implements FormValueControl<number> {
@@ -1770,6 +1805,37 @@ describe('field directive', () => {
 
         act(() => fixture.componentInstance.min.set(5));
         expect(element.min).toBe('5');
+      });
+
+      it('should bind to native control with dynamic type', () => {
+        @Component({
+          imports: [FormField],
+          template: `<input [type]="inputType()" [formField]="f" />`,
+        })
+        class TestCmp {
+          readonly inputType = signal<string>('text');
+          readonly min = signal(10);
+          readonly f = form(signal(15), (p) => {
+            min(p, this.min);
+          });
+        }
+
+        const fixture = act(() => TestBed.createComponent(TestCmp));
+        const element = fixture.nativeElement.firstChild as HTMLInputElement;
+
+        expect(element.min).toBe('');
+        expect(element.type).toBe('text');
+
+        act(() => fixture.componentInstance.inputType.set('number'));
+        expect(element.type).toBe('number');
+        expect(element.min).toBe('10');
+
+        act(() => fixture.componentInstance.min.set(5));
+        expect(element.min).toBe('5');
+
+        act(() => fixture.componentInstance.inputType.set('text'));
+        expect(element.type).toBe('text');
+        expect(element.min).toBe('');
       });
 
       it('should bind to custom control', () => {


### PR DESCRIPTION
Ensure that FormField re-evaluates native property acceptance when input type is dynamic

Fixes #66987