### PR TITLE
build: add skills in antigravity

### DIFF
--- a/.agent/skills
+++ b/.agent/skills
@@ -1,0 +1,1 @@
+../.gemini/skills

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -304,6 +304,7 @@ groups:
       - >
         contains_any_globs(files.exclude('.pullapprove.yml'), [
           '{*,.*}',
+          '.agent/**/{*,.*}',
           '.devcontainer/**/{*,.*}',
           '.github/**/{*,.*}',
           '.husky/**/{*,.*}',


### PR DESCRIPTION
Adds a symlink `.agent/skills` to `.gemini/skills`. This will allow antrigravity which searches under `.agent` to see them.
