### PR TITLE
feat(language-service): add control flow blocks to navigation tree for sticky scroll

### DIFF
--- a/packages/compiler-cli/src/ngtsc/perf/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/perf/src/api.ts
@@ -190,6 +190,11 @@ export enum PerfPhase {
   LSSemanticClassification,
 
   /**
+   * Time spent by the Angular Language Service calculating navigation tree items.
+   */
+  LsNavigationTree,
+
+  /**
    * Tracks the number of `PerfPhase`s, and must appear at the end of the list.
    */
   LAST,

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -37,6 +37,7 @@ import {CompilerFactory} from './compiler_factory';
 import {CompletionBuilder} from './completions';
 import {DefinitionBuilder} from './definitions';
 import {getLinkedEditingRangeAtPosition} from './linked_editing_range';
+import {getNavigationTree} from './navigation_tree';
 import {getOutliningSpans} from './outlining_spans';
 import {QuickInfoBuilder} from './quick_info';
 import {ReferencesBuilder, RenameBuilder} from './references_and_rename';
@@ -488,6 +489,12 @@ export class LanguageService {
   getOutliningSpans(fileName: string): ts.OutliningSpan[] {
     return this.withCompilerAndPerfTracing(PerfPhase.OutliningSpans, (compiler) => {
       return getOutliningSpans(compiler, fileName);
+    });
+  }
+
+  getNavigationTree(fileName: string, tsNavigationTree: ts.NavigationTree): ts.NavigationTree {
+    return this.withCompilerAndPerfTracing(PerfPhase.LsNavigationTree, (compiler) => {
+      return getNavigationTree(compiler, tsNavigationTree, fileName);
     });
   }
 

--- a/packages/language-service/src/navigation_tree.ts
+++ b/packages/language-service/src/navigation_tree.ts
@@ -1,0 +1,241 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  TmplAstDeferredBlock,
+  TmplAstElement,
+  TmplAstForLoopBlock,
+  TmplAstIfBlock,
+  TmplAstNode,
+  TmplAstRecursiveVisitor,
+  TmplAstSwitchBlock,
+  TmplAstTemplate,
+  tmplAstVisitAll,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import ts from 'typescript';
+
+import {getFirstComponentForTemplateFile, isTypeScriptFile, toTextSpan} from './utils';
+
+/**
+ * Augments the navigation tree provided by the TypeScript language service with
+ * Angular template control flow blocks (`@if`, `@for`, `@switch`, `@defer`) and
+ * HTML elements. This enables VS Code features like Sticky Scroll and the
+ * document outline to display Angular-specific template structures.
+ */
+export function getNavigationTree(
+  compiler: NgCompiler,
+  tsNavigationTree: ts.NavigationTree,
+  fileName: string,
+): ts.NavigationTree {
+  if (isTypeScriptFile(fileName)) {
+    const sf = compiler.getCurrentProgram().getSourceFile(fileName);
+    if (sf === undefined) {
+      return tsNavigationTree;
+    }
+
+    // Find inline templates and inject navigation items into the TS tree.
+    for (const stmt of sf.statements) {
+      if (!isNamedClassDeclaration(stmt)) {
+        continue;
+      }
+      const resources = compiler.getDirectiveResources(stmt);
+      if (
+        resources === null ||
+        resources.template === null ||
+        isExternalResource(resources.template)
+      ) {
+        continue;
+      }
+      const template = compiler.getTemplateTypeChecker().getTemplate(stmt);
+      if (template === null) {
+        continue;
+      }
+
+      const templateChildren = buildNavigationTreeForTemplate(template);
+      if (templateChildren.length > 0) {
+        injectChildrenIntoTree(tsNavigationTree, templateChildren, stmt.name!);
+      }
+    }
+
+    return tsNavigationTree;
+  } else {
+    // External template file: build a standalone navigation tree.
+    const typeCheckInfo = getFirstComponentForTemplateFile(fileName, compiler);
+    if (typeCheckInfo === undefined) {
+      return tsNavigationTree;
+    }
+    const children = buildNavigationTreeForTemplate(typeCheckInfo.nodes);
+    if (children.length === 0) {
+      return tsNavigationTree;
+    }
+    return {
+      text: '<template>',
+      kind: ts.ScriptElementKind.unknown,
+      kindModifiers: '',
+      spans: [ts.createTextSpanFromBounds(0, 0)],
+      nameSpan: undefined,
+      childItems: children,
+    };
+  }
+}
+
+/**
+ * Injects Angular template navigation children into the appropriate location
+ * in the existing TypeScript navigation tree. We find the class node matching
+ * the component declaration and add the template children as nested items.
+ */
+function injectChildrenIntoTree(
+  tree: ts.NavigationTree,
+  templateChildren: ts.NavigationTree[],
+  className: ts.Identifier,
+): void {
+  if (tree.childItems) {
+    for (const child of tree.childItems) {
+      if (child.text === className.text && child.kind === ts.ScriptElementKind.classElement) {
+        // Find or create the `template` property node
+        child.childItems = [...(child.childItems ?? []), ...templateChildren];
+        return;
+      }
+      injectChildrenIntoTree(child, templateChildren, className);
+    }
+  }
+}
+
+function buildNavigationTreeForTemplate(nodes: TmplAstNode[]): ts.NavigationTree[] {
+  const visitor = new NavigationTreeVisitor();
+  tmplAstVisitAll(visitor, nodes);
+  return visitor.items;
+}
+
+class NavigationTreeVisitor extends TmplAstRecursiveVisitor {
+  readonly items: ts.NavigationTree[] = [];
+
+  override visitElement(element: TmplAstElement): void {
+    const children = buildNavigationTreeForTemplate(element.children);
+    const item: ts.NavigationTree = {
+      text: `<${element.name}>`,
+      kind: ts.ScriptElementKind.jsxAttribute,
+      kindModifiers: '',
+      spans: [toTextSpan(element.sourceSpan)],
+      nameSpan: toTextSpan(element.startSourceSpan),
+      childItems: children.length > 0 ? children : undefined,
+    };
+    this.items.push(item);
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    const tagName = template.tagName ?? 'ng-template';
+    const children = buildNavigationTreeForTemplate(template.children);
+    const item: ts.NavigationTree = {
+      text: `<${tagName}>`,
+      kind: ts.ScriptElementKind.jsxAttribute,
+      kindModifiers: '',
+      spans: [toTextSpan(template.sourceSpan)],
+      nameSpan: toTextSpan(template.startSourceSpan),
+      childItems: children.length > 0 ? children : undefined,
+    };
+    this.items.push(item);
+  }
+
+  override visitIfBlock(block: TmplAstIfBlock): void {
+    const branchItems: ts.NavigationTree[] = [];
+    for (const branch of block.branches) {
+      const label = branch.expression ? '@if' : '@else';
+      const children = buildNavigationTreeForTemplate(branch.children);
+      branchItems.push({
+        text: label,
+        kind: ts.ScriptElementKind.label,
+        kindModifiers: '',
+        spans: [toTextSpan(branch.sourceSpan)],
+        nameSpan: toTextSpan(branch.startSourceSpan),
+        childItems: children.length > 0 ? children : undefined,
+      });
+    }
+
+    const item: ts.NavigationTree = {
+      text: '@if',
+      kind: ts.ScriptElementKind.label,
+      kindModifiers: '',
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+      childItems: branchItems.length > 0 ? branchItems : undefined,
+    };
+    this.items.push(item);
+  }
+
+  override visitForLoopBlock(block: TmplAstForLoopBlock): void {
+    const children = buildNavigationTreeForTemplate(block.children);
+    const childItems: ts.NavigationTree[] = children;
+
+    if (block.empty) {
+      const emptyChildren = buildNavigationTreeForTemplate(block.empty.children);
+      childItems.push({
+        text: '@empty',
+        kind: ts.ScriptElementKind.label,
+        kindModifiers: '',
+        spans: [toTextSpan(block.empty.sourceSpan)],
+        nameSpan: toTextSpan(block.empty.startSourceSpan),
+        childItems: emptyChildren.length > 0 ? emptyChildren : undefined,
+      });
+    }
+
+    const item: ts.NavigationTree = {
+      text: '@for',
+      kind: ts.ScriptElementKind.label,
+      kindModifiers: '',
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+      childItems: childItems.length > 0 ? childItems : undefined,
+    };
+    this.items.push(item);
+  }
+
+  override visitSwitchBlock(block: TmplAstSwitchBlock): void {
+    const caseItems: ts.NavigationTree[] = [];
+    for (const group of block.groups) {
+      for (const caseNode of group.cases) {
+        const label = caseNode.expression ? '@case' : '@default';
+        const children = buildNavigationTreeForTemplate(group.children);
+        caseItems.push({
+          text: label,
+          kind: ts.ScriptElementKind.label,
+          kindModifiers: '',
+          spans: [toTextSpan(group.sourceSpan)],
+          nameSpan: toTextSpan(caseNode.startSourceSpan),
+          childItems: children.length > 0 ? children : undefined,
+        });
+      }
+    }
+
+    const item: ts.NavigationTree = {
+      text: '@switch',
+      kind: ts.ScriptElementKind.label,
+      kindModifiers: '',
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+      childItems: caseItems.length > 0 ? caseItems : undefined,
+    };
+    this.items.push(item);
+  }
+
+  override visitDeferredBlock(block: TmplAstDeferredBlock): void {
+    const children = buildNavigationTreeForTemplate(block.children);
+    const item: ts.NavigationTree = {
+      text: '@defer',
+      kind: ts.ScriptElementKind.label,
+      kindModifiers: '',
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+      childItems: children.length > 0 ? children : undefined,
+    };
+    this.items.push(item);
+  }
+}

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -220,6 +220,11 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     return withFallback(fileName, (ls) => ls.getOutliningSpans(fileName)) ?? [];
   }
 
+  function getNavigationTree(fileName: string): ts.NavigationTree {
+    const tsTree = tsLS.getNavigationTree(fileName);
+    return ngLS.getNavigationTree(fileName, tsTree);
+  }
+
   function getTcb(fileName: string, position: number): GetTcbResponse | undefined {
     return ngLS.getTcb(fileName, position);
   }
@@ -374,6 +379,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getComponentLocationsForTemplate,
     getSignatureHelpItems,
     getOutliningSpans,
+    getNavigationTree,
     getTemplateLocationForComponent,
     hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),
     getCodeFixesAtPosition,

--- a/packages/language-service/test/grp1/navigation_tree_spec.ts
+++ b/packages/language-service/test/grp1/navigation_tree_spec.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import ts from 'typescript';
+
+import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv} from '../../testing';
+
+describe('navigation tree', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it('should include @if block in the navigation tree for an inline template', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        @if (condition) {
+          <div>content</div>
+        }
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+        condition = true;
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const ifItem = findNavigationItem(tree, '@if');
+    expect(ifItem).toBeDefined();
+  });
+
+  it('should include @for block in the navigation tree', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        @for (item of items; track $index) {
+          <span>{{ item }}</span>
+        } @empty {
+          <p>No items</p>
+        }
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+        items: string[] = [];
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const forItem = findNavigationItem(tree, '@for');
+    expect(forItem).toBeDefined();
+    const emptyItem = findNavigationItem(forItem!, '@empty');
+    expect(emptyItem).toBeDefined();
+  });
+
+  it('should include @switch block in the navigation tree', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        @switch (val) {
+          @case ('a') {
+            <span>A</span>
+          }
+          @default {
+            <span>default</span>
+          }
+        }
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+        val = 'a';
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const switchItem = findNavigationItem(tree, '@switch');
+    expect(switchItem).toBeDefined();
+    const caseItem = findNavigationItem(switchItem!, '@case');
+    expect(caseItem).toBeDefined();
+    const defaultItem = findNavigationItem(switchItem!, '@default');
+    expect(defaultItem).toBeDefined();
+  });
+
+  it('should include @defer block in the navigation tree', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        @defer {
+          <div>deferred content</div>
+        }
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const deferItem = findNavigationItem(tree, '@defer');
+    expect(deferItem).toBeDefined();
+  });
+
+  it('should include HTML elements in the navigation tree', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        <div>
+          <span>content</span>
+        </div>
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const divItem = findNavigationItem(tree, '<div>');
+    expect(divItem).toBeDefined();
+    const spanItem = findNavigationItem(divItem!, '<span>');
+    expect(spanItem).toBeDefined();
+  });
+
+  it('should include control flow blocks for an external template', () => {
+    const files = {
+      'app.ts': `
+        import {Component} from '@angular/core';
+
+        @Component({
+          templateUrl: './app.html',
+          standalone: false,
+        })
+        export class AppCmp {
+          condition = true;
+        }`,
+      'app.html': `
+        @if (condition) {
+          <div>content</div>
+        }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.html');
+    const tree = appFile.getNavigationTree();
+    const ifItem = findNavigationItem(tree, '@if');
+    expect(ifItem).toBeDefined();
+  });
+
+  it('should include nested control flow blocks', () => {
+    const files = {
+      'app.ts': `
+      import {Component} from '@angular/core';
+
+      @Component({
+        template: \`
+        @if (showList) {
+          @for (item of items; track $index) {
+            <div>{{ item }}</div>
+          }
+        }
+        \`,
+        standalone: false,
+      })
+      export class AppCmp {
+        showList = true;
+        items: string[] = [];
+      }`,
+    };
+    const env = LanguageServiceTestEnv.setup();
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    project.expectNoSourceDiagnostics();
+
+    const appFile = project.openFile('app.ts');
+    const tree = appFile.getNavigationTree();
+    const ifItem = findNavigationItem(tree, '@if');
+    expect(ifItem).toBeDefined();
+    const forItem = findNavigationItem(ifItem!, '@for');
+    expect(forItem).toBeDefined();
+  });
+});
+
+function findNavigationItem(tree: ts.NavigationTree, text: string): ts.NavigationTree | undefined {
+  if (tree.text === text) {
+    return tree;
+  }
+  if (tree.childItems) {
+    for (const child of tree.childItems) {
+      const found = findNavigationItem(child, text);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -113,6 +113,12 @@ export class OpenBuffer {
     return this.ngLS.getOutliningSpans(this.scriptInfo.fileName);
   }
 
+  getNavigationTree(): ts.NavigationTree {
+    const tsLS = this.project.getLanguageService();
+    const tsTree = tsLS.getNavigationTree(this.scriptInfo.fileName);
+    return this.ngLS.getNavigationTree(this.scriptInfo.fileName, tsTree);
+  }
+
   getTemplateLocationForComponent() {
     return this.ngLS.getTemplateLocationForComponent(this.scriptInfo.fileName, this._cursor);
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The Angular language service provides outlining spans (folding ranges) for control flow blocks (`@if`, `@for`, `@switch`, `@defer`), but does not provide navigation tree items for them. VS Code's **Sticky Scroll** feature uses the `outlineModel` (document outline / navigation tree), not folding ranges.

As a result, Angular's new control flow syntax is invisible to Sticky Scroll and the document symbol outline, making the feature significantly less useful for Angular developers.

Closes #65488

## What is the new behavior?

The language service now implements `getNavigationTree` which augments the TypeScript navigation tree with Angular template structures:

- **Control flow blocks**: `@if`/`@else`, `@for`/`@empty`, `@switch`/`@case`/`@default`, `@defer`
- **HTML elements** and `ng-template` directives
- **Nested hierarchical structure** matching the template DOM

For inline templates, the Angular navigation items are injected into the existing TypeScript navigation tree under the component class node. For external template files (`.html`), a standalone navigation tree is built from the template AST.

This enables VS Code's Sticky Scroll and Breadcrumbs to properly display Angular control flow blocks, making navigation in large templates much easier.

## Additional context

- The implementation follows the same architectural pattern as the existing `getOutliningSpans` feature: a visitor walks the template AST and produces TypeScript-compatible data structures.
- A new `PerfPhase.LsNavigationTree` enum value was added for performance tracing.
- Added `getNavigationTree` method to `OpenBuffer` test helper for testing convenience.
- 7 test cases cover: `@if`, `@for` with `@empty`, `@switch` with `@case`/`@default`, `@defer`, HTML elements, external templates, and nested control flow.