### PR TITLE
refactor(core): Add migration to add `ChangeDetectionStrategy.Eager` …

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -102,6 +102,10 @@ bundle_entrypoints = [
         "packages/core/schematics/migrations/common-to-standalone-migration/index.js",
     ],
     [
+        "change-detection-eager",
+        "packages/core/schematics/migrations/change-detection-eager/index.js",
+    ],
+    [
         "control-flow-migration",
         "packages/core/schematics/migrations/control-flow-migration/index.js",
     ],
@@ -151,6 +155,7 @@ rollup.rollup(
         "//packages/core/schematics/migrations/add-bootstrap-context-to-server-main",
         "//packages/core/schematics/migrations/application-config-core",
         "//packages/core/schematics/migrations/bootstrap-options-migration",
+        "//packages/core/schematics/migrations/change-detection-eager",
         "//packages/core/schematics/migrations/common-to-standalone-migration",
         "//packages/core/schematics/migrations/control-flow-migration",
         "//packages/core/schematics/migrations/ngclass-to-class-migration",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -30,6 +30,11 @@
       "version": "21.0.0",
       "description": "Migrates deprecated bootstrap options to providers.",
       "factory": "./bundles/bootstrap-options-migration.cjs#migrate"
+    },
+    "change-detection-eager": {
+      "version": "22.0.0",
+      "description": "Adds `ChangeDetectionStrategy.Eager` to all components.",
+      "factory": "./bundles/change-detection-eager.cjs#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/change-detection-eager/BUILD.bazel
+++ b/packages/core/schematics/migrations/change-detection-eager/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "change-detection-eager",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/@types/node",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/private",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":change-detection-eager",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli/private",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+zoneless_jasmine_test(
+    name = "test",
+    data = [":test_lib"],
+    env = {"FORCE_COLOR": "3"},
+)

--- a/packages/core/schematics/migrations/change-detection-eager/index.ts
+++ b/packages/core/schematics/migrations/change-detection-eager/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {ChangeDetectionEagerMigration} from './migration';
+
+interface Options {
+  path: string;
+}
+
+export function migrate(options: Options): Rule {
+  return async (tree, context) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: (fs) => new ChangeDetectionEagerMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/migrations/change-detection-eager/migration.spec.ts
+++ b/packages/core/schematics/migrations/change-detection-eager/migration.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {absoluteFrom} from '@angular/compiler-cli';
+import {initMockFileSystem} from '@angular/compiler-cli/private/testing';
+import {runTsurgeMigration} from '../../utils/tsurge/testing';
+import {ChangeDetectionEagerMigration} from './migration';
+
+describe('ChangeDetectionEager migration', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it('should add ChangeDetectionStrategy.Eager if explicit strategy is missing', async () => {
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            template: ''
+          })
+          export class TestComponent {}
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toContain('changeDetection: ChangeDetectionStrategy.Eager');
+    expect(content).toContain(
+      `import { Component, ChangeDetectionStrategy } from '@angular/core';`,
+    );
+  });
+
+  it('should replace ChangeDetectionStrategy.Default with Eager', async () => {
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            changeDetection: ChangeDetectionStrategy.Default,
+            template: ''
+          })
+          export class TestComponent {}
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toContain('changeDetection: ChangeDetectionStrategy.Eager');
+    expect(content).not.toContain('ChangeDetectionStrategy.Default');
+  });
+
+  it('should not change ChangeDetectionStrategy.OnPush', async () => {
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            changeDetection: ChangeDetectionStrategy.OnPush,
+            template: ''
+          })
+          export class TestComponent {}
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).not.toContain('changeDetection: ChangeDetectionStrategy.Eager');
+    expect(content).toContain('changeDetection: ChangeDetectionStrategy.OnPush');
+  });
+
+  it('should handle existing other properties correctly', async () => {
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            template: '',
+            standalone: true
+          })
+          export class TestComponent {}
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toMatch(
+      /standalone: true,\n\s+changeDetection: ChangeDetectionStrategy\.Eager/,
+    );
+  });
+
+  it('should handle aliased imports', async () => {
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component, ChangeDetectionStrategy as CDS } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            changeDetection: CDS.Default,
+            template: ''
+          })
+          export class TestComponent {}
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toContain('changeDetection: CDS.Eager');
+  });
+
+  it('should handle aliased imports when adding property', async () => {
+    // This case tests if it reuses existing import even if aliased, or adds new one.
+    // ImportManager should handle it.
+    const {fs} = await runTsurgeMigration(new ChangeDetectionEagerMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          import { Component, ChangeDetectionStrategy as CDS } from '@angular/core';
+
+          @Component({
+            selector: 'app-test',
+            template: ''
+          })
+          export class TestComponent {}
+       `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    // If ImportManager is smart, it reuses CDS.
+    // If not, it might add ChangeDetectionStrategy.
+    // Our migration uses `importManager.addImport`.
+    // Let's see what happens.
+    // We expect either `CDS.Eager` or `ChangeDetectionStrategy.Eager` (with new import).
+    // Ideally it should reuse `CDS`.
+    expect(content).toContain('changeDetection: CDS.Eager');
+  });
+});

--- a/packages/core/schematics/migrations/change-detection-eager/migration.ts
+++ b/packages/core/schematics/migrations/change-detection-eager/migration.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import ts from 'typescript';
+import {getAngularDecorators} from '../../utils/ng_decorators';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+
+export interface ChangeDetectionEagerMigrationPhase1Data {
+  replacements: Replacement[];
+}
+
+export class ChangeDetectionEagerMigration extends TsurgeFunnelMigration<
+  ChangeDetectionEagerMigrationPhase1Data,
+  ChangeDetectionEagerMigrationPhase1Data
+> {
+  constructor(
+    private readonly config: {shouldMigrate?: (file: {rootRelativePath: string}) => boolean} = {},
+  ) {
+    super();
+  }
+
+  override async analyze(
+    info: ProgramInfo,
+  ): Promise<Serializable<ChangeDetectionEagerMigrationPhase1Data>> {
+    const {sourceFiles, program} = info;
+    const typeChecker = program.getTypeChecker();
+    const replacements: Replacement[] = [];
+    const importManager = new ImportManager();
+
+    const printer = ts.createPrinter();
+
+    for (const sf of sourceFiles) {
+      const file = projectFile(sf, info);
+
+      if (this.config.shouldMigrate && !this.config.shouldMigrate(file)) {
+        continue;
+      }
+
+      ts.forEachChild(sf, (node) => {
+        if (!ts.isClassDeclaration(node)) {
+          return;
+        }
+
+        const decorators = getAngularDecorators(typeChecker, ts.getDecorators(node) || []);
+        const componentDecorator = decorators.find(
+          (d) => d.name === 'Component' && d.moduleName === '@angular/core',
+        );
+
+        if (!componentDecorator) {
+          return;
+        }
+
+        // The helper `getAngularDecorators` guarantees that `node` is `CallExpressionDecorator`.
+        // So `componentDecorator.node.expression` is `ts.CallExpression`.
+        const callExpression = componentDecorator.node.expression;
+        if (
+          callExpression.arguments.length !== 1 ||
+          !ts.isObjectLiteralExpression(callExpression.arguments[0])
+        ) {
+          return;
+        }
+
+        const metadata = callExpression.arguments[0] as ts.ObjectLiteralExpression;
+        const changeDetectionProp = metadata.properties.find(
+          (p) =>
+            ts.isPropertyAssignment(p) &&
+            (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
+            p.name.text === 'changeDetection',
+        ) as ts.PropertyAssignment | undefined;
+
+        if (!changeDetectionProp) {
+          // Property missing. Add it.
+
+          const changeDetectionStrategyExpr = importManager.addImport({
+            exportModuleSpecifier: '@angular/core',
+            exportSymbolName: 'ChangeDetectionStrategy',
+            requestedFile: sf,
+          });
+
+          // Print the identifier
+          const exprText = printer.printNode(
+            ts.EmitHint.Unspecified,
+            changeDetectionStrategyExpr,
+            sf,
+          );
+
+          const properties = metadata.properties;
+          let insertPos: number;
+          let toInsert: string;
+
+          if (properties.length > 0) {
+            const lastProp = properties[properties.length - 1];
+            insertPos = lastProp.getEnd();
+
+            // Simpler approach: check comma after last property.
+            const textAfter = sf.text.substring(lastProp.getEnd());
+            const hasComma = /^\s*,/.test(textAfter);
+            const prefix = hasComma ? '' : ',';
+
+            toInsert = `${prefix}\n  changeDetection: ${exprText}.Eager`;
+          } else {
+            insertPos = metadata.getStart() + 1;
+            toInsert = `\n  changeDetection: ${exprText}.Eager\n`;
+          }
+
+          replacements.push(
+            new Replacement(
+              projectFile(sf, info),
+              new TextUpdate({
+                position: insertPos,
+                end: insertPos,
+                toInsert: toInsert,
+              }),
+            ),
+          );
+          return;
+        }
+
+        // Check if explicitly set to Default.
+        if (!ts.isPropertyAccessExpression(changeDetectionProp.initializer)) {
+          return;
+        }
+
+        const initializer = changeDetectionProp.initializer;
+        // Best effort check for ChangeDetectionStrategy.Default
+        if (!ts.isIdentifier(initializer.expression) || initializer.name.text !== 'Default') {
+          return;
+        }
+
+        // Verify it is indeed ChangeDetectionStrategy.
+        // We can check if the symbol of the expression is imported from @angular/core and named ChangeDetectionStrategy.
+        const symbol = typeChecker.getSymbolAtLocation(initializer.expression);
+
+        if (!symbol || !symbol.declarations || symbol.declarations.length === 0) {
+          return;
+        }
+
+        const declaration = symbol.declarations[0];
+        if (!ts.isImportSpecifier(declaration)) {
+          return;
+        }
+
+        const propertyName = declaration.propertyName?.text ?? declaration.name.text;
+        const importDecl = declaration.parent.parent.parent;
+
+        if (
+          !ts.isImportDeclaration(importDecl) ||
+          !ts.isStringLiteral(importDecl.moduleSpecifier) ||
+          importDecl.moduleSpecifier.text !== '@angular/core' ||
+          propertyName !== 'ChangeDetectionStrategy'
+        ) {
+          return;
+        }
+
+        replacements.push(
+          new Replacement(
+            projectFile(sf, info),
+            new TextUpdate({
+              position: initializer.name.getStart(),
+              end: initializer.name.getEnd(),
+              toInsert: 'Eager',
+            }),
+          ),
+        );
+      });
+    }
+
+    applyImportManagerChanges(importManager, replacements, sourceFiles, info);
+
+    return confirmAsSerializable({
+      replacements,
+    });
+  }
+
+  override async combine(
+    unitA: ChangeDetectionEagerMigrationPhase1Data,
+    unitB: ChangeDetectionEagerMigrationPhase1Data,
+  ): Promise<Serializable<ChangeDetectionEagerMigrationPhase1Data>> {
+    return confirmAsSerializable({
+      replacements: [...unitA.replacements, ...unitB.replacements],
+    });
+  }
+
+  override async globalMeta(
+    combinedData: ChangeDetectionEagerMigrationPhase1Data,
+  ): Promise<Serializable<ChangeDetectionEagerMigrationPhase1Data>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats(
+    globalMetadata: ChangeDetectionEagerMigrationPhase1Data,
+  ): Promise<Serializable<unknown>> {
+    return confirmAsSerializable({});
+  }
+
+  override async migrate(
+    globalData: ChangeDetectionEagerMigrationPhase1Data,
+  ): Promise<{replacements: Replacement[]}> {
+    return {replacements: globalData.replacements};
+  }
+}


### PR DESCRIPTION
…where applicable

In v22, `OnPush` becomes the default strategy. To maintain the ChangeDetection behavior of exisiting apps, components without an explicit change detectino strategy will get `Eager` assigned.
