### PR TITLE
release: cut the zone.js-0.16.1 release

### DIFF
--- a/packages/zone.js/CHANGELOG.md
+++ b/packages/zone.js/CHANGELOG.md
@@ -1,3 +1,8 @@
+## <small>0.16.1 (2026-02-18)</small>
+
+* fix(zone.js): support passthrough of Promise.try API ([fc557f0](https://github.com/angular/angular/commit/fc557f0)), closes [#67057](https://github.com/angular/angular/issues/67057)
+
+
 ## <small>0.16.0 (2025-11-19)</small>
 
 - fix(zone.js): Support jasmine v6 ([48abe00](https://github.com/angular/angular/commit/48abe00))

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone.js",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Zones for JavaScript",
   "main": "./bundles/zone.umd.js",
   "module": "./fesm2015/zone.js",


### PR DESCRIPTION
caretaker note: updated release instructions are in https://github.com/angular/angular/pull/67110