### PR TITLE
refactor(common): log a warning when a KeyValuePipe receives a signal

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -20,7 +20,7 @@ import {
 } from '@angular/core';
 import type {Observable, Subscribable, Unsubscribable} from 'rxjs';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 interface SubscriptionStrategy {
   createSubscription(

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -8,7 +8,7 @@
 
 import {Pipe, PipeTransform, Type} from '@angular/core';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 /**
  * Transforms text to all lower case.

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -11,7 +11,7 @@ import {Inject, InjectionToken, LOCALE_ID, Optional, Pipe, PipeTransform} from '
 import {formatDate} from '../i18n/format_date';
 
 import {DatePipeConfig, DEFAULT_DATE_FORMAT} from './date_pipe_config';
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 /**
  * Optionally-provided default timezone to use for all instances of `DatePipe` (such as `'+0430'`).

--- a/packages/common/src/pipes/i18n_plural_pipe.ts
+++ b/packages/common/src/pipes/i18n_plural_pipe.ts
@@ -10,7 +10,7 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 import {getPluralCategory, NgLocalization} from '../i18n/localization';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 const _INTERPOLATION_REGEXP: RegExp = /#/g;
 

--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -8,7 +8,7 @@
 
 import {Pipe, PipeTransform} from '@angular/core';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 /**
  * @ngModule CommonModule

--- a/packages/common/src/pipes/json_pipe.ts
+++ b/packages/common/src/pipes/json_pipe.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {isSignal, Pipe, PipeTransform} from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
+import {warnIfSignal} from './utils';
 
 /**
  * @ngModule CommonModule
@@ -34,9 +35,7 @@ export class JsonPipe implements PipeTransform {
    * @param value A value of any type to convert into a JSON-format string.
    */
   transform(value: any): string {
-    if (ngDevMode && isSignal(value)) {
-      console.warn(`The JsonPipe does not unwrap signals. Received a signal with value:`, value());
-    }
+    ngDevMode && warnIfSignal('JsonPipe', value);
 
     return JSON.stringify(value, null, 2);
   }

--- a/packages/common/src/pipes/keyvalue_pipe.ts
+++ b/packages/common/src/pipes/keyvalue_pipe.ts
@@ -14,6 +14,7 @@ import {
   Pipe,
   PipeTransform,
 } from '@angular/core';
+import {warnIfSignal} from './utils';
 
 function makeKeyValuePair<K, V>(key: K, value: V): KeyValue<K, V> {
   return {key: key, value: value};
@@ -109,6 +110,8 @@ export class KeyValuePipe implements PipeTransform {
     input: undefined | null | {[key: string]: V; [key: number]: V} | ReadonlyMap<K, V>,
     compareFn: ((a: KeyValue<K, V>, b: KeyValue<K, V>) => number) | null = defaultComparator,
   ): Array<KeyValue<K, V>> | null {
+    ngDevMode && warnIfSignal('KeyValuePipe', input);
+
     if (!input || (!(input instanceof Map) && typeof input !== 'object')) {
       return null;
     }

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -18,7 +18,7 @@ import {
 import {formatCurrency, formatNumber, formatPercent} from '../i18n/format_number';
 import {getCurrencySymbol} from '../i18n/locale_data_api';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 import {RuntimeErrorCode} from '../errors';
 
 /**

--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -8,7 +8,7 @@
 
 import {Pipe, PipeTransform} from '@angular/core';
 
-import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
+import {invalidPipeArgumentError} from './utils';
 
 /**
  * @ngModule CommonModule

--- a/packages/common/src/pipes/utils.ts
+++ b/packages/common/src/pipes/utils.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type, ɵRuntimeError as RuntimeError, ɵstringify as stringify} from '@angular/core';
+import {
+  Type,
+  ɵRuntimeError as RuntimeError,
+  ɵstringify as stringify,
+  isSignal,
+} from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
 
@@ -15,4 +20,10 @@ export function invalidPipeArgumentError(type: Type<any>, value: Object) {
     RuntimeErrorCode.INVALID_PIPE_ARGUMENT,
     ngDevMode && `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'`,
   );
+}
+
+export function warnIfSignal(pipeName: string, value: unknown): void {
+  if (isSignal(value)) {
+    console.warn(`The ${pipeName} does not unwrap signals. Received a signal with value:`, value());
+  }
 }


### PR DESCRIPTION
Add signal warning for `KeyValuePipe` and consolidates the `invalidPipeArgumentError` function into a `utils`

Inspired by https://github.com/angular/angular/pull/66993

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

 ```ts
@Component({
  template: `
    @for (item of jsonObject | keyvalue; track item.key) { // It never fails and works quietly
      <div>{{ item.key }}:{{ item.value }}</div> 
    }
  `,
  imports: [KeyValuePipe],
})
export class Dummy {
  jsonObject = signal({ name: 'Angular', version: 'v21' });
}
```

## What is the new behavior?

A warning similar to JsonPipe is added

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
