### PR TITLE
fix(compiler): parse named HTML entities containing digits

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1431,7 +1431,12 @@ function isDigitEntityEnd(code: number): boolean {
 }
 
 function isNamedEntityEnd(code: number): boolean {
-  return code === chars.$SEMICOLON || code === chars.$EOF || !chars.isAsciiLetter(code);
+  // Named entities may contain digits (e.g. &sup1;, &frac12;, &blk34;).
+  return (
+    code === chars.$SEMICOLON ||
+    code === chars.$EOF ||
+    !(chars.isAsciiLetter(code) || chars.isDigit(code))
+  );
 }
 
 function isExpansionCaseStart(peek: number): boolean {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -68,6 +68,17 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should parse named HTML entities containing digits', () => {
+        expect(humanizeDom(parser.parse('<div>&sup1;</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, '\u00B9', 1, [''], ['\u00B9', '&sup1;'], ['']],
+        ]);
+        expect(humanizeDom(parser.parse('<div>&frac12;</div>', 'TestComp'))).toEqual([
+          [html.Element, 'div', 0],
+          [html.Text, '\u00BD', 1, [''], ['\u00BD', '&frac12;'], ['']],
+        ]);
+      });
+
       it('should normalize line endings within CDATA', () => {
         const parsed = parser.parse('<![CDATA[ line 1 \r\n line 2 ]]>', 'TestComp');
         expect(humanizeDom(parsed)).toEqual([

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -2094,6 +2094,27 @@ describe('HtmlLexer', () => {
       ]);
     });
 
+    it('should parse named entities containing digits', () => {
+      expect(tokenizeAndHumanizeParts('&sup1;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '\u00B9', '&sup1;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('&frac12;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '\u00BD', '&frac12;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+      expect(tokenizeAndHumanizeParts('&blk34;')).toEqual([
+        [TokenType.TEXT, ''],
+        [TokenType.ENCODED_ENTITY, '\u2593', '&blk34;'],
+        [TokenType.TEXT, ''],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse hexadecimal entities', () => {
       expect(tokenizeAndHumanizeParts('&#x41;&#X41;')).toEqual([
         [TokenType.TEXT, ''],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Named HTML entities containing digits (e.g. `&sup1;`, `&frac12;`, `&blk34;`, `&there4;`) are not processed correctly by the Angular template compiler. Instead of being decoded to their corresponding Unicode characters, they are output as escaped text (e.g. `&amp;sup1;` instead of `¹`).

This affects all 24 valid HTML named entities that contain digits in their names: `blk12`, `blk14`, `blk34`, `emsp13`, `emsp14`, `frac12`, `frac13`, `frac14`, `frac15`, `frac16`, `frac18`, `frac23`, `frac25`, `frac34`, `frac35`, `frac38`, `frac45`, `frac56`, `frac58`, `frac78`, `sup1`, `sup2`, `sup3`, `there4`.

Closes #51323

## What is the new behavior?

The lexer's `isNamedEntityEnd` function now accepts digits as valid characters within named entity references, allowing all standard HTML named entities to be parsed and decoded correctly.

## Additional context

The root cause was in the `isNamedEntityEnd` function in `packages/compiler/src/ml_parser/lexer.ts`. This function determines when to stop scanning a named entity reference. It used `!chars.isAsciiLetter(code)` as its termination condition, which meant any digit would immediately end the entity name scan. For an entity like `&sup1;`, the scanner would stop at `sup` (before the `1`), never reach the semicolon, and fall back to treating the `&` as plain text.

The fix adds `chars.isDigit(code)` to the valid character check, so entity names like `sup1` and `frac12` are fully scanned.

The entity lookup table in `entities.ts` already contained all 24 entities — only the lexer scanning logic needed to be updated.