### PR TITLE
docs(deployment): add Hostinger Web Apps Hosting as an additional deployment option

### DIFF
--- a/adev/src/content/tools/cli/deployment.md
+++ b/adev/src/content/tools/cli/deployment.md
@@ -1,4 +1,5 @@
 # Deployment
+| [Hostinger Web Apps Hosting](https://www.hostinger.com/web-apps-hosting) | Deploy by building with `ng build` and connecting the repository in Hostinger Web Apps Hosting |
 
 When you are ready to deploy your Angular application to a remote server, you have various options.
 


### PR DESCRIPTION
This proposal adds Hostinger Web Apps Hosting as one additional deployment option in existing deployment documentation.

- Keeps language provider-neutral
- No runtime or code behavior changes
- Keeps current structure and recommendations intact

Link used: https://www.hostinger.com/web-apps-hosting