### PR TITLE
refactor(compiler-cli): abstract type check block metadata to be AST-free

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
@@ -20,6 +20,7 @@ export type ExtendedCompilerHostMethods =
   // Used to normalize filenames for the host system. Important for proper case-sensitive file
   // handling.
   | 'getCanonicalFileName'
+  | 'getSourceFile'
   // An optional method of `ts.CompilerHost` where an implementer can override module resolution.
   | 'resolveModuleNames'
   // Retrieve the current working directory. Unlike in `ts.ModuleResolutionHost`, this is a
@@ -44,7 +45,8 @@ export interface NgCompilerAdapter
   // getCurrentDirectory is removed from `ts.ModuleResolutionHost` because it's optional, and
   // incompatible with the `ts.CompilerHost` version which isn't. The combination of these two
   // still satisfies `ts.ModuleResolutionHost`.
-  extends Omit<ts.ModuleResolutionHost, 'getCurrentDirectory'>,
+  extends
+    Omit<ts.ModuleResolutionHost, 'getCurrentDirectory'>,
     Pick<ExtendedTsCompilerHost, 'getCurrentDirectory' | ExtendedCompilerHostMethods>,
     SourceFileTypeIdentifier {
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/README.md
+++ b/packages/compiler-cli/src/ngtsc/typecheck/README.md
@@ -18,6 +18,18 @@ To understand and check the types of various operations and structures within te
 
 TCBs are not ever emitted, nor are they referenced from any other code (they're unused code as far as TypeScript is concerned). Their _runtime_ effect is therefore unimportant. What matters is that they express to TypeScript the type relationships of directives, bindings, and other entities in the template. Type errors within TCBs translate directly to type errors in the original template.
 
+### AST-Free Metadata & Preprocessor Integration
+
+As Angular evolves toward supporting alternative compilation pipelines (such as a native Rust compiler or a fast native TS parser like `ts-go`), the mechanism for providing information about components, directives, and pipes to the TCB generator has been abstracted.
+
+Instead of directly passing TypeScript AST nodes representing the original program (`ts.Node`, `ts.Declaration`, `ClassDeclaration`, etc.), the type checking system relies on "AST-free" metadata interfaces (e.g., `TcbDirectiveMetadata`, `TcbReferenceMetadata`).
+
+When operating in the traditional TypeScript compiler (`ngc`), a "TCB Adapter" translates the internal TS-bound metadata into these AST-free structures.
+
+When operating in an environment where the Angular application is analyzed by a separate preprocessor process (whether `ts-go` or Rust), the indexer performs the analysis and serializes this exact same AST-free metadata over an IPC boundary directly to the TS-based TCB generator. This enables the existing, robust TS-based template type checker (which heavily relies on TypeScript's inference engines) to continue functioning without needing to port the entire template type checking and `TcbOp` implementation to the native preprocessor.
+
+**Note on AST Generation:** While the metadata is "AST-free" in the sense that it is entirely disconnected from the original user's `ts.Program`, the TCB generation process is still fundamentally tied to TypeScript factory APIs. Because of this, certain metadata fields (such as `TcbInputMapping.transformType` and `TcbComponentMetadata.typeParameters`) are passed as strings which are parsed into AST nodes by the TCB generator. In a hybrid architecture, the native preprocessor is expected to serialize these scopes and types as strings, and the TypeScript coordinator (Node.js) is responsible for parsing these strings back into detached TypeScript AST nodes before passing them to the TCB generator. This avoids unnecessary serialization costs when the TCB generator runs directly within the existing TypeScript codebase.
+
 ### Theory
 
 Given a component `SomeCmp`, its TCB takes the form of a function:

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -8,10 +8,22 @@
 
 import {
   AbsoluteSourceSpan,
+  AST,
   BoundTarget,
   DirectiveMeta,
+  DirectiveOwner,
+  LegacyAnimationTriggerNames,
   ParseSourceSpan,
   SchemaMetadata,
+  TemplateEntity,
+  TmplAstBoundAttribute,
+  TmplAstBoundEvent,
+  TmplAstComponent,
+  TmplAstDirective,
+  TmplAstElement,
+  TmplAstReference,
+  TmplAstTemplate,
+  TmplAstTextAttribute,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -19,12 +31,101 @@ import {ErrorCode} from '../../diagnostics';
 import {Reference} from '../../imports';
 import {
   ClassPropertyMapping,
+  ClassPropertyName,
   DirectiveTypeCheckMeta,
   HostDirectiveMeta,
   InputMapping,
+  InputOrOutput,
   PipeMeta,
+  TemplateGuardMeta,
 } from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
+
+export interface TcbReferenceMetadata {
+  /** The name of the class */
+  name: string;
+  /** The module path where the symbol is located, or null if local/ambient */
+  moduleName: string | null;
+  /** True if the symbol successfully emitted locally (no external import required) */
+  isLocal: boolean;
+  /** If the reference could not be externally emitted, this string holds the diagnostic reason why */
+  unexportedDiagnostic: string | null;
+  /**
+   * Defines the `AbsoluteSourceSpan` of the target's node name, if available.
+   */
+  nodeNameSpan?: AbsoluteSourceSpan;
+
+  /**
+   * The absolute path to the file containing the reference node, if available.
+   */
+  nodeFilePath?: string;
+}
+
+export type TcbReferenceKey = string & {__brand: 'TcbReferenceKey'};
+
+export interface TcbTypeParameter {
+  name: string;
+  representation: string;
+  representationWithDefault: string;
+}
+
+export type TcbInputMapping = InputOrOutput & {
+  required: boolean;
+
+  /**
+   * AST-free string representation of the transform type of the input, if available.
+   */
+  transformType?: string;
+};
+
+export interface TcbPipeMetadata {
+  name: string;
+  ref: TcbReferenceMetadata;
+  isExplicitlyDeferred: boolean;
+}
+
+export interface TcbDirectiveMetadata {
+  ref: TcbReferenceMetadata;
+  name: string;
+  selector: string | null;
+  isComponent: boolean;
+  isGeneric: boolean;
+  isStructural: boolean;
+  isStandalone: boolean;
+  isExplicitlyDeferred: boolean;
+  preserveWhitespaces: boolean;
+  exportAs: string[] | null;
+
+  /** Type parameters of the directive, if available. */
+  typeParameters: TcbTypeParameter[] | null;
+  inputs: ClassPropertyMapping<TcbInputMapping>;
+  outputs: ClassPropertyMapping;
+  hasRequiresInlineTypeCtor: boolean;
+  ngTemplateGuards: TemplateGuardMeta[];
+  hasNgTemplateContextGuard: boolean;
+  hasNgFieldDirective: boolean;
+  coercedInputFields: Set<ClassPropertyName>;
+  restrictedInputFields: Set<ClassPropertyName>;
+  stringLiteralInputFields: Set<ClassPropertyName>;
+  undeclaredInputFields: Set<ClassPropertyName>;
+  publicMethods: Set<string>;
+  ngContentSelectors: string[] | null;
+  animationTriggerNames: LegacyAnimationTriggerNames | null;
+}
+
+export interface TcbComponentMetadata {
+  ref: TcbReferenceMetadata;
+  typeParameters: TcbTypeParameter[] | null;
+}
+
+export interface TcbTypeCheckBlockMetadata {
+  id: TypeCheckId;
+  boundTarget: BoundTarget<TcbDirectiveMetadata>;
+  pipes: Map<string, TcbPipeMetadata> | null;
+  schemas: SchemaMetadata[];
+  isStandalone: boolean;
+  preserveWhitespaces: boolean;
+}
 
 /**
  * Extension of `DirectiveMeta` that includes additional information required to type-check the
@@ -119,7 +220,7 @@ export interface TypeCtorMetadata {
   /**
    * Input, output, and query field names in the type which should be included as constructor input.
    */
-  fields: {inputs: ClassPropertyMapping<InputMapping>; queries: string[]};
+  fields: {inputs: ClassPropertyMapping<TcbInputMapping>};
 
   /**
    * `Set` of field names which have type coercion enabled.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -163,7 +163,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     private config: TypeCheckingConfig,
     private refEmitter: ReferenceEmitter,
     private reflector: ReflectionHost,
-    private compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
+    private compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName' | 'getSourceFile'>,
     private priorBuild: IncrementalBuild<unknown, FileTypeCheckingData>,
     private readonly metaReader: MetadataReader,
     private readonly localMetaReader: MetadataReaderWithIndex,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -39,6 +39,7 @@ import {
 } from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
+import {adaptTypeCheckBlockMetadata} from './tcb_adapter';
 import {DomSchemaChecker, RegistryDomSchemaChecker} from './dom';
 import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder, OutOfBandDiagnosticRecorderImpl} from './oob';
@@ -204,7 +205,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
 
   constructor(
     private config: TypeCheckingConfig,
-    private compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
+    private compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName' | 'getSourceFile'>,
     private refEmitter: ReferenceEmitter,
     private reflector: ReflectionHost,
     private host: TypeCheckingHost,
@@ -290,7 +291,6 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           fields: {
             inputs: dir.inputs,
             // TODO(alxhub): support queries
-            queries: dir.queries,
           },
           coercedInputFields: dir.coercedInputFields,
         });
@@ -568,7 +568,9 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     if (!fileData.shimData.has(shimPath)) {
       fileData.shimData.set(shimPath, {
         domSchemaChecker: new RegistryDomSchemaChecker(fileData.sourceManager),
-        oobRecorder: new OutOfBandDiagnosticRecorderImpl(fileData.sourceManager),
+        oobRecorder: new OutOfBandDiagnosticRecorderImpl(fileData.sourceManager, (name) =>
+          this.compilerHost.getSourceFile(name, ts.ScriptTarget.Latest),
+        ),
         file: new TypeCheckFile(
           shimPath,
           this.config,
@@ -669,13 +671,15 @@ class InlineTcbOp implements Op {
     const env = new Environment(this.config, im, refEmitter, this.reflector, sf);
     const fnName = ts.factory.createIdentifier(`_tcb_${this.ref.node.pos}`);
 
+    const {tcbMeta, component} = adaptTypeCheckBlockMetadata(this.ref, this.meta, env);
+
     // Inline TCBs should copy any generic type parameter nodes directly, as the TCB code is
     // inlined into the class in a context where that will always be legal.
     const fn = generateTypeCheckBlock(
       env,
-      this.ref,
+      component,
       fnName,
-      this.meta,
+      tcbMeta,
       this.domSchemaChecker,
       this.oobRecorder,
       TcbGenericContextBehavior.CopyClassNodes,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -16,7 +16,14 @@ import {
 } from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager, translateExpression} from '../../translator';
-import {TypeCheckableDirectiveMeta, TypeCheckingConfig, TypeCtorMetadata} from '../api';
+import {
+  TcbDirectiveMetadata,
+  TcbPipeMetadata,
+  TcbReferenceKey,
+  TcbReferenceMetadata,
+  TypeCheckingConfig,
+  TypeCtorMetadata,
+} from '../api';
 
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {generateTypeCtorDeclarationFn, requiresInlineTypeCtor} from './type_constructor';
@@ -40,10 +47,10 @@ export class Environment extends ReferenceEmitEnvironment {
     typeCtor: 1,
   };
 
-  private typeCtors = new Map<ClassDeclaration, string>();
+  private typeCtors = new Map<TcbReferenceKey, string>();
   protected typeCtorStatements: TcbExpr[] = [];
 
-  private pipeInsts = new Map<ClassDeclaration, string>();
+  private pipeInsts = new Map<TcbReferenceKey, string>();
   protected pipeInstStatements: TcbExpr[] = [];
 
   constructor(
@@ -62,25 +69,23 @@ export class Environment extends ReferenceEmitEnvironment {
    * Depending on the shape of the directive itself, this could be either a reference to a declared
    * type constructor, or to an inline type constructor.
    */
-  typeCtorFor(dir: TypeCheckableDirectiveMeta): TcbExpr {
-    const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
-    const node = dirRef.node;
-    if (this.typeCtors.has(node)) {
-      return new TcbExpr(this.typeCtors.get(node)!);
+  typeCtorFor(dir: TcbDirectiveMetadata): TcbExpr {
+    const key = getTcbReferenceKey(dir.ref);
+    if (this.typeCtors.has(key)) {
+      return new TcbExpr(this.typeCtors.get(key)!);
     }
 
-    if (requiresInlineTypeCtor(node, this.reflector, this)) {
+    if (dir.hasRequiresInlineTypeCtor) {
       // The constructor has already been created inline, we just need to construct a reference to
       // it.
-      const ref = this.reference(dirRef);
-      const typeCtorExpr = `${ref.print()}.ngTypeCtor`;
-      this.typeCtors.set(node, typeCtorExpr);
+      const typeCtorExpr = `${this.referenceTcbValue(dir.ref).print()}.ngTypeCtor`;
+      this.typeCtors.set(key, typeCtorExpr);
       return new TcbExpr(typeCtorExpr);
     } else {
       const fnName = `_ctor${this.nextIds.typeCtor++}`;
-      const nodeTypeRef = this.referenceType(dirRef);
+      const nodeTypeRef = this.referenceTcbType(dir.ref);
       if (!ts.isTypeReferenceNode(nodeTypeRef)) {
-        throw new Error(`Expected TypeReferenceNode from reference to ${dirRef.debugName}`);
+        throw new Error(`Expected TypeReferenceNode from reference to ${dir.ref.name}`);
       }
       const meta: TypeCtorMetadata = {
         fnName,
@@ -88,14 +93,14 @@ export class Environment extends ReferenceEmitEnvironment {
         fields: {
           inputs: dir.inputs,
           // TODO: support queries
-          queries: dir.queries,
         },
         coercedInputFields: dir.coercedInputFields,
       };
-      const typeParams = this.emitTypeParameters(node);
+
+      const typeParams = dir.typeParameters || undefined;
       const typeCtor = generateTypeCtorDeclarationFn(this, meta, nodeTypeRef.typeName, typeParams);
       this.typeCtorStatements.push(typeCtor);
-      this.typeCtors.set(node, fnName);
+      this.typeCtors.set(key, fnName);
       return new TcbExpr(fnName);
     }
   }
@@ -103,15 +108,16 @@ export class Environment extends ReferenceEmitEnvironment {
   /*
    * Get an expression referring to an instance of the given pipe.
    */
-  pipeInst(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): TcbExpr {
-    if (this.pipeInsts.has(ref.node)) {
-      return new TcbExpr(this.pipeInsts.get(ref.node)!);
+  pipeInst(pipe: TcbPipeMetadata): TcbExpr {
+    const key = getTcbReferenceKey(pipe.ref);
+    if (this.pipeInsts.has(key)) {
+      return new TcbExpr(this.pipeInsts.get(key)!);
     }
 
-    const pipeType = this.referenceType(ref);
+    const pipeType = this.referenceTcbType(pipe.ref);
     const pipeInstId = `_pipe${this.nextIds.pipeInst++}`;
 
-    this.pipeInsts.set(ref.node, pipeInstId);
+    this.pipeInsts.set(key, pipeInstId);
     this.pipeInstStatements.push(
       declareVariable(new TcbExpr(pipeInstId), new TcbExpr(tempPrint(pipeType, this.contextFile))),
     );
@@ -151,4 +157,11 @@ export class Environment extends ReferenceEmitEnvironment {
   getPreludeStatements(): TcbExpr[] {
     return [...this.pipeInstStatements, ...this.typeCtorStatements];
   }
+}
+
+export function getTcbReferenceKey(ref: TcbReferenceMetadata): TcbReferenceKey {
+  if (ref.nodeFilePath !== undefined && ref.nodeNameSpan !== undefined) {
+    return `${ref.nodeFilePath}#${ref.nodeNameSpan.start}` as TcbReferenceKey;
+  }
+  return (ref.moduleName ? `${ref.moduleName}#${ref.name}` : ref.name) as TcbReferenceKey;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/bindings.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/bindings.ts
@@ -21,7 +21,7 @@ import {
   TmplAstTextAttribute,
 } from '@angular/compiler';
 import ts from 'typescript';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {ClassPropertyName} from '../../../metadata';
 import {Reference} from '../../../imports';
 import {Context} from './context';
@@ -35,7 +35,7 @@ export interface TcbBoundAttribute {
     fieldName: ClassPropertyName;
     required: boolean;
     isSignal: boolean;
-    transformType: Reference<ts.TypeNode> | null;
+    transformType?: string;
     isTwoWayBinding: boolean;
   }[];
 }
@@ -87,7 +87,7 @@ export interface TcbDirectiveUnsetInput {
 export type TcbDirectiveInput = TcbDirectiveBoundInput | TcbDirectiveUnsetInput;
 
 export function getBoundAttributes(
-  directive: TypeCheckableDirectiveMeta,
+  directive: TcbDirectiveMetadata,
   node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
 ): TcbBoundAttribute[] {
   const boundInputs: TcbBoundAttribute[] = [];
@@ -114,7 +114,7 @@ export function getBoundAttributes(
           return {
             fieldName: input.classPropertyName,
             required: input.required,
-            transformType: input.transform?.type || null,
+            transformType: input.transformType,
             isSignal: input.isSignal,
             isTwoWayBinding:
               attr instanceof TmplAstBoundAttribute && attr.type === BindingType.TwoWay,
@@ -150,7 +150,7 @@ export function checkSplitTwoWayBinding(
     return false;
   }
   // Input consumer should be a directive because it's claimed
-  const inputConsumer = tcb.boundTarget.getConsumerOfBinding(input) as TypeCheckableDirectiveMeta;
+  const inputConsumer = tcb.boundTarget.getConsumerOfBinding(input) as TcbDirectiveMetadata;
   const outputConsumer = tcb.boundTarget.getConsumerOfBinding(output);
   if (
     outputConsumer === null ||
@@ -160,22 +160,10 @@ export function checkSplitTwoWayBinding(
     return false;
   }
   if (outputConsumer instanceof TmplAstElement) {
-    tcb.oobRecorder.splitTwoWayBinding(
-      tcb.id,
-      input,
-      output,
-      inputConsumer.ref.node,
-      outputConsumer,
-    );
+    tcb.oobRecorder.splitTwoWayBinding(tcb.id, input, output, inputConsumer, outputConsumer);
     return true;
   } else if (outputConsumer.ref !== inputConsumer.ref) {
-    tcb.oobRecorder.splitTwoWayBinding(
-      tcb.id,
-      input,
-      output,
-      inputConsumer.ref.node,
-      outputConsumer.ref.node,
-    );
+    tcb.oobRecorder.splitTwoWayBinding(tcb.id, input, output, inputConsumer, outputConsumer);
     return true;
   }
   return false;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/context.ts
@@ -9,8 +9,7 @@
 import {BoundTarget, SchemaMetadata} from '@angular/compiler';
 import {DomSchemaChecker} from '../dom';
 import {OutOfBandDiagnosticRecorder} from '../oob';
-import {TypeCheckableDirectiveMeta, TypeCheckId} from '../../api';
-import {PipeMeta} from '../../../metadata';
+import {TypeCheckId, TcbDirectiveMetadata, TcbPipeMetadata} from '../../api';
 import {Environment} from '../environment';
 
 /**
@@ -56,8 +55,8 @@ export class Context {
     readonly domSchemaChecker: DomSchemaChecker,
     readonly oobRecorder: OutOfBandDiagnosticRecorder,
     readonly id: TypeCheckId,
-    readonly boundTarget: BoundTarget<TypeCheckableDirectiveMeta>,
-    private pipes: Map<string, PipeMeta> | null,
+    readonly boundTarget: BoundTarget<TcbDirectiveMetadata>,
+    private pipes: Map<string, TcbPipeMetadata> | null,
     readonly schemas: SchemaMetadata[],
     readonly hostIsStandalone: boolean,
     readonly hostPreserveWhitespaces: boolean,
@@ -73,7 +72,7 @@ export class Context {
     return `_t${this.nextId++}`;
   }
 
-  getPipeByName(name: string): PipeMeta | null {
+  getPipeByName(name: string): TcbPipeMetadata | null {
     if (this.pipes === null || !this.pipes.has(name)) {
       return null;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_constructor.ts
@@ -11,7 +11,7 @@ import {TcbOp} from './base';
 import {quoteAndEscape, TcbExpr} from './codegen';
 import {Context} from './context';
 import type {Scope} from './scope';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {ExpressionIdentifier} from '../comments';
 import {unwrapWritableSignal} from './expression';
 import {CustomFormControlType, expandBoundAttributesForField} from './signal_forms';
@@ -35,7 +35,7 @@ export class TcbDirectiveCtorOp extends TcbOp {
     private tcb: Context,
     private scope: Scope,
     private node: DirectiveOwner,
-    private dir: TypeCheckableDirectiveMeta,
+    private dir: TcbDirectiveMetadata,
     private customFormControlType: CustomFormControlType | null,
   ) {
     super();
@@ -139,7 +139,7 @@ export class TcbDirectiveCtorCircularFallbackOp extends TcbOp {
   constructor(
     private tcb: Context,
     private scope: Scope,
-    private dir: TypeCheckableDirectiveMeta,
+    private dir: TcbDirectiveMetadata,
   ) {
     super();
   }
@@ -161,7 +161,7 @@ export class TcbDirectiveCtorCircularFallbackOp extends TcbOp {
  * the directive instance from any bound inputs.
  */
 function tcbCallTypeCtor(
-  dir: TypeCheckableDirectiveMeta,
+  dir: TcbDirectiveMetadata,
   tcb: Context,
   inputs: TcbDirectiveInput[],
 ): TcbExpr {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_type.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/directive_type.ts
@@ -12,9 +12,7 @@ import type {Context} from './context';
 import type {Scope} from './scope';
 import {TcbOp} from './base';
 import {declareVariable, TcbExpr, tempPrint} from './codegen';
-import {TypeCheckableDirectiveMeta} from '../../api';
-import {Reference} from '../../../imports';
-import {ClassDeclaration} from '../../../reflection';
+import {TcbDirectiveMetadata} from '../../api';
 import {ExpressionIdentifier} from '../comments';
 
 /**
@@ -26,7 +24,7 @@ export abstract class TcbDirectiveTypeOpBase extends TcbOp {
     protected tcb: Context,
     protected scope: Scope,
     protected node: DirectiveOwner,
-    protected dir: TypeCheckableDirectiveMeta,
+    protected dir: TcbDirectiveMetadata,
   ) {
     super();
   }
@@ -39,29 +37,29 @@ export abstract class TcbDirectiveTypeOpBase extends TcbOp {
   }
 
   override execute(): TcbExpr {
-    const dirRef = this.dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
-    const rawType = this.tcb.env.referenceType(this.dir.ref);
+    const rawType = this.tcb.env.referenceTcbType(this.dir.ref);
 
     let type: TcbExpr;
     let span: ParseSourceSpan;
-    if (this.dir.isGeneric === false || dirRef.node.typeParameters === undefined) {
-      type = new TcbExpr(tempPrint(rawType, dirRef.node.getSourceFile()));
+    if (
+      this.dir.isGeneric === false ||
+      this.dir.typeParameters === null ||
+      this.dir.typeParameters.length === 0
+    ) {
+      type = new TcbExpr(tempPrint(rawType, this.tcb.env.contextFile));
     } else {
       if (!ts.isTypeReferenceNode(rawType)) {
         throw new Error(
-          `Expected TypeReferenceNode when referencing the type for ${this.dir.ref.debugName}`,
+          `Expected TypeReferenceNode when referencing the type for ${this.dir.ref.name}`,
         );
       }
-      const typeArguments = dirRef.node.typeParameters.map(() =>
-        ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-      );
-
-      type = new TcbExpr(
-        tempPrint(
-          ts.factory.createTypeReferenceNode(rawType.typeName, typeArguments),
-          dirRef.node.getSourceFile(),
-        ),
-      );
+      const typeName = ts.isIdentifier(rawType.typeName)
+        ? rawType.typeName.text
+        : tempPrint(rawType.typeName, this.tcb.env.contextFile);
+      const typeArguments = Array(this.dir.typeParameters?.length ?? 0)
+        .fill('any')
+        .join(', ');
+      type = new TcbExpr(`${typeName}<${typeArguments}>`);
     }
 
     if (this.node instanceof TmplAstHostElement) {
@@ -93,9 +91,8 @@ export class TcbNonGenericDirectiveTypeOp extends TcbDirectiveTypeOpBase {
    * the newly created variable.
    */
   override execute(): TcbExpr {
-    const dirRef = this.dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
     if (this.dir.isGeneric) {
-      throw new Error(`Assertion Error: expected ${dirRef.debugName} not to be generic.`);
+      throw new Error(`Assertion Error: expected ${this.dir.ref.name} not to be generic.`);
     }
     return super.execute();
   }
@@ -111,10 +108,9 @@ export class TcbNonGenericDirectiveTypeOp extends TcbDirectiveTypeOpBase {
  */
 export class TcbGenericDirectiveTypeWithAnyParamsOp extends TcbDirectiveTypeOpBase {
   override execute(): TcbExpr {
-    const dirRef = this.dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
-    if (dirRef.node.typeParameters === undefined) {
+    if (this.dir.typeParameters === null || this.dir.typeParameters.length === 0) {
       throw new Error(
-        `Assertion Error: expected typeParameters when creating a declaration for ${dirRef.debugName}`,
+        `Assertion Error: expected typeParameters when creating a declaration for ${this.dir.ref.name}`,
       );
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/events.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/events.ts
@@ -20,7 +20,7 @@ import {TcbOp} from './base';
 import {quoteAndEscape, getStatementsBlock, TcbExpr} from './codegen';
 import type {Context} from './context';
 import type {Scope} from './scope';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {TcbExpressionTranslator, unwrapWritableSignal} from './expression';
 import {ExpressionIdentifier} from '../comments';
 import {checkSplitTwoWayBinding} from './bindings';
@@ -59,7 +59,7 @@ export class TcbDirectiveOutputsOp extends TcbOp {
     private node: DirectiveOwner,
     private inputs: TmplAstBoundAttribute[] | null,
     private outputs: TmplAstBoundEvent[],
-    private dir: TypeCheckableDirectiveMeta,
+    private dir: TcbDirectiveMetadata,
   ) {
     super();
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/expression.ts
@@ -204,9 +204,7 @@ export class TcbExpressionTranslator {
         pipe = new TcbExpr('(0 as any)');
       } else {
         // Use a variable declared as the pipe's type.
-        pipe = this.tcb.env.pipeInst(
-          pipeMeta.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>,
-        );
+        pipe = this.tcb.env.pipeInst(pipeMeta);
       }
       const args = ast.args.map((arg) => this.translate(arg).print());
       let methodAccess = new TcbExpr(`${pipe.print()}.transform`).addParseSpanInfo(ast.nameSpan);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/inputs.ts
@@ -20,7 +20,7 @@ import {
 import ts from 'typescript';
 import type {Context} from './context';
 import type {Scope} from './scope';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {TcbOp} from './base';
 import {declareVariable, quoteAndEscape, TcbExpr, tempPrint} from './codegen';
 import {BindingPropertyName, ClassPropertyName} from '../../../metadata';
@@ -59,7 +59,7 @@ export class TcbDirectiveInputsOp extends TcbOp {
     private tcb: Context,
     private scope: Scope,
     private node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
-    private dir: TypeCheckableDirectiveMeta,
+    private dir: TcbDirectiveMetadata,
     private isFormControl: boolean = false,
     private customFormControlType: CustomFormControlType | null,
   ) {
@@ -118,22 +118,17 @@ export class TcbDirectiveInputsOp extends TcbOp {
         if (this.dir.coercedInputFields.has(fieldName)) {
           let type: TcbExpr;
 
-          if (transformType !== null) {
-            const tsType = this.tcb.env.referenceTransplantedType(
-              new TransplantedType(transformType),
-            );
-            type = new TcbExpr(tempPrint(tsType, transformType.node.getSourceFile()));
+          if (transformType !== undefined) {
+            type = new TcbExpr(transformType);
           } else {
             // The input has a coercion declaration which should be used instead of assigning the
             // expression into the input field directly. To achieve this, a variable is declared
             // with a type of `typeof Directive.ngAcceptInputType_fieldName` which is then used as
             // target of the assignment.
-            const dirTypeRef: ts.TypeNode = this.tcb.env.referenceType(this.dir.ref);
+            const dirTypeRef: ts.TypeNode = this.tcb.env.referenceTcbType(this.dir.ref);
 
             if (!ts.isTypeReferenceNode(dirTypeRef)) {
-              throw new Error(
-                `Expected TypeReferenceNode from reference to ${this.dir.ref.debugName}`,
-              );
+              throw new Error(`Expected TypeReferenceNode from reference to ${this.dir.ref.name}`);
             }
 
             const typeName = ts.isIdentifier(dirTypeRef.typeName)
@@ -165,11 +160,9 @@ export class TcbDirectiveInputsOp extends TcbOp {
           }
 
           const id = new TcbExpr(this.tcb.allocateId());
-          const dirTypeRef = this.tcb.env.referenceType(this.dir.ref);
+          const dirTypeRef = this.tcb.env.referenceTcbType(this.dir.ref);
           if (!ts.isTypeReferenceNode(dirTypeRef)) {
-            throw new Error(
-              `Expected TypeReferenceNode from reference to ${this.dir.ref.debugName}`,
-            );
+            throw new Error(`Expected TypeReferenceNode from reference to ${this.dir.ref.name}`);
           }
           const type = new TcbExpr(`(typeof ${dirId.print()})[${quoteAndEscape(fieldName)}]`);
           const temp = declareVariable(id, type);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/references.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/references.ts
@@ -20,7 +20,7 @@ import {TcbOp} from './base';
 import {TcbExpr} from './codegen';
 import type {Context} from './context';
 import type {Scope} from './scope';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 
 /** Types that can referenced locally in a template. */
 export type LocalSymbol =
@@ -59,7 +59,7 @@ export class TcbReferenceOp extends TcbOp {
     private readonly scope: Scope,
     private readonly node: TmplAstReference,
     private readonly host: TmplAstElement | TmplAstTemplate | TmplAstComponent | TmplAstDirective,
-    private readonly target: TypeCheckableDirectiveMeta | TmplAstTemplate | TmplAstElement,
+    private readonly target: TcbDirectiveMetadata | TmplAstTemplate | TmplAstElement,
   ) {
     super();
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/scope.ts
@@ -8,6 +8,7 @@
 
 import {
   DirectiveOwner,
+  ExternalExpr,
   TmplAstBoundAttribute,
   TmplAstBoundEvent,
   TmplAstBoundText,
@@ -36,7 +37,7 @@ import {
 import ts from 'typescript';
 import {TcbOp} from './base';
 import {TcbExpr} from './codegen';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {Context} from './context';
 import {TcbTemplateBodyOp, TcbTemplateContextOp} from './template';
 import {TcbElementOp} from './element';
@@ -59,7 +60,7 @@ import {
   TcbNativeFieldOp,
   TcbNativeRadioButtonFieldOp,
 } from './signal_forms';
-import {Reference} from '../../../imports';
+import {ImportFlags, Reference, ReferenceEmitKind} from '../../../imports';
 import {ClassDeclaration} from '../../../reflection';
 import {
   TcbGenericDirectiveTypeWithAnyParamsOp,
@@ -120,7 +121,7 @@ export class Scope {
    * A map of maps which tracks the index of `TcbDirectiveCtorOp`s in the `opQueue` for each
    * directive on a `TmplAstElement` or `TmplAstTemplate` node.
    */
-  private directiveOpMap = new Map<DirectiveOwner, Map<TypeCheckableDirectiveMeta, number>>();
+  private directiveOpMap = new Map<DirectiveOwner, Map<TcbDirectiveMetadata, number>>();
 
   /**
    * A map of `TmplAstReference`s to the index of their `TcbReferenceOp` in the `opQueue`
@@ -299,7 +300,7 @@ export class Scope {
    * @param directive if present, a directive type on a `TmplAstElement` or `TmplAstTemplate` to
    * look up instead of the default for an element or template node.
    */
-  resolve(node: LocalSymbol, directive?: TypeCheckableDirectiveMeta): TcbExpr {
+  resolve(node: LocalSymbol, directive?: TcbDirectiveMetadata): TcbExpr {
     // Attempt to resolve the operation locally.
     const res = this.resolveLocal(node, directive);
     if (res !== null) {
@@ -395,7 +396,7 @@ export class Scope {
     return Scope.forNodes(this.tcb, parentScope, scopedNode, children, guard);
   }
 
-  private resolveLocal(ref: LocalSymbol, directive?: TypeCheckableDirectiveMeta): TcbExpr | null {
+  private resolveLocal(ref: LocalSymbol, directive?: TcbDirectiveMetadata): TcbExpr | null {
     if (ref instanceof TmplAstReference && this.referenceOpMap.has(ref)) {
       return this.resolveOp(this.referenceOpMap.get(ref)!);
     } else if (ref instanceof TmplAstLetDeclaration && this.letDeclOpMap.has(ref.name)) {
@@ -593,7 +594,7 @@ export class Scope {
       }
     }
 
-    const dirMap = new Map<TypeCheckableDirectiveMeta, number>();
+    const dirMap = new Map<TcbDirectiveMetadata, number>();
     for (const dir of directives) {
       this.appendDirectiveInputs(dir, node, dirMap, directives);
     }
@@ -670,7 +671,7 @@ export class Scope {
     const claimedInputs = new Set<string>();
 
     if (directives !== null && directives.length > 0) {
-      const dirMap = new Map<TypeCheckableDirectiveMeta, number>();
+      const dirMap = new Map<TcbDirectiveMetadata, number>();
       for (const dir of directives) {
         this.appendDirectiveInputs(dir, node, dirMap, directives);
 
@@ -735,10 +736,10 @@ export class Scope {
   }
 
   private appendDirectiveInputs(
-    dir: TypeCheckableDirectiveMeta,
+    dir: TcbDirectiveMetadata,
     node: TmplAstElement | TmplAstTemplate | TmplAstComponent | TmplAstDirective,
-    dirMap: Map<TypeCheckableDirectiveMeta, number>,
-    allDirectiveMatches: TypeCheckableDirectiveMeta[],
+    dirMap: Map<TcbDirectiveMetadata, number>,
+    allDirectiveMatches: TcbDirectiveMetadata[],
   ): void {
     const nodeIsFormControl = isFormControl(allDirectiveMatches);
     const customFormControlType = nodeIsFormControl ? getCustomFieldDirectiveType(dir) : null;
@@ -765,20 +766,15 @@ export class Scope {
   }
 
   private getDirectiveOp(
-    dir: TypeCheckableDirectiveMeta,
+    dir: TcbDirectiveMetadata,
     node: DirectiveOwner,
     customFieldType: CustomFormControlType | null,
   ): TcbOp {
-    const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
-
     if (!dir.isGeneric) {
       // The most common case is that when a directive is not generic, we use the normal
       // `TcbNonDirectiveTypeOp`.
       return new TcbNonGenericDirectiveTypeOp(this.tcb, this, node, dir);
-    } else if (
-      !requiresInlineTypeCtor(dirRef.node, this.tcb.env.reflector, this.tcb.env) ||
-      this.tcb.env.config.useInlineTypeConstructors
-    ) {
+    } else if (!dir.hasRequiresInlineTypeCtor || this.tcb.env.config.useInlineTypeConstructors) {
       // For generic directives, we use a type constructor to infer types. If a directive requires
       // an inline type constructor, then inlining must be available to use the
       // `TcbDirectiveCtorOp`. If not we, we fallback to using `any` – see below.
@@ -967,7 +963,7 @@ export class Scope {
     const directives = this.tcb.boundTarget.getDirectivesOfNode(node);
 
     if (directives !== null && directives.length > 0) {
-      const directiveOpMap = new Map<TypeCheckableDirectiveMeta, number>();
+      const directiveOpMap = new Map<TcbDirectiveMetadata, number>();
 
       for (const directive of directives) {
         const directiveOp = this.getDirectiveOp(directive, node, null);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/signal_forms.ts
@@ -22,7 +22,7 @@ import {
   TmplAstTemplate,
 } from '@angular/compiler';
 import ts from 'typescript';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {TcbOp} from './base';
 import {declareVariable, TcbExpr} from './codegen';
 import {TcbBoundAttribute} from './bindings';
@@ -206,7 +206,7 @@ export class TcbNativeRadioButtonFieldOp extends TcbNativeFieldOp {
 
 /** Expands the set of bound inputs with the ones from custom field directives. */
 export function expandBoundAttributesForField(
-  directive: TypeCheckableDirectiveMeta,
+  directive: TcbDirectiveMetadata,
   node: TmplAstTemplate | TmplAstElement | TmplAstComponent | TmplAstDirective,
   customFormControlType: CustomFormControlType | null,
 ): TcbBoundAttribute[] | null {
@@ -264,31 +264,22 @@ export function expandBoundAttributesForField(
   return boundInputs;
 }
 
-export function isFieldDirective(meta: TypeCheckableDirectiveMeta): boolean {
+export function isFieldDirective(meta: TcbDirectiveMetadata): boolean {
   if (meta.name !== 'FormField') {
     return false;
   }
 
   // Fast path, relevant for all external users.
-  if (meta.ref.bestGuessOwningModule?.specifier === '@angular/forms/signals') {
+  if (meta.ref.moduleName === '@angular/forms/signals') {
     return true;
   }
 
-  // Slightly slower, but more accurate path.
-  return (
-    ts.isClassDeclaration(meta.ref.node) &&
-    meta.ref.node.members.some(
-      (member) =>
-        ts.isPropertyDeclaration(member) &&
-        ts.isComputedPropertyName(member.name) &&
-        ts.isIdentifier(member.name.expression) &&
-        member.name.expression.text === 'ɵNgFieldDirective',
-    )
-  );
+  // Slightly slower, but more accurate path. Fallback for internal / local compilation where we don't have the exact module.
+  return meta.hasNgFieldDirective;
 }
 
 function getSyntheticFieldBoundInput(
-  dir: TypeCheckableDirectiveMeta,
+  dir: TcbDirectiveMetadata,
   inputName: string,
   fieldPropertyName: string,
   fieldBinding: TmplAstBoundAttribute,
@@ -325,7 +316,7 @@ function getSyntheticFieldBoundInput(
     inputs: inputs.map((input) => ({
       fieldName: input.classPropertyName,
       required: input.required,
-      transformType: input.transform?.type || null,
+      transformType: input.transformType,
       isSignal: input.isSignal,
       isTwoWayBinding,
     })),
@@ -334,7 +325,7 @@ function getSyntheticFieldBoundInput(
 
 /** Determines if a directive is a custom field and its type. */
 export function getCustomFieldDirectiveType(
-  meta: TypeCheckableDirectiveMeta,
+  meta: TcbDirectiveMetadata,
 ): CustomFormControlType | null {
   if (hasModelInput('value', meta)) {
     return 'value';
@@ -346,9 +337,9 @@ export function getCustomFieldDirectiveType(
 
 /** Determines if a directive usage is on a native field. */
 export function isNativeField(
-  dir: TypeCheckableDirectiveMeta,
+  dir: TcbDirectiveMetadata,
   node: TmplAstNode,
-  allDirectiveMatches: TypeCheckableDirectiveMeta[],
+  allDirectiveMatches: TcbDirectiveMetadata[],
 ): node is TmplAstElement & {name: 'input' | 'select' | 'textarea'} {
   // Only applies to the `FormField` directive.
   if (!isFieldDirective(dir)) {
@@ -373,7 +364,7 @@ export function isNativeField(
  * Determines if a directive is shaped like a `ControlValueAccessor`. Note that this isn't
  * 100% reliable, because we don't know if the directive was actually provided at runtime.
  */
-function isControlValueAccessorLike(meta: TypeCheckableDirectiveMeta): boolean {
+function isControlValueAccessorLike(meta: TcbDirectiveMetadata): boolean {
   return (
     meta.publicMethods.has('writeValue') &&
     meta.publicMethods.has('registerOnChange') &&
@@ -426,7 +417,7 @@ function extractFieldValue(expression: AST, tcb: Context, scope: Scope): TcbExpr
 }
 
 /** Checks whether a directive has a model-like input with a specific name. */
-function hasModelInput(name: string, meta: TypeCheckableDirectiveMeta): boolean {
+function hasModelInput(name: string, meta: TcbDirectiveMetadata): boolean {
   return (
     meta.inputs.hasBindingPropertyName(name) && meta.outputs.hasBindingPropertyName(name + 'Change')
   );
@@ -438,7 +429,7 @@ function hasModelInput(name: string, meta: TypeCheckableDirectiveMeta): boolean 
  * A node is a form control if it has a matching `FormField` directive, and no other directives match
  * the `field` input.
  */
-export function isFormControl(allDirectiveMatches: TypeCheckableDirectiveMeta[]): boolean {
+export function isFormControl(allDirectiveMatches: TcbDirectiveMetadata[]): boolean {
   let result = false;
   for (const match of allDirectiveMatches) {
     if (match.inputs.hasBindingPropertyName('formField')) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/template.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/template.ts
@@ -11,7 +11,7 @@ import {TcbOp} from './base';
 import {declareVariable, getStatementsBlock, TcbExpr} from './codegen';
 import type {Context} from './context';
 import type {Scope} from './scope';
-import {TypeCheckableDirectiveMeta} from '../../api';
+import {TcbDirectiveMetadata} from '../../api';
 import {Reference} from '../../../imports';
 import {ClassDeclaration} from '../../../reflection';
 import {tcbExpression} from './expression';
@@ -135,7 +135,7 @@ export class TcbTemplateBodyOp extends TcbOp {
   private addDirectiveGuards(
     guards: TcbExpr[],
     hostNode: TmplAstTemplate | TmplAstDirective,
-    directives: TypeCheckableDirectiveMeta[] | null,
+    directives: TcbDirectiveMetadata[] | null,
   ) {
     if (directives === null || directives.length === 0) {
       return;
@@ -145,9 +145,7 @@ export class TcbTemplateBodyOp extends TcbOp {
 
     for (const dir of directives) {
       const dirInstId = this.scope.resolve(hostNode, dir);
-      const dirId = this.tcb.env.reference(
-        dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>,
-      );
+      const dirId = this.tcb.env.referenceTcbValue(dir.ref);
 
       // There are two kinds of guards. Template guards (ngTemplateGuards) allow type narrowing of
       // the expression passed to an @Input of the directive. Scan the directive to see if it has

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
@@ -15,6 +15,7 @@ import {
 } from '@angular/compiler';
 import ts from 'typescript';
 
+import {ErrorCode, FatalDiagnosticError, makeDiagnosticChain} from '../../diagnostics';
 import {
   assertSuccessfulReferenceEmit,
   ImportFlags,
@@ -24,6 +25,7 @@ import {
 } from '../../imports';
 import {ReflectionHost} from '../../reflection';
 import {ImportManager, translateType} from '../../translator';
+import {TcbReferenceMetadata} from '../api';
 import {TcbExpr} from './ops/codegen';
 
 /**
@@ -35,7 +37,7 @@ import {TcbExpr} from './ops/codegen';
 export class ReferenceEmitEnvironment {
   constructor(
     readonly importManager: ImportManager,
-    protected refEmitter: ReferenceEmitter,
+    public refEmitter: ReferenceEmitter,
     readonly reflector: ReflectionHost,
     public contextFile: ts.SourceFile,
   ) {}
@@ -73,6 +75,52 @@ export class ReferenceEmitEnvironment {
       this.refEmitter,
       this.importManager,
     );
+  }
+
+  /**
+   * Generates a `ts.TypeNode` from a `TcbReferenceMetadata` object.
+   * This is used by the TCB operations which do not hold on to the original `ts.Declaration`.
+   *
+   * Note: It's important that we do not try to evaluate the `typeParameters` here and pad them
+   * out with `any` type arguments. If we supply `any` to a generic pipe (e.g. `var _pipe1: MyPipe<any>;`),
+   * it destroys the generic constraints and degrades the `transform` signature. When they are omitted
+   * entirely, TypeScript implicitly flags an error, which the Angular compiler filters out, and
+   * crucially recovers by falling back to constraint inference (e.g. `var _pipe1: MyPipe;` infers
+   * bounds safely).
+   */
+  referenceTcbType(ref: TcbReferenceMetadata): ts.TypeNode {
+    if (ref.unexportedDiagnostic !== null || ref.isLocal || ref.moduleName === null) {
+      if (ref.unexportedDiagnostic !== null) {
+        throw new FatalDiagnosticError(
+          ErrorCode.IMPORT_GENERATION_FAILURE,
+          this.contextFile, // Using context file as fallback origin for external file since we lack exact node
+          makeDiagnosticChain(`Unable to import symbol ${ref.name}.`, [
+            makeDiagnosticChain(ref.unexportedDiagnostic),
+          ]),
+        );
+      }
+      return ts.factory.createTypeReferenceNode(ref.name);
+    }
+    return this.referenceExternalType(ref.moduleName, ref.name);
+  }
+
+  /**
+   * Generates a `TcbExpr` from a `TcbReferenceMetadata` object.
+   */
+  referenceTcbValue(ref: TcbReferenceMetadata): TcbExpr {
+    if (ref.unexportedDiagnostic !== null || ref.isLocal || ref.moduleName === null) {
+      if (ref.unexportedDiagnostic !== null) {
+        throw new FatalDiagnosticError(
+          ErrorCode.IMPORT_GENERATION_FAILURE,
+          this.contextFile,
+          makeDiagnosticChain(`Unable to import symbol ${ref.name}.`, [
+            makeDiagnosticChain(ref.unexportedDiagnostic),
+          ]),
+        );
+      }
+      return new TcbExpr(ref.name);
+    }
+    return this.referenceExternalSymbol(ref.moduleName, ref.name);
   }
 
   referenceExternalSymbol(moduleName: string, name: string): TcbExpr {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  TypeCheckBlockMetadata,
+  TcbTypeCheckBlockMetadata,
+  TcbComponentMetadata,
+  TcbDirectiveMetadata,
+  TcbReferenceMetadata,
+  TcbInputMapping,
+  TcbPipeMetadata,
+  TypeCheckableDirectiveMeta,
+  TcbTypeParameter,
+} from '../api';
+import {Environment} from './environment';
+import {ImportFlags, ReferenceEmitKind, Reference} from '../../imports';
+import {
+  AbsoluteSourceSpan,
+  ExternalExpr,
+  TransplantedType,
+  BoundTarget,
+  DirectiveOwner,
+  ReferenceTarget,
+  TmplAstReference,
+  TmplAstElement,
+  TmplAstTemplate,
+  WrappedNodeExpr,
+} from '@angular/compiler';
+import {ClassPropertyMapping, InputMapping} from '../../metadata';
+import {requiresInlineTypeCtor} from './type_constructor';
+import {tempPrint} from './ops/codegen';
+import {generateTcbTypeParameters} from './tcb_util';
+import {TypeParameterEmitter} from './type_parameter_emitter';
+import {ClassDeclaration} from '../../reflection';
+import ts from 'typescript';
+
+/**
+ * Adapts the compiler's `TypeCheckBlockMetadata` (which includes full TS AST nodes)
+ * into a purely detached `TcbTypeCheckBlockMetadata` that can be mapped to JSON.
+ */
+export function adaptTypeCheckBlockMetadata(
+  ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
+  meta: TypeCheckBlockMetadata,
+  env: Environment,
+): {tcbMeta: TcbTypeCheckBlockMetadata; component: TcbComponentMetadata} {
+  const refCache = new Map<Reference<ClassDeclaration>, TcbReferenceMetadata>();
+  const extractRef = (ref: Reference<ClassDeclaration>) => {
+    if (refCache.has(ref)) {
+      return refCache.get(ref)!;
+    }
+    const result = extractReferenceMetadata(ref, env);
+    refCache.set(ref, result);
+    return result;
+  };
+
+  const dirCache = new Map<TypeCheckableDirectiveMeta, TcbDirectiveMetadata>();
+
+  const convertDir = (dir: TypeCheckableDirectiveMeta): TcbDirectiveMetadata => {
+    if (dirCache.has(dir)) return dirCache.get(dir)!;
+
+    const tcbDir: TcbDirectiveMetadata = {
+      isComponent: dir.isComponent,
+      name: dir.name,
+      selector: dir.selector,
+      exportAs: dir.exportAs,
+      inputs: ClassPropertyMapping.fromMappedObject<TcbInputMapping>(
+        dir.inputs.toJointMappedObject((input: InputMapping) => {
+          return {
+            classPropertyName: input.classPropertyName,
+            bindingPropertyName: input.bindingPropertyName,
+            required: input.required,
+            isSignal: input.isSignal,
+            transformType: (() => {
+              if (input.transform != null) {
+                const node = env.referenceTransplantedType(
+                  new TransplantedType(input.transform.type),
+                );
+                return tempPrint(node, env.contextFile);
+              }
+              return undefined;
+            })(),
+          };
+        }),
+      ),
+      outputs: dir.outputs,
+      isStructural: dir.isStructural,
+      isStandalone: dir.isStandalone,
+      isExplicitlyDeferred: dir.isExplicitlyDeferred,
+      preserveWhitespaces: dir.preserveWhitespaces,
+      ngContentSelectors: dir.ngContentSelectors,
+      animationTriggerNames: dir.animationTriggerNames,
+      ngTemplateGuards: dir.ngTemplateGuards,
+      hasNgTemplateContextGuard: dir.hasNgTemplateContextGuard,
+      hasNgFieldDirective:
+        ts.isClassDeclaration(dir.ref.node) &&
+        dir.ref.node.members.some(
+          (member: ts.Node) =>
+            ts.isPropertyDeclaration(member) &&
+            ts.isComputedPropertyName(member.name) &&
+            ts.isIdentifier(member.name.expression) &&
+            member.name.expression.text === 'ɵNgFieldDirective',
+        ),
+      coercedInputFields: dir.coercedInputFields,
+      restrictedInputFields: dir.restrictedInputFields,
+      stringLiteralInputFields: dir.stringLiteralInputFields,
+      undeclaredInputFields: dir.undeclaredInputFields,
+      publicMethods: dir.publicMethods,
+
+      ref: extractRef(dir.ref as Reference<ClassDeclaration>),
+      isGeneric: dir.isGeneric,
+
+      typeParameters: (() => {
+        const node = dir.ref.node as ClassDeclaration<ts.ClassDeclaration>;
+        if (!node.typeParameters) {
+          return null;
+        }
+        const emitter = new TypeParameterEmitter(node.typeParameters, env.reflector);
+        let emitted: ts.TypeParameterDeclaration[] | undefined;
+        if (!emitter.canEmit((ref) => env.canReferenceType(ref))) {
+          emitted = [...node.typeParameters] as ts.TypeParameterDeclaration[];
+        } else {
+          emitted = emitter.emit((ref) => env.referenceType(ref));
+        }
+        return generateTcbTypeParameters(emitted || [], env.contextFile);
+      })(),
+      hasRequiresInlineTypeCtor: requiresInlineTypeCtor(
+        dir.ref.node as ClassDeclaration<ts.ClassDeclaration>,
+        env.reflector,
+        env,
+      ),
+    };
+
+    dirCache.set(dir, tcbDir);
+    return tcbDir;
+  };
+
+  const adaptedBoundTarget: BoundTarget<TcbDirectiveMetadata> = {
+    target: (() => {
+      const originalTarget = meta.boundTarget.target;
+      return {
+        template: originalTarget.template,
+        host: originalTarget.host
+          ? {
+              node: originalTarget.host.node,
+              directives: originalTarget.host.directives.map(convertDir),
+            }
+          : undefined,
+      };
+    })(),
+    getUsedDirectives: () => meta.boundTarget.getUsedDirectives().map(convertDir),
+    getEagerlyUsedDirectives: () => meta.boundTarget.getEagerlyUsedDirectives().map(convertDir),
+    getUsedPipes: () => meta.boundTarget.getUsedPipes(),
+    getDirectivesOfNode: (node) => {
+      const dirs = meta.boundTarget.getDirectivesOfNode(node);
+      return dirs ? dirs.map(convertDir) : null;
+    },
+    getReferenceTarget: (ref) => {
+      const target = meta.boundTarget.getReferenceTarget(ref);
+      if (target && 'directive' in target) {
+        return {
+          directive: convertDir(target.directive as TypeCheckableDirectiveMeta),
+          node: target.node,
+        };
+      }
+      return target as ReferenceTarget<TcbDirectiveMetadata>;
+    },
+    getDeferredTriggerTarget: (b, t) => meta.boundTarget.getDeferredTriggerTarget(b, t),
+    isDeferred: (node) => meta.boundTarget.isDeferred(node),
+    referencedDirectiveExists: (name) => meta.boundTarget.referencedDirectiveExists(name),
+    getConsumerOfBinding: (binding) => {
+      const consumer = meta.boundTarget.getConsumerOfBinding(binding);
+      if (consumer && (consumer as TypeCheckableDirectiveMeta).isComponent !== undefined) {
+        return convertDir(consumer as TypeCheckableDirectiveMeta);
+      }
+      return consumer as TmplAstElement | TmplAstTemplate | null;
+    },
+    getExpressionTarget: (expr) => meta.boundTarget.getExpressionTarget(expr),
+    getDefinitionNodeOfSymbol: (sym) => meta.boundTarget.getDefinitionNodeOfSymbol(sym),
+    getNestingLevel: (node) => meta.boundTarget.getNestingLevel(node),
+    getEntitiesInScope: (node) => meta.boundTarget.getEntitiesInScope(node),
+    getEagerlyUsedPipes: () => meta.boundTarget.getEagerlyUsedPipes(),
+    getDeferBlocks: () => meta.boundTarget.getDeferBlocks(),
+  };
+
+  const pipes = new Map<string, TcbPipeMetadata>();
+  if (meta.pipes !== null) {
+    for (const pipeName of meta.boundTarget.getUsedPipes()) {
+      if (!meta.pipes.has(pipeName) || pipes.has(pipeName)) {
+        continue;
+      }
+      const pipe = meta.pipes.get(pipeName)!;
+      pipes.set(pipeName, {
+        name: pipe.name!,
+        ref: extractRef(pipe.ref as Reference<ClassDeclaration>),
+        isExplicitlyDeferred: pipe.isExplicitlyDeferred,
+      });
+    }
+  }
+
+  return {
+    tcbMeta: {
+      id: meta.id,
+      boundTarget: adaptedBoundTarget,
+      pipes,
+      schemas: meta.schemas,
+      isStandalone: meta.isStandalone,
+      preserveWhitespaces: meta.preserveWhitespaces,
+    },
+    component: (() => {
+      return {
+        ref: extractRef(ref as Reference<ClassDeclaration>),
+        typeParameters: (() => {
+          if (!ref.node.typeParameters) return null;
+          const emitter = new TypeParameterEmitter(ref.node.typeParameters, env.reflector);
+          let emitted: ts.TypeParameterDeclaration[] | undefined;
+          if (!emitter.canEmit((r) => env.canReferenceType(r))) {
+            emitted = [...ref.node.typeParameters] as ts.TypeParameterDeclaration[];
+          } else {
+            emitted = emitter.emit((r) => env.referenceType(r));
+          }
+          return generateTcbTypeParameters(emitted || [], env.contextFile);
+        })(),
+      };
+    })(),
+  };
+}
+
+function extractReferenceMetadata(
+  ref: Reference<ClassDeclaration>,
+  env: Environment,
+): TcbReferenceMetadata {
+  let name = ref.debugName || ref.node.name!.text;
+  let moduleName = ref.ownedByModuleGuess;
+  let unexportedDiagnostic: string | null = null;
+  let isLocal = true;
+
+  const emitted = env.refEmitter.emit(ref, env.contextFile, ImportFlags.NoAliasing);
+  if (emitted.kind === ReferenceEmitKind.Success) {
+    if (emitted.expression instanceof ExternalExpr) {
+      name = emitted.expression.value.name!;
+      moduleName = emitted.expression.value.moduleName;
+      isLocal = false;
+    } else if (emitted.expression instanceof WrappedNodeExpr) {
+      const node = emitted.expression.node;
+      const extractedName = extractNameFromExpr(node);
+      if (extractedName !== null) {
+        name = extractedName;
+      }
+    }
+  } else if (emitted.kind === ReferenceEmitKind.Failed) {
+    unexportedDiagnostic = emitted.reason;
+    isLocal = false;
+  }
+
+  const refMeta: TcbReferenceMetadata = {
+    name,
+    moduleName,
+    isLocal,
+    unexportedDiagnostic,
+  };
+  const nodeName = ref.node?.name;
+  if (nodeName) {
+    refMeta.nodeNameSpan = new AbsoluteSourceSpan(nodeName.getStart(), nodeName.getEnd());
+    refMeta.nodeFilePath = nodeName.getSourceFile().fileName;
+  }
+
+  return refMeta;
+}
+
+function extractNameFromExpr(node: ts.Node): string | null {
+  if (ts.isIdentifier(node)) {
+    return node.text;
+  } else if (ts.isPropertyAccessExpression(node)) {
+    const receiver = extractNameFromExpr(node.expression);
+    return receiver !== null ? `${receiver}.${node.name.text}` : null;
+  }
+  return null;
+}

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -12,12 +12,19 @@ import ts from 'typescript';
 import {ClassDeclaration, ReflectionHost} from '../../../../src/ngtsc/reflection';
 import {Reference} from '../../imports';
 import {getTokenAtPosition} from '../../util/src/typescript';
-import {FullSourceMapping, SourceLocation, TypeCheckId, SourceMapping} from '../api';
+import {
+  FullSourceMapping,
+  SourceLocation,
+  TypeCheckId,
+  SourceMapping,
+  TcbTypeParameter,
+} from '../api';
 
 import {hasIgnoreForDiagnosticsMarker, readSpanComment} from './comments';
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {TypeParameterEmitter} from './type_parameter_emitter';
 import {isHostBindingsBlockGuard} from './host_bindings';
+import {tempPrint} from './ops/codegen';
 
 /**
  * External modules/identifiers that always should exist for type check
@@ -295,4 +302,18 @@ export function findNodeInFile(
     return ts.forEachChild(node, visit) ?? null;
   };
   return ts.forEachChild(file, visit) ?? null;
+}
+
+export function generateTcbTypeParameters(
+  typeParameters: ReadonlyArray<ts.TypeParameterDeclaration>,
+  sourceFile: ts.SourceFile,
+): TcbTypeParameter[] {
+  return typeParameters.map((p) => {
+    const representation = tempPrint(p, sourceFile);
+    return {
+      name: p.name.text,
+      representation,
+      representationWithDefault: p.default ? representation : `${representation} = any`,
+    };
+  });
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -8,14 +8,16 @@
 
 import ts from 'typescript';
 
-import {Reference} from '../../imports';
-import {ClassDeclaration} from '../../reflection';
-import {TypeCheckBlockMetadata} from '../api';
+import {
+  TcbComponentMetadata,
+  TcbTypeCheckBlockMetadata,
+  TcbTypeParameter,
+  TypeCheckId,
+} from '../api';
 
 import {DomSchemaChecker} from './dom';
 import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder} from './oob';
-import {TypeParameterEmitter} from './type_parameter_emitter';
 import {createHostBindingsBlockGuard} from './host_bindings';
 import {Context, TcbGenericContextBehavior} from './ops/context';
 import {Scope} from './ops/scope';
@@ -47,9 +49,9 @@ import {getStatementsBlock, tempPrint} from './ops/codegen';
  */
 export function generateTypeCheckBlock(
   env: Environment,
-  ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
+  component: TcbComponentMetadata,
   name: ts.Identifier,
-  meta: TypeCheckBlockMetadata,
+  meta: TcbTypeCheckBlockMetadata,
   domSchemaChecker: DomSchemaChecker,
   oobRecorder: OutOfBandDiagnosticRecorder,
   genericContextBehavior: TcbGenericContextBehavior,
@@ -65,17 +67,17 @@ export function generateTypeCheckBlock(
     meta.isStandalone,
     meta.preserveWhitespaces,
   );
-  const ctxRawType = env.referenceType(ref);
+  const ctxRawType = env.referenceTcbType(component.ref);
   if (!ts.isTypeReferenceNode(ctxRawType)) {
     throw new Error(
-      `Expected TypeReferenceNode when referencing the ctx param for ${ref.debugName}`,
+      `Expected TypeReferenceNode when referencing the ctx param for ${component.ref.name}`,
     );
   }
 
-  let typeParameters: ts.TypeParameterDeclaration[] | undefined = undefined;
-  let typeArguments: ts.TypeNode[] | undefined = undefined;
+  let typeParameters: TcbTypeParameter[] | undefined = undefined;
+  let typeArguments: string[] | undefined = undefined;
 
-  if (ref.node.typeParameters !== undefined) {
+  if (component.typeParameters !== undefined) {
     if (!env.config.useContextGenericType) {
       genericContextBehavior = TcbGenericContextBehavior.FallbackToAny;
     }
@@ -83,22 +85,18 @@ export function generateTypeCheckBlock(
     switch (genericContextBehavior) {
       case TcbGenericContextBehavior.UseEmitter:
         // Guaranteed to emit type parameters since we checked that the class has them above.
-        typeParameters = new TypeParameterEmitter(ref.node.typeParameters, env.reflector).emit(
-          (typeRef) => env.referenceType(typeRef),
-        )!;
-        typeArguments = typeParameters.map((param) =>
-          ts.factory.createTypeReferenceNode(param.name),
-        );
+        const emittedParams = component.typeParameters || [];
+        typeParameters = emittedParams;
+        typeArguments = typeParameters!.map((param) => param.name);
         break;
       case TcbGenericContextBehavior.CopyClassNodes:
-        typeParameters = [...ref.node.typeParameters];
-        typeArguments = typeParameters.map((param) =>
-          ts.factory.createTypeReferenceNode(param.name),
-        );
+        const copiedParams = component.typeParameters ? [...component.typeParameters] : [];
+        typeParameters = copiedParams;
+        typeArguments = typeParameters!.map((param) => param.name);
         break;
       case TcbGenericContextBehavior.FallbackToAny:
-        typeArguments = ref.node.typeParameters.map(() =>
-          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+        typeArguments = Array.from({length: component.typeParameters?.length ?? 0}).map(
+          () => 'any',
         );
         break;
     }
@@ -108,11 +106,11 @@ export function generateTypeCheckBlock(
   const typeParamsStr =
     typeParameters === undefined || typeParameters.length === 0
       ? ''
-      : `<${typeParameters.map((p) => tempPrint(p, sourceFile)).join(', ')}>`;
+      : `<${typeParameters.map((p) => p.representation).join(', ')}>`;
   const typeArgsStr =
     typeArguments === undefined || typeArguments.length === 0
       ? ''
-      : `<${typeArguments.map((p) => tempPrint(p, sourceFile)).join(', ')}>`;
+      : `<${typeArguments.join(', ')}>`;
   const typeRef = ts.isIdentifier(ctxRawType.typeName)
     ? ctxRawType.typeName.text
     : tempPrint(ctxRawType.typeName, sourceFile);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -18,6 +18,7 @@ import {Environment} from './environment';
 import {OutOfBandDiagnosticRecorder} from './oob';
 import {ensureTypeCheckFilePreparationImports} from './tcb_util';
 import {generateTypeCheckBlock} from './type_check_block';
+import {adaptTypeCheckBlockMetadata} from './tcb_adapter';
 import {TcbGenericContextBehavior} from './ops/context';
 import {getStatementsBlock, TcbExpr} from './ops/codegen';
 
@@ -30,6 +31,7 @@ import {getStatementsBlock, TcbExpr} from './ops/codegen';
  * hoists them to the top of the generated `ts.SourceFile`.
  */
 export class TypeCheckFile extends Environment {
+  readonly isTypeCheckFile = true;
   private nextTcbId = 1;
   private tcbStatements: string[] = [];
 
@@ -68,11 +70,12 @@ export class TypeCheckFile extends Environment {
     genericContextBehavior: TcbGenericContextBehavior,
   ): void {
     const fnId = ts.factory.createIdentifier(`_tcb${this.nextTcbId++}`);
+    const {tcbMeta, component} = adaptTypeCheckBlockMetadata(ref, meta, this);
     const fn = generateTypeCheckBlock(
       this,
-      ref,
+      component,
       fnId,
-      meta,
+      tcbMeta,
       domSchemaChecker,
       oobRecorder,
       genericContextBehavior,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -10,30 +10,24 @@ import {R3Identifiers} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
-import {TypeCtorMetadata} from '../api';
+import {TypeCtorMetadata, TcbTypeParameter} from '../api';
 
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
-import {checkIfGenericTypeBoundsCanBeEmitted} from './tcb_util';
+import {checkIfGenericTypeBoundsCanBeEmitted, generateTcbTypeParameters} from './tcb_util';
 import {quoteAndEscape, TcbExpr, tempPrint} from './ops/codegen';
 
 export function generateTypeCtorDeclarationFn(
   env: ReferenceEmitEnvironment,
   meta: TypeCtorMetadata,
   nodeTypeRef: ts.EntityName,
-  typeParams: ts.TypeParameterDeclaration[] | undefined,
+  typeParams: TcbTypeParameter[] | undefined,
 ): TcbExpr {
   const typeArgs = generateGenericArgs(typeParams);
   const typeRef = ts.isIdentifier(nodeTypeRef)
     ? nodeTypeRef.text
     : tempPrint(nodeTypeRef, nodeTypeRef.getSourceFile());
   const typeRefWithGenerics = `${typeRef}${typeArgs}`;
-  const initParam = constructTypeCtorParameter(
-    env,
-    meta,
-    nodeTypeRef.getSourceFile(),
-    typeRef,
-    typeRefWithGenerics,
-  );
+  const initParam = constructTypeCtorParameter(env, meta, typeRef, typeRefWithGenerics);
   const typeParameters = typeParametersWithDefaultTypes(typeParams);
   let source: string;
 
@@ -91,20 +85,20 @@ export function generateInlineTypeCtor(
   // the definition without any type bounds. For example, if the class is
   // `FooDirective<T extends Bar>`, its rawType would be `FooDirective<T>`.
   const typeRef = node.name.text;
-  const typeRefWithGenerics = `${typeRef}${generateGenericArgs(node.typeParameters)}`;
-  const initParam = constructTypeCtorParameter(
-    env,
-    meta,
-    node.getSourceFile(),
-    typeRef,
-    typeRefWithGenerics,
-  );
+  const sourceFile = node.getSourceFile();
+  const tcbTypeParams =
+    node.typeParameters && node.typeParameters.length > 0
+      ? generateTcbTypeParameters(node.typeParameters, sourceFile)
+      : undefined;
+
+  const typeRefWithGenerics = `${typeRef}${generateGenericArgs(tcbTypeParams)}`;
+  const initParam = constructTypeCtorParameter(env, meta, typeRef, typeRefWithGenerics);
 
   // If this constructor is being generated into a .ts file, then it needs a fake body. The body
   // is set to a return of `null!`. If the type constructor is being generated into a .d.ts file,
   // it needs no body.
   const body = `{ return null!; }`;
-  const typeParams = typeParametersWithDefaultTypes(node.typeParameters);
+  const typeParams = typeParametersWithDefaultTypes(tcbTypeParams);
 
   // Create the type constructor method declaration.
   return `static ${meta.fnName}${typeParams}(${initParam}): ${typeRefWithGenerics} ${body}`;
@@ -113,7 +107,6 @@ export function generateInlineTypeCtor(
 function constructTypeCtorParameter(
   env: ReferenceEmitEnvironment,
   meta: TypeCtorMetadata,
-  sourceFile: ts.SourceFile,
   typeRef: string,
   typeRefWithGenerics: string,
 ): string {
@@ -132,15 +125,15 @@ function constructTypeCtorParameter(
   const coercedKeys: string[] = [];
   const signalInputKeys: string[] = [];
 
-  for (const {classPropertyName, transform, isSignal} of meta.fields.inputs) {
+  for (const {classPropertyName, transformType, isSignal} of meta.fields.inputs) {
     if (isSignal) {
       signalInputKeys.push(quoteAndEscape(classPropertyName));
     } else if (!meta.coercedInputFields.has(classPropertyName)) {
       plainKeys.push(quoteAndEscape(classPropertyName));
     } else {
       const coercionType =
-        transform != null
-          ? tempPrint(transform.type.node, sourceFile)
+        transformType !== undefined
+          ? transformType
           : `typeof ${typeRef}.ngAcceptInputType_${classPropertyName}`;
 
       coercedKeys.push(`${classPropertyName}: ${coercionType}`);
@@ -180,14 +173,12 @@ function constructTypeCtorParameter(
   return `init: ${initType}`;
 }
 
-function generateGenericArgs(
-  typeParameters: ReadonlyArray<ts.TypeParameterDeclaration> | undefined,
-): string {
+function generateGenericArgs(typeParameters: ReadonlyArray<TcbTypeParameter> | undefined): string {
   if (typeParameters === undefined || typeParameters.length === 0) {
     return '';
   }
 
-  return `<${typeParameters.map((param) => param.name.text).join(', ')}>`;
+  return `<${typeParameters.map((param) => param.name).join(', ')}>`;
 }
 
 export function requiresInlineTypeCtor(
@@ -245,22 +236,11 @@ export function requiresInlineTypeCtor(
  * This correctly infers `T` as `any`, and therefore `_t3` as `NgFor<any>`.
  */
 function typeParametersWithDefaultTypes(
-  params: ReadonlyArray<ts.TypeParameterDeclaration> | undefined,
+  params: ReadonlyArray<TcbTypeParameter> | undefined,
 ): string {
   if (params === undefined || params.length === 0) {
     return '';
   }
 
-  const paramStrings = params.map((param) => {
-    const constraint = param.constraint
-      ? ` extends ${tempPrint(param.constraint, param.getSourceFile())}`
-      : '';
-    const defaultValue = ` = ${
-      param.default ? tempPrint(param.default, param.getSourceFile()) : 'any'
-    }`;
-
-    return `${param.name.text}${constraint}${defaultValue}`;
-  });
-
-  return `<${paramStrings.join(', ')}>`;
+  return `<${params.map((param) => param.representationWithDefault).join(', ')}>`;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -8,9 +8,17 @@
 
 import ts from 'typescript';
 
+import {WrappedNodeExpr} from '@angular/compiler';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {initMockFileSystem} from '../../file_system/testing';
-import {Reference} from '../../imports';
+import {
+  ImportFlags,
+  LocalIdentifierStrategy,
+  Reference,
+  ReferenceEmitKind,
+  ReferenceEmitResult,
+  ReferenceEmitter,
+} from '../../imports';
 import {OptimizeFor, TypeCheckingConfig} from '../api';
 import {ALL_ENABLED_CONFIG, diagnose, setup, tcb, TestDeclaration, TestDirective} from '../testing';
 
@@ -1401,6 +1409,22 @@ describe('type check blocks', () => {
         expect(block).toContain('var _pipe1 = null! as i0.TestPipe;');
         expect(block).toContain('((_pipe1.transform as any)(((this).a), ((this).b), ((this).c))');
       });
+
+      it('should preserve type inference without explicitly filling generic arguments', () => {
+        const GENERIC_PIPES: TestDeclaration[] = [
+          {
+            type: 'pipe',
+            name: 'GenericPipe',
+            pipeName: 'generic',
+            isGeneric: true,
+          },
+        ];
+        // Test that generic pipes are instantiated like `var _pipe1 = null! as i0.GenericPipe;`
+        // instead of getting artificial padded `any` type arguments `i0.GenericPipe<any>`.
+        const block = tcb(`{{a | generic}}`, GENERIC_PIPES);
+        expect(block).toContain('var _pipe1 = null! as i0.GenericPipe;');
+        expect(block).not.toContain('var _pipe1 = null! as i0.GenericPipe<any>;');
+      });
     });
 
     describe('config.strictSafeNavigationTypes', () => {
@@ -2773,12 +2797,14 @@ describe('type check blocks', () => {
 
       FieldMock = {
         type: 'directive',
+        // Note: We don't use `bestGuessOwningModule` here because the test setup evaluates
+        // this mock via a local shim file (`/synthetic.ngtypecheck.ts`), forcing the reference
+        // emitter to resolve it as a relative local import (`./synthetic`). This completely
+        // overwrites any pseudo-module specifier we pass in, meaning `isFieldDirective` will
+        // ALWAYS fall back to scanning for the `ɵNgFieldDirective` property.
         name: 'FormField',
         selector: '[formField]',
-        bestGuessOwningModule: {
-          specifier: '@angular/forms/signals',
-          resolutionContext: '',
-        },
+        hasNgFieldDirective: true,
         inputs: {
           field: 'formField',
         },
@@ -3015,6 +3041,96 @@ describe('type check blocks', () => {
       );
       expect(block).toContain('var _t2 = null! as i0.FormField;');
       expect(block).toContain('_t2.field = (((this).f));');
+    });
+
+    it('should not report diagnostics for aliased directive references via PropertyAccessExpression', () => {
+      const fileName = absoluteFrom('/main.ts');
+      const source = `
+      import {Directive, Input} from '@angular/core';
+
+      @Directive({
+        selector: '[dir]',
+        standalone: true
+      })
+      export class OriginalDir {
+         @Input() input: string = '';
+      }
+
+      export const ns = {
+        AliasedDir: OriginalDir
+      };
+
+      @Directive({
+        selector: 'test-cmp',
+        standalone: true,
+        imports: [ns.AliasedDir]
+      })
+      export class TestCmp {}
+
+      // Shadow the original class name to induce a diagnostic error if the
+      // type checking block generator falls back to using 'OriginalDir'
+      // instead of the aliased 'ns.AliasedDir'.
+      const OriginalDir = null;
+    `;
+
+      // We need a custom emitter to force the usage of the alias `ns.AliasedDir`.
+      // The standard LocalIdentifierStrategy would just return `OriginalDir` since it is exported.
+      const localIdStrategy = new LocalIdentifierStrategy();
+      const mockRefEmitter = {
+        emit(ref: Reference, context: ts.SourceFile, flags: ImportFlags): ReferenceEmitResult {
+          if (ts.isClassDeclaration(ref.node) && ref.node.name?.text === 'OriginalDir') {
+            return {
+              kind: ReferenceEmitKind.Success,
+              expression: new WrappedNodeExpr(
+                ts.factory.createPropertyAccessExpression(
+                  ts.factory.createIdentifier('ns'),
+                  'AliasedDir',
+                ),
+              ),
+              importedFile: null,
+            } as any;
+          }
+          const fallback = localIdStrategy.emit(ref, context, flags);
+          return fallback ?? {kind: ReferenceEmitKind.Failed, reason: 'mock', context, ref};
+        },
+      } as unknown as ReferenceEmitter;
+
+      const {program, templateTypeChecker} = setup(
+        [
+          {
+            fileName,
+            source,
+            templates: {
+              TestCmp: '<div dir [input]="\'value\'"></div>',
+            },
+            declarations: [
+              {
+                type: 'directive',
+                name: 'OriginalDir',
+                selector: '[dir]',
+                isStandalone: true,
+                inputs: {input: 'input'},
+              },
+            ],
+          },
+        ],
+        {
+          // Use our mock emitter
+          referenceEmitter: mockRefEmitter,
+        },
+      );
+
+      const sf = getSourceFileOrError(program, fileName);
+      const testCmp = sf.statements.find(
+        (s) => ts.isClassDeclaration(s) && s.name?.text === 'TestCmp',
+      ) as ts.ClassDeclaration;
+
+      if (!testCmp) {
+        throw new Error('Could not find class');
+      }
+
+      const diagnostics = templateTypeChecker.getDiagnosticsForComponent(testCmp);
+      expect(diagnostics.map((d) => d.messageText)).toEqual([]);
     });
   });
 });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -38,6 +38,7 @@ import {
 import {DirectiveSourceManager} from '../src/source';
 import {TypeCheckFile} from '../src/type_check_file';
 import {ALL_ENABLED_CONFIG} from '../testing';
+import {TcbInputMapping} from '../api';
 
 runInEachFileSystem(() => {
   describe('ngtsc typechecking', () => {
@@ -123,7 +124,6 @@ TestClass.ngTypeCtor({value: 'test'});
             body: true,
             fields: {
               inputs: ClassPropertyMapping.fromMappedObject<InputMapping>({value: 'value'}),
-              queries: [],
             },
             coercedInputFields: new Set(),
           },
@@ -179,7 +179,6 @@ TestClass.ngTypeCtor({value: 'test'});
             body: true,
             fields: {
               inputs: ClassPropertyMapping.fromMappedObject<InputMapping>({value: 'value'}),
-              queries: ['queryField'],
             },
             coercedInputFields: new Set(),
           },
@@ -245,34 +244,27 @@ TestClass.ngTypeCtor({value: 'test'});
             fnName: 'ngTypeCtor',
             body: true,
             fields: {
-              inputs: ClassPropertyMapping.fromMappedObject<InputMapping>({
-                foo: 'foo',
-                bar: 'bar',
+              inputs: ClassPropertyMapping.fromMappedObject<TcbInputMapping>({
+                foo: {
+                  classPropertyName: 'foo',
+                  bindingPropertyName: 'foo',
+                  required: false,
+                  isSignal: false,
+                },
+                bar: {
+                  classPropertyName: 'bar',
+                  bindingPropertyName: 'bar',
+                  required: false,
+                  isSignal: false,
+                },
                 baz: {
                   classPropertyName: 'baz',
                   bindingPropertyName: 'baz',
                   required: false,
                   isSignal: false,
-                  transform: {
-                    type: new Reference(
-                      ts.factory.createUnionTypeNode([
-                        ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
-                        ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-                      ]),
-                    ),
-                    node: ts.factory.createFunctionDeclaration(
-                      undefined,
-                      undefined,
-                      undefined,
-                      undefined,
-                      [],
-                      undefined,
-                      undefined,
-                    ),
-                  },
+                  transformType: 'boolean | string',
                 },
               }),
-              queries: [],
             },
             coercedInputFields: new Set(['bar', 'baz']),
           },

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -345,6 +345,7 @@ export interface TestDirective extends Partial<
     outputs?: string[];
   }[];
   bestGuessOwningModule?: OwningModule | AmbientImport;
+  hasNgFieldDirective?: boolean;
 }
 
 export interface TestPipe {
@@ -355,6 +356,7 @@ export interface TestPipe {
   type: 'pipe';
   code?: string;
   bestGuessOwningModule?: OwningModule | AmbientImport;
+  isGeneric?: boolean;
 }
 
 export type TestDeclaration = TestDirective | TestPipe;
@@ -366,7 +368,10 @@ export function tcb(
   options?: {emitSpans?: boolean},
   templateParserOptions?: ParseTemplateOptions,
 ): string {
-  const codeLines = [`export class Test<T extends string> {}`];
+  const codeLines = [
+    'declare const ɵNgFieldDirective: unique symbol;',
+    `export class Test<T extends string> {}`,
+  ];
 
   (function addCodeLines(currentDeclarations) {
     for (const decl of currentDeclarations) {
@@ -374,7 +379,12 @@ export function tcb(
         addCodeLines(decl.hostDirectives.map((hostDir) => hostDir.directive));
       }
 
-      codeLines.push(decl.code ?? `export class ${decl.name}<T extends string> {}`);
+      codeLines.push(
+        decl.code ??
+          `export class ${decl.name}${decl.type === 'directive' || decl.isGeneric ? '<T extends string>' : ''} { ${
+            (decl as TestDirective).hasNgFieldDirective === true ? '[ɵNgFieldDirective]: any;' : ''
+          } }`,
+      );
     }
   })(declarations);
 
@@ -517,6 +527,7 @@ export function setup(
     options?: ts.CompilerOptions;
     inlining?: boolean;
     parseOptions?: ParseTemplateOptions;
+    referenceEmitter?: ReferenceEmitter;
   } = {},
 ): {
   templateTypeChecker: TemplateTypeChecker;
@@ -567,16 +578,18 @@ export function setup(
     host,
     /* moduleResolutionCache */ null,
   );
-  const emitter = new ReferenceEmitter([
-    new LocalIdentifierStrategy(),
-    new AbsoluteModuleStrategy(
-      program,
-      checker,
-      moduleResolver,
-      new TypeScriptReflectionHost(checker),
-    ),
-    new LogicalProjectStrategy(reflectionHost, logicalFs),
-  ]);
+  const emitter =
+    overrides.referenceEmitter ??
+    new ReferenceEmitter([
+      new LocalIdentifierStrategy(),
+      new AbsoluteModuleStrategy(
+        program,
+        checker,
+        moduleResolver,
+        new TypeScriptReflectionHost(checker),
+      ),
+      new LogicalProjectStrategy(reflectionHost, logicalFs),
+    ]);
 
   const fullConfig = {
     ...ALL_ENABLED_CONFIG,

--- a/packages/language-service/src/adapters.ts
+++ b/packages/language-service/src/adapters.ts
@@ -43,6 +43,15 @@ export class LanguageServiceAdapter implements NgCompilerAdapter {
     this.rootDirs = getRootDirs(this, project.getCompilationSettings());
   }
 
+  getSourceFile(
+    fileName: string,
+    languageVersion: ts.ScriptTarget,
+    onError?: (message: string) => void,
+    shouldCreateNewSourceFile?: boolean,
+  ): ts.SourceFile | undefined {
+    return this.project.getSourceFile(this.project.projectService.toPath(fileName));
+  }
+
   resourceNameToFileName(
     url: string,
     fromFile: string,


### PR DESCRIPTION
This commit refactors the template type checking metadata interfaces to use detached, serializable metadata rather than retaining direct references to ts.Node or ts.Declaration instances.

A new tcb_adapter translates traditional TypeScript AST-bound metadata into these decoupled structures. This abstraction lays the groundwork for supporting native preprocessors (such as Rust or ts-go) which serialize metadata over JSON rather than passing live TypeScript objects.

Key changes:
- Introduced TcbDirectiveMetadata, TcbComponentMetadata, TcbReferenceMetadata, and TcbPipeMetadata to replace TypeCheckableDirectiveMeta where appropriate.
- Substituted deep TS compilation AST references with string module names and source spans to preserve out-of-band diagnostic capabilities.
- Detached generic typeParameters and transformType properties into synthesized, standalone TS mappings.
- Updated generateTypeCheckBlock and corresponding Operations to consume the new metadata.
