### PR TITLE
fix(upgrade): prevent APP_BASE_HREF duplication in locationShim.path

### DIFF
--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -85,7 +85,15 @@ export class $locationShim {
     this.$$state = this.browserState();
 
     this.removeOnUrlChangeFn = this.location.onUrlChange((newUrl, newState) => {
-      this.urlChanges.next({newUrl, newState});
+      let url = newUrl;
+      // When `Location` fires the `onUrlChange` event, it passes the external URL.
+      // If the application is configured with a base href, the external URL will
+      // include the base href. `Location.normalize` strips the base href and
+      // returns the internal URL that `$locationShim` expects.
+      if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        url = this.location.normalize(url);
+      }
+      this.urlChanges.next({newUrl: url, newState});
     });
 
     if (isPromise($injector)) {

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -92,6 +92,11 @@ export class $locationShim {
       // returns the internal URL that `$locationShim` expects.
       if (!url.startsWith('http://') && !url.startsWith('https://')) {
         url = this.location.normalize(url);
+        // Location.normalize might return an empty string or a path that does not start with a slash
+        // $locationShim expects the path to start with a slash
+        if (!url.startsWith('/')) {
+          url = '/' + url;
+        }
       }
       this.urlChanges.next({newUrl: url, newState});
     });

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -8,7 +8,7 @@
 
 import {inject, TestBed} from '@angular/core/testing';
 import {UpgradeModule} from '@angular/upgrade/static';
-import {CommonModule} from '../../index';
+import {CommonModule, Location} from '../../index';
 
 import {$locationShim} from '../src/location_shim';
 
@@ -504,6 +504,16 @@ describe('New URL Parsing with appBaseHref', () => {
     $location.path('/new/path');
     expect($location.absUrl()).toBe('http://server/base/new/path?a');
   });
+
+  it('should not duplicate appBaseHref when Location triggers onUrlChange', inject(
+    [Location],
+    (location: Location) => {
+      location.go('/test');
+
+      expect($location.path()).toBe('/test');
+      expect($location.absUrl()).toBe('http://server/base/test');
+    },
+  ));
 });
 
 describe('New URL Parsing', () => {

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -514,6 +514,19 @@ describe('New URL Parsing with appBaseHref', () => {
       expect($location.absUrl()).toBe('http://server/base/test');
     },
   ));
+
+  it('should not throw error when Location triggers onUrlChange with /', inject(
+    [Location],
+    (location: Location) => {
+      location.go('/');
+      expect($location.path()).toBe('/');
+      expect($location.absUrl()).toBe('http://server/base/');
+
+      location.go('/?test=1');
+      expect($location.path()).toBe('/');
+      expect($location.search()).toEqual({test: '1'});
+    },
+  ));
 });
 
 describe('New URL Parsing', () => {


### PR DESCRIPTION
When  receives URL updates from Location.onUrlChange, it expects an internal path. However, Location emits the external path which includes the configured baseHref. Parsing this external path caused the baseHref parameter to be duplicated within locationShim.path.

This commit updates  to use Location.normalize() to strip the baseHref from the emitted URL before parsing it.

This is not a breaking change as the  Subject is private, and its subscriber expects an internal URL. Emitting the correct internal URL ensures public API functions and events like
carry accurate paths without duplication.

fixes #67153
