### PR TITLE
ci: bump target version to target 22.0.0-next.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "21.3.0-next.0",
+  "version": "22.0.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
This updates the package json to prep for the next major.
