### PR TITLE
feat(http): add missing HTTP 418 status code

### DIFF
--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -493,6 +493,7 @@ export enum HttpStatusCode {
   RangeNotSatisfiable = 416,
   ExpectationFailed = 417,
   ImATeapot = 418,
+  PageExpired = 419,
   MisdirectedRequest = 421,
   UnprocessableEntity = 422,
   Locked = 423,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: complete the listed HTTP status codes in an existing enum

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

`HttpStatusCode` now also lists `HTTP 419` `Page Expired`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I noticed that most entries for HTTP 400 were included in [`HttpStatusCode`](https://angular.dev/api/common/http/HttpStatusCode) except for `HTTP 419`.

