### PR TITLE
refactor(core): remove outdated TODO comments

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -114,7 +114,6 @@ export const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
 const COMPUTED_NODE = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -123,7 +123,6 @@ export function linkedSignalUpdateFn<S, D>(
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `LINKED_SIGNAL_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
 export const LINKED_SIGNAL_NODE: object = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,

--- a/packages/core/primitives/signals/src/signal.ts
+++ b/packages/core/primitives/signals/src/signal.ts
@@ -108,7 +108,6 @@ export function runPostSignalSetFn<T>(node: SignalNode<T>): void {
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
 export const SIGNAL_NODE: SignalNode<unknown> = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -140,7 +140,6 @@ const NOOP_CLEANUP_FN: WatchCleanupFn = () => {};
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
 const WATCH_NODE: Partial<WatchNode> = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,

--- a/packages/core/src/authoring/input/input_signal_node.ts
+++ b/packages/core/src/authoring/input/input_signal_node.ts
@@ -39,7 +39,6 @@ export interface InputSignalNode<T, TransformT> extends SignalNode<T> {
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-// TODO: remove when https://github.com/evanw/esbuild/issues/3392 is resolved.
 export const INPUT_SIGNAL_NODE: InputSignalNode<unknown, unknown> = /* @__PURE__ */ (() => {
   return {
     ...SIGNAL_NODE,


### PR DESCRIPTION
Cleans up TODO comments that are no longer planned

Fixes #67191
