### PR TITLE
devtools: fix messaging bus

### DIFF
--- a/devtools/projects/shell-browser/src/app/detect-angular.ts
+++ b/devtools/projects/shell-browser/src/app/detect-angular.ts
@@ -13,13 +13,13 @@ import {
   appIsAngularIvy,
   appIsSupportedAngularVersion,
 } from '../../../shared-utils';
-import {getDetectAngularScriptUri} from './comm-utils';
+import {getContentScriptUri, getDetectAngularScriptUri} from './comm-utils';
 
 import {SamePageMessageBus} from './same-page-message-bus';
 
 const detectAngularMessageBus = new SamePageMessageBus(
   getDetectAngularScriptUri(),
-  getDetectAngularScriptUri(),
+  getContentScriptUri(),
 );
 
 let detectAngularTimeout: ReturnType<typeof setTimeout>;


### PR DESCRIPTION
devtools: fix messaging bus

The bus wasn't initialized correctly and never recieved the backend installed messages.

fixes #67143