### PR TITLE
refactor(devtools): improve formatting of injector providers token labels

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -407,7 +407,7 @@ const getDependenciesForDirective = (
 
 const valueToLabel = (value: any): string => {
   if (isInjectionToken(value)) {
-    return `InjectionToken(${value['_desc']})`;
+    return value.toString();
   }
 
   if (typeof value === 'object') {


### PR DESCRIPTION
Use `InjectionToken.toString` for the string representation of `InjectionToken`s for better readibility.