### PR TITLE
refactor(compiler-cli): update updateImportClause away from deprecate…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/node_js_file_system_spec.ts
@@ -89,7 +89,7 @@ describe('NodeJSReadonlyFileSystem', () => {
 
   describe('readFileBuffer()', () => {
     it('should delegate to fs.readFileSync()', () => {
-      const buffer = new Buffer('Some contents');
+      const buffer = Buffer.from('Some contents');
       const spy = spyOn(realFs, 'readFileSync').and.returnValue(buffer);
       const result = fs.readFileBuffer(abcPath);
       expect(result).toBe(buffer);

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager/import_typescript_transform.ts
@@ -77,7 +77,7 @@ export function createTsTransformForImportManager(
 
       const newClause = ctx.factory.updateImportClause(
         clause,
-        clause.phaseModifier === ts.SyntaxKind.TypeKeyword,
+        clause.phaseModifier,
         clause.name,
         updatedImports.get(clause.namedBindings),
       );


### PR DESCRIPTION
…d signature

Updates the `updateImportClause` call to use the non-deprecated signature. Also update test `new Buffer` to `Buffer.from`
 