### PR TITLE
Support optional timeout for idle deferred triggers

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -846,7 +846,7 @@ export interface HostListenerDecorator {
 // @public
 export interface IdleService {
     cancelOnIdle(id: number): void;
-    requestOnIdle(callback: (deadline?: IdleDeadline) => void): number;
+    requestOnIdle(callback: (deadline?: IdleDeadline) => void, options?: IdleRequestOptions): number;
 }
 
 // @public

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -1385,3 +1385,42 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_on_idle_with_timeout.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    message = 'hello';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "17.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    @defer (on idle(500ms)) {
+      {{message}}
+    } @placeholder {
+      <p>Placeholder</p>
+    }
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    @defer (on idle(500ms)) {
+      {{message}}
+    } @placeholder {
+      <p>Placeholder</p>
+    }
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_on_idle_with_timeout.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -374,6 +374,21 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should generate a defer block with an `on idle` trigger that has a timeout",
+      "inputFiles": ["deferred_on_idle_with_timeout.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_on_idle_with_timeout_template.js",
+              "generated": "deferred_on_idle_with_timeout.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_idle_with_timeout.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_idle_with_timeout.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    @defer (on idle(500ms)) {
+      {{message}}
+    } @placeholder {
+      <p>Placeholder</p>
+    }
+  `,
+})
+export class MyApp {
+  message = 'hello';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_idle_with_timeout_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_on_idle_with_timeout_template.js
@@ -1,0 +1,8 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵdomTemplate(0, MyApp_Defer_0_Template, 1, 1)(1, MyApp_DeferPlaceholder_1_Template, 2, 0);
+    $r3$.ɵɵdefer(2, 0, null, null, 1);
+    $r3$.ɵɵdeferOnIdle(500);
+  }
+  …
+}

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -208,7 +208,18 @@ export class BoundDeferredTrigger extends DeferredTrigger {
 
 export class NeverDeferredTrigger extends DeferredTrigger {}
 
-export class IdleDeferredTrigger extends DeferredTrigger {}
+export class IdleDeferredTrigger extends DeferredTrigger {
+  constructor(
+    nameSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan,
+    prefetchSpan: ParseSourceSpan | null,
+    onSourceSpan: ParseSourceSpan | null,
+    hydrateSpan: ParseSourceSpan | null,
+    public timeout: number | null,
+  ) {
+    super(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  }
+}
 
 export class ImmediateDeferredTrigger extends DeferredTrigger {}
 

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -488,11 +488,26 @@ function createIdleTrigger(
   onSourceSpan: ParseSourceSpan | null,
   hydrateSpan: ParseSourceSpan | null,
 ): t.IdleDeferredTrigger {
-  if (parameters.length > 0) {
-    throw new Error(`"${OnTriggerType.IDLE}" trigger cannot have parameters`);
+  if (parameters.length > 1) {
+    throw new Error(`"${OnTriggerType.IDLE}" trigger can only have zero or one parameters`);
   }
 
-  return new t.IdleDeferredTrigger(nameSpan, sourceSpan, prefetchSpan, onSourceSpan, hydrateSpan);
+  let timeout: number | null = null;
+  if (parameters[0]) {
+    timeout = parseDeferredTime(parameters[0].expression);
+    if (timeout === null) {
+      throw new Error(`Could not parse time value of trigger "${OnTriggerType.IDLE}"`);
+    }
+  }
+
+  return new t.IdleDeferredTrigger(
+    nameSpan,
+    sourceSpan,
+    prefetchSpan,
+    onSourceSpan,
+    hydrateSpan,
+    timeout,
+  );
 }
 
 function createTimerTrigger(

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1382,6 +1382,8 @@ interface DeferTriggerWithTargetBase extends DeferTriggerBase {
 
 interface DeferIdleTrigger extends DeferTriggerBase {
   kind: DeferTriggerKind.Idle;
+
+  timeout: number | null;
 }
 
 interface DeferImmediateTrigger extends DeferTriggerBase {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -749,7 +749,7 @@ function ingestDeferBlock(unit: ViewCompilationUnit, deferBlock: t.DeferredBlock
     deferOnOps.push(
       ir.createDeferOnOp(
         deferXref,
-        {kind: ir.DeferTriggerKind.Idle},
+        {kind: ir.DeferTriggerKind.Idle, timeout: null},
         ir.DeferOpModifierKind.NONE,
         null!,
       ),
@@ -778,7 +778,7 @@ function ingestDeferTriggers(
   if (triggers.idle !== undefined) {
     const deferOnOp = ir.createDeferOnOp(
       deferXref,
-      {kind: ir.DeferTriggerKind.Idle},
+      {kind: ir.DeferTriggerKind.Idle, timeout: triggers.idle.timeout ?? null},
       modifier,
       triggers.idle.sourceSpan,
     );

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -383,8 +383,12 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         let args: o.Expression[] = [];
         switch (op.trigger.kind) {
           case ir.DeferTriggerKind.Never:
-          case ir.DeferTriggerKind.Idle:
           case ir.DeferTriggerKind.Immediate:
+            break;
+          case ir.DeferTriggerKind.Idle:
+            if (op.trigger.timeout != null) {
+              args = [o.literal(op.trigger.timeout)];
+            }
             break;
           case ir.DeferTriggerKind.Timer:
             args = [o.literal(op.trigger.delay)];

--- a/packages/core/src/defer/idle_scheduler.ts
+++ b/packages/core/src/defer/idle_scheduler.ts
@@ -17,87 +17,135 @@ import {ApplicationRef} from '../application/application_ref';
  *
  * @param callback A function to be invoked when a browser becomes idle.
  * @param injector injector for the app
+ * @param options Optional options passed to `requestIdleCallback`.
  */
-export function onIdle(callback: VoidFunction, injector: Injector) {
+export function onIdle(callback: VoidFunction, injector: Injector, options?: IdleRequestOptions) {
   const scheduler = injector.get(IdleScheduler);
   const cleanupFn = () => scheduler.remove(callback);
-  scheduler.add(callback);
+
+  scheduler.add(callback, options);
   return cleanupFn;
+}
+
+export function onIdleWrapper(options?: IdleRequestOptions) {
+  return (callback: VoidFunction, injector: Injector) => onIdle(callback, injector, options);
+}
+
+/**
+ * A bucket groups callbacks sharing the same idle request options into a single
+ * `requestIdleCallback` invocation.
+ */
+interface IdleBucket {
+  idleId: number | null;
+  readonly queue: Set<VoidFunction>;
 }
 
 /**
  * Helper service to schedule `requestIdleCallback`s for batches of defer blocks,
  * to avoid calling `requestIdleCallback` for each defer block (e.g. if
  * defer blocks are defined inside a for loop).
+ *
+ * Callbacks are grouped into buckets by their serialized options key. Each bucket is
+ * scheduled independently with its own `requestIdleCallback` call, so different
+ * options never interfere with each other. Callbacks that share the same
+ * options (including no options) are batched together.
  */
 export class IdleScheduler implements OnDestroy {
-  // Currently scheduled idle callback id.
-  idleId: number | null = null;
+  // Serialize options rather than using the object reference to ensure
+  // that different IdleRequestOptions references with the same values
+  // are batched into the same bucket.
+  private readonly buckets = new Map<string, IdleBucket>();
 
-  // Queue of callbacks to be invoked next.
-  queue = new Set<VoidFunction>();
-  applicationRef = inject(ApplicationRef);
+  // Lookup from callback to its bucket key.
+  private readonly callbackBucket = new Map<VoidFunction, string>();
+  private readonly applicationRef = inject(ApplicationRef);
 
-  ngZone = inject(NgZone);
+  private readonly ngZone = inject(NgZone);
   private readonly idleService = inject(IDLE_SERVICE);
 
-  add(callback: VoidFunction) {
-    this.queue.add(callback);
-    this.scheduleIdleCallback();
+  add(callback: VoidFunction, options?: IdleRequestOptions) {
+    const key = getIdleRequestKey(options);
+    this.callbackBucket.set(callback, key);
+
+    let bucket = this.buckets.get(key);
+    if (bucket == null) {
+      bucket = {idleId: null, queue: new Set()};
+      this.buckets.set(key, bucket);
+    }
+    bucket.queue.add(callback);
+    this.scheduleBucket(bucket, options);
   }
 
   remove(callback: VoidFunction) {
-    this.queue.delete(callback);
+    const key = this.callbackBucket.get(callback);
+    if (key === undefined) return;
 
-    // If the last callback was removed and there is a pending
+    this.callbackBucket.delete(callback);
+
+    const bucket = this.buckets.get(key);
+    if (!bucket) return;
+
+    bucket.queue.delete(callback);
+
+    // If the last callback in this bucket was removed, cancel the
     // idle callback - cancel it.
-    if (this.queue.size === 0) {
-      this.cancelIdleCallback();
+    if (bucket.queue.size === 0) {
+      this.cancelBucket(bucket);
+      this.buckets.delete(key);
     }
   }
 
-  private scheduleIdleCallback() {
-    if (this.idleId !== null) {
+  private scheduleBucket(bucket: IdleBucket, options?: IdleRequestOptions) {
+    if (bucket.idleId !== null) {
       return;
     }
 
+    const key = getIdleRequestKey(options);
     const callback = (deadline?: IdleDeadline) => {
-      this.cancelIdleCallback();
+      this.cancelBucket(bucket);
 
-      for (const callbackFn of this.queue) {
-        callbackFn();
+      for (const cb of bucket.queue) {
+        cb();
         // _tick here is an optimized change detection check and is safe to call here.
         // We also account for the time it takes to run change detection
         // for the newly-created view as a part of the same idle callback.
         this.applicationRef._tick();
-        this.queue.delete(callbackFn);
+        bucket.queue.delete(cb);
+        this.callbackBucket.delete(cb);
 
         if (deadline && deadline.timeRemaining() === 0 && !deadline.didTimeout) {
           break;
         }
       }
 
-      if (this.queue.size > 0) {
-        this.scheduleIdleCallback();
+      if (bucket.queue.size > 0) {
+        this.scheduleBucket(bucket, options);
+      } else {
+        this.buckets.delete(key);
       }
     };
+
     // Ensure that the callback runs in the NgZone since
     // the `requestIdleCallback` is not currently patched by Zone.js.
-    this.idleId = this.idleService.requestOnIdle((deadline) =>
-      this.ngZone.run(() => callback(deadline)),
-    ) as number;
+    bucket.idleId = this.idleService.requestOnIdle(
+      (deadline) => this.ngZone.run(() => callback(deadline)),
+      options,
+    );
   }
 
-  private cancelIdleCallback() {
-    if (this.idleId !== null) {
-      this.idleService.cancelOnIdle(this.idleId);
-      this.idleId = null;
+  private cancelBucket(bucket: IdleBucket) {
+    if (bucket.idleId !== null) {
+      this.idleService.cancelOnIdle(bucket.idleId);
+      bucket.idleId = null;
     }
   }
 
   ngOnDestroy() {
-    this.cancelIdleCallback();
-    this.queue.clear();
+    for (const bucket of this.buckets.values()) {
+      this.cancelBucket(bucket);
+    }
+    this.buckets.clear();
+    this.callbackBucket.clear();
   }
 
   /** @nocollapse */
@@ -106,4 +154,13 @@ export class IdleScheduler implements OnDestroy {
     providedIn: 'root',
     factory: () => new IdleScheduler(),
   });
+}
+
+/** Generates a string that can be used to find identical idle request option objects. */
+function getIdleRequestKey(options?: IdleRequestOptions): string {
+  if (!options || options.timeout == null) {
+    return '';
+  }
+
+  return `${options.timeout}`;
 }

--- a/packages/core/src/defer/idle_service.ts
+++ b/packages/core/src/defer/idle_service.ts
@@ -18,8 +18,14 @@ import {makeEnvironmentProviders} from '../di/provider_collection';
  * Note: we wrap the `requestIdleCallback` call into a function, so that it can be
  * overridden/mocked in test environment and picked up by the runtime code.
  */
-const _requestIdleCallback = () =>
-  (typeof requestIdleCallback !== 'undefined' ? requestIdleCallback : setTimeout).bind(globalThis);
+const _requestIdleCallback = (): ((
+  callback: (deadline?: IdleDeadline) => void,
+  options?: IdleRequestOptions,
+) => number) =>
+  typeof requestIdleCallback !== 'undefined'
+    ? requestIdleCallback.bind(globalThis)
+    : (callback) => setTimeout(callback) as unknown as number;
+
 const _cancelIdleCallback = () =>
   (typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback : clearTimeout).bind(globalThis);
 
@@ -34,7 +40,7 @@ export interface IdleService {
    *
    * @returns an id which allows the scheduled callback to be cancelled before it executes.
    */
-  requestOnIdle(callback: (deadline?: IdleDeadline) => void): number;
+  requestOnIdle(callback: (deadline?: IdleDeadline) => void, options?: IdleRequestOptions): number;
 
   /**
    * Cancel a previously scheduled callback using the id associated with it.
@@ -74,8 +80,8 @@ class RequestIdleCallbackService implements IdleService {
   private readonly requestIdleCallback = _requestIdleCallback();
   private readonly cancelIdleCallback = _cancelIdleCallback();
 
-  requestOnIdle(callback: (deadline?: IdleDeadline) => void): number {
-    return this.requestIdleCallback(callback) as unknown as number;
+  requestOnIdle(callback: (deadline?: IdleDeadline) => void, options?: IdleRequestOptions): number {
+    return this.requestIdleCallback(callback, options);
   }
 
   cancelOnIdle(id: number): void {

--- a/packages/core/src/defer/idle_service.ts
+++ b/packages/core/src/defer/idle_service.ts
@@ -18,13 +18,13 @@ import {makeEnvironmentProviders} from '../di/provider_collection';
  * Note: we wrap the `requestIdleCallback` call into a function, so that it can be
  * overridden/mocked in test environment and picked up by the runtime code.
  */
-const _requestIdleCallback = (): ((
-  callback: (deadline?: IdleDeadline) => void,
-  options?: IdleRequestOptions,
-) => number) =>
-  typeof requestIdleCallback !== 'undefined'
-    ? requestIdleCallback.bind(globalThis)
-    : (callback) => setTimeout(callback) as unknown as number;
+type RequestIdle = typeof requestIdleCallback;
+
+const _requestIdleCallback = () =>
+  (typeof requestIdleCallback !== 'undefined'
+    ? requestIdleCallback
+    : (cb: VoidFunction) => setTimeout(cb) as unknown as number
+  ).bind(globalThis) as RequestIdle;
 
 const _cancelIdleCallback = () =>
   (typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback : clearTimeout).bind(globalThis);

--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -29,7 +29,7 @@ import {performanceMarkFeature} from '../util/performance';
 import {invokeAllTriggerCleanupFns, storeTriggerCleanupFn} from './cleanup';
 import {onViewportWrapper, registerDomTrigger} from './dom_triggers';
 import {onHover, onInteraction} from '../../primitives/defer/src/triggers';
-import {onIdle} from './idle_scheduler';
+import {onIdleWrapper} from './idle_scheduler';
 import {
   DEFER_BLOCK_STATE,
   DeferBlockInternalState,
@@ -366,46 +366,48 @@ export function ɵɵdeferHydrateNever() {
  * Sets up logic to handle the `on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferOnIdle() {
+export function ɵɵdeferOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
-
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'on idle');
+    const expression = timeout ? `on idle(${timeout})` : 'on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Regular, lView, tNode)) return;
 
-  scheduleDelayedTrigger(onIdle);
+  scheduleDelayedTrigger(onIdleWrapper({timeout}));
 }
 
 /**
  * Sets up logic to handle the `prefetch on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferPrefetchOnIdle() {
+export function ɵɵdeferPrefetchOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'prefetch on idle');
+    const expression = timeout ? `prefetch on idle(${timeout})` : 'prefetch on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Prefetch, lView, tNode)) return;
 
-  scheduleDelayedPrefetching(onIdle);
+  scheduleDelayedPrefetching(onIdleWrapper({timeout}));
 }
 
 /**
  * Sets up logic to handle the `on idle` deferred trigger.
  * @codeGenApi
  */
-export function ɵɵdeferHydrateOnIdle() {
+export function ɵɵdeferHydrateOnIdle(timeout?: number) {
   const lView = getLView();
   const tNode = getCurrentTNode()!;
 
   if (ngDevMode) {
-    trackTriggerForDebugging(lView[TVIEW], tNode, 'hydrate on idle');
+    const expression = timeout ? `hydrate on idle(${timeout})` : 'hydrate on idle';
+    trackTriggerForDebugging(lView[TVIEW], tNode, expression);
   }
 
   if (!shouldAttachTrigger(TriggerType.Hydrate, lView, tNode)) return;
@@ -417,7 +419,7 @@ export function ɵɵdeferHydrateOnIdle() {
     // We are on the server and SSR for defer blocks is enabled.
     triggerDeferBlock(TriggerType.Hydrate, lView, tNode);
   } else {
-    scheduleDelayedHydrating(onIdle, lView, tNode);
+    scheduleDelayedHydrating(onIdleWrapper({timeout}), lView, tNode);
   }
 }
 

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -1578,17 +1578,31 @@ describe('@defer', () => {
      * Sets up interceptors for when an idle callback is requested
      * and when it's cancelled. This is needed to keep track of calls
      * made to `requestIdleCallback` and `cancelIdleCallback` APIs.
+     *
+     * The mock enforces the per-bucket invariant: for a given timeout
+     * value, at most ONE `requestIdleCallback` should be active at a
+     * time. Different timeout values (buckets) may run concurrently.
      */
     let id = 0;
     let idleCallbacksRequested: number;
     let idleCallbacksInvoked: number;
     let idleCallbacksCancelled: number;
     const onIdleCallbackQueue: Map<number, IdleRequestCallback> = new Map();
+    let capturedOptions: IdleRequestOptions | undefined;
+
+    // Tracks active idle callback counts per serialized options key, enforcing
+    // that each bucket never has more than one concurrent request.
+    const activePerTimeout = new Map<string, number>();
+    // Reverse lookup: callback id → options key (for cleanup in cancel).
+    const idToTimeout = new Map<number, string>();
 
     function resetCounters() {
       idleCallbacksRequested = 0;
       idleCallbacksInvoked = 0;
       idleCallbacksCancelled = 0;
+      capturedOptions = undefined;
+      activePerTimeout.clear();
+      idToTimeout.clear();
     }
     resetCounters();
 
@@ -1602,15 +1616,38 @@ describe('@defer', () => {
       callback: IdleRequestCallback,
       options?: IdleRequestOptions,
     ): number => {
+      capturedOptions = options;
       onIdleCallbackQueue.set(id, callback);
-      expect(idleCallbacksRequested).toBe(0);
       expect(NgZone.isInAngularZone()).toBe(true);
+
+      // Enforce per-bucket invariant: a given options key must not
+      // already have an active requestIdleCallback.
+      const timeoutKey = options?.timeout != null ? `${options.timeout}` : '';
+      const activeCount = activePerTimeout.get(timeoutKey) ?? 0;
+      expect(activeCount)
+        .withContext(
+          `Expected 0 active idle callbacks for key='${timeoutKey}', ` +
+            `but found ${activeCount}. Each options bucket should have at most one.`,
+        )
+        .toBe(0);
+      activePerTimeout.set(timeoutKey, activeCount + 1);
+      idToTimeout.set(id, timeoutKey);
+
       idleCallbacksRequested++;
       return id++;
     };
 
     const mockCancelIdleCallback = (id: number) => {
       onIdleCallbackQueue.delete(id);
+
+      // Decrement per-bucket active count.
+      const timeoutKey = idToTimeout.get(id);
+      if (timeoutKey !== undefined) {
+        const count = activePerTimeout.get(timeoutKey) ?? 0;
+        activePerTimeout.set(timeoutKey, Math.max(0, count - 1));
+        idToTimeout.delete(id);
+      }
+
       idleCallbacksRequested--;
       idleCallbacksCancelled++;
     };
@@ -1899,7 +1936,10 @@ describe('@defer', () => {
       class CustomIdleService implements IdleService {
         private callbacks: Array<((deadline?: IdleDeadline) => void) | undefined> = [];
 
-        requestOnIdle(callback: (deadline?: IdleDeadline) => void): number {
+        requestOnIdle(
+          callback: (deadline?: IdleDeadline) => void,
+          options?: IdleRequestOptions,
+        ): number {
           return this.callbacks.push(callback) - 1;
         }
 
@@ -2038,6 +2078,180 @@ describe('@defer', () => {
       expect(loadingFnInvokedTimes).toBe(1);
     });
 
+    it('should trigger prefetching based on `on idle(<timeout>)` with timeout only once', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Rendering {{ block }} block.',
+      })
+      class NestedCmp {
+        @Input() block!: string;
+      }
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @for (item of items; track item) {
+            @defer (when deferCond; prefetch on idle(1500)) {
+              <nested-cmp [block]="'primary for \`' + item + '\` with timeout'" />
+            } @placeholder {
+              Placeholder with timeout \`{{ item }}\`
+            }
+          }
+        `,
+      })
+      class RootCmp {
+        deferCond = false;
+        items = ['x', 'y', 'z'];
+      }
+
+      let loadingFnInvokedTimes = 0;
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => {
+            loadingFnInvokedTimes++;
+            return [dynamicImportOf(NestedCmp)];
+          };
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [{provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor}],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder with timeout `x`');
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder with timeout `y`');
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder with timeout `z`');
+
+      // Verify that requestIdleCallback was called with timeout for prefetch
+      expect(idleCallbacksRequested).toBe(1);
+      expect(capturedOptions).toBeDefined();
+      expect(capturedOptions!.timeout).toBe(1500);
+
+      // Make sure loading function is not yet invoked.
+      expect(loadingFnInvokedTimes).toBe(0);
+
+      triggerIdleCallbacks();
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expect that the loading resources function was invoked once for prefetch.
+      expect(loadingFnInvokedTimes).toBe(1);
+
+      // Expect that placeholder content is still rendered after prefetch.
+      expect(fixture.nativeElement.outerHTML).toContain('Placeholder with timeout `x`');
+
+      // Trigger main content.
+      fixture.componentInstance.deferCond = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify primary blocks content with prefetched resources.
+      expect(fixture.nativeElement.outerHTML).toContain(
+        'Rendering primary for `x` with timeout block',
+      );
+      expect(fixture.nativeElement.outerHTML).toContain(
+        'Rendering primary for `y` with timeout block',
+      );
+      expect(fixture.nativeElement.outerHTML).toContain(
+        'Rendering primary for `z` with timeout block',
+      );
+
+      // Expect that the loading resources function was not invoked again (counter remains 1).
+      expect(loadingFnInvokedTimes).toBe(1);
+    });
+
+    it('should support mixed prefetch triggers with and without timeout', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Rendering {{ block }} block.',
+      })
+      class NestedCmp {
+        @Input() block!: string;
+      }
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (when loadFirst; prefetch on idle) {
+            <nested-cmp [block]="'no-timeout'" />
+          } @placeholder {
+            No Timeout Placeholder
+          }
+
+          @defer (when loadSecond; prefetch on idle(3000)) {
+            <nested-cmp [block]="'with-timeout'" />
+          } @placeholder {
+            With Timeout Placeholder
+          }
+        `,
+      })
+      class RootCmp {
+        loadFirst = false;
+        loadSecond = false;
+      }
+
+      let loadingFnInvokedTimes = 0;
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => {
+            loadingFnInvokedTimes++;
+            return [dynamicImportOf(NestedCmp)];
+          };
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [{provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor}],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.outerHTML).toContain('No Timeout Placeholder');
+      expect(fixture.nativeElement.outerHTML).toContain('With Timeout Placeholder');
+
+      // Verify that idle callbacks were requested (one bucket per distinct timeout)
+      expect(idleCallbacksRequested).toBe(2);
+
+      // Make sure loading function is not yet invoked.
+      expect(loadingFnInvokedTimes).toBe(0);
+
+      triggerIdleCallbacks();
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expect that invoked onIdle trigger for prefetching both blocks
+      expect(loadingFnInvokedTimes).toBe(2);
+
+      // Both placeholders should still be visible after prefetch
+      expect(fixture.nativeElement.outerHTML).toContain('No Timeout Placeholder');
+      expect(fixture.nativeElement.outerHTML).toContain('With Timeout Placeholder');
+
+      // Trigger first block
+      fixture.componentInstance.loadFirst = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify first block is rendered
+      expect(fixture.nativeElement.outerHTML).toContain(
+        '<nested-cmp ng-reflect-block="no-timeout">Rendering no-timeout block.</nested-cmp>',
+      );
+      expect(fixture.nativeElement.outerHTML).toContain('With Timeout Placeholder');
+    });
+
     it('should trigger fetching based on `on idle` only once', async () => {
       @Component({
         selector: 'nested-cmp',
@@ -2101,6 +2315,85 @@ describe('@defer', () => {
       expect(fixture.nativeElement.outerHTML).toContain('Rendering primary for `a` block');
       expect(fixture.nativeElement.outerHTML).toContain('Rendering primary for `b` block');
       expect(fixture.nativeElement.outerHTML).toContain('Rendering primary for `c` block');
+
+      // Expect that the loading resources function was not invoked again (counter remains 1).
+      expect(loadingFnInvokedTimes).toBe(1);
+    });
+
+    it('should support `prefetch on idle(3000)` condition with timeout', async () => {
+      @Component({
+        selector: 'nested-cmp',
+        template: 'Rendering {{ block }} block.',
+      })
+      class NestedCmp {
+        @Input() block!: string;
+      }
+
+      @Component({
+        selector: 'root-app',
+        imports: [NestedCmp],
+        template: `
+          @defer (when deferCond; prefetch on idle(3000)) {
+            <nested-cmp [block]="'prefetched-with-timeout'" />
+          } @placeholder {
+            Placeholder for prefetch idle timeout test
+          }
+        `,
+      })
+      class RootCmp {
+        deferCond = false;
+      }
+
+      let loadingFnInvokedTimes = 0;
+      const deferDepsInterceptor = {
+        intercept() {
+          return () => {
+            loadingFnInvokedTimes++;
+            return [dynamicImportOf(NestedCmp)];
+          };
+        },
+      };
+
+      TestBed.configureTestingModule({
+        providers: [{provide: ɵDEFER_BLOCK_DEPENDENCY_INTERCEPTOR, useValue: deferDepsInterceptor}],
+      });
+
+      clearDirectiveDefs(RootCmp);
+
+      const fixture = TestBed.createComponent(RootCmp);
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.outerHTML).toContain(
+        'Placeholder for prefetch idle timeout test',
+      );
+
+      // Make sure loading function is not yet invoked.
+      expect(loadingFnInvokedTimes).toBe(0);
+
+      triggerIdleCallbacks();
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Expect that the loading resources function was invoked once (prefetch).
+      expect(loadingFnInvokedTimes).toBe(1);
+
+      // Expect that placeholder content is still rendered after prefetch.
+      expect(fixture.nativeElement.outerHTML).toContain(
+        'Placeholder for prefetch idle timeout test',
+      );
+
+      // Trigger main content.
+      fixture.componentInstance.deferCond = true;
+      fixture.detectChanges();
+
+      await allPendingDynamicImports();
+      fixture.detectChanges();
+
+      // Verify primary block content with prefetched resources.
+      const primaryBlockHTML = fixture.nativeElement.outerHTML;
+      expect(primaryBlockHTML).toContain(
+        '<nested-cmp ng-reflect-block="prefetched-with-timeout">Rendering prefetched-with-timeout block.</nested-cmp>',
+      );
 
       // Expect that the loading resources function was not invoked again (counter remains 1).
       expect(loadingFnInvokedTimes).toBe(1);
@@ -4538,8 +4831,11 @@ describe('IdleScheduler', () => {
   class CustomIdleService implements IdleService {
     requestOnIdleSpy = jasmine.createSpy('requestOnIdleFn');
 
-    requestOnIdle(callback: (deadline?: IdleDeadline) => void): number {
-      return this.requestOnIdleSpy(callback);
+    requestOnIdle(
+      callback: (deadline?: IdleDeadline) => void,
+      options?: IdleRequestOptions,
+    ): number {
+      return this.requestOnIdleSpy(callback, options);
     }
 
     cancelOnIdle(id: number): void {}
@@ -4700,6 +4996,131 @@ describe('IdleScheduler', () => {
     let cb1 = jasmine.createSpy('cb1');
     scheduler.add(cb1);
     capturedCb!(undefined);
+    expect(cb1).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass timeout option to idleService.requestOnIdle', () => {
+    let capturedOptions: any = undefined;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any, options: any) => {
+      capturedOptions = options;
+      return 1;
+    });
+
+    scheduler.add(jasmine.createSpy('cb'), {timeout: 500});
+
+    expect(customIdleService.requestOnIdleSpy).toHaveBeenCalledTimes(1);
+    expect(capturedOptions).toEqual({timeout: 500});
+  });
+
+  it('should not pass timeout option when timeout is not specified', () => {
+    let capturedOptions: any = 'NOT_CALLED';
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any, options: any) => {
+      capturedOptions = options;
+      return 1;
+    });
+
+    scheduler.add(jasmine.createSpy('cb'));
+
+    expect(customIdleService.requestOnIdleSpy).toHaveBeenCalledTimes(1);
+    expect(capturedOptions).toBeUndefined();
+  });
+
+  it('should create independent buckets for different timeouts', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let capturedOptions: any[] = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any, options: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      capturedOptions.push(options);
+      return 100 + ricCount;
+    });
+
+    const cb1 = jasmine.createSpy('cb1');
+    const cb2 = jasmine.createSpy('cb2');
+
+    // First callback with 1000ms timeout
+    scheduler.add(cb1, {timeout: 1000});
+    expect(ricCount).toBe(1);
+    expect(capturedOptions[0]).toEqual({timeout: 1000});
+
+    // Second callback with 200ms timeout → separate bucket, separate requestIdleCallback
+    scheduler.add(cb2, {timeout: 200});
+    expect(ricCount).toBe(2);
+    expect(capturedOptions[1]).toEqual({timeout: 200});
+
+    // Fire the 200ms bucket first (browser would call this sooner)
+    capturedCbs[1]({didTimeout: true, timeRemaining: () => 0});
+    expect(cb2).toHaveBeenCalledTimes(1);
+    expect(cb1).toHaveBeenCalledTimes(0); // Not in this bucket
+
+    // Fire the 1000ms bucket
+    capturedCbs[0]({didTimeout: true, timeRemaining: () => 0});
+    expect(cb1).toHaveBeenCalledTimes(1);
+  });
+
+  it('should batch callbacks with the same timeout into one bucket', () => {
+    let capturedCb: ((deadline: any) => void) | null = null;
+    let capturedOptions: any[] = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any, options: any) => {
+      ricCount++;
+      capturedCb = cb;
+      capturedOptions.push(options);
+      return 100 + ricCount;
+    });
+
+    const cb1 = jasmine.createSpy('cb1');
+    const cb2 = jasmine.createSpy('cb2');
+
+    // Both callbacks with the same 500ms timeout → same bucket
+    scheduler.add(cb1, {timeout: 500});
+    scheduler.add(cb2, {timeout: 500});
+    expect(ricCount).toBe(1); // Only one requestIdleCallback
+    expect(capturedOptions[0]).toEqual({timeout: 500});
+
+    // Fire the bucket — both should run
+    capturedCb!({didTimeout: true, timeRemaining: () => 0});
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep no-timeout bucket independent from timeout buckets', () => {
+    let capturedCbs: Array<(deadline: any) => void> = [];
+    let capturedOptions: any[] = [];
+    let ricCount = 0;
+
+    customIdleService.requestOnIdleSpy.and.callFake((cb: any, options: any) => {
+      ricCount++;
+      capturedCbs.push(cb);
+      capturedOptions.push(options);
+      return 100 + ricCount;
+    });
+
+    const cb1 = jasmine.createSpy('cb1');
+    const cb2 = jasmine.createSpy('cb2');
+
+    // No timeout
+    scheduler.add(cb1);
+    expect(ricCount).toBe(1);
+    expect(capturedOptions[0]).toBeUndefined();
+
+    // With 300ms timeout → separate bucket
+    scheduler.add(cb2, {timeout: 300});
+    expect(ricCount).toBe(2);
+    expect(capturedOptions[1]).toEqual({timeout: 300});
+
+    // Fire the 300ms bucket
+    capturedCbs[1]({didTimeout: true, timeRemaining: () => 0});
+    expect(cb2).toHaveBeenCalledTimes(1);
+    expect(cb1).toHaveBeenCalledTimes(0);
+
+    // Fire the no-timeout bucket
+    capturedCbs[0]({didTimeout: false, timeRemaining: () => 10});
     expect(cb1).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/language-service/src/quick_info_built_ins.ts
+++ b/packages/language-service/src/quick_info_built_ins.ts
@@ -170,7 +170,8 @@ const BUILT_IN_NAMES_TO_DOC_MAP: {
     displayInfoKind: DisplayInfoKind.KEYWORD,
   },
   'idle': {
-    docString: triggerDescriptionPreamble + `the browser reports idle state (default).`,
+    docString:
+      triggerDescriptionPreamble + `the browser reports idle state. Accepts an optional timeout.`,
     links: ['[Reference](https://angular.dev/guide/templates/defer#on-idle)'],
     displayInfoKind: DisplayInfoKind.TRIGGER,
   },

--- a/packages/language-service/test/grp3/quick_info_spec.ts
+++ b/packages/language-service/test/grp3/quick_info_spec.ts
@@ -734,6 +734,14 @@ describe('quick info', () => {
             });
           });
 
+          it('idle with timeout', () => {
+            expectQuickInfo({
+              templateOverride: `@defer (on i¦dle(500ms)) { } `,
+              expectedSpanText: 'idle',
+              expectedDisplayString: '(trigger) idle',
+            });
+          });
+
           it('hover', () => {
             expectQuickInfo({
               templateOverride: `@defer (on hov¦er(x)) { } <div #x></div> `,

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -42,6 +42,7 @@ import {
   TmplAstSwitchExhaustiveCheck as SwitchExhaustiveCheck,
   TmplAstTemplate as Template,
   TmplAstTextAttribute as TextAttribute,
+  TmplAstIdleDeferredTrigger as IdleDeferredTrigger,
   TmplAstTimerDeferredTrigger as TimerDeferredTrigger,
   TmplAstVariable as Variable,
 } from '@angular/compiler';
@@ -1237,6 +1238,15 @@ describe('blocks', () => {
     expect(isTemplateNode(node!)).toBe(true);
     expect(node).toBeInstanceOf(TimerDeferredTrigger);
     expect((node as TimerDeferredTrigger).delay).toBe(2000);
+  });
+
+  it('should visit idle on conditions on defer blocks with timeout', () => {
+    const {nodes, position} = parse(` @defer (on idle(5¦00ms)) { } `);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isTemplateNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(IdleDeferredTrigger);
+    expect((node as IdleDeferredTrigger).timeout).toBe(500);
   });
 
   // TODO: Should the parser ingest a property read for `localRef`, instead of a string?


### PR DESCRIPTION
 This change allows supply a timeout value in the on idle trigger of an Angular `@defer` block, which translates into passing the `timeout` option to `requestIdleCallback`.

That way, if the browser doesn’t schedule the callback soon enough, the work will run no later than the specified timeout in [options](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback#options) 

Closes #67187
 
 ### Usage
 
 ```html
 @defer (on idle(500)) {
  <heavy-component />
}

@defer (prefetch on idle(500)) {
  <heavy-component />
}

@defer (hydrate on idle(500)) {
  <heavy-component />
}
 ```
 
 ### Other information

- Add option-based buckets in `IdleScheduler` to group callbacks and avoid redundant idle scheduling  
- Add `IdleRequestOptions` support to `IdleService`  
- Add language service support to detect the new `@defer idle(300)` syntax
 