### PR TITLE
docs: inline documentation and remove unused references

### DIFF
--- a/adev/src/content/examples/built-in-directives/src/app/app.component.ts
+++ b/adev/src/content/examples/built-in-directives/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {JsonPipe} from '@angular/common';
+import {JsonPipe, NgClass, NgStyle} from '@angular/common';
 // #docregion import-ng-if
 import {NgIf} from '@angular/common';
 // #enddocregion import-ng-if
@@ -9,12 +9,6 @@ import {NgFor} from '@angular/common';
 // #docregion import-ng-switch
 import {NgSwitch, NgSwitchCase, NgSwitchDefault} from '@angular/common';
 // #enddocregion import-ng-switch
-// #docregion import-ng-style
-import {NgStyle} from '@angular/common';
-// #enddocregion import-ng-style
-// #docregion import-ng-class
-import {NgClass} from '@angular/common';
-// #enddocregion import-ng-class
 // #docregion import-forms-module
 import {FormsModule} from '@angular/forms';
 // #enddocregion import-forms-module
@@ -23,31 +17,27 @@ import {ItemDetailComponent} from './item-detail/item-detail.component';
 import {ItemSwitchComponents} from './item-switch.component';
 import {StoutItemComponent} from './item-switch.component';
 
-// #docregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
+// #docregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module
 @Component({
-  // #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
+  // #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 
   imports: [
+    NgClass,
+    NgStyle,
     // #docregion import-ng-if
     NgIf, // <-- import into the component
     // #enddocregion import-ng-if
     // #docregion import-ng-for
     NgFor, // <-- import into the component
     // #enddocregion import-ng-for
-    // #docregion import-ng-style
-    NgStyle, // <-- import into the component
-    // #enddocregion import-ng-style
     // #docregion import-ng-switch
     NgSwitch, // <-- import into the component
     NgSwitchCase,
     NgSwitchDefault,
     // #enddocregion import-ng-switch
-    // #docregion import-ng-class
-    NgClass, // <-- import into the component
-    // #enddocregion import-ng-class
     // #docregion import-forms-module
     FormsModule, // <--- import into the component
     // #enddocregion import-forms-module
@@ -55,11 +45,11 @@ import {StoutItemComponent} from './item-switch.component';
     ItemDetailComponent,
     ItemSwitchComponents,
     StoutItemComponent,
-    // #docregion import-ng-if, import-ng-for, import-ng-style, import-ng-switch, import-ng-class, import-forms-module
+    // #docregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module
   ],
 })
 export class AppComponent implements OnInit {
-  // #enddocregion import-ng-if, import-ng-for, import-ng-style, import-ng-switch, import-ng-class, import-forms-module
+  // #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module
   canSave = true;
   isSpecial = true;
   isUnchanged = true;
@@ -170,6 +160,6 @@ export class AppComponent implements OnInit {
   getValue(event: Event): string {
     return (event.target as HTMLInputElement).value;
   }
-  // #docregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
+  // #docregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module
 }
-// #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-ng-style, import-ng-class, import-forms-module
+// #enddocregion import-ng-if, import-ng-for, import-ng-switch, import-forms-module

--- a/adev/src/content/guide/directives/overview.md
+++ b/adev/src/content/guide/directives/overview.md
@@ -38,7 +38,15 @@ HELPFUL: To add or remove a _single_ class, use [class binding](/guide/templates
 
 To use `NgClass`, add it to the component's `imports` list.
 
-<docs-code header="app.component.ts (NgClass import)" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" region="import-ng-class"/>
+```angular-ts
+import {NgClass} from '@angular/common';
+
+@Component({
+  /* ... */
+  imports: [NgClass],
+})
+export class AppComponent {}
+```
 
 ### Using `NgClass` with an expression
 
@@ -61,7 +69,7 @@ Because `isSpecial` is true, `ngClass` applies the class of `special` to the `<d
 
 1. In the template, add the `ngClass` property binding to `currentClasses` to set the element's classes:
 
-<docs-code header="app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" region="NgClass-1"/>
+   <docs-code header="app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" region="NgClass-1"/>
 
 For this use case, Angular applies the classes on initialization and in case of changes caused by reassigning the `currentClasses` object.
 The full example calls `setCurrentClasses()` initially with `ngOnInit()` when the user clicks on the `Refresh currentClasses` button.
@@ -75,7 +83,15 @@ HELPFUL: To add or remove a _single_ style, use [style bindings](guide/templates
 
 To use `NgStyle`, add it to the component's `imports` list.
 
-<docs-code header="app.component.ts (NgStyle import)" path="adev/src/content/examples/built-in-directives/src/app/app.component.ts" region="import-ng-style"/>
+```angular-ts
+import {NgStyle} from '@angular/common';
+
+@Component({
+  /* ... */
+  imports: [NgStyle],
+})
+export class AppComponent {}
+```
 
 Use `NgStyle` to set multiple inline styles simultaneously, based on the state of the component.
 
@@ -87,7 +103,7 @@ Use `NgStyle` to set multiple inline styles simultaneously, based on the state o
 
 1. To set the element's styles, add an `ngStyle` property binding to `currentStyles`.
 
-<docs-code header="app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" region="NgStyle-2"/>
+   <docs-code header="app.component.html" path="adev/src/content/examples/built-in-directives/src/app/app.component.html" region="NgStyle-2"/>
 
 For this use case, Angular applies the styles upon initialization and in case of changes.
 To do this, the full example calls `setCurrentStyles()` initially with `ngOnInit()` and when the dependent properties change through a button click.


### PR DESCRIPTION
Replaces referenced doc blocks with inline documentation, cleans up unused referenced code, and fixes broken list formatting

## What is the current behavior?
Too messy
<img width="1600" height="860" alt="image" src="https://github.com/user-attachments/assets/097e6e8e-26f3-4e13-a1ba-532ac9a0065e" />

Breaks list
<img width="1656" height="466" alt="image" src="https://github.com/user-attachments/assets/1cf8f2ce-f5cf-4bd7-8ec8-cba222455a15" />


## What is the new behavior?
<img width="1700" height="474" alt="image" src="https://github.com/user-attachments/assets/a23f2045-542d-43f1-be6d-b43beabe0e36" />
<img width="1720" height="378" alt="image" src="https://github.com/user-attachments/assets/589d7963-9926-4dee-a5ad-66b51b6fa6e3" />
