### PR TITLE
feat(http): support custom JSON parser in HttpClient

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -14,6 +14,7 @@ import { Observable } from 'rxjs';
 import { Provider } from '@angular/core';
 import { ResourceRef } from '@angular/core';
 import { Signal } from '@angular/core';
+import { Type } from '@angular/core';
 import { ValueEqualityFn } from '@angular/core';
 import { WritableResource } from '@angular/core';
 
@@ -29,6 +30,9 @@ export class FetchBackend implements HttpBackend {
 
 // @public
 export const HTTP_INTERCEPTORS: InjectionToken<readonly HttpInterceptor[]>;
+
+// @public
+export const HTTP_JSON_PARSER: InjectionToken<HttpJsonParser>;
 
 // @public
 export const HTTP_TRANSFER_CACHE_ORIGIN_MAP: InjectionToken<Record<string, string>>;
@@ -2674,6 +2678,8 @@ export enum HttpFeatureKind {
     // (undocumented)
     Interceptors = 0,
     // (undocumented)
+    JsonParser = 7,
+    // (undocumented)
     JsonpSupport = 4,
     // (undocumented)
     LegacyInterceptors = 1,
@@ -2682,7 +2688,7 @@ export enum HttpFeatureKind {
     // (undocumented)
     RequestsMadeViaParent = 5,
     // (undocumented)
-    Xhr = 7
+    Xhr = 8
 }
 
 // @public
@@ -2737,6 +2743,12 @@ export interface HttpInterceptor {
 
 // @public
 export type HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => Observable<HttpEvent<unknown>>;
+
+// @public
+export abstract class HttpJsonParser {
+    // (undocumented)
+    abstract parse(text: string): any;
+}
 
 // @public
 export interface HttpParameterCodec {
@@ -3339,6 +3351,9 @@ export function withInterceptors(interceptorFns: HttpInterceptorFn[]): HttpFeatu
 
 // @public
 export function withInterceptorsFromDi(): HttpFeature<HttpFeatureKind.LegacyInterceptors>;
+
+// @public
+export function withJsonParser(parser: Type<HttpJsonParser>): HttpFeature<HttpFeatureKind.JsonParser>;
 
 // @public
 export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport>;

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -22,6 +22,7 @@ export {
   HttpInterceptor,
   HttpInterceptorFn,
 } from './src/interceptor';
+export {HttpJsonParser, HTTP_JSON_PARSER} from './src/json_parser';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';
 export {
@@ -39,6 +40,7 @@ export {
   withInterceptors,
   withInterceptorsFromDi,
   withJsonpSupport,
+  withJsonParser,
   withNoXsrfProtection,
   withRequestsMadeViaParent,
   withXsrfConfiguration,

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -19,6 +19,7 @@ import {RuntimeErrorCode} from './errors';
 
 import type {HttpBackend} from './backend';
 import {HttpHeaders} from './headers';
+import {HTTP_JSON_PARSER} from './json_parser';
 import {ACCEPT_HEADER, ACCEPT_HEADER_VALUE, CONTENT_TYPE_HEADER, HttpRequest} from './request';
 import {
   HTTP_STATUS_CODE_OK,
@@ -27,6 +28,7 @@ import {
   HttpEvent,
   HttpEventType,
   HttpHeaderResponse,
+  HttpJsonParseError,
   HttpResponse,
 } from './response';
 
@@ -63,6 +65,7 @@ export class FetchBackend implements HttpBackend {
     inject(FetchFactory, {optional: true})?.fetch ?? ((...args) => globalThis.fetch(...args));
   private readonly ngZone = inject(NgZone);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly jsonParser = inject(HTTP_JSON_PARSER);
 
   handle(request: HttpRequest<any>): Observable<HttpEvent<any>> {
     return new Observable((observer) => {
@@ -289,21 +292,22 @@ export class FetchBackend implements HttpBackend {
     switch (request.responseType) {
       case 'json':
         // stripping the XSSI when present
-        const text = new TextDecoder().decode(binContent).replace(XSSI_PREFIX, '');
+        const originalText = new TextDecoder().decode(binContent);
+        const text = originalText.replace(XSSI_PREFIX, '');
         if (text === '') {
           return null;
         }
         try {
-          return JSON.parse(text) as object;
-        } catch (e: unknown) {
+          return this.jsonParser.parse(text) as object;
+        } catch (error: unknown) {
           // Allow handling non-JSON errors (!) as plain text, same as the XHR
           // backend. Without this special sauce, any non-JSON error would be
-          // completely inaccessible downstream as the `HttpErrorResponse.error`
-          // would be set to the `SyntaxError` from then failing `JSON.parse`.
-          if (status < 200 || status >= 300) {
-            return text;
+          // completely inaccessible downstream as the \`HttpErrorResponse.error\`
+          // would be set to the \`SyntaxError\` from then failing \`JSON.parse\`.
+          if (status >= 200 && status < 300) {
+            throw {error, text: originalText} as HttpJsonParseError;
           }
-          throw e;
+          return text;
         }
       case 'text':
         return new TextDecoder().decode(binContent);

--- a/packages/common/http/src/json_parser.ts
+++ b/packages/common/http/src/json_parser.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+/**
+ * A parser for JSON responses.
+ *
+ * @publicApi
+ */
+export abstract class HttpJsonParser {
+  abstract parse(text: string): any;
+}
+
+/**
+ * A default implementation of `HttpJsonParser` that uses the browser's `JSON.parse`.
+ */
+export class DefaultHttpJsonParser implements HttpJsonParser {
+  parse(text: string): any {
+    return JSON.parse(text);
+  }
+}
+
+/**
+ * An `InjectionToken` that can be used to provide a custom `HttpJsonParser`.
+ *
+ * @publicApi
+ */
+export const HTTP_JSON_PARSER = new InjectionToken<HttpJsonParser>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'HttpJsonParser' : '',
+  {
+    providedIn: 'root',
+    factory: () => new DefaultHttpJsonParser(),
+  },
+);

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -12,6 +12,7 @@ import {
   InjectionToken,
   makeEnvironmentProviders,
   Provider,
+  Type,
 } from '@angular/core';
 
 import {HttpBackend, HttpHandler, HttpInterceptorHandler} from './backend';
@@ -19,6 +20,7 @@ import {NG_DEFAULT_HTTP_BACKEND} from './backend-default-value';
 import {HttpClient} from './client';
 import {FETCH_BACKEND, FetchBackend} from './fetch';
 import {HTTP_INTERCEPTOR_FNS, HttpInterceptorFn, legacyInterceptorFnFactory} from './interceptor';
+import {HTTP_JSON_PARSER, HttpJsonParser} from './json_parser';
 import {
   jsonpCallbackContext,
   JsonpCallbackContext,
@@ -41,6 +43,7 @@ export enum HttpFeatureKind {
   JsonpSupport,
   RequestsMadeViaParent,
   Fetch,
+  JsonParser,
   Xhr,
 }
 
@@ -298,6 +301,21 @@ export function withFetch(): HttpFeature<HttpFeatureKind.Fetch> {
     FetchBackend,
     {provide: FETCH_BACKEND, useExisting: FetchBackend},
     {provide: HttpBackend, useExisting: FetchBackend},
+  ]);
+}
+
+/**
+ * Configures the current `HttpClient` instance to use a custom JSON parser.
+ *
+ * @param parser The class of the custom JSON parser.
+ * @see {@link provideHttpClient}
+ * @publicApi
+ */
+export function withJsonParser(
+  parser: Type<HttpJsonParser>,
+): HttpFeature<HttpFeatureKind.JsonParser> {
+  return makeHttpFeature(HttpFeatureKind.JsonParser, [
+    {provide: HTTP_JSON_PARSER, useClass: parser},
   ]);
 }
 

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -21,6 +21,7 @@ import {switchMap} from 'rxjs/operators';
 import type {HttpBackend} from './backend';
 import {RuntimeErrorCode} from './errors';
 import {HttpHeaders} from './headers';
+import {HTTP_JSON_PARSER} from './json_parser';
 import {ACCEPT_HEADER, ACCEPT_HEADER_VALUE, CONTENT_TYPE_HEADER, HttpRequest} from './request';
 import {
   HTTP_STATUS_CODE_NO_CONTENT,
@@ -109,6 +110,7 @@ export class HttpXhrBackend implements HttpBackend {
   private readonly tracingService: TracingService<TracingSnapshot> | null = inject(TracingService, {
     optional: true,
   });
+  private readonly jsonParser = inject(HTTP_JSON_PARSER);
 
   constructor(private xhrFactory: XhrFactory) {}
 
@@ -262,7 +264,7 @@ export class HttpXhrBackend implements HttpBackend {
               try {
                 // Attempt the parse. If it fails, a parse error should be delivered to the
                 // user.
-                body = body !== '' ? JSON.parse(body) : null;
+                body = body !== '' ? this.jsonParser.parse(body) : null;
               } catch (error) {
                 // Since the JSON.parse failed, it's reasonable to assume this might not have
                 // been a JSON response. Restore the original body (including any XSSI prefix)

--- a/packages/common/http/test/json_parser_spec.ts
+++ b/packages/common/http/test/json_parser_spec.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {XhrFactory} from '../../index';
+import {HttpJsonParser} from '../src/json_parser';
+import {HttpRequest} from '../src/request';
+import {HttpEventType, HttpJsonParseError} from '../src/response';
+import {HttpXhrBackend} from '../src/xhr';
+import {FetchBackend, FetchFactory} from '../src/fetch';
+import {MockXhrFactory} from './xhr_mock';
+import {provideHttpClient, withJsonParser, withFetch} from '../src/provider';
+
+class CustomJsonParser implements HttpJsonParser {
+  parse(text: string): any {
+    const data = JSON.parse(text);
+    data.custom = true;
+    return data;
+  }
+}
+
+export class MockFetchFactory extends FetchFactory {
+  private lastResolve: (res: Response) => void = null!;
+  override fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    return new Promise((resolve) => {
+      this.lastResolve = resolve;
+    });
+  };
+
+  mockFlush(
+    status: number,
+    statusText: string,
+    body: string,
+    headers: Record<string, string> = {},
+  ) {
+    this.lastResolve({
+      status,
+      statusText,
+      headers: new Headers(headers),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(body));
+          controller.close();
+        },
+      }),
+      url: '/test',
+      ok: status >= 200 && status < 300,
+    } as Response);
+  }
+}
+
+describe('HttpJsonParser', () => {
+  describe('HttpXhrBackend', () => {
+    let factory: MockXhrFactory = null!;
+    let backend: HttpXhrBackend = null!;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withJsonParser(CustomJsonParser)),
+          {provide: XhrFactory, useClass: MockXhrFactory},
+        ],
+      });
+      factory = TestBed.inject(XhrFactory) as MockXhrFactory;
+      backend = TestBed.inject(HttpXhrBackend);
+    });
+
+    it('uses the custom JSON parser', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toEqual({data: 'test', custom: true});
+          done();
+        }
+      });
+      factory.mock.mockFlush(200, 'OK', '{"data": "test"}');
+    });
+
+    it('strips XSSI prefix before calling the custom parser', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toEqual({data: 'test', custom: true});
+          done();
+        }
+      });
+      factory.mock.mockFlush(200, 'OK', ")]}',\n" + '{"data": "test"}');
+    });
+
+    it('returns null for empty response body', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toBeNull();
+          done();
+        }
+      });
+      factory.mock.mockFlush(200, 'OK', '');
+    });
+
+    it('handles parsing errors by returning an HttpErrorResponse with HttpJsonParseError', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe({
+        error: (error) => {
+          expect(error.error.text).toBe('invalid json');
+          expect(error.error.error instanceof SyntaxError).toBeTrue();
+          done();
+        },
+      });
+      factory.mock.mockFlush(200, 'OK', 'invalid json');
+    });
+  });
+
+  describe('FetchBackend', () => {
+    let factory: MockFetchFactory = null!;
+    let backend: FetchBackend = null!;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withFetch(), withJsonParser(CustomJsonParser)),
+          {provide: FetchFactory, useClass: MockFetchFactory},
+        ],
+      });
+      factory = TestBed.inject(FetchFactory) as MockFetchFactory;
+      backend = TestBed.inject(FetchBackend);
+    });
+
+    it('uses the custom JSON parser', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toEqual({data: 'test', custom: true});
+          done();
+        }
+      });
+      factory.mockFlush(200, 'OK', '{"data": "test"}');
+    });
+
+    it('strips XSSI prefix before calling the custom parser', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toEqual({data: 'test', custom: true});
+          done();
+        }
+      });
+      factory.mockFlush(200, 'OK', ")]}',\n" + '{"data": "test"}');
+    });
+
+    it('returns null for empty response body', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe((event) => {
+        if (event.type === HttpEventType.Response) {
+          expect(event.body).toBeNull();
+          done();
+        }
+      });
+      factory.mockFlush(200, 'OK', '');
+    });
+
+    it('handles parsing errors by returning an HttpErrorResponse with HttpJsonParseError', (done) => {
+      const req = new HttpRequest('GET', '/test', {responseType: 'json'});
+      backend.handle(req).subscribe({
+        error: (error) => {
+          expect(error.error.text).toBe('invalid json');
+          expect(error.error.error instanceof SyntaxError).toBeTrue();
+          done();
+        },
+      });
+      factory.mockFlush(200, 'OK', 'invalid json');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Built-in JSON parsing in `HttpClient` is not easily customizable. While interceptors can be used, they require manual handling of XSSI prefix stripping and consistent error mapping, which is error-prone and inconsistent with the framework's default behavior.

Issue Number: #48167

## What is the new behavior?

This PR introduces the `HttpJsonParser` interface and `HTTP_JSON_PARSER` injection token, allowing developers to provide a custom JSON parsing implementation. 

- New `HttpJsonParser` abstract class and `DefaultHttpJsonParser` implementation.
- `HTTP_JSON_PARSER` token to override the default parser.
- `withJsonParser(parser: Type<HttpJsonParser>)` feature for `provideHttpClient`.
- Integrated into both `HttpXhrBackend` and `FetchBackend`.
- Maintains automatic XSSI prefix stripping and consistent `HttpJsonParseError` handling.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
