### PR TITLE
fix(common): allow mixed pixel and responsive values in NgOptimizedIm…

### DIFF
--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -2366,7 +2366,32 @@ describe('Image directive', () => {
         );
       });
 
-      it('should throw if a complex `sizes` is used', () => {
+      it('should throw if `sizes` contains only pixel values', () => {
+        setupTestingModule();
+
+        const template = '<img ngSrc="path/img.png" width="100" height="50" sizes="500px">';
+        expect(() => {
+          const fixture = createTestComponent(template);
+          fixture.detectChanges();
+        }).toThrowError(
+          'NG02952: The NgOptimizedImage directive has detected that `sizes` was set to a string that only includes pixel values. ' +
+            'For automatic `srcset` generation, `sizes` must include responsive values, such as `sizes="50vw"` or ' +
+            '`sizes="(min-width: 768px) 50vw, 100vw"`. Pixel values can be mixed with responsive values, ' +
+            'for example `sizes="(max-width: 768px) 100vw, 370px"`. ' +
+            'To fix this, modify the `sizes` attribute, or provide your own `ngSrcset` value directly.',
+        );
+      });
+      it('should throw if `sizes` contains only pixel values with media queries', () => {
+        setupTestingModule();
+
+        const template =
+          '<img ngSrc="path/img.png" width="100" height="50" sizes="(min-width: 768px) 500px, 300px">';
+        expect(() => {
+          const fixture = createTestComponent(template);
+          fixture.detectChanges();
+        }).toThrowError(/NG02952/);
+      });
+      it('should not throw if `sizes` mixes pixel and responsive values', () => {
         setupTestingModule();
 
         const template =
@@ -2374,13 +2399,20 @@ describe('Image directive', () => {
         expect(() => {
           const fixture = createTestComponent(template);
           fixture.detectChanges();
-        }).toThrowError(
-          'NG02952: The NgOptimizedImage directive has detected that `sizes` was set to a string including pixel values. ' +
-            'For automatic `srcset` generation, `sizes` must only include responsive values, such as `sizes="50vw"` or ' +
-            '`sizes="(min-width: 768px) 50vw, 100vw"`. To fix this, modify the `sizes` attribute, or provide your own `ngSrcset` value directly.',
-        );
+        }).not.toThrow();
       });
-      it('should throw if a complex `sizes` is used with srcset', () => {
+      it('should not throw if `sizes` has a pixel fallback with responsive media queries', () => {
+        setupTestingModule();
+
+        const template =
+          '<img ngSrc="path/img.png" width="100" height="50" ' +
+          'sizes="(max-width: 540px) 100vw, (max-width: 960px) 50vw, 370px">';
+        expect(() => {
+          const fixture = createTestComponent(template);
+          fixture.detectChanges();
+        }).not.toThrow();
+      });
+      it('should not throw if `sizes` mixes pixel and responsive values with srcset', () => {
         setupTestingModule();
 
         const template =
@@ -2388,11 +2420,7 @@ describe('Image directive', () => {
         expect(() => {
           const fixture = createTestComponent(template);
           fixture.detectChanges();
-        }).toThrowError(
-          'NG02952: The NgOptimizedImage directive has detected that `sizes` was set to a string including pixel values. ' +
-            'For automatic `srcset` generation, `sizes` must only include responsive values, such as `sizes="50vw"` or ' +
-            '`sizes="(min-width: 768px) 50vw, 100vw"`. To fix this, modify the `sizes` attribute, or provide your own `ngSrcset` value directly.',
-        );
+        }).not.toThrow();
       });
       it('should not throw if a complex `sizes` is used with ngSrcset', () => {
         setupTestingModule();


### PR DESCRIPTION
Fixes #59495

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not required – behavior correction)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

The assertNoComplexSizes validation in NgOptimizedImage rejects any `sizes` attribute containing pixel (`px`) values, even when those pixel values are used alongside responsive units such as `vw`.

This prevents valid use cases where a pixel fallback is intentionally combined with responsive media queries.

## What is the new behavior?

The heuristic now throws only when the `sizes` attribute contains exclusively pixel values and no responsive units.

If responsive units (e.g., `vw`) are present alongside pixel values, validation passes.

This ensures:
- Valid responsive configurations are allowed.
- Fixed-size configurations still trigger guidance to omit `sizes` and rely on 1x/2x density descriptors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change aligns validation behavior with real-world responsive image patterns while preserving guidance for fixed-size usage.
