### PR TITLE
Revert "refactor(compiler): Add info about unclosed element."

### DIFF
--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -753,30 +753,13 @@ class _TreeBuilder {
   }
 
   private _consumeBlockClose(token: BlockCloseToken) {
-    const initialStackLength = this._containerStack.length;
-    const topNode = this._containerStack[initialStackLength - 1];
     if (!this._popContainer(null, html.Block, token.sourceSpan)) {
-      if (this._containerStack.length < initialStackLength) {
-        const nodeName = topNode instanceof html.Component ? topNode.fullName : topNode.name;
-        this.errors.push(
-          TreeError.create(
-            null,
-            token.sourceSpan,
-            `Unexpected closing block. The block may have been closed earlier. ` +
-              `Did you forget to close the <${nodeName}> element? ` +
-              `If you meant to write the \`}\` character, you should use the "&#125;" ` +
-              `HTML entity instead.`,
-          ),
-        );
-        return;
-      }
-
       this.errors.push(
         TreeError.create(
           null,
           token.sourceSpan,
           `Unexpected closing block. The block may have been closed earlier. ` +
-            `If you meant to write the \`}\` character, you should use the "&#125;" ` +
+            `If you meant to write the } character, you should use the "&#125;" ` +
             `HTML entity instead.`,
         ),
       );

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1108,7 +1108,7 @@ describe('HtmlParser', () => {
         expect(humanizeErrors(errors)).toEqual([
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:5',
           ],
         ]);
@@ -1120,7 +1120,7 @@ describe('HtmlParser', () => {
         expect(humanizeErrors(errors)).toEqual([
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. Did you forget to close the <strong> element? If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:21',
           ],
         ]);
@@ -1137,7 +1137,7 @@ describe('HtmlParser', () => {
           ],
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:28',
           ],
         ]);


### PR DESCRIPTION
This reverts commit 9b69e296032a0c1572356c2b9f7b74fad6290052.

The tooling ran into an error. Reverting this change to enable re-running the merge on https://github.com/angular/angular/pull/66983.