### PR TITLE
fix(compiler): add mglyph src to security schema to prevent XSS

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -10,11 +10,11 @@ import {SecurityContext} from '../core';
 
 // =================================================================================================
 // =================================================================================================
-// =========== S T O P   -  S T O P   -  S T O P   -  S T O P   -  S T O P   -  S T O P  ===========
+// =========== S T O P   -   S T O P   -   S T O P   -   S T O P   -   S T O P   -   S T O P ===========
 // =================================================================================================
 // =================================================================================================
 //
-//        DO NOT EDIT THIS LIST OF SECURITY SENSITIVE PROPERTIES WITHOUT A SECURITY REVIEW!
+//         DO NOT EDIT THIS LIST OF SECURITY SENSITIVE PROPERTIES WITHOUT A SECURITY REVIEW!
 //
 // =================================================================================================
 
@@ -58,6 +58,7 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'mfrac|xlink:href',
       'mglyph|href',
       'mglyph|xlink:href',
+      'mglyph|src', // <--- التعديل الأمني هنا: إضافة السمة الناقصة لمنع XSS
       'msub|href',
       'msub|xlink:href',
       'msup|href',

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -58,7 +58,7 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'mfrac|xlink:href',
       'mglyph|href',
       'mglyph|xlink:href',
-      'mglyph|src', // <--- التعديل الأمني هنا: إضافة السمة الناقصة لمنع XSS
+      'mglyph|src', 
       'msub|href',
       'msub|xlink:href',
       'msup|href',


### PR DESCRIPTION
This PR adds the src attribute of the MathML mglyph element to the SECURITY_SCHEMA.

Problem: Currently, mglyph[src] is not mapped to any SecurityContext, causing it to default to SecurityContext.NONE. This allows an attacker to bypass Angular's DomSanitizer and execute arbitrary JavaScript using javascript: URIs.

Solution: By adding mglyph|src to the schema, Angular will correctly sanitize the attribute as a URL context, aligning it with how mglyph[href] and mglyph[xlink:href] are handled.