### PR TITLE
fix(docs-infra): support comparing reveal answer with user work-in-progress

### DIFF
--- a/adev/src/app/editor/code-editor/code-mirror-editor.service.spec.ts
+++ b/adev/src/app/editor/code-editor/code-mirror-editor.service.spec.ts
@@ -75,9 +75,8 @@ class MockWorker {
 describe('CodeMirrorEditor', () => {
   let service: CodeMirrorEditor;
   let mockWorker: MockWorker;
-
-  const fakeNodeRuntimeSandbox = new FakeNodeRuntimeSandbox();
-  const fakeEmbeddedTutorialManager = new FakeEmbeddedTutorialManager();
+  let fakeNodeRuntimeSandbox: FakeNodeRuntimeSandbox;
+  let fakeEmbeddedTutorialManager: FakeEmbeddedTutorialManager;
 
   function dispatchDocumentChange(newContent: string) {
     for (let i = 0; i < newContent.length; i++) {
@@ -89,6 +88,8 @@ describe('CodeMirrorEditor', () => {
   }
 
   beforeEach(() => {
+    fakeNodeRuntimeSandbox = new FakeNodeRuntimeSandbox();
+    fakeEmbeddedTutorialManager = new FakeEmbeddedTutorialManager();
     mockWorker = new MockWorker();
 
     TestBed.configureTestingModule({

--- a/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
+++ b/adev/src/app/editor/code-editor/code-mirror-editor.service.ts
@@ -483,6 +483,10 @@ export class CodeMirrorEditor {
         file.filename === this.currentFile().filename ? {...file, content: newContent} : file,
       ),
     );
+    this.embeddedTutorialManager.tutorialFiles.update((files) => ({
+      ...files,
+      [this.currentFile().filename]: newContent,
+    }));
 
     // send current file content to Ts Vfs worker to run diagnostics on current file state
     this.sendRequestToTsVfs<CodeChangeRequest>({

--- a/adev/src/app/editor/embedded-tutorial-manager.service.spec.ts
+++ b/adev/src/app/editor/embedded-tutorial-manager.service.spec.ts
@@ -69,6 +69,42 @@ describe('EmbeddedTutorialManager', () => {
     expect(service.openFiles()).toEqual(openFiles);
   });
 
+  it('should restore the user work in progress files', () => {
+    const initialTutorialFiles = {'file.ts': 'initial'};
+    const workInProgressTutorialFiles = {'file.ts': 'work-in-progress', 'extra.ts': 'extra'};
+    const answerFiles = {'file.ts': 'answer', 'answer-only.ts': 'answer-only'};
+    const initialOpenFiles = ['file.ts'];
+    const workInProgressOpenFiles = ['file.ts', 'extra.ts'];
+    const workInProgressAllFiles = ['file.ts', 'extra.ts'];
+
+    service['metadata'].set({
+      answerFiles,
+      tutorialFiles: initialTutorialFiles,
+      openFiles: initialOpenFiles,
+      hiddenFiles: [],
+      type: TutorialType.EDITOR,
+      dependencies: {},
+      allFiles: initialOpenFiles,
+    });
+
+    service['tutorialFiles'].set(workInProgressTutorialFiles);
+    service['openFiles'].set(workInProgressOpenFiles);
+    service['allFiles'].set(workInProgressAllFiles);
+    service['answerFiles'].set(answerFiles);
+
+    service.revealAnswer();
+
+    expect(service.tutorialFiles()['file.ts']).toBe('answer');
+    expect(service.tutorialFiles()['extra.ts']).toBe('extra');
+    expect(service.openFiles()).toContain('answer-only.ts');
+
+    service.restoreWorkInProgress();
+
+    expect(service.tutorialFiles()).toEqual(workInProgressTutorialFiles);
+    expect(service.openFiles()).toEqual(workInProgressOpenFiles);
+    expect(service['allFiles']()).toEqual(workInProgressAllFiles);
+  });
+
   it('should not have hiddenFiles in openFiles on reveal and reset answer', () => {
     const hiddenFiles = ['hidden1.ts', 'hidden2.ts'];
     const openFiles = ['open.ts'];

--- a/adev/src/app/features/tutorial/tutorial.component.html
+++ b/adev/src/app/features/tutorial/tutorial.component.html
@@ -64,6 +64,18 @@
         >
           {{ answerRevealed() ? 'Reset' : 'Reveal Answer' }}
         </button>
+        @if (answerRevealed()) {
+          <button
+            type="button"
+            (click)="handleBackToMyCode()"
+            [disabled]="!canRevealAnswer()"
+            class="docs-reveal-answer-button adev-reveal-desktop-button docs-primary-btn"
+            [attr.text]="'Back to My Code'"
+            aria-label="Back to My Code"
+          >
+            Back to My Code
+          </button>
+        }
       }
 
       <!-- Download code -->
@@ -118,6 +130,18 @@
           >
             {{ answerRevealed() ? 'Reset' : 'Reveal Answer' }}
           </button>
+          @if (answerRevealed()) {
+            <button
+              type="button"
+              (click)="handleBackToMyCode()"
+              [disabled]="!canRevealAnswer()"
+              class="docs-reveal-answer-button adev-reveal-mobile-button docs-primary-btn"
+              [attr.text]="'Back to My Code'"
+              aria-label="Back to My Code"
+            >
+              Back to My Code
+            </button>
+          }
         }
       </div>
 

--- a/adev/src/app/features/tutorial/tutorial.component.spec.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.spec.ts
@@ -59,6 +59,7 @@ describe('Tutorial', () => {
     type: signal(TutorialType.EDITOR),
     revealAnswer: () => {},
     resetRevealAnswer: () => {},
+    restoreWorkInProgress: () => {},
     tutorialChanged$: of(false),
     openFiles: signal<NonNullable<TutorialConfig['openFiles']>>(['app.component.ts']),
   };
@@ -189,5 +190,20 @@ describe('Tutorial', () => {
     await fixture.whenStable();
 
     expect(component.revealAnswerButton()).toBe(undefined);
+  });
+
+  it('should reset to initial state when requested', async () => {
+    setupResetRevealAnswerValues();
+    await fixture.whenStable();
+
+    const restoreWorkInProgressSpy = spyOn(
+      component['embeddedTutorialManager'],
+      'restoreWorkInProgress',
+    );
+
+    await component.handleBackToMyCode();
+
+    expect(restoreWorkInProgressSpy).toHaveBeenCalled();
+    expect(component['answerRevealed']()).toBe(false);
   });
 });

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -180,6 +180,22 @@ export default class Tutorial {
     this.answerRevealed.set(false);
   }
 
+  async handleBackToMyCode() {
+    if (!this.canRevealAnswer()) return;
+
+    this.embeddedTutorialManager.restoreWorkInProgress();
+
+    const nodeRuntimeSandbox = await injectNodeRuntimeSandbox(this.environmentInjector);
+
+    await Promise.all(
+      Object.entries(this.embeddedTutorialManager.tutorialFiles()).map(([path, contents]) =>
+        nodeRuntimeSandbox.writeFile(path, contents as string | Uint8Array),
+      ),
+    );
+
+    this.answerRevealed.set(false);
+  }
+
   /**
    * Set tutorial data based on current tutorial
    */


### PR DESCRIPTION
Preserve learner work in progress when revealing answers and add a dedicated action to return to personal code without losing the default reset behavior. Fixes #52656.
