### PR TITLE
feat(core): support customization of @defer's on idle behavior

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -844,6 +844,12 @@ export interface HostListenerDecorator {
 }
 
 // @public
+export interface IdleService {
+    cancelOnIdle(id: number): void;
+    requestOnIdle(callback: (deadline?: IdleDeadline) => void): number;
+}
+
+// @public
 export function importProvidersFrom(...sources: ImportProvidersSource[]): EnvironmentProviders;
 
 // @public
@@ -1488,6 +1494,9 @@ export function provideCheckNoChangesConfig(options: {
 
 // @public
 export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
+
+// @public
+export function provideIdleServiceWith(useExisting: AbstractType<IdleService> | InjectionToken<IdleService>): EnvironmentProviders;
 
 // @public
 export function provideNgReflectAttributes(): EnvironmentProviders;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -131,6 +131,7 @@ export {
   AnimationFunction,
   MAX_ANIMATION_TIMEOUT,
 } from './animation/interfaces';
+export {IdleService, provideIdleServiceWith} from './defer/idle_service';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/src/defer/idle_service.ts
+++ b/packages/core/src/defer/idle_service.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AbstractType} from '../interface/type';
+import {InjectionToken} from '../di/injection_token';
+import type {EnvironmentProviders} from '../di/interface/provider';
+import {makeEnvironmentProviders} from '../di/provider_collection';
+
+/**
+ * Use shims for the `requestIdleCallback` and `cancelIdleCallback` functions for
+ * environments where those functions are not available (e.g. Node.js and Safari).
+ *
+ * Note: we wrap the `requestIdleCallback` call into a function, so that it can be
+ * overridden/mocked in test environment and picked up by the runtime code.
+ */
+const _requestIdleCallback = () =>
+  typeof requestIdleCallback !== 'undefined' ? requestIdleCallback.bind(globalThis) : setTimeout;
+const _cancelIdleCallback = () =>
+  typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback.bind(globalThis) : clearTimeout;
+
+/**
+ * Service which configures custom 'on idle' behavior for Angular features like `@defer`.
+ *
+ * @publicApi
+ */
+export interface IdleService {
+  /**
+   * Schedule `callback` to be executed when the current application or browser is considered idle.
+   *
+   * @returns an id which allows the scheduled callback to be cancelled before it executes.
+   */
+  requestOnIdle(callback: (deadline?: IdleDeadline) => void): number;
+
+  /**
+   * Cancel a previously scheduled callback using the id associated with it.
+   */
+  cancelOnIdle(id: number): void;
+}
+
+export const IDLE_SERVICE = new InjectionToken<IdleService>(ngDevMode ? 'IDLE_SERVICE' : '', {
+  providedIn: 'root',
+  factory: () => new RequestIdleCallbackService(),
+});
+
+/**
+ * Configures Angular to use the given DI token as its `IdleService`.
+ *
+ * The given token must be available for injection from the root injector, and the injected value
+ * must implement the `IdleService` interface.
+ *
+ * @publicApi
+ */
+export function provideIdleServiceWith(
+  useExisting: AbstractType<IdleService> | InjectionToken<IdleService>,
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: IDLE_SERVICE,
+      useExisting,
+    },
+  ]);
+}
+
+/**
+ * Default implementation of `IDLE_SERVICE` which uses `requestIdleCallback` when available or
+ * `setTimeout` when not.
+ */
+class RequestIdleCallbackService implements IdleService {
+  private readonly requestIdleCallback = _requestIdleCallback();
+  private readonly cancelIdleCallback = _cancelIdleCallback();
+
+  requestOnIdle(callback: (deadline?: IdleDeadline) => void): number {
+    return this.requestIdleCallback(callback) as unknown as number;
+  }
+
+  cancelOnIdle(id: number): void {
+    return this.cancelIdleCallback(id);
+  }
+}


### PR DESCRIPTION
This commit makes the behavior of `on idle` in `@defer` configurable via DI. It defines an `IdleService` interface that an application can implement and provide to Angular:

```ts
@Injectable({providedIn: 'root'})
export class CustomIdleService implements IdleService {
  requestOnIdle(callback: () => void): number {...}
  cancelOnIdle(id: number): void {...}
}
```

Then the idle service can be used by providing the `IDLE_SERVICE` token with the custom implementation.
