### PR TITLE
fix(core): improve error message for binding-like attributes in ICU expressions

### DIFF
--- a/packages/core/test/render3/i18n/i18n_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_spec.ts
@@ -15,6 +15,7 @@ import {
   icuContainerIteratorNext,
   IcuIteratorState,
 } from '../../../src/render3/i18n/i18n_icu_container_visitor';
+import {assertValidIcuAttribute} from '../../../src/render3/i18n/i18n_apply';
 import {getTIcu} from '../../../src/render3/i18n/i18n_util';
 import {TNodeType} from '../../../src/render3/interfaces/node';
 
@@ -999,6 +1000,34 @@ describe('Runtime i18n', () => {
           insertBeforeIndex: HEADER_OFFSET + 31,
         }),
       );
+    });
+  });
+
+  describe('assertValidIcuAttribute', () => {
+    it('should throw for binding-like attribute names', () => {
+      expect(() => assertValidIcuAttribute('[dir]')).toThrowError(
+        /ICU expressions cannot contain bindings or structural directives/,
+      );
+      expect(() => assertValidIcuAttribute('(click)')).toThrowError(
+        /ICU expressions cannot contain bindings or structural directives/,
+      );
+      expect(() => assertValidIcuAttribute('*ngIf')).toThrowError(
+        /ICU expressions cannot contain bindings or structural directives/,
+      );
+      expect(() => assertValidIcuAttribute('#ref')).toThrowError(
+        /ICU expressions cannot contain bindings or structural directives/,
+      );
+      expect(() => assertValidIcuAttribute('@trigger')).toThrowError(
+        /ICU expressions cannot contain bindings or structural directives/,
+      );
+    });
+
+    it('should not throw for valid static attribute names', () => {
+      expect(() => assertValidIcuAttribute('class')).not.toThrow();
+      expect(() => assertValidIcuAttribute('title')).not.toThrow();
+      expect(() => assertValidIcuAttribute('id')).not.toThrow();
+      expect(() => assertValidIcuAttribute('data-value')).not.toThrow();
+      expect(() => assertValidIcuAttribute('aria-label')).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (improved error message / developer experience)

## What is the current behavior?

When a binding-like attribute (e.g. `[dir]`, `(click)`, `*ngIf`) is used on an element inside an ICU expression, the DOM's `setAttribute` call throws a cryptic `InvalidCharacterError`:

```
InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '[custom-directive]' is not a valid attribute name.
```

This error gives no indication that the real problem is using Angular-specific syntax inside an ICU expression where only static HTML attributes are supported.

Closes #37298

## What is the new behavior?

In development mode (`ngDevMode`), Angular now detects binding-like attribute names before they reach the DOM API and throws a descriptive error:

```
NG0700: ICU expressions cannot contain bindings or structural directives. The attribute "[dir]" on an element inside an ICU expression is not supported. Only static attributes are allowed inside ICU cases.
```

The check catches attributes that start with `[`, `(`, `*`, `#`, or `@`, which are all Angular-specific syntaxes that are not valid inside ICU expressions.

If the attribute name is valid (plain HTML attribute), behavior is unchanged.

## Additional context

The fix adds an `assertValidIcuAttribute` function in `packages/core/src/render3/i18n/i18n_apply.ts` and calls it (guarded by `ngDevMode`) at both code paths that set attributes in ICU context:

1. `applyMutableOpCodes` - when ICU cases are created (static attributes)
2. `applyUpdateOpCodes` - when ICU expressions are updated (dynamic attribute values in ICU context)

This follows the guidance from @AndrewKushnir in the issue: add a `ngDevMode` check that detects binding-like attribute names and throws a descriptive error.

Unit tests are included in `packages/core/test/render3/i18n/i18n_spec.ts`.