### PR TITLE
feat(core): add TestBed.getFixture

### DIFF
--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -119,6 +119,7 @@ export interface TestBed {
     execute(tokens: any[], fn: Function, context?: any): any;
     // @deprecated
     flushEffects(): void;
+    getFixture<T = unknown>(): ComponentFixture<T>;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -172,6 +172,12 @@ export interface TestBed {
   createComponent<T>(component: Type<T>, options?: TestComponentOptions): ComponentFixture<T>;
 
   /**
+   * Returns the most recently created `ComponentFixture`, or throws an error if one has not
+   * yet been created.
+   */
+  getFixture<T = unknown>(): ComponentFixture<T>;
+
+  /**
    * Execute any pending effects.
    *
    * @deprecated use `TestBed.tick()` instead
@@ -412,6 +418,10 @@ export class TestBedImpl implements TestBed {
     options?: TestComponentOptions,
   ): ComponentFixture<T> {
     return TestBedImpl.INSTANCE.createComponent(component, options);
+  }
+
+  static getFixture<T = unknown>(): ComponentFixture<T> {
+    return TestBedImpl.INSTANCE.getFixture();
   }
 
   static resetTestingModule(): TestBed {
@@ -707,6 +717,19 @@ export class TestBedImpl implements TestBed {
     const fixture = ngZone ? ngZone.run(initComponent) : initComponent();
     this._activeFixtures.push(fixture);
     return fixture;
+  }
+
+  getFixture<T = unknown>(): ComponentFixture<T> {
+    if (this._activeFixtures.length === 0) {
+      throw new Error('No fixture has been created yet.');
+    }
+    if (this._activeFixtures.length > 1) {
+      throw new Error(
+        `More than one component fixture has been created. Use \`TestBed.createComponent\` ` +
+          `and store the fixture on the test context, rather than using \`TestBed.getFixture\`.`,
+      );
+    }
+    return this._activeFixtures[0];
   }
 
   /**

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -1103,6 +1103,32 @@ Did you run and wait for 'resolveComponentResources()'?`);
       componentFixture.detectChanges();
       expect(componentFixture.nativeElement).toHaveText('injected value: mocked out value');
     }));
+
+    describe('getFixture', () => {
+      it('should return the last created fixture', () => {
+        const fixture = TestBed.createComponent(ChildComp);
+        expect(TestBed.getFixture()).toBe(fixture);
+      });
+
+      it('should throw if no fixture has been created', () => {
+        expect(() => TestBed.getFixture()).toThrowError('No fixture has been created yet.');
+      });
+
+      it('should throw an error if multiple fixtures are present', () => {
+        TestBed.createComponent(ChildComp);
+        TestBed.createComponent(ParentComp);
+        expect(() => TestBed.getFixture()).toThrowError(
+          `More than one component fixture has been created. Use \`TestBed.createComponent\` ` +
+            `and store the fixture on the test context, rather than using \`TestBed.getFixture\`.`,
+        );
+      });
+
+      it('should clear the fixture after reset', () => {
+        TestBed.createComponent(ChildComp);
+        TestBed.resetTestingModule();
+        expect(() => TestBed.getFixture()).toThrowError('No fixture has been created yet.');
+      });
+    });
   });
   describe('using alternate components', () => {
     beforeEach(() => {


### PR DESCRIPTION
This adds a new method to the TestBed to retrieve the most recently created component fixture. This is useful for cases where the fixture is created in a beforeEach and needs to be accessed in a test.
