### PR TITLE
feat(core): allow debouncing signals

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -94,6 +94,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     INVALID_MULTI_PROVIDER = -209,
     // (undocumented)
+    INVALID_RESOURCE_CREATION_IN_PARAMS = 992,
+    // (undocumented)
     INVALID_SET_INPUT_CALL = 317,
     // (undocumented)
     INVALID_SKIP_HYDRATION_HOST = -504,

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -502,6 +502,15 @@ export const CSP_NONCE: InjectionToken<string | null>;
 // @public
 export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata;
 
+// @public
+export function debounced<T>(source: () => T, wait: NoInfer<number | ((value: T, lastValue: ResourceSnapshot<T>) => Promise<void> | void)>, options?: NoInfer<DebouncedOptions<T>>): Resource<T>;
+
+// @public
+export interface DebouncedOptions<T> {
+    equal?: ValueEqualityFn<T>;
+    injector?: Injector;
+}
+
 // @public (undocumented)
 export class DebugElement extends DebugNode {
     constructor(nativeNode: Element);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -157,6 +157,7 @@ export const enum RuntimeErrorCode {
   // resource() API errors
   MUST_PROVIDE_STREAM_OPTION = 990,
   RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE = 991,
+  INVALID_RESOURCE_CREATION_IN_PARAMS = 992,
 
   // Upper bounds for core runtime errors is 999
 }

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -297,3 +297,11 @@ export type ResourceSnapshot<T> =
   | {readonly status: 'loading' | 'reloading'; readonly value: T}
   | {readonly status: 'resolved' | 'local'; readonly value: T}
   | {readonly status: 'error'; readonly error: Error};
+
+/** Options for `debounced`. */
+export interface DebouncedOptions<T> {
+  /** The `Injector` to use for the debounced resource. */
+  injector?: Injector;
+  /** The equality function to use for comparing values. */
+  equal?: ValueEqualityFn<T>;
+}

--- a/packages/core/src/resource/debounce.ts
+++ b/packages/core/src/resource/debounce.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject} from '../di';
+import {DestroyRef} from '../linker';
+import {effect} from '../render3/reactivity/effect';
+import {signal} from '../render3/reactivity/signal';
+import {untracked} from '../render3/reactivity/untracked';
+import {Resource, ResourceSnapshot, type BaseResourceOptions} from './api';
+import {resourceFromSnapshots} from './from_snapshots';
+
+export interface DebounceResourceOptions<T> extends BaseResourceOptions<T, T> {
+  params: () => T;
+  wait: number | ((value: T, lastValue: ResourceSnapshot<T | undefined>) => Promise<void> | void);
+}
+
+export function debounceResource<T>(
+  options: DebounceResourceOptions<T> & {
+    wait: number | ((value: T, lastValue: ResourceSnapshot<T>) => Promise<void> | void);
+    defaultValue: NoInfer<T>;
+  },
+): Resource<T>;
+export function debounceResource<T>(options: DebounceResourceOptions<T>): Resource<T | undefined>;
+export function debounceResource<T>(options: DebounceResourceOptions<T>): Resource<T | undefined> {
+  const {params, wait, injector, defaultValue} = options;
+
+  const state = signal<ResourceSnapshot<T | undefined>>({
+    status: 'loading',
+    value: defaultValue,
+  });
+
+  let active: Promise<void> | void | undefined;
+  let pendingValue: T | undefined;
+
+  (injector?.get(DestroyRef) ?? inject(DestroyRef)).onDestroy(() => {
+    active = undefined;
+  });
+
+  effect(
+    () => {
+      // Enter error state if the source throws.
+      // TODO: does this make sense?
+      let value: T;
+      try {
+        value = params();
+      } catch (err) {
+        state.set({status: 'error', error: err as Error});
+        active = pendingValue = undefined;
+        return;
+      }
+
+      const currentState = untracked(state);
+
+      // Check if the value is the same as the previous one.
+      const equal = options.equal ?? Object.is;
+      if (currentState.status === 'reloading') {
+        if (equal(value, pendingValue!)) return;
+      } else if (currentState.status === 'resolved') {
+        if (equal(value, currentState.value!)) return;
+      }
+
+      const waitFn =
+        typeof wait === 'number'
+          ? () => new Promise<void>((resolve) => setTimeout(resolve, wait))
+          : wait;
+
+      const result = waitFn(value, currentState);
+
+      if (result === undefined) {
+        // Synchronous case, go straight to resolved.
+        state.set({status: 'resolved', value});
+        active = pendingValue = undefined;
+      } else {
+        // Asynchronous case, change to loading or reloading state while the promise is pending.
+        if (currentState.status === 'error') {
+          state.set({status: 'loading', value: defaultValue});
+        } else if (currentState.status !== 'loading' && currentState.status !== 'reloading') {
+          state.set({status: 'reloading', value: currentState.value});
+        }
+        active = result;
+        pendingValue = value;
+
+        // Once the promise resolves, update the state to resolved.
+        result.then(() => {
+          if (active === result) {
+            state.set({status: 'resolved', value});
+            active = pendingValue = undefined;
+          }
+        });
+      }
+    },
+    {injector: injector},
+  );
+
+  return resourceFromSnapshots(state);
+}

--- a/packages/core/src/resource/debounce.ts
+++ b/packages/core/src/resource/debounce.ts
@@ -65,7 +65,6 @@ export function debounced<T>(
   effect(
     () => {
       // Enter error state if the source throws.
-      // TODO: does this make sense?
       let value: T;
       try {
         setInParamsFunction(true);

--- a/packages/core/src/resource/debounce.ts
+++ b/packages/core/src/resource/debounce.ts
@@ -28,7 +28,7 @@ import {
  *   returns a promise that resolves when the debounced value should be updated.
  * @param options The options to use for the debounced signal.
  * @returns A resource representing the debounced signal.
- * @experimental
+ * @experimental 22.0
  */
 export function debounced<T>(
   source: () => T,

--- a/packages/core/src/resource/debounce.ts
+++ b/packages/core/src/resource/debounce.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject} from '../di';
+import {assertInInjectionContext, inject, Injector} from '../di';
 import {DestroyRef} from '../linker';
 import {effect} from '../render3/reactivity/effect';
 import {signal} from '../render3/reactivity/signal';
@@ -28,6 +28,7 @@ import {
  *   returns a promise that resolves when the debounced value should be updated.
  * @param options The options to use for the debounced signal.
  * @returns A resource representing the debounced signal.
+ * @experimental
  */
 export function debounced<T>(
   source: () => T,
@@ -37,6 +38,10 @@ export function debounced<T>(
   if (isInParamsFunction()) {
     throw invalidResourceCreationInParams();
   }
+  if (ngDevMode && !options?.injector) {
+    assertInInjectionContext(debounced);
+  }
+  const injector = options?.injector ?? inject(Injector);
 
   const state = signal<ResourceSnapshot<T>>({
     status: 'resolved',
@@ -53,7 +58,7 @@ export function debounced<T>(
   let active: Promise<void> | void | undefined;
   let pendingValue: T | undefined;
 
-  (options?.injector?.get(DestroyRef) ?? inject(DestroyRef)).onDestroy(() => {
+  injector.get(DestroyRef).onDestroy(() => {
     active = undefined;
   });
 
@@ -114,7 +119,7 @@ export function debounced<T>(
         });
       }
     },
-    {injector: options?.injector},
+    {injector},
   );
 
   return resourceFromSnapshots(state);

--- a/packages/core/src/resource/index.ts
+++ b/packages/core/src/resource/index.ts
@@ -9,3 +9,4 @@
 export * from './api';
 export {resourceFromSnapshots} from './from_snapshots';
 export {resource} from './resource';
+

--- a/packages/core/src/resource/index.ts
+++ b/packages/core/src/resource/index.ts
@@ -7,6 +7,6 @@
  */
 
 export * from './api';
+export {debounced} from './debounce';
 export {resourceFromSnapshots} from './from_snapshots';
 export {resource} from './resource';
-

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -17,19 +17,20 @@ import {
   ResourceLoaderParams,
   ResourceOptions,
   ResourceParamsStatus,
-  ResourceRef,
   ResourceSnapshot,
   ResourceStatus,
   ResourceStreamingLoader,
   ResourceStreamItem,
   StreamingResourceOptions,
-  WritableResource,
   type ResourceParamsContext,
+  type ResourceRef,
+  type WritableResource,
 } from './api';
 
 import {assertInInjectionContext} from '../di/contextual';
 import {Injector} from '../di/injector';
 import {inject} from '../di/injector_compatibility';
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {DestroyRef} from '../linker/destroy_ref';
 import {PendingTasks} from '../pending_tasks';
 import {linkedSignal} from '../render3/reactivity/linked_signal';
@@ -205,6 +206,10 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     injector: Injector,
     getInitialStream?: (request: R) => Signal<ResourceStreamItem<T>> | undefined,
   ) {
+    if (isInParamsFunction()) {
+      throw invalidResourceCreationInParams();
+    }
+
     super(
       // Feed a computed signal for the value to `BaseWritableResource`, which will upgrade it to a
       // `WritableSignal` that delegates to `ResourceImpl.set`.
@@ -235,14 +240,18 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     this.extRequest = linkedSignal<WrappedRequest>(
       () => {
         try {
+          setInParamsFunction(true);
           return {request: request(paramsContext), reload: 0};
         } catch (error) {
+          rethrowFatalErrors(error);
           if (error === ResourceParamsStatus.IDLE) {
             return {status: 'idle', reload: 0};
           } else if (error === ResourceParamsStatus.LOADING) {
             return {status: 'loading', reload: 0};
           }
           return {error: error as Error, reload: 0};
+        } finally {
+          setInParamsFunction(false);
         }
       },
       ngDevMode ? createDebugNameObject(debugName, 'extRequest') : undefined,
@@ -438,6 +447,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
         stream,
       });
     } catch (err) {
+      rethrowFatalErrors(err);
       if (abortSignal.aborted || untracked(this.extRequest) !== extRequest) {
         return;
       }
@@ -589,3 +599,29 @@ export const paramsContext: ResourceParamsContext = {
     return resource.value();
   },
 };
+
+let inParamsFunction = false;
+
+export function isInParamsFunction() {
+  return inParamsFunction;
+}
+
+export function setInParamsFunction(value: boolean) {
+  inParamsFunction = value;
+}
+
+export function invalidResourceCreationInParams(): Error {
+  return new RuntimeError(
+    RuntimeErrorCode.INVALID_RESOURCE_CREATION_IN_PARAMS,
+    ngDevMode && `Cannot create a resource inside the \`params\` of another resource`,
+  );
+}
+
+export function rethrowFatalErrors(error: unknown) {
+  if (
+    error instanceof RuntimeError &&
+    error.code === RuntimeErrorCode.INVALID_RESOURCE_CREATION_IN_PARAMS
+  ) {
+    throw error;
+  }
+}

--- a/packages/core/test/resource/debounce_spec.ts
+++ b/packages/core/test/resource/debounce_spec.ts
@@ -1,0 +1,358 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector} from '../../src/di/injector';
+import {EnvironmentInjector} from '../../src/di/r3_injector';
+import {createEnvironmentInjector} from '../../src/render3/ng_module_ref';
+import {computed} from '../../src/render3/reactivity/computed';
+import {signal} from '../../src/render3/reactivity/signal';
+import {debounceResource} from '../../src/resource/debounce';
+import {TestBed} from '../../testing';
+
+describe('debounceResource', () => {
+  it('should start with loading state and resolve after wait', async () => {
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 1, injector: TestBed.inject(Injector)});
+
+    TestBed.tick();
+
+    expect(res.status()).toBe('loading');
+    expect(res.value()).toBeUndefined();
+
+    await delay(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('initial');
+  });
+
+  it('should debounce updates', async () => {
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 2, injector: TestBed.inject(Injector)});
+
+    TestBed.tick();
+    await delay(2);
+    expect(res.status()).toBe('resolved');
+
+    source.set('updated');
+    TestBed.tick();
+
+    // Should be reloading now
+    expect(res.status()).toBe('reloading');
+    expect(res.value()).toBe('initial'); // Keeps old value while reloading
+
+    await delay(1);
+    expect(res.status()).toBe('reloading');
+
+    await delay(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('updated');
+  });
+
+  it('should restart debounce on rapid updates', async () => {
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 2, injector: TestBed.inject(Injector)});
+
+    TestBed.tick();
+    await delay(2);
+
+    source.set('update1');
+    TestBed.tick();
+    expect(res.status()).toBe('reloading');
+
+    await delay(1);
+    source.set('update2');
+    TestBed.tick();
+
+    // Timer should have reset
+    await delay(1); // Total 2 from start, but only 1 from update2
+    expect(res.status()).toBe('reloading');
+    expect(res.value()).toBe('initial');
+
+    await delay(1); // Total 2 from update2
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('update2');
+  });
+
+  it('should transition to error state if source throws', async () => {
+    const val = signal('initial');
+    const source = computed(() => {
+      if (val() === 'error') throw new Error('fail');
+      return val();
+    });
+
+    const res = debounceResource({params: source, wait: 1, injector: TestBed.inject(Injector)});
+    TestBed.tick();
+    await delay(1);
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('initial');
+
+    val.set('error');
+    TestBed.tick();
+
+    expect(res.status()).toBe('error');
+    expect(res.error()).toEqual(new Error('fail'));
+
+    // Recover
+    val.set('recovered');
+    TestBed.tick();
+    // It should start loading (undefined value) because we were in error state
+    expect(res.status()).toBe('loading');
+    expect(res.value()).toBeUndefined();
+
+    await delay(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('recovered');
+  });
+
+  it('should cleanup timer when injector is destroyed', async () => {
+    const parentInjector = TestBed.inject(EnvironmentInjector);
+    const injector = createEnvironmentInjector([], parentInjector);
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 1, injector});
+
+    TestBed.tick();
+    await delay(1);
+
+    source.set('updated');
+    TestBed.tick();
+
+    expect(res.status()).toBe('reloading');
+
+    injector.destroy();
+
+    await delay(2);
+
+    // Verify it didn't update to 'resolved'
+    expect(res.status()).toBe('reloading');
+    expect(res.value()).toBe('initial');
+  });
+
+  it('should support a custom wait function returning a promise', async () => {
+    const source = signal('initial');
+    let release: () => void = () => {};
+    let calls = 0;
+    const waitFn = () =>
+      new Promise<void>((resolve) => {
+        calls++;
+        release = resolve;
+      });
+
+    const res = debounceResource({
+      params: source,
+      wait: waitFn,
+      injector: TestBed.inject(Injector),
+    });
+
+    // Initial load
+    expect(res.status()).toBe('loading');
+
+    TestBed.tick(); // trigger effect (if not already triggered)
+
+    // Release initial
+    release();
+    // We need to wait for the promise to resolve, which is async
+    await Promise.resolve();
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('initial');
+
+    source.set('updated');
+    TestBed.tick();
+
+    expect(res.status()).toBe('reloading');
+    expect(res.value()).toBe('initial');
+
+    release();
+    // Promise resolution is microtask
+    await Promise.resolve();
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('updated');
+  });
+
+  it('should support a custom wait function returning void (synchronous)', async () => {
+    const source = signal('initial');
+    const waitFn = () => {};
+
+    const res = debounceResource({
+      params: source,
+      wait: waitFn,
+      injector: TestBed.inject(Injector),
+    });
+
+    // Initially loading before effect runs
+    expect(res.status()).toBe('loading');
+
+    TestBed.tick();
+
+    // Should be resolved after effect runs
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('initial');
+
+    source.set('updated');
+    TestBed.tick();
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('updated');
+  });
+
+  it('should cancel previous promise when new value arrives', async () => {
+    const source = signal('initial');
+    let releaseInitial: () => void = () => {};
+    let release1: () => void = () => {};
+    let release2: () => void = () => {};
+
+    const waitFn = (val: string) =>
+      new Promise<void>((resolve) => {
+        if (val === 'initial') releaseInitial = resolve;
+        if (val === 'update1') release1 = resolve;
+        if (val === 'update2') release2 = resolve;
+      });
+
+    const res = debounceResource({
+      params: source,
+      wait: waitFn,
+      injector: TestBed.inject(Injector),
+    });
+
+    // Initial load
+    expect(res.status()).toBe('loading');
+    TestBed.tick();
+
+    releaseInitial();
+    await Promise.resolve();
+    expect(res.status()).toBe('resolved');
+
+    source.set('update1');
+    TestBed.tick();
+    expect(res.status()).toBe('reloading');
+
+    source.set('update2');
+    TestBed.tick();
+    expect(res.status()).toBe('reloading');
+
+    // Release first promise - should be ignored
+    release1();
+    await Promise.resolve();
+    expect(res.status()).toBe('reloading');
+    expect(res.value()).toBe('initial');
+
+    // Release second promise - should update
+    release2();
+    await Promise.resolve();
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('update2');
+  });
+
+  it('should not reload if value is equal to current resolved value (default equality)', async () => {
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 1, injector: TestBed.inject(Injector)});
+
+    TestBed.tick();
+    await delay(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('initial');
+
+    source.set('initial'); // Same value
+    TestBed.tick();
+
+    expect(res.status()).toBe('resolved'); // Should not change status
+  });
+
+  it('should not restart debounce if value is equal to current pending value (default equality)', async () => {
+    const source = signal('initial');
+    const res = debounceResource({params: source, wait: 2, injector: TestBed.inject(Injector)});
+
+    TestBed.tick();
+    await delay(2);
+    expect(res.status()).toBe('resolved');
+
+    source.set('update1');
+    TestBed.tick();
+    expect(res.status()).toBe('reloading');
+
+    await delay(1);
+    source.set('update1'); // Same pending value
+    TestBed.tick();
+
+    await delay(1); // Total 2 from first update1
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('update1');
+  });
+
+  it('should use custom equality function', async () => {
+    const source = signal({id: 1, val: 'a'});
+    const res = debounceResource({
+      params: source,
+      wait: 1,
+      injector: TestBed.inject(Injector),
+      equal: (a, b) => a.id === b.id,
+    });
+
+    TestBed.tick();
+    await delay(1);
+    expect(res.value()).toEqual({id: 1, val: 'a'});
+
+    source.set({id: 1, val: 'b'}); // Different object, same ID
+    TestBed.tick();
+
+    expect(res.status()).toBe('resolved'); // Should not reload
+    expect(res.value()).toEqual({id: 1, val: 'a'}); // Should keep old value
+  });
+
+  it('should use defaultValue for initial value', () => {
+    const source = signal('initial');
+    const res = debounceResource({
+      params: source,
+      wait: 1,
+      injector: TestBed.inject(Injector),
+      defaultValue: 'default',
+    });
+
+    TestBed.tick(); // Start effect
+    expect(res.status()).toBe('loading');
+    expect(res.value()).toBe('default');
+  });
+
+  it('should use defaultValue when recovering from error state', async () => {
+    const val = signal('initial');
+    const source = computed(() => {
+      if (val() === 'error') throw new Error('fail');
+      return val();
+    });
+
+    const res = debounceResource({
+      params: source,
+      wait: 1,
+      injector: TestBed.inject(Injector),
+      defaultValue: 'default',
+    });
+
+    TestBed.tick();
+    await delay(1);
+    expect(res.value()).toBe('initial');
+
+    val.set('error');
+    TestBed.tick();
+    expect(res.status()).toBe('error');
+
+    val.set('recovered');
+    TestBed.tick();
+
+    // Should go back to loading with defaultValue
+    expect(res.status()).toBe('loading');
+    expect(res.value()).toBe('default');
+
+    await delay(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('recovered');
+  });
+});
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Adds a utility `debounced` to create a debounced version of a signal,
represented as a `Resource`. The resource's value contained the
debounced value of the signal, while its status (`resolved`, `loading`,
or `error`) indicates if the value is settled, if there is a value
currently pending debounce, or if the source signal threw an error.

The status is helpful when the resource is used in conjunction with the
`chain` function introduced by https://github.com/angular/angular/pull/67084 to implement resources
that fetch data based on debounced user input.