### PR TITLE
refactor(forms): clean up

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -180,7 +180,7 @@ export function form<TModel>(model: WritableSignal<TModel>, schema: SchemaOrSche
 export const FORM_FIELD: InjectionToken<FormField<unknown>>;
 
 // @public
-export interface FormCheckboxControl extends FormUiControl<boolean> {
+export interface FormCheckboxControl extends FormUiControl {
     readonly checked: ModelSignal<boolean>;
     readonly value?: undefined;
 }
@@ -241,7 +241,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
 }
 
 // @public
-export interface FormUiControl<TValue> {
+export interface FormUiControl {
     readonly dirty?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
     readonly disabled?: InputSignal<boolean> | InputSignalWithTransform<boolean, unknown>;
     readonly disabledReasons?: InputSignal<readonly WithOptionalFieldTree<DisabledReason>[]> | InputSignalWithTransform<readonly WithOptionalFieldTree<DisabledReason>[], unknown>;
@@ -262,7 +262,7 @@ export interface FormUiControl<TValue> {
 }
 
 // @public
-export interface FormValueControl<TValue> extends FormUiControl<TValue> {
+export interface FormValueControl<TValue> extends FormUiControl {
     readonly checked?: undefined;
     readonly value: ModelSignal<TValue>;
 }

--- a/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
+++ b/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
@@ -108,7 +108,7 @@ export class SignalFormControl<T> extends AbstractControl {
     this.fieldTree = wrapFieldTreeForSyncUpdates(rawTree, () =>
       this.parent?.updateValueAndValidity({sourceControl: this} as any),
     );
-    this.fieldState = this.fieldTree() as FieldState<T>;
+    this.fieldState = this.fieldTree();
 
     this.defineCompatProperties();
 

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -17,7 +17,7 @@ import type {DisabledReason} from './types';
  * @category control
  * @experimental 21.0.0
  */
-export interface FormUiControl<TValue> {
+export interface FormUiControl {
   /**
    * An input to receive the errors for the field. If implemented, the `Field` directive will
    * automatically bind errors from the bound field to this input.
@@ -131,7 +131,7 @@ export interface FormUiControl<TValue> {
 // However, we don't want to add it as an actual `extends` clause to avoid confusing users.
 type Check<T extends true> = T;
 type FormUiControlImplementsFormFieldBindingOptions = Check<
-  FormUiControl<unknown> extends FormFieldBindingOptions ? true : false
+  FormUiControl extends FormFieldBindingOptions ? true : false
 >;
 
 /**
@@ -147,7 +147,7 @@ type FormUiControlImplementsFormFieldBindingOptions = Check<
  * @category control
  * @experimental 21.0.0
  */
-export interface FormValueControl<TValue> extends FormUiControl<TValue> {
+export interface FormValueControl<TValue> extends FormUiControl {
   /**
    * The value is the only required property in this contract. A component that wants to integrate
    * with the `Field` directive via this contract, *must* provide a `model()` that will be kept in
@@ -177,7 +177,7 @@ export interface FormValueControl<TValue> extends FormUiControl<TValue> {
  * @experimental 21.0.0
  */
 // TODO: should we make this generic extends `boolean | null` so people can use `null` for parse error?
-export interface FormCheckboxControl extends FormUiControl<boolean> {
+export interface FormCheckboxControl extends FormUiControl {
   /**
    * The checked is the only required property in this contract. A component that wants to integrate
    * with the `Field` directive, *must* provide a `model()` that will be kept in sync with the

--- a/packages/forms/signals/src/directive/control_custom.ts
+++ b/packages/forms/signals/src/directive/control_custom.ts
@@ -25,7 +25,7 @@ export function customControlCreate(
   host.listenToCustomControlModel((value) => parent.state().controlValue.set(value));
   host.listenToCustomControlOutput('touchedChange', () => parent.state().markAsTouched());
 
-  parent.registerAsBinding(host.customControl as FormUiControl<unknown>);
+  parent.registerAsBinding(host.customControl as FormUiControl);
 
   const bindings = createBindings<ControlBindingKey | 'controlValue'>();
   return () => {

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -6,20 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Component,
-  Input,
-  Injector,
-  input,
-  signal,
-  ApplicationRef,
-  effect,
-  untracked,
-  computed,
-} from '@angular/core';
+import {Injector, signal, ApplicationRef, effect, untracked} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {form, FieldTree} from '../../public_api';
-import {ChangeDetectionStrategy} from '@angular/compiler';
+import {form} from '../../public_api';
 
 describe('FieldTree proxy', () => {
   it('should not forward methods through the proxy', () => {


### PR DESCRIPTION
* Remove unused `TValue` type parameter from `FormUiControl`
* Remove unused imports
* Remove unnecessary cast