### PR TITLE
feat(forms): introduce extractValue utility for signal forms

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -48,6 +48,15 @@ export class CompatValidationError<T = unknown> implements ValidationError {
 }
 
 // @public
+export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
+
+// @public (undocumented)
+export function extractValue<T>(field: FieldTree<T>, filter: ExtractFilter): DeepPartial<RawValue<T>> | undefined;
+
+// @public (undocumented)
+export function extractValue<T>(field: FieldTree<T>, filter?: ExtractFilter): RawValue<T> | DeepPartial<RawValue<T>> | undefined;
+
+// @public
 export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];
 
 // @public

--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -50,11 +50,8 @@ export class CompatValidationError<T = unknown> implements ValidationError {
 // @public
 export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
 
-// @public (undocumented)
-export function extractValue<T>(field: FieldTree<T>, filter: ExtractFilter): DeepPartial<RawValue<T>> | undefined;
-
-// @public (undocumented)
-export function extractValue<T>(field: FieldTree<T>, filter?: ExtractFilter): RawValue<T> | DeepPartial<RawValue<T>> | undefined;
+// @public
+export function extractValue<T>(field: FieldTree<T>, filter: ExtractFilter): DeepPartial<RawValue<T>>;
 
 // @public
 export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];

--- a/packages/forms/signals/compat/public_api.ts
+++ b/packages/forms/signals/compat/public_api.ts
@@ -12,6 +12,7 @@
  * Entry point for all public APIs of this package.
  */
 export * from './src/api/compat_form';
+export {extractValue} from './src/api/extract';
 export {CompatValidationError} from '../src/compat/validation_errors';
 export * from './src/api/di';
 export {SignalFormControl} from './src/signal_form_control/signal_form_control';

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -84,16 +84,15 @@ function visitFieldTree(
   field: FieldTree<unknown>,
   filter?: ExtractFilter,
 ): RawValue<unknown> | DeepPartial<RawValue<unknown>> | undefined {
-  const fieldFn = field as () => FieldState<unknown>;
   return untracked(() => {
-    const state = fieldFn();
+    const state = field();
     const value = state.value();
 
     if (!matchesFilter(state, filter)) {
       return undefined;
     }
 
-    const extracted = extractChildren(fieldFn, value, filter);
+    const extracted = extractChildren(field, value, filter);
     return hasChildren(extracted) ? extracted : value;
   });
 }

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -33,7 +33,7 @@ export type RawValue<T> =
  */
 export type DeepPartial<T> =
   | (T extends (infer U)[]
-      ? (DeepPartial<U> | undefined)[]
+      ? DeepPartial<U>[]
       : T extends object
         ? {[K in keyof T]?: DeepPartial<T[K]>}
         : T)
@@ -123,17 +123,14 @@ function extractChildren(
   filter?: ExtractFilter,
 ): unknown {
   if (isArray(value)) {
-    const record = field as unknown as Record<number, unknown>;
-    const arrayValue = value as readonly unknown[];
+    const record = field as unknown as Record<number, FieldTree<unknown>>;
+    const arrayValue = value as readonly FieldTree<unknown>[];
     const result: unknown[] = new Array(arrayValue.length);
     let hasMatch = false;
 
     for (let i = 0; i < arrayValue.length; i++) {
       const child = record[i];
-      if (!isFieldTreeNode(child)) {
-        result[i] = undefined;
-        continue;
-      }
+
       const childResult = visitFieldTree(child, filter);
       if (childResult !== undefined) {
         hasMatch = true;
@@ -157,7 +154,7 @@ function extractChildren(
         const childResult = visitFieldTree(child, filter);
         return childResult !== undefined ? ([key, childResult] as [string, unknown]) : undefined;
       })
-      .filter(isKeyedResult);
+      .filter((v) => v !== undefined);
 
     return entries.length ? Object.fromEntries(entries) : undefined;
   }
@@ -172,10 +169,6 @@ function isFieldTreeNode(value: unknown): value is FieldTree<unknown> {
 function isKeyedChild(
   value: [string, FieldTree<unknown>] | undefined,
 ): value is [string, FieldTree<unknown>] {
-  return value !== undefined;
-}
-
-function isKeyedResult(value: [string, unknown] | undefined): value is [string, unknown] {
   return value !== undefined;
 }
 

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {untracked} from '@angular/core';
+import {AbstractControl} from '@angular/forms';
+import {FieldState, FieldTree} from '../../../src/api/types';
+import {isArray, isObject} from '../../../src/util/type_guards';
+
+/**
+ * Type utility that recursively unwraps the value type of a `FieldTree`.
+ *
+ * If the value type contains `AbstractControl` instances (common in compat mode),
+ * they are replaced with their underlying value types.
+ */
+export type RawValue<T> =
+  T extends AbstractControl<infer TValue, any>
+    ? TValue
+    : T extends (infer U)[]
+      ? RawValue<U>[]
+      : T extends object
+        ? {[K in keyof T]: RawValue<T[K]>}
+        : T;
+
+/**
+ * A type that recursively makes all properties of T optional.
+ * Used for the result of `extractValue` when filtering is applied.
+ * @experimental 21.2.0
+ */
+export type DeepPartial<T> = T extends (infer U)[]
+  ? DeepPartial<U>[]
+  : T extends object
+    ? {[K in keyof T]?: DeepPartial<T[K]>}
+    : T;
+
+/**
+ * Criteria that determine whether a field should be included in the extraction.
+ *
+ * Each property is optional; when provided, the field must match the specified state.
+ *
+ * @category interop
+ * @experimental 21.2.0
+ */
+export interface ExtractFilter {
+  readonly dirty?: boolean;
+  readonly touched?: boolean;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Utility to unwrap a {@link FieldTree} into its underlying raw value.
+ *
+ * This function is recursive, so if the field tree represents an object or an array,
+ * the result will be an object or an array of the raw values of its children.
+ *
+ * @param field The field tree to extract the value from.
+ * @param filter Optional predicate to include only fields matching certain criteria.
+ * @returns The raw value of the field tree, or a partial value if filtering is applied.
+ *
+ * @category interop
+ * @experimental 21.2.0
+ */
+export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
+export function extractValue<T>(
+  field: FieldTree<T>,
+  filter: ExtractFilter,
+): DeepPartial<RawValue<T>> | undefined;
+export function extractValue<T>(
+  field: FieldTree<T>,
+  filter?: ExtractFilter,
+): RawValue<T> | DeepPartial<RawValue<T>> | undefined;
+export function extractValue<T>(
+  field: FieldTree<T>,
+  filter?: ExtractFilter,
+): RawValue<T> | DeepPartial<RawValue<T>> | undefined {
+  return visitFieldTree(field, filter) as RawValue<T> | DeepPartial<RawValue<T>> | undefined;
+}
+
+function visitFieldTree(
+  field: FieldTree<unknown>,
+  filter?: ExtractFilter,
+): RawValue<unknown> | DeepPartial<RawValue<unknown>> | undefined {
+  const fieldFn = field as () => FieldState<unknown>;
+  return untracked(() => {
+    const state = fieldFn();
+    const value = state.value();
+
+    if (!matchesFilter(state, filter)) {
+      return undefined;
+    }
+
+    const extracted = extractChildren(fieldFn, value, filter);
+    return hasChildren(extracted) ? extracted : value;
+  });
+}
+
+function extractChildren(
+  field: FieldTree<unknown>,
+  value: unknown,
+  filter?: ExtractFilter,
+): unknown {
+  if (isArray(value)) {
+    const record = field as unknown as Record<number, unknown>;
+    const arrayValue = value as readonly unknown[];
+    const result: unknown[] = new Array(arrayValue.length);
+    let hasMatch = false;
+
+    for (let i = 0; i < arrayValue.length; i++) {
+      const child = record[i];
+      if (!isFieldTreeNode(child)) {
+        result[i] = undefined;
+        continue;
+      }
+      const extracted = visitFieldTree(child, filter);
+      if (hasChildren(extracted)) {
+        hasMatch = true;
+      }
+      result[i] = extracted;
+    }
+
+    return hasMatch ? result : undefined;
+  }
+
+  if (isObject(value)) {
+    const record = field as unknown as Record<string, unknown>;
+    const objectValue = value as Record<string, unknown>;
+    const entries = Object.keys(objectValue)
+      .map<[string, FieldTree<unknown>] | undefined>((key) => {
+        const child = record[key];
+        return isFieldTreeNode(child) ? [key, child] : undefined;
+      })
+      .filter(isKeyedChild)
+      .map(([key, child]) => {
+        const extracted = visitFieldTree(child, filter);
+        return hasChildren(extracted) ? ([key, extracted] as [string, unknown]) : undefined;
+      })
+      .filter(isKeyedResult);
+
+    return entries.length ? Object.fromEntries(entries) : undefined;
+  }
+
+  return undefined;
+}
+
+function isFieldTreeNode(value: unknown): value is FieldTree<unknown> {
+  return typeof value === 'function';
+}
+
+function isKeyedChild(
+  value: [string, FieldTree<unknown>] | undefined,
+): value is [string, FieldTree<unknown>] {
+  return value !== undefined;
+}
+
+function isKeyedResult(value: [string, unknown] | undefined): value is [string, unknown] {
+  return value !== undefined;
+}
+
+function hasChildren(value: unknown): value is Exclude<unknown, undefined> {
+  return value !== undefined;
+}
+
+function matchesFilter(state: FieldState<unknown>, filter?: ExtractFilter): boolean {
+  if (!filter) {
+    return true;
+  }
+
+  if (filter.dirty !== undefined && state.dirty() !== filter.dirty) {
+    return false;
+  }
+
+  if (filter.touched !== undefined && state.touched() !== filter.touched) {
+    return false;
+  }
+
+  if (filter.enabled !== undefined) {
+    const enabled = !state.disabled();
+    if (enabled !== filter.enabled) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -106,38 +106,47 @@ describe('extractValue', () => {
     f.a().markAsDirty();
     f.c[1]().markAsDirty();
 
-    const dirtyValue = extractValue(f, {dirty: true});
-    const dirtyArray = dirtyValue?.c as Array<number | undefined> | undefined;
-
-    expect(dirtyValue).toBeDefined();
-    expect(dirtyValue!.a).toBe(1);
-    expect(dirtyArray).toEqual([undefined, 2]);
+    expect(extractValue(f, {dirty: true})).toEqual({
+      a: 1,
+      c: [undefined, 2],
+    });
   });
 
-  it('should filter by touched: true', () => {
-    const model = {a: 1};
-    const f = form(signal(model), {injector});
+  describe('filtering by touched (upward propagation)', () => {
+    it('should drop the entire container if `touched: true` and all children are untouched', () => {
+      const model = {a: 1, b: 2};
+      const f = form(signal(model), {injector});
 
-    expect(extractValue(f, {touched: true})).toBeUndefined();
+      f().markAsTouched();
 
-    f().markAsTouched();
+      expect(extractValue(f, {touched: true})).toBeUndefined();
+    });
 
-    expect(extractValue(f, {touched: true})).toEqual(model);
-  });
+    it('should include only touched children if `touched: true`', () => {
+      const model = {a: 1, b: 2};
+      const f = form(signal(model), {injector});
 
-  it('should filter by touched: false', () => {
-    const model = {a: 1, b: 2};
-    const f = form(signal(model), {injector});
+      f.a().markAsTouched();
 
-    expect(extractValue(f, {touched: false})).toEqual(model);
+      expect(extractValue(f, {touched: true})).toEqual({a: 1});
+    });
 
-    f.a().markAsTouched();
+    it('should traverse into touched containers if `touched: false`', () => {
+      const model = {a: 1, b: 2};
+      const f = form(signal(model), {injector});
+      f.a().markAsTouched();
 
-    expect(extractValue(f, {touched: false})).toBeUndefined();
+      expect(extractValue(f, {touched: false})).toEqual({b: 2});
+    });
 
-    f().markAsTouched();
-
-    expect(extractValue(f, {touched: false})).toBeUndefined();
+    it('should drop container if `touched: false` and all children are touched', () => {
+      const model = {a: 1, b: 2};
+      const f = form(signal(model), {injector});
+      f.a().markAsTouched();
+      f.b().markAsTouched();
+      // Parent fails filter. All children fail filter.
+      expect(extractValue(f, {touched: false})).toBeUndefined();
+    });
   });
 
   it('should return undefined if the root is filtered out', () => {
@@ -170,42 +179,92 @@ describe('extractValue', () => {
     expect(extractValue(f, {enabled: true, dirty: true})).toEqual({a: 1});
   });
 
-  it('should preserve array positions when filtering', () => {
-    const model = {items: [1, 2, 3, 4]};
-    const f = form(
-      signal(model),
-      (p) => {
-        applyEach(p.items, (item) => {
-          disabled(item, ({value}) => value() === 2 || value() === 4);
-        });
-      },
-      {injector},
-    );
+  describe('filtering by enabled (downward propagation)', () => {
+    it('should drop the entire container if `enabled: true` and all children are disabled', () => {
+      const model = {a: 1, b: 2};
+      // In Signal forms, disabling children does NOT propagate disabling up to the parent.
+      // So the parent remains `enabled: true`.
+      const f = form(
+        signal(model),
+        (p) => {
+          disabled(p.a);
+          disabled(p.b);
+        },
+        {injector},
+      );
 
-    expect(f.items[1]().disabled()).toBe(true);
+      // Parent matches `enabled: true`. All children fail it.
+      // Container should fully drop because it has no enabled leaf fields.
+      expect(extractValue(f, {enabled: true})).toBeUndefined();
+    });
 
-    const enabledItems = extractValue(f, {enabled: true})?.items as
-      | Array<number | undefined>
-      | undefined;
-    expect(enabledItems).toEqual([1, undefined, 3, undefined]);
-  });
+    it('should traverse into enabled containers if `enabled: false`', () => {
+      const model = {a: 1, b: 2};
+      const f = form(
+        signal(model),
+        (p) => {
+          disabled(p.b);
+        },
+        {injector},
+      );
 
-  it('should keep indexes when only later array elements match filter', () => {
-    const model = {items: [10, 20, 30, 40]};
-    const f = form(
-      signal(model),
-      (p) => {
-        applyEach(p.items, (item) => {
-          disabled(item, ({value}) => value() !== 30);
-        });
-      },
-      {injector},
-    );
+      // Parent is enabled (fails `enabled: false` filter).
+      // Child `a` is enabled (fails). Child `b` is disabled (matches).
+      // Traversal must pierce the failing parent to find the matching child.
+      expect(extractValue(f, {enabled: false})).toEqual({b: 2});
+    });
 
-    const enabledItems = extractValue(f, {enabled: true})?.items as
-      | Array<number | undefined>
-      | undefined;
-    expect(enabledItems).toEqual([undefined, undefined, 30, undefined]);
+    it('should drop the entire container if `enabled: false` and all children are enabled', () => {
+      const model = {a: 1, b: 2};
+      const f = form(signal(model), {injector});
+
+      // Parent fails filter. All children fail filter.
+      expect(extractValue(f, {enabled: false})).toBeUndefined();
+    });
+    it('should preserve array positions when filtering', () => {
+      const model = {items: [1, 2, 3, 4]};
+      const f = form(
+        signal(model),
+        (p) => {
+          applyEach(p.items, (item) => {
+            disabled(item, ({value}) => value() === 2 || value() === 4);
+          });
+        },
+        {injector},
+      );
+
+      expect(extractValue(f, {enabled: true})).toEqual({items: [1, undefined, 3, undefined]});
+    });
+
+    it('should keep indexes when only later array elements match filter', () => {
+      const model = {items: [10, 20, 30, 40]};
+      const f = form(
+        signal(model),
+        (p) => {
+          applyEach(p.items, (item) => {
+            disabled(item, ({value}) => value() !== 30);
+          });
+        },
+        {injector},
+      );
+
+      expect(extractValue(f, {enabled: true})).toEqual({
+        items: [undefined, undefined, 30, undefined],
+      });
+    });
+
+    it('should handle enabled: false filter', () => {
+      const model = {value: 1};
+      const f = form(
+        signal(model),
+        (p) => {
+          disabled(p);
+        },
+        {injector},
+      );
+
+      expect(extractValue(f, {enabled: false})).toEqual(model);
+    });
   });
 
   it('should handle hybrid deep nesting', () => {

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector, signal} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {FormControl, FormGroup} from '@angular/forms';
+import {applyEach, disabled, form} from '@angular/forms/signals';
+import {compatForm, extractValue, SignalFormControl} from '@angular/forms/signals/compat';
+
+describe('extractValue', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    injector = TestBed.inject(Injector);
+  });
+
+  it('should extract a primitive value', () => {
+    const f = form(signal(123), {injector});
+    expect(extractValue(f)).toBe(123);
+  });
+
+  it('should extract an object with primitives', () => {
+    const model = {a: 1, b: 'two'};
+    const f = form(signal(model), {injector});
+    expect(extractValue(f)).toEqual(model);
+  });
+
+  it('should extract nested objects and arrays', () => {
+    const model = {
+      nested: {
+        array: [1, 2, 3],
+      },
+      other: 'value',
+    };
+    const f = form(signal(model), {injector});
+    expect(extractValue(f)).toEqual(model);
+  });
+
+  it('should unwrap AbstractControl in compatForm', () => {
+    const lastNameControl = new FormControl('Doe');
+    const model = {
+      firstName: 'John',
+      lastName: lastNameControl,
+    };
+    const f = compatForm(signal(model), {injector});
+
+    expect(extractValue(f)).toEqual({
+      firstName: 'John',
+      lastName: 'Doe',
+    });
+
+    lastNameControl.setValue('Smith');
+    expect(extractValue(f)).toEqual({
+      firstName: 'John',
+      lastName: 'Smith',
+    });
+  });
+
+  it('should unwrap nested FormGroup in compatForm', () => {
+    const group = new FormGroup({
+      inner: new FormControl('value'),
+    });
+    const model = {
+      group: group,
+    };
+    const f = compatForm(signal(model), {injector});
+
+    expect(extractValue(f)).toEqual({
+      group: {
+        inner: 'value',
+      },
+    });
+
+    group.get('inner')!.setValue('changed');
+    expect(extractValue(f)).toEqual({
+      group: {
+        inner: 'changed',
+      },
+    });
+  });
+
+  it('should filter by enabled: true', () => {
+    const model = {a: 1, b: 2};
+    const f = form(
+      signal(model),
+      (p) => {
+        disabled(p.b);
+      },
+      {injector},
+    );
+
+    expect(extractValue(f, {enabled: true})).toEqual({a: 1});
+  });
+
+  it('should filter by dirty: true', () => {
+    const model = {a: 1, b: 2, c: [1, 2]};
+    const f = form(signal(model), {injector});
+
+    expect(extractValue(f, {dirty: true})).toBeUndefined();
+
+    f.a().markAsDirty();
+    f.c[1]().markAsDirty();
+
+    const dirtyValue = extractValue(f, {dirty: true});
+    const dirtyArray = dirtyValue?.c as Array<number | undefined> | undefined;
+
+    expect(dirtyValue).toBeDefined();
+    expect(dirtyValue!.a).toBe(1);
+    expect(dirtyArray).toEqual([undefined, 2]);
+  });
+
+  it('should filter by touched: true', () => {
+    const model = {a: 1};
+    const f = form(signal(model), {injector});
+
+    expect(extractValue(f, {touched: true})).toBeUndefined();
+
+    f().markAsTouched();
+
+    expect(extractValue(f, {touched: true})).toEqual(model);
+  });
+
+  it('should filter by touched: false', () => {
+    const model = {a: 1, b: 2};
+    const f = form(signal(model), {injector});
+
+    expect(extractValue(f, {touched: false})).toEqual(model);
+
+    f.a().markAsTouched();
+
+    expect(extractValue(f, {touched: false})).toBeUndefined();
+
+    f().markAsTouched();
+
+    expect(extractValue(f, {touched: false})).toBeUndefined();
+  });
+
+  it('should return undefined if the root is filtered out', () => {
+    const f = form(
+      signal(123),
+      (p) => {
+        disabled(p);
+      },
+      {injector},
+    );
+
+    expect(extractValue(f, {enabled: true})).toBeUndefined();
+    expect(extractValue(f, {enabled: false})).toBe(123);
+  });
+
+  it('should handle combined filters (Intersection)', () => {
+    const model = {a: 1, b: 2, c: 3};
+    const f = form(
+      signal(model),
+      (p) => {
+        disabled(p.c);
+      },
+      {injector},
+    );
+
+    f.a().markAsDirty();
+    // f.b is enabled but pristine
+    // f.c is disabled and pristine
+
+    expect(extractValue(f, {enabled: true, dirty: true})).toEqual({a: 1});
+  });
+
+  it('should preserve array positions when filtering', () => {
+    const model = {items: [1, 2, 3, 4]};
+    const f = form(
+      signal(model),
+      (p) => {
+        applyEach(p.items, (item) => {
+          disabled(item, ({value}) => value() === 2 || value() === 4);
+        });
+      },
+      {injector},
+    );
+
+    expect(f.items[1]().disabled()).toBe(true);
+
+    const enabledItems = extractValue(f, {enabled: true})?.items as
+      | Array<number | undefined>
+      | undefined;
+    expect(enabledItems).toEqual([1, undefined, 3, undefined]);
+  });
+
+  it('should keep indexes when only later array elements match filter', () => {
+    const model = {items: [10, 20, 30]};
+    const f = form(
+      signal(model),
+      (p) => {
+        applyEach(p.items, (item) => {
+          disabled(item, ({value}) => value() !== 30);
+        });
+      },
+      {injector},
+    );
+
+    const enabledItems = extractValue(f, {enabled: true})?.items as
+      | Array<number | undefined>
+      | undefined;
+    expect(enabledItems).toEqual([undefined, undefined, 30]);
+  });
+
+  it('should handle hybrid deep nesting', () => {
+    TestBed.runInInjectionContext(() => {
+      const sfc = new SignalFormControl('sfc-value');
+      const group = new FormGroup({
+        inner: sfc,
+      });
+      const model = {
+        wrapper: {
+          group: group,
+        },
+      };
+      const f = compatForm(signal(model), {injector});
+
+      expect(extractValue(f)).toEqual({
+        wrapper: {
+          group: {
+            inner: 'sfc-value',
+          },
+        },
+      });
+    });
+  });
+
+  it('should handle enabled: false filter', () => {
+    const model = {value: 1};
+    const f = form(
+      signal(model),
+      (p) => {
+        disabled(p);
+      },
+      {injector},
+    );
+
+    expect(extractValue(f, {enabled: false})).toEqual(model);
+  });
+});

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -191,7 +191,7 @@ describe('extractValue', () => {
   });
 
   it('should keep indexes when only later array elements match filter', () => {
-    const model = {items: [10, 20, 30]};
+    const model = {items: [10, 20, 30, 40]};
     const f = form(
       signal(model),
       (p) => {
@@ -205,7 +205,7 @@ describe('extractValue', () => {
     const enabledItems = extractValue(f, {enabled: true})?.items as
       | Array<number | undefined>
       | undefined;
-    expect(enabledItems).toEqual([undefined, undefined, 30]);
+    expect(enabledItems).toEqual([undefined, undefined, 30, undefined]);
   });
 
   it('should handle hybrid deep nesting', () => {

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -236,7 +236,7 @@ describe('extractValue', () => {
       expect(extractValue(f, {enabled: true})).toEqual({items: [1, undefined, 3, undefined]});
     });
 
-    it('should keep indexes when only later array elements match filter', () => {
+    it('should keep undefined regardless of the position', () => {
       const model = {items: [10, 20, 30, 40]};
       const f = form(
         signal(model),
@@ -288,18 +288,5 @@ describe('extractValue', () => {
         },
       });
     });
-  });
-
-  it('should handle enabled: false filter', () => {
-    const model = {value: 1};
-    const f = form(
-      signal(model),
-      (p) => {
-        disabled(p);
-      },
-      {injector},
-    );
-
-    expect(extractValue(f, {enabled: false})).toEqual(model);
   });
 });


### PR DESCRIPTION
Adds `extractValue` utility to the `forms/signals/compat` package. This function extracts the raw value from a `FieldTree`, recursively unwrapping `AbstractControl` instances.

It also allows to filter out only dirty/touched/enabled values or their combination to help reproduce ReactiveForms behavior.

## Key Features
- **Unwraps AbstractControls**: Automatically resolves any `AbstractControl` instances in the `FieldTree` to their underlying values (essential for `compatForm`).
- **Structured Filtering**: Adds `ExtractFilter` to selectively extract fields based on state (`dirty`, `touched`, `enabled`).
- **Array Preservation**: Unlike Reactive Forms which removes filtered array items, `extractValue` preserves index positions by setting filtered items to `undefined`.

## Usage
```ts
const f = compatForm(signal({first: 'Alice', last: new FormControl('Doe')}));
extractValue(f); // {first: 'Alice', last: 'Doe'}

// With filter
extractValue(f, {touched: true});
```