### PR TITLE
docs: add documentation for SSR security and host validation, including details on `allowedHosts` configuration

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -30,6 +30,8 @@ const LINK_EXEMPT = new Set([
   'Event',
   'form',
   'type',
+  'Host',
+  'filter',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
@@ -41,6 +41,7 @@ export const docsCodeBlockExtension = {
       const headerRule = /header\s*:\s*(['"`])([^'"`]+)\1/; // The 2nd capture matters here
       const highlightRule = /highlight\s*:\s*(.*)([^,])/;
       const hideCopyRule = /hideCopy/;
+      const hideDollarRule = /hideDollar/;
       const preferRule = /\b(prefer|avoid)\b/;
       const linenumsRule = /linenums/;
 
@@ -52,6 +53,7 @@ export const docsCodeBlockExtension = {
         header: headerRule.exec(metadataStr)?.[2],
         highlight: highlightRule.exec(metadataStr)?.[1],
         hideCopy: hideCopyRule.test(metadataStr),
+        hideDollar: hideDollarRule.test(metadataStr),
         style: preferRule.exec(metadataStr)?.[1] as 'prefer' | 'avoid' | undefined,
         linenums: linenumsRule.test(metadataStr),
       };

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code.mts
@@ -32,6 +32,7 @@ const visibleLinesRule = /visibleLines="([^"]*)"/;
 const regionRule = /region="([^"]*)"/;
 const previewRule = /preview/;
 const hideCodeRule = /hideCode/;
+const hideDollarRule = /hideDollar/;
 const preferRule = /\b(prefer|avoid)\b/;
 
 export const docsCodeExtension = {
@@ -52,8 +53,9 @@ export const docsCodeExtension = {
       const language = languageRule.exec(attr);
       const visibleLines = visibleLinesRule.exec(attr);
       const region = regionRule.exec(attr);
-      const preview = previewRule.exec(attr) ? true : false;
-      const hideCode = hideCodeRule.exec(attr) ? true : false;
+      const preview = previewRule.test(attr);
+      const hideCode = hideCodeRule.test(attr);
+      const hideDollar = hideDollarRule.test(attr);
       const classes = classRule.exec(attr);
       const style = preferRule.exec(attr);
 
@@ -78,6 +80,7 @@ export const docsCodeExtension = {
         region: region?.[1],
         preview: preview,
         hideCode,
+        hideDollar,
         style: style?.[1] as 'prefer' | 'avoid' | undefined,
         classes: classes?.[1]?.split(' '),
       };

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
@@ -39,6 +39,8 @@ export interface CodeToken extends Tokens.Generic {
   highlight?: string;
   /** Whether to hide the copy button */
   hideCopy?: boolean;
+  /** Whether to hide the dollar sign in the shell code */
+  hideDollar?: boolean;
 
   // additional classes for the element
   classes?: string[];
@@ -132,6 +134,10 @@ function applyContainerAttributesAndClasses(el: Element, token: CodeToken) {
   if (token.hideCopy) {
     el.setAttribute('hideCopy', 'true');
   }
+  if (token.hideDollar) {
+    el.setAttribute('hideDollar', 'true');
+  }
+
   const language = token.language;
 
   if (language === 'mermaid') {

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.md
@@ -11,3 +11,7 @@ this is a code block
 ```
 code block without language
 ```
+
+```shell {hideDollar}
+echo "hello"
+```

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
@@ -27,10 +27,10 @@ describe('markdown to html', () => {
     expect(codeBlock?.textContent?.trim()).toBe('this is a code block');
   });
 
-  it('should parse all 3 code blocks', () => {
+  it('should parse all 4 code blocks', () => {
     const codeBlocks = markdownDocument.querySelectorAll('.docs-code');
 
-    expect(codeBlocks.length).toBe(3);
+    expect(codeBlocks.length).toBe(4);
   });
 
   it('should deindent code blocks correctly', () => {
@@ -41,5 +41,10 @@ describe('markdown to html', () => {
   it('should handle code blocks without language', () => {
     const codeBlock = markdownDocument.querySelectorAll('.docs-code')[2];
     expect(codeBlock).toBeDefined();
+  });
+
+  it('should parse the hideDollar attribute', () => {
+    const codeBlock = markdownDocument.querySelectorAll('.docs-code')[3];
+    expect(codeBlock.getAttribute('hideDollar')).toBe('true');
   });
 });

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
@@ -12,3 +12,5 @@ const form = {
   state: ['']  
 };  
 </docs-code>
+
+<docs-code hideDollar code="echo 'hello world'" />

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
@@ -52,4 +52,9 @@ describe('markdown to html', () => {
     const codeBlock = markdownDocument.querySelectorAll('code')[4];
     expect(codeBlock?.innerHTML).not.toContain('<a href="/api/animations/state">state</a>');
   });
+
+  it('should parse the hideDollar attribute', () => {
+    const codeBlock = markdownDocument.querySelectorAll('.docs-code')[5];
+    expect(codeBlock.getAttribute('hideDollar')).toBe('true');
+  });
 });

--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -204,15 +204,24 @@ $code-font-size: 0.875rem;
       white-space: nowrap;
     }
 
-    .shiki .line {
-      &::before {
-        content: '$';
-        padding-inline-end: 0.5rem;
+    &:not([hideDollar]) {
+      .shiki {
+        .line {
+          &::before {
+            content: '$';
+            padding-inline-end: 0.5rem;
+          }
+        }
       }
-      display: block;
+    }
 
-      &.hidden {
-        display: none;
+    .shiki {
+      .line {
+        display: block;
+
+        &.hidden {
+          display: none;
+        }
       }
     }
   }

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -617,65 +617,6 @@ export const reqHandler = createRequestHandler(async (req: Request) => {
 });
 ```
 
-## Security and host validation
+## Security
 
-Angular includes strict validation for `Host`, `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-Port` headers in the request handling pipeline to prevent header-based [Server-Side Request Forgery (SSRF)](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/SSRF).
-
-The validation rules are:
-
-- `Host` and `X-Forwarded-Host` headers are validated against a strict allowlist.
-- `Host` and `X-Forwarded-Host` headers cannot contain path separators.
-- `X-Forwarded-Port` header must be numeric.
-- `X-Forwarded-Proto` header must be `http` or `https`.
-
-Requests with invalid or disallowed headers will now log an error and fallback to Client-Side Rendering (CSR). In a future major version, these requests will be rejected with a `400 Bad Request`.
-
-NOTE: Most cloud providers and CDNs already validate these headers before the request reaches the application, but this change adds an essential layer of defense-in-depth.
-
-### Configuring allowed hosts
-
-To allow a specific hostname, you must configure the `allowedHosts` list in your `angular.json` to include all hostnames where your application is deployed. This is critical for ensuring your application works correctly and securely when deployed. The patterns support wildcards for flexible hostname matching.
-
-```json {hideCopy}
-{
-  // ...
-  "projects": {
-    "your-project-name": {
-      // ...
-      "architect": {
-        "build": {
-          "builder": "@angular/build:application",
-          "options": {
-            "security": {
-              "allowedHosts": [
-                "example.com",
-                "*.example.com" // allows all subdomains of example.com
-              ]
-            }
-            // ... other options
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-You can also configure `allowedHosts` when initializing the application engine:
-
-```typescript
-const appEngine = new AngularAppEngine({
-  allowedHosts: ['example.com', '*.trusted-example.com'],
-});
-
-const nodeAppEngine = new AngularNodeAppEngine({
-  allowedHosts: ['example.com', '*.trusted-example.com'],
-});
-```
-
-For the Node.js variant `AngularNodeAppEngine`, you can also provide `NG_ALLOWED_HOSTS` (comma-separated list) and `HOSTNAME` environment variables for authorizing hosts.
-
-```bash {hideDollar}
-export NG_ALLOWED_HOSTS="example.com,*.trusted-example.com"
-export HOSTNAME="example.com"
-```
+For detailed information on preventing Server-Side Request Forgery (SSRF) and configuring allowed hosts, see the [Server-side security](best-practices/security#preventing-server-side-request-forgery-ssrf) guide.

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -387,12 +387,15 @@ export class MyComponent {
 }
 ```
 
+<!-- UL is used below as otherwise the list will not be include as part of the note. -->
 <!-- prettier-ignore-start -->
-IMPORTANT: The above tokens will be `null` in the following scenarios:
-- During the build processes.
-- When the application is rendered in the browser (CSR).
-- When performing static site generation (SSG).
-- During route extraction in development (at the time of the request).
+
+IMPORTANT: The above tokens will be `null` in the following scenarios:<ul class="docs-list">
+  <li>During the build processes.</li>
+  <li>When the application is rendered in the browser (CSR).</li>
+  <li>When performing static site generation (SSG).</li>
+  <li>During route extraction in development (at the time of the request).</li>
+</ul>
 
 <!-- prettier-ignore-end -->
 

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -636,7 +636,7 @@ NOTE: Most cloud providers and CDNs already validate these headers before the re
 
 To allow a specific hostname, you must configure the `allowedHosts` list in your `angular.json` to include all hostnames where your application is deployed. This is critical for ensuring your application works correctly and securely when deployed. The patterns support wildcards for flexible hostname matching.
 
-```json
+```json {hideCopy}
 {
   // ...
   "projects": {
@@ -675,9 +675,7 @@ const nodeAppEngine = new AngularNodeAppEngine({
 
 For the Node.js variant `AngularNodeAppEngine`, you can also provide `NG_ALLOWED_HOSTS` (comma-separated list) and `HOSTNAME` environment variables for authorizing hosts.
 
-Example:
-
-```bash
+```bash {hideDollar}
 export NG_ALLOWED_HOSTS="example.com,*.trusted-example.com"
 export HOSTNAME="example.com"
 ```

--- a/adev/src/content/kitchen-sink.md
+++ b/adev/src/content/kitchen-sink.md
@@ -170,19 +170,20 @@ console.log('Awesome Angular Docs!');
 
 #### `<docs-code>` Attributes
 
-| Attributes     | Type                 | Details                                              |
-| :------------- | :------------------- | :--------------------------------------------------- |
-| code           | `string`             | Anything between tags is treated as code             |
-| `path`         | `string`             | Path to code example (root: `content/examples/`)     |
-| `header`       | `string`             | Title of the example (default: `file-name`)          |
-| `language`     | `string`             | code language                                        |
-| `linenums`     | `boolean`            | (False) displays line numbers                        |
-| `highlight`    | `string of number[]` | lines highlighted                                    |
-| `diff`         | `string`             | path to changed code                                 |
-| `visibleLines` | `string of number[]` | range of lines for collapse mode                     |
-| `region`       | `string`             | only show the provided region.                       |
-| `preview`      | `boolean`            | (False) display preview                              |
-| `hideCode`     | `boolean`            | (False) Whether to collapse code example by default. |
+| Attributes     | Type                 | Details                                                         |
+| :------------- | :------------------- | :-------------------------------------------------------------- |
+| code           | `string`             | Anything between tags is treated as code                        |
+| `path`         | `string`             | Path to code example (root: `content/examples/`)                |
+| `header`       | `string`             | Title of the example (default: `file-name`)                     |
+| `language`     | `string`             | code language                                                   |
+| `linenums`     | `boolean`            | (False) displays line numbers                                   |
+| `highlight`    | `string of number[]` | lines highlighted                                               |
+| `diff`         | `string`             | path to changed code                                            |
+| `visibleLines` | `string of number[]` | range of lines for collapse mode                                |
+| `region`       | `string`             | only show the provided region.                                  |
+| `preview`      | `boolean`            | (False) display preview                                         |
+| `hideCode`     | `boolean`            | (False) Whether to collapse code example by default.            |
+| `hideDollar`   | `boolean`            | (False) Whether to hide the dollar sign in shell code examples. |
 
 ### Multifile examples
 
@@ -201,12 +202,13 @@ You can create multifile examples by wrapping the examples inside a `<docs-code-
 
 #### `<docs-code-multifile>` Attributes
 
-| Attributes    | Type      | Details                                              |
-| :------------ | :-------- | :--------------------------------------------------- |
-| body contents | `string`  | nested tabs of `docs-code` examples                  |
-| `path`        | `string`  | Path to code example for preview and external link   |
-| `preview`     | `boolean` | (False) display preview                              |
-| `hideCode`    | `boolean` | (False) Whether to collapse code example by default. |
+| Attributes    | Type      | Details                                                         |
+| :------------ | :-------- | :-------------------------------------------------------------- |
+| body contents | `string`  | nested tabs of `docs-code` examples                             |
+| `path`        | `string`  | Path to code example for preview and external link              |
+| `preview`     | `boolean` | (False) display preview                                         |
+| `hideCode`    | `boolean` | (False) Whether to collapse code example by default.            |
+| `hideDollar`  | `boolean` | (False) Whether to hide the dollar sign in shell code examples. |
 
 ### Adding `preview` to your code example
 


### PR DESCRIPTION


This document adds more information about `allowedHost` option
