### PR TITLE
fix(forms): preserve custom-control focus context in signal forms

### DIFF
--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -251,7 +251,7 @@ export class FormField<T> {
     this.installClassBindingEffect();
 
     if (bindingOptions?.focus) {
-      this.focuser = bindingOptions.focus;
+      this.focuser = (focusOptions?: FocusOptions) => bindingOptions.focus!(focusOptions);
     }
 
     // Register this control on the field state it is currently bound to. We do this at the end of

--- a/packages/forms/signals/test/web/focus.spec.ts
+++ b/packages/forms/signals/test/web/focus.spec.ts
@@ -45,12 +45,14 @@ describe('FieldState focus behavior', () => {
     @Component({
       selector: 'custom-control',
       host: {'tabindex': '-1'},
-      template: '',
+      template: '<input #input />',
     })
     class CustomControl {
       readonly value = model<string>();
+      readonly input = viewChild.required<ElementRef<HTMLInputElement>>('input');
       focus() {
         focusCalled = true;
+        this.input().nativeElement.focus();
       }
     }
 
@@ -68,6 +70,7 @@ describe('FieldState focus behavior', () => {
     await act(() => fixture.componentInstance.f().focusBoundControl());
     expect(focusCalled).toBeTrue();
     expect(document.activeElement).not.toBe(customControl);
+    expect(document.activeElement).toBe(customControl.querySelector('input'));
   });
 
   it('should directly focus a custom control that has no custom focus logic', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Without this, custom focus methods that access instance members throw at runtime when `focusBoundControl()` is called.

Issue Number: #67051

## What is the new behavior

Store custom control focus callbacks in a wrapper so method invocation keeps the original object context. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
