### PR TITLE
feat(forms): add `valueChanges`, `statusChanges` and `events` support in InteropNgControl

### DIFF
--- a/packages/forms/signals/src/controls/interop_ng_control.ts
+++ b/packages/forms/signals/src/controls/interop_ng_control.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵRuntimeError as RuntimeError} from '@angular/core';
+import {
+  effect,
+  EventEmitter,
+  type Injector,
+  untracked,
+  ɵRuntimeError as RuntimeError,
+} from '@angular/core';
 import {RuntimeErrorCode} from '../errors';
 import {signalErrorsToValidationErrors} from '../compat/validation_errors';
 
@@ -17,6 +23,11 @@ import {
   type FormControlStatus,
   type ValidationErrors,
   type ValidatorFn,
+  ValueChangeEvent,
+  TouchedChangeEvent,
+  PristineChangeEvent,
+  ControlEvent,
+  StatusChangeEvent,
 } from '@angular/forms';
 import type {ReadonlyFieldState} from '../api/types';
 
@@ -47,6 +58,9 @@ interface CombinedControl {
   pristine: boolean;
   dirty: boolean;
   status: FormControlStatus;
+  events: AbstractControl['events'];
+  statusChanges: AbstractControl['statusChanges'];
+  valueChanges: AbstractControl['valueChanges'];
   control: AbstractControl<any, any>;
   valueAccessor: ControlValueAccessor | null;
   hasValidator(validator: ValidatorFn): boolean;
@@ -61,9 +75,60 @@ interface CombinedControl {
  * equivalent in signal forms.
  */
 export class InteropNgControl implements CombinedControl {
-  constructor(protected field: () => ReadonlyFieldState<unknown>) {}
+  /**
+   * @internal
+   */
+  readonly _events = new EventEmitter<ControlEvent>();
 
+  readonly valueChanges = new EventEmitter<any>();
+  readonly statusChanges = new EventEmitter<FormControlStatus>();
+  readonly events = this._events.asObservable();
   readonly control: AbstractControl<any, any> = this as unknown as AbstractControl<any, any>;
+
+  constructor(
+    protected field: () => ReadonlyFieldState<unknown>,
+    readonly injector: Injector,
+  ) {
+    const self = this as unknown as AbstractControl;
+
+    effect(
+      () => {
+        const value = this.value;
+        untracked(() => {
+          this.valueChanges.emit(value);
+          this._events.emit(new ValueChangeEvent(value, self));
+        });
+      },
+      {injector},
+    );
+
+    effect(
+      () => {
+        const status = this.status;
+        untracked(() => {
+          this.statusChanges.emit(status);
+          this._events.emit(new StatusChangeEvent(status, self));
+        });
+      },
+      {injector},
+    );
+
+    effect(
+      () => {
+        const isTouched = this.touched;
+        untracked(() => this._events.emit(new TouchedChangeEvent(isTouched, self)));
+      },
+      {injector},
+    );
+
+    effect(
+      () => {
+        const isDirty = this.dirty;
+        untracked(() => this._events.emit(new PristineChangeEvent(isDirty, self)));
+      },
+      {injector},
+    );
+  }
 
   get value(): unknown {
     // CVA controls are not aware of user debouncing and will expect `NgControl.value` to reflect their latest writes.

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -169,7 +169,7 @@ export class FormField<T> {
   /** Lazily instantiates a fake `NgControl` for this form field. */
   /** @internal */
   get interopNgControl(): InteropNgControl {
-    return (this._interopNgControl ??= new InteropNgControl(this.state));
+    return (this._interopNgControl ??= new InteropNgControl(this.state, this.injector));
   }
 
   /** @internal */

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -31,6 +31,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {NgControl} from '@angular/forms';
 
 function isFirefox() {
   const userAgent = navigator.userAgent.toLowerCase();
@@ -66,6 +67,7 @@ import {
 } from '../../public_api';
 import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
 import {TestInputValidityMonitor} from './test_input_validity_monitor';
+import {InteropNgControl} from '../../src/controls/interop_ng_control';
 
 function configureTestValidityMonitor() {
   TestBed.configureTestingModule({
@@ -5414,6 +5416,170 @@ describe('field directive', () => {
       });
 
       expect(field().dirty()).toBe(true);
+    });
+  });
+
+  describe('NgControl interop', () => {
+    it('should emit on valueChanges', () => {
+      @Directive({
+        selector: '[observeNgControl]',
+      })
+      class ObserveNgControlDirective {
+        readonly ngControl = inject(NgControl);
+      }
+
+      @Component({
+        imports: [FormField, ObserveNgControlDirective],
+        template: `<input [formField]="f" observeNgControl />`,
+      })
+      class TestCmp {
+        readonly f = form(signal('initial'));
+        readonly observer = viewChild.required(ObserveNgControlDirective);
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const cmp = fix.componentInstance;
+      const ngControl = cmp.observer().ngControl;
+
+      const callback = jasmine.createSpy('valueChanges').and.callFake(() => {});
+      const sub = ngControl.valueChanges!.subscribe(callback);
+
+      act(() => cmp.f().value.set('updated'));
+      expect(callback).toHaveBeenCalledWith('updated');
+      expect(callback).toHaveBeenCalledTimes(1);
+      callback.calls.reset();
+
+      act(() => cmp.f().value.set('again'));
+      expect(callback).toHaveBeenCalledWith('again');
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      sub.unsubscribe();
+    });
+
+    it('should emit on statusChanges', () => {
+      @Directive({
+        selector: '[observeNgControl]',
+      })
+      class ObserveNgControlDirective {
+        readonly ngControl = inject(NgControl);
+      }
+
+      @Component({
+        imports: [FormField, ObserveNgControlDirective],
+        template: `<input [formField]="f" observeNgControl />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(''), (p) => {
+          required(p);
+        });
+        readonly observer = viewChild.required(ObserveNgControlDirective);
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const cmp = fix.componentInstance;
+      const ngControl = cmp.observer().ngControl;
+
+      const callback = jasmine.createSpy('statusChanges').and.callFake(() => {});
+      const sub = ngControl.statusChanges!.subscribe(callback);
+
+      // Initially invalid (empty string with required rule)
+      expect(ngControl.status).toBe('INVALID');
+
+      act(() => cmp.f().value.set('valid'));
+      expect(callback).toHaveBeenCalledWith('VALID');
+      expect(callback).toHaveBeenCalledTimes(1);
+      callback.calls.reset();
+
+      act(() => cmp.f().value.set(''));
+      expect(callback).toHaveBeenCalledWith('INVALID');
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      sub.unsubscribe();
+    });
+
+    it('should emit value and status events', () => {
+      @Directive({
+        selector: '[observeNgControl]',
+      })
+      class ObserveNgControlDirective {
+        readonly ngControl = inject(NgControl);
+      }
+
+      @Component({
+        imports: [FormField, ObserveNgControlDirective],
+        template: `<input [formField]="f" observeNgControl />`,
+      })
+      class TestCmp {
+        readonly f = form(signal<string>('', {equal: Object.is}), (p) => {
+          required(p);
+        });
+        readonly observer = viewChild.required(ObserveNgControlDirective);
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const cmp = fix.componentInstance;
+      const ngControl = cmp.observer().ngControl;
+      const interopNgControl = ngControl as unknown as InteropNgControl;
+
+      const callback = jasmine.createSpy('events').and.callFake(() => {});
+      const sub = interopNgControl.events.subscribe(callback);
+
+      act(() => cmp.f().value.set('valid'));
+
+      const eventNames = callback.calls
+        .allArgs()
+        .map(([event]) => (event as {constructor: {name: string}}).constructor.name);
+      expect(eventNames).toContain('ValueChangeEvent');
+      expect(eventNames).toContain('StatusChangeEvent');
+
+      sub.unsubscribe();
+    });
+
+    it('should emit valueChanges and statusChanges when NgControl is injected in custom control', () => {
+      @Component({
+        selector: 'my-input',
+        template: '<input #i [value]="value()" (input)="value.set(i.value)" />',
+      })
+      class CustomInput implements FormValueControl<string> {
+        readonly value = model.required<string>();
+        readonly ngControl = inject(NgControl);
+      }
+
+      @Component({
+        imports: [FormField, CustomInput],
+        template: `<my-input [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal(''), (p) => {
+          required(p);
+        });
+        readonly myInput = viewChild.required(CustomInput);
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const cmp = fix.componentInstance;
+      const ngControl = cmp.myInput().ngControl;
+
+      expect(ngControl.valueChanges).toBeTruthy();
+      expect(ngControl.statusChanges).toBeTruthy();
+
+      const valueCallback = jasmine.createSpy('valueChanges').and.callFake(() => {});
+      const statusCallback = jasmine.createSpy('statusChanges').and.callFake(() => {});
+      const valueSub = ngControl.valueChanges!.subscribe(valueCallback);
+      const statusSub = ngControl.statusChanges!.subscribe(statusCallback);
+
+      act(() => cmp.f().value.set('world'));
+      expect(valueCallback).toHaveBeenCalledWith('world');
+      expect(statusCallback).toHaveBeenCalledWith('VALID');
+      valueCallback.calls.reset();
+      statusCallback.calls.reset();
+
+      act(() => cmp.f().value.set(''));
+      expect(valueCallback).toHaveBeenCalledWith('');
+      expect(statusCallback).toHaveBeenCalledWith('INVALID');
+
+      valueSub.unsubscribe();
+      statusSub.unsubscribe();
     });
   });
 


### PR DESCRIPTION
The current `interop_ng_control` implementation does not expose several commonly used `NgControl` APIs when injected inside custom ControlValueAccessor implementations:
- valueChanges
- statusChanges
- events

This mean that existing directives and abstractions built for template driven or reactive forms cannot be reused while using the new `formField`  directive.

Example: [https://github.com/taiga-family/taiga-ui/blob/main/projects/cdk/classes/control.ts#L83](https://github.com/taiga-family/taiga-ui/blob/main/projects/cdk/classes/control.ts#L83)

I intentionally avoided introducing a dependency in bazel on rxjs/rxjs-interop in order to keep signal-based forms independent from RxJS-specific implementation details.
