### PR TITLE
fix(common): remove assertNoComplexSizes from NgOptimizedImage

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -445,9 +445,6 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       }
       assertValidLoadingInput(this);
       assertValidDecodingInput(this);
-      if (!this.ngSrcset) {
-        assertNoComplexSizes(this);
-      }
       assertValidPlaceholder(this, this.imageLoader);
       assertNotMissingBuiltInLoader(this.ngSrc, this.imageLoader);
       assertNoNgSrcsetWithoutLoader(this, this.imageLoader);
@@ -828,22 +825,6 @@ function assertNotBase64Image(dir: NgOptimizedImage) {
         `(${ngSrc}). NgOptimizedImage does not support Base64-encoded strings. ` +
         `To fix this, disable the NgOptimizedImage directive for this element ` +
         `by removing \`ngSrc\` and using a standard \`src\` attribute instead.`,
-    );
-  }
-}
-
-/**
- * Verifies that the 'sizes' only includes responsive values.
- */
-function assertNoComplexSizes(dir: NgOptimizedImage) {
-  let sizes = dir.sizes;
-  if (sizes?.match(/((\)|,)\s|^)\d+px/)) {
-    throw new RuntimeError(
-      RuntimeErrorCode.INVALID_INPUT,
-      `${imgDirectiveDetails(dir.ngSrc, false)} \`sizes\` was set to a string including ` +
-        `pixel values. For automatic \`srcset\` generation, \`sizes\` must only include responsive ` +
-        `values, such as \`sizes="50vw"\` or \`sizes="(min-width: 768px) 50vw, 100vw"\`. ` +
-        `To fix this, modify the \`sizes\` attribute, or provide your own \`ngSrcset\` value directly.`,
     );
   }
 }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -2366,44 +2366,6 @@ describe('Image directive', () => {
         );
       });
 
-      it('should throw if a complex `sizes` is used', () => {
-        setupTestingModule();
-
-        const template =
-          '<img ngSrc="path/img.png" width="100" height="50" sizes="(min-width: 768px) 500px, 100vw">';
-        expect(() => {
-          const fixture = createTestComponent(template);
-          fixture.detectChanges();
-        }).toThrowError(
-          'NG02952: The NgOptimizedImage directive has detected that `sizes` was set to a string including pixel values. ' +
-            'For automatic `srcset` generation, `sizes` must only include responsive values, such as `sizes="50vw"` or ' +
-            '`sizes="(min-width: 768px) 50vw, 100vw"`. To fix this, modify the `sizes` attribute, or provide your own `ngSrcset` value directly.',
-        );
-      });
-      it('should throw if a complex `sizes` is used with srcset', () => {
-        setupTestingModule();
-
-        const template =
-          '<img ngSrc="path/img.png" width="100" height="50" sizes="(min-width: 768px) 500px, 100vw" srcset="www.example.com/img.png?w=500 768w, www.example.com/img.png?w=2000" >';
-        expect(() => {
-          const fixture = createTestComponent(template);
-          fixture.detectChanges();
-        }).toThrowError(
-          'NG02952: The NgOptimizedImage directive has detected that `sizes` was set to a string including pixel values. ' +
-            'For automatic `srcset` generation, `sizes` must only include responsive values, such as `sizes="50vw"` or ' +
-            '`sizes="(min-width: 768px) 50vw, 100vw"`. To fix this, modify the `sizes` attribute, or provide your own `ngSrcset` value directly.',
-        );
-      });
-      it('should not throw if a complex `sizes` is used with ngSrcset', () => {
-        setupTestingModule();
-
-        const template =
-          '<img ngSrc="path/img.png" width="100" height="50" sizes="(min-width: 768px) 500px, 100vw" ngSrcset="100w, 200w">';
-        expect(() => {
-          const fixture = createTestComponent(template);
-          fixture.detectChanges();
-        }).not.toThrow();
-      });
     });
 
     describe('automatic srcset generation', () => {


### PR DESCRIPTION
## Summary
- Remove the `assertNoComplexSizes` assertion that throws NG02952 in dev mode when `sizes` contains pixel values (e.g. `370px`)
- Pixel values in `sizes` are valid HTML and work correctly in production, so the assertion blocks valid use cases like `sizes="(max-width: 540px) 100vw, (max-width: 960px) 50vw, 370px"`
- Remove the corresponding tests for the removed assertion

Closes #59495

## Test plan
- [ ] Verify existing NgOptimizedImage tests pass (`bazel test //packages/common/test:test`)
- [ ] Confirm `sizes` attributes with pixel values no longer throw NG02952 in dev mode