### PR TITLE
refactor(compiler-cli): use phaseModifier for type-only import detection

### DIFF
--- a/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
@@ -128,7 +128,7 @@ function isLocalFile(sf: ts.SourceFile): boolean {
 
 function isTypeOnlyImportClause(node: ts.ImportClause): boolean {
   // The clause itself is type-only (e.g. `import type {foo} from '...'`).
-  if (node.isTypeOnly) {
+  if (node.phaseModifier === ts.SyntaxKind.TypeKeyword) {
     return true;
   }
 

--- a/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/class_extractor.ts
@@ -166,7 +166,6 @@ class NgModuleExtractor extends ClassExtractor {
   constructor(
     declaration: {name: ts.Identifier} & ts.ClassDeclaration,
     protected reference: Reference,
-    private metadata: NgModuleMeta,
     typeChecker: ts.TypeChecker,
   ) {
     super(declaration, typeChecker);
@@ -199,7 +198,7 @@ export function extractClass(
   } else if (pipeMetadata) {
     extractor = new PipeExtractor(classDeclaration, ref, pipeMetadata, typeChecker);
   } else if (ngModuleMetadata) {
-    extractor = new NgModuleExtractor(classDeclaration, ref, ngModuleMetadata, typeChecker);
+    extractor = new NgModuleExtractor(classDeclaration, ref, typeChecker);
   } else {
     extractor = new ClassExtractor(classDeclaration, typeChecker);
   }

--- a/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
+++ b/packages/compiler-cli/src/ngtsc/hmr/src/extract_dependencies.ts
@@ -173,7 +173,7 @@ function getTopLevelDeclarationNames(sourceFile: ts.SourceFile): Set<string> {
       const importClause = node.importClause;
 
       // Skip over type-only imports since they won't be emitted to JS.
-      if (importClause.isTypeOnly) {
+      if (importClause.phaseModifier === ts.SyntaxKind.TypeKeyword) {
         continue;
       }
 

--- a/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
@@ -60,7 +60,7 @@ export class DeferredSymbolTracker {
     }
 
     // If the entire import is a type-only import, none of the symbols can be eager.
-    if (importDecl.importClause.isTypeOnly) {
+    if (importDecl.importClause.phaseModifier === ts.SyntaxKind.TypeKeyword) {
       return symbolMap;
     }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -78,7 +78,7 @@ export function typeToValue(
       // This is a default import.
       //   import Foo from 'foo';
 
-      if (firstDecl.isTypeOnly) {
+      if (firstDecl.phaseModifier === ts.SyntaxKind.TypeKeyword) {
         // Type-only imports cannot be represented as value.
         return typeOnlyImport(typeNode, firstDecl);
       }
@@ -103,7 +103,7 @@ export function typeToValue(
         return typeOnlyImport(typeNode, firstDecl);
       }
 
-      if (firstDecl.parent.parent.isTypeOnly) {
+      if (firstDecl.parent.parent.phaseModifier === ts.SyntaxKind.TypeKeyword) {
         // The import specifier can't be inside a type-only import clause
         // (e.g. `import type {Foo} from '...')`.
         return typeOnlyImport(typeNode, firstDecl.parent.parent);
@@ -134,7 +134,7 @@ export function typeToValue(
       // The import is a namespace import
       //   import * as Foo from 'foo';
 
-      if (firstDecl.parent.isTypeOnly) {
+      if (firstDecl.parent.phaseModifier === ts.SyntaxKind.TypeKeyword) {
         // Type-only imports cannot be represented as value.
         return typeOnlyImport(typeNode, firstDecl.parent);
       }

--- a/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/selectorless_scope.ts
@@ -98,7 +98,7 @@ export class SelectorlessComponentScopeReader implements ComponentScopeReader {
         if (
           ts.isImportDeclaration(stmt) &&
           stmt.importClause !== undefined &&
-          !stmt.importClause.isTypeOnly
+          !(stmt.importClause.phaseModifier === ts.SyntaxKind.TypeKeyword)
         ) {
           const clause = stmt.importClause;
           if (clause.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
@@ -77,7 +77,7 @@ export function createTsTransformForImportManager(
 
       const newClause = ctx.factory.updateImportClause(
         clause,
-        clause.isTypeOnly,
+        clause.phaseModifier === ts.SyntaxKind.TypeKeyword,
         clause.name,
         updatedImports.get(clause.namedBindings),
       );

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/reuse_source_file_imports.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/reuse_source_file_imports.ts
@@ -61,7 +61,10 @@ export function attemptToReuseExistingSourceFileImports(
 
     // Side-effect imports are ignored, or type-only imports.
     // TODO: Consider re-using type-only imports efficiently.
-    if (!statement.importClause || statement.importClause.isTypeOnly) {
+    if (
+      !statement.importClause ||
+      statement.importClause.phaseModifier === ts.SyntaxKind.TypeKeyword
+    ) {
       continue;
     }
 


### PR DESCRIPTION
The `isTypeOnly` property was deprecated in TypeScript and replaced by `phaseModifier`.

Updates the check to use `phaseModifier`, which is the recommended API for detecting type-only imports.

Additionally, removes the unused `metadata` parameter from the `NgModuleExtractor`
 
