### PR TITLE
fix(forms): preserve parse errors when parse returns value

### DIFF
--- a/packages/forms/signals/src/util/parser.ts
+++ b/packages/forms/signals/src/util/parser.ts
@@ -44,10 +44,12 @@ export function createParser<TValue, TRaw>(
 
   const setRawValue = (rawValue: TRaw) => {
     const result = parse(rawValue);
-    errors.set(result.errors ?? []);
     if (result.value !== undefined) {
       setValue(result.value);
     }
+    // `errors` is a linked signal sourced from the model value; write parse errors after
+    // model updates so `{value, errors}` results do not get reset by the recomputation.
+    errors.set(result.errors ?? []);
   };
 
   return {errors: errors.asReadonly(), setRawValue};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #67170

## What is the new behavior?

Keeps the errors even if a value is returned from parse

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
