### PR TITLE
refactor(compiler-cli): Add report readonly signals in two-way bindings

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/model_signal_diagnostics_spec.ts
@@ -680,6 +680,9 @@ runInEachFileSystem(() => {
         component: `val!: InputSignal<boolean>;`,
         expected: [
           `TestComponent.html(1, 10): Type 'InputSignal<boolean>' is not assignable to type 'boolean'.`,
+          jasmine.stringContaining(
+            `TestComponent.html(1, 21): Type 'InputSignal<boolean>' is missing the following properties from type 'WritableSignal<boolean>':`,
+          ),
           `TestComponent.html(1, 10): Type 'boolean' is not assignable to type 'InputSignal<boolean>'.`,
         ],
       },

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -875,8 +875,10 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as i0.TwoWay;');
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('var _t2 = i1.ɵassertWritableTwoWayBinding(((this).value));');
+    expect(block).toContain('_t2 = ((this).value);');
+    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t3 = $event;');
   });
 
   it('should handle a two-way binding to an input/output pair of a generic directive', () => {
@@ -899,8 +901,10 @@ describe('type check blocks', () => {
       'var _t1 = _ctor1({ "input": (i1.ɵunwrapWritableSignal(((this).value))) });',
     );
     expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('var _t2 = i1.ɵassertWritableTwoWayBinding(((this).value));');
+    expect(block).toContain('_t2 = ((this).value);');
+    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t3 = $event;');
   });
 
   it('should handle a two-way binding to a model()', () => {
@@ -927,8 +931,10 @@ describe('type check blocks', () => {
     expect(block).toContain(
       '_t1.input[i1.ɵINPUT_SIGNAL_BRAND_WRITE_TYPE] = i1.ɵunwrapWritableSignal((((this).value)));',
     );
-    expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t2 = $event;');
+    expect(block).toContain('var _t2 = i1.ɵassertWritableTwoWayBinding(((this).value));');
+    expect(block).toContain('_t2 = ((this).value);');
+    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t3 = $event;');
   });
 
   it('should handle a two-way binding to an input with a transform', () => {
@@ -970,8 +976,10 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
     expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
-    expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal(((this).value));');
-    expect(block).toContain('_t3 = $event;');
+    expect(block).toContain('var _t3 = i1.ɵassertWritableTwoWayBinding(((this).value));');
+    expect(block).toContain('_t3 = ((this).value);');
+    expect(block).toContain('var _t4 = i1.ɵunwrapWritableSignal(((this).value));');
+    expect(block).toContain('_t4 = $event;');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {
@@ -1099,8 +1107,12 @@ describe('type check blocks', () => {
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain('var _t1 = null! as i0.TwoWay;');
       expect(block).toContain('_t1.input = i1.ɵunwrapWritableSignal(((((this).value) as any)));');
-      expect(block).toContain('var _t2 = i1.ɵunwrapWritableSignal((((this).value) as any));');
-      expect(block).toContain('_t2 = $event;');
+      expect(block).toContain(
+        'var _t2 = i1.ɵassertWritableTwoWayBinding((((this).value) as any));',
+      );
+      expect(block).toContain('_t2 = (((this).value) as any);');
+      expect(block).toContain('var _t3 = i1.ɵunwrapWritableSignal((((this).value) as any));');
+      expect(block).toContain('_t3 = $event;');
     });
 
     it('should detect writes to template variables', () => {
@@ -1573,6 +1585,7 @@ describe('type check blocks', () => {
           allowSignalsInTwoWayBindings: false,
         });
         expect(block).not.toContain('ɵunwrapWritableSignal');
+        expect(block).not.toContain('ɵassertWritableTwoWayBinding');
       });
 
       it('should not unwrap signals in two-way bindings to generic directives', () => {
@@ -1592,6 +1605,7 @@ describe('type check blocks', () => {
           allowSignalsInTwoWayBindings: false,
         });
         expect(block).not.toContain('ɵunwrapWritableSignal');
+        expect(block).not.toContain('ɵassertWritableTwoWayBinding');
       });
     });
   });

--- a/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/authoring_models_spec.ts
@@ -382,12 +382,109 @@ runInEachFileSystem(() => {
         );
 
         const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(2);
+        expect(diags.length).toBe(3);
         expect(diags[0].messageText).toBe(
           `Type 'InputSignal<number>' is not assignable to type 'number'.`,
         );
-        expect(diags[1].messageText).toBe(
+
+        expect(diags[1].messageText).toEqual(
+          jasmine.stringContaining(
+            `Type 'InputSignal<number>' is missing the following properties from type 'WritableSignal<number>':`,
+          ),
+        );
+        expect(diags[2].messageText).toBe(
           `Type 'number' is not assignable to type 'InputSignal<number>'.`,
+        );
+      });
+
+      it('should not allow a computed() signal directly bound to an any-typed model input', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, model, computed, signal} from '@angular/core';
+
+          @Directive({selector: '[anyModel]'})
+          export class AnyModel {
+            anyModel = model.required<any>();
+          }
+
+          @Component({
+            template: \`<input anyModel [(anyModel)]="computedValue" />\`,
+            imports: [AnyModel],
+          })
+          export class TestComp {
+            base = signal(1);
+            computedValue = computed(() => this.base() + 1);
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toEqual(
+          jasmine.stringContaining(
+            `Type 'Signal<number>' is missing the following properties from type 'WritableSignal<number>':`,
+          ),
+        );
+      });
+
+      it('should not allow a signal().asReadonly() directly bound to an any-typed model input', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, model, signal} from '@angular/core';
+
+          @Directive({selector: '[anyModel]'})
+          export class AnyModel {
+            anyModel = model.required<any>();
+          }
+
+          @Component({
+            template: \`<input anyModel [(anyModel)]="valueReadonly" />\`,
+            imports: [AnyModel],
+          })
+          export class TestComp {
+            valueReadonly = signal(1).asReadonly();
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toEqual(
+          jasmine.stringContaining(
+            `Type 'Signal<number>' is missing the following properties from type 'WritableSignal<number>':`,
+          ),
+        );
+      });
+
+      it('should not allow an input() signal directly bound to an any-typed model input', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, model, input} from '@angular/core';
+
+          @Directive({selector: '[anyModel]'})
+          export class AnyModel {
+            anyModel = model.required<any>();
+          }
+
+          @Component({
+            template: \`<input anyModel [(anyModel)]="inputValue" />\`,
+            imports: [AnyModel],
+          })
+          export class TestComp {
+            inputValue = input(1);
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toEqual(
+          jasmine.stringContaining(
+            `Type 'InputSignal<number>' is missing the following properties from type 'WritableSignal<number>':`,
+          ),
         );
       });
 
@@ -410,6 +507,34 @@ runInEachFileSystem(() => {
           })
           export class TestComp {
             value = model(0);
+          }
+        `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should allow a generic type parameter in a two-way binding', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component, Directive, model} from '@angular/core';
+
+          @Directive({
+            selector: '[dir]',
+          })
+          export class TestDir {
+            value = model.required<any>();
+          }
+
+          @Component({
+            selector: 'generic-comp',
+            template: \`<div dir [(value)]="activeDate"></div>\`,
+            imports: [TestDir],
+          })
+          export class GenericComp<D> {
+            activeDate!: D;
           }
         `,
         );

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -491,5 +491,6 @@ export class Identifiers {
   static InputSignalBrandWriteType = {name: 'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE', moduleName: CORE};
   static UnwrapDirectiveSignalInputs = {name: 'ɵUnwrapDirectiveSignalInputs', moduleName: CORE};
   static unwrapWritableSignal = {name: 'ɵunwrapWritableSignal', moduleName: CORE};
+  static assertWritableTwoWayBinding = {name: 'ɵassertWritableTwoWayBinding', moduleName: CORE};
   static assertType = {name: 'ɵassertType', moduleName: CORE};
 }

--- a/packages/compiler/src/typecheck/ops/events.ts
+++ b/packages/compiler/src/typecheck/ops/events.ts
@@ -14,7 +14,11 @@ import {getStatementsBlock, TcbExpr} from './codegen';
 import type {Context} from './context';
 import type {Scope} from './scope';
 import {TcbDirectiveMetadata} from '../api';
-import {TcbExpressionTranslator, unwrapWritableSignal} from './expression';
+import {
+  assertWritableTwoWayBinding,
+  TcbExpressionTranslator,
+  unwrapWritableSignal,
+} from './expression';
 import {ExpressionIdentifier} from '../comments';
 import {checkSplitTwoWayBinding} from './bindings';
 import {LocalSymbol} from './references';
@@ -295,6 +299,14 @@ function tcbCreateEventHandler(
 
   if (assertionExpression !== undefined) {
     statements.push(assertionExpression);
+  }
+
+  if (event.type === ParsedEventType.TwoWay && tcb.env.config.allowSignalsInTwoWayBindings) {
+    const assertTarget = tcb.allocateId();
+    statements.push(
+      new TcbExpr(`var ${assertTarget} = ${assertWritableTwoWayBinding(handler, tcb).print()}`),
+      new TcbExpr(`${assertTarget} = ${handler.print()}`),
+    );
   }
 
   // TODO(crisbeto): remove the `checkTwoWayBoundEvents` check in v20.

--- a/packages/compiler/src/typecheck/ops/expression.ts
+++ b/packages/compiler/src/typecheck/ops/expression.ts
@@ -47,6 +47,17 @@ export function unwrapWritableSignal(expression: TcbExpr, tcb: Context): TcbExpr
 }
 
 /**
+ * Ensures two-way bindings are writable or non-signal values.
+ */
+export function assertWritableTwoWayBinding(expression: TcbExpr, tcb: Context): TcbExpr {
+  const assertRef = tcb.env.referenceExternalSymbol(
+    R3Identifiers.assertWritableTwoWayBinding.moduleName,
+    R3Identifiers.assertWritableTwoWayBinding.name,
+  );
+  return new TcbExpr(`${assertRef.print()}(${expression.print()})`);
+}
+
+/**
  * A `TcbOp` which renders an Angular expression (e.g. `{{foo() && bar.baz}}`).
  *
  * Executing this operation returns nothing.

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -14,6 +14,7 @@ export {
   CreateSignalOptions,
   signal,
   WritableSignal,
+  ɵassertWritableTwoWayBinding,
   ɵunwrapWritableSignal,
 } from './render3/reactivity/signal';
 export {linkedSignal} from './render3/reactivity/linked_signal';

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -51,6 +51,24 @@ export function ɵunwrapWritableSignal<T>(value: T | {[ɵWRITABLE_SIGNAL]: T}): 
 }
 
 /**
+ * Utility used during template type-checking for two-way bindings.
+ *
+ * Overloads are used to differentiate writable and readonly signals:
+ * - `WritableSignal<T>` remains writable.
+ * - `Signal<T>` (readonly) resolves to `WritableSignal<T>`, producing a type error
+ *   when assigned back to the original expression.
+ * - Any other type `T` is returned unchanged.
+ *
+ * @codeGenApi
+ */
+export function ɵassertWritableTwoWayBinding<T>(value: WritableSignal<T>): WritableSignal<T>;
+export function ɵassertWritableTwoWayBinding<T>(value: Signal<T>): WritableSignal<T>;
+export function ɵassertWritableTwoWayBinding<T>(value: T): T;
+export function ɵassertWritableTwoWayBinding(value: unknown): unknown {
+  return null!;
+}
+
+/**
  * Options passed to the `signal` creation function.
  */
 export interface CreateSignalOptions<T> {

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -40,6 +40,7 @@ const AOT_ONLY = new Set<string>([
   'ɵINPUT_SIGNAL_BRAND_WRITE_TYPE',
   'ɵUnwrapDirectiveSignalInputs',
   'ɵunwrapWritableSignal',
+  'ɵassertWritableTwoWayBinding',
   'ɵassertType',
 ]);
 


### PR DESCRIPTION
Adds a diagnostic error when a read-only signal is used in a two-way binding.

Fixes #67188


## What is the current behavior?
```ts
@Directive({
  selector: '[anyModel]',
})
export class AnyModel {
  // The 'any' or 'unknown' type here suppresses the check for WritableSignal requirements
  anyModel = model.required<unknown>();
}

@Component({
  selector: 'app-root',
  imports: [FormsModule,  AnyModel],
  template: `
    <input [(ngModel)]="value" name="ngModel" /> 
    <input [(anyModel)]="value" name="anyModel" />
   <!-- or --!>
     @let letRefComputed = computedValue; // Similar for Signal , InputSignal 
    <input [(anyModel)]="letRefComputed" name="anyModel" />
  `,
})
export class Main {
  value = signal(1).asReadonly();
  computedValue= computed(()=> value() + 1 )
}

```

## What is the new behavior?

Now throw exception like 

```
 Argument of type 'Signal<number>' is not assignable to parameter of type 'WritableSignal<number>'
```


 