### PR TITLE
refactor(core): place Eager value first

### DIFF
--- a/packages/core/src/change_detection/constants.ts
+++ b/packages/core/src/change_detection/constants.ts
@@ -25,17 +25,17 @@ export enum ChangeDetectionStrategy {
   OnPush = 0,
 
   /**
-   * Use the default `CheckAlways` strategy, in which change detection is automatic until
-   * explicitly deactivated.
-   * @deprecated Use `Eager` instead.
-   */
-  Default = 1,
-
-  /**
    * Use the `Eager` strategy, meaning that the component is checked eagerly when the change
    * detection traversal reaches it, rather than only checking under certain circumstances (e.g.
    * `markForCheck`, a signal in the template changed, etc).
    */
-  // tslint:disable-next-line:no-duplicate-enum-values
   Eager = 1,
+
+  /**
+   * Use the default `CheckAlways` strategy, in which change detection is automatic until
+   * explicitly deactivated.
+   * @deprecated Use `Eager` instead.
+   */
+  // tslint:disable-next-line:no-duplicate-enum-values
+  Default = 1,
 }


### PR DESCRIPTION
This way the jsdoc wouldn't collapse if/when we remove the `Default` value.
