### PR TITLE
fix(core): block creation of sensitive URI attributes from ICU messages

### DIFF
--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -3434,7 +3434,7 @@ describe('runtime i18n', () => {
           {parameters.length, plural,
             =1 {
               Affects parameter
-              <span class="parameter-name" attr="should_be_present">{{ parameters[0].name }}</span>
+              <span class="parameter-name" label="should_be_present">{{ parameters[0].name }}</span>
             }
             other {
               Affects {{parameters.length}} parameters, including
@@ -3453,7 +3453,7 @@ describe('runtime i18n', () => {
     const fixture = TestBed.createComponent(MyApp);
     fixture.detectChanges();
     const span = (fixture.nativeElement as HTMLElement).querySelector('span')!;
-    expect(span.getAttribute('attr')).toEqual('should_be_present');
+    expect(span.getAttribute('label')).toEqual('should_be_present');
     expect(span.getAttribute('class')).toEqual('parameter-name');
   });
 


### PR DESCRIPTION
Translators are not allowed to write HTML which creates URI attributes. I opted to ban any values going into an attribute at all, to prevent even links to malicious content, rather than just sanitizing URIs.

I also converted this blocklist into an allowlist. Now, we only allowing setting known attributes (while sanitizing URI attributes). This significantly reduces risk of missing a vulnerable attribute and does not require an exhaustive list of all potential attributes.

BREAKING CHANGE: Angular now only applies known attributes from HTML in translated ICU content. Unknown attributes are dropped and not rendered.

See: [b/483947315](http://b/483947315)

/cc @AndrewKushnir @securityMB @aaronshim