### PR TITLE
feat(core): add special return statuses for resource params

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -12,6 +12,7 @@ import { Injector } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Provider } from '@angular/core';
+import { ResourceParamsContext } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
 import { ValueEqualityFn } from '@angular/core';
@@ -2980,43 +2981,43 @@ export const httpResource: HttpResourceFn;
 
 // @public
 export interface HttpResourceFn {
-    <TResult = unknown>(url: () => string | undefined, options: HttpResourceOptions<TResult, unknown> & {
+    <TResult = unknown>(url: (ctx: ResourceParamsContext) => string | undefined, options: HttpResourceOptions<TResult, unknown> & {
         defaultValue: NoInfer<TResult>;
     }): HttpResourceRef<TResult>;
-    <TResult = unknown>(url: () => string | undefined, options?: HttpResourceOptions<TResult, unknown>): HttpResourceRef<TResult | undefined>;
-    <TResult = unknown>(request: () => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, unknown> & {
+    <TResult = unknown>(url: (ctx: ResourceParamsContext) => string | undefined, options?: HttpResourceOptions<TResult, unknown>): HttpResourceRef<TResult | undefined>;
+    <TResult = unknown>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, unknown> & {
         defaultValue: NoInfer<TResult>;
     }): HttpResourceRef<TResult>;
-    <TResult = unknown>(request: () => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, unknown>): HttpResourceRef<TResult | undefined>;
+    <TResult = unknown>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, unknown>): HttpResourceRef<TResult | undefined>;
     arrayBuffer: {
-        <TResult = ArrayBuffer>(url: () => string | undefined, options: HttpResourceOptions<TResult, ArrayBuffer> & {
+        <TResult = ArrayBuffer>(url: (ctx: ResourceParamsContext) => string | undefined, options: HttpResourceOptions<TResult, ArrayBuffer> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = ArrayBuffer>(url: () => string | undefined, options?: HttpResourceOptions<TResult, ArrayBuffer>): HttpResourceRef<TResult | undefined>;
-        <TResult = ArrayBuffer>(request: () => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, ArrayBuffer> & {
+        <TResult = ArrayBuffer>(url: (ctx: ResourceParamsContext) => string | undefined, options?: HttpResourceOptions<TResult, ArrayBuffer>): HttpResourceRef<TResult | undefined>;
+        <TResult = ArrayBuffer>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, ArrayBuffer> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = ArrayBuffer>(request: () => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, ArrayBuffer>): HttpResourceRef<TResult | undefined>;
+        <TResult = ArrayBuffer>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, ArrayBuffer>): HttpResourceRef<TResult | undefined>;
     };
     blob: {
-        <TResult = Blob>(url: () => string | undefined, options: HttpResourceOptions<TResult, Blob> & {
+        <TResult = Blob>(url: (ctx: ResourceParamsContext) => string | undefined, options: HttpResourceOptions<TResult, Blob> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = Blob>(url: () => string | undefined, options?: HttpResourceOptions<TResult, Blob>): HttpResourceRef<TResult | undefined>;
-        <TResult = Blob>(request: () => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, Blob> & {
+        <TResult = Blob>(url: (ctx: ResourceParamsContext) => string | undefined, options?: HttpResourceOptions<TResult, Blob>): HttpResourceRef<TResult | undefined>;
+        <TResult = Blob>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, Blob> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = Blob>(request: () => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, Blob>): HttpResourceRef<TResult | undefined>;
+        <TResult = Blob>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, Blob>): HttpResourceRef<TResult | undefined>;
     };
     text: {
-        <TResult = string>(url: () => string | undefined, options: HttpResourceOptions<TResult, string> & {
+        <TResult = string>(url: (ctx: ResourceParamsContext) => string | undefined, options: HttpResourceOptions<TResult, string> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = string>(url: () => string | undefined, options?: HttpResourceOptions<TResult, string>): HttpResourceRef<TResult | undefined>;
-        <TResult = string>(request: () => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, string> & {
+        <TResult = string>(url: (ctx: ResourceParamsContext) => string | undefined, options?: HttpResourceOptions<TResult, string>): HttpResourceRef<TResult | undefined>;
+        <TResult = string>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options: HttpResourceOptions<TResult, string> & {
             defaultValue: NoInfer<TResult>;
         }): HttpResourceRef<TResult>;
-        <TResult = string>(request: () => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, string>): HttpResourceRef<TResult | undefined>;
+        <TResult = string>(request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined, options?: HttpResourceOptions<TResult, string>): HttpResourceRef<TResult | undefined>;
     };
 }
 

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -185,7 +185,7 @@ export interface BaseResourceOptions<T, R> {
     defaultValue?: NoInfer<T>;
     equal?: ValueEqualityFn<T>;
     injector?: Injector;
-    params?: () => R;
+    params?: (ctx: ResourceParamsContext) => R;
 }
 
 // @public
@@ -1658,6 +1658,12 @@ export function resource<T, R>(options: ResourceOptions<T, R> & {
 export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
 
 // @public
+export class ResourceDependencyError extends Error {
+    constructor(dependency: Resource<unknown>);
+    readonly dependency: Resource<unknown>;
+}
+
+// @public
 export function resourceFromSnapshots<T>(source: () => ResourceSnapshot<T>): Resource<T>;
 
 // @public
@@ -1679,6 +1685,17 @@ export interface ResourceLoaderParams<R> {
 export type ResourceOptions<T, R> = (PromiseResourceOptions<T, R> | StreamingResourceOptions<T, R>) & {
     debugName?: string;
 };
+
+// @public
+export interface ResourceParamsContext {
+    readonly chain: <T>(resource: Resource<T>) => T;
+}
+
+// @public
+export class ResourceParamsStatus extends Error {
+    static readonly IDLE: ResourceParamsStatus;
+    static readonly LOADING: ResourceParamsStatus;
+}
 
 // @public
 export interface ResourceRef<T> extends WritableResource<T> {

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isNode} from '@angular/private/testing';
-import {ApplicationRef, Injector, signal} from '@angular/core';
+import {ApplicationRef, Injector, resourceFromSnapshots, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {isNode} from '@angular/private/testing';
 import {
-  HttpEventType,
-  provideHttpClient,
-  httpResource,
   HttpContext,
   HttpContextToken,
+  HttpEventType,
+  httpResource,
   HttpResourceRef,
+  provideHttpClient,
 } from '../index';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 import {withHttpTransferCache} from '../src/transfer_cache';
@@ -356,6 +356,17 @@ describe('httpResource', () => {
     expect(res.headers()).toBe(undefined);
     expect(res.progress()).toBe(undefined);
     expect(res.statusCode()).toBe(undefined);
+  });
+
+  it('should support chain', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const endpoint = resourceFromSnapshots(signal({status: 'resolved', value: '/data'}));
+    const res = httpResource(({chain}) => chain(endpoint), {injector: TestBed.inject(Injector)});
+    TestBed.tick();
+    const req = backend.expectOne('/data');
+    req.flush([]);
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
   });
 
   describe('types', () => {

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -10,6 +10,45 @@ import {Injector} from '../di/injector';
 import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {WritableSignal} from '../render3/reactivity/signal';
 
+/** Error thrown when a `Resource` dependency of another resource errors. */
+export class ResourceDependencyError extends Error {
+  /** The dependency that errored. */
+  readonly dependency: Resource<unknown>;
+
+  constructor(dependency: Resource<unknown>) {
+    super('Dependency error', {cause: dependency.error()});
+    this.name = 'ResourceDependencyError';
+    this.dependency = dependency;
+  }
+}
+
+/**
+ * Special status codes that can be thrown from a resource's `params` or `request` function to
+ * indicate that the resource should transition to that status.
+ */
+export class ResourceParamsStatus extends Error {
+  private readonly _brand: undefined;
+  private constructor(msg: string) {
+    super(msg);
+  }
+
+  /** Status code that transitions the resource to `idle` status. */
+  static readonly IDLE = new ResourceParamsStatus('IDLE');
+
+  /** Status code that transitions the resource to `loading` status. */
+  static readonly LOADING = new ResourceParamsStatus('LOADING');
+}
+
+/** Context received by a resource's `params` or `request` function. */
+export interface ResourceParamsContext {
+  /**
+   * Chains the current params off of the value of another resource, returning the value
+   * of the other resource if it is available, or propagating the status to the current resource by
+   * throwing the appropriate status code if the value is not available.
+   */
+  readonly chain: <T>(resource: Resource<T>) => T;
+}
+
 /**
  * String value capturing the status of a `Resource`.
  *
@@ -175,7 +214,7 @@ export interface BaseResourceOptions<T, R> {
    *
    * If a params function isn't provided, the loader won't rerun unless the resource is reloaded.
    */
-  params?: () => R;
+  params?: (ctx: ResourceParamsContext) => R;
 
   /**
    * The value which will be returned from the resource when a server value is unavailable, such as

--- a/packages/core/test/resource/BUILD.bazel
+++ b/packages/core/test/resource/BUILD.bazel
@@ -12,6 +12,7 @@ ng_project(
         "//packages/core",
         "//packages/core/src/util",
         "//packages/core/testing",
+        "//packages/private/testing",
     ],
 )
 

--- a/packages/core/test/resource/chain_spec.ts
+++ b/packages/core/test/resource/chain_spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Injector,
+  ResourceDependencyError,
+  resourceFromSnapshots,
+  ResourceParamsStatus,
+  signal,
+  type ResourceSnapshot,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {timeout} from '@angular/private/testing';
+import {paramsContext, resource} from '../../src/resource/resource';
+
+describe('chain', () => {
+  it('should throw idle if resource is idle', () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'idle', value: 0});
+    const res = resourceFromSnapshots(state);
+    expect(() => paramsContext.chain(res)).toThrow(ResourceParamsStatus.IDLE);
+  });
+
+  it('should throw loading if resource is loading', () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'loading', value: 0});
+    const res = resourceFromSnapshots(state);
+    expect(() => paramsContext.chain(res)).toThrow(ResourceParamsStatus.LOADING);
+  });
+
+  it('should throw loading if resource is reloading', () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'reloading', value: 2});
+    const res = resourceFromSnapshots(state);
+    expect(() => paramsContext.chain(res)).toThrow(ResourceParamsStatus.LOADING);
+  });
+
+  it('should throw dependency error if resource is error', () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'error', error: new Error('fail')});
+    const res = resourceFromSnapshots(state);
+    expect(() => paramsContext.chain(res)).toThrow(jasmine.any(ResourceDependencyError));
+  });
+
+  it('should return value when resolved', () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'resolved', value: 2});
+    const res = resourceFromSnapshots(state);
+    expect(paramsContext.chain(res)).toEqual(2);
+  });
+
+  it('should chain resources together', async () => {
+    const state = signal<ResourceSnapshot<number>>({status: 'idle', value: 0});
+    const res1 = resourceFromSnapshots(state);
+    const loaderSpy = jasmine.createSpy('loader');
+    const res2 = resource({
+      params: () => paramsContext.chain(res1) * 2,
+      loader: async ({params}) => {
+        loaderSpy();
+        return params;
+      },
+      injector: TestBed.inject(Injector),
+    });
+
+    // Idle because res1 is idle
+    expect(res2.status()).toBe('idle');
+    expect(loaderSpy).not.toHaveBeenCalled();
+
+    state.set({status: 'loading', value: 0});
+    TestBed.tick();
+
+    // Loading because res1 is loading, res2 loader not run yet.
+    expect(res2.status()).toBe('loading');
+    expect(loaderSpy).not.toHaveBeenCalled();
+
+    state.set({status: 'resolved', value: 2});
+    TestBed.tick();
+
+    // Loading because res2 loader is running.
+    expect(res2.status()).toBe('loading');
+    expect(loaderSpy).toHaveBeenCalled();
+
+    await timeout();
+
+    // Resolved.
+    expect(res2.status()).toBe('resolved');
+    expect(res2.value()).toBe(4);
+
+    const error = Error('fail');
+    state.set({status: 'error', error});
+    TestBed.tick();
+
+    // Error due to error in res1.
+    expect(res2.status()).toBe('error');
+    expect(res2.error()).toBeInstanceOf(ResourceDependencyError);
+    expect(res2.error()?.cause).toBe(error);
+  });
+});

--- a/packages/core/test/resource/params_status_spec.ts
+++ b/packages/core/test/resource/params_status_spec.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ApplicationRef, Injector, resource, ResourceParamsStatus, signal} from '../../src/core';
+import {TestBed} from '../../testing';
+
+function throwStatusAndErrors<T>(source: () => T | ResourceParamsStatus | Error): () => T {
+  return () => {
+    const value = source();
+    if (value instanceof Error) throw value;
+    if (value === ResourceParamsStatus.IDLE || value === ResourceParamsStatus.LOADING) throw value;
+    return value as T;
+  };
+}
+
+describe('resource with ResourceParamsStatus', () => {
+  it('should transition to idle when params throws ResourceParamsStatus.IDLE', async () => {
+    const s = signal<string | ResourceParamsStatus>('foo');
+    const res = await act(() =>
+      resource({
+        params: throwStatusAndErrors(s),
+        loader: async ({params}) => {
+          return params;
+        },
+        injector: TestBed.inject(Injector),
+      }),
+    );
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('foo');
+
+    await act(() => s.set(ResourceParamsStatus.IDLE));
+
+    expect(res.status()).toBe('idle');
+    expect(res.value()).toBe(undefined);
+  });
+
+  it('should transition to loading when params throws ResourceParamsStatus.LOADING', async () => {
+    const s = signal<string | ResourceParamsStatus>('foo');
+    let loadCount = 0;
+    const res = await act(() =>
+      resource({
+        params: throwStatusAndErrors(s),
+        loader: async ({params}) => {
+          loadCount++;
+          return params as string;
+        },
+        injector: TestBed.inject(Injector),
+      }),
+    );
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('foo');
+    expect(loadCount).toBe(1);
+
+    await act(() => s.set(ResourceParamsStatus.LOADING));
+
+    expect(res.status()).toBe('loading');
+    expect(res.value()).toBe(undefined);
+    expect(loadCount).toBe(1);
+  });
+
+  it('should transition to error when params throws an Error', async () => {
+    const s = signal<string | Error>('foo');
+    const res = await act(() =>
+      resource({
+        params: throwStatusAndErrors(s),
+        loader: async ({params}) => params as string,
+        injector: TestBed.inject(Injector),
+      }),
+    );
+
+    expect(res.status()).toBe('resolved');
+
+    const err = new Error('params error');
+    await act(() => s.set(err));
+
+    expect(res.status()).toBe('error');
+    expect(res.error()).toEqual(err);
+    expect(() => res.value()).toThrowError(/params error/);
+  });
+
+  it('should recover from special statuses', async () => {
+    const s = signal<string | ResourceParamsStatus | Error>(ResourceParamsStatus.IDLE);
+    let loadCount = 0;
+    const res = await act(() =>
+      resource({
+        params: throwStatusAndErrors(s),
+        loader: async ({params}) => {
+          loadCount++;
+          return params;
+        },
+        injector: TestBed.inject(Injector),
+      }),
+    );
+
+    expect(res.status()).toBe('idle');
+
+    await act(() => s.set(ResourceParamsStatus.LOADING));
+
+    expect(res.status()).toBe('loading');
+    expect(loadCount).toBe(0);
+
+    await act(() => s.set(new Error('fail')));
+
+    expect(res.status()).toBe('error');
+    expect(loadCount).toBe(0);
+
+    await act(() => s.set('foo'));
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('foo');
+    expect(loadCount).toBe(1);
+  });
+});
+
+async function act<T>(fn: () => T): Promise<T> {
+  const result = fn();
+  await TestBed.inject(ApplicationRef).whenStable();
+  return result;
+}


### PR DESCRIPTION
Allows throwing from the resource's params function to transition the
resource to a status other than resolved.

In particular, the following values can be thrown from params:
- `ResourceParamsStatus.IDLE` causes the resource to become `idle`
  (equivalent to returning `undefined`)
- `ResourceParamsStatus.LOADING` causes the resource to become `loading`
- Any `Error` object causes the resource to become `error` and report
  the error that was thrown via `.error()`

To simplify chaining together resources, this PR also introduces a
context object passed into to the `params` functon. This context
contains a `chain` function that can be used to get the value of a
resource that the params want to depend on, while automatically
propagating the idle, loading, and erorr states of the resource forward.