### PR TITLE
fix(core): destroy platform injector when PlatformRef is destroyed

### DIFF
--- a/packages/core/src/platform/platform_ref.ts
+++ b/packages/core/src/platform/platform_ref.ts
@@ -11,6 +11,7 @@ import {BootstrapOptions, optionsReducer} from '../application/application_ref';
 import {validAppIdInitializer} from '../application/application_tokens';
 import {provideZonelessChangeDetectionInternal} from '../change_detection/scheduling/zoneless_scheduling_impl';
 import {EnvironmentProviders, Injectable, Injector, Provider} from '../di';
+import {type R3Injector} from '../di/r3_injector';
 import {errorHandlerEnvironmentInitializer} from '../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
@@ -134,6 +135,13 @@ export class PlatformRef {
     if (destroyListeners) {
       destroyListeners.forEach((listener) => listener());
       destroyListeners.clear();
+    }
+
+    // Destroy the platform injector, which triggers DestroyRef callbacks and
+    // ngOnDestroy lifecycle hooks for platform-scoped services.
+    const injector = this._injector as R3Injector;
+    if (injector.destroy && !injector.destroyed) {
+      injector.destroy();
     }
 
     this._destroyed = true;

--- a/packages/core/test/acceptance/bootstrap_spec.ts
+++ b/packages/core/test/acceptance/bootstrap_spec.ts
@@ -10,6 +10,7 @@ import {
   ApplicationRef,
   COMPILER_OPTIONS,
   Component,
+  DestroyRef,
   destroyPlatform,
   forwardRef,
   NgModule,
@@ -423,6 +424,25 @@ describe('bootstrap', () => {
           ngModuleRef.destroy();
 
           expect(ngZone.onError.observers.length).toBe(0);
+        }),
+      );
+
+      it(
+        'should invoke DestroyRef callbacks when the platform is destroyed',
+        withBody('<my-app></my-app>', async () => {
+          const TestModule = createComponentAndModule();
+          const platformRef = platformBrowser();
+
+          await platformRef.bootstrapModule(TestModule);
+
+          let destroyed = false;
+          const destroyRef = platformRef.injector.get(DestroyRef);
+          destroyRef.onDestroy(() => (destroyed = true));
+
+          expect(destroyed).toBe(false);
+
+          platformRef.destroy();
+          expect(destroyed).toBe(true);
         }),
       );
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When `PlatformRef.destroy()` is called, the platform injector is not destroyed. This means:

- `DestroyRef.onDestroy()` callbacks registered on the platform injector are never invoked
- `ngOnDestroy` lifecycle hooks for platform-scoped services are never called
- `DestroyRef.destroyed` remains `false` even after the platform is destroyed

This breaks the expected lifecycle contract of `DestroyRef`, which is documented as the standard mechanism for registering teardown logic tied to an injector's lifetime.

Closes #67095

## What is the new behavior?

`PlatformRef.destroy()` now calls `injector.destroy()` on the platform injector after all other cleanup (module destruction, listener invocation) is complete. This triggers `DestroyRef.onDestroy()` callbacks and `ngOnDestroy` lifecycle hooks for platform-scoped services.

This follows the same pattern already used by `ApplicationRef.destroy()`, which calls `injector.destroy()` on the application's environment injector.

## Additional context

The fix adds `injector.destroy()` at the end of the `PlatformRef.destroy()` method, after all existing cleanup but before setting `_destroyed = true`. The injector is cast to `R3Injector` and checked for `destroy` support and prior destruction state, matching the defensive pattern used in `ApplicationRef.destroy()`.

An acceptance test is included that verifies `DestroyRef.onDestroy()` callbacks from the platform injector are invoked when `PlatformRef.destroy()` is called.