### PR TITLE
refactor(forms): restrict reactive logic to a readonly API

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -40,7 +40,7 @@ export class CompatValidationError<T = unknown> implements ValidationError {
     // (undocumented)
     readonly control: AbstractControl;
     // (undocumented)
-    readonly fieldTree: FieldTree<unknown>;
+    readonly fieldTree: ReadonlyFieldTree<unknown>;
     // (undocumented)
     readonly kind: string;
     // (undocumented)

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -180,6 +180,14 @@ export class FormField<T> {
     static ɵfac: i0.ɵɵFactoryDeclaration<FormField<any>, never>;
 }
 
+// @public
+export interface FormFieldBinding {
+    readonly element: HTMLElement;
+    focus(options?: FocusOptions): void;
+    readonly injector: Injector;
+    readonly state: Signal<ReadonlyFieldState<unknown>>;
+}
+
 // @public (undocumented)
 export interface FormFieldBindingOptions {
     readonly focus?: (focusOptions?: FocusOptions) => void;
@@ -480,7 +488,7 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
     readonly errorSummary: Signal<ValidationError.WithFieldTree[]>;
     readonly fieldTree: ReadonlyFieldTree<unknown, TKey>;
     focusBoundControl(options?: FocusOptions): void;
-    readonly formFieldBindings: Signal<readonly FormField<unknown>[]>;
+    readonly formFieldBindings: Signal<readonly FormFieldBinding[]>;
     hasMetadata(key: MetadataKey<any, any, any>): boolean;
     readonly hidden: Signal<boolean>;
     readonly invalid: Signal<boolean>;
@@ -580,7 +588,7 @@ export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
 // @public
 export interface SignalFormsConfig {
     classes?: {
-        [className: string]: (state: FormField<unknown>) => boolean;
+        [className: string]: (formField: FormFieldBinding) => boolean;
     };
 }
 

--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -7,8 +7,8 @@
  */
 
 import {type Provider} from '@angular/core';
+import type {FormFieldBinding} from '../api/types';
 import {SIGNAL_FORMS_CONFIG} from '../field/di';
-import type {FormField} from '../directive/form_field_directive';
 
 /**
  * Configuration options for signal forms.
@@ -17,7 +17,9 @@ import type {FormField} from '../directive/form_field_directive';
  */
 export interface SignalFormsConfig {
   /** A map of CSS class names to predicate functions that determine when to apply them. */
-  classes?: {[className: string]: (state: FormField<unknown>) => boolean};
+  classes?: {
+    [className: string]: (formField: FormFieldBinding) => boolean;
+  };
 }
 
 /**

--- a/packages/forms/signals/src/api/rules/validation/standard_schema.ts
+++ b/packages/forms/signals/src/api/rules/validation/standard_schema.ts
@@ -9,7 +9,7 @@
 import {resource, ɵisPromise} from '@angular/core';
 import type {StandardSchemaV1} from '@standard-schema/spec';
 import {addDefaultField} from '../../../field/validation';
-import type {FieldTree, LogicFn, SchemaPath, SchemaPathTree} from '../../types';
+import type {LogicFn, ReadonlyFieldTree, SchemaPath, SchemaPathTree} from '../../types';
 import {createMetadataKey, metadata} from '../metadata';
 import {validateAsync} from './validate_async';
 import {validateTree} from './validate_tree';
@@ -159,13 +159,13 @@ export function standardSchemaError(
  * @returns A `ValidationError` representing the issue.
  */
 function standardIssueToFormTreeError(
-  fieldTree: FieldTree<unknown>,
+  fieldTree: ReadonlyFieldTree<unknown>,
   issue: StandardSchemaV1.Issue,
 ): StandardSchemaValidationError {
-  let target = fieldTree as FieldTree<Record<PropertyKey, unknown>>;
+  let target = fieldTree as ReadonlyFieldTree<Record<PropertyKey, unknown>>;
   for (const pathPart of issue.path ?? []) {
     const pathKey = typeof pathPart === 'object' ? pathPart.key : pathPart;
-    target = target[pathKey] as FieldTree<Record<PropertyKey, unknown>>;
+    target = target[pathKey] as ReadonlyFieldTree<Record<PropertyKey, unknown>>;
   }
   return addDefaultField(standardSchemaError(issue, {message: issue.message}), target);
 }

--- a/packages/forms/signals/src/api/rules/validation/validation_errors.ts
+++ b/packages/forms/signals/src/api/rules/validation/validation_errors.ts
@@ -7,7 +7,7 @@
  */
 
 import type {FormField} from '../../../directive/form_field_directive';
-import type {FieldTree} from '../../types';
+import type {ReadonlyFieldTree} from '../../types';
 import type {StandardSchemaValidationError} from './standard_schema';
 
 /**
@@ -24,7 +24,7 @@ export interface ValidationErrorOptions {
  *
  * @experimental 21.0.0
  */
-export type WithFieldTree<T> = T & {fieldTree: FieldTree<unknown>};
+export type WithFieldTree<T> = T & {fieldTree: ReadonlyFieldTree<unknown>};
 /** @deprecated Use `WithFieldTree` instead  */
 export type WithField<T> = WithFieldTree<T>;
 
@@ -34,7 +34,9 @@ export type WithField<T> = WithFieldTree<T>;
  *
  * @experimental 21.0.0
  */
-export type WithOptionalFieldTree<T> = Omit<T, 'fieldTree'> & {fieldTree?: FieldTree<unknown>};
+export type WithOptionalFieldTree<T> = Omit<T, 'fieldTree'> & {
+  fieldTree?: ReadonlyFieldTree<unknown>;
+};
 /** @deprecated Use `WithOptionalFieldTree` instead  */
 export type WithOptionalField<T> = WithOptionalFieldTree<T>;
 
@@ -281,7 +283,7 @@ export declare namespace ValidationError {
    */
   export interface WithFieldTree extends ValidationError {
     /** The field associated with this error. */
-    readonly fieldTree: FieldTree<unknown>;
+    readonly fieldTree: ReadonlyFieldTree<unknown>;
     readonly formField?: FormField<unknown>;
   }
   /** @deprecated Use `ValidationError.WithFieldTree` instead  */
@@ -302,7 +304,7 @@ export declare namespace ValidationError {
    */
   export interface WithOptionalFieldTree extends ValidationError {
     /** The field associated with this error. */
-    readonly fieldTree?: FieldTree<unknown>;
+    readonly fieldTree?: ReadonlyFieldTree<unknown>;
   }
   /** @deprecated Use `ValidationError.WithOptionalFieldTree` instead  */
   export type WithOptionalField = WithOptionalFieldTree;
@@ -335,7 +337,7 @@ export abstract class BaseNgValidationError implements ValidationError {
   readonly kind: string = '';
 
   /** The field associated with this error. */
-  readonly fieldTree!: FieldTree<unknown>;
+  readonly fieldTree!: ReadonlyFieldTree<unknown>;
 
   /** Human readable error message. */
   readonly message?: string;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, WritableSignal} from '@angular/core';
+import {Injector, Signal, WritableSignal} from '@angular/core';
 import {AbstractControl} from '@angular/forms';
 import type {FormField} from '../directive/form_field_directive';
 import type {MetadataKey, ValidationError} from './rules';
@@ -451,7 +451,7 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
   /**
    * The {@link FormField} directives that bind this field to a UI control.
    */
-  readonly formFieldBindings: Signal<readonly FormField<unknown>[]>;
+  readonly formFieldBindings: Signal<readonly FormFieldBinding[]>;
 
   /**
    * Reads a metadata value from the field.
@@ -572,6 +572,36 @@ export type FieldStateByMode<
   TKey extends string | number,
   TMode extends 'writable' | 'readonly',
 > = TMode extends 'writable' ? FieldState<TValue, TKey> : ReadonlyFieldState<TValue, TKey>;
+
+/**
+ * Represents a binding between a field and a UI control through a {@link FormField} directive.
+ *
+ * @experimental 21.3.0
+ */
+export interface FormFieldBinding {
+  /**
+   * The HTML element on which the {@link FormField} directive is applied.
+   */
+  readonly element: HTMLElement;
+
+  /**
+   * The node injector for the element hosting this field binding.
+   */
+  readonly injector: Injector;
+
+  /**
+   * The {@link FieldState} of the field bound to the {@link FormField} directive.
+   */
+  readonly state: Signal<ReadonlyFieldState<unknown>>;
+
+  /**
+   * Focuses this field binding.
+   *
+   * By default, this will focus {@link element}. However, custom controls can implement their own
+   * focus behavior.
+   */
+  focus(options?: FocusOptions): void;
+}
 
 /**
  * Allows declaring whether the Rules are supported for a given path.

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -107,7 +107,7 @@ export declare namespace PathKind {
  */
 export interface DisabledReason {
   /** The field that is disabled. */
-  readonly fieldTree: FieldTree<unknown>;
+  readonly fieldTree: ReadonlyFieldTree<unknown>;
   /** A user-facing message describing the reason for the disablement. */
   readonly message?: string;
 }
@@ -188,17 +188,23 @@ export type Field<TValue, TKey extends string | number = string | number> = () =
 /**
  * An object that represents a tree of fields in a form. This includes both primitive value fields
  * (e.g. fields that contain a `string` or `number`), as well as "grouping fields" that contain
- * sub-fields. `FieldTree` objects are arranged in a tree whose structure mimics the structure of the
- * underlying data. For example a `FieldTree<{x: number}>` has a property `x` which contains a
+ * sub-fields. `FieldTree` objects are arranged in a tree whose structure mimics the structure of
+ * the underlying data. For example a `FieldTree<{x: number}>` has a property `x` which contains a
  * `FieldTree<number>`. To access the state associated with a field, call it as a function.
  *
  * @template TValue The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
+ * @template TMode Determines whether the field state is readonly or writable. Defaults to writable.
+ *   For readonly, use {@link ReadonlyFieldTree}.
  *
  * @category types
  * @experimental 21.0.0
  */
-export type FieldTree<TModel, TKey extends string | number = string | number> =
+export type FieldTree<
+  TModel,
+  TKey extends string | number = string | number,
+  TMode extends 'writable' | 'readonly' = 'writable',
+> =
   // Note: We use `[TModel]` in several places below to avoid the condition from being distributed
   // over a recursive union type, which seems to result in infinite type recursion. By adding the
   // tuple we're not testing a naked type parameter, and thus the condition is not distributed.
@@ -210,31 +216,45 @@ export type FieldTree<TModel, TKey extends string | number = string | number> =
   // type Test = FieldTree<RecursiveType> // Infinite type recursion if condition distributes.
   // ```
   (() => [TModel] extends [AbstractControl]
-    ? CompatFieldState<TModel, TKey>
-    : FieldState<TModel, TKey>) &
+    ? CompatFieldState<TModel, TKey, TMode>
+    : FieldStateByMode<TModel, TKey, TMode>) &
     // Children:
     ([TModel] extends [AbstractControl]
       ? object
       : [TModel] extends [ReadonlyArray<infer U>]
-        ? ReadonlyArrayLike<MaybeFieldTree<U, number>>
+        ? ReadonlyArrayLike<MaybeFieldTree<U, number, TMode>>
         : TModel extends Record<string, any>
-          ? Subfields<TModel>
+          ? Subfields<TModel, TMode>
           : object);
+
+/**
+ * A readonly {@link FieldTree}.
+ *
+ * @category types
+ * @experimental 21.3.0
+ */
+export type ReadonlyFieldTree<TModel, TKey extends string | number = string | number> = FieldTree<
+  TModel,
+  TKey,
+  'readonly'
+>;
 
 /**
  * The sub-fields that a user can navigate to from a `FieldTree<TModel>`.
  *
  * @template TModel The type of the data which the parent field is wrapped around.
+ * @template TMode Determines whether the field state is readonly or writable.
  *
  * @experimental 21.0.0
  */
-export type Subfields<TModel> = {
+export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'> = {
   readonly [K in keyof TModel as TModel[K] extends Function ? never : K]: MaybeFieldTree<
     TModel[K],
-    string
+    string,
+    TMode
   >;
 } & {
-  [Symbol.iterator](): Iterator<[string, MaybeFieldTree<TModel[keyof TModel], string>]>;
+  [Symbol.iterator](): Iterator<[string, MaybeFieldTree<TModel[keyof TModel], string, TMode>]>;
 };
 
 /**
@@ -250,33 +270,38 @@ export type ReadonlyArrayLike<T> = Pick<
 >;
 
 /**
- * Helper type for defining `FieldTree`. Given a type `TValue` that may include `undefined`, it extracts
- * the `undefined` outside the `FieldTree` type.
+ * Helper type for defining `FieldTree`. Given a type `TValue` that may include `undefined`,
+ * it extracts the `undefined` outside the `FieldTree` type.
  *
- * For example `MaybeField<{a: number} | undefined, TKey>` would be equivalent to
+ * For example `MaybeFieldTree<{a: number} | undefined, TKey>` would be equivalent to
  * `undefined | FieldTree<{a: number}, TKey>`.
  *
  * @template TModel The type of the data which the field is wrapped around.
  * @template TKey The type of the property key which this field resides under in its parent.
+ * @template TMode Determines whether the field state is readonly or writable.
  *
- * @experimental 21.0.0
+ * @experimental 21.3.0
  */
-export type MaybeFieldTree<TModel, TKey extends string | number = string | number> =
-  | (TModel & undefined)
-  | FieldTree<Exclude<TModel, undefined>, TKey>;
+export type MaybeFieldTree<
+  TModel,
+  TKey extends string | number = string | number,
+  TMode extends 'writable' | 'readonly' = 'writable',
+> = (TModel & undefined) | FieldTree<Exclude<TModel, undefined>, TKey, TMode>;
 
 /**
- * Contains all of the state (e.g. value, statuses, etc.) associated with a `FieldTree`, exposed as
- * signals.
+ * A readonly view of a {@link FieldTree}'s state.
+ *
+ * @template TValue The type of the data which the field is wrapped around.
+ * @template TKey The type of the property key which this field resides under in its parent.
  *
  * @category structure
- * @experimental 21.0.0
+ * @experimental 21.3.0
  */
-export interface FieldState<TValue, TKey extends string | number = string | number> {
+export interface ReadonlyFieldState<TValue, TKey extends string | number = string | number> {
   /**
    * The {@link FieldTree} associated with this field state.
    */
-  readonly fieldTree: FieldTree<unknown, TKey>;
+  readonly fieldTree: ReadonlyFieldTree<unknown, TKey>;
 
   /**
    * A writable signal containing the value for this field.
@@ -286,7 +311,16 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * While updates from the UI control are eventually reflected here, they may be delayed if
    * debounced.
    */
-  readonly value: WritableSignal<TValue>;
+  readonly value: Signal<TValue>;
+
+  /**
+   * A signal containing the value of the control to which this field is bound.
+   *
+   * This differs from {@link value} in that it's not subject to debouncing, and thus is used to
+   * buffer debounced updates from the control to the field. This will also not take into account
+   * the {@link controlValue} of children.
+   */
+  readonly controlValue: Signal<TValue>;
 
   /**
    * A signal indicating whether the field is currently disabled.
@@ -384,6 +418,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * However `invalid()` is also `false` because there are no errors.
    */
   readonly valid: Signal<boolean>;
+
   /**
    * A signal indicating whether the field's value is currently invalid.
    *
@@ -396,10 +431,12 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * However `valid()` is also `false` because of the pending validator.
    */
   readonly invalid: Signal<boolean>;
+
   /**
    * Whether there are any validators still pending for this field.
    */
   readonly pending: Signal<boolean>;
+
   /**
    * A signal indicating whether the field is currently in the process of being submitted.
    */
@@ -410,10 +447,59 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * array-valued, for example, this is the index of this field in that array.
    */
   readonly keyInParent: Signal<TKey>;
+
   /**
    * The {@link FormField} directives that bind this field to a UI control.
    */
   readonly formFieldBindings: Signal<readonly FormField<unknown>[]>;
+
+  /**
+   * Reads a metadata value from the field.
+   * @param key The metadata key to read.
+   */
+  metadata<M>(key: MetadataKey<M, any, any>): M | undefined;
+
+  /**
+   * Checks whether a metadata value exists on the field.
+   * @param key The metadata key to check.
+   */
+  hasMetadata(key: MetadataKey<any, any, any>): boolean;
+
+  /**
+   * Focuses the first UI control in the DOM that is bound to this field state.
+   * If no UI control is bound, does nothing.
+   * @param options Optional focus options to pass to the native focus() method.
+   */
+  focusBoundControl(options?: FocusOptions): void;
+}
+
+/**
+ * A writable view of a {@link FieldTree}'s state.
+ *
+ * @template TValue The type of the data which the field is wrapped around.
+ * @template TKey The type of the property key which this field resides under in its parent.
+ *
+ * @category structure
+ * @experimental 21.0.0
+ */
+export interface FieldState<
+  TValue,
+  TKey extends string | number = string | number,
+> extends ReadonlyFieldState<TValue, TKey> {
+  /**
+   * The {@link FieldTree} associated with this field state.
+   */
+  readonly fieldTree: FieldTree<unknown, TKey>;
+
+  /**
+   * A writable signal containing the value for this field.
+   *
+   * Updating this signal will update the data model that the field is bound to.
+   *
+   * While updates from the UI control are eventually reflected here, they may be delayed if
+   * debounced.
+   */
+  readonly value: WritableSignal<TValue>;
 
   /**
    * A signal containing the value of the control to which this field is bound.
@@ -435,12 +521,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
   markAsTouched(): void;
 
   /**
-   * Reads a metadata value from the field.
-   * @param key The metadata key to read.
-   */
-  metadata<M>(key: MetadataKey<M, any, any>): M | undefined;
-
-  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.
@@ -448,13 +528,6 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
    * @param value Optional value to set to the form. If not passed, the value will not be changed.
    */
   reset(value?: TValue): void;
-
-  /**
-   * Focuses the first UI control in the DOM that is bound to this field state.
-   * If no UI control is bound, does nothing.
-   * @param options Optional focus options to pass to the native focus() method.
-   */
-  focusBoundControl(options?: FocusOptions): void;
 }
 
 /**
@@ -466,9 +539,39 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 export type CompatFieldState<
   TControl extends AbstractControl,
   TKey extends string | number = string | number,
-> = FieldState<TControl extends AbstractControl<unknown, infer TValue> ? TValue : never, TKey> & {
+  TMode extends 'writable' | 'readonly' = 'writable',
+> = FieldStateByMode<
+  TControl extends AbstractControl<unknown, infer TValue> ? TValue : never,
+  TKey,
+  TMode
+> & {
   control: Signal<TControl>;
 };
+
+/**
+ * A readonly {@link CompatFieldState}.
+ *
+ * @category interop
+ * @experimental 21.3.0
+ */
+export type ReadonlyCompatFieldState<
+  TControl extends AbstractControl,
+  TKey extends string | number = string | number,
+> = CompatFieldState<TControl, TKey, 'readonly'>;
+
+/**
+ * Helper type that resolves to either a {@link FieldState} or {@link ReadonlyFieldState} based on
+ * the access mode.
+ *
+ * @template TValue The type of the value stored in the field.
+ * @template TKey The type of the property key.
+ * @template TMode The access mode ('readonly' or 'writable').
+ */
+export type FieldStateByMode<
+  TValue,
+  TKey extends string | number,
+  TMode extends 'writable' | 'readonly',
+> = TMode extends 'writable' ? FieldState<TValue, TKey> : ReadonlyFieldState<TValue, TKey>;
 
 /**
  * Allows declaring whether the Rules are supported for a given path.
@@ -748,9 +851,9 @@ export interface RootFieldContext<TValue> {
   /** A signal containing the value of the current field. */
   readonly value: Signal<TValue>;
   /** The state of the current field. */
-  readonly state: FieldState<TValue>;
+  readonly state: ReadonlyFieldState<TValue>;
   /** The current field. */
-  readonly fieldTree: FieldTree<TValue>;
+  readonly fieldTree: ReadonlyFieldTree<TValue>;
 
   /** Gets the value of the field represented by the given path. */
   valueOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): PValue;
@@ -758,10 +861,10 @@ export interface RootFieldContext<TValue> {
   /** Gets the state of the field represented by the given path. */
   stateOf<PControl extends AbstractControl>(
     p: CompatSchemaPath<PControl>,
-  ): CompatFieldState<PControl>;
-  stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): FieldState<PValue>;
+  ): ReadonlyCompatFieldState<PControl>;
+  stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): ReadonlyFieldState<PValue>;
   /** Gets the field represented by the given path. */
-  fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): FieldTree<PModel>;
+  fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): ReadonlyFieldTree<PModel>;
   /** The list of keys that lead from the root field to the current field. */
   readonly pathKeys: Signal<readonly string[]>;
 }

--- a/packages/forms/signals/src/compat/validation_errors.ts
+++ b/packages/forms/signals/src/compat/validation_errors.ts
@@ -8,7 +8,7 @@
 
 import {AbstractControl, FormArray, FormGroup, ValidationErrors} from '@angular/forms';
 import {ValidationError} from '../api/rules';
-import {FieldTree} from '../api/types';
+import {ReadonlyFieldTree} from '../api/types';
 
 /**
  * An error used for compat errors.
@@ -19,7 +19,7 @@ import {FieldTree} from '../api/types';
 export class CompatValidationError<T = unknown> implements ValidationError {
   readonly kind: string = 'compat';
   readonly control: AbstractControl;
-  readonly fieldTree!: FieldTree<unknown>;
+  readonly fieldTree!: ReadonlyFieldTree<unknown>;
   readonly context: T;
   readonly message?: string;
 

--- a/packages/forms/signals/src/controls/interop_ng_control.ts
+++ b/packages/forms/signals/src/controls/interop_ng_control.ts
@@ -18,7 +18,7 @@ import {
   type ValidationErrors,
   type ValidatorFn,
 } from '@angular/forms';
-import type {FieldState} from '../api/types';
+import type {ReadonlyFieldState} from '../api/types';
 
 // TODO: Also consider supporting (if possible):
 // - hasError
@@ -61,7 +61,7 @@ interface CombinedControl {
  * equivalent in signal forms.
  */
 export class InteropNgControl implements CombinedControl {
-  constructor(protected field: () => FieldState<unknown>) {}
+  constructor(protected field: () => ReadonlyFieldState<unknown>) {}
 
   readonly control: AbstractControl<any, any> = this as unknown as AbstractControl<any, any>;
 

--- a/packages/forms/signals/src/directive/bindings.ts
+++ b/packages/forms/signals/src/directive/bindings.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {FieldState} from '../api/types';
+import type {ReadonlyFieldState} from '../api/types';
 
 /**
  * Branded type for the public name of an input we bind on control components or DOM elements.
@@ -39,7 +39,7 @@ const FIELD_STATE_KEY_TO_CONTROL_BINDING = {
   readonly: 'readonly' as ControlBindingKey,
   required: 'required' as ControlBindingKey,
   touched: 'touched' as ControlBindingKey,
-} as const satisfies {[K in keyof FieldState<unknown>]?: ControlBindingKey};
+} as const satisfies {[K in keyof ReadonlyFieldState<unknown>]?: ControlBindingKey};
 
 /**
  * Inverts `FIELD_STATE_KEY_TO_CONTROL_BINDING` to look up the minified name of the corresponding
@@ -56,7 +56,7 @@ const CONTROL_BINDING_TO_FIELD_STATE_KEY = /* @__PURE__ */ (() => {
 })();
 
 export function readFieldStateBindingValue(
-  fieldState: FieldState<unknown>,
+  fieldState: ReadonlyFieldState<unknown>,
   key: ControlBindingKey,
 ): unknown {
   const property = CONTROL_BINDING_TO_FIELD_STATE_KEY[key];

--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -27,7 +27,7 @@ import {
 } from '@angular/core';
 import {type ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
 import {type ValidationError} from '../api/rules';
-import type {Field} from '../api/types';
+import type {Field, FieldState} from '../api/types';
 import {InteropNgControl} from '../controls/interop_ng_control';
 import {RuntimeErrorCode} from '../errors';
 import {SIGNAL_FORMS_CONFIG} from '../field/di';
@@ -98,18 +98,21 @@ export const FORM_FIELD = new InjectionToken<FormField<unknown>>(
   ],
 })
 export class FormField<T> {
+  /**
+   * The field to bind to the underlying form control.
+   */
   readonly field = input.required<Field<T>>({alias: 'formField'});
+
+  /**
+   * `FieldState` for the currently bound field.
+   */
+  readonly state = computed<FieldState<T>>(() => this.field()());
 
   /** @internal */
   readonly renderer = inject(Renderer2);
 
   /** @internal */
   readonly destroyRef = inject(DestroyRef);
-
-  /**
-   * `FieldState` for the currently bound field.
-   */
-  readonly state = computed(() => this.field()());
 
   /**
    * The node injector for the element this field binding.

--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -115,7 +115,7 @@ export class FormField<T> {
   readonly destroyRef = inject(DestroyRef);
 
   /**
-   * The node injector for the element this field binding.
+   * The node injector for the DOM element hosting this field binding.
    */
   readonly injector = inject(Injector);
 
@@ -196,8 +196,7 @@ export class FormField<T> {
    */
   private installClassBindingEffect(): void {
     const classes = Object.entries(this.config?.classes ?? {}).map(
-      ([className, computation]) =>
-        [className, computed(() => computation(this as FormField<unknown>))] as const,
+      ([className, computation]) => [className, computed(() => computation(this))] as const,
     );
     if (classes.length === 0) {
       return;

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -17,8 +17,8 @@ import {RuntimeErrorCode} from '../errors';
 import {AbstractControl} from '@angular/forms';
 import {
   FieldContext,
-  FieldState,
-  FieldTree,
+  ReadonlyFieldState,
+  ReadonlyFieldTree,
   SchemaPath,
   SchemaPathRules,
   SchemaPathTree,
@@ -42,7 +42,7 @@ export class FieldNodeContext implements FieldContext<unknown> {
    */
   private readonly cache = new WeakMap<
     SchemaPath<unknown, SchemaPathRules>,
-    Signal<FieldTree<unknown>>
+    Signal<ReadonlyFieldTree<unknown>>
   >();
 
   constructor(
@@ -55,9 +55,9 @@ export class FieldNodeContext implements FieldContext<unknown> {
    * @param target The path to resolve
    * @returns The field corresponding to the target path.
    */
-  private resolve<U>(target: SchemaPath<U, SchemaPathRules>): FieldTree<U> {
+  private resolve<U>(target: SchemaPath<U, SchemaPathRules>): ReadonlyFieldTree<U> {
     if (!this.cache.has(target)) {
-      const resolver = computed<FieldTree<unknown>>(() => {
+      const resolver = computed<ReadonlyFieldTree<unknown>>(() => {
         const targetPathNode = FieldPathNode.unwrapFieldPath(target);
 
         // First, find the field where the root our target path was merged in.
@@ -100,14 +100,14 @@ export class FieldNodeContext implements FieldContext<unknown> {
 
       this.cache.set(target, resolver);
     }
-    return this.cache.get(target)!() as FieldTree<U>;
+    return this.cache.get(target)!() as ReadonlyFieldTree<U>;
   }
 
-  get fieldTree(): FieldTree<unknown> {
+  get fieldTree(): ReadonlyFieldTree<unknown> {
     return this.node.fieldProxy;
   }
 
-  get state(): FieldState<unknown> {
+  get state(): ReadonlyFieldState<unknown> {
     return this.node;
   }
 

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -8,7 +8,7 @@
 
 import {computed, Signal, untracked, ɵWritable} from '@angular/core';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
-import type {FieldTree, TreeValidationResult, ValidationResult} from '../api/types';
+import type {ReadonlyFieldTree, TreeValidationResult, ValidationResult} from '../api/types';
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
 import {shortCircuitFalse} from './util';
@@ -368,16 +368,16 @@ function normalizeErrors<T extends ValidationResult>(error: T | readonly T[]): r
  */
 export function addDefaultField<E extends ValidationError.WithOptionalFieldTree>(
   error: E,
-  fieldTree: FieldTree<unknown>,
-): E & {fieldTree: FieldTree<unknown>};
+  fieldTree: ReadonlyFieldTree<unknown>,
+): E & {fieldTree: ReadonlyFieldTree<unknown>};
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  fieldTree: FieldTree<unknown>,
-): ValidationResult<E & {fieldTree: FieldTree<unknown>}>;
+  fieldTree: ReadonlyFieldTree<unknown>,
+): ValidationResult<E & {fieldTree: ReadonlyFieldTree<unknown>}>;
 export function addDefaultField<E extends ValidationError>(
   errors: TreeValidationResult<E>,
-  fieldTree: FieldTree<unknown>,
-): ValidationResult<E & {fieldTree: FieldTree<unknown>}> {
+  fieldTree: ReadonlyFieldTree<unknown>,
+): ValidationResult<E & {fieldTree: ReadonlyFieldTree<unknown>}> {
   if (isArray(errors)) {
     for (const error of errors) {
       (error as ɵWritable<ValidationError.WithOptionalFieldTree>).fieldTree ??= fieldTree;
@@ -385,7 +385,7 @@ export function addDefaultField<E extends ValidationError>(
   } else if (errors) {
     (errors as ɵWritable<ValidationError.WithOptionalFieldTree>).fieldTree ??= fieldTree;
   }
-  return errors as ValidationResult<E & {fieldTree: FieldTree<unknown>}>;
+  return errors as ValidationResult<E & {fieldTree: ReadonlyFieldTree<unknown>}>;
 }
 
 function getFirstBoundElement(error: ValidationError.WithFieldTree) {

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {signal, WritableSignal} from '@angular/core';
-import {FieldTree, form, required, schema, SchemaFn} from '../../public_api';
+import {FieldTree, form, ReadonlyFieldState, required, schema, SchemaFn} from '../../public_api';
 
 interface Order {
   id: string;
@@ -111,6 +111,13 @@ function typeVerificationOnlyDoNotRunMe() {
         const p: FieldTree<string> = product;
         p().value();
       }
+    });
+
+    it('should allow assigning FieldState to ReadonlyFieldState', () => {
+      const pizzaOrder: WritableSignal<PizzaOrder> = null!;
+      const f = form(pizzaOrder);
+      const readonlyState: ReadonlyFieldState<PizzaOrder> = f();
+      readonlyState.value();
     });
   });
 }

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -7,7 +7,16 @@
  */
 
 import {signal, WritableSignal} from '@angular/core';
-import {FieldTree, form, ReadonlyFieldState, required, schema, SchemaFn} from '../../public_api';
+import {
+  FieldTree,
+  form,
+  provideSignalFormsConfig,
+  ReadonlyFieldState,
+  required,
+  schema,
+  SchemaFn,
+  validate,
+} from '../../public_api';
 
 interface Order {
   id: string;
@@ -118,6 +127,32 @@ function typeVerificationOnlyDoNotRunMe() {
       const f = form(pizzaOrder);
       const readonlyState: ReadonlyFieldState<PizzaOrder> = f();
       readonlyState.value();
+    });
+
+    it('should prevent writing to field value through context in a validation rule', () => {
+      schema<PizzaOrder>((p) => {
+        validate(p.id, (ctx) => {
+          // @ts-expect-error
+          ctx.value.set('new value');
+          // @ts-expect-error
+          ctx.state.value.set('new value');
+          // @ts-expect-error
+          ctx.stateOf(p.details).value.set({total: 0});
+          return null;
+        });
+      });
+    });
+
+    it('should prevent writing to field value through context in a signal provider', () => {
+      provideSignalFormsConfig({
+        classes: {
+          'my-class': (binding) => {
+            // @ts-expect-error
+            binding.state().value.set('new value');
+            return true;
+          },
+        },
+      });
     });
   });
 }

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -9,10 +9,10 @@
 import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
-  FieldTree,
   form,
   NgValidationError,
   patternError,
+  ReadonlyFieldTree,
   requiredError,
   validate,
   validateAsync,
@@ -26,7 +26,7 @@ function validateValue(value: string): ValidationError[] {
 
 function validateValueForChild(
   value: string,
-  fieldTree: FieldTree<unknown> | undefined,
+  fieldTree: ReadonlyFieldTree<unknown> | undefined,
 ): ValidationError.WithOptionalFieldTree[] {
   return value === 'INVALID' ? [{kind: 'custom', fieldTree: fieldTree}] : [];
 }


### PR DESCRIPTION
Reactive logic in forms is not intended to mutate state, but this was poorly communicated by the permissive and highly mutable field context provided to all logic functions. This change splits all of the state-related API into writable and readonly interfaces.

* Top-level functions that produce a `FieldTree` (e.g. `form()`) expose writable signals (e.g. `value: WritableSignal<T>`) and mutating methods (e.g. `markAsDirty()`).

* Reactive logic expose readonly signals (e.g. `value: Signal<T>`) and omit mutating methods.

Fix https://github.com/angular/angular/issues/65779.