### PR TITLE
ci: update pullapprove for manual_api docs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -243,6 +243,8 @@ groups:
       - >
         contains_any_globs(files, [
           'adev/**/{*,.*}',
+          'tools/manual_api_docs/blocks/**/*.md',
+          'tools/manual_api_docs/elements/**/*.md',
         ])
     reviewers:
       users:
@@ -295,7 +297,11 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude('.pullapprove.yml'), [
+        contains_any_globs(files
+            .exclude('.pullapprove.yml') 
+            .exclude('tools/manual_api_docs/blocks/**/*.md')
+            .exclude('tools/manual_api_docs/elements/**/*.md'),
+        [
           '{*,.*}',
           '.agent/**/{*,.*}',
           '.devcontainer/**/{*,.*}',


### PR DESCRIPTION
The markdown files shouldn't require dev-infra approval.
