### PR TITLE
Revert "refactor(compiler): Add info about unclosed element."

### DIFF
--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -753,30 +753,13 @@ class _TreeBuilder {
   }
 
   private _consumeBlockClose(token: BlockCloseToken) {
-    const initialStackLength = this._containerStack.length;
-    const topNode = this._containerStack[initialStackLength - 1];
     if (!this._popContainer(null, html.Block, token.sourceSpan)) {
-      if (this._containerStack.length < initialStackLength) {
-        const nodeName = topNode instanceof html.Component ? topNode.fullName : topNode.name;
-        this.errors.push(
-          TreeError.create(
-            null,
-            token.sourceSpan,
-            `Unexpected closing block. The block may have been closed earlier. ` +
-              `Did you forget to close the <${nodeName}> element? ` +
-              `If you meant to write the \`}\` character, you should use the "&#125;" ` +
-              `HTML entity instead.`,
-          ),
-        );
-        return;
-      }
-
       this.errors.push(
         TreeError.create(
           null,
           token.sourceSpan,
           `Unexpected closing block. The block may have been closed earlier. ` +
-            `If you meant to write the \`}\` character, you should use the "&#125;" ` +
+            `If you meant to write the } character, you should use the "&#125;" ` +
             `HTML entity instead.`,
         ),
       );

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1108,7 +1108,7 @@ describe('HtmlParser', () => {
         expect(humanizeErrors(errors)).toEqual([
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:5',
           ],
         ]);
@@ -1120,7 +1120,7 @@ describe('HtmlParser', () => {
         expect(humanizeErrors(errors)).toEqual([
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. Did you forget to close the <strong> element? If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:21',
           ],
         ]);
@@ -1137,7 +1137,7 @@ describe('HtmlParser', () => {
           ],
           [
             null,
-            'Unexpected closing block. The block may have been closed earlier. If you meant to write the `}` character, you should use the "&#125;" HTML entity instead.',
+            'Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead.',
             '0:28',
           ],
         ]);


### PR DESCRIPTION
This reverts commit 097208454bb0d5ebaad701a991125d2a33d1f79b.

Reverts the commit associated with https://github.com/angular/angular/pull/66983 again since the tooling is still failing...