### PR TITLE
refactor(core): rename primitives/di inject to injectFromCurrentInjector

### DIFF
--- a/packages/core/primitives/di/src/injector.ts
+++ b/packages/core/primitives/di/src/injector.ts
@@ -33,8 +33,8 @@ export function setCurrentInjector(
   return former;
 }
 
-export function inject<T>(token: InjectionToken<T> | Constructor<T>): T;
-export function inject<T>(
+export function injectFromCurrentInjector<T>(token: InjectionToken<T> | Constructor<T>): T;
+export function injectFromCurrentInjector<T>(
   token: InjectionToken<T> | Constructor<T>,
   options?: unknown,
 ): T | NotFound {


### PR DESCRIPTION
Both @angular/core and @angular/core/primitives/di export a function named inject, causing a named export conflict when merging into a single SystemJS bundle. Rename the primitives/di version to injectFromCurrentInjector to reflect its actual behavior and align with the existing getCurrentInjector and setCurrentInjector naming convention in that module.