### PR TITLE
docs(ai-tutor): add troubleshooting for MCP setup issues

### DIFF
--- a/adev/src/content/ai/ai-tutor.md
+++ b/adev/src/content/ai/ai-tutor.md
@@ -97,6 +97,36 @@ If you want to learn about a specific topic out of order (e.g., jump from the ba
 
 ## **Troubleshooting**
 
+### Setup Issues
+
+**"launch the Angular AI tutor" doesn't do anything?**
+
+Make sure you have a project open first. The tutor needs an actual Angular project to work with:
+
+```bash
+ng new my-app
+cd my-app
+code .
+```
+
+Then ensure your MCP server is running. In VS Code, open the `.vscode/mcp.json` file and click the **"Start"** button at the top of the file.
+
+When you type "launch the Angular AI tutor", you should see a checkmark saying
+"Reviewed .vscode/mcp.json and ran start task" and a prompt asking to
+"Allow task run?" — go ahead and click Allow.
+
+**Still not working?**
+
+Try typing `#angular-cli` first to load the Angular context, then paste the tutorial URL: `https://angular.dev/ai/ai-tutor`
+
+**How to verify the server is running**
+
+Open the Command Palette (`Ctrl+Shift+P`), type "MCP: List Running Servers", and look for "angular-cli" in the list.
+
+---
+
+### General Issues
+
 If the tutor doesn't respond correctly or you suspect an issue with your application, here are a few things to try:
 
 1. **Type "proceed":** This can often nudge the tutor to continue to the next step in the event it gets stuck.


### PR DESCRIPTION
### What’s changed

Added a troubleshooting section to the Angular AI Tutor documentation to clarify
common setup issues when launching the tutor via the Angular MCP server.

### Why

Typing "launch the Angular AI tutor" may not trigger anything unless:
- an Angular project is open
- the angular-cli MCP server is running
- the Angular CLI context is explicitly loaded

This documents the expected setup, how to verify the MCP server status,
and a workaround that consistently triggers the tutor.

### Scope

Documentation only. No code changes.

Closes #66526
