### PR TITLE
ci: declare explicit read-only GITHUB_TOKEN permission in manual workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
     inputs: {}
 
+permissions:
+  contents: read
+
 jobs:
   # Bazel saucelabs job resides in `manual.yml` because it's currently unstable, but
   # kept as "runnable" for debugging/stabilization effort purposes.


### PR DESCRIPTION
## Summary\n- add explicit `permissions: contents: read` to `.github/workflows/manual.yml`\n\n## Why\nThis workflow currently relies on implicit token defaults. Declaring explicit read-only permissions follows least-privilege guidance and makes workflow intent clear.\n\n## Notes\n- configuration-only change\n- no test/build logic changes\n