### PR TITLE
refactor(core): remove outdated TODO comments referencing TypeScript 2.1

### DIFF
--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -239,7 +239,6 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
    */
   @Input()
   set ngForTemplate(value: TemplateRef<NgForOfContext<T, U>>) {
-    // TODO(TS2.1): make TemplateRef<Partial<NgForRowOf<T>>> once we move to TS v2.1
     // The current type is too restrictive; a template that just uses index, for example,
     // should be acceptable.
     if (value) {

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -34,8 +34,6 @@ export interface KeyValueDiffer<K, V> {
    * `diff()` invocation.
    */
   diff(object: {[key: string]: V}): KeyValueChanges<string, V> | null;
-  // TODO(TS2.1): diff<KP extends string>(this: KeyValueDiffer<KP, V>, object: Record<KP, V>):
-  // KeyValueDiffer<KP, V>;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (not applicable – no functional changes)
- [ ] Docs have been added / updated (not applicable – no functional changes)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

The files keyvalue_differs.ts and ng_for_of.ts contain outdated TODO comments referencing TypeScript 2.1 features. Angular now requires TypeScript >= 5.9, making those comments obsolete.

Issue Number: N/A

## What is the new behavior?

Removed outdated TypeScript 2.1 TODO comments.
No functional changes.
No API changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change removes legacy comments that are no longer relevant and improves maintainability.
