### PR TITLE
refactor(forms): hide adapter in public options

### DIFF
--- a/packages/forms/signals/compat/src/api/compat_form.ts
+++ b/packages/forms/signals/compat/src/api/compat_form.ts
@@ -41,11 +41,11 @@ export type CompatFormOptions<TModel> = Omit<FormOptions<TModel>, 'adapter'>;
  *
  * nameForm.last().value(); // lastName, not FormControl
  * ```
- * 
+ *
  * @param model A writable signal that contains the model data for the form. The resulting field
  * structure will match the shape of the model and any changes to the form data will be written to
  * the model.
-
+ *
  * @category interop
  * @experimental 21.0.0
  */
@@ -130,5 +130,5 @@ export function compatForm<TModel>(...args: any[]): FieldTree<TModel> {
 
   const options = {...maybeOptions, adapter: new CompatFieldAdapter()};
   const schema = maybeSchema || ((() => {}) as SchemaOrSchemaFn<TModel, PathKind>);
-  return form(model, schema, options) as FieldTree<TModel>;
+  return form(model, schema, options);
 }

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -55,13 +55,6 @@ export interface FormOptions<TModel> {
   name?: string;
   /** Options that define how to handle form submission. */
   submission?: FormSubmitOptions<TModel, unknown>;
-
-  /**
-   * Adapter allows managing fields in a more flexible way.
-   * Currently this is used to support interop with reactive forms.
-   * @internal
-   */
-  adapter?: FieldAdapter;
 }
 
 /**
@@ -192,7 +185,10 @@ export function form<TModel>(
 ): FieldTree<TModel>;
 
 export function form<TModel>(...args: any[]): FieldTree<TModel> {
-  const [model, schema, options] = normalizeFormArgs<TModel>(args);
+  const [model, schema, options] = normalizeFormArgs<
+    TModel,
+    FormOptions<TModel> & {adapter?: FieldAdapter}
+  >(args);
   const injector = options?.injector ?? inject(Injector);
   const pathNode = runInInjectionContext(injector, () => SchemaImpl.rootCompile(schema));
   const fieldManager = new FormFieldManager(

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -185,10 +185,7 @@ export function form<TModel>(
 ): FieldTree<TModel>;
 
 export function form<TModel>(...args: any[]): FieldTree<TModel> {
-  const [model, schema, options] = normalizeFormArgs<
-    TModel,
-    FormOptions<TModel> & {adapter?: FieldAdapter}
-  >(args);
+  const [model, schema, options] = normalizeFormArgs<TModel>(args);
   const injector = options?.injector ?? inject(Injector);
   const pathNode = runInInjectionContext(injector, () => SchemaImpl.rootCompile(schema));
   const fieldManager = new FormFieldManager(

--- a/packages/forms/signals/src/util/normalize_form_args.ts
+++ b/packages/forms/signals/src/util/normalize_form_args.ts
@@ -14,12 +14,12 @@ import {isSchemaOrSchemaFn} from '../schema/schema';
 /**
  * Extracts the model, schema, and options from the arguments passed to `form()`.
  */
-export function normalizeFormArgs<TModel>(
+export function normalizeFormArgs<TModel, TOptions = FormOptions<TModel>>(
   args: any[],
-): [WritableSignal<TModel>, SchemaOrSchemaFn<TModel> | undefined, FormOptions<TModel> | undefined] {
+): [WritableSignal<TModel>, SchemaOrSchemaFn<TModel> | undefined, TOptions | undefined] {
   let model: WritableSignal<TModel>;
   let schema: SchemaOrSchemaFn<TModel> | undefined;
-  let options: FormOptions<TModel> | undefined;
+  let options: TOptions | undefined;
 
   if (args.length === 3) {
     [model, schema, options] = args;

--- a/packages/forms/signals/src/util/normalize_form_args.ts
+++ b/packages/forms/signals/src/util/normalize_form_args.ts
@@ -9,17 +9,22 @@
 import type {WritableSignal} from '@angular/core';
 import type {FormOptions} from '../api/structure';
 import type {SchemaOrSchemaFn} from '../api/types';
+import {FieldAdapter} from '../field/field_adapter';
 import {isSchemaOrSchemaFn} from '../schema/schema';
 
 /**
  * Extracts the model, schema, and options from the arguments passed to `form()`.
  */
-export function normalizeFormArgs<TModel, TOptions = FormOptions<TModel>>(
+export function normalizeFormArgs<TModel>(
   args: any[],
-): [WritableSignal<TModel>, SchemaOrSchemaFn<TModel> | undefined, TOptions | undefined] {
+): [
+  WritableSignal<TModel>,
+  SchemaOrSchemaFn<TModel> | undefined,
+  (FormOptions<TModel> & {adapter?: FieldAdapter}) | undefined,
+] {
   let model: WritableSignal<TModel>;
   let schema: SchemaOrSchemaFn<TModel> | undefined;
-  let options: TOptions | undefined;
+  let options: (FormOptions<TModel> & {adapter?: FieldAdapter}) | undefined;
 
   if (args.length === 3) {
     [model, schema, options] = args;


### PR DESCRIPTION
Moves adapter to internal options to prevent exposure but keep compatibility.