### PR TITLE
refactor(upgrade): remove `getAngularLib`/`setAngularLib`

### DIFF
--- a/goldens/public-api/upgrade/static/index.api.md
+++ b/goldens/public-api/upgrade/static/index.api.md
@@ -42,14 +42,8 @@ export function downgradeModule<T>(moduleOrBootstrapFn: NgModuleFactory<T>): str
 // @public
 export function getAngularJSGlobal(): any;
 
-// @public @deprecated (undocumented)
-export function getAngularLib(): any;
-
 // @public
 export function setAngularJSGlobal(ng: any): void;
-
-// @public @deprecated (undocumented)
-export function setAngularLib(ng: any): void;
 
 // @public
 export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {

--- a/packages/upgrade/static/public_api.ts
+++ b/packages/upgrade/static/public_api.ts
@@ -6,18 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {
-  getAngularJSGlobal,
-  getAngularLib,
-  setAngularJSGlobal,
-  setAngularLib,
-} from '../src/common/src/angular1';
+export {getAngularJSGlobal, setAngularJSGlobal} from '../src/common/src/angular1';
 export {downgradeComponent} from '../src/common/src/downgrade_component';
 export {downgradeInjectable} from '../src/common/src/downgrade_injectable';
 export {VERSION} from '../src/common/src/version';
+export * from './common';
 export {downgradeModule} from './src/downgrade_module';
 export {UpgradeComponent} from './src/upgrade_component';
 export {UpgradeModule} from './src/upgrade_module';
-export * from './common';
 
 // This file only re-exports items to appear in the public api. Keep it that way.


### PR DESCRIPTION
Both functions were deprecated in v5 and are replaced by `getAngularJSGlobal`/`setAngularJSGlobal`

BREAKING CHANGE: Deprecated `getAngularLib`/`setAngularLib` have been removed use `getAngularJSGlobal`/`setAngularJSGlobal` instead.
