### PR TITLE
docs: remove inconsistent padding in update page

### DIFF
--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -46,8 +46,6 @@ h4 {
 }
 
 .wizard {
-  padding-inline: 1rem;
-
   .show-button {
     display: block;
     margin-block-start: 2rem;
@@ -163,9 +161,15 @@ h4 {
     }
   }
 
-  .adev-complexity-1 { --badge-color: var(--super-green); }
-  .adev-complexity-2 { --badge-color: var(--bright-blue); }
-  .adev-complexity-3 { --badge-color: var(--symbolic-orange); }
+  .adev-complexity-1 {
+    --badge-color: var(--super-green);
+  }
+  .adev-complexity-2 {
+    --badge-color: var(--bright-blue);
+  }
+  .adev-complexity-3 {
+    --badge-color: var(--symbolic-orange);
+  }
 
   // Code blocks are generable from the markdown, we need to opt-out of the scoping
   ::ng-deep code {


### PR DESCRIPTION
Removes extra padding applied to the update page so its layout matches the rest of the documentation where no padding exists between the title and content.

## What is the current behavior?
<img width="1484" height="775" alt="image" src="https://github.com/user-attachments/assets/48ca9db2-8508-44f7-bf39-9d113c33a2aa" />


## What is the new behavior?
<img width="1484" height="775" alt="image" src="https://github.com/user-attachments/assets/739ca7b5-b2a8-44a0-a9cf-e416c37b83da" />
