### PR TITLE
refactor(http): expose `withXhr` to prepare for fetch by default

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -2680,7 +2680,9 @@ export enum HttpFeatureKind {
     // (undocumented)
     NoXsrfProtection = 3,
     // (undocumented)
-    RequestsMadeViaParent = 5
+    RequestsMadeViaParent = 5,
+    // (undocumented)
+    Xhr = 7
 }
 
 // @public
@@ -3346,6 +3348,9 @@ export function withNoXsrfProtection(): HttpFeature<HttpFeatureKind.NoXsrfProtec
 
 // @public
 export function withRequestsMadeViaParent(): HttpFeature<HttpFeatureKind.RequestsMadeViaParent>;
+
+// @public
+export function withXhr(): HttpFeature<HttpFeatureKind.Xhr>;
 
 // @public
 export function withXsrfConfiguration({ cookieName, headerName, }: {

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -35,6 +35,7 @@ export {
   HttpFeatureKind,
   provideHttpClient,
   withFetch,
+  withXhr,
   withInterceptors,
   withInterceptorsFromDi,
   withJsonpSupport,

--- a/packages/common/http/src/backend-default-value.ts
+++ b/packages/common/http/src/backend-default-value.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpXhrBackend} from './xhr';
+
+/**
+ * A constant defining the default the default Http Backend.
+ * Extracted to a separate file to facilitate G3 patches.
+ */
+export const NG_DEFAULT_HTTP_BACKEND = HttpXhrBackend;


### PR DESCRIPTION
This commit sets up the necessary changes that would allow us to safely migrate G3 before switch to the `FetchBackend` by default.

For now the `HttpXhrBackend` is still the default backend for the `HttpClient`.
