### PR TITLE
refactor(compiler): clean up pipeline compatibility distinction

### DIFF
--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -490,16 +490,6 @@ export enum SemanticVariableKind {
 }
 
 /**
- * Whether to compile in compatibilty mode. In compatibility mode, the template pipeline will
- * attempt to match the output of `TemplateDefinitionBuilder` as exactly as possible, at the cost
- * of producing quirky or larger code in some cases.
- */
-export enum CompatibilityMode {
-  Normal,
-  TemplateDefinitionBuilder,
-}
-
-/**
  * Enumeration of the types of attributes which can be applied to an element.
  */
 export enum BindingKind {

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -154,9 +154,6 @@ export interface BindingOp extends Op<UpdateOp> {
 
   /**
    * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`).
-   *
-   * This needs to be tracked for compatibility with `TemplateDefinitionBuilder` which treats
-   * `style` and `class` TextAttributes differently from `[attr.style]` and `[attr.class]`.
    */
   isTextAttribute: boolean;
 
@@ -576,9 +573,6 @@ export interface AttributeOp extends Op<UpdateOp> {
 
   /**
    * Whether the binding is a TextAttribute (e.g. `some-attr="some-value"`).
-   *
-   * This needs to be tracked for compatibility with `TemplateDefinitionBuilder` which treats
-   * `style` and `class` TextAttributes differently from `[attr.style]` and `[attr.class]`.
    */
   isTextAttribute: boolean;
 

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -34,7 +34,6 @@ export abstract class CompilationJob {
   constructor(
     readonly componentName: string,
     readonly pool: ConstantPool,
-    readonly compatibility: ir.CompatibilityMode,
     readonly mode: TemplateCompilationMode,
   ) {}
 
@@ -78,7 +77,6 @@ export class ComponentCompilationJob extends CompilationJob {
   constructor(
     componentName: string,
     pool: ConstantPool,
-    compatibility: ir.CompatibilityMode,
     mode: TemplateCompilationMode,
     readonly relativeContextFilePath: string,
     readonly i18nUseExternalIds: boolean,
@@ -87,7 +85,7 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly relativeTemplatePath: string | null,
     readonly enableDebugLocations: boolean,
   ) {
-    super(componentName, pool, compatibility, mode);
+    super(componentName, pool, mode);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);
     this.views.set(this.root.xref, this.root);
   }
@@ -265,13 +263,8 @@ export class ViewCompilationUnit extends CompilationUnit {
  * Compilation-in-progress of a host binding, which contains a single unit for that host binding.
  */
 export class HostBindingCompilationJob extends CompilationJob {
-  constructor(
-    componentName: string,
-    pool: ConstantPool,
-    compatibility: ir.CompatibilityMode,
-    mode: TemplateCompilationMode,
-  ) {
-    super(componentName, pool, compatibility, mode);
+  constructor(componentName: string, pool: ConstantPool, mode: TemplateCompilationMode) {
+    super(componentName, pool, mode);
     this.root = new HostBindingCompilationUnit(this);
   }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -30,8 +30,6 @@ import {
 } from './compilation';
 import {BINARY_OPERATORS, namespaceForKey, prefixWithNamespace} from './conversion';
 
-const compatibilityMode = ir.CompatibilityMode.TemplateDefinitionBuilder;
-
 // Schema containing DOM elements and their properties.
 const domSchema = new DomElementSchemaRegistry();
 
@@ -69,7 +67,6 @@ export function ingestComponent(
   const job = new ComponentCompilationJob(
     componentName,
     constantPool,
-    compatibilityMode,
     compilationMode,
     relativeContextFilePath,
     i18nUseExternalIds,
@@ -102,7 +99,6 @@ export function ingestHostBinding(
   const job = new HostBindingCompilationJob(
     input.componentName,
     constantPool,
-    compatibilityMode,
     TemplateCompilationMode.DomOnly,
   );
   for (const property of input.properties ?? []) {
@@ -486,16 +482,12 @@ function ingestBoundText(
 
   const textXref = unit.job.allocateXrefId();
   unit.create.push(ir.createTextOp(textXref, '', icuPlaceholder, text.sourceSpan));
-  // TemplateDefinitionBuilder does not generate source maps for sub-expressions inside an
-  // interpolation. We copy that behavior in compatibility mode.
-  // TODO: is it actually correct to generate these extra maps in modern mode?
-  const baseSourceSpan = unit.job.compatibility ? null : text.sourceSpan;
   unit.update.push(
     ir.createInterpolateTextOp(
       textXref,
       new ir.Interpolation(
         value.strings,
-        value.expressions.map((expr) => convertAst(expr, unit.job, baseSourceSpan)),
+        value.expressions.map((expr) => convertAst(expr, unit.job, null)),
         i18nPlaceholders,
       ),
       text.sourceSpan,

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -77,10 +77,7 @@ export function extractAttributes(job: CompilationJob): void {
           // The old compiler treated empty style bindings as regular bindings for the purpose of
           // directive matching. That behavior is incorrect, but we emulate it in compatibility
           // mode.
-          if (
-            unit.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-            op.expression instanceof ir.EmptyExpr
-          ) {
+          if (op.expression instanceof ir.EmptyExpr) {
             ir.OpList.insertBefore<ir.CreateOp>(
               ir.createExtractedAttributeOp(
                 op.target,
@@ -109,14 +106,9 @@ export function extractAttributes(job: CompilationJob): void {
               SecurityContext.NONE,
             );
             if (job.kind === CompilationJobKind.Host) {
-              if (job.compatibility) {
-                // TemplateDefinitionBuilder does not extract listener bindings to the const array
-                // (which is honestly pretty inconsistent).
-                break;
-              }
-              // This attribute will apply to the enclosing host binding compilation unit, so order
-              // doesn't matter.
-              unit.create.push(extractedAttributeOp);
+              // TemplateDefinitionBuilder does not extract listener bindings to the const array
+              // (which is honestly pretty inconsistent).
+              break;
             } else {
               ir.OpList.insertBefore<ir.CreateOp>(
                 extractedAttributeOp,
@@ -175,14 +167,9 @@ function extractAttributeOp(
     return;
   }
 
-  let extractable = op.isTextAttribute || op.expression.isConstant();
-  if (unit.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder) {
-    // TemplateDefinitionBuilder only extracts text attributes. It does not extract attriibute
-    // bindings, even if they are constants.
-    extractable &&= op.isTextAttribute;
-  }
-
-  if (extractable) {
+  // TemplateDefinitionBuilder only extracts text attributes. It does not extract attriibute
+  // bindings, even if they are constants.
+  if (op.isTextAttribute) {
     const extractedAttributeOp = ir.createExtractedAttributeOp(
       op.target,
       op.isStructuralTemplateAttribute ? ir.BindingKind.Template : ir.BindingKind.Attribute,

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -27,8 +27,7 @@ export function collectElementConsts(job: CompilationJob): void {
   for (const unit of job.units) {
     for (const op of unit.create) {
       if (op.kind === ir.OpKind.ExtractedAttribute) {
-        const attributes =
-          allElementAttributes.get(op.target) || new ElementAttributes(job.compatibility);
+        const attributes = allElementAttributes.get(op.target) || new ElementAttributes();
         allElementAttributes.set(op.target, attributes);
         attributes.add(op.bindingKind, op.name, op.expression, op.namespace, op.trustedValueFn);
         ir.OpList.remove<ir.CreateOp>(op);
@@ -138,8 +137,6 @@ class ElementAttributes {
     return this.byKind.get(ir.BindingKind.I18n) ?? FLYWEIGHT_ARRAY;
   }
 
-  constructor(private compatibility: ir.CompatibilityMode) {}
-
   private isKnown(kind: ir.BindingKind, name: string) {
     const nameToValue = this.known.get(kind) ?? new Set<string>();
     this.known.set(kind, nameToValue);
@@ -161,10 +158,9 @@ class ElementAttributes {
     // array. This seems inefficient, we can probably keep just the first one or the last value
     // (whichever actually gets applied when multiple values are listed for the same attribute).
     const allowDuplicates =
-      this.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-      (kind === ir.BindingKind.Attribute ||
-        kind === ir.BindingKind.ClassName ||
-        kind === ir.BindingKind.StyleProperty);
+      kind === ir.BindingKind.Attribute ||
+      kind === ir.BindingKind.ClassName ||
+      kind === ir.BindingKind.StyleProperty;
     if (!allowDuplicates && this.isKnown(kind, name)) {
       return;
     }

--- a/packages/compiler/src/template/pipeline/src/phases/deduplicate_text_bindings.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/deduplicate_text_bindings.ts
@@ -18,20 +18,12 @@ export function deduplicateTextBindings(job: CompilationJob): void {
     for (const op of unit.update.reversed()) {
       if (op.kind === ir.OpKind.Binding && op.isTextAttribute) {
         const seenForElement = seen.get(op.target) || new Set();
-        if (seenForElement.has(op.name)) {
-          if (job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder) {
-            // For most duplicated attributes, TemplateDefinitionBuilder lists all of the values in
-            // the consts array. However, for style and class attributes it only keeps the last one.
-            // We replicate that behavior here since it has actual consequences for apps with
-            // duplicate class or style attrs.
-            if (op.name === 'style' || op.name === 'class') {
-              ir.OpList.remove<ir.UpdateOp>(op);
-            }
-          } else {
-            // TODO: Determine the correct behavior. It would probably make sense to merge multiple
-            // style and class attributes. Alternatively we could just throw an error, as HTML
-            // doesn't permit duplicate attributes.
-          }
+        // For most duplicated attributes, TemplateDefinitionBuilder lists all of the values in
+        // the consts array. However, for style and class attributes it only keeps the last one.
+        // We replicate that behavior here since it has actual consequences for apps with
+        // duplicate class or style attrs.
+        if (seenForElement.has(op.name) && (op.name === 'style' || op.name === 'class')) {
+          ir.OpList.remove<ir.UpdateOp>(op);
         }
         seenForElement.add(op.name);
         seen.set(op.target, seenForElement);

--- a/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
@@ -106,9 +106,7 @@ function eliminateTemporaryAssignments(
         // temporary variables to themselves. This happens because some subexpression that the
         // temporary refers to, possibly through nested temporaries, has a function call. We copy that
         // behavior here.
-        return ctx.job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder
-          ? new ir.AssignTemporaryExpr(read, read.xref)
-          : read;
+        return new ir.AssignTemporaryExpr(read, read.xref);
       }
       return e;
     },

--- a/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_projection_def.ts
@@ -19,7 +19,7 @@ import {literalOrArrayLiteral} from '../conversion';
  */
 export function generateProjectionDefs(job: ComponentCompilationJob): void {
   // TODO: Why does TemplateDefinitionBuilder force a shared constant?
-  const share = job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder;
+  const share = true;
 
   // Collect all selectors from this component, and its nested views. Also, assign each projection a
   // unique ascending projection slot index.

--- a/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
@@ -37,19 +37,12 @@ function processPipeBindingsInView(unit: CompilationUnit): void {
         throw new Error(`AssertionError: pipe bindings should not appear in child expressions`);
       }
 
-      if (unit.job.compatibility) {
-        // TODO: We can delete this cast and check once compatibility mode is removed.
-        const slotHandle = (updateOp as any).target;
-        if (slotHandle == undefined) {
-          throw new Error(`AssertionError: expected slot handle to be assigned for pipe creation`);
-        }
-        addPipeToCreationBlock(unit, (updateOp as any).target, expr);
-      } else {
-        // When not in compatibility mode, we just add the pipe to the end of the create block. This
-        // is not only simpler and faster, but allows more chaining opportunities for other
-        // instructions.
-        unit.create.push(ir.createPipeOp(expr.target, expr.targetSlot, expr.name));
+      // TODO: We can delete this cast and check once compatibility mode is removed.
+      const slotHandle = (updateOp as any).target;
+      if (slotHandle == undefined) {
+        throw new Error(`AssertionError: expected slot handle to be assigned for pipe creation`);
       }
+      addPipeToCreationBlock(unit, (updateOp as any).target, expr);
     });
   }
 }

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -37,10 +37,7 @@ export function countVariables(job: CompilationJob): void {
       // TemplateDefinitionBuilder assigns variable offsets for everything but pure functions
       // first, and then assigns offsets to pure functions lazily. We emulate that behavior by
       // assigning offsets in two passes instead of one, only in compatibility mode.
-      if (
-        job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
-        expr instanceof ir.PureFunctionExpr
-      ) {
+      if (expr instanceof ir.PureFunctionExpr) {
         return;
       }
 
@@ -81,13 +78,11 @@ export function countVariables(job: CompilationJob): void {
       ir.visitExpressionsInOp(updateOp, firstPassCountExpressionVars);
     }
 
-    if (job.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder) {
-      for (const createOp of unit.create) {
-        ir.visitExpressionsInOp(createOp, secondPassCountExpressionVars);
-      }
-      for (const updateOp of unit.update) {
-        ir.visitExpressionsInOp(updateOp, secondPassCountExpressionVars);
-      }
+    for (const createOp of unit.create) {
+      ir.visitExpressionsInOp(createOp, secondPassCountExpressionVars);
+    }
+    for (const updateOp of unit.update) {
+      ir.visitExpressionsInOp(updateOp, secondPassCountExpressionVars);
     }
 
     unit.vars = varCount;


### PR DESCRIPTION
Removes the switch for compatibility mode from the template pipeline since we never got around to removing it and at this point it causes a bunch of runtime errors.
