### PR TITLE
fix(common): fix LCP image detection with duplicate URLs

### DIFF
--- a/packages/core/test/bundling/image-directive/BUILD.bazel
+++ b/packages/core/test/bundling/image-directive/BUILD.bazel
@@ -12,6 +12,7 @@ ng_project(
         "e2e/image-perf-warnings-lazy/image-perf-warnings-lazy.ts",
         "e2e/image-perf-warnings-oversized/image-perf-warnings-oversized.ts",
         "e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings.ts",
+        "e2e/lcp-check-duplicate/lcp-check-duplicate.ts",
         "e2e/lcp-check/lcp-check.ts",
         "e2e/oversized-image/oversized-image.ts",
         "e2e/preconnect-check/preconnect-check.ts",

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.e2e-spec.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/* tslint:disable:no-console  */
+import {browser, by, element} from 'protractor';
+import {logging} from 'selenium-webdriver';
+
+import {collectBrowserLogs} from '../browser-logs-util';
+
+describe('NgOptimizedImage directive', () => {
+  it('should log a warning when a `priority` is missing on an LCP image', async () => {
+    await browser.get('/e2e/lcp-check-duplicate');
+    // Verify that both images were rendered.
+    const imgs = element.all(by.css('img'));
+    let srcB = await imgs.get(0).getAttribute('src');
+    expect(srcB.endsWith('b.png')).toBe(true);
+    let srcA = await imgs.get(1).getAttribute('src');
+    expect(srcA.endsWith('a.png')).toBe(true);
+    // The `b.png` and `a.png` images are used twice in a template.
+    srcB = await imgs.get(2).getAttribute('src');
+    expect(srcB.endsWith('b.png')).toBe(true);
+    srcA = await imgs.get(3).getAttribute('src');
+    expect(srcA.endsWith('a.png')).toBe(true);
+
+    // Make sure that no warnings are in the console for image `a.png`,
+    // since the first instance has the `priority` attribute, and is the LCP element.
+    const logs = await collectBrowserLogs(logging.Level.SEVERE);
+    expect(logs.length).toEqual(0);
+  });
+});

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check-duplicate/lcp-check-duplicate.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {NgOptimizedImage} from '@angular/common';
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'lcp-check',
+  imports: [NgOptimizedImage],
+  template: `
+    <!--
+      'b.png' should *not* be treated as an LCP element,
+      since there is a bigger one right below it
+    -->
+    <img ngSrc="/e2e/b.png" width="5" height="5" />
+
+    <br />
+
+    <!-- 'a.png' should be treated as an LCP element, and has priority -->
+    <img ngSrc="/e2e/a.png" width="2500" height="2500" priority />
+
+    <br />
+
+    <!--
+      'b.png' should *not* be treated as an LCP element here
+      as well, since it's below the fold
+    -->
+    <img ngSrc="/e2e/b.png" width="10" height="10" />
+
+    <!-- 'a.png' doesn't have priority, and is not the LCP element -->
+    <img ngSrc="/e2e/a.png" width="1000" height="1000" />
+
+    <br />
+  `,
+})
+export class LcpCheckDuplicate {}

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {browser, by, element, ExpectedConditions} from 'protractor';
+import {browser} from 'protractor';
 import {logging} from 'selenium-webdriver';
 
 import {collectBrowserLogs} from '../browser-logs-util';

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -27,6 +27,7 @@ import {
 } from './e2e/oversized-image/oversized-image';
 import {PreconnectCheckComponent} from './e2e/preconnect-check/preconnect-check';
 import {PlaygroundComponent} from './playground';
+import {LcpCheckDuplicate} from './e2e/lcp-check-duplicate/lcp-check-duplicate';
 
 @Component({
   selector: 'app-root',
@@ -42,6 +43,7 @@ const ROUTES = [
   // Paths below are used for e2e testing:
   {path: 'e2e/basic', component: BasicComponent},
   {path: 'e2e/lcp-check', component: LcpCheckComponent},
+  {path: 'e2e/lcp-check-duplicate', component: LcpCheckDuplicate},
   {path: 'e2e/image-perf-warnings-lazy', component: ImagePerfWarningsLazyComponent},
   {path: 'e2e/image-perf-warnings-oversized', component: ImagePerfWarningsOversizedComponent},
   {path: 'e2e/svg-no-perf-oversized-warnings', component: SvgNoOversizedPerfWarningsComponent},


### PR DESCRIPTION
This change adds a counter for each image URL. The observer only treats an image as gone when the count hits zero, so LCP stays accurate even with duplicate URLs.


Fixes #53278
 