### PR TITLE
build: patch `@angular/build` to allow CI to build adev

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,9 @@
     "typescript": "6.0.0-beta"
   },
   "pnpm": {
-    "patchedDependencies": {},
+    "patchedDependencies": {
+      "@angular/build": "patches/@angular__build.patch"
+    },
     "packageExtensions": {
       "grpc-gcp": {
         "peerDependencies": {

--- a/patches/@angular__build.patch
+++ b/patches/@angular__build.patch
@@ -1,0 +1,51 @@
+diff --git a/src/utils/version.js b/src/utils/version.js
+index 4a2fe8ac8e57fc0c0d3c58000346887d5072f712..7a78858d7b5ae14c284f521ce7f6056074cdf33f 100755
+--- a/src/utils/version.js
++++ b/src/utils/version.js
+@@ -11,9 +11,6 @@ exports.assertCompatibleAngularVersion = assertCompatibleAngularVersion;
+ /* eslint-disable no-console */
+ const node_module_1 = require("node:module");
+ const semver_1 = require("semver");
+-// Matches exactly '0.0.0' or any string ending in '.0.0-next.0'
+-// This allows FW to bump the package.json to a new major version without requiring a new CLI version.
+-const angularVersionRegex = /^0\.0\.0$|\.0\.0-next\.0$/;
+ function assertCompatibleAngularVersion(projectRoot) {
+     let angularPkgJson;
+     // Create a custom require function for ESM compliance.
+@@ -31,16 +28,31 @@ function assertCompatibleAngularVersion(projectRoot) {
+             'This likely indicates a corrupted local installation. Please try reinstalling your packages.');
+         process.exit(2);
+     }
++    const angularCoreSemVer = new semver_1.SemVer(angularPkgJson['version']);
++    const { version, build, raw } = angularCoreSemVer;
+     const supportedAngularSemver = '^21.0.0 || ^21.2.0-next.0';
+-    if (angularVersionRegex.test(angularPkgJson['version']) ||
+-        supportedAngularSemver.startsWith('0.0.0')) {
++  if (version.startsWith('0.0.0') || supportedAngularSemver.startsWith('0.0.0')) {
+         // Internal CLI and FW testing version.
+         return;
+     }
+-    const angularVersion = new semver_1.SemVer(angularPkgJson['version']);
+-    if (!(0, semver_1.satisfies)(angularVersion, supportedAngularSemver, { includePrerelease: true })) {
++    if (build.length && version.endsWith('.0.0-next.0')) {
++        // Special handle for local builds only when it's prerelease of major version and it's the 0th version.
++        // This happends when we are bumping to a new major version. and the cli has not releated a verion.
++
++        // Example:
++        // raw: '22.0.0-next.0+sha-c7dc705-with-local-changes',
++        // major: 22,
++        // minor: 0,
++        // patch: 0,
++        // prerelease: [ 'next', 0 ],
++        // build: [ 'sha-c7dc705-with-local-changes' ],
++        // version: '22.0.0-next.0'
++
++        return;
++    }
++    if (!(0, semver_1.satisfies)(angularCoreSemVer, supportedAngularSemver, { includePrerelease: true })) {
+         console.error(`Error: The current version of "@angular/build" supports Angular versions ${supportedAngularSemver},\n` +
+-            `but detected Angular version ${angularVersion} instead.\n` +
++            `but detected Angular version ${raw} instead.\n` +
+             'Please visit the link below to find instructions on how to update Angular.\nhttps://update.angular.dev/');
+         process.exit(3);
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ packageExtensionsChecksum: sha256-3L73Fw32UVtE6x5BJxJPBtQtH/mgsr31grNpdhHP1IY=
 
 pnpmfileChecksum: sha256-TYPFsbGgXlr65uhno3A1oHE+n2qqt8R+w/szQ+Wq97s=
 
+patchedDependencies:
+  '@angular/build':
+    hash: f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651
+    path: patches/@angular__build.patch
+
 importers:
 
   .:
@@ -34,7 +39,7 @@ importers:
         version: link:packages/benchpress
       '@angular/build':
         specifier: 21.2.0-rc.1
-        version: 21.2.0-rc.1(a12689b79fb7a7a5ed808a49ec725854)
+        version: 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(a12689b79fb7a7a5ed808a49ec725854)
       '@angular/cdk':
         specifier: 21.2.0-rc.0
         version: 21.2.0-rc.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
@@ -479,7 +484,7 @@ importers:
         version: 21.2.0-rc.0(@angular/cdk@21.2.0-rc.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/core@packages+core)
       '@angular/build':
         specifier: 21.2.0-rc.1
-        version: 21.2.0-rc.1(c30b52169b3b2ee1cc161f9c79b2b533)
+        version: 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(c30b52169b3b2ee1cc161f9c79b2b533)
       '@angular/cdk':
         specifier: 21.2.0-rc.0
         version: 21.2.0-rc.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
@@ -847,7 +852,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: 21.2.0-rc.1
-        version: 21.2.0-rc.1(c30b52169b3b2ee1cc161f9c79b2b533)
+        version: 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(c30b52169b3b2ee1cc161f9c79b2b533)
       '@angular/cli':
         specifier: 21.2.0-rc.1
         version: 21.2.0-rc.1(@types/node@24.10.11)(chokidar@5.0.0)
@@ -919,7 +924,7 @@ importers:
         version: link:../packages/benchpress
       '@angular/build':
         specifier: 21.2.0-rc.1
-        version: 21.2.0-rc.1(c30b52169b3b2ee1cc161f9c79b2b533)
+        version: 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(c30b52169b3b2ee1cc161f9c79b2b533)
       '@angular/common':
         specifier: workspace:*
         version: link:../packages/common
@@ -1090,7 +1095,7 @@ importers:
         version: link:../../../animations
       '@angular/build':
         specifier: 21.2.0-rc.1
-        version: 21.2.0-rc.1(c30b52169b3b2ee1cc161f9c79b2b533)
+        version: 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(c30b52169b3b2ee1cc161f9c79b2b533)
       '@angular/common':
         specifier: workspace:*
         version: link:../../../common
@@ -13510,7 +13515,7 @@ snapshots:
       '@angular-devkit/architect': 0.2102.0-rc.1(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.0-rc.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)(webpack@5.105.2(esbuild@0.27.3)))(webpack@5.105.2(esbuild@0.27.3))
       '@angular-devkit/core': 21.2.0-rc.1(chokidar@5.0.0)
-      '@angular/build': 21.2.0-rc.1(fc8ee6f57910011df997b5d298742fa0)
+      '@angular/build': 21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(fc8ee6f57910011df997b5d298742fa0)
       '@angular/compiler-cli': link:packages/compiler-cli
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -13635,7 +13640,7 @@ snapshots:
       '@angular/core': link:packages/core
       tslib: 2.8.1
 
-  '@angular/build@21.2.0-rc.1(a12689b79fb7a7a5ed808a49ec725854)':
+  '@angular/build@21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(a12689b79fb7a7a5ed808a49ec725854)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0-rc.1(chokidar@5.0.0)
@@ -13695,7 +13700,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.0-rc.1(c30b52169b3b2ee1cc161f9c79b2b533)':
+  '@angular/build@21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(c30b52169b3b2ee1cc161f9c79b2b533)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0-rc.1(chokidar@5.0.0)
@@ -13755,7 +13760,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.0-rc.1(fc8ee6f57910011df997b5d298742fa0)':
+  '@angular/build@21.2.0-rc.1(patch_hash=f2be8afee6ac2d252d2dba358fe772a45b4b543df9e2f98278f224969bdb8651)(fc8ee6f57910011df997b5d298742fa0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0-rc.1(chokidar@5.0.0)


### PR DESCRIPTION
See angular/angular-cli/pull/32553
This patch can be removed when the `@angular/build` dependency has been updated after the next release