### PR TITLE
fix(docs-infra): use shared heading ID generation logic

### DIFF
--- a/adev/scripts/routes/BUILD.bazel
+++ b/adev/scripts/routes/BUILD.bazel
@@ -29,6 +29,7 @@ ts_project(
     deps = [
         "//adev:node_modules/@angular/docs",
         "//adev:node_modules/@types/node",
+        "//adev/shared-docs/pipeline/shared:heading",
         "//adev/src/app/routing/navigation-entries",
         "//adev/src/content/reference/errors:route-nav-items",
         "//adev/src/content/reference/extended-diagnostics:route-nav-items",

--- a/adev/scripts/routes/generate-routes.mts
+++ b/adev/scripts/routes/generate-routes.mts
@@ -7,6 +7,7 @@
  */
 
 import {ALL_ITEMS} from '../../src/app/routing/navigation-entries/index.js';
+import {getIdFromHeading} from '../../shared-docs/pipeline/shared/heading.mjs';
 import {NavigationItem} from '@angular/docs';
 import {writeFileSync, readFileSync} from 'fs';
 import {join, resolve} from 'path';
@@ -72,11 +73,3 @@ function main() {
 }
 
 main();
-
-// TODO: refactor so this function is shared with the generation pipeline (adev/shared-docs/pipeline/shared/marked/transformations/heading.mts)
-function getIdFromHeading(heading: string): string {
-  return heading
-    .toLowerCase()
-    .replace(/\s|\//g, '-') // replace spaces and slashes with dashes
-    .replace(/[^\p{L}\d\-]/gu, ''); // only keep letters, digits & dashes
-}

--- a/adev/shared-docs/pipeline/shared/BUILD.bazel
+++ b/adev/shared-docs/pipeline/shared/BUILD.bazel
@@ -11,6 +11,15 @@ ts_project(
 )
 
 ts_project(
+    name = "heading",
+    srcs = ["heading.mts"],
+    visibility = [
+        "//adev/scripts/routes:__subpackages__",
+        "//adev/shared-docs/pipeline:__subpackages__",
+    ],
+)
+
+ts_project(
     name = "shiki",
     srcs = ["shiki.mts"],
     visibility = [
@@ -35,4 +44,18 @@ ts_project(
 zoneless_jasmine_test(
     name = "linking_test",
     data = [":linking_test_lib"],
+)
+
+ts_project(
+    name = "heading_test_lib",
+    testonly = True,
+    srcs = ["test/heading.spec.mts"],
+    deps = [
+        ":heading",
+    ],
+)
+
+zoneless_jasmine_test(
+    name = "heading_test",
+    data = [":heading_test_lib"],
 )

--- a/adev/shared-docs/pipeline/shared/heading.mts
+++ b/adev/shared-docs/pipeline/shared/heading.mts
@@ -1,0 +1,29 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Extracts the ID from a heading text.
+ * Supports custom ID syntax: `## My Heading {#custom-id}`
+ */
+export function getIdFromHeading(heading: string): string {
+  // extract the extended markdown heading id
+  // ex:  ## MyHeading {# myId}
+  // This is recommended in case we end up having duplicate Ids but we still want the same heading text.
+  // We don't want to make Id generation stateful/too complex to handle duplicates automatically.
+  const customIdRegex = /{#\s*([\w-]+)\s*}/g;
+  const customId = customIdRegex.exec(heading)?.[1];
+
+  if (customId) {
+    return customId;
+  }
+
+  return heading
+    .toLowerCase()
+    .replace(/\s|\//g, '-') // replace spaces and slashes with dashes
+    .replace(/[^\p{L}\d\-]/gu, ''); // only keep letters, digits & dashes
+}

--- a/adev/shared-docs/pipeline/shared/marked/BUILD.bazel
+++ b/adev/shared-docs/pipeline/shared/marked/BUILD.bazel
@@ -18,6 +18,7 @@ ts_project(
         "//adev:node_modules/mermaid",
         "//adev:node_modules/playwright-core",
         "//adev:node_modules/shiki",
+        "//adev/shared-docs/pipeline/shared:heading",
         "//adev/shared-docs/pipeline/shared:linking",
         "//adev/shared-docs/pipeline/shared:shiki",
         "//adev/shared-docs/pipeline/shared/regions",

--- a/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
@@ -8,6 +8,7 @@
 
 import {Tokens} from 'marked';
 import {AdevDocsRenderer} from '../renderer.mjs';
+import {getIdFromHeading} from '../../heading.mjs';
 
 export function headingRender(
   this: AdevDocsRenderer,
@@ -25,14 +26,7 @@ export function headingRender(
     `;
   }
 
-  // extract the extended markdown heading id
-  // ex:  ## MyHeading {# myId}
-  // This is recommended in case we end up having duplicate Ids but we still want the same heading text.
-  // We don't want to make Id generation stateful/too complex to handle duplicates automatically.
-  const customIdRegex = /{#\s*([\w-]+)\s*}/g;
-  const customId = customIdRegex.exec(headingText)?.[1];
-
-  const link = customId ?? getIdFromHeading(headingText);
+  const link = getIdFromHeading(headingText);
 
   // Replace code backticks and remove custom ID syntax from the displayed label
   let label = parsedText.replace(/`(.*?)`/g, '<code>$1</code>');
@@ -66,11 +60,4 @@ export function getPageTitle(text: string, filePath?: string): string {
         : ''
     }
   </div>`;
-}
-
-function getIdFromHeading(heading: string): string {
-  return heading
-    .toLowerCase()
-    .replace(/\s|\//g, '-') // replace spaces and slashes with dashes
-    .replace(/[^\p{L}\d\-]/gu, ''); // only keep letters, digits & dashes
 }

--- a/adev/shared-docs/pipeline/shared/test/heading.spec.mts
+++ b/adev/shared-docs/pipeline/shared/test/heading.spec.mts
@@ -1,0 +1,31 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getIdFromHeading} from '../heading.mjs';
+
+describe('getIdFromHeading', () => {
+  it('should generate id from simple text', () => {
+    expect(getIdFromHeading('My Heading')).toBe('my-heading');
+  });
+
+  it('should generate id from text with special characters', () => {
+    expect(getIdFromHeading('Step 2 - Add component')).toBe('step-2---add-component');
+  });
+
+  it('should extract custom id when present', () => {
+    expect(getIdFromHeading('My Heading {#custom-id}')).toBe('custom-id');
+  });
+
+  it('should extract custom id ignoring surrounding spaces', () => {
+    expect(getIdFromHeading('My Heading {#  custom-id  }')).toBe('custom-id');
+  });
+
+  it('should prioritize custom id over text content', () => {
+    expect(getIdFromHeading('Duplicate Heading {#unique-id}')).toBe('unique-id');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The route generation script (`generate-routes.mts`) ignores custom heading IDs (`{#id}`) and generates routes based on the heading text only. This is inconsistent with the markdown pipeline (`heading.mts`), which respects custom IDs.

Issue Number: #67200

## What is the new behavior?

The logic for generating heading IDs has been extracted into a shared utility (`adev/shared-docs/pipeline/shared/heading.mts`). Both `generate-routes.mts` and `heading.mts` now use this shared logic, ensuring consistent behavior. Custom IDs are now correctly respected in generated routes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
