### PR TITLE
fix(language-service): honor existing quote style for generated imports

### DIFF
--- a/packages/language-service/test/grp1/code_fixes_spec.ts
+++ b/packages/language-service/test/grp1/code_fixes_spec.ts
@@ -600,7 +600,7 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooComponent`, [
-        [``, `import { BarComponent } from "./bar";`],
+        [``, `import { BarComponent } from './bar';`],
         [``, `, imports: [BarComponent]`],
       ]);
     });
@@ -642,7 +642,7 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarModule from './bar' on FooComponent`, [
-        [``, `import { BarModule } from "./bar";`],
+        [``, `import { BarModule } from './bar';`],
         [``, `, imports: [BarModule]`],
       ]);
     });
@@ -684,7 +684,7 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooModule`, [
-        [``, `import { BarComponent } from "./bar";`],
+        [``, `import { BarComponent } from './bar';`],
         [`imports: []`, `imports: [BarComponent]`],
       ]);
     });
@@ -723,7 +723,7 @@ describe('code fixes', () => {
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
 
       actionChangesMatch(actionChanges, `Import BarPipe from './bar' on FooComponent`, [
-        [``, `import { BarPipe } from "./bar";`],
+        [``, `import { BarPipe } from './bar';`],
         ['', `, imports: [BarPipe]`],
       ]);
     });
@@ -770,11 +770,11 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarModule from './bar' on FooComponent`, [
-        [``, `import { BarModule } from "./bar";`],
+        [``, `import { BarModule } from './bar';`],
         [``, `, imports: [BarModule]`],
       ]);
       actionChangesMatch(actionChanges, `Import Bar2Module from './bar' on FooComponent`, [
-        [``, `import { Bar2Module } from "./bar";`],
+        [``, `import { Bar2Module } from './bar';`],
         [``, `, imports: [Bar2Module]`],
       ]);
     });
@@ -810,7 +810,7 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooComponent`, [
-        [``, `import BarComponent from "./bar";`],
+        [``, `import BarComponent from './bar';`],
         [``, `, imports: [BarComponent]`],
       ]);
     });
@@ -950,7 +950,7 @@ describe('code fixes', () => {
       ]);
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import MatCard from '@angular/common' on FooComponent`, [
-        [``, `import { MatCard } from "@angular/common";`],
+        [``, `import { MatCard } from '@angular/common';`],
         [``, `, imports: [MatCard]`],
       ]);
     });
@@ -990,7 +990,7 @@ describe('code fixes', () => {
       );
       const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
       actionChangesMatch(actionChanges, `Import BarComponent from '@app/bar' on FooComponent`, [
-        [``, `import { BarComponent } from "@app/bar";`],
+        [``, `import { BarComponent } from '@app/bar';`],
         [``, `, imports: [BarComponent]`],
       ]);
     });
@@ -1043,7 +1043,7 @@ describe('code fixes', () => {
         actionChanges,
         `Import NewBarComponent3 from '@app/index' on FooComponent`,
         [
-          [``, `import { NewBarComponent3 } from "@app/index";`],
+          [``, `import { NewBarComponent3 } from '@app/index';`],
           [``, `, imports: [NewBarComponent3]`],
         ],
       );


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When using the Angular Language Service quick fix to import a missing component/directive/pipe, the generated import statement always uses double quotes for the module specifier, regardless of the existing code style in the file.

For example, in a file that consistently uses single quotes:
```typescript
import {Component} from '@angular/core';
```
The quick fix generates:
```typescript
import {BarComponent} from "./bar";  // double quotes
```

Closes #67108

## What is the new behavior?
The generated import now matches the predominant quote style of existing imports in the file:
```typescript
import {BarComponent} from './bar';  // single quotes, matching existing style
```

A new `detectImportQuoteStyle` helper inspects all existing `import` declarations in the source file and uses a majority vote to determine whether to use single or double quotes. When no imports exist or the count is equal, it defaults to double quotes (preserving backward compatibility).

## Additional context
The fix modifies `generateImport` in `ts_utils.ts` to accept an `isSingleQuote` parameter, and `updateImportsForTypescriptFile` now detects the quote style from existing imports before generating a new import declaration. The `ts.factory.createStringLiteral` API already supports a `isSingleQuote` parameter.

Tests added:
- Unit tests for `detectImportQuoteStyle` (single, double, empty, mixed)
- Unit test for `generateImport` with single quote option
- Updated existing code fix tests to reflect correct quote-matching behavior