### PR TITLE
refactor(router): expose `ROUTES` token as `ReadonlyArray`

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -971,7 +971,7 @@ export class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
 }
 
 // @public
-export const ROUTES: InjectionToken<Route[][]>;
+export const ROUTES: InjectionToken<readonly Route[][]>;
 
 // @public
 export type Routes = Route[];

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -14,15 +14,15 @@ import {
   InjectionToken,
   Injector,
   NgModuleFactory,
+  ɵresolveComponentResources as resolveComponentResources,
   runInInjectionContext,
   Type,
-  ɵresolveComponentResources as resolveComponentResources,
 } from '@angular/core';
 
-import {DefaultExport, LoadedRouterConfig, Route, Routes} from './models';
-import {assertStandalone, validateConfig} from './utils/config';
 import {standardizeConfig} from './components/empty_outlet';
+import {DefaultExport, LoadedRouterConfig, Route, Routes} from './models';
 import {wrapIntoPromise} from './utils/collection';
+import {assertStandalone, validateConfig} from './utils/config';
 
 /**
  * The DI token for a router configuration.
@@ -34,7 +34,7 @@ import {wrapIntoPromise} from './utils/collection';
  *
  * @publicApi
  */
-export const ROUTES = new InjectionToken<Route[][]>(
+export const ROUTES = new InjectionToken<ReadonlyArray<Route[]>>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'ROUTES' : '',
 );
 


### PR DESCRIPTION
This is to satisfy linting rules that would expect a ReadonlyArray when `multi: true`.
