### PR TITLE
release: bump Angular DevTools version to 1.11.0

### DIFF
--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "minimum_chrome_version": "102",
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"

--- a/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.firefox.json
@@ -3,7 +3,7 @@
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Firefox DevTools adding Angular specific debugging and profiling capabilities.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "icons": {
     "16": "assets/icon16.png",


### PR DESCRIPTION
- fix(devtools): injector tree errors when inspecting null nodes
- fix(devtools): scope the message bus with URLs to prevent cross message interference
- feat(devtools): add dependencies highlighting to the signal graph
- fix(devtools): runtime error when a cluster preview node is missing
- fix(devtools): duplicated props in the properties panel
- fix(devtools): signal node value preview for afterRenderEffect