### PR TITLE
docs: release notes for the v21.1.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="21.1.5"></a>
+# 21.1.5 (2026-02-18)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="21.2.0-next.3"></a>
 # 21.2.0-next.3 (2026-02-11)
 ### common


### PR DESCRIPTION
Cherry-picks the changelog from the "21.1.x" branch to the next branch (main).