### PR TITLE
feat(compiler): add nativeOptionalChainingSemantics option

### DIFF
--- a/adev/src/content/tools/cli/template-typecheck.md
+++ b/adev/src/content/tools/cli/template-typecheck.md
@@ -120,6 +120,29 @@ Unless otherwise commented, each following option is set to the value for `stric
 | `strictContextGenerics`      | Whether the type parameters of generic components will be inferred correctly \(including any generic bounds\). If disabled, any type parameters will be `any`.                                                                                                                                                                                                                |
 | `strictLiteralTypes`         | Whether object and array literals declared in the template will have their type inferred. If disabled, the type of such literals will be `any`. This flag is `true` when _either_ `fullTemplateTypeCheck` or `strictTemplates` is set to `true`.                                                                                                                              |
 
+### Optional chaining semantics
+
+By default, Angular templates use legacy semantics for the safe navigation operator (`?.`), where `a?.b` evaluates to `null` when `a` is `null` or `undefined`. This differs from native ECMAScript optional chaining, which evaluates to `undefined`.
+
+To opt into native ECMAScript semantics, set `nativeOptionalChainingSemantics` to `true` in `angularCompilerOptions`:
+
+<docs-code language="json">
+{
+  "angularCompilerOptions": {
+    "nativeOptionalChainingSemantics": true
+  }
+}
+</docs-code>
+
+When enabled:
+
+- `a?.b` evaluates to `undefined` (instead of `null`) at runtime when `a` is nullish
+- This aligns runtime behavior with TypeScript's type inference (which already uses `| undefined`)
+- The flag only affects components compiled in the current project — libraries from npm retain the semantics they were compiled with
+- The per-template `optionalChainingSemantics` metadata is written into partial declarations so that the linker always respects the intended behavior
+
+**Migration note:** Use `ng generate @angular/core:optional-chaining-semantics-migration` to identify components with `?.` usage in their templates. Review each component to ensure it does not depend on the `null` return value before enabling the flag. Note that `a?.b ?? null` is **not** a safe blanket migration — it would incorrectly change genuinely `undefined` property values (e.g., when the property exists but is `undefined`) to `null`.
+
 If you still have issues after troubleshooting with these flags, fall back to full mode by disabling `strictTemplates`.
 
 If that doesn't work, an option of last resort is to turn off full mode entirely with `fullTemplateTypeCheck: false`.

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -11,6 +11,7 @@ import {
   ForwardRefHandling,
   LegacyInputPartialMapping,
   makeBindingParser,
+  OptionalChainingSemantics,
   outputAst as o,
   ParseLocation,
   ParseSourceFile,
@@ -104,6 +105,11 @@ export function toR3DirectiveMeta<TExpression>(
       ? metaObj.getBoolean('isStandalone')
       : getDefaultStandaloneValue(version),
     isSignal: metaObj.has('isSignal') ? metaObj.getBoolean('isSignal') : false,
+    hostOptionalChainingSemantics:
+      metaObj.has('hostOptionalChainingSemantics') &&
+      metaObj.getString('hostOptionalChainingSemantics') === 'native'
+        ? OptionalChainingSemantics.Native
+        : OptionalChainingSemantics.Legacy,
     hostDirectives: metaObj.has('hostDirectives')
       ? toHostDirectivesMetadata(metaObj.getValue('hostDirectives'))
       : null,

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -466,4 +466,22 @@ export interface MiscOptions {
    * another library without option set will not issue error if rendered in orphan way.
    */
   forbidOrphanComponents?: boolean;
+
+  /**
+   * When enabled, safe navigation (`?.`) expressions in templates of components compiled in
+   * this compilation unit return `undefined` on short-circuit, matching JavaScript/TypeScript
+   * optional chaining semantics (TC39 spec).
+   *
+   * When disabled (default), safe navigation returns `null` on short-circuit, which is
+   * Angular's historical behavior.
+   *
+   * This flag only affects components compiled directly in this project. Libraries consumed
+   * from npm (partially or fully compiled) retain the semantics they were compiled with.
+   * The linker reads each library's `optionalChainingSemantics` metadata and defaults to
+   * `'legacy'` when the metadata is absent, ensuring backward compatibility regardless of
+   * this flag's value in the consuming application.
+   *
+   * Defaults to `false`.
+   */
+  nativeOptionalChainingSemantics?: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1541,6 +1541,7 @@ export class NgCompiler {
         typeCheckHostBindings,
         this.enableSelectorless,
         this.emitDeclarationOnly,
+        !!this.options.nativeOptionalChainingSemantics,
       ),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
@@ -1570,6 +1571,7 @@ export class NgCompiler {
         this.usePoisonedData,
         typeCheckHostBindings,
         this.emitDeclarationOnly,
+        !!this.options.nativeOptionalChainingSemantics,
       ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null, unknown>>,
       // Pipe handler must be before injectable handler in list so pipe factories are printed
       // before injectable factories (so injectable factories can delegate to them)

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -644,6 +644,20 @@ export enum ErrorCode {
   FORBIDDEN_REQUIRED_INITIALIZER_INVOCATION = 8118,
 
   /**
+   * Safe navigation (`?.`) is used in a template that still uses legacy semantics
+   * (returning `null` on short-circuit instead of `undefined`).
+   *
+   * This diagnostic helps identify `?.` usage that may behave differently after
+   * enabling `nativeOptionalChainingSemantics`. It is only active when the
+   * `legacySafeNavigationUsage` extended diagnostic is enabled.
+   *
+   * ```html
+   * {{ user?.name }}
+   * ```
+   */
+  LEGACY_SAFE_NAVIGATION_USAGE = 8119,
+
+  /**
    * The template type-checking engine would need to generate an inline type check block for a
    * component, but the current type-checking environment doesn't support it.
    */

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
@@ -34,4 +34,5 @@ export enum ExtendedTemplateDiagnosticName {
   UNPARENTHESIZED_NULLISH_COALESCING = 'unparenthesizedNullishCoalescing',
   UNINVOKED_FUNCTION_IN_TEXT_INTERPOLATION = 'uninvokedFunctionInTextInterpolation',
   DEFER_TRIGGER_MISCONFIGURATION = 'deferTriggerMisconfiguration',
+  LEGACY_SAFE_NAVIGATION_USAGE = 'legacySafeNavigationUsage',
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
@@ -16,6 +16,7 @@ ts_project(
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/invalid_banana_in_box",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_ngforof_let",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_structural_directive",

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools:defaults.bzl", "ts_project")
+
+ts_project(
+    name = "legacy_safe_navigation_usage",
+    srcs = ["index.ts"],
+    visibility = ["//packages/compiler-cli/src/ngtsc:__subpackages__"],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AST, SafeCall, SafeKeyedRead, SafePropertyRead, TmplAstNode} from '@angular/compiler';
+import ts from 'typescript';
+
+import {NgCompilerOptions} from '../../../../core/api';
+import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../../../diagnostics';
+import {NgTemplateDiagnostic} from '../../../api';
+import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '../../api';
+
+/**
+ * Warns when safe navigation (`?.`) is used in a template that still uses legacy
+ * semantics (returning `null` on short-circuit instead of `undefined`).
+ *
+ * This diagnostic helps developers identify `?.` usage that will behave differently
+ * after enabling `nativeOptionalChainingSemantics: true`. It is off by default and
+ * must be explicitly enabled via `extendedDiagnostics` configuration:
+ *
+ * ```json
+ * {
+ *   "angularCompilerOptions": {
+ *     "extendedDiagnostics": {
+ *       "checks": {
+ *         "legacySafeNavigationUsage": "warning"
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Once all flagged expressions have been reviewed and the migration applied,
+ * the developer can enable `nativeOptionalChainingSemantics: true` and remove
+ * this diagnostic.
+ */
+class LegacySafeNavigationUsageCheck extends TemplateCheckWithVisitor<ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE> {
+  override code = ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE as const;
+
+  override visitNode(
+    ctx: TemplateContext<ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE>,
+    component: ts.ClassDeclaration,
+    node: TmplAstNode | AST,
+  ): NgTemplateDiagnostic<ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE>[] {
+    if (
+      !(node instanceof SafeCall) &&
+      !(node instanceof SafePropertyRead) &&
+      !(node instanceof SafeKeyedRead)
+    ) {
+      return [];
+    }
+
+    const symbol = ctx.templateTypeChecker.getSymbolOfNode(node, component);
+    if (symbol === null) {
+      return [];
+    }
+
+    if (!('tcbLocation' in symbol)) {
+      return [];
+    }
+
+    const templateMapping = ctx.templateTypeChecker.getSourceMappingAtTcbLocation(
+      symbol.tcbLocation,
+    );
+    if (templateMapping === null) {
+      return [];
+    }
+
+    const diagnostic = ctx.makeTemplateDiagnostic(
+      templateMapping.span,
+      `This safe navigation expression uses legacy Angular semantics (returns 'null' on short-circuit). ` +
+        `With 'nativeOptionalChainingSemantics' enabled, it would return 'undefined' instead, ` +
+        `matching native ECMAScript optional chaining behavior. ` +
+        `Run the optional chaining migration to auto-convert simple property chains, ` +
+        `or manually verify this expression before enabling native semantics.`,
+    );
+    return [diagnostic];
+  }
+}
+
+export const factory: TemplateCheckFactory<
+  ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE,
+  ExtendedTemplateDiagnosticName.LEGACY_SAFE_NAVIGATION_USAGE
+> = {
+  code: ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE,
+  name: ExtendedTemplateDiagnosticName.LEGACY_SAFE_NAVIGATION_USAGE,
+  create: (options: NgCompilerOptions) => {
+    // Only report when the project is NOT yet using native semantics.
+    // If nativeOptionalChainingSemantics is already enabled, the diagnostic is not needed.
+    if (options.nativeOptionalChainingSemantics) {
+      return null;
+    }
+    return new LegacySafeNavigationUsageCheck();
+  },
+};

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
@@ -16,6 +16,7 @@ import {factory as missingNgForOfLetFactory} from './checks/missing_ngforof_let'
 import {factory as missingStructuralDirectiveFactory} from './checks/missing_structural_directive';
 import {factory as nullishCoalescingNotNullableFactory} from './checks/nullish_coalescing_not_nullable';
 import {factory as optionalChainNotNullableFactory} from './checks/optional_chain_not_nullable';
+import {factory as legacySafeNavigationUsageFactory} from './checks/legacy_safe_navigation_usage';
 import {factory as skipHydrationNotStaticFactory} from './checks/skip_hydration_not_static';
 import {factory as suffixNotSupportedFactory} from './checks/suffix_not_supported';
 import {factory as textAttributeNotBindingFactory} from './checks/text_attribute_not_binding';
@@ -35,6 +36,7 @@ export const ALL_DIAGNOSTIC_FACTORIES: readonly TemplateCheckFactory<
   invalidBananaInBoxFactory,
   nullishCoalescingNotNullableFactory,
   optionalChainNotNullableFactory,
+  legacySafeNavigationUsageFactory,
   missingControlFlowDirectiveFactory,
   textAttributeNotBindingFactory,
   missingNgForOfLetFactory,

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/legacy_safe_navigation_usage/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/legacy_safe_navigation_usage/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["legacy_safe_navigation_usage_spec.ts"],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/legacy_safe_navigation_usage",
+        "//packages/compiler-cli/src/ngtsc/typecheck/testing",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [
+        ":test_lib",
+        "//packages/core:npm_package",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/legacy_safe_navigation_usage/legacy_safe_navigation_usage_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/legacy_safe_navigation_usage/legacy_safe_navigation_usage_spec.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
+import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
+import {runInEachFileSystem} from '../../../../../file_system/testing';
+import {getSourceCodeForDiagnostic} from '../../../../../testing';
+import {getClass, setup} from '../../../../testing';
+import {factory as legacySafeNavigationUsageFactory} from '../../../checks/legacy_safe_navigation_usage';
+import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checker';
+
+runInEachFileSystem(() => {
+  describe('LegacySafeNavigationUsageCheck', () => {
+    it('binds the error code to its extended template diagnostic name', () => {
+      expect(legacySafeNavigationUsageFactory.code).toBe(ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE);
+      expect(legacySafeNavigationUsageFactory.name).toBe(
+        ExtendedTemplateDiagnosticName.LEGACY_SAFE_NAVIGATION_USAGE,
+      );
+    });
+
+    it('should return a check when nativeOptionalChainingSemantics is not enabled', () => {
+      expect(legacySafeNavigationUsageFactory.create({})).toBeDefined();
+    });
+
+    it('should return a check when nativeOptionalChainingSemantics is explicitly false', () => {
+      expect(
+        legacySafeNavigationUsageFactory.create({nativeOptionalChainingSemantics: false}),
+      ).toBeDefined();
+    });
+
+    it('should NOT return a check when nativeOptionalChainingSemantics is enabled', () => {
+      expect(
+        legacySafeNavigationUsageFactory.create({nativeOptionalChainingSemantics: true}),
+      ).toBeNull();
+    });
+
+    it('should produce warning for safe property read in legacy mode', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `{{ var1?.bar }}`,
+          },
+          source: 'export class TestCmp { var1: { bar: string } | null = null; }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [legacySafeNavigationUsageFactory],
+        {} /* options — no nativeOptionalChainingSemantics */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE));
+      expect(diags[0].messageText).toContain('legacy Angular semantics');
+    });
+
+    it('should produce warning for safe keyed read', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `{{ var1?.['key'] }}`,
+          },
+          source: 'export class TestCmp { var1: Record<string, string> | null = null; }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [legacySafeNavigationUsageFactory],
+        {} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE));
+    });
+
+    it('should produce warning for safe method call', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `{{ var1?.method() }}`,
+          },
+          source: 'export class TestCmp { var1: { method(): string } | null = null; }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [legacySafeNavigationUsageFactory],
+        {} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(1);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.LEGACY_SAFE_NAVIGATION_USAGE));
+    });
+
+    it('should produce multiple warnings for multiple safe reads', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `{{ a?.b }} {{ c?.d }}`,
+          },
+          source:
+            'export class TestCmp { a: {b: string}|null = null; c: {d: string}|null = null; }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [legacySafeNavigationUsageFactory],
+        {} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(2);
+    });
+
+    it('should not produce warning for regular property read', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': `{{ var1.bar }}`,
+          },
+          source: 'export class TestCmp { var1 = { bar: "hello" }; }',
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [legacySafeNavigationUsageFactory],
+        {} /* options */,
+      );
+      const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+      expect(diags.length).toBe(0);
+    });
+  });
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -340,3 +340,53 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_native_semantics.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.p = null;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
+  <span>Safe Property: {{ p?.a?.b }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b'] }}</span>
+`, isInline: true, optionalChainingSemantics: "native" });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+        type: Component,
+        args: [{
+                template: `
+  <span>Safe Property: {{ p?.a?.b }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b'] }}</span>
+`,
+                standalone: false
+            }]
+    }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+        type: NgModule,
+        args: [{ declarations: [MyApp] }]
+    }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_native_semantics.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    p: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -98,6 +98,24 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should use undefined for safe navigation with native optional chaining semantics",
+      "inputFiles": ["safe_access_native_semantics.ts"],
+      "angularCompilerOptions": {
+        "nativeOptionalChainingSemantics": true
+      },
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_access_native_semantics_template.js",
+              "generated": "safe_access_native_semantics.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_native_semantics.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_native_semantics.ts
@@ -1,0 +1,16 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+    template: `
+  <span>Safe Property: {{ p?.a?.b }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b'] }}</span>
+`,
+    standalone: false
+})
+export class MyApp {
+  p: any = null;
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_native_semantics_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_native_semantics_template.js
@@ -1,0 +1,6 @@
+} if (rf & 2) {
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate1("Safe Property: ", ctx.p == null ? undefined : ctx.p.a == null ? undefined : ctx.p.a.b);
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Safe Keyed: ", ctx.p == null ? undefined : ctx.p["a"] == null ? undefined : ctx.p["a"]["b"]);
+}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -1026,13 +1026,16 @@ runInEachFileSystem(() => {
         env.tsconfig({strictTemplates: true});
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(2);
+        // The legacy safe navigation usage diagnostic (NG8119) fires since
+        // nativeOptionalChainingSemantics is not explicitly enabled.
+        expect(diags.length).toBe(3);
         expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toEqual(
           `Type 'boolean | undefined' is not assignable to type 'boolean'.`,
         );
         expect(diags[1].messageText).toEqual(
           `Property 'invalid' does not exist on type 'TestCmp'.`,
         );
+        expect(diags[2].messageText).toContain('legacy Angular semantics');
       });
 
       it('should not infer result type for safe navigation expressions when not enabled', () => {

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -205,11 +205,13 @@ export interface R3DirectiveMetadataFacade {
   isStandalone: boolean;
   hostDirectives: R3HostDirectiveMetadataFacade[] | null;
   isSignal: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   template: string;
   preserveWhitespaces: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
   animations: OpaqueValue[] | undefined;
   declarations: R3TemplateDependencyFacade[];
   styles: string[];
@@ -258,6 +260,7 @@ export interface R3DeclareDirectiveFacade {
   isStandalone?: boolean;
   isSignal?: boolean;
   hostDirectives?: R3HostDirectiveMetadataFacade[] | null;
+  hostOptionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
@@ -279,6 +282,7 @@ export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
   changeDetection?: ChangeDetectionStrategy;
   encapsulation?: ViewEncapsulation;
   preserveWhitespaces?: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export type R3DeclareTemplateDependencyFacade = {

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1483,6 +1483,7 @@ export interface ExpressionVisitor {
 
 export const NULL_EXPR = new LiteralExpr(null, null, null);
 export const TYPED_NULL_EXPR = new LiteralExpr(null, INFERRED_TYPE, null);
+export const UNDEFINED_EXPR = new LiteralExpr(undefined, null, null);
 
 //// Statements
 export enum StmtModifier {

--- a/packages/compiler/src/render3/partial/api.ts
+++ b/packages/compiler/src/render3/partial/api.ts
@@ -146,6 +146,11 @@ export interface R3DeclareDirectiveMetadata extends R3PartialDeclaration {
   isSignal?: boolean;
 
   /**
+   * Optional chaining semantics for host binding expressions.
+   */
+  hostOptionalChainingSemantics?: 'legacy' | 'native';
+
+  /**
    * Additional directives applied to the directive host.
    */
   hostDirectives?: R3DeclareHostDirectiveMetadata[];
@@ -236,6 +241,14 @@ export interface R3DeclareComponentMetadata extends R3DeclareDirectiveMetadata {
    * Whether whitespace in the template should be preserved. Defaults to false.
    */
   preserveWhitespaces?: boolean;
+
+  /**
+   * The semantics used for safe navigation (`?.`) expressions in this template.
+   * `'legacy'` means safe navigation returns `null` on short-circuit (default).
+   * `'native'` means safe navigation returns `undefined`, matching native ECMAScript optional chaining.
+   * If not present, defaults to `'legacy'`.
+   */
+  optionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export type R3DeclareTemplateDependencyMetadata =

--- a/packages/compiler/src/render3/partial/component.ts
+++ b/packages/compiler/src/render3/partial/component.ts
@@ -14,6 +14,7 @@ import {generateForwardRef, R3CompiledExpression} from '../util';
 import {
   DeclarationListEmitMode,
   DeferBlockDepsEmitMode,
+  OptionalChainingSemantics,
   R3ComponentMetadata,
   R3TemplateDependencyKind,
   R3TemplateDependencyMetadata,
@@ -128,6 +129,11 @@ export function createComponentDefinitionMap(
   if (template.preserveWhitespaces === true) {
     definitionMap.set('preserveWhitespaces', o.literal(true));
   }
+
+  // Always write optionalChainingSemantics so the linker knows the intended behavior.
+  // Default is 'legacy' for backward compatibility with libraries compiled before this feature.
+  const semantics = meta.template.optionalChainingSemantics ?? OptionalChainingSemantics.Legacy;
+  definitionMap.set('optionalChainingSemantics', o.literal(semantics));
 
   if (meta.defer.mode === DeferBlockDepsEmitMode.PerBlock) {
     const resolvers: o.Expression[] = [];

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -12,7 +12,12 @@ import {
   generateForwardRef,
   R3CompiledExpression,
 } from '../util';
-import {R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from '../view/api';
+import {
+  OptionalChainingSemantics,
+  R3DirectiveMetadata,
+  R3HostMetadata,
+  R3QueryMetadata,
+} from '../view/api';
 import {createDirectiveType, createHostDirectivesMappingArray} from '../view/compiler';
 import {
   asLiteral,
@@ -60,6 +65,10 @@ export function createDirectiveDefinitionMap(
   if (meta.isSignal) {
     definitionMap.set('isSignal', o.literal(meta.isSignal));
   }
+
+  const hostOptionalChainingSemantics =
+    meta.hostOptionalChainingSemantics ?? OptionalChainingSemantics.Legacy;
+  definitionMap.set('hostOptionalChainingSemantics', o.literal(hostOptionalChainingSemantics));
 
   // e.g. `selector: 'some-dir'`
   if (meta.selector !== null) {

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -121,6 +121,27 @@ export interface R3DirectiveMetadata {
    * Additional directives applied to the directive host.
    */
   hostDirectives: R3HostDirectiveMetadata[] | null;
+
+  /**
+   * Optional chaining semantics for host binding expressions.
+   * When `Native`, safe navigation (`?.`) in host bindings evaluates to `undefined`.
+   * When `Legacy` (default), safe navigation evaluates to `null`.
+   */
+  hostOptionalChainingSemantics?: OptionalChainingSemantics;
+}
+
+/**
+ * Specifies the semantics used for safe navigation (`?.`) expressions in a template.
+ *
+ * - `Legacy`: Safe navigation returns `null` on short-circuit (Angular's historical behavior).
+ * - `Native`: Safe navigation returns `undefined` on short-circuit, matching native ECMAScript
+ *   optional chaining semantics (TC39 spec).
+ */
+export enum OptionalChainingSemantics {
+  /** Legacy Angular semantics: `a?.b` evaluates to `null` when `a` is nullish. */
+  Legacy = 'legacy',
+  /** Native ECMAScript semantics: `a?.b` evaluates to `undefined` when `a` is nullish. */
+  Native = 'native',
 }
 
 /**
@@ -219,6 +240,13 @@ export interface R3ComponentMetadata<
      * Whether the template preserves whitespaces from the user's code.
      */
     preserveWhitespaces?: boolean;
+
+    /**
+     * The semantics used for safe navigation (`?.`) expressions in this template.
+     * When set to `OptionalChainingSemantics.Native`, safe navigation returns `undefined`
+     * on short-circuit (matching native ECMAScript optional chaining). Defaults to `Legacy` (`null`).
+     */
+    optionalChainingSemantics?: OptionalChainingSemantics;
   };
 
   declarations: DeclarationT[];

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -22,6 +22,7 @@ import {R3CompiledExpression, typeWithParameters} from '../util';
 import {
   DeclarationListEmitMode,
   DeferBlockDepsEmitMode,
+  OptionalChainingSemantics,
   R3ComponentMetadata,
   R3DeferResolverFunctionMetadata,
   R3DirectiveMetadata,
@@ -80,6 +81,7 @@ function baseDirectiveFields(
       meta.selector || '',
       meta.name,
       definitionMap,
+      meta.hostOptionalChainingSemantics,
     ),
   );
 
@@ -248,6 +250,7 @@ export function compileComponentFromMetadata(
     allDeferrableDepsFn,
     meta.relativeTemplatePath,
     getTemplateSourceLocationsEnabled(),
+    meta.template.optionalChainingSemantics ?? OptionalChainingSemantics.Legacy,
   );
 
   // Then the IR is transformed to prepare it for code generation.
@@ -487,6 +490,7 @@ function createHostBindingsFunction(
   selector: string,
   name: string,
   definitionMap: DefinitionMap,
+  optionalChainingSemantics?: OptionalChainingSemantics,
 ): o.Expression | null {
   const bindings = bindingParser.createBoundHostProperties(
     hostBindingsMetadata.properties,
@@ -521,6 +525,7 @@ function createHostBindingsFunction(
       properties: bindings,
       events: eventBindings,
       attributes: hostBindingsMetadata.attributes,
+      optionalChainingSemantics,
     },
     bindingParser,
     constantPool,

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -17,6 +17,7 @@ import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry
 import {BindingParser} from '../../template_parser/binding_parser';
 import * as t from '../r3_ast';
 import {htmlAstToRender3Ast} from '../r3_template_transform';
+import {OptionalChainingSemantics} from './api';
 
 import {I18nMetaVisitor} from './i18n/meta';
 
@@ -295,6 +296,13 @@ export interface ParsedTemplate {
    * Include whitespace nodes in the parsed output.
    */
   preserveWhitespaces?: boolean;
+
+  /**
+   * The semantics used for safe navigation (`?.`) expressions in this template.
+   * When `'native'`, safe navigation returns `undefined` on short-circuit.
+   * When `'legacy'` or not set, safe navigation returns `null`.
+   */
+  optionalChainingSemantics?: OptionalChainingSemantics;
 
   /**
    * Any errors from parsing the template the first time.

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -8,7 +8,7 @@
 
 import {ConstantPool} from '../../../constant_pool';
 import * as o from '../../../output/output_ast';
-import {R3ComponentDeferMetadata} from '../../../render3/view/api';
+import {OptionalChainingSemantics, R3ComponentDeferMetadata} from '../../../render3/view/api';
 import * as ir from '../ir';
 
 export enum CompilationJobKind {
@@ -86,6 +86,7 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly allDeferrableDepsFn: o.ReadVarExpr | null,
     readonly relativeTemplatePath: string | null,
     readonly enableDebugLocations: boolean,
+    readonly optionalChainingSemantics: OptionalChainingSemantics = OptionalChainingSemantics.Legacy,
   ) {
     super(componentName, pool, compatibility, mode);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);
@@ -270,6 +271,7 @@ export class HostBindingCompilationJob extends CompilationJob {
     pool: ConstantPool,
     compatibility: ir.CompatibilityMode,
     mode: TemplateCompilationMode,
+    readonly optionalChainingSemantics: OptionalChainingSemantics = OptionalChainingSemantics.Legacy,
   ) {
     super(componentName, pool, compatibility, mode);
     this.root = new HostBindingCompilationUnit(this);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -14,7 +14,11 @@ import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import * as t from '../../../render3/r3_ast';
-import {DeferBlockDepsEmitMode, R3ComponentDeferMetadata} from '../../../render3/view/api';
+import {
+  DeferBlockDepsEmitMode,
+  OptionalChainingSemantics,
+  R3ComponentDeferMetadata,
+} from '../../../render3/view/api';
 import {icuFromI18nMessage} from '../../../render3/view/i18n/util';
 import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {BindingParser} from '../../../template_parser/binding_parser';
@@ -65,6 +69,7 @@ export function ingestComponent(
   allDeferrableDepsFn: o.ReadVarExpr | null,
   relativeTemplatePath: string | null,
   enableDebugLocations: boolean,
+  optionalChainingSemantics: OptionalChainingSemantics = OptionalChainingSemantics.Legacy,
 ): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
     componentName,
@@ -77,6 +82,7 @@ export function ingestComponent(
     allDeferrableDepsFn,
     relativeTemplatePath,
     enableDebugLocations,
+    optionalChainingSemantics,
   );
   ingestNodes(job.root, template);
   return job;
@@ -88,6 +94,7 @@ export interface HostBindingInput {
   properties: e.ParsedProperty[] | null;
   attributes: {[key: string]: o.Expression};
   events: e.ParsedEvent[] | null;
+  optionalChainingSemantics?: OptionalChainingSemantics;
 }
 
 /**
@@ -104,6 +111,7 @@ export function ingestHostBinding(
     constantPool,
     compatibilityMode,
     TemplateCompilationMode.DomOnly,
+    input.optionalChainingSemantics ?? OptionalChainingSemantics.Legacy,
   );
   for (const property of input.properties ?? []) {
     let bindingKind = ir.BindingKind.Property;

--- a/packages/core/schematics/migrations/optional-chaining-semantics-migration/BUILD.bazel
+++ b/packages/core/schematics/migrations/optional-chaining-semantics-migration/BUILD.bazel
@@ -1,0 +1,38 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+ts_project(
+    name = "migration",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    visibility = [
+        "//packages/core/schematics:__subpackages__",
+    ],
+    deps = [
+        "//:node_modules/@types/node",
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(
+        ["**/*.spec.ts"],
+    ),
+    deps = [
+        ":migration",
+        "//packages/compiler",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [":test_lib"],
+    env = {"FORCE_COLOR": "3"},
+)

--- a/packages/core/schematics/migrations/optional-chaining-semantics-migration/add-null-coalescing.ts
+++ b/packages/core/schematics/migrations/optional-chaining-semantics-migration/add-null-coalescing.ts
@@ -1,0 +1,593 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  AST,
+  ASTWithSource,
+  Binary,
+  Conditional,
+  Interpolation,
+  NonNullAssert,
+  parseTemplate,
+  PrefixNot,
+  PropertyRead,
+  RecursiveAstVisitor,
+  SafeCall,
+  SafeKeyedRead,
+  SafePropertyRead,
+  TmplAstBoundAttribute,
+  TmplAstBoundEvent,
+  TmplAstBoundText,
+  TmplAstRecursiveVisitor,
+  tmplAstVisitAll,
+} from '@angular/compiler';
+
+/**
+ * Result of attempting to migrate a single template.
+ */
+export interface TemplateMigrationResult {
+  /** The migrated template text (only meaningful if `fullyMigrated` is true). */
+  migrated: string;
+  /** Whether ALL `?.` expressions in this template were successfully handled. */
+  fullyMigrated: boolean;
+  /** Number of `?.` expressions converted to ternaries. */
+  migratedCount: number;
+  /** Number of `?.` expressions safely left as-is (null/undefined equivalent context). */
+  safeAsIsCount: number;
+  /** Number of `?.` expressions that could NOT be safely auto-migrated. */
+  skippedCount: number;
+  /** Whether the template had any `?.` expressions at all. */
+  hasSafeNavigation: boolean;
+}
+
+/**
+ * Context in which a safe navigation expression is used.
+ * Determines whether null vs undefined semantics matter.
+ */
+enum SafeNavContext {
+  /** The exact value (null vs undefined) matters — must be migrated. */
+  Sensitive,
+  /** null and undefined behave identically in this context — safe to leave as-is. */
+  NullSafe,
+}
+
+/**
+ * Information about a single safe navigation expression found in a template.
+ */
+interface SafeNavOccurrence {
+  /** The AST node (SafePropertyRead, SafeKeyedRead, or SafeCall). */
+  node: SafePropertyRead | SafeKeyedRead | SafeCall;
+  /** Whether the expression is in a null-safe context. */
+  context: SafeNavContext;
+  /** Absolute source span start offset in the template string. */
+  start: number;
+  /** Absolute source span end offset in the template string. */
+  end: number;
+}
+
+/**
+ * Attempts to migrate ALL safe navigation expressions in a template using AST analysis.
+ *
+ * For each `?.` expression in the template:
+ * 1. Parses the template using Angular's template parser to get proper AST nodes.
+ * 2. Walks the AST to find all SafePropertyRead, SafeKeyedRead, SafeCall occurrences.
+ * 3. Analyzes the parent expression context to determine if null/undefined are equivalent.
+ * 4. For sensitive contexts with simple property chains, converts to ternary form.
+ * 5. Otherwise marks as skipped (needs manual review).
+ *
+ * **Null-safe contexts (left as-is, no migration needed):**
+ * - Standalone interpolation `{{ a?.b }}` — Angular renders null/undefined as ""
+ * - `a?.b ?? 'fallback'` — `??` catches both null and undefined
+ * - `a?.b || 'fallback'` — `||` treats both as falsy
+ * - `a?.b && x` — both null/undefined are falsy, short-circuit the same
+ * - `!a?.b` / `!!a?.b` — negation produces same boolean for both
+ * - `a?.b ? x : y` — condition position, truthiness check
+ * - `a?.b == null` / `a?.b != null` — loose equality matches both
+ *
+ * **Must be converted (sensitive contexts):**
+ * - `'prefix' + a?.b` — string concat differs: "prefixnull" vs "prefixundefined"
+ * - `a?.b === null` — strict equality: null===null is true, undefined===null is false
+ *
+ * **Why ternary (not `?? null`):**
+ *   `a?.b?.c` where `c` is genuinely `undefined`:
+ *   - `?? null` changes the real `undefined` to `null` — WRONG
+ *   - Ternary replicates legacy compiler output exactly
+ */
+export function migrateTemplate(template: string): TemplateMigrationResult {
+  // Quick check: does the template even contain `?.`?
+  if (!template.includes('?.')) {
+    return {
+      migrated: template,
+      fullyMigrated: true,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: false,
+    };
+  }
+
+  // Parse the template using Angular's template parser
+  const parsed = parseTemplate(template, 'migration.html', {});
+
+  if (parsed.errors && parsed.errors.length > 0) {
+    // If the template can't be parsed, we can't migrate it
+    return {
+      migrated: template,
+      fullyMigrated: false,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: template.includes('?.'),
+    };
+  }
+
+  // Walk the AST to find all safe navigation occurrences
+  const collector = new SafeNavCollector();
+  tmplAstVisitAll(collector, parsed.nodes);
+
+  if (collector.occurrences.length === 0) {
+    return {
+      migrated: template,
+      fullyMigrated: true,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: false,
+    };
+  }
+
+  let migratedCount = 0;
+  let safeAsIsCount = 0;
+  let skippedCount = 0;
+  let fullyMigrated = true;
+
+  // Sort occurrences by position (descending) so we can apply replacements from end to start
+  // without invalidating earlier positions
+  const sorted = [...collector.occurrences].sort((a, b) => b.start - a.start);
+
+  let result = template;
+
+  for (const occ of sorted) {
+    if (occ.context === SafeNavContext.NullSafe) {
+      safeAsIsCount++;
+      continue;
+    }
+
+    // Try to build ternary replacement for the outermost safe nav chain
+    const ternary = tryBuildTernary(occ.node, template);
+    if (ternary !== null) {
+      migratedCount++;
+      result = result.substring(0, occ.start) + ternary + result.substring(occ.end);
+    } else {
+      skippedCount++;
+      fullyMigrated = false;
+    }
+  }
+
+  return {
+    migrated: fullyMigrated ? result : template,
+    fullyMigrated,
+    migratedCount,
+    safeAsIsCount,
+    skippedCount,
+    hasSafeNavigation: true,
+  };
+}
+
+/**
+ * Best-effort mode. Falls back to `?? null` for expressions that can't be
+ * safely converted to ternaries.
+ *
+ * **⚠️ DANGEROUS**: `?? null` can incorrectly convert genuinely `undefined`
+ * runtime values to `null`. Similar to signal migration's `--best-effort-mode`.
+ */
+export function migrateTemplateBestEffort(template: string): TemplateMigrationResult {
+  if (!template.includes('?.')) {
+    return {
+      migrated: template,
+      fullyMigrated: true,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: false,
+    };
+  }
+
+  const parsed = parseTemplate(template, 'migration.html', {});
+  if (parsed.errors && parsed.errors.length > 0) {
+    return {
+      migrated: template,
+      fullyMigrated: false,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: true,
+    };
+  }
+
+  const collector = new SafeNavCollector();
+  tmplAstVisitAll(collector, parsed.nodes);
+
+  if (collector.occurrences.length === 0) {
+    return {
+      migrated: template,
+      fullyMigrated: true,
+      migratedCount: 0,
+      safeAsIsCount: 0,
+      skippedCount: 0,
+      hasSafeNavigation: false,
+    };
+  }
+
+  let migratedCount = 0;
+  let safeAsIsCount = 0;
+  let skippedCount = 0;
+
+  const sorted = [...collector.occurrences].sort((a, b) => b.start - a.start);
+  let result = template;
+
+  for (const occ of sorted) {
+    if (occ.context === SafeNavContext.NullSafe) {
+      safeAsIsCount++;
+      continue;
+    }
+
+    const ternary = tryBuildTernary(occ.node, template);
+    if (ternary !== null) {
+      migratedCount++;
+      result = result.substring(0, occ.start) + ternary + result.substring(occ.end);
+    } else {
+      if (isImmediatelyFollowedByCall(occ.node, template)) {
+        skippedCount++;
+        continue;
+      }
+      // Best-effort: append ?? null to the original expression text
+      const originalText = template.substring(occ.start, occ.end);
+      migratedCount++;
+      result =
+        result.substring(0, occ.start) + originalText + ' ?? null' + result.substring(occ.end);
+    }
+  }
+
+  return {
+    migrated: result,
+    fullyMigrated: skippedCount === 0,
+    migratedCount,
+    safeAsIsCount,
+    skippedCount,
+    hasSafeNavigation: true,
+  };
+}
+
+/**
+ * Template-level AST visitor that finds all expressions containing safe navigation
+ * and determines the context of each occurrence.
+ */
+class SafeNavCollector extends TmplAstRecursiveVisitor {
+  occurrences: SafeNavOccurrence[] = [];
+
+  override visitBoundText(text: TmplAstBoundText): void {
+    const expr = text.value;
+    if (expr instanceof ASTWithSource) {
+      this.analyzeExpression(expr.ast);
+    } else {
+      this.analyzeExpression(expr);
+    }
+  }
+
+  override visitBoundAttribute(attribute: TmplAstBoundAttribute): void {
+    const expr = attribute.value;
+    if (expr instanceof ASTWithSource) {
+      this.analyzeExpression(expr.ast);
+    } else {
+      this.analyzeExpression(expr);
+    }
+    super.visitBoundAttribute(attribute);
+  }
+
+  override visitBoundEvent(event: TmplAstBoundEvent): void {
+    const expr = event.handler;
+    if (expr instanceof ASTWithSource) {
+      this.analyzeExpression(expr.ast);
+    } else {
+      this.analyzeExpression(expr);
+    }
+    super.visitBoundEvent(event);
+  }
+
+  private analyzeExpression(ast: AST): void {
+    if (ast instanceof Interpolation) {
+      // Each interpolation expression is analyzed independently
+      for (const expr of ast.expressions) {
+        this.analyzeExprForSafeNav(expr, SafeNavContext.NullSafe);
+      }
+    } else {
+      this.analyzeExprForSafeNav(ast, SafeNavContext.Sensitive);
+    }
+  }
+
+  /**
+   * Walk an expression tree to find safe navigation nodes.
+   * The `parentContext` indicates whether the parent makes null/undefined indistinguishable.
+   */
+  private analyzeExprForSafeNav(ast: AST, parentContext: SafeNavContext): void {
+    const finder = new SafeNavExpressionFinder(parentContext);
+    finder.visit(ast);
+    // Only collect the outermost safe nav in each expression tree
+    this.occurrences.push(...finder.occurrences);
+  }
+}
+
+/**
+ * Expression-level AST visitor that finds safe navigation nodes and determines their context.
+ *
+ * For chains like `a?.b?.c`, the AST is:
+ *   SafePropertyRead('c', receiver: SafePropertyRead('b', receiver: ImplicitReceiver))
+ * We only want to record the OUTERMOST safe read (the `c` node) because it represents
+ * the entire chain. Inner safe reads are part of the same chain and should not be recorded
+ * separately.
+ */
+class SafeNavExpressionFinder extends RecursiveAstVisitor {
+  occurrences: SafeNavOccurrence[] = [];
+  private contextStack: SafeNavContext[] = [];
+  /**
+   * Set of AST nodes that are receivers of a safe navigation node.
+   * These should NOT be recorded as separate occurrences.
+   */
+  private receiverNodes = new Set<AST>();
+
+  constructor(private rootContext: SafeNavContext) {
+    super();
+    this.contextStack.push(rootContext);
+  }
+
+  private get currentContext(): SafeNavContext {
+    return this.contextStack[this.contextStack.length - 1];
+  }
+
+  /**
+   * Mark all receiver nodes in a safe navigation chain so they won't be recorded.
+   */
+  private markReceiverChain(node: AST): void {
+    if (
+      node instanceof SafePropertyRead ||
+      node instanceof SafeKeyedRead ||
+      node instanceof SafeCall
+    ) {
+      this.receiverNodes.add(node);
+      this.markReceiverChain(node.receiver);
+    } else if (node instanceof PropertyRead) {
+      this.markReceiverChain(node.receiver);
+    } else if (node instanceof NonNullAssert) {
+      this.markReceiverChain(node.expression);
+    }
+  }
+
+  override visitSafePropertyRead(ast: SafePropertyRead, context?: any): any {
+    // If this node is a receiver of a larger safe chain, skip it
+    if (this.receiverNodes.has(ast)) {
+      return;
+    }
+    // Mark all inner receivers so they won't be recorded separately
+    this.markReceiverChain(ast.receiver);
+    this.occurrences.push({
+      node: ast,
+      context: this.currentContext,
+      start: ast.sourceSpan.start,
+      end: ast.sourceSpan.end,
+    });
+    // Visit the receiver to find any independent safe nav in sub-expressions
+    this.visit(ast.receiver, context);
+  }
+
+  override visitSafeKeyedRead(ast: SafeKeyedRead, context?: any): any {
+    if (this.receiverNodes.has(ast)) {
+      return;
+    }
+    this.markReceiverChain(ast.receiver);
+    this.occurrences.push({
+      node: ast,
+      context: this.currentContext,
+      start: ast.sourceSpan.start,
+      end: ast.sourceSpan.end,
+    });
+    this.visit(ast.receiver, context);
+    this.visit(ast.key, context);
+  }
+
+  override visitSafeCall(ast: SafeCall, context?: any): any {
+    if (this.receiverNodes.has(ast)) {
+      return;
+    }
+    this.markReceiverChain(ast.receiver);
+    this.occurrences.push({
+      node: ast,
+      context: this.currentContext,
+      start: ast.sourceSpan.start,
+      end: ast.sourceSpan.end,
+    });
+    this.visit(ast.receiver, context);
+    this.visitAll(ast.args, context);
+  }
+
+  override visitBinary(ast: Binary, context?: any): any {
+    // Determine context for children based on operator
+    const ctx = classifyBinaryContext(ast);
+    this.contextStack.push(ctx);
+    this.visit(ast.left, context);
+    this.contextStack.pop();
+
+    // Right side of binary is always sensitive (e.g. `x + a?.b`)
+    this.contextStack.push(SafeNavContext.Sensitive);
+    this.visit(ast.right, context);
+    this.contextStack.pop();
+  }
+
+  override visitConditional(ast: Conditional, context?: any): any {
+    // Condition position is null-safe (truthiness check)
+    this.contextStack.push(SafeNavContext.NullSafe);
+    this.visit(ast.condition, context);
+    this.contextStack.pop();
+
+    // Branches are sensitive
+    this.contextStack.push(SafeNavContext.Sensitive);
+    this.visit(ast.trueExp, context);
+    this.visit(ast.falseExp, context);
+    this.contextStack.pop();
+  }
+
+  override visitPrefixNot(ast: PrefixNot, context?: any): any {
+    // !a?.b — negation makes null/undefined equivalent (both falsy → true)
+    this.contextStack.push(SafeNavContext.NullSafe);
+    this.visit(ast.expression, context);
+    this.contextStack.pop();
+  }
+
+  override visitNonNullAssert(ast: NonNullAssert, context?: any): any {
+    // a?.b! — non-null assertion doesn't change null/undefined equivalence
+    this.visit(ast.expression, context);
+  }
+}
+
+/**
+ * Classify the context of the left side of a binary expression.
+ */
+function classifyBinaryContext(ast: Binary): SafeNavContext {
+  switch (ast.operation) {
+    case '&&':
+    case '||':
+      // Logical operators: both null and undefined are falsy
+      return SafeNavContext.NullSafe;
+    case '??':
+      // Nullish coalescing: catches both null and undefined
+      return SafeNavContext.NullSafe;
+    case '==':
+    case '!=':
+      // Loose equality: null == undefined is true
+      return SafeNavContext.NullSafe;
+    case '===':
+    case '!==':
+      // Strict equality: null !== undefined
+      return SafeNavContext.Sensitive;
+    case '+':
+      // String concatenation differs: "prefixnull" vs "prefixundefined"
+      return SafeNavContext.Sensitive;
+    default:
+      return SafeNavContext.Sensitive;
+  }
+}
+
+/**
+ * Try to build a ternary replacement for a safe navigation expression.
+ *
+ * Converts `a?.b?.c` → `a != null ? (a.b != null ? a.b.c : null) : null`
+ *
+ * Returns null if the expression can't be safely converted (e.g., method calls,
+ * keyed access, pipes).
+ */
+function tryBuildTernary(
+  node: SafePropertyRead | SafeKeyedRead | SafeCall,
+  template: string,
+): string | null {
+  // If the safe-navigation node is immediately called (e.g. `user?.getName()` where
+  // the node span is `user?.getName` and the next token is `(`), replacing only the
+  // node span would produce invalid output. Leave these for manual review.
+  if (isImmediatelyFollowedByCall(node, template)) {
+    return null;
+  }
+
+  // Only handle simple property chains for ternary conversion
+  const chain = collectSafeChain(node);
+  if (chain === null) {
+    return null;
+  }
+
+  return buildTernaryFromChain(chain);
+}
+
+interface ChainSegment {
+  name: string;
+  safe: boolean;
+}
+
+/**
+ * Collect a property chain from a safe navigation node.
+ * Returns null if the chain contains method calls, keyed reads, or other complex expressions.
+ */
+function collectSafeChain(node: AST): ChainSegment[] | null {
+  const segments: ChainSegment[] = [];
+  let current: AST = node;
+
+  while (true) {
+    if (current instanceof SafePropertyRead) {
+      segments.unshift({name: current.name, safe: true});
+      current = current.receiver;
+    } else if (current instanceof PropertyRead) {
+      segments.unshift({name: current.name, safe: false});
+      current = current.receiver;
+    } else if (current instanceof NonNullAssert) {
+      // a?.b!.c — skip the non-null assertion, take the inner expression
+      current = current.expression;
+    } else if (current instanceof SafeKeyedRead || current instanceof SafeCall) {
+      // Can't convert keyed reads or calls to ternary
+      return null;
+    } else {
+      // Should be the implicit receiver or a simple identifier
+      break;
+    }
+  }
+
+  if (segments.length < 2) {
+    return null;
+  }
+
+  // Must have at least one safe segment
+  if (!segments.some((s) => s.safe)) {
+    return null;
+  }
+
+  return segments;
+}
+
+function buildTernaryFromChain(segments: ChainSegment[]): string {
+  const safeIndices: number[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].safe) {
+      safeIndices.push(i);
+    }
+  }
+
+  function pathUpTo(endIdx: number): string {
+    let path = segments[0].name;
+    for (let i = 1; i <= endIdx; i++) {
+      path += '.' + segments[i].name;
+    }
+    return path;
+  }
+
+  const fullPath = pathUpTo(segments.length - 1);
+  let result = fullPath;
+
+  for (let si = safeIndices.length - 1; si >= 0; si--) {
+    const guard = pathUpTo(safeIndices[si] - 1);
+    result = `${guard} != null ? ${result} : null`;
+  }
+
+  return result;
+}
+
+function isImmediatelyFollowedByCall(
+  node: SafePropertyRead | SafeKeyedRead | SafeCall,
+  template: string,
+): boolean {
+  let idx = node.sourceSpan.end;
+  while (idx < template.length && /\s/.test(template[idx])) {
+    idx++;
+  }
+  return template[idx] === '(';
+}

--- a/packages/core/schematics/migrations/optional-chaining-semantics-migration/optional-chaining-semantics-migration.spec.ts
+++ b/packages/core/schematics/migrations/optional-chaining-semantics-migration/optional-chaining-semantics-migration.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {migrateTemplate, migrateTemplateBestEffort} from './add-null-coalescing';
+import {
+  escapeForHostStringLiteral,
+  migrateHostExpression,
+} from './optional-chaining-semantics-migration';
+import ts from 'typescript';
+
+describe('migrateTemplate (AST-based)', () => {
+  describe('no-op cases', () => {
+    it('should return unchanged for template without ?.', () => {
+      const r = migrateTemplate('<div>{{ a.b }}</div>');
+      expect(r.hasSafeNavigation).toBe(false);
+      expect(r.fullyMigrated).toBe(true);
+    });
+
+    it('should return unchanged for empty template', () => {
+      const r = migrateTemplate('');
+      expect(r.hasSafeNavigation).toBe(false);
+      expect(r.fullyMigrated).toBe(true);
+    });
+
+    it('should return unchanged for template with only text', () => {
+      const r = migrateTemplate('Hello world');
+      expect(r.hasSafeNavigation).toBe(false);
+    });
+  });
+
+  describe('null-safe contexts (left as-is)', () => {
+    it('standalone interpolation: {{ a?.b }}', () => {
+      const r = migrateTemplate('{{ a?.b }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBe(1);
+      expect(r.migratedCount).toBe(0);
+      expect(r.migrated).toBe('{{ a?.b }}');
+    });
+
+    it('standalone deep chain: {{ a?.b?.c?.d }}', () => {
+      const r = migrateTemplate('{{ a?.b?.c?.d }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+      expect(r.migrated).toBe('{{ a?.b?.c?.d }}');
+    });
+
+    it('nullish coalescing: {{ a?.b ?? "fallback" }}', () => {
+      const r = migrateTemplate(`{{ a?.b ?? 'fallback' }}`);
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('logical OR fallback: {{ a?.b || "default" }}', () => {
+      const r = migrateTemplate(`{{ a?.b || 'default' }}`);
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('logical AND: {{ a?.b && something }}', () => {
+      const r = migrateTemplate('{{ a?.b && something }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('negation: {{ !a?.b }}', () => {
+      const r = migrateTemplate('{{ !a?.b }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('double negation: {{ !!a?.b }}', () => {
+      const r = migrateTemplate('{{ !!a?.b }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('loose equality with null: {{ a?.b == null }}', () => {
+      const r = migrateTemplate('{{ a?.b == null }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('loose inequality with null: {{ a?.b != null }}', () => {
+      const r = migrateTemplate('{{ a?.b != null }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('ternary with ?. in condition: {{ a?.b ? x : y }}', () => {
+      const r = migrateTemplate('{{ a?.b ? x : y }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('negated ternary condition: {{ !a?.b?.c ? x : y }}', () => {
+      const r = migrateTemplate('{{ !a?.b?.c ? x : y }}');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('unsafe contexts (must convert or skip)', () => {
+    it('strict equality is NOT safe: {{ a?.b === null }}', () => {
+      const r = migrateTemplate('{{ a?.b === null }}');
+      // Strict equality makes null vs undefined distinguishable
+      expect(r.safeAsIsCount).toBe(0);
+    });
+
+    it('addition/concat is NOT safe', () => {
+      // "prefix" + null → "prefixnull", "prefix" + undefined → "prefixundefined"
+      // The + operator with a string literal is sensitive
+      const r = migrateTemplate(`{{ "prefix" + a?.b }}`);
+      expect(r.safeAsIsCount).toBe(0);
+    });
+  });
+
+  describe('mixed templates', () => {
+    it('template with multiple safe interpolations is fully safe', () => {
+      const r = migrateTemplate('<div>{{ a?.b }}</div><span>{{ c?.d }}</span>');
+      expect(r.fullyMigrated).toBe(true);
+      expect(r.safeAsIsCount).toBeGreaterThanOrEqual(2);
+      expect(r.migratedCount).toBe(0);
+      expect(r.skippedCount).toBe(0);
+    });
+
+    it('reports hasSafeNavigation when ?. is present', () => {
+      const r = migrateTemplate('{{ a?.b }}');
+      expect(r.hasSafeNavigation).toBe(true);
+    });
+
+    it('no safe navigation', () => {
+      const r = migrateTemplate('<div>{{ a.b }}</div>');
+      expect(r.hasSafeNavigation).toBe(false);
+    });
+  });
+
+  describe('correctness rationale: why null and undefined are equivalent', () => {
+    it('interpolation renders both as empty string', () => {
+      // Angular's renderStringify: String(null) and String(undefined) both → ""
+      const r = migrateTemplate('{{ user?.name }}');
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('?? catches both null and undefined per ECMAScript spec', () => {
+      const r = migrateTemplate(`{{ user?.name ?? 'Anonymous' }}`);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('|| treats both as falsy per ECMAScript spec', () => {
+      const r = migrateTemplate(`{{ user?.name || 'fallback' }}`);
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('== null matches both per ECMAScript abstract equality', () => {
+      const r = migrateTemplate('{{ a?.b == null }}');
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('!x converts both to true (both are falsy)', () => {
+      const r = migrateTemplate('{{ !a?.b }}');
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+
+    it('ternary condition treats both as falsy', () => {
+      const r = migrateTemplate('{{ a?.b ? yes : no }}');
+      expect(r.safeAsIsCount).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('migrateTemplateBestEffort (AST-based)', () => {
+  it('should leave null-safe contexts as-is', () => {
+    const r = migrateTemplateBestEffort('{{ a?.b }}');
+    expect(r.safeAsIsCount).toBeGreaterThan(0);
+    expect(r.migrated).toBe('{{ a?.b }}');
+  });
+
+  it('should still mark null-safe ?? as safe', () => {
+    const r = migrateTemplateBestEffort(`{{ a?.b ?? 'x' }}`);
+    expect(r.safeAsIsCount).toBeGreaterThan(0);
+  });
+
+  it('empty template', () => {
+    const r = migrateTemplateBestEffort('');
+    expect(r.hasSafeNavigation).toBe(false);
+    expect(r.fullyMigrated).toBe(true);
+  });
+});
+
+describe('migrateHostExpression', () => {
+  it('should migrate a simple host expression with safe navigation', () => {
+    const r = migrateHostExpression('user?.name', false);
+    expect(r.hasSafeNavigation).toBe(true);
+    expect(r.fullyMigrated).toBe(true);
+    expect(r.migrated).toContain('user != null ? user.name : null');
+  });
+
+  it('should use best-effort fallback for unsupported host expressions', () => {
+    const r = migrateHostExpression('user?.getName()', true);
+    expect(r.hasSafeNavigation).toBe(true);
+    expect(r.fullyMigrated).toBe(false);
+    expect(r.skippedCount).toBeGreaterThan(0);
+    expect(r.migrated).toContain('user?.getName()');
+  });
+
+  it('should preserve escaped single quotes for insertion into single-quoted TS host strings', () => {
+    const original = `'prefix ' + user?.name + ' suffix'`;
+    const r = migrateHostExpression(original, false);
+
+    const initializer = {getText: () => "''"} as unknown as ts.StringLiteralLike;
+    const escaped = escapeForHostStringLiteral(r.migrated, initializer);
+
+    const tsSource = `
+      import {Directive} from '@angular/core';
+      @Directive({
+        selector: '[x]',
+        host: {
+          '[attr.title]': '${escaped}'
+        }
+      })
+      class TestDir {}
+    `;
+    const transpileResult = ts.transpileModule(tsSource, {
+      compilerOptions: {target: ts.ScriptTarget.ES2022},
+      reportDiagnostics: true,
+    });
+    expect((transpileResult.diagnostics ?? []).length).toBe(0);
+  });
+});

--- a/packages/core/schematics/migrations/optional-chaining-semantics-migration/optional-chaining-semantics-migration.ts
+++ b/packages/core/schematics/migrations/optional-chaining-semantics-migration/optional-chaining-semantics-migration.ts
@@ -1,0 +1,343 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  ProjectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {extractAngularClassMetadata} from '../../utils/extract_metadata';
+import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
+import {getPropertyNameText} from '../../utils/typescript/property_name';
+import {AbsoluteFsPath} from '../../../../compiler-cli';
+import {migrateTemplate, migrateTemplateBestEffort} from './add-null-coalescing';
+
+export interface MigrationConfig {
+  /**
+   * Whether to migrate this component template.
+   */
+  shouldMigrate?: (containingFile: ProjectFile) => boolean;
+
+  /**
+   * When enabled, uses `?? null` for expressions that can't be safely converted
+   * to ternaries (method calls, keyed access, pipes, etc).
+   *
+   * **⚠️ DANGEROUS**: `?? null` can incorrectly convert genuinely `undefined`
+   * runtime values to `null`. Only use this if you've verified that affected
+   * expressions never legitimately produce `undefined`. Similar to signal
+   * migration's `--best-effort-mode`.
+   */
+  bestEffortMode?: boolean;
+
+  /**
+   * When enabled, prompts the user for each template before applying changes.
+   * Only applicable when running via CLI (not programmatic API).
+   *
+   * The prompt shows the before/after diff for each template and lets the
+   * user accept, skip, or abort the migration.
+   */
+  interactiveMode?: boolean;
+
+  /**
+   * Callback for interactive mode. Called for each template with `?.` usage.
+   * Return `true` to apply changes, `false` to skip.
+   * If not provided and `interactiveMode` is true, defaults to accepting all.
+   */
+  promptForTemplate?: (info: TemplatePromptInfo) => Promise<boolean>;
+}
+
+export interface TemplatePromptInfo {
+  componentName: string;
+  filePath: string;
+  originalContent: string;
+  migratedContent: string;
+  fullyMigrated: boolean;
+  migratedCount: number;
+  skippedCount: number;
+}
+
+export interface TemplateResult {
+  file: ProjectFile;
+  templateFile: ProjectFile;
+  componentName: string;
+  fullyMigrated: boolean;
+  migratedCount: number;
+  skippedCount: number;
+  /** Original template content for interactive mode diff display. */
+  originalContent: string;
+  /** Migrated template content (only valid when fullyMigrated or bestEffortMode). */
+  migratedContent: string;
+  replacements: Replacement[];
+  /** Whether this template was approved in interactive mode. Null = not interactive. */
+  approved: boolean | null;
+}
+
+export function migrateHostExpression(expression: string, bestEffort: boolean) {
+  const prefix = `<div [x]="`;
+  const suffix = `"></div>`;
+  const escapedExpr = expression.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const wrapped = `${prefix}${escapedExpr}${suffix}`;
+
+  const result = bestEffort ? migrateTemplateBestEffort(wrapped) : migrateTemplate(wrapped);
+  const migratedEscaped = result.migrated.substring(
+    prefix.length,
+    result.migrated.length - suffix.length,
+  );
+  const migrated = migratedEscaped.replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+  return {
+    ...result,
+    migrated,
+  };
+}
+
+export function escapeForHostStringLiteral(
+  content: string,
+  initializer: ts.StringLiteralLike,
+): string {
+  const text = initializer.getText();
+  const quote = text[0];
+
+  let escaped = content.replace(/\\/g, '\\\\');
+  if (quote === "'") {
+    escaped = escaped.replace(/'/g, "\\'");
+  } else if (quote === '"') {
+    escaped = escaped.replace(/"/g, '\\"');
+  } else if (quote === '`') {
+    escaped = escaped.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+  }
+  return escaped;
+}
+
+export interface CompilationUnitData {
+  templates: TemplateResult[];
+}
+
+/**
+ * Migration for switching from legacy to native optional chaining semantics.
+ *
+ * Modes:
+ *
+ * **Default (safe):** Converts `a?.b?.c` → `a != null ? (a.b != null ? a.b.c : null) : null`
+ * Only modifies a template if ALL its `?.` expressions were successfully converted.
+ * Templates with method calls, pipes, keyed access, etc. are left untouched.
+ *
+ * **Best-effort (dangerous):** Also applies `?? null` to expressions that can't be
+ * converted to ternaries. This covers more cases but may incorrectly convert
+ * genuinely `undefined` values to `null`. Use `--best-effort-mode` CLI flag.
+ *
+ * **Interactive:** Prompts for each template before applying. Use `--interactive` CLI flag.
+ *
+ * The project-wide `nativeOptionalChainingSemantics: true` should only be enabled when
+ * ALL templates were either fully migrated or have no `?.` usage.
+ */
+export class OptionalChainingSemanticsMigration extends TsurgeFunnelMigration<
+  CompilationUnitData,
+  CompilationUnitData
+> {
+  constructor(private readonly config: MigrationConfig = {}) {
+    super();
+  }
+
+  override async analyze(info: ProgramInfo): Promise<Serializable<CompilationUnitData>> {
+    const {sourceFiles, program} = info;
+    const typeChecker = program.getTypeChecker();
+    const templates: TemplateResult[] = [];
+    const bestEffort = this.config.bestEffortMode ?? false;
+
+    for (const sf of sourceFiles) {
+      ts.forEachChild(sf, (node: ts.Node) => {
+        if (!ts.isClassDeclaration(node)) return;
+
+        const file = projectFile(node.getSourceFile(), info);
+        if (this.config.shouldMigrate && !this.config.shouldMigrate(file)) return;
+
+        const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
+        templateVisitor.visitNode(node);
+
+        templateVisitor.resolvedTemplates.forEach((tpl) => {
+          const result = bestEffort
+            ? migrateTemplateBestEffort(tpl.content)
+            : migrateTemplate(tpl.content);
+
+          // Skip templates with no safe navigation — already native-safe
+          if (!result.hasSafeNavigation) return;
+
+          const canApply = result.fullyMigrated;
+          const replacements: Replacement[] = [];
+
+          if (canApply) {
+            const fileToMigrate = tpl.inline
+              ? file
+              : projectFile(tpl.filePath as AbsoluteFsPath, info);
+            replacements.push(
+              new Replacement(
+                fileToMigrate,
+                new TextUpdate({
+                  position: tpl.start,
+                  end: tpl.start + tpl.content.length,
+                  toInsert: result.migrated,
+                }),
+              ),
+            );
+          }
+
+          templates.push({
+            file,
+            templateFile: tpl.inline ? file : projectFile(tpl.filePath as AbsoluteFsPath, info),
+            componentName: node.name?.text ?? '<anonymous>',
+            fullyMigrated: canApply,
+            migratedCount: result.migratedCount,
+            skippedCount: result.skippedCount,
+            originalContent: tpl.content,
+            migratedContent: result.migrated,
+            replacements,
+            approved: null,
+          });
+        });
+
+        const classMetadata = extractAngularClassMetadata(typeChecker, node);
+        if (classMetadata !== null) {
+          for (const property of classMetadata.node.properties) {
+            if (!ts.isPropertyAssignment(property)) {
+              continue;
+            }
+            const propertyName = getPropertyNameText(property.name);
+            if (propertyName !== 'host' || !ts.isObjectLiteralExpression(property.initializer)) {
+              continue;
+            }
+
+            for (const hostProp of property.initializer.properties) {
+              if (
+                !ts.isPropertyAssignment(hostProp) ||
+                !ts.isStringLiteralLike(hostProp.initializer)
+              ) {
+                continue;
+              }
+
+              const expression = hostProp.initializer.text;
+              const result = migrateHostExpression(expression, bestEffort);
+              if (!result.hasSafeNavigation) {
+                continue;
+              }
+
+              const canApply = result.fullyMigrated;
+              const replacements: Replacement[] = [];
+              if (canApply) {
+                const escapedMigrated = escapeForHostStringLiteral(
+                  result.migrated,
+                  hostProp.initializer,
+                );
+                replacements.push(
+                  new Replacement(
+                    file,
+                    new TextUpdate({
+                      position: hostProp.initializer.getStart() + 1,
+                      end: hostProp.initializer.getEnd() - 1,
+                      toInsert: escapedMigrated,
+                    }),
+                  ),
+                );
+              }
+
+              templates.push({
+                file,
+                templateFile: file,
+                componentName: node.name?.text ?? '<anonymous>',
+                fullyMigrated: canApply,
+                migratedCount: result.migratedCount,
+                skippedCount: result.skippedCount,
+                originalContent: expression,
+                migratedContent: result.migrated,
+                replacements,
+                approved: null,
+              });
+            }
+          }
+        }
+      });
+    }
+
+    // Interactive mode: prompt for each template
+    if (this.config.interactiveMode && this.config.promptForTemplate) {
+      for (const tpl of templates) {
+        if (!tpl.fullyMigrated) {
+          tpl.approved = false;
+          continue;
+        }
+        tpl.approved = await this.config.promptForTemplate({
+          componentName: tpl.componentName,
+          filePath: tpl.templateFile.rootRelativePath,
+          originalContent: tpl.originalContent,
+          migratedContent: tpl.migratedContent,
+          fullyMigrated: tpl.fullyMigrated,
+          migratedCount: tpl.migratedCount,
+          skippedCount: tpl.skippedCount,
+        });
+      }
+    }
+
+    return confirmAsSerializable({templates});
+  }
+
+  override async combine(
+    unitA: CompilationUnitData,
+    unitB: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable({
+      templates: [...unitA.templates, ...unitB.templates],
+    });
+  }
+
+  override async globalMeta(
+    combinedData: CompilationUnitData,
+  ): Promise<Serializable<CompilationUnitData>> {
+    return confirmAsSerializable({templates: combinedData.templates});
+  }
+
+  override async stats(globalData: CompilationUnitData) {
+    const total = globalData.templates.length;
+    const fullyMigrated = globalData.templates.filter((t) => t.fullyMigrated).length;
+    const needsManualReview = globalData.templates.filter((t) => !t.fullyMigrated).length;
+    const totalExprMigrated = globalData.templates.reduce((a, t) => a + t.migratedCount, 0);
+    const totalExprSkipped = globalData.templates.reduce((a, t) => a + t.skippedCount, 0);
+    const canEnableProjectWideFlag = needsManualReview === 0;
+
+    return confirmAsSerializable({
+      componentsWithSafeNavigation: total,
+      fullyMigrated,
+      needsManualReview,
+      totalExpressionsMigrated: totalExprMigrated,
+      totalExpressionsSkipped: totalExprSkipped,
+      canEnableProjectWideFlag,
+      manualReviewComponents: globalData.templates
+        .filter((t) => !t.fullyMigrated)
+        .map((t) => `${t.componentName} in ${t.file.rootRelativePath} (${t.skippedCount} expr)`),
+    });
+  }
+
+  override async migrate(globalData: CompilationUnitData) {
+    const interactive = this.config.interactiveMode ?? false;
+
+    const replacements = globalData.templates
+      .filter((t) => {
+        if (!t.fullyMigrated) return false;
+        // In interactive mode, only apply approved templates
+        if (interactive && t.approved !== true) return false;
+        return true;
+      })
+      .flatMap((t) => t.replacements);
+
+    return {replacements};
+  }
+}

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -203,13 +203,15 @@ export interface R3DirectiveMetadataFacade {
   providers: Provider[] | null;
   viewQueries: R3QueryMetadataFacade[];
   isStandalone: boolean;
-  isSignal: boolean;
   hostDirectives: R3HostDirectiveMetadataFacade[] | null;
+  isSignal: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export interface R3ComponentMetadataFacade extends R3DirectiveMetadataFacade {
   template: string;
   preserveWhitespaces: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
   animations: OpaqueValue[] | undefined;
   declarations: R3TemplateDependencyFacade[];
   styles: string[];
@@ -254,12 +256,11 @@ export interface R3DeclareDirectiveFacade {
   exportAs?: string[];
   usesInheritance?: boolean;
   usesOnChanges?: boolean;
-  controlCreate?: {
-    passThroughInput: string | null;
-  };
+  controlCreate?: {passThroughInput: string | null};
   isStandalone?: boolean;
-  hostDirectives?: R3HostDirectiveMetadataFacade[] | null;
   isSignal?: boolean;
+  hostDirectives?: R3HostDirectiveMetadataFacade[] | null;
+  hostOptionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
@@ -281,6 +282,7 @@ export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
   changeDetection?: ChangeDetectionStrategy;
   encapsulation?: ViewEncapsulation;
   preserveWhitespaces?: boolean;
+  optionalChainingSemantics?: 'legacy' | 'native';
 }
 
 export type R3DeclareTemplateDependencyFacade = {
@@ -395,8 +397,8 @@ export interface R3DeclareNgModuleFacade {
 
 export interface R3DeclarePipeFacade {
   type: Type;
-  name: string;
   version: string;
+  name: string;
   pure?: boolean;
   isStandalone?: boolean;
 }

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -344,6 +344,14 @@ export interface Directive {
   signals?: boolean;
 
   /**
+   * Controls optional chaining semantics for host binding expressions on this directive.
+   *
+   * - `'legacy'` (default): safe navigation returns `null` on short-circuit.
+   * - `'native'`: safe navigation returns `undefined`, matching JavaScript optional chaining.
+   */
+  optionalChainingSemantics?: 'legacy' | 'native';
+
+  /**
    * Standalone directives that should be applied to the host whenever the directive is matched.
    * By default, none of the inputs or outputs of the host directives will be available on the host,
    * unless they are specified in the `inputs` or `outputs` properties.
@@ -620,6 +628,32 @@ export interface Component extends Directive {
    * overridden in compiler options.
    */
   preserveWhitespaces?: boolean;
+
+  /**
+   * Controls the semantics of the safe navigation operator (`?.`) in this component's template.
+   *
+   * - `'legacy'` (default): `?.` returns `null` on short-circuit. This is Angular's historical
+   *   behavior.
+   * - `'native'`: `?.` returns `undefined` on short-circuit, matching JavaScript/TypeScript
+   *   optional chaining semantics (TC39 spec).
+   *
+   * This per-component setting overrides the project-wide `nativeOptionalChainingSemantics`
+   * compiler option. Use it to opt individual components into native semantics while keeping
+   * the rest of the project on legacy, or vice versa.
+   *
+   * @usageNotes
+   *
+   * ```typescript
+   * @Component({
+   *   template: '{{ user?.name }}',
+   *   optionalChainingSemantics: 'native',
+   * })
+   * class MyComponent {
+   *   user: {name: string} | null = null;
+   * }
+   * ```
+   */
+  optionalChainingSemantics?: 'legacy' | 'native';
 
   /**
    * Set `standalone` to `false` if you want to import the directive into an NgModule.

--- a/packages/core/src/render3/jit/jit_options.ts
+++ b/packages/core/src/render3/jit/jit_options.ts
@@ -10,6 +10,12 @@ import {ViewEncapsulation} from '../../metadata/view';
 export interface JitCompilerOptions {
   defaultEncapsulation?: ViewEncapsulation;
   preserveWhitespaces?: boolean;
+  /**
+   * When enabled, safe navigation (`?.`) expressions in templates return `undefined` on
+   * short-circuit, matching JavaScript/TypeScript optional chaining semantics.
+   * When disabled (default), safe navigation returns `null` (Angular's historical behavior).
+   */
+  nativeOptionalChainingSemantics?: boolean;
 }
 
 let jitOptions: JitCompilerOptions | null = null;
@@ -27,6 +33,13 @@ export function setJitOptions(options: JitCompilerOptions): void {
       ngDevMode &&
         console.error(
           'Provided value for `preserveWhitespaces` can not be changed once it has been set.',
+        );
+      return;
+    }
+    if (options.nativeOptionalChainingSemantics !== jitOptions.nativeOptionalChainingSemantics) {
+      ngDevMode &&
+        console.error(
+          'Provided value for `nativeOptionalChainingSemantics` can not be changed once it has been set.',
         );
       return;
     }


### PR DESCRIPTION
This PR introduces `nativeOptionalChainingSemantics`, a compiler option that aligns Angular template safe navigation (`?.`) with native ECMAScript optional chaining behavior.

## Problem

Angular's safe navigation operator (`?.`) has historically returned `null` when short-circuiting, while JavaScript/TypeScript's optional chaining returns `undefined`. This causes subtle bugs:

- `config?.timeout ?? 30` behaves differently in templates vs TypeScript — in templates, `null` passes through `??` when it shouldn't
- `config?.timeout === undefined` is `false` in templates but `true` in TypeScript  
- Type inference already uses `| undefined`, creating a mismatch between static types and runtime behavior

Community issues: #34385, #37622, #37619

## Solution

### Compiler option: `nativeOptionalChainingSemantics`

```json
{
  "angularCompilerOptions": {
    "nativeOptionalChainingSemantics": true
  }
}
```

When enabled, `a?.b` evaluates to `undefined` (instead of `null`) at runtime when `a` is nullish, matching JavaScript/TypeScript semantics.

### Per-component override: `optionalChainingSemantics`

Components and directives can override the project-wide setting:

```typescript
@Component({
  optionalChainingSemantics: 'legacy', // or 'native'
  template: `{{ config?.timeout }}`,
})
export class MyComponent {}
```

This enables gradual migration — individual components can opt in/out independently, and the setting is preserved in partial declarations for library distribution.

### Host bindings & directives

Each directive/component uses its own semantics independently, including:
- Template expressions
- Host binding expressions (`[attr.x]`, `[class.x]`, `[style.x]`)
- `hostDirectives` — each keeps its own semantics regardless of the parent component

### Extended template diagnostic: NG8119

When `nativeOptionalChainingSemantics` is enabled project-wide, components that haven't adopted native semantics (or use explicit `'legacy'`) receive an informational diagnostic (NG8119) flagging `?.` usage that returns `null` instead of `undefined`.

### Migration schematic

```bash
ng generate @angular/core:optional-chaining-semantics-migration
```

Uses AST-based analysis to identify `?.` usage in templates. The migration adds `?? null` coalescing where needed for components that depend on the `null` return value, making them safe to enable native semantics.

**Design note:** The migration does NOT blindly add `?? null` everywhere — it analyzes usage patterns (strict equality checks, nullish coalescing, ternary fallbacks) and only patches expressions where the null-to-undefined change would alter observable behavior.

### Partial linker support

The `optionalChainingSemantics` metadata is written into partial declarations (`ɵɵngDeclareComponent`/`ɵɵngDeclareDirective`) so the linker respects the intended behavior when consuming pre-compiled libraries.

### Documentation

Updated `adev/src/content/tools/cli/template-typecheck.md` with a new "Optional chaining semantics" section covering the option, migration, and caveats.

## Implementation details

- **Compiler pipeline:** `expand_safe_reads` phase checks the compilation unit's `optionalChainingSemantics` and emits either `null` or `undefined` for the safe ternary fallback
- **JIT support:** `nativeOptionalChainingSemantics` is available via `setJitOptions()` for JIT-compiled components
- **No runtime overhead:** The change only affects what constant value the compiler emits in the ternary expansion — no new runtime code paths

## What this does NOT change

- Libraries published to npm retain whatever semantics they were compiled with
- Existing code without the flag continues to work identically (legacy `null` behavior)
- The flag is opt-in and off by default

## Live Demo

A complete demo application showcasing the feature is available at:
**https://kbrilla.github.io/angular-next-features/**

It demonstrates:
- Side-by-side legacy vs native behavior
- Mix-and-match components with different semantics
- Host binding behavior
- Migration patterns and edge cases

---

> **AI Disclosure:** This feature was implemented with the assistance of GitHub Copilot (Claude) under my orchestration and direction. All architectural decisions, code review, and testing were performed by me. The AI assisted with code generation, research, and iterative refinement.
