### PR TITLE
refactor(http): ensure `HttpClientModule` always uses the xhr backend

### DIFF
--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -14,6 +14,7 @@ import {
   withInterceptorsFromDi,
   withJsonpSupport,
   withNoXsrfProtection,
+  withXhr,
   withXsrfConfiguration,
 } from './provider';
 import {
@@ -90,6 +91,9 @@ export class HttpClientXsrfModule {
  * You can add interceptors to the chain behind `HttpClient` by binding them to the
  * multiprovider for built-in DI token `HTTP_INTERCEPTORS`.
  *
+ * When importing the `HttpClientModule`, the `HttpBackend` is set to using the `HttpXhrBackend`.
+ * If you want to use the `FetchBackend`, use `provideHttpClient` instead.
+ *
  * @publicApi
  * @deprecated use `provideHttpClient(withInterceptorsFromDi())` as providers instead
  */
@@ -98,7 +102,7 @@ export class HttpClientXsrfModule {
    * Configures the dependency injector where it is imported
    * with supporting services for HTTP communications.
    */
-  providers: [provideHttpClient(withInterceptorsFromDi())],
+  providers: [provideHttpClient(withInterceptorsFromDi(), withXhr())],
 })
 export class HttpClientModule {}
 


### PR DESCRIPTION
This is a follow-up of #67231, in preparation of making the `FetchBackend` the default
