### PR TITLE
docs(docs-infra): fixed missing gray color palette definitions for li…

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -137,14 +137,14 @@ dialog {
 .docs-search-results__start-typing,
 .docs-search-results__no-results {
   padding: 0.75rem;
-  color: var(--gray-400);
+  color: var(--quaternary-contrast);
 }
 
 .docs-search-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: var(--gray-400);
+  color: var(--quaternary-contrast);
   padding: 1rem;
   font-size: 0.75rem;
   font-weight: 500;

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.scss
@@ -143,7 +143,7 @@
     height: fit-content;
 
     docs-icon {
-      color: var(--gray-400);
+      color: var(--quaternary-contrast);
       transition: color 0.3s ease;
     }
 

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -87,7 +87,7 @@
                 fill="none"
               >
                 <path
-                  fill="var(--gray-400)"
+                  fill="var(--quaternary-contrast)"
                   d="M3.4 22 2 20.6 8.6 14H4v-2h8v8h-2v-4.6L3.4 22ZM12 12V4h2v4.6L20.6 2 22 3.4 15.4 10H20v2h-8Z"
                 />
               </svg>

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
@@ -2,11 +2,11 @@
   .docs-example-viewer-preview {
     .docs-dark-mode & {
       color: var(--primary-contrast);
-      background: var(--gray-900);
+      background: var(--primary-constrast);
     }
     @media screen and (prefers-color-scheme: dark) {
       color: var(--primary-contrast);
-      background: var(--gray-900);
+      background: var(--primary-constrast);
     }
     .docs-light-mode & {
       background: var(--page-background);
@@ -70,7 +70,7 @@
       cursor: pointer;
       height: 24px;
       width: 24px;
-      color: var(--gray-400);
+      color: var(--quaternary-contrast);
 
       path {
         transition: fill 0.3s ease;

--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -51,7 +51,7 @@
     }
 
     .docs-reference-category {
-      color: var(--gray-400);
+      color: var(--quaternary-contrast);
       font-size: 0.875rem;
       font-weight: 500;
       line-height: 1.4rem;

--- a/adev/shared-docs/styles/docs/_card.scss
+++ b/adev/shared-docs/styles/docs/_card.scss
@@ -6,68 +6,66 @@
     border-radius: 0.25rem;
     margin: 1rem 0;
 
-      .docs-card-container-header {
-        align-items: flex-end;
-        border-bottom: 1px solid var(--senary-contrast);
-        display: flex;
-        justify-content: space-between;
+    .docs-card-container-header {
+      align-items: flex-end;
+      border-bottom: 1px solid var(--senary-contrast);
+      display: flex;
+      justify-content: space-between;
 
-        h2 {
-          padding: 2.5rem 1rem 2.5rem 2.5rem;
-          min-width: 350px;
+      h2 {
+        padding: 2.5rem 1rem 2.5rem 2.5rem;
+        min-width: 350px;
+      }
+
+      .theme-fill-bg {
+        fill: var(--page-background);
+        stroke: var(--primary-contrast);
+      }
+      .theme-fill-accent-bg {
+        fill: var(--septenary-contrast);
+        stroke: var(--primary-contrast);
+      }
+      .theme-stroke-primary {
+        stroke: var(--primary-contrast);
+      }
+      .theme-fill-primary {
+        fill: var(--primary-contrast);
+      }
+      .theme-fill-secondary {
+        fill: var(--octonary-contrast);
+      }
+      .theme-stroke-accent {
+        stroke: var(--vivid-pink);
+      }
+      .theme-fill-accent {
+        fill: var(--vivid-pink);
+        stroke: var(--primary-contrast);
+      }
+      .theme-stroke-secondary {
+        stroke: var(--senary-contrast);
+      }
+      .theme-fill-secondary {
+        fill: var(--senary-contrast);
+      }
+
+      .header-img {
+        margin-top: 5px;
+        overflow: hidden;
+        margin-bottom: -5px;
+      }
+
+      svg {
+        fill-opacity: 1;
+
+        @container header (max-width: 550px) {
+          display: none;
         }
 
-        .theme-fill-bg {
-          fill: var(--page-background);
-          stroke: var(--primary-contrast);
-        }
-        .theme-fill-accent-bg {
-          fill: var(--septenary-contrast);
-          stroke: var(--primary-contrast);
-        }
-        .theme-stroke-primary {
-          stroke: var(--primary-contrast);
-        }
-        .theme-fill-primary {
-          fill: var(--primary-contrast);
-        }
-        .theme-fill-secondary {
-          fill: var(--octonary-contrast);
-        }
-        .theme-stroke-accent {
-          stroke: var(--vivid-pink);
-        }
-        .theme-fill-accent {
-          fill: var(--vivid-pink);
-          stroke: var(--primary-contrast);
-        }
-        .theme-stroke-secondary {
-          stroke: var(--senary-contrast);
-        }
-        .theme-fill-secondary {
-          fill: var(--senary-contrast);
-        }
-
-
-
-        .header-img {
-          margin-top: 5px;
-          overflow: hidden;
-          margin-bottom: -5px;
-        }
-
-        svg {
-          fill-opacity: 1;
-
-          @container header (max-width: 550px) {
-            display: none;
-          }
-
-          rect {
-            fill: transparent;
-          }
+        rect {
+          fill: transparent;
         }
       }
+    }
 
     .docs-card-container-content {
       margin: 1rem;
@@ -214,7 +212,10 @@
     &:before {
       content: '';
       position: absolute;
-      top: 0; right: 0; bottom: 0; left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
       z-index: -1;
       margin: -1px;
       border-radius: inherit;
@@ -223,7 +224,7 @@
 
     .docs-nav-card-title {
       background: var(--pink-to-highlight-to-purple-to-blue-horizontal-gradient);
-      padding: 1.5rem 1.5rem .5rem;
+      padding: 1.5rem 1.5rem 0.5rem;
       -webkit-background-clip: text;
       background-clip: text;
       color: transparent;
@@ -264,11 +265,11 @@
         gap: 8px;
 
         h3 {
-          margin-block-end: .5rem;
+          margin-block-end: 0.5rem;
         }
 
         svg path {
-          fill: var(--gray-400);
+          fill: var(--quaternary-contrast);
         }
       }
 

--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -239,7 +239,7 @@ $code-font-size: 0.875rem;
       opacity: 1;
       path {
         transition: fill 0.3s ease;
-        fill: var(--gray-400);
+        fill: var(--quaternary-contrast);
       }
     }
     .docs-check {

--- a/adev/src/app/app.component.scss
+++ b/adev/src/app/app.component.scss
@@ -91,7 +91,7 @@
     width: 100vw;
     height: 100vh;
     backdrop-filter: blur(2px);
-    background-color: color-mix(in srgb, var(--gray-1000) 5%, transparent);
+    background-color: color-mix(in srgb, var(--page-background) 5%, transparent);
     z-index: 50;
     visibility: hidden;
     opacity: 0;

--- a/adev/src/app/editor/code-editor/code-editor.component.scss
+++ b/adev/src/app/editor/code-editor/code-editor.component.scss
@@ -159,7 +159,7 @@
 .docs-delete-file,
 .docs-rename-file {
   docs-icon {
-    color: var(--gray-400);
+    color: var(--quaternary-contrast);
     transition: color 0.3s ease;
     font-size: 1.2rem;
   }
@@ -270,7 +270,7 @@
   border-inline-start: 1px solid var(--senary-contrast);
 
   docs-icon {
-    color: var(--gray-400);
+    color: var(--quaternary-contrast);
     transition: color 0.3s ease;
     font-size: 1.3rem;
   }

--- a/adev/src/app/editor/embedded-editor.component.scss
+++ b/adev/src/app/editor/embedded-editor.component.scss
@@ -106,7 +106,7 @@ $width-breakpoint: 950px;
   z-index: var(--z-index-content);
 
   docs-icon {
-    color: var(--gray-400);
+    color: var(--quaternary-contrast);
     margin: auto;
     font-size: 1.3rem;
     transition: color 0.3s ease;
@@ -120,7 +120,7 @@ $width-breakpoint: 950px;
 
   &:disabled {
     docs-icon {
-      color: var(--gray-400);
+      color: var(--quaternary-contrast);
     }
   }
 }

--- a/adev/src/app/editor/preview/preview.component.scss
+++ b/adev/src/app/editor/preview/preview.component.scss
@@ -3,7 +3,7 @@
 
   .docs-dark-mode & {
     .adev-embedded-editor-preview-container {
-      background: var(--gray-100);
+      background: var(--primary-constrast);
     }
   }
 

--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -110,7 +110,7 @@
       var(--symbolic-yellow) var(--item-attr-base-mix),
       var(--octonary-contrast)
     );
-    color: var(--gray-1000);
+    color: var(--page-background);
   }
 
   &.adev-experimental {
@@ -119,7 +119,7 @@
       var(--symbolic-green) var(--item-attr-base-mix),
       var(--octonary-contrast)
     );
-    color: var(--gray-1000);
+    color: var(--page-background);
   }
 
   &.adev-deprecated {

--- a/adev/src/app/features/tutorial/tutorial-navigation.scss
+++ b/adev/src/app/features/tutorial/tutorial-navigation.scss
@@ -25,7 +25,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    color: var(--gray-400);
+    color: var(--quaternary-contrast);
     background-color: var(--page-background);
     border-block-start: 1px solid var(--senary-contrast);
     border-radius: 0 0 0.25rem 0.25rem;

--- a/adev/src/content/examples/aria/accordion/src/disabled-focusable/retro/app/app.css
+++ b/adev/src/content/examples/aria/accordion/src/disabled-focusable/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--symbolic-yellow) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--quaternary-contrast), 0px 4px 0px 0px var(--quaternary-contrast),
+    -4px 0px 0px 0px var(--quaternary-contrast), 0px -4px 0px 0px var(--quaternary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast), 8px 8px 0px 0px var(--quaternary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast), 0px 0px 0px 0px var(--quaternary-contrast);
 }
 
 [ngAccordionGroup] {

--- a/adev/src/content/examples/aria/accordion/src/multi-expansion/retro/app/app.css
+++ b/adev/src/content/examples/aria/accordion/src/multi-expansion/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--symbolic-yellow) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngAccordionGroup] {

--- a/adev/src/content/examples/aria/accordion/src/single-expansion/retro/app/app.css
+++ b/adev/src/content/examples/aria/accordion/src/single-expansion/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--symbolic-yellow) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngAccordionGroup] {

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
@@ -12,17 +12,17 @@
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .retro-autocomplete {

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
@@ -12,17 +12,17 @@
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .retro-autocomplete {

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
@@ -12,17 +12,17 @@
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .retro-autocomplete {

--- a/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.css
+++ b/adev/src/content/examples/aria/combobox/src/dialog/retro/app/app.css
@@ -12,17 +12,17 @@
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngComboboxInput] {
@@ -175,7 +175,7 @@
 }
 
 .dialog [ngComboboxInput] {
-  border-bottom: 4px solid var(--gray-700, #374151);
+  border-bottom: 4px solid var(--tertiary-contrast, #374151);
 }
 
 [ngCombobox]:focus-within [ngComboboxInput]:not(.combobox-input) {

--- a/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.css
+++ b/adev/src/content/examples/aria/grid/src/calendar/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--always-pink) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--always-pink) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--always-pink) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .calendar {

--- a/adev/src/content/examples/aria/grid/src/pill-list/retro/app/app.css
+++ b/adev/src/content/examples/aria/grid/src/pill-list/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--always-pink) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--always-pink) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--always-pink) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngGrid] {

--- a/adev/src/content/examples/aria/grid/src/table/retro/app/app.css
+++ b/adev/src/content/examples/aria/grid/src/table/retro/app/app.css
@@ -6,28 +6,28 @@
   justify-content: center;
   font-family: 'Press Start 2P';
 
-  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--symbolic-yellow) 90%, var(--page-background));
   --retro-button-text-color: color-mix(in srgb, var(--symbolic-yellow) 10%, white);
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .hidden {

--- a/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/listbox/src/basic/retro/app/app.css
@@ -7,12 +7,12 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
 }
 
 .retro-listbox {

--- a/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.css
+++ b/adev/src/content/examples/aria/listbox/src/horizontal/retro/app/app.css
@@ -7,15 +7,15 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow-small:
-    2px 0px 0px 0px var(--gray-700), 0px 2px 0px 0px var(--gray-700),
-    -2px 0px 0px 0px var(--gray-700), 0px -2px 0px 0px var(--gray-700);
+    2px 0px 0px 0px var(--tertiary-contrast), 0px 2px 0px 0px var(--tertiary-contrast),
+    -2px 0px 0px 0px var(--tertiary-contrast), 0px -2px 0px 0px var(--tertiary-contrast);
 }
 
 .retro-listbox {

--- a/adev/src/content/examples/aria/menu/src/menu-context/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-context/app/app.css
@@ -1,9 +1,12 @@
 h1 {
-  background: var(--gray-600);
+  background: var(--tertiary-contrast);
   color: #e0e0e0;
   padding: 2rem;
   margin: 0;
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
   font-size: 2rem;
   text-align: center;
 }

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/material/app/app.css
@@ -78,7 +78,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-standalone/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenu] {

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/material/app/app.css
@@ -92,7 +92,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger-disabled/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenuTrigger] {

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/material/app/app.css
@@ -92,7 +92,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.css
+++ b/adev/src/content/examples/aria/menu/src/menu-trigger/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenuTrigger] {

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.css
@@ -67,7 +67,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenuBar] {

--- a/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.css
@@ -67,7 +67,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenuBar] {

--- a/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.css
@@ -67,7 +67,7 @@
 }
 
 [ngMenu] .separator {
-  border-top: 1px solid var(--gray-500);
+  border-top: 1px solid var(--quaternary-contrast);
   margin: 0.25rem 0;
   opacity: 0.25;
 }

--- a/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.css
+++ b/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.css
@@ -14,22 +14,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngMenuBar] {

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/select/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/basic/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/select/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/disabled/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/select/src/icons/retro/app/app.css
+++ b/adev/src/content/examples/aria/select/src/icons/retro/app/app.css
@@ -7,27 +7,27 @@
   font-size: 0.8rem;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 .select {

--- a/adev/src/content/examples/aria/tabs/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/tabs/src/disabled/retro/app/app.css
@@ -12,22 +12,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngTabs] {

--- a/adev/src/content/examples/aria/tabs/src/explicit-selection/retro/app/app.css
+++ b/adev/src/content/examples/aria/tabs/src/explicit-selection/retro/app/app.css
@@ -12,22 +12,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--quaternary-contrast), 0px 4px 0px 0px var(--quaternary-contrast),
+    -4px 0px 0px 0px var(--quaternary-contrast), 0px -4px 0px 0px var(--quaternary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast), 8px 8px 0px 0px var(--quaternary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--quaternary-contrast),
+    0px 4px 0px 0px var(--quaternary-contrast), -4px 0px 0px 0px var(--quaternary-contrast),
+    0px -4px 0px 0px var(--quaternary-contrast), 0px 0px 0px 0px var(--quaternary-contrast);
 }
 
 [ngTabs] {

--- a/adev/src/content/examples/aria/tabs/src/selection-follows-focus/retro/app/app.css
+++ b/adev/src/content/examples/aria/tabs/src/selection-follows-focus/retro/app/app.css
@@ -12,22 +12,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngTabs] {

--- a/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.css
+++ b/adev/src/content/examples/aria/tabs/src/vertical/retro/app/app.css
@@ -12,22 +12,22 @@
   --retro-shadow-dark: color-mix(in srgb, #000 20%, transparent);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngTabs] {

--- a/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/basic/retro/app/app.css
@@ -5,27 +5,27 @@
   justify-content: center;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngToolbar] {

--- a/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/disabled/retro/app/app.css
@@ -5,27 +5,27 @@
   justify-content: center;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngToolbar] {
@@ -79,7 +79,7 @@
   outline: 4px dashed var(--retro-button-color);
 }
 
-[ngToolbarWidget][aria-disabled="true"] {
+[ngToolbarWidget][aria-disabled='true'] {
   cursor: default;
   opacity: 0.45;
 }

--- a/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/rtl/retro/app/app.css
@@ -5,27 +5,27 @@
   justify-content: center;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngToolbar] {

--- a/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.css
+++ b/adev/src/content/examples/aria/toolbar/src/vertical/retro/app/app.css
@@ -5,27 +5,27 @@
   justify-content: flex-start;
 
   font-family: 'Press Start 2P';
-  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--gray-1000));
+  --retro-button-color: color-mix(in srgb, var(--vivid-pink) 80%, var(--page-background));
   --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
   --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
   --retro-elevated-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
   --retro-flat-shadow:
-    4px 0px 0px 0px var(--gray-700), 0px 4px 0px 0px var(--gray-700),
-    -4px 0px 0px 0px var(--gray-700), 0px -4px 0px 0px var(--gray-700);
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
   --retro-clickable-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-light),
-    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 8px 8px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
   --retro-pressed-shadow:
     inset 4px 4px 0px 0px var(--retro-shadow-dark),
-    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--gray-700),
-    0px 4px 0px 0px var(--gray-700), -4px 0px 0px 0px var(--gray-700),
-    0px -4px 0px 0px var(--gray-700), 0px 0px 0px 0px var(--gray-700);
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
 }
 
 [ngToolbar] {


### PR DESCRIPTION
 
Adds the missing gray color palette definitions for both light and dark modes


## What is the current behavior?
https://next.angular.dev/best-practices/a11y
<img width="738" height="376" alt="image" src="https://github.com/user-attachments/assets/d7fdfd12-d8bb-4c3d-9dde-a70aaf0d8525" />


## What is the new behavior?


<img width="732" height="92" alt="image" src="https://github.com/user-attachments/assets/29f1dcff-fd5c-4a62-a8d0-1fd878eae6ef" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

 