### PR TITLE
docs: improve lazy loading of homepage examples

### DIFF
--- a/adev/src/app/features/home/home.component.html
+++ b/adev/src/app/features/home/home.component.html
@@ -50,35 +50,35 @@
 
       <div class="sliding-window">
         <div ngTabPanel [preserveContent]="true" value="signals">
-          <ng-template ngTabContent>
-            @defer (on idle) {
+          @defer (on idle) {
+            <ng-template ngTabContent>
               <adev-signals-demo />
-            }
-          </ng-template>
+            </ng-template>
+          }
         </div>
 
         <div ngTabPanel [preserveContent]="true" value="control-flow">
-          <ng-template ngTabContent>
-            @defer (on idle) {
+          @defer (on idle) {
+            <ng-template ngTabContent>
               <adev-control-flow-example />
-            }
-          </ng-template>
+            </ng-template>
+          }
         </div>
 
         <div ngTabPanel [preserveContent]="true" value="deferrable-views">
-          <ng-template ngTabContent>
-            @defer {
+          @defer (on idle) {
+            <ng-template ngTabContent>
               <adev-defer-example />
-            }
-          </ng-template>
+            </ng-template>
+          }
         </div>
 
         <div ngTabPanel [preserveContent]="true" value="hydration">
-          <ng-template ngTabContent>
-            @defer {
+          @defer (on idle) {
+            <ng-template ngTabContent>
               <adev-hydration-example />
-            }
-          </ng-template>
+            </ng-template>
+          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
The aria tab content are only instantiated when the tab is selected which also delays the prefetching.

By having the defer block around the ng-conten we actually allow angular to prefetch the chuncks without the tab being visible

Change is already backported on the patch PR #67122 