### PR TITLE
WIP: inline template/style bridge hardening and scoped style references

### DIFF
--- a/packages/language-service/src/document_symbols.ts
+++ b/packages/language-service/src/document_symbols.ts
@@ -1,0 +1,772 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  AST,
+  ASTWithSource,
+  ParseSourceSpan,
+  TmplAstBoundAttribute,
+  TmplAstBoundDeferredTrigger,
+  TmplAstBoundEvent,
+  TmplAstComponent,
+  TmplAstContent,
+  TmplAstDeferredBlock,
+  TmplAstDeferredBlockError,
+  TmplAstDeferredBlockLoading,
+  TmplAstDeferredBlockPlaceholder,
+  TmplAstElement,
+  TmplAstForLoopBlock,
+  TmplAstForLoopBlockEmpty,
+  TmplAstHoverDeferredTrigger,
+  TmplAstIfBlock,
+  TmplAstIfBlockBranch,
+  TmplAstInteractionDeferredTrigger,
+  TmplAstLetDeclaration,
+  TmplAstNode,
+  TmplAstRecursiveVisitor,
+  TmplAstReference,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+  TmplAstSwitchBlockCaseGroup,
+  TmplAstTemplate,
+  TmplAstTextAttribute,
+  TmplAstTimerDeferredTrigger,
+  TmplAstVariable,
+  TmplAstViewportDeferredTrigger,
+  tmplAstVisitAll,
+} from '@angular/compiler';
+import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
+import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
+import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import ts from 'typescript';
+
+import {AngularSymbolKind, TemplateDocumentSymbol} from '../api';
+
+import {getFirstComponentForTemplateFile, isTypeScriptFile, toTextSpan} from './utils';
+
+// Re-export for consumers that import from this file
+export {AngularSymbolKind, DocumentSymbolsOptions, TemplateDocumentSymbol} from '../api';
+import {DocumentSymbolsOptions} from '../api';
+
+/** Maximum length for expression text in symbol names */
+const MAX_EXPRESSION_LENGTH = 30;
+
+/**
+ * Gets the source text for an expression, truncated if too long.
+ */
+function getExpressionText(expr: AST | null): string {
+  if (expr === null) {
+    return '';
+  }
+  // ASTWithSource contains the original source text
+  if (expr instanceof ASTWithSource && expr.source !== null) {
+    const source = expr.source.trim();
+    if (source.length > MAX_EXPRESSION_LENGTH) {
+      return source.substring(0, MAX_EXPRESSION_LENGTH) + '…';
+    }
+    return source;
+  }
+  // Fallback for other AST types - just use ellipsis
+  return '…';
+}
+
+/**
+ * Gets document symbols for Angular templates in the given file.
+ * For TypeScript files with inline templates, returns symbols for each template.
+ * For external template files (.html), returns symbols for the template content.
+ *
+ * @param compiler The Angular compiler instance
+ * @param fileName The file path to get template symbols for
+ * @param options Optional configuration for document symbols behavior
+ */
+export function getTemplateDocumentSymbols(
+  compiler: NgCompiler,
+  fileName: string,
+  options?: DocumentSymbolsOptions,
+): TemplateDocumentSymbol[] {
+  if (isTypeScriptFile(fileName)) {
+    const sf = compiler.getCurrentProgram().getSourceFile(fileName);
+    if (sf === undefined) {
+      return [];
+    }
+
+    const symbols: TemplateDocumentSymbol[] = [];
+    for (const stmt of sf.statements) {
+      if (isNamedClassDeclaration(stmt)) {
+        const resources = compiler.getDirectiveResources(stmt);
+        if (
+          resources === null ||
+          resources.template === null ||
+          isExternalResource(resources.template)
+        ) {
+          continue;
+        }
+        const template = compiler.getTemplateTypeChecker().getTemplate(stmt);
+        if (template === null) {
+          continue;
+        }
+        // For inline templates, create symbols with className for proper merging
+        const className = stmt.name.text;
+        const templateSymbols = TemplateSymbolVisitor.getSymbols(template, options);
+        // Set className on root-level symbols for multi-component file support
+        for (const symbol of templateSymbols) {
+          symbol.className = className;
+        }
+        if (templateSymbols.length > 0) {
+          symbols.push(...templateSymbols);
+        }
+      }
+    }
+    return symbols;
+  } else {
+    // External template file
+    const typeCheckInfo = getFirstComponentForTemplateFile(fileName, compiler);
+    if (typeCheckInfo === undefined) {
+      return [];
+    }
+    return TemplateSymbolVisitor.getSymbols(typeCheckInfo.nodes, options);
+  }
+}
+
+/**
+ * Visitor that walks the template AST and creates document symbols.
+ */
+class TemplateSymbolVisitor extends TmplAstRecursiveVisitor {
+  private readonly symbols: TemplateDocumentSymbol[] = [];
+  private readonly symbolStack: TemplateDocumentSymbol[][] = [];
+  /**
+   * Set of variables that have already been processed explicitly.
+   * Used to prevent duplicates when visitVariable is called via tmplAstVisitAll.
+   */
+  private readonly processedVariables = new Set<TmplAstVariable>();
+  /**
+   * Options for customizing symbol generation behavior.
+   */
+  private readonly options: DocumentSymbolsOptions;
+
+  constructor(options?: DocumentSymbolsOptions) {
+    super();
+    this.options = options ?? {};
+  }
+
+  static getSymbols(
+    templateNodes: TmplAstNode[],
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    const visitor = new TemplateSymbolVisitor(options);
+    visitor.symbolStack.push(visitor.symbols);
+    tmplAstVisitAll(visitor, templateNodes);
+    return visitor.symbols;
+  }
+
+  private addSymbol(symbol: TemplateDocumentSymbol): void {
+    const current = this.symbolStack[this.symbolStack.length - 1];
+    current.push(symbol);
+  }
+
+  private pushChildren(symbol: TemplateDocumentSymbol): void {
+    symbol.childItems = [];
+    this.symbolStack.push(symbol.childItems);
+  }
+
+  private popChildren(): void {
+    this.symbolStack.pop();
+  }
+
+  // Control flow blocks
+  override visitIfBlock(block: TmplAstIfBlock): void {
+    // Visit branches with index to differentiate @if from @else if
+    for (let i = 0; i < block.branches.length; i++) {
+      this.visitIfBlockBranchWithIndex(block.branches[i], i);
+    }
+  }
+
+  private visitIfBlockBranchWithIndex(branch: TmplAstIfBlockBranch, index: number): void {
+    let name: string;
+    if (branch.expression === null) {
+      // No expression means @else
+      name = '@else';
+    } else if (index === 0) {
+      // First branch with expression is @if
+      const exprText = getExpressionText(branch.expression);
+      const aliasText = branch.expressionAlias ? `; as ${branch.expressionAlias.name}` : '';
+      name = `@if (${exprText}${aliasText})`;
+    } else {
+      // Subsequent branches with expression are @else if
+      const exprText = getExpressionText(branch.expression);
+      const aliasText = branch.expressionAlias ? `; as ${branch.expressionAlias.name}` : '';
+      name = `@else if (${exprText}${aliasText})`;
+    }
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // Control flow → Struct 🔶
+      spans: [toTextSpan(branch.sourceSpan)],
+      nameSpan: toTextSpan(branch.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add expression alias as a child variable if present
+    if (branch.expressionAlias) {
+      this.processedVariables.add(branch.expressionAlias);
+      const aliasSymbol: TemplateDocumentSymbol = {
+        text: `as ${branch.expressionAlias.name}`,
+        kind: ts.ScriptElementKind.localVariableElement,
+        spans: [toTextSpan(branch.expressionAlias.keySpan)],
+        nameSpan: toTextSpan(branch.expressionAlias.keySpan),
+      };
+      this.addSymbol(aliasSymbol);
+    }
+
+    tmplAstVisitAll(this, branch.children);
+    this.popChildren();
+  }
+
+  // Keep the base class method as a no-op since we handle branches in visitIfBlock
+  override visitIfBlockBranch(_branch: TmplAstIfBlockBranch): void {
+    // Handled by visitIfBlockBranchWithIndex
+  }
+
+  override visitForLoopBlock(block: TmplAstForLoopBlock): void {
+    // Get expression text for the collection being iterated
+    const exprText = getExpressionText(block.expression);
+    const name = `@for (${block.item.name} of ${exprText})`;
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Array, // @for loop → Array 📦
+      spans: [toTextSpan(block.mainBlockSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add the loop item variable (mark as processed to avoid duplicates)
+    this.processedVariables.add(block.item);
+    const itemSymbol: TemplateDocumentSymbol = {
+      text: `let ${block.item.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(block.item.keySpan)],
+      nameSpan: toTextSpan(block.item.keySpan),
+    };
+    this.addSymbol(itemSymbol);
+
+    // Add context variables ($index, $count, $first, $last, $even, $odd)
+    // By default, only show explicitly aliased ones (e.g., `let i = $index`)
+    // If showImplicitForVariables is true, show all including implicit ones
+    for (const contextVar of block.contextVariables) {
+      this.processedVariables.add(contextVar);
+      // Show if explicitly aliased (name differs from value) OR if showImplicitForVariables is enabled
+      const isExplicitlyAliased = contextVar.name !== contextVar.value;
+      if (isExplicitlyAliased || this.options.showImplicitForVariables) {
+        const contextSymbol: TemplateDocumentSymbol = {
+          text: `let ${contextVar.name}`,
+          kind: ts.ScriptElementKind.localVariableElement,
+          spans: [toTextSpan(contextVar.keySpan)],
+          nameSpan: toTextSpan(contextVar.keySpan),
+        };
+        this.addSymbol(contextSymbol);
+      }
+    }
+
+    tmplAstVisitAll(this, block.children);
+    if (block.empty) {
+      block.empty.visit(this);
+    }
+    this.popChildren();
+  }
+
+  override visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: '@empty',
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Array, // @empty is part of @for → Array
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitSwitchBlock(block: TmplAstSwitchBlock): void {
+    // Get expression text for the switch condition
+    const exprText = getExpressionText(block.expression);
+    const name = `@switch (${exprText})`;
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // @switch → Struct 🔶
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.groups);
+    this.popChildren();
+  }
+
+  override visitSwitchBlockCaseGroup(group: TmplAstSwitchBlockCaseGroup): void {
+    // A case group represents multiple cases that share the same body (fall-through)
+    // Create a single symbol for the group with all case labels
+    if (group.cases.length === 0) {
+      return;
+    }
+
+    // Build the name by combining all case labels
+    const caseLabels: string[] = [];
+    let hasDefault = false;
+    for (const caseBlock of group.cases) {
+      if (caseBlock.expression === null) {
+        hasDefault = true;
+        caseLabels.push('@default');
+      } else {
+        const exprText = getExpressionText(caseBlock.expression);
+        caseLabels.push(`@case (${exprText})`);
+      }
+    }
+
+    // For a single case, just use the case name
+    // For multiple cases (fall-through), join with " | " to indicate grouping
+    const name = caseLabels.length === 1 ? caseLabels[0] : caseLabels.join(' | ');
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: hasDefault ? ts.ScriptElementKind.label : ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Struct, // @case/@default → Struct 🔶
+      spans: [toTextSpan(group.sourceSpan)],
+      nameSpan: toTextSpan(group.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, group.children);
+    this.popChildren();
+  }
+
+  // Keep the base class method as a no-op since we handle cases in visitSwitchBlockCaseGroup
+  override visitSwitchBlockCase(_block: TmplAstSwitchBlockCase): void {
+    // Handled by visitSwitchBlockCaseGroup
+  }
+
+  override visitDeferredBlock(block: TmplAstDeferredBlock): void {
+    // Build defer name with trigger information
+    const triggers = this.getDeferTriggerInfo(block);
+    const name = triggers.length > 0 ? `@defer (${triggers.join('; ')})` : '@defer';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @defer → Event ⚡
+      spans: [toTextSpan(block.mainBlockSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add prefetch trigger info as child if present
+    const prefetchTriggers = this.getPrefetchTriggerInfo(block);
+    if (prefetchTriggers.length > 0) {
+      const prefetchSymbol: TemplateDocumentSymbol = {
+        text: `prefetch ${prefetchTriggers.join('; ')}`,
+        kind: ts.ScriptElementKind.keyword,
+        spans: [toTextSpan(block.startSourceSpan)],
+        nameSpan: toTextSpan(block.startSourceSpan),
+      };
+      this.addSymbol(prefetchSymbol);
+    }
+
+    tmplAstVisitAll(this, block.children);
+    if (block.placeholder) {
+      block.placeholder.visit(this);
+    }
+    if (block.loading) {
+      block.loading.visit(this);
+    }
+    if (block.error) {
+      block.error.visit(this);
+    }
+    this.popChildren();
+  }
+
+  /**
+   * Gets human-readable trigger information for a @defer block.
+   */
+  private getDeferTriggerInfo(block: TmplAstDeferredBlock): string[] {
+    const triggers: string[] = [];
+    const t = block.triggers;
+
+    if (t.when) {
+      const exprText = getExpressionText((t.when as TmplAstBoundDeferredTrigger).value);
+      triggers.push(`when ${exprText}`);
+    }
+    if (t.idle) {
+      triggers.push('on idle');
+    }
+    if (t.immediate) {
+      triggers.push('on immediate');
+    }
+    if (t.timer) {
+      const delay = (t.timer as TmplAstTimerDeferredTrigger).delay;
+      triggers.push(`on timer(${delay}ms)`);
+    }
+    if (t.viewport) {
+      const ref = (t.viewport as TmplAstViewportDeferredTrigger).reference;
+      triggers.push(ref ? `on viewport(${ref})` : 'on viewport');
+    }
+    if (t.interaction) {
+      const ref = (t.interaction as TmplAstInteractionDeferredTrigger).reference;
+      triggers.push(ref ? `on interaction(${ref})` : 'on interaction');
+    }
+    if (t.hover) {
+      const ref = (t.hover as TmplAstHoverDeferredTrigger).reference;
+      triggers.push(ref ? `on hover(${ref})` : 'on hover');
+    }
+    if (t.never) {
+      triggers.push('on never');
+    }
+
+    return triggers;
+  }
+
+  /**
+   * Gets human-readable prefetch trigger information for a @defer block.
+   */
+  private getPrefetchTriggerInfo(block: TmplAstDeferredBlock): string[] {
+    const triggers: string[] = [];
+    const t = block.prefetchTriggers;
+
+    if (t.when) {
+      const exprText = getExpressionText((t.when as TmplAstBoundDeferredTrigger).value);
+      triggers.push(`when ${exprText}`);
+    }
+    if (t.idle) {
+      triggers.push('on idle');
+    }
+    if (t.immediate) {
+      triggers.push('on immediate');
+    }
+    if (t.timer) {
+      const delay = (t.timer as TmplAstTimerDeferredTrigger).delay;
+      triggers.push(`on timer(${delay}ms)`);
+    }
+    if (t.viewport) {
+      const ref = (t.viewport as TmplAstViewportDeferredTrigger).reference;
+      triggers.push(ref ? `on viewport(${ref})` : 'on viewport');
+    }
+    if (t.interaction) {
+      const ref = (t.interaction as TmplAstInteractionDeferredTrigger).reference;
+      triggers.push(ref ? `on interaction(${ref})` : 'on interaction');
+    }
+    if (t.hover) {
+      const ref = (t.hover as TmplAstHoverDeferredTrigger).reference;
+      triggers.push(ref ? `on hover(${ref})` : 'on hover');
+    }
+
+    return triggers;
+  }
+
+  override visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder): void {
+    // Include minimum time parameter if present
+    const minTime = block.minimumTime;
+    const name = minTime !== null ? `@placeholder (minimum ${minTime}ms)` : '@placeholder';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @placeholder → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitDeferredBlockLoading(block: TmplAstDeferredBlockLoading): void {
+    // Include timing parameters if present
+    const timings: string[] = [];
+    if (block.afterTime !== null) {
+      timings.push(`after ${block.afterTime}ms`);
+    }
+    if (block.minimumTime !== null) {
+      timings.push(`minimum ${block.minimumTime}ms`);
+    }
+    const name = timings.length > 0 ? `@loading (${timings.join('; ')})` : '@loading';
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @loading → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  override visitDeferredBlockError(block: TmplAstDeferredBlockError): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: '@error',
+      kind: ts.ScriptElementKind.functionElement,
+      lspKind: AngularSymbolKind.Event, // @error → Event ⚡
+      spans: [toTextSpan(block.sourceSpan)],
+      nameSpan: toTextSpan(block.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+    tmplAstVisitAll(this, block.children);
+    this.popChildren();
+  }
+
+  // Elements and components
+  override visitElement(element: TmplAstElement): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `<${element.name}>`,
+      kind: ts.ScriptElementKind.memberVariableElement,
+      // Use Object for elements 🟡
+      lspKind: AngularSymbolKind.Object,
+      spans: [toTextSpan(element.sourceSpan)],
+      nameSpan: toTextSpan(element.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references as children
+    for (const ref of element.references) {
+      ref.visit(this);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, element.children);
+    this.popChildren();
+  }
+
+  override visitComponent(component: TmplAstComponent): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `<${component.tagName || component.componentName}>`,
+      kind: ts.ScriptElementKind.classElement,
+      spans: [toTextSpan(component.sourceSpan)],
+      nameSpan: toTextSpan(component.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references as children
+    for (const ref of component.references) {
+      ref.visit(this);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, component.children);
+    this.popChildren();
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    // Check if this template is from a structural directive (has directives and tagName)
+    const structuralDirective = this.getStructuralDirectiveInfo(template);
+
+    let name: string;
+    let kind: ts.ScriptElementKind;
+    let lspKind: AngularSymbolKind | undefined;
+
+    if (structuralDirective) {
+      // Display structural directive like control flow: *ngIf (expr), *ngFor (let item of items)
+      name = structuralDirective.displayName;
+      // Use Class icon for all structural directives (like components)
+      kind = ts.ScriptElementKind.classElement;
+      lspKind = undefined; // Use default Class mapping
+    } else {
+      // Regular ng-template or template element → keep as Field to match HTML elements
+      name = template.tagName ? `<${template.tagName}>` : '<ng-template>';
+      kind = ts.ScriptElementKind.memberVariableElement;
+      lspKind = undefined; // Use default Field mapping
+    }
+
+    const symbol: TemplateDocumentSymbol = {
+      text: name,
+      kind,
+      lspKind,
+      spans: [toTextSpan(template.sourceSpan)],
+      nameSpan: toTextSpan(template.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+    this.pushChildren(symbol);
+
+    // Add references and variables as children
+    for (const ref of template.references) {
+      ref.visit(this);
+    }
+    for (const variable of template.variables) {
+      this.addTemplateVariableSymbol(variable, structuralDirective !== null);
+    }
+
+    // Visit child elements
+    tmplAstVisitAll(this, template.children);
+    this.popChildren();
+  }
+
+  private addTemplateVariableSymbol(
+    variable: TmplAstVariable,
+    isStructuralDirectiveTemplate: boolean,
+  ): void {
+    // Compiler microsyntax parser preserves key/value spans for variables.
+    // For `export as local`, `valueSpan` appears before `keySpan`.
+    // For `let local = export`, `keySpan` appears before `valueSpan`.
+    const isAsSyntax =
+      variable.valueSpan !== undefined && variable.value !== '$implicit'
+        ? variable.valueSpan.start.offset < variable.keySpan.start.offset
+        : false;
+    const isMicrosyntaxAlias =
+      isStructuralDirectiveTemplate && variable.value !== '$implicit' && isAsSyntax;
+    const text = isMicrosyntaxAlias ? `as ${variable.name}` : `let ${variable.name}`;
+
+    const symbol: TemplateDocumentSymbol = {
+      text,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(variable.keySpan)],
+      nameSpan: toTextSpan(variable.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  /**
+   * Detects structural directives and returns generic display information based
+   * on microsyntax/template bindings (without directive-specific hardcoding).
+   */
+  private getStructuralDirectiveInfo(
+    template: TmplAstTemplate,
+  ): {displayName: string; directiveName: string} | null {
+    // If no templateAttrs, not a structural directive template
+    if (template.templateAttrs.length === 0) {
+      return null;
+    }
+
+    const textAttrs = template.templateAttrs.filter(
+      (attr): attr is TmplAstTextAttribute => attr instanceof TmplAstTextAttribute,
+    );
+    const boundAttrs = template.templateAttrs.filter(
+      (attr): attr is TmplAstBoundAttribute => attr instanceof TmplAstBoundAttribute,
+    );
+
+    // For inline structural syntax (`*prefix="..."`), this text attribute is
+    // the directive prefix (`prefix`).
+    const prefixAttr = textAttrs[0];
+    if (prefixAttr) {
+      const directiveName = prefixAttr.name;
+      const directiveNameLower = directiveName.toLowerCase();
+
+      const primaryBound = boundAttrs.find(
+        (attr) => attr.name.toLowerCase() === directiveNameLower,
+      );
+      if (primaryBound) {
+        const expr = getExpressionText(primaryBound.value);
+        return {displayName: `*${directiveName} (${expr})`, directiveName};
+      }
+
+      const keyedBound = boundAttrs.find(
+        (attr) =>
+          attr.name.toLowerCase().startsWith(directiveNameLower) &&
+          attr.name.length > directiveName.length,
+      );
+      if (keyedBound) {
+        const itemVar = template.variables.find((v) => v.value === '$implicit');
+        const itemName = itemVar?.name || 'item';
+        const expr = getExpressionText(keyedBound.value);
+        const rawKeyword = keyedBound.name.slice(directiveName.length);
+        const keyword = rawKeyword[0].toLowerCase() + rawKeyword.slice(1);
+        return {
+          displayName: `*${directiveName} (let ${itemName} ${keyword} ${expr})`,
+          directiveName,
+        };
+      }
+
+      const firstBound = boundAttrs[0];
+      if (firstBound) {
+        const expr = getExpressionText(firstBound.value);
+        return {displayName: `*${directiveName} (${expr})`, directiveName};
+      }
+
+      return {displayName: `*${directiveName}`, directiveName};
+    }
+
+    if (boundAttrs.length > 0) {
+      const firstBound = boundAttrs[0];
+      const expr = getExpressionText(firstBound.value);
+      return {displayName: `*${firstBound.name} (${expr})`, directiveName: firstBound.name};
+    }
+
+    return null;
+  }
+
+  /**
+   * Gets the expression text for a template attribute by name.
+   */
+  private getTemplateAttrExpression(template: TmplAstTemplate, attrName: string): string {
+    for (const attr of template.templateAttrs) {
+      if (attr instanceof TmplAstBoundAttribute && attr.name === attrName) {
+        return getExpressionText(attr.value);
+      }
+      if (attr instanceof TmplAstTextAttribute && attr.name === attrName) {
+        return attr.value || '';
+      }
+    }
+    return '…';
+  }
+
+  override visitContent(content: TmplAstContent): void {
+    const selector = content.selector ? ` select="${content.selector}"` : '';
+    const symbol: TemplateDocumentSymbol = {
+      text: `<ng-content${selector}>`,
+      kind: ts.ScriptElementKind.interfaceElement,
+      spans: [toTextSpan(content.sourceSpan)],
+      nameSpan: toTextSpan(content.startSourceSpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  // Template variables and references
+  override visitReference(reference: TmplAstReference): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `#${reference.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(reference.sourceSpan)],
+      nameSpan: toTextSpan(reference.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  override visitVariable(variable: TmplAstVariable): void {
+    // Skip variables that were already processed explicitly (e.g., @for item, @if alias)
+    if (this.processedVariables.has(variable)) {
+      return;
+    }
+    const symbol: TemplateDocumentSymbol = {
+      text: `let ${variable.name}`,
+      kind: ts.ScriptElementKind.localVariableElement,
+      spans: [toTextSpan(variable.sourceSpan)],
+      nameSpan: toTextSpan(variable.keySpan),
+    };
+    this.addSymbol(symbol);
+  }
+
+  override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+    const symbol: TemplateDocumentSymbol = {
+      text: `@let ${decl.name}`,
+      kind: ts.ScriptElementKind.letElement,
+      spans: [toTextSpan(decl.sourceSpan)],
+      nameSpan: toTextSpan(decl.nameSpan),
+    };
+    this.addSymbol(symbol);
+  }
+}

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -37,6 +37,11 @@ import {CompilerFactory} from './compiler_factory';
 import {CompletionBuilder} from './completions';
 import {DefinitionBuilder} from './definitions';
 import {getLinkedEditingRangeAtPosition} from './linked_editing_range';
+import {
+  DocumentSymbolsOptions,
+  getTemplateDocumentSymbols,
+  TemplateDocumentSymbol,
+} from './document_symbols';
 import {getOutliningSpans} from './outlining_spans';
 import {QuickInfoBuilder} from './quick_info';
 import {ReferencesBuilder, RenameBuilder} from './references_and_rename';
@@ -488,6 +493,23 @@ export class LanguageService {
   getOutliningSpans(fileName: string): ts.OutliningSpan[] {
     return this.withCompilerAndPerfTracing(PerfPhase.OutliningSpans, (compiler) => {
       return getOutliningSpans(compiler, fileName);
+    });
+  }
+
+  /**
+   * Gets document symbols for Angular templates, including control flow blocks,
+   * elements, components, template references, and @let declarations.
+   * Returns symbols in NavigationTree format for compatibility with TypeScript.
+   *
+   * @param fileName The file path to get template symbols for
+   * @param options Optional configuration for document symbols behavior
+   */
+  getTemplateDocumentSymbols(
+    fileName: string,
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    return this.withCompilerAndPerfTracing(PerfPhase.LsComponentLocations, (compiler) => {
+      return getTemplateDocumentSymbols(compiler, fileName, options);
     });
   }
 

--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -11,12 +11,14 @@ import type ts from 'typescript';
 import {
   ApplyRefactoringProgressFn,
   ApplyRefactoringResult,
+  DocumentSymbolsOptions,
   GetComponentLocationsForTemplateResponse,
   GetTcbResponse,
   GetTemplateLocationForComponentResponse,
   isNgLanguageService,
   LinkedEditingRanges,
   NgLanguageService,
+  TemplateDocumentSymbol,
 } from '../api';
 
 import {LanguageService} from './language_service';
@@ -350,6 +352,13 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     ngLS.ensureProjectAnalyzed();
   }
 
+  function getTemplateDocumentSymbols(
+    fileName: string,
+    options?: DocumentSymbolsOptions,
+  ): TemplateDocumentSymbol[] {
+    return ngLS.getTemplateDocumentSymbols(fileName, options);
+  }
+
   return {
     ...tsLS,
     ensureProjectAnalyzed,
@@ -375,6 +384,7 @@ export function create(info: ts.server.PluginCreateInfo): NgLanguageService {
     getSignatureHelpItems,
     getOutliningSpans,
     getTemplateLocationForComponent,
+    getTemplateDocumentSymbols,
     hasCodeFixesForErrorCode: ngLS.hasCodeFixesForErrorCode.bind(ngLS),
     getCodeFixesAtPosition,
     getCombinedCodeFix,

--- a/vscode-ng-language-service/INLINE_STYLES_ISSUES_TRIAGE.md
+++ b/vscode-ng-language-service/INLINE_STYLES_ISSUES_TRIAGE.md
@@ -1,0 +1,54 @@
+# Inline Styles Issues Triage (`area: vscode-extension`)
+
+Date: 2026-02-24
+Source query: open Angular issues with label `area: vscode-extension`
+
+## Scope
+
+This document focuses on open issues directly related to inline styles support in the VS Code extension, and adjacent issues that share the same embedded-content/scanner architecture.
+
+## Directly related to inline styles
+
+| Issue                                                     | Title                                                | Relation to Inline Styles                                             | Can we fix in extension? | Notes / Proposed approach                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#65521](https://github.com/angular/angular/issues/65521) | Syntax highlighting for inline styles other than CSS | Core issue for inline styles language handling (`css/scss/less/styl`) | **Partial**              | We can improve provider-side features (symbols/color/definition/selection), but TextMate syntax highlighting is constrained by static grammar mapping and marked `blocked on upstream`. Practical path: keep provider bridges robust; add optional user override for style language; document limitation. |
+
+## Strongly adjacent (shared embedded/scanner infrastructure)
+
+| Issue                                                     | Title                                                                | Why it matters for inline styles work                                                                                                     | Can we fix in extension? | Notes / Proposed approach                                                                                                                                                      |
+| --------------------------------------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [#65516](https://github.com/angular/angular/issues/65516) | String interpolation before inline template breaks language features | Same scanner/token boundary logic in `embedded_support.ts`; robustness here affects style/template region detection reliability           | **Yes**                  | Replace scanner heuristics with TS AST-based region extraction for all embedded contexts where possible. Add regression tests with preceding template literals/interpolations. |
+| [#65493](https://github.com/angular/angular/issues/65493) | Inline template Template Literals is not highlighted properly        | Indicates embedded tokenization instability around nested template literals; similar class of problems can affect style literals          | **Partial**              | Provider features can be made robust via AST + virtual docs, but full highlight behavior remains tied to grammar limitations.                                                  |
+| [#65494](https://github.com/angular/angular/issues/65494) | Template literals cause malfunction to quick suggestions             | Same root class: context detection in TS literals breaks suggestion routing                                                               | **Yes**                  | Strengthen context detection with AST and avoid scanner-only assumptions.                                                                                                      |
+| [#65500](https://github.com/angular/angular/issues/65500) | Highlighting within inline templates                                 | Highlights mismatch between file language (`typescript`) and embedded language behaviors; same architectural limitation applies to styles | **Partial**              | Similar to #65521: some behavior can be bridged provider-side; full editor language-mode parity is limited by VS Code grammar model.                                           |
+| [#65508](https://github.com/angular/angular/issues/65508) | Template fold variable break                                         | Folding in embedded template regions; style folding would rely on same virtual-region reliability                                         | **Yes**                  | Reuse robust region mapping and delegate folding provider on virtual docs where supported.                                                                                     |
+
+## Related config issue that affects style-language resolution
+
+| Issue                                                     | Title                                           | Relation                                                                                                              | Can we fix in extension? | Notes / Proposed approach                                                                                                                                        |
+| --------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#65509](https://github.com/angular/angular/issues/65509) | Support angular.json configuration for tsconfig | Project resolution quality impacts style-language policy when trying to infer inline style mode from workspace config | **Yes**                  | Improve project mapping from file -> effective project config; do not assume single root `tsconfig.json`. Useful for any future style-language selection policy. |
+
+## What we can realistically ship in `lsp-inline-styles-support`
+
+1. Robust provider bridges for inline styles in TS files:
+
+- document symbols
+- definition
+- selection ranges
+- color provider + color edit propagation
+
+2. Region detection hardening:
+
+- prefer AST extraction over scanner-only heuristics for embedded regions
+- add regressions around template literals/interpolation noise
+
+3. Explicitly document known limitation:
+
+- inline style syntax highlighting language switching remains partially blocked by upstream VS Code grammar capabilities.
+
+## Suggested sequencing
+
+1. Land provider reliability + tests (branch `lsp-inline-styles-support`).
+2. Land scanner/AST robustness fixes that reduce false negatives in embedded detection.
+3. Track `#65521` as partial: provider side improved now; grammar parity deferred/upstream-dependent.

--- a/vscode-ng-language-service/README.md
+++ b/vscode-ng-language-service/README.md
@@ -11,6 +11,7 @@ and external templates including:
 - AOT Diagnostic messages
 - Quick info
 - Go to definition
+- Document Symbols for Outline panel, breadcrumbs, and "Go to Symbol"
 
 ## Download
 
@@ -29,6 +30,35 @@ as shown in the following example:
 ```
 
 For more information, see the [Angular compiler options](https://angular.io/guide/angular-compiler-options) guide.
+
+## Extension Settings
+
+### Document Symbols
+
+Document Symbols enable the Outline panel, breadcrumbs navigation, and "Go to Symbol" (Cmd+Shift+O / Ctrl+Shift+O) to show Angular template elements like `@if`, `@for`, structural directives, and template references.
+
+| Setting                                            | Default | Description                                                                                  |
+| -------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `angular.documentSymbols.enabled`                  | `true`  | Enable Angular-specific document symbols                                                     |
+| `angular.documentSymbols.showImplicitForVariables` | `false` | Show implicit `@for` loop variables (`$index`, `$count`, `$first`, `$last`, `$even`, `$odd`) |
+
+For TypeScript files with inline templates, the Outline shows only the component class with template symbols nested inside:
+
+```
+MyComponent (class)
+└── (template)
+    ├── @if (condition)
+    └── <button>
+```
+
+Example configuration:
+
+```json
+{
+  "angular.documentSymbols.enabled": true,
+  "angular.documentSymbols.showImplicitForVariables": false
+}
+```
 
 ## Versioning
 

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -239,6 +239,15 @@ export class AngularLanguageClient implements vscode.Disposable {
 
           return angularCompletionsPromise;
         },
+        provideDocumentSymbols: async (
+          document: vscode.TextDocument,
+          token: vscode.CancellationToken,
+          next: lsp.ProvideDocumentSymbolsSignature,
+        ) => {
+          if (await this.isInAngularProject(document)) {
+            return next(document, token);
+          }
+        },
         provideFoldingRanges: async (
           document: vscode.TextDocument,
           context: vscode.FoldingContext,
@@ -470,6 +479,11 @@ export class AngularLanguageClient implements vscode.Disposable {
     if (suppressAngularDiagnosticCodes) {
       args.push('--suppressAngularDiagnosticCodes', suppressAngularDiagnosticCodes);
     }
+
+    // Note: Document symbols settings (angular.documentSymbols.enabled,
+    // angular.documentSymbols.showImplicitForVariables) are now fetched
+    // dynamically via workspace/configuration request by the server.
+    // This allows users to change these settings without restarting.
 
     const tsdk = config.get('typescript.tsdk', '');
     if (tsdk.trim().length > 0) {

--- a/vscode-ng-language-service/client/src/extension.ts
+++ b/vscode-ng-language-service/client/src/extension.ts
@@ -17,18 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Push the disposable to the context's subscriptions so that the
   // client can be deactivated on extension deactivation
   registerCommands(client, context);
-
-  // Restart the server on configuration change.
-  const disposable = vscode.workspace.onDidChangeConfiguration(
-    async (e: vscode.ConfigurationChangeEvent) => {
-      if (!e.affectsConfiguration('angular')) {
-        return;
-      }
-      await client.stop();
-      await client.start();
-    },
-  );
-  context.subscriptions.push(client, disposable);
+  context.subscriptions.push(client);
 
   client.start();
 }

--- a/vscode-ng-language-service/client/src/inline_styles_support.ts
+++ b/vscode-ng-language-service/client/src/inline_styles_support.ts
@@ -1,0 +1,63 @@
+import type * as vscode from 'vscode';
+
+export class InlineStylesDocCache {
+  private readonly entries = new Map<string, {version: number; document: vscode.TextDocument}>();
+
+  get(sourceUri: string, sourceVersion: number): vscode.TextDocument | null {
+    const entry = this.entries.get(sourceUri);
+    if (!entry) {
+      return null;
+    }
+    return entry.version === sourceVersion ? entry.document : null;
+  }
+
+  set(sourceUri: string, sourceVersion: number, document: vscode.TextDocument): void {
+    this.entries.set(sourceUri, {version: sourceVersion, document});
+  }
+
+  invalidate(sourceUri: string): void {
+    this.entries.delete(sourceUri);
+  }
+}
+
+export function normalizeColorPresentations(
+  presentations: vscode.ColorPresentation[],
+  range: vscode.Range,
+): vscode.ColorPresentation[] {
+  return presentations.map((presentation) => {
+    const replacement = presentation.textEdit?.newText ?? presentation.label;
+    return {
+      ...presentation,
+      textEdit: {range, newText: replacement} as vscode.TextEdit,
+    };
+  });
+}
+
+export function createFallbackColorPresentations(
+  color: vscode.Color,
+  range: vscode.Range,
+): vscode.ColorPresentation[] {
+  const red = Math.round(color.red * 255);
+  const green = Math.round(color.green * 255);
+  const blue = Math.round(color.blue * 255);
+  const alpha = Number(color.alpha.toFixed(3));
+  const cssText =
+    alpha < 1 ? `rgb(${red} ${green} ${blue} / ${alpha})` : `rgb(${red} ${green} ${blue})`;
+
+  return [
+    {
+      label: cssText,
+      textEdit: {range, newText: cssText} as vscode.TextEdit,
+    },
+  ];
+}
+
+export function selectColorPresentations(
+  providerPresentations: vscode.ColorPresentation[],
+  color: vscode.Color,
+  range: vscode.Range,
+): vscode.ColorPresentation[] {
+  return providerPresentations.length > 0
+    ? normalizeColorPresentations(providerPresentations, range)
+    : createFallbackColorPresentations(color, range);
+}

--- a/vscode-ng-language-service/client/src/tests/inline_styles_support_spec.ts
+++ b/vscode-ng-language-service/client/src/tests/inline_styles_support_spec.ts
@@ -1,0 +1,88 @@
+import type * as vscode from 'vscode';
+
+import {
+  InlineStylesDocCache,
+  createFallbackColorPresentations,
+  normalizeColorPresentations,
+  selectColorPresentations,
+} from '../inline_styles_support';
+
+describe('inline styles support helpers', () => {
+  it('normalizes provider presentations to the requested range', () => {
+    const range = makeRange(1, 2, 1, 7);
+    const provider = [{label: 'rgb(1 2 3)'} as vscode.ColorPresentation];
+
+    const actual = normalizeColorPresentations(provider, range);
+
+    expect(actual.length).toBe(1);
+    expect(actual[0].textEdit?.range).toEqual(range);
+  });
+
+  it('uses provider presentation when available', () => {
+    const range = makeRange(0, 0, 0, 3);
+    const color = makeColor(1, 0, 0, 1);
+    const provider = [{label: 'from-provider'} as vscode.ColorPresentation];
+
+    const actual = selectColorPresentations(provider, color, range);
+
+    expect(actual.length).toBe(1);
+    expect(actual[0].textEdit?.newText).toBe('from-provider');
+  });
+
+  it('falls back when provider returns no presentations', () => {
+    const range = makeRange(0, 0, 0, 3);
+    const color = makeColor(200 / 255, 200 / 255, 200 / 255, 0.5);
+
+    const actual = selectColorPresentations([], color, range);
+
+    expect(actual.length).toBe(1);
+    expect(actual[0].textEdit?.newText).toContain('rgb(');
+  });
+
+  it('reuses cached inline styles document for same source version and invalidates', () => {
+    const cache = new InlineStylesDocCache();
+    const sourceUri = 'file:///tmp/source.ts';
+    const doc = {
+      uri: {toString: () => 'untitled:InlineStyles-1'} as vscode.Uri,
+      version: 1,
+    } as vscode.TextDocument;
+
+    cache.set(sourceUri, 7, doc);
+    const first = cache.get(sourceUri, 7);
+    const miss = cache.get(sourceUri, 8);
+
+    expect(first).toBe(doc);
+    expect(miss).toBeNull();
+
+    cache.invalidate(sourceUri);
+    const afterInvalidate = cache.get(sourceUri, 7);
+    expect(afterInvalidate).toBeNull();
+  });
+
+  it('creates fallback color presentation with text edit', () => {
+    const range = makeRange(3, 1, 3, 9);
+    const color = makeColor(2 / 255, 2 / 255, 2 / 255, 1);
+
+    const actual = createFallbackColorPresentations(color, range);
+
+    expect(actual.length).toBe(1);
+    expect(actual[0].textEdit).toBeDefined();
+    expect(actual[0].textEdit?.range).toEqual(range);
+  });
+});
+
+function makeRange(
+  startLine: number,
+  startCharacter: number,
+  endLine: number,
+  endCharacter: number,
+): vscode.Range {
+  return {
+    start: {line: startLine, character: startCharacter} as vscode.Position,
+    end: {line: endLine, character: endCharacter} as vscode.Position,
+  } as vscode.Range;
+}
+
+function makeColor(red: number, green: number, blue: number, alpha: number): vscode.Color {
+  return {red, green, blue, alpha} as vscode.Color;
+}

--- a/vscode-ng-language-service/integration/e2e/color_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/color_spec.ts
@@ -1,0 +1,124 @@
+import * as vscode from 'vscode';
+import {setTimeout} from 'node:timers/promises';
+
+import {activate, APP_COMPONENT_URI, COLOR_COMMAND, COLOR_PRESENTATION_COMMAND} from './helper';
+
+describe('Angular LS inline styles colors', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 30_000;
+
+  beforeAll(async () => {
+    await activate(APP_COMPONENT_URI);
+  });
+
+  it('returns color infos for inline component styles mapped to source TypeScript URI', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const colors = await waitForColors(APP_COMPONENT_URI);
+
+    expect(colors.length).toBe(1);
+
+    const colorTexts = colors.map((colorInfo) => document.getText(colorInfo.range));
+    expect(colorTexts).toEqual(['#ff0000']);
+
+    const expectedColorOffset = document.getText().indexOf('#ff0000');
+    const expectedColorStart = document.positionAt(expectedColorOffset);
+    expect(colors[0].range.start.isEqual(expectedColorStart)).toBeTrue();
+  });
+
+  it('returns color infos isolated to style blocks in a multi-style component', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const sourceText = document.getText();
+    const colorLiteralOffset = sourceText.indexOf('#ff0000');
+    const secondStyleOffset = sourceText.indexOf('.blue {');
+    const templateOffset = sourceText.indexOf('Hello {{ name }}');
+
+    expect(colorLiteralOffset).toBeGreaterThan(-1);
+    expect(secondStyleOffset).toBeGreaterThan(-1);
+    expect(templateOffset).toBeGreaterThan(-1);
+
+    const colorLiteralPosition = document.positionAt(colorLiteralOffset);
+    const secondStylePosition = document.positionAt(secondStyleOffset);
+    const templatePosition = document.positionAt(templateOffset);
+
+    const colors = await waitForColors(APP_COMPONENT_URI);
+
+    expect(colors.length).toBe(1);
+
+    const hasFirstBlockColor = colors.some((colorInfo) =>
+      colorInfo.range.contains(colorLiteralPosition),
+    );
+    const hasSecondBlockColor = colors.some((colorInfo) =>
+      colorInfo.range.contains(secondStylePosition),
+    );
+    const leaksIntoTemplate = colors.some((colorInfo) =>
+      colorInfo.range.contains(templatePosition),
+    );
+
+    expect(hasFirstBlockColor).toBeTrue();
+    expect(hasSecondBlockColor).toBeFalse();
+    expect(leaksIntoTemplate).toBeFalse();
+  });
+
+  it('returns color presentations with normalized text edits for inline style ranges', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const colors = await waitForColors(APP_COMPONENT_URI);
+    const swatch = colors.find((colorInfo) => document.getText(colorInfo.range) === '#ff0000');
+
+    expect(swatch).toBeDefined();
+
+    const presentations =
+      (await vscode.commands.executeCommand<vscode.ColorPresentation[]>(
+        COLOR_PRESENTATION_COMMAND,
+        swatch!.color,
+        {uri: APP_COMPONENT_URI, range: swatch!.range},
+      )) ?? [];
+
+    expect(presentations.length).toBeGreaterThan(0);
+    expect(
+      presentations.some((presentation) => presentation.textEdit?.range.isEqual(swatch!.range)),
+    ).toBeTrue();
+
+    for (const presentation of presentations) {
+      expect(presentation.label.length).toBeGreaterThan(0);
+      expect(presentation.textEdit).toBeDefined();
+      expect(presentation.textEdit!.newText.length).toBeGreaterThan(0);
+      expect(presentation.textEdit!.range.isEqual(swatch!.range)).toBeTrue();
+    }
+  });
+
+  it('does not return color presentations outside inline styles', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const sourceText = document.getText();
+    const templateOffset = sourceText.indexOf('Hello {{ name }}');
+
+    expect(templateOffset).toBeGreaterThan(-1);
+
+    const templateStart = document.positionAt(templateOffset);
+    const templateRange = new vscode.Range(templateStart, templateStart.translate(0, 5));
+
+    const presentations =
+      (await vscode.commands.executeCommand<vscode.ColorPresentation[]>(
+        COLOR_PRESENTATION_COMMAND,
+        new vscode.Color(1, 0, 0, 1),
+        {uri: APP_COMPONENT_URI, range: templateRange},
+      )) ?? [];
+
+    expect(presentations.length).toBe(0);
+  });
+});
+
+async function waitForColors(uri: vscode.Uri): Promise<vscode.ColorInformation[]> {
+  const timeoutMs = 20_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const colors =
+      (await vscode.commands.executeCommand<vscode.ColorInformation[]>(COLOR_COMMAND, uri)) ?? [];
+    if (colors.length > 0) {
+      return colors;
+    }
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for colors at ${uri.toString()}`);
+}

--- a/vscode-ng-language-service/integration/e2e/completion_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/completion_spec.ts
@@ -7,22 +7,111 @@
  */
 
 import * as vscode from 'vscode';
+import {setTimeout} from 'node:timers/promises';
 
 import {activate, COMPLETION_COMMAND, FOO_TEMPLATE_URI} from './helper';
 
+function toLabelString(label: string | vscode.CompletionItemLabel): string {
+  return typeof label === 'string' ? label : label.label;
+}
+
+function hasValidCompletionDocumentation(item: vscode.CompletionItem): boolean {
+  const documentation = item.documentation;
+  return (
+    documentation === undefined ||
+    typeof documentation === 'string' ||
+    documentation instanceof vscode.MarkdownString
+  );
+}
+
 describe('Angular LS completions', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+
   beforeAll(async () => {
     await activate(FOO_TEMPLATE_URI);
   });
 
   it(`does not duplicate HTML completions in external templates`, async () => {
-    const position = new vscode.Position(0, 0);
-    const completionItem = await vscode.commands.executeCommand<vscode.CompletionList>(
-      COMPLETION_COMMAND,
+    const position = new vscode.Position(1, 1);
+    const completionItem = await waitForCompletionsWithLabel(
       FOO_TEMPLATE_URI,
       position,
+      'span',
+      '<',
     );
-    const regionCompletions = completionItem?.items?.filter((i) => i.label === '#region') ?? [];
-    expect(regionCompletions.length).toBe(1);
+    const spanCompletions = completionItem.items.filter((i) => i.label === 'span');
+    expect(spanCompletions.length).toBe(1);
+
+    const identityKeys = spanCompletions.map((completion) => {
+      const textEditNewText =
+        completion.textEdit !== undefined && 'newText' in completion.textEdit
+          ? completion.textEdit.newText
+          : '';
+      const insertText = typeof completion.insertText === 'string' ? completion.insertText : '';
+      return `${completion.label}|${completion.kind ?? ''}|${completion.detail ?? ''}|${insertText}|${textEditNewText}`;
+    });
+    expect(new Set(identityKeys).size).toBe(1);
+
+    const completion = spanCompletions[0];
+    const textEditNewText =
+      completion.textEdit !== undefined && 'newText' in completion.textEdit
+        ? completion.textEdit.newText
+        : undefined;
+    const insertionText =
+      textEditNewText ??
+      (typeof completion.insertText === 'string'
+        ? completion.insertText
+        : toLabelString(completion.label));
+    expect(insertionText.toLowerCase()).toContain('span');
+    expect(spanCompletions.every((item) => hasValidCompletionDocumentation(item))).toBeTrue();
   });
 });
+
+async function waitForCompletions(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  triggerCharacter?: string,
+): Promise<vscode.CompletionList | undefined> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const completions = await vscode.commands.executeCommand<vscode.CompletionList>(
+      COMPLETION_COMMAND,
+      uri,
+      position,
+      triggerCharacter,
+    );
+    if ((completions?.items?.length ?? 0) > 0) {
+      return completions;
+    }
+    await setTimeout(pollMs);
+  }
+
+  return undefined;
+}
+
+async function waitForCompletionsWithLabel(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  expectedLabel: string,
+  triggerCharacter?: string,
+): Promise<vscode.CompletionList> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const completions = await waitForCompletions(uri, position, triggerCharacter);
+    if (
+      completions !== undefined &&
+      completions.items.some((item) => item.label === expectedLabel)
+    ) {
+      return completions;
+    }
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for completion label '${expectedLabel}' at ${uri.toString()}`);
+}

--- a/vscode-ng-language-service/integration/e2e/helper.ts
+++ b/vscode-ng-language-service/integration/e2e/helper.ts
@@ -6,12 +6,45 @@ import {APP_COMPONENT, FOO_TEMPLATE} from '../test_constants';
 export const COMPLETION_COMMAND = 'vscode.executeCompletionItemProvider';
 export const HOVER_COMMAND = 'vscode.executeHoverProvider';
 export const DEFINITION_COMMAND = 'vscode.executeDefinitionProvider';
+export const REFERENCE_COMMAND = 'vscode.executeReferenceProvider';
+export const COLOR_COMMAND = 'vscode.executeDocumentColorProvider';
+export const COLOR_PRESENTATION_COMMAND = 'vscode.executeColorPresentationProvider';
+export const DOCUMENT_SYMBOL_COMMAND = 'vscode.executeDocumentSymbolProvider';
+export const SELECTION_RANGE_COMMAND = 'vscode.executeSelectionRangeProvider';
+export const DOCUMENT_HIGHLIGHT_COMMAND = 'vscode.executeDocumentHighlights';
+export const CODE_ACTION_COMMAND = 'vscode.executeCodeActionProvider';
+export const PREPARE_RENAME_COMMAND = 'vscode.prepareRename';
+export const RENAME_COMMAND = 'vscode.executeDocumentRenameProvider';
 export const APP_COMPONENT_URI = vscode.Uri.file(APP_COMPONENT);
 export const FOO_TEMPLATE_URI = vscode.Uri.file(FOO_TEMPLATE);
 
 export async function activate(uri: vscode.Uri): Promise<void> {
   await vscode.window.showTextDocument(uri);
-  // This is needed for stabilization and to reduce flakes.
-  // The timeout gives the language server time to warm up.
-  await setTimeout(3_000);
+  await waitForAngularReady(uri);
+}
+
+async function waitForAngularReady(uri: vscode.Uri): Promise<void> {
+  const timeoutMs = 20_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const symbols =
+        (await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+          DOCUMENT_SYMBOL_COMMAND,
+          uri,
+        )) ?? [];
+
+      if (symbols.length > 0) {
+        return;
+      }
+    } catch {
+      // The language server may still be initializing, retry until timeout.
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for Angular LS readiness for ${uri.toString()}`);
 }

--- a/vscode-ng-language-service/integration/e2e/hover_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/hover_spec.ts
@@ -1,19 +1,69 @@
 import * as vscode from 'vscode';
+import {setTimeout} from 'node:timers/promises';
 
 import {activate, FOO_TEMPLATE_URI, HOVER_COMMAND} from './helper';
 
 describe('Angular LS quick info', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+
   beforeAll(async () => {
     await activate(FOO_TEMPLATE_URI);
   });
 
   it(`returns quick info from built in extension for class in template`, async () => {
-    const position = new vscode.Position(1, 8);
-    const quickInfo = await vscode.commands.executeCommand<vscode.Hover[]>(
-      HOVER_COMMAND,
-      FOO_TEMPLATE_URI,
-      position,
-    );
-    expect(quickInfo?.length).toBe(1);
+    const position = new vscode.Position(1, 1);
+    const hovers = await waitForHover(FOO_TEMPLATE_URI, position);
+
+    expect(hovers.length).toBeGreaterThan(0);
+    expect(hovers.some((hover) => hover.range?.contains(position) ?? false)).toBeTrue();
+
+    const hoverTexts = hovers.map((hover) => hoverToText(hover).toLowerCase()).join('\n');
+    expect(hoverTexts).toContain('span');
   });
 });
+
+async function waitForHover(uri: vscode.Uri, position: vscode.Position): Promise<vscode.Hover[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const quickInfo =
+      (await vscode.commands.executeCommand<vscode.Hover[]>(HOVER_COMMAND, uri, position)) ?? [];
+    if (quickInfo.length > 0) {
+      return quickInfo;
+    }
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for hover at ${uri.toString()}`);
+}
+
+function hoverToText(hover: vscode.Hover): string {
+  if (Array.isArray(hover.contents)) {
+    return hover.contents.map((content) => markupLikeToText(content)).join('\n');
+  }
+
+  return markupLikeToText(hover.contents);
+}
+
+function markupLikeToText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (isValueCarrier(content)) {
+    return content.value;
+  }
+
+  return '';
+}
+
+function isValueCarrier(value: unknown): value is {value: string} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'value' in value &&
+    typeof (value as {value?: unknown}).value === 'string'
+  );
+}

--- a/vscode-ng-language-service/integration/e2e/index.ts
+++ b/vscode-ng-language-service/integration/e2e/index.ts
@@ -38,6 +38,9 @@ async function main() {
         PROJECT_PATH,
         // This disables all extensions except the one being tested
         '--disable-extensions',
+        // Avoid macOS Keychain prompts that can freeze Extension Development Host in local e2e runs.
+        '--password-store=basic',
+        '--use-mock-keychain',
         '--disable-gpu',
         '--no-sandbox',
         '--disable-dev-shm-usage',

--- a/vscode-ng-language-service/integration/e2e/inline_styles_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/inline_styles_spec.ts
@@ -1,0 +1,268 @@
+import * as vscode from 'vscode';
+import {setTimeout} from 'node:timers/promises';
+
+import {
+  activate,
+  APP_COMPONENT_URI,
+  COMPLETION_COMMAND,
+  DEFINITION_COMMAND,
+  DOCUMENT_SYMBOL_COMMAND,
+  SELECTION_RANGE_COMMAND,
+} from './helper';
+
+describe('Angular LS inline styles command bridges', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+
+  beforeAll(async () => {
+    await activate(APP_COMPONENT_URI);
+  });
+
+  it('includes style symbol containers for each inline styles block and maps ranges to source TS', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const firstBlockOffset = content.indexOf('$color: #ff0000;');
+    const secondBlockOffset = content.indexOf('.blue {');
+
+    expect(firstBlockOffset).toBeGreaterThan(-1);
+    expect(secondBlockOffset).toBeGreaterThan(-1);
+
+    const firstBlockPosition = document.positionAt(firstBlockOffset);
+    const secondBlockPosition = document.positionAt(secondBlockOffset);
+
+    const symbols = await waitForDocumentSymbols(APP_COMPONENT_URI);
+    const styleContainers = collectDocumentSymbolsByPrefix(symbols, '(styles)');
+
+    expect(styleContainers.length).toBe(2);
+    expect(styleContainers.every((symbol) => symbol.children.length > 0)).toBeTrue();
+
+    const firstCovered = styleContainers.some((symbol) =>
+      symbol.range.contains(firstBlockPosition),
+    );
+    const secondCovered = styleContainers.some((symbol) =>
+      symbol.range.contains(secondBlockPosition),
+    );
+    expect(firstCovered).toBeTrue();
+    expect(secondCovered).toBeTrue();
+
+    const childNames = styleContainers
+      .flatMap((symbol) => symbol.children)
+      .map((child) => child.name)
+      .join('\n');
+    expect(childNames).toContain('.red');
+    expect(childNames).toContain('.blue');
+  });
+
+  it('returns one selection range chain per inline-style position across separate blocks', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const firstUsageOffset = content.indexOf('$color;');
+    const secondUsageOffset = content.indexOf('$color;', firstUsageOffset + 1);
+
+    expect(firstUsageOffset).toBeGreaterThan(-1);
+    expect(secondUsageOffset).toBeGreaterThan(-1);
+
+    const firstPosition = document.positionAt(firstUsageOffset + 2);
+    const secondPosition = document.positionAt(secondUsageOffset + 2);
+
+    const ranges =
+      (await vscode.commands.executeCommand<vscode.SelectionRange[]>(
+        SELECTION_RANGE_COMMAND,
+        APP_COMPONENT_URI,
+        [firstPosition, secondPosition],
+      )) ?? [];
+
+    expect(ranges.length).toBe(2);
+    expect(ranges[0].range.contains(firstPosition)).toBeTrue();
+    expect(ranges[1].range.contains(secondPosition)).toBeTrue();
+    expect(ranges[0].range.start.line).not.toBe(ranges[1].range.start.line);
+    expect(document.getText(ranges[0].range)).toContain('$color');
+    expect(document.getText(ranges[1].range)).toContain('$color');
+    expect(ranges[0].parent).toBeDefined();
+    expect(ranges[1].parent).toBeDefined();
+  });
+
+  it('maps inline style definition results back to source TypeScript URI and declaration text', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const declarationIndex = content.indexOf('$color:');
+    const usageIndex = content.indexOf('$color;', declarationIndex + 1);
+
+    expect(declarationIndex).toBeGreaterThan(-1);
+    expect(usageIndex).toBeGreaterThan(-1);
+
+    const usagePosition = document.positionAt(usageIndex + 1);
+    const definitions = await waitForDefinitions(APP_COMPONENT_URI, usagePosition);
+
+    expect(definitions.length).toBe(1);
+
+    const first = definitions[0];
+    const targetUri = 'targetUri' in first ? first.targetUri : first.uri;
+    const targetRange = 'targetRange' in first ? first.targetRange : first.range;
+    expect(targetUri.toString()).toBe(APP_COMPONENT_URI.toString());
+
+    const declarationText = document.getText(targetRange);
+    expect(declarationText).toContain('$color');
+    expect(declarationText).toContain(': #ff0000');
+
+    const declarationLineText = document.lineAt(targetRange.start.line).text;
+    expect(declarationLineText).toContain('$color: #ff0000;');
+
+    const expectedDeclarationLine = document.positionAt(declarationIndex).line;
+    expect(targetRange.start.line).toBe(expectedDeclarationLine);
+  });
+
+  it('does not resolve definitions across inline style blocks', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const declarationIndex = content.indexOf('$color:');
+    const firstUsageIndex = content.indexOf('$color;', declarationIndex + 1);
+    const secondUsageIndex = content.indexOf('$color;', firstUsageIndex + 1);
+
+    expect(secondUsageIndex).toBeGreaterThan(-1);
+
+    const secondUsagePosition = document.positionAt(secondUsageIndex + 1);
+    const definitions =
+      (await vscode.commands.executeCommand<(vscode.Location | vscode.DefinitionLink)[]>(
+        DEFINITION_COMMAND,
+        APP_COMPONENT_URI,
+        secondUsagePosition,
+      )) ?? [];
+
+    expect(definitions.length).toBe(0);
+  });
+
+  it('returns inline template style-attribute completions with valid documentation markup', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const styleAttrIndex = content.indexOf('style="co"');
+
+    expect(styleAttrIndex).toBeGreaterThan(-1);
+
+    const position = document.positionAt(styleAttrIndex + 'style="co'.length);
+    const completionList =
+      (await vscode.commands.executeCommand<vscode.CompletionList>(
+        COMPLETION_COMMAND,
+        APP_COMPONENT_URI,
+        position,
+        undefined,
+        25,
+      )) ?? new vscode.CompletionList([]);
+
+    expect(completionList.items.length).toBeGreaterThan(0);
+
+    const sampledItems = completionList.items.slice(0, 25);
+
+    expect(sampledItems.length).toBeGreaterThan(0);
+    expect(sampledItems.every((item) => hasValidCompletionDocumentation(item))).toBeTrue();
+  });
+});
+
+function hasDocumentSymbolName(
+  symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[],
+  name: string,
+): boolean {
+  if (symbols.length === 0) {
+    return false;
+  }
+
+  if (isSymbolInformationArray(symbols)) {
+    return symbols.some((symbol) => symbol.name === name);
+  }
+
+  const stack = [...symbols];
+  while (stack.length > 0) {
+    const symbol = stack.pop()!;
+    if (symbol.name === name) {
+      return true;
+    }
+    stack.push(...symbol.children);
+  }
+
+  return false;
+}
+
+function collectDocumentSymbolsByPrefix(
+  symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[],
+  namePrefix: string,
+): vscode.DocumentSymbol[] {
+  if (symbols.length === 0 || isSymbolInformationArray(symbols)) {
+    return [];
+  }
+
+  const matches: vscode.DocumentSymbol[] = [];
+  const stack = [...symbols];
+  while (stack.length > 0) {
+    const symbol = stack.pop()!;
+    if (symbol.name.startsWith(namePrefix)) {
+      matches.push(symbol);
+    }
+    stack.push(...symbol.children);
+  }
+
+  return matches;
+}
+
+function isSymbolInformationArray(
+  symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[],
+): symbols is vscode.SymbolInformation[] {
+  return symbols.length > 0 && !('children' in symbols[0]);
+}
+
+function hasValidCompletionDocumentation(item: vscode.CompletionItem): boolean {
+  const documentation = item.documentation;
+  return (
+    documentation === undefined ||
+    typeof documentation === 'string' ||
+    documentation instanceof vscode.MarkdownString
+  );
+}
+
+async function waitForDocumentSymbols(
+  uri: vscode.Uri,
+): Promise<vscode.DocumentSymbol[] | vscode.SymbolInformation[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const symbols =
+      (await vscode.commands.executeCommand<vscode.DocumentSymbol[] | vscode.SymbolInformation[]>(
+        DOCUMENT_SYMBOL_COMMAND,
+        uri,
+      )) ?? [];
+
+    if (hasDocumentSymbolName(symbols, '(styles)')) {
+      return symbols;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for inline styles symbols in ${uri.toString()}`);
+}
+
+async function waitForDefinitions(
+  uri: vscode.Uri,
+  position: vscode.Position,
+): Promise<(vscode.Location | vscode.DefinitionLink)[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const definitions =
+      (await vscode.commands.executeCommand<(vscode.Location | vscode.DefinitionLink)[]>(
+        DEFINITION_COMMAND,
+        uri,
+        position,
+      )) ?? [];
+
+    if (definitions.length > 0) {
+      return definitions;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for definitions in ${uri.toString()}`);
+}

--- a/vscode-ng-language-service/integration/e2e/inline_styles_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/inline_styles_spec.ts
@@ -4,9 +4,13 @@ import {setTimeout} from 'node:timers/promises';
 import {
   activate,
   APP_COMPONENT_URI,
+  CODE_ACTION_COMMAND,
+  COLOR_COMMAND,
   COMPLETION_COMMAND,
   DEFINITION_COMMAND,
+  DOCUMENT_HIGHLIGHT_COMMAND,
   DOCUMENT_SYMBOL_COMMAND,
+  REFERENCE_COMMAND,
   SELECTION_RANGE_COMMAND,
 } from './helper';
 
@@ -131,6 +135,38 @@ describe('Angular LS inline styles command bridges', () => {
     expect(definitions.length).toBe(0);
   });
 
+  it('returns strict inline-style document highlights scoped to the active styles block', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const declarationIndex = content.indexOf('$color:');
+    const firstUsageIndex = content.indexOf('$color;', declarationIndex + 1);
+    const secondUsageIndex = content.indexOf('$color;', firstUsageIndex + 1);
+
+    expect(declarationIndex).toBeGreaterThan(-1);
+    expect(firstUsageIndex).toBeGreaterThan(-1);
+    expect(secondUsageIndex).toBeGreaterThan(-1);
+
+    const usagePosition = document.positionAt(firstUsageIndex + 1);
+    const highlights = await waitForDocumentHighlights(APP_COMPONENT_URI, usagePosition, 1);
+
+    expect(highlights.length).toBe(2);
+
+    const highlightedTexts = highlights
+      .map((highlight) => document.getText(highlight.range))
+      .sort();
+    expect(highlightedTexts).toEqual(['$color', '$color']);
+
+    const highlightedLines = highlights
+      .map((highlight) => highlight.range.start.line)
+      .sort((left, right) => left - right);
+    const expectedDeclarationLine = document.positionAt(declarationIndex).line;
+    const expectedFirstUsageLine = document.positionAt(firstUsageIndex).line;
+    const unexpectedSecondUsageLine = document.positionAt(secondUsageIndex).line;
+
+    expect(highlightedLines).toEqual([expectedDeclarationLine, expectedFirstUsageLine]);
+    expect(highlightedLines).not.toContain(unexpectedSecondUsageLine);
+  });
+
   it('returns inline template style-attribute completions with valid documentation markup', async () => {
     const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
     const content = document.getText();
@@ -155,7 +191,113 @@ describe('Angular LS inline styles command bridges', () => {
     expect(sampledItems.length).toBeGreaterThan(0);
     expect(sampledItems.every((item) => hasValidCompletionDocumentation(item))).toBeTrue();
   });
+
+  it('surfaces SCSS quick fixes for inline styles and remaps edits back to source TS URI/range', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const typo = 'dispay';
+    const typoIndex = content.indexOf(typo);
+
+    expect(typoIndex).toBeGreaterThan(-1);
+
+    const typoStart = document.positionAt(typoIndex);
+    const typoEnd = document.positionAt(typoIndex + typo.length);
+    const typoRange = new vscode.Range(typoStart, typoEnd);
+
+    const actions = await waitForCodeActions(APP_COMPONENT_URI, typoRange, {
+      kind: vscode.CodeActionKind.QuickFix.value,
+      match: (codeAction) => {
+        const textEdits = getWorkspaceEditTextEdits(codeAction.edit);
+        return textEdits.some(
+          ({uri, edit}) =>
+            uri.toString() === APP_COMPONENT_URI.toString() &&
+            edit.newText === 'display' &&
+            edit.range.start.isEqual(typoStart) &&
+            edit.range.end.isEqual(typoEnd),
+        );
+      },
+    });
+
+    const matchingAction = actions.find((action) => {
+      if (!isCodeAction(action) || action.edit === undefined) {
+        return false;
+      }
+      return getWorkspaceEditTextEdits(action.edit).some(
+        ({uri, edit}) =>
+          uri.toString() === APP_COMPONENT_URI.toString() &&
+          edit.newText === 'display' &&
+          edit.range.start.isEqual(typoStart) &&
+          edit.range.end.isEqual(typoEnd),
+      );
+    });
+
+    expect(matchingAction).toBeDefined();
+
+    const edits = getWorkspaceEditTextEdits((matchingAction as vscode.CodeAction).edit);
+    expect(edits.length).toBeGreaterThan(0);
+    expect(edits.every(({uri}) => uri.toString() === APP_COMPONENT_URI.toString())).toBeTrue();
+    expect(
+      edits.some(
+        ({edit}) =>
+          edit.newText === 'display' &&
+          edit.range.start.isEqual(typoStart) &&
+          edit.range.end.isEqual(typoEnd),
+      ),
+    ).toBeTrue();
+  });
+
+  it('does not create new untitled documents while executing inline-style command bridges', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+    const usageIndex = content.indexOf('$color;');
+    const typo = 'dispay';
+    const typoIndex = content.indexOf(typo);
+
+    expect(usageIndex).toBeGreaterThan(-1);
+    expect(typoIndex).toBeGreaterThan(-1);
+
+    const usagePosition = document.positionAt(usageIndex + 1);
+    const typoRange = new vscode.Range(
+      document.positionAt(typoIndex),
+      document.positionAt(typoIndex + typo.length),
+    );
+
+    const untitledEditorsBefore = getUntitledEditorUris();
+
+    const references = await waitForReferences(APP_COMPONENT_URI, usagePosition, 1);
+    expect(references.length).toBeGreaterThan(0);
+
+    const colors = await waitForDocumentColors(APP_COMPONENT_URI, 1);
+    expect(colors.length).toBeGreaterThan(0);
+
+    const actions = await waitForCodeActions(APP_COMPONENT_URI, typoRange, {
+      kind: vscode.CodeActionKind.QuickFix.value,
+      match: (codeAction) =>
+        getWorkspaceEditTextEdits(codeAction.edit).some(
+          ({uri, edit}) =>
+            uri.toString() === APP_COMPONENT_URI.toString() && edit.newText === 'display',
+        ),
+    });
+    expect(actions.some((action) => isCodeAction(action))).toBeTrue();
+
+    const untitledEditorsAfter = getUntitledEditorUris();
+    const newlyVisibleUntitled = untitledEditorsAfter.filter(
+      (uri) => !untitledEditorsBefore.includes(uri),
+    );
+    expect(newlyVisibleUntitled).toEqual([]);
+    expect(
+      vscode.window.visibleTextEditors.every((editor) => editor.document.uri.scheme !== 'untitled'),
+    ).toBeTrue();
+  });
 });
+
+function getUntitledEditorUris(): string[] {
+  return vscode.window.visibleTextEditors
+    .map((editor) => editor.document.uri)
+    .filter((uri) => uri.scheme === 'untitled')
+    .map((uri) => uri.toString())
+    .sort();
+}
 
 function hasDocumentSymbolName(
   symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[],
@@ -217,6 +359,26 @@ function hasValidCompletionDocumentation(item: vscode.CompletionItem): boolean {
   );
 }
 
+function isCodeAction(action: vscode.Command | vscode.CodeAction): action is vscode.CodeAction {
+  return 'edit' in action;
+}
+
+function getWorkspaceEditTextEdits(
+  edit: vscode.WorkspaceEdit | undefined,
+): Array<{uri: vscode.Uri; edit: vscode.TextEdit}> {
+  if (edit === undefined) {
+    return [];
+  }
+
+  const textEdits: Array<{uri: vscode.Uri; edit: vscode.TextEdit}> = [];
+  for (const [uri, edits] of edit.entries()) {
+    for (const item of edits) {
+      textEdits.push({uri, edit: item});
+    }
+  }
+  return textEdits;
+}
+
 async function waitForDocumentSymbols(
   uri: vscode.Uri,
 ): Promise<vscode.DocumentSymbol[] | vscode.SymbolInformation[]> {
@@ -265,4 +427,113 @@ async function waitForDefinitions(
   }
 
   throw new Error(`Timed out waiting for definitions in ${uri.toString()}`);
+}
+
+async function waitForDocumentHighlights(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  minimumCount: number,
+): Promise<vscode.DocumentHighlight[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const highlights =
+      (await vscode.commands.executeCommand<vscode.DocumentHighlight[]>(
+        DOCUMENT_HIGHLIGHT_COMMAND,
+        uri,
+        position,
+      )) ?? [];
+
+    if (highlights.length >= minimumCount) {
+      return highlights;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for at least ${minimumCount} document highlights in ${uri.toString()}`,
+  );
+}
+
+async function waitForCodeActions(
+  uri: vscode.Uri,
+  range: vscode.Range,
+  options: {
+    kind: string;
+    match: (action: vscode.CodeAction) => boolean;
+  },
+): Promise<Array<vscode.Command | vscode.CodeAction>> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const actions =
+      (await vscode.commands.executeCommand<Array<vscode.Command | vscode.CodeAction>>(
+        CODE_ACTION_COMMAND,
+        uri,
+        range,
+        options.kind,
+      )) ?? [];
+
+    if (actions.some((action) => isCodeAction(action) && options.match(action))) {
+      return actions;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(
+    `Timed out waiting for code actions matching ${options.kind} at ${uri.toString()}`,
+  );
+}
+
+async function waitForReferences(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  minimumCount: number,
+): Promise<vscode.Location[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const references =
+      (await vscode.commands.executeCommand<vscode.Location[]>(REFERENCE_COMMAND, uri, position, {
+        includeDeclaration: true,
+      })) ?? [];
+
+    if (references.length >= minimumCount) {
+      return references;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for references in ${uri.toString()}`);
+}
+
+async function waitForDocumentColors(
+  uri: vscode.Uri,
+  minimumCount: number,
+): Promise<vscode.ColorInformation[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const colors =
+      (await vscode.commands.executeCommand<vscode.ColorInformation[]>(COLOR_COMMAND, uri)) ?? [];
+
+    if (colors.length >= minimumCount) {
+      return colors;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for document colors in ${uri.toString()}`);
 }

--- a/vscode-ng-language-service/integration/e2e/references_spec.ts
+++ b/vscode-ng-language-service/integration/e2e/references_spec.ts
@@ -1,0 +1,132 @@
+import * as vscode from 'vscode';
+import {setTimeout} from 'node:timers/promises';
+
+import {activate, APP_COMPONENT_URI, REFERENCE_COMMAND} from './helper';
+
+describe('Angular LS inline styles references', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 20_000;
+
+  beforeAll(async () => {
+    await activate(APP_COMPONENT_URI);
+  });
+
+  it('returns same-block references and documents declaration inclusion behavior for includeDeclaration', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+
+    const declarationOffset = content.indexOf('$color:');
+    const firstUsageOffset = content.indexOf('$color;', declarationOffset + 1);
+
+    expect(declarationOffset).toBeGreaterThan(-1);
+    expect(firstUsageOffset).toBeGreaterThan(-1);
+
+    const position = document.positionAt(firstUsageOffset + 1);
+    const referencesWithDeclaration = await waitForReferences(APP_COMPONENT_URI, position, true);
+    const referencesWithoutDeclaration = await waitForReferences(
+      APP_COMPONENT_URI,
+      position,
+      false,
+    );
+
+    expect(referencesWithDeclaration.length).toBe(2);
+    expect(referencesWithoutDeclaration.length).toBe(2);
+
+    const declarationStartPos = document.positionAt(declarationOffset);
+    const firstUsagePos = document.positionAt(firstUsageOffset);
+    const expectedWithDeclaration = [
+      `${declarationStartPos.line}:${declarationStartPos.character}`,
+      `${firstUsagePos.line}:${firstUsagePos.character}`,
+    ];
+    const actualWithDeclaration = referencesWithDeclaration
+      .map(toPositionKey)
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(actualWithDeclaration).toEqual(
+      expectedWithDeclaration.sort((a, b) => a.localeCompare(b)),
+    );
+
+    const hasDeclarationReferenceWhenIncluded = referencesWithDeclaration.some(
+      (ref) =>
+        ref.uri.toString() === APP_COMPONENT_URI.toString() &&
+        ref.range.start.line === declarationStartPos.line &&
+        ref.range.start.character === declarationStartPos.character,
+    );
+    expect(hasDeclarationReferenceWhenIncluded).toBeTrue();
+
+    const hasDeclarationReferenceWhenExcluded = referencesWithoutDeclaration.some(
+      (ref) =>
+        ref.uri.toString() === APP_COMPONENT_URI.toString() &&
+        ref.range.start.line === declarationStartPos.line &&
+        ref.range.start.character === declarationStartPos.character,
+    );
+    expect(hasDeclarationReferenceWhenExcluded).toBeTrue();
+
+    const actualWithoutDeclaration = referencesWithoutDeclaration
+      .map(toPositionKey)
+      .sort((a, b) => a.localeCompare(b));
+    expect(actualWithoutDeclaration).toEqual(
+      expectedWithDeclaration.sort((a, b) => a.localeCompare(b)),
+    );
+  });
+
+  it('does not leak references across separate inline style blocks', async () => {
+    const document = await vscode.workspace.openTextDocument(APP_COMPONENT_URI);
+    const content = document.getText();
+
+    const declarationOffset = content.indexOf('$color:');
+    const firstUsageOffset = content.indexOf('$color;', declarationOffset + 1);
+    const secondUsageOffset = content.indexOf('$color;', firstUsageOffset + 1);
+
+    expect(declarationOffset).toBeGreaterThan(-1);
+    expect(secondUsageOffset).toBeGreaterThan(-1);
+
+    const secondUsagePosition = document.positionAt(secondUsageOffset + 1);
+    const declarationPos = document.positionAt(declarationOffset);
+
+    const references = await waitForReferences(APP_COMPONENT_URI, secondUsagePosition, true);
+
+    expect(references.length).toBe(1);
+    expect(toPositionKey(references[0])).toBe(
+      `${document.positionAt(secondUsageOffset).line}:${document.positionAt(secondUsageOffset).character}`,
+    );
+
+    const leaksFirstBlockDeclaration = references.some(
+      (ref) =>
+        ref.uri.toString() === APP_COMPONENT_URI.toString() &&
+        ref.range.start.line === declarationPos.line &&
+        ref.range.start.character === declarationPos.character,
+    );
+
+    expect(leaksFirstBlockDeclaration).toBeFalse();
+  });
+});
+
+function toPositionKey(reference: vscode.Location): string {
+  expect(reference.uri.toString()).toBe(APP_COMPONENT_URI.toString());
+  return `${reference.range.start.line}:${reference.range.start.character}`;
+}
+
+async function waitForReferences(
+  uri: vscode.Uri,
+  position: vscode.Position,
+  includeDeclaration: boolean,
+): Promise<vscode.Location[]> {
+  const timeoutMs = 15_000;
+  const pollMs = 250;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const references =
+      (await vscode.commands.executeCommand<vscode.Location[]>(REFERENCE_COMMAND, uri, position, {
+        includeDeclaration,
+      })) ?? [];
+
+    if (references.length > 0) {
+      return references;
+    }
+
+    await setTimeout(pollMs);
+  }
+
+  throw new Error(`Timed out waiting for references at ${uri.toString()}`);
+}

--- a/vscode-ng-language-service/integration/lsp/ivy_spec.ts
+++ b/vscode-ng-language-service/integration/lsp/ivy_spec.ts
@@ -287,6 +287,857 @@ export class AppComponent {
     expect(response).toContain({startLine: 32, endLine: 33}); // empty
   });
 
+  it('provides document symbols for TypeScript files (default: filtered to components)', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component, Input, Output, EventEmitter} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: '<div>{{name}}</div>',
+})
+export class AppComponent {
+  name = 'Angular';
+
+  constructor() {}
+
+  greet(): string {
+    return 'Hello, ' + this.name;
+  }
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // Only component classes with templates are shown, without TypeScript children (methods, properties)
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+    expect(appComponentSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    // Class should only have template children, not TypeScript symbols
+    expect(appComponentSymbol!.children).toBeDefined();
+    // Should have (template) container with template symbols
+    const templateSymbol = appComponentSymbol!.children!.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+    // Should NOT have TypeScript method/property children
+    const nameSymbol = appComponentSymbol!.children!.find((c) => c.name === 'name');
+    expect(nameSymbol).toBeUndefined();
+    const constructorSymbol = appComponentSymbol!.children!.find((c) => c.name === 'constructor');
+    expect(constructorSymbol).toBeUndefined();
+    const greetSymbol = appComponentSymbol!.children!.find((c) => c.name === 'greet');
+    expect(greetSymbol).toBeUndefined();
+  });
+
+  it('handles multiple components in a single file', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'first-comp',
+  template: '<h1>First</h1>',
+})
+export class FirstComponent {
+  value = 1;
+}
+
+@Component({
+  selector: 'second-comp',
+  template: '<h2>Second</h2>',
+})
+export class SecondComponent {
+  value = 2;
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // Both components should be present
+    const firstSymbol = response.find((s) => s.name === 'FirstComponent');
+    expect(firstSymbol).toBeDefined();
+    expect(firstSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    const firstTemplateSymbol = firstSymbol!.children!.find((c) => c.name === '(template)');
+    expect(firstTemplateSymbol).toBeDefined();
+
+    const secondSymbol = response.find((s) => s.name === 'SecondComponent');
+    expect(secondSymbol).toBeDefined();
+    expect(secondSymbol!.kind).toBe(lsp.SymbolKind.Class);
+    const secondTemplateSymbol = secondSymbol!.children!.find((c) => c.name === '(template)');
+    expect(secondTemplateSymbol).toBeDefined();
+
+    // Neither should have TypeScript property children by default
+    const firstValue = firstSymbol!.children!.find((c) => c.name === 'value');
+    expect(firstValue).toBeUndefined();
+    const secondValue = secondSymbol!.children!.find((c) => c.name === 'value');
+    expect(secondValue).toBeUndefined();
+  });
+
+  it('returns empty symbols for TypeScript files without Angular templates', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+// A regular TypeScript file with no Angular components
+export interface User {
+  name: string;
+  age: number;
+}
+
+export function greet(user: User): string {
+  return 'Hello, ' + user.name;
+}
+
+export class UserService {
+  private users: User[] = [];
+
+  addUser(user: User): void {
+    this.users.push(user);
+  }
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+    expect(Array.isArray(response)).toBe(true);
+    // With default filtering, no symbols should be returned for non-Angular files
+    // (TypeScript LS handles these files instead)
+    expect(response.length).toBe(0);
+  });
+
+  it('provides document symbols for Angular templates with control flow', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (showContent) {
+      <div class="container">
+        <router-outlet></router-outlet>
+      </div>
+    } @else {
+      <p>No content</p>
+    }
+
+    @for (item of items; track item) {
+      <span #itemRef>{{ item }}</span>
+    } @empty {
+      <p>No items</p>
+    }
+
+    @let message = 'Hello';
+    <ng-content select="header"></ng-content>
+  \`,
+})
+export class AppComponent {
+  showContent = true;
+  items = [1, 2, 3];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    expect(Array.isArray(response)).toBe(true);
+
+    // Should contain the class symbol
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+    expect(appComponentSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // The class should have a (template) child containing Angular template symbols
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+    expect(templateSymbol!.children).toBeDefined();
+
+    // Check for @if block (now shows actual expression)
+    const ifSymbol = templateSymbol!.children!.find((c) => c.name === '@if (showContent)');
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.kind).toBe(lsp.SymbolKind.Struct); // Control flow → Struct
+
+    // Check for @else block
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+
+    // Check for @for block (now shows actual expression)
+    const forSymbol = templateSymbol!.children!.find((c) => c.name === '@for (item of items)');
+    expect(forSymbol).toBeDefined();
+    expect(forSymbol!.kind).toBe(lsp.SymbolKind.Array); // @for loop → Array
+
+    // Check for @let declaration
+    const letSymbol = templateSymbol!.children!.find((c) => c.name === '@let message');
+    expect(letSymbol).toBeDefined();
+    expect(letSymbol!.kind).toBe(lsp.SymbolKind.Variable);
+
+    // Check for ng-content
+    const ngContentSymbol = templateSymbol!.children!.find((c) => c.name.includes('ng-content'));
+    expect(ngContentSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for external HTML template files', async () => {
+    openTextDocument(
+      client,
+      FOO_TEMPLATE,
+      `
+@if (condition) {
+  <div>
+    <router-outlet name="primary"></router-outlet>
+  </div>
+}
+
+@for (item of items; track item) {
+  <span #ref>{{ item }}</span>
+} @empty {
+  <p>Empty</p>
+}
+
+@defer {
+  <heavy-component></heavy-component>
+} @placeholder {
+  <p>Loading...</p>
+}
+`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: FOO_TEMPLATE_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    expect(Array.isArray(response)).toBe(true);
+
+    // External templates should have template symbols at the root level
+    // Check for @if block (now shows actual expression)
+    const ifSymbol = response.find((s) => s.name === '@if (condition)');
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.kind).toBe(lsp.SymbolKind.Struct); // Control flow → Struct
+
+    // Check for @for block (now shows actual expression)
+    const forSymbol = response.find((s) => s.name === '@for (item of items)');
+    expect(forSymbol).toBeDefined();
+
+    // Check for @defer block
+    const deferSymbol = response.find((s) => s.name === '@defer');
+    expect(deferSymbol).toBeDefined();
+    expect(deferSymbol!.children).toBeDefined();
+
+    // @defer should have @placeholder as a child
+    const placeholderSymbol = deferSymbol!.children!.find((c) => c.name === '@placeholder');
+    expect(placeholderSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @else if branches', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (status === 'active') {
+      <p>Active</p>
+    } @else if (status === 'pending') {
+      <p>Pending</p>
+    } @else if (status === 'error') {
+      <p>Error</p>
+    } @else {
+      <p>Unknown</p>
+    }
+  \`,
+})
+export class AppComponent {
+  status = 'active';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block
+    const ifSymbol = templateSymbol!.children!.find((c) =>
+      c.name.startsWith("@if (status === 'active')"),
+    );
+    expect(ifSymbol).toBeDefined();
+
+    // Check for @else if blocks (should show actual condition)
+    const elseIfPending = templateSymbol!.children!.find((c) =>
+      c.name.includes("@else if (status === 'pending')"),
+    );
+    expect(elseIfPending).toBeDefined();
+
+    const elseIfError = templateSymbol!.children!.find((c) =>
+      c.name.includes("@else if (status === 'error')"),
+    );
+    expect(elseIfError).toBeDefined();
+
+    // Check for @else block
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @switch with case fall-through', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @switch (color) {
+      @case ('red') {
+        <p>Red color</p>
+      }
+      @case ('green') {
+        <p>Green color</p>
+      }
+      @default {
+        <p>Unknown color</p>
+      }
+    }
+  \`,
+})
+export class AppComponent {
+  color = 'red';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @switch block (should show actual expression)
+    const switchSymbol = templateSymbol!.children!.find((c) => c.name === '@switch (color)');
+    expect(switchSymbol).toBeDefined();
+    expect(switchSymbol!.children).toBeDefined();
+
+    // Check for @case blocks (should show actual case values)
+    const caseRed = switchSymbol!.children!.find((c) => c.name.includes("@case ('red')"));
+    expect(caseRed).toBeDefined();
+
+    const caseGreen = switchSymbol!.children!.find((c) => c.name.includes("@case ('green')"));
+    expect(caseGreen).toBeDefined();
+
+    // Check for @default
+    const defaultCase = switchSymbol!.children!.find((c) => c.name === '@default');
+    expect(defaultCase).toBeDefined();
+  });
+
+  it('provides document symbols for @for with context variables', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @for (item of items; track item.id; let i = $index; let first = $first; let last = $last) {
+      <div>{{ i }}: {{ item.name }}</div>
+    } @empty {
+      <div>No items</div>
+    }
+  \`,
+})
+export class AppComponent {
+  items = [{id: 1, name: 'A'}, {id: 2, name: 'B'}];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @for block (shows loop variable and collection)
+    const forSymbol = templateSymbol!.children!.find((c) => c.name.includes('@for (item of'));
+    expect(forSymbol).toBeDefined();
+    expect(forSymbol!.children).toBeDefined();
+
+    // Check for loop item variable
+    const itemVar = forSymbol!.children!.find((c) => c.name === 'let item');
+    expect(itemVar).toBeDefined();
+
+    // Check for context variables (aliased)
+    const indexVar = forSymbol!.children!.find((c) => c.name === 'let i');
+    expect(indexVar).toBeDefined();
+
+    const firstVar = forSymbol!.children!.find((c) => c.name === 'let first');
+    expect(firstVar).toBeDefined();
+
+    const lastVar = forSymbol!.children!.find((c) => c.name === 'let last');
+    expect(lastVar).toBeDefined();
+
+    // Check for @empty block
+    const emptySymbol = forSymbol!.children!.find((c) => c.name === '@empty');
+    expect(emptySymbol).toBeDefined();
+  });
+
+  it('provides document symbols for @if with expression alias', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @if (user$ | async; as user) {
+      <p>Welcome, {{ user.name }}</p>
+    }
+  \`,
+})
+export class AppComponent {
+  user$ = of({name: 'Test'});
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block with alias (shows expression and alias)
+    const ifSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@if') && c.name.includes('as user'),
+    );
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.children).toBeDefined();
+
+    // Check for alias variable
+    const aliasVar = ifSymbol!.children!.find((c) => c.name === 'let user');
+    expect(aliasVar).toBeDefined();
+  });
+
+  it('provides document symbols for @defer with triggers', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  template: \`
+    @defer (on viewport) {
+      <p>Loaded</p>
+    } @placeholder {
+      <p>Placeholder</p>
+    } @loading {
+      <p>Loading...</p>
+    } @error {
+      <p>Error!</p>
+    }
+  \`,
+})
+export class AppComponent {
+  value = 'test';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    expect(appComponentSymbol).toBeDefined();
+
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @defer block with trigger info
+    const deferSymbol = templateSymbol!.children!.find((c) => c.name.includes('@defer'));
+    expect(deferSymbol).toBeDefined();
+    expect(deferSymbol!.name).toContain('on viewport');
+    expect(deferSymbol!.children).toBeDefined();
+
+    // Check for @placeholder
+    const placeholderSymbol = deferSymbol!.children!.find((c) => c.name.includes('@placeholder'));
+    expect(placeholderSymbol).toBeDefined();
+
+    // Check for @loading
+    const loadingSymbol = deferSymbol!.children!.find((c) => c.name.includes('@loading'));
+    expect(loadingSymbol).toBeDefined();
+
+    // Check for @error
+    const errorSymbol = deferSymbol!.children!.find((c) => c.name === '@error');
+    expect(errorSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for *ngFor structural directive', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  imports: [CommonModule],
+  template: \`
+    <ul>
+      <li *ngFor="let item of items; let i = index; let isFirst = first">
+        {{ i }}: {{ item }}
+      </li>
+    </ul>
+  \`,
+})
+export class AppComponent {
+  items = ['a', 'b', 'c'];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Find the <ul> element
+    const ulSymbol = templateSymbol!.children!.find((c) => c.name === '<ul>');
+    expect(ulSymbol).toBeDefined();
+
+    // Check for *ngFor directive (should show like control flow)
+    const ngForSymbol = ulSymbol!.children!.find((c) => c.name.includes('*ngFor'));
+    expect(ngForSymbol).toBeDefined();
+    expect(ngForSymbol!.name).toContain('let item of');
+
+    // Check for let- variables as children
+    expect(ngForSymbol!.children).toBeDefined();
+    const itemVar = ngForSymbol!.children!.find((c) => c.name === 'let item');
+    expect(itemVar).toBeDefined();
+
+    const indexVar = ngForSymbol!.children!.find((c) => c.name === 'let i');
+    expect(indexVar).toBeDefined();
+
+    const firstVar = ngForSymbol!.children!.find((c) => c.name === 'let isFirst');
+    expect(firstVar).toBeDefined();
+  });
+
+  it('provides document symbols for *ngIf structural directive', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  imports: [CommonModule],
+  template: \`
+    <div *ngIf="isVisible; else notVisible">
+      Visible content
+    </div>
+    <ng-template #notVisible>
+      <p>Not visible</p>
+    </ng-template>
+  \`,
+})
+export class AppComponent {
+  isVisible = true;
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for *ngIf directive (should show the condition)
+    const ngIfSymbol = templateSymbol!.children!.find((c) => c.name.includes('*ngIf'));
+    expect(ngIfSymbol).toBeDefined();
+    expect(ngIfSymbol!.name).toContain('isVisible');
+
+    // Check for ng-template with reference
+    const ngTemplateSymbol = templateSymbol!.children!.find((c) => c.name === '<ng-template>');
+    expect(ngTemplateSymbol).toBeDefined();
+
+    // Check for the #notVisible reference
+    const notVisibleRef = ngTemplateSymbol!.children!.find((c) => c.name === '#notVisible');
+    expect(notVisibleRef).toBeDefined();
+  });
+
+  it('provides document symbols for @if with expression alias', async () => {
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  template: \`
+    @if (user; as currentUser) {
+      <div>Hello, {{ currentUser.name }}!</div>
+    } @else if (guestName; as name) {
+      <div>Welcome, {{ name }}!</div>
+    } @else {
+      <div>Anonymous</div>
+    }
+  \`,
+})
+export class AppComponent {
+  user = { name: 'John' };
+  guestName = '';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Check for @if block with alias
+    const ifSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@if') && c.name.includes('currentUser'),
+    );
+    expect(ifSymbol).toBeDefined();
+    expect(ifSymbol!.name).toContain('as currentUser');
+
+    // The alias should appear exactly once as a child
+    const currentUserAliases = ifSymbol!.children!.filter((c) => c.name === 'let currentUser');
+    expect(currentUserAliases.length).toBe(1);
+
+    // Check for @else if block with alias
+    const elseIfSymbol = templateSymbol!.children!.find(
+      (c) => c.name.includes('@else if') && c.name.includes('name'),
+    );
+    expect(elseIfSymbol).toBeDefined();
+    expect(elseIfSymbol!.name).toContain('as name');
+
+    // The alias should appear exactly once
+    const nameAliases = elseIfSymbol!.children!.filter((c) => c.name === 'let name');
+    expect(nameAliases.length).toBe(1);
+
+    // Check for @else block (no alias)
+    const elseSymbol = templateSymbol!.children!.find((c) => c.name === '@else');
+    expect(elseSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for nested @if with alias inside @for', async () => {
+    // Test case similar to user's template structure
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-app',
+  standalone: true,
+  template: \`
+    @for (category of categories; track category.name) {
+      <div class="category">
+        @for (test of category.tests; track test.name; let i = $index) {
+          @if (!test.passed; as tr) {
+            <div class="failed">{{ tr }}</div>
+          }
+        }
+      </div>
+    }
+  \`,
+})
+export class AppComponent {
+  categories = [
+    { name: 'Category 1', tests: [{ name: 'Test 1', passed: true }, { name: 'Test 2', passed: false }] }
+  ];
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    const appComponentSymbol = response.find((s) => s.name === 'AppComponent');
+    const templateSymbol = appComponentSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+
+    // Find the outer @for - name is "@for (category of categories)"
+    const outerForSymbol = templateSymbol!.children!.find(
+      (c) => c.name.startsWith('@for') && c.name.includes('category'),
+    );
+    expect(outerForSymbol).toBeDefined();
+
+    // Find the <div> inside outer @for
+    const divSymbol = outerForSymbol!.children!.find((c) => c.name === '<div>');
+    expect(divSymbol).toBeDefined();
+
+    // Find nested @for inside <div> - name is "@for (test of category.tests)"
+    const nestedForSymbol = divSymbol!.children!.find(
+      (c) => c.name.startsWith('@for') && c.name.includes('test of'),
+    );
+    expect(nestedForSymbol).toBeDefined();
+
+    // Check for 'let test' and 'let i' (explicit alias for $index)
+    const testVar = nestedForSymbol!.children!.filter((c) => c.name === 'let test');
+    expect(testVar.length).toBe(1);
+    const indexVar = nestedForSymbol!.children!.filter((c) => c.name === 'let i');
+    expect(indexVar.length).toBe(1);
+
+    // Find @if with alias inside nested @for - name is "@if (!test.passed; as tr)"
+    const ifSymbol = nestedForSymbol!.children!.find(
+      (c) => c.name.startsWith('@if') && c.name.includes('as tr'),
+    );
+    expect(ifSymbol).toBeDefined();
+
+    // The 'tr' alias should appear exactly once
+    const trAliases = ifSymbol!.children!.filter((c) => c.name === 'let tr');
+    expect(trAliases.length).toBe(1);
+  });
+
+  it('provides document symbols for component without "Component" suffix', async () => {
+    // Test that components like "NxWelcome" (without "Component" suffix) still get template symbols
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-welcome',
+  template: \`
+    @if (title) {
+      <span>{{ title }}</span>
+    }
+  \`,
+})
+export class Welcome {
+  title = 'Hello';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    // Should contain the class symbol
+    const welcomeSymbol = response.find((s) => s.name === 'Welcome');
+    expect(welcomeSymbol).toBeDefined();
+    expect(welcomeSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // The class should have a (template) child containing Angular template symbols
+    const templateSymbol = welcomeSymbol!.children?.find((c) => c.name === '(template)');
+    expect(templateSymbol).toBeDefined();
+    expect(templateSymbol!.kind).toBe(lsp.SymbolKind.Namespace);
+
+    // Check for @if block
+    const ifSymbol = templateSymbol!.children!.find((c) => c.name === '@if (title)');
+    expect(ifSymbol).toBeDefined();
+  });
+
+  it('provides document symbols for multiple components in one file', async () => {
+    // Test that files with multiple components (common in tests/storybooks) work correctly
+    openTextDocument(
+      client,
+      APP_COMPONENT,
+      `
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  template: \`<button>{{ label }}</button>\`,
+})
+export class ButtonComponent {
+  label = 'Click me';
+}
+
+@Component({
+  selector: 'app-input',
+  template: \`<input [placeholder]="hint" />\`,
+})
+export class InputComponent {
+  hint = 'Type here';
+}`,
+    );
+    const response = (await client.sendRequest(lsp.DocumentSymbolRequest.type, {
+      textDocument: {
+        uri: APP_COMPONENT_URI,
+      },
+    })) as lsp.DocumentSymbol[];
+
+    // Should contain both class symbols
+    const buttonSymbol = response.find((s) => s.name === 'ButtonComponent');
+    expect(buttonSymbol).toBeDefined();
+    expect(buttonSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    const inputSymbol = response.find((s) => s.name === 'InputComponent');
+    expect(inputSymbol).toBeDefined();
+    expect(inputSymbol!.kind).toBe(lsp.SymbolKind.Class);
+
+    // ButtonComponent should have its own (template) with <button>
+    const buttonTemplate = buttonSymbol!.children?.find((c) => c.name === '(template)');
+    expect(buttonTemplate).toBeDefined();
+    const buttonElement = buttonTemplate!.children!.find((c) => c.name === '<button>');
+    expect(buttonElement).toBeDefined();
+
+    // InputComponent should have its own (template) with <input>
+    const inputTemplate = inputSymbol!.children?.find((c) => c.name === '(template)');
+    expect(inputTemplate).toBeDefined();
+    const inputElement = inputTemplate!.children!.find((c) => c.name === '<input>');
+    expect(inputElement).toBeDefined();
+  });
+
   describe('signature help', () => {
     it('should show signature help for an empty call', async () => {
       client.sendNotification(lsp.DidOpenTextDocumentNotification.type, {

--- a/vscode-ng-language-service/integration/project/app/app.component.ts
+++ b/vscode-ng-language-service/integration/project/app/app.component.ts
@@ -2,7 +2,22 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 
 @Component({
   selector: 'my-app',
-  template: `<h1>Hello {{ name }}</h1>`,
+  template: `<h1>Hello {{ name }}</h1>
+    <div style="co"></div>`,
+  styles: [
+    `
+      $color: #ff0000;
+      .red {
+        color: $color;
+        displai: block;
+      }
+    `,
+    `
+      .blue {
+        color: $color;
+      }
+    `,
+  ],
   standalone: false,
 })
 export class AppComponent {

--- a/vscode-ng-language-service/integration/project/app/app.component.ts
+++ b/vscode-ng-language-service/integration/project/app/app.component.ts
@@ -9,7 +9,7 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
       $color: #ff0000;
       .red {
         color: $color;
-        displai: block;
+        dispay: block;
       }
     `,
     `

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-template",
-  "displayName": "Angular Language Service",
+  "displayName": "Angular",
   "description": "Editor services for Angular templates",
   "version": "22.0.0-rc.0",
   "private": true,
@@ -99,68 +99,70 @@
         }
       ]
     },
-    "configuration": {
-      "title": "Angular Language Service",
-      "properties": {
-        "angular.log": {
-          "type": "string",
-          "enum": [
-            "off",
-            "terse",
-            "normal",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
-        },
-        "angular.enable-strict-mode-prompt": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.dev/reference/configs/angular-compiler-options)."
-        },
-        "angular.trace.server": {
-          "type": "string",
-          "scope": "window",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the Angular language server."
-        },
-        "angular.suggest.includeAutomaticOptionalChainCompletions": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled."
-        },
-        "angular.suggest.includeCompletionsWithSnippetText": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace."
-        },
-        "angular.suggest.autoImports": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable/disable auto import suggestions for the exported Angular components from the current project."
-        },
-        "angular.forceStrictTemplates": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
-        },
-        "angular.suppressAngularDiagnosticCodes": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "A comma-separated list of error codes in templates whose diagnostics should be ignored."
-        },
-        "angular.server.useClientSideFileWatcher": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+    "configuration": [
+      {
+        "title": "Preferences",
+        "properties": {
+          "angular.log": {
+            "type": "string",
+            "enum": [
+              "off",
+              "terse",
+              "normal",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Enables logging of the Angular server to a file. This log can be used to diagnose Angular Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project."
+          },
+          "angular.trace.server": {
+            "type": "string",
+            "scope": "window",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "default": "off",
+            "description": "Traces the communication between VS Code and the Angular language server."
+          },
+          "angular.enable-strict-mode-prompt": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Prompt to enable the [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) flag in [angularCompilerOptions](https://angular.dev/reference/configs/angular-compiler-options)."
+          },
+          "angular.forceStrictTemplates": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enabling this option will force the language service to use [strictTemplates](https://angular.dev/reference/configs/angular-compiler-options#stricttemplates) and ignore the user settings in the `tsconfig.json`."
+          },
+          "angular.suppressAngularDiagnosticCodes": {
+            "type": "string",
+            "default": "",
+            "markdownDescription": "A comma-separated list of error codes in templates whose diagnostics should be ignored."
+          },
+          "angular.suggest.includeAutomaticOptionalChainCompletions": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable showing completions on potentially undefined values that insert an optional chain call. Requires TS 3.7+ and strict null checks to be enabled."
+          },
+          "angular.suggest.includeCompletionsWithSnippetText": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable snippet completions from Angular language server. Requires using TypeScript 4.3+ in the workspace."
+          },
+          "angular.suggest.autoImports": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable/disable auto import suggestions for the exported Angular components from the current project."
+          },
+          "angular.server.useClientSideFileWatcher": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+          }
         }
       }
-    },
+    ],
     "grammars": [
       {
         "path": "./syntaxes/inline-template.json",

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -159,6 +159,16 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "When enabled, the Angular Language Service will delegate file watching to VS Code instead of creating its own internal file watchers. This can significantly improve performance (greater than 10x faster initialization) and reduce resource usage in large repositories."
+          },
+          "angular.documentSymbols.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Enable Angular-specific document symbols in the Outline view and breadcrumbs. Shows control flow blocks (`@if`, `@for`, `@defer`), elements, variables, and structural directives."
+          },
+          "angular.documentSymbols.showImplicitForVariables": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Show all implicit `@for` loop variables (`$index`, `$count`, `$first`, `$last`, `$even`, `$odd`) in document symbols. When disabled (default), only explicitly aliased variables like `let i = $index` are shown."
           }
         }
       }

--- a/vscode-ng-language-service/server/src/config.ts
+++ b/vscode-ng-language-service/server/src/config.ts
@@ -1,0 +1,148 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as lsp from 'vscode-languageserver/node';
+
+const workspaceConfigCache = new WeakMap<lsp.Connection, Map<string, unknown[]>>();
+
+/**
+ * A single configuration item to request from the client.
+ *
+ * See LSP spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration
+ */
+export interface ConfigurationItem {
+  /**
+   * The scope to get the configuration section for.
+   * This is typically a file URI (e.g., file:///path/to/file.ts).
+   * When provided, VS Code returns workspace folder-specific settings
+   * that apply to that file's workspace folder.
+   */
+  scopeUri?: string;
+
+  /**
+   * The configuration section asked for.
+   * For example: 'typescript.inlayHints' or 'angular.inlayHints'
+   * This corresponds to the key prefix in settings.json.
+   */
+  section?: string;
+}
+
+/**
+ * Request workspace configuration from the client.
+ *
+ * This uses the LSP workspace/configuration request which allows the server
+ * to pull configuration from the client on-demand. This is the preferred
+ * approach over CLI arguments because:
+ *
+ * 1. Configuration changes take effect immediately without restarting
+ * 2. Supports per-workspace and per-folder configuration
+ * 3. VS Code automatically merges settings from different scopes:
+ *    - Default settings
+ *    - User settings (global)
+ *    - Workspace settings
+ *    - Workspace folder settings
+ *    - Language-specific settings
+ *
+ * The client returns the effective (merged) configuration value for each item.
+ *
+ * @param connection The LSP connection to the client
+ * @param items Array of configuration items to request
+ * @returns Array of configuration values, one for each requested item
+ *
+ * @example
+ * ```typescript
+ * const [tsConfig, angularConfig] = await getWorkspaceConfiguration(
+ *   session.connection,
+ *   [
+ *     { section: 'typescript.inlayHints', scopeUri: documentUri },
+ *     { section: 'angular.inlayHints', scopeUri: documentUri },
+ *   ]
+ * );
+ * ```
+ */
+export async function getWorkspaceConfiguration<T = unknown>(
+  connection: lsp.Connection,
+  items: ConfigurationItem[],
+): Promise<T[]> {
+  try {
+    return await connection.workspace.getConfiguration(items);
+  } catch (error) {
+    // Return empty objects if the client doesn't support workspace/configuration
+    // This provides graceful degradation for older clients
+    return items.map(() => ({}) as T);
+  }
+}
+
+/**
+ * Request workspace configuration with simple per-connection memoization.
+ *
+ * Cache entries are invalidated when the server receives workspace/didChangeConfiguration.
+ */
+export async function getWorkspaceConfigurationCached<T = unknown>(
+  connection: lsp.Connection,
+  items: ConfigurationItem[],
+): Promise<T[]> {
+  const key = JSON.stringify(items);
+  let cache = workspaceConfigCache.get(connection);
+  if (!cache) {
+    cache = new Map();
+    workspaceConfigCache.set(connection, cache);
+  }
+
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached as T[];
+  }
+
+  const value = await getWorkspaceConfiguration<T>(connection, items);
+  cache.set(key, value as unknown[]);
+  return value;
+}
+
+export function clearWorkspaceConfigurationCache(connection: lsp.Connection): void {
+  workspaceConfigCache.delete(connection);
+}
+
+/**
+ * Flatten a nested configuration object into a flat object with dot-notation keys.
+ *
+ * VS Code returns configuration as nested objects based on the section hierarchy.
+ * This utility flattens them into a format that's easier to work with when
+ * mapping to internal configuration formats.
+ *
+ * @param config The nested configuration object
+ * @param prefix The prefix to use for the keys (typically the section name)
+ * @returns A flat object with dot-notation keys
+ *
+ * @example
+ * ```typescript
+ * // Input: { parameterNames: { enabled: 'all' } }
+ * // Output: { 'typescript.inlayHints.parameterNames.enabled': 'all' }
+ * const flat = flattenConfiguration(tsConfig, 'typescript.inlayHints');
+ * ```
+ */
+export function flattenConfiguration(
+  config: Record<string, unknown>,
+  prefix: string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  function flatten(obj: Record<string, unknown>, currentPrefix: string): void {
+    for (const [key, value] of Object.entries(obj)) {
+      const newKey = `${currentPrefix}.${key}`;
+      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        flatten(value as Record<string, unknown>, newKey);
+      } else {
+        result[newKey] = value;
+      }
+    }
+  }
+
+  flatten(config, prefix);
+  return result;
+}

--- a/vscode-ng-language-service/server/src/handlers/document_symbols.ts
+++ b/vscode-ng-language-service/server/src/handlers/document_symbols.ts
@@ -1,0 +1,427 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+import * as lsp from 'vscode-languageserver';
+import * as ts from 'typescript/lib/tsserverlibrary';
+import {isNgLanguageService, TemplateDocumentSymbol} from '@angular/language-service/api';
+
+import {getWorkspaceConfiguration} from '../config';
+import {Session} from '../session';
+import {tsTextSpanToLspRange} from '../utils';
+
+/**
+ * Configuration for document symbols feature.
+ * These settings control how document symbols are generated for Angular templates.
+ */
+interface DocumentSymbolsConfig {
+  /**
+   * Whether to enable document symbols for Angular templates.
+   * When enabled (default), shows control flow blocks, elements, variables, etc.
+   * When disabled, only TypeScript symbols are shown in the outline.
+   */
+  enabled: boolean;
+  /**
+   * Whether to show 'implicit' annotation for template variables
+   * that are implicitly typed by Angular (e.g., `let item` in `@for`).
+   */
+  showImplicitForVariables: boolean;
+}
+
+/**
+ * Handles textDocument/documentSymbol requests.
+ *
+ * Returns a hierarchical list of symbols in the document that appears in:
+ * - The Outline view in VS Code
+ * - The breadcrumbs navigation bar
+ * - The "Go to Symbol" picker (Ctrl+Shift+O / Cmd+Shift+O)
+ */
+export async function onDocumentSymbol(
+  session: Session,
+  params: lsp.DocumentSymbolParams,
+): Promise<lsp.DocumentSymbol[] | null> {
+  const lsInfo = session.getLSAndScriptInfo(params.textDocument);
+  if (lsInfo === null) {
+    return null;
+  }
+  const {scriptInfo, languageService} = lsInfo;
+  const isHtmlFile = params.textDocument.uri.endsWith('.html');
+
+  // Fetch document symbols configuration from the client using workspace/configuration.
+  // This allows users to change settings without restarting the language server.
+  const [config] = await getWorkspaceConfiguration<DocumentSymbolsConfig>(session.connection, [
+    {scopeUri: params.textDocument.uri, section: 'angular.documentSymbols'},
+  ]);
+
+  // Check if document symbols are enabled (default: true)
+  const isEnabled = config?.enabled !== false;
+
+  // For HTML template files, we only need Angular template symbols (no TS symbols)
+  if (isHtmlFile) {
+    if (isEnabled && isNgLanguageService(languageService)) {
+      const templateSymbols = languageService.getTemplateDocumentSymbols(scriptInfo.fileName, {
+        showImplicitForVariables: config?.showImplicitForVariables ?? false,
+      });
+      if (templateSymbols.length > 0) {
+        return convertTemplateSymbols(templateSymbols, scriptInfo);
+      }
+    }
+    return null;
+  }
+
+  // Get template symbols for Angular files
+  let templateSymbols: TemplateDocumentSymbol[] = [];
+  if (isEnabled && isNgLanguageService(languageService)) {
+    templateSymbols = languageService.getTemplateDocumentSymbols(scriptInfo.fileName, {
+      showImplicitForVariables: config?.showImplicitForVariables ?? false,
+    });
+  }
+
+  // For TypeScript files, get the navigation tree which includes
+  // classes, functions, variables, imports, etc.
+  const navigationTree = languageService.getNavigationTree(scriptInfo.fileName);
+  if (!navigationTree) {
+    return null;
+  }
+
+  // Get the set of class names that have templates
+  const classNamesWithTemplates = new Set<string>();
+  for (const symbol of templateSymbols) {
+    if (symbol.className) {
+      classNamesWithTemplates.add(symbol.className);
+    }
+  }
+
+  // Filter TypeScript symbols to only show classes with templates (no methods/properties)
+  // This implements the hybrid approach where component classes are shown as containers
+  // with template symbols nested inside
+  const tsSymbols = filterNavigationTreeToTemplateClasses(
+    navigationTree,
+    scriptInfo,
+    classNamesWithTemplates,
+  );
+
+  // For Angular TypeScript files, merge template symbols into component classes
+  if (templateSymbols.length > 0) {
+    mergeTemplateSymbolsIntoClass(tsSymbols, templateSymbols, scriptInfo);
+  }
+
+  return tsSymbols;
+}
+
+/**
+ * Merges Angular template symbols into the component class in the TypeScript symbol tree.
+ * This places control flow blocks, elements, etc. under the component class they belong to.
+ * Supports multiple components in the same file by matching on className.
+ */
+function mergeTemplateSymbolsIntoClass(
+  tsSymbols: lsp.DocumentSymbol[],
+  templateSymbols: TemplateDocumentSymbol[],
+  scriptInfo: ts.server.ScriptInfo,
+): void {
+  if (templateSymbols.length === 0) {
+    return;
+  }
+
+  // Group template symbols by their className
+  const symbolsByClass = new Map<string, TemplateDocumentSymbol[]>();
+  const symbolsWithoutClass: TemplateDocumentSymbol[] = [];
+
+  for (const symbol of templateSymbols) {
+    if (symbol.className) {
+      const existing = symbolsByClass.get(symbol.className) ?? [];
+      existing.push(symbol);
+      symbolsByClass.set(symbol.className, existing);
+    } else {
+      symbolsWithoutClass.push(symbol);
+    }
+  }
+
+  // For each class in the TypeScript symbols, try to find matching template symbols
+  for (const tsSymbol of tsSymbols) {
+    if (tsSymbol.kind === lsp.SymbolKind.Class) {
+      const classTemplateSymbols = symbolsByClass.get(tsSymbol.name);
+      if (classTemplateSymbols && classTemplateSymbols.length > 0) {
+        const converted = convertTemplateSymbols(classTemplateSymbols, scriptInfo);
+        addTemplateSymbolsToClass(tsSymbol, converted);
+        symbolsByClass.delete(tsSymbol.name);
+      }
+    }
+  }
+
+  // Handle any remaining symbols without className (fallback for older API or edge cases)
+  if (symbolsWithoutClass.length > 0) {
+    const converted = convertTemplateSymbols(symbolsWithoutClass, scriptInfo);
+    // Find first class to merge into
+    for (const tsSymbol of tsSymbols) {
+      if (tsSymbol.kind === lsp.SymbolKind.Class) {
+        addTemplateSymbolsToClass(tsSymbol, converted);
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Adds template symbols as children of a component class symbol.
+ */
+function addTemplateSymbolsToClass(
+  classSymbol: lsp.DocumentSymbol,
+  templateSymbols: lsp.DocumentSymbol[],
+): void {
+  if (!classSymbol.children) {
+    classSymbol.children = [];
+  }
+  // Create a "(template)" container to group template symbols
+  const templateContainer: lsp.DocumentSymbol = {
+    name: '(template)',
+    kind: lsp.SymbolKind.Namespace,
+    range: templateSymbols[0].range,
+    selectionRange: templateSymbols[0].selectionRange,
+    children: templateSymbols,
+  };
+  classSymbol.children.push(templateContainer);
+}
+
+/**
+ * Filters the TypeScript NavigationTree to only include classes that have Angular templates.
+ * This implements the hybrid approach where:
+ * - Classes with templates are shown (without their methods/properties)
+ * - Classes without templates are filtered out
+ * - Non-class symbols (functions, variables, etc.) are filtered out
+ *
+ * This provides a cleaner outline for Angular files, showing only the component
+ * structure with template symbols nested inside.
+ */
+function filterNavigationTreeToTemplateClasses(
+  tree: ts.NavigationTree,
+  scriptInfo: ts.server.ScriptInfo,
+  classNamesWithTemplates: Set<string>,
+): lsp.DocumentSymbol[] {
+  const result: lsp.DocumentSymbol[] = [];
+
+  // If no classes have templates, return empty array
+  // This means we show nothing for non-Angular files (TypeScript handles those)
+  if (classNamesWithTemplates.size === 0) {
+    return result;
+  }
+
+  // The root node is the file itself, process its children
+  if (tree.kind === ts.ScriptElementKind.moduleElement && tree.childItems) {
+    for (const child of tree.childItems) {
+      const filtered = filterNavigationItem(child, scriptInfo, classNamesWithTemplates);
+      if (filtered) {
+        result.push(filtered);
+      }
+    }
+  } else {
+    // For non-module roots, filter the node itself
+    const filtered = filterNavigationItem(tree, scriptInfo, classNamesWithTemplates);
+    if (filtered) {
+      result.push(filtered);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Filters a single NavigationTree item.
+ * - If it's a class with a template, return the class node (without children - no methods/properties)
+ * - If it's a container (module, namespace), recurse and keep if any children match
+ * - Otherwise, return null (filter out)
+ */
+function filterNavigationItem(
+  item: ts.NavigationTree,
+  scriptInfo: ts.server.ScriptInfo,
+  classNamesWithTemplates: Set<string>,
+): lsp.DocumentSymbol | null {
+  // Check if this is a class with a template
+  if (
+    (item.kind === ts.ScriptElementKind.classElement ||
+      item.kind === ts.ScriptElementKind.localClassElement) &&
+    item.text &&
+    classNamesWithTemplates.has(item.text)
+  ) {
+    // Return the class node WITHOUT its children (methods, properties)
+    // The template symbols will be added later by mergeTemplateSymbolsIntoClass
+    const spans = item.spans;
+    if (!spans || spans.length === 0) {
+      return null;
+    }
+
+    const range = tsTextSpanToLspRange(scriptInfo, spans[0]);
+    const selectionRange =
+      item.nameSpan !== undefined ? tsTextSpanToLspRange(scriptInfo, item.nameSpan) : range;
+
+    return {
+      name: item.text,
+      kind: lsp.SymbolKind.Class,
+      range,
+      selectionRange,
+      // No children - template symbols will be added later
+    };
+  }
+
+  // For container types (module, namespace), recurse into children
+  // and keep the container if any children match
+  if (
+    item.kind === ts.ScriptElementKind.moduleElement ||
+    item.kind === ts.ScriptElementKind.directory
+  ) {
+    if (item.childItems && item.childItems.length > 0) {
+      const filteredChildren: lsp.DocumentSymbol[] = [];
+      for (const child of item.childItems) {
+        const filtered = filterNavigationItem(child, scriptInfo, classNamesWithTemplates);
+        if (filtered) {
+          filteredChildren.push(filtered);
+        }
+      }
+
+      // If any children matched, return this container with filtered children
+      if (filteredChildren.length > 0) {
+        const spans = item.spans;
+        if (!spans || spans.length === 0) {
+          // If no span for container, just return children directly
+          return null;
+        }
+
+        const range = tsTextSpanToLspRange(scriptInfo, spans[0]);
+        const selectionRange =
+          item.nameSpan !== undefined ? tsTextSpanToLspRange(scriptInfo, item.nameSpan) : range;
+
+        return {
+          name: item.text || '',
+          kind: scriptElementKindToSymbolKind(item.kind),
+          range,
+          selectionRange,
+          children: filteredChildren,
+        };
+      }
+    }
+  }
+
+  // Filter out everything else (functions, variables, interfaces, etc.)
+  return null;
+}
+
+/**
+ * Maps TypeScript's ScriptElementKind to LSP SymbolKind.
+ */
+function scriptElementKindToSymbolKind(kind: ts.ScriptElementKind): lsp.SymbolKind {
+  switch (kind) {
+    case ts.ScriptElementKind.moduleElement:
+      return lsp.SymbolKind.Module;
+    case ts.ScriptElementKind.classElement:
+      return lsp.SymbolKind.Class;
+    case ts.ScriptElementKind.localClassElement:
+      return lsp.SymbolKind.Class;
+    case ts.ScriptElementKind.interfaceElement:
+      return lsp.SymbolKind.Interface;
+    case ts.ScriptElementKind.typeElement:
+      return lsp.SymbolKind.TypeParameter;
+    case ts.ScriptElementKind.enumElement:
+      return lsp.SymbolKind.Enum;
+    case ts.ScriptElementKind.enumMemberElement:
+      return lsp.SymbolKind.EnumMember;
+    case ts.ScriptElementKind.variableElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.localVariableElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.functionElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.localFunctionElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.memberFunctionElement:
+      return lsp.SymbolKind.Method;
+    case ts.ScriptElementKind.memberGetAccessorElement:
+      return lsp.SymbolKind.Property;
+    case ts.ScriptElementKind.memberSetAccessorElement:
+      return lsp.SymbolKind.Property;
+    case ts.ScriptElementKind.memberVariableElement:
+      return lsp.SymbolKind.Field;
+    case ts.ScriptElementKind.constructorImplementationElement:
+      return lsp.SymbolKind.Constructor;
+    case ts.ScriptElementKind.callSignatureElement:
+      return lsp.SymbolKind.Function;
+    case ts.ScriptElementKind.indexSignatureElement:
+      return lsp.SymbolKind.Key;
+    case ts.ScriptElementKind.constructSignatureElement:
+      return lsp.SymbolKind.Constructor;
+    case ts.ScriptElementKind.parameterElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.typeParameterElement:
+      return lsp.SymbolKind.TypeParameter;
+    case ts.ScriptElementKind.constElement:
+      return lsp.SymbolKind.Constant;
+    case ts.ScriptElementKind.letElement:
+      return lsp.SymbolKind.Variable;
+    case ts.ScriptElementKind.alias:
+      return lsp.SymbolKind.Variable;
+    default:
+      return lsp.SymbolKind.Variable;
+  }
+}
+
+/**
+ * Converts Angular template symbols to LSP DocumentSymbol[].
+ */
+function convertTemplateSymbols(
+  symbols: TemplateDocumentSymbol[],
+  scriptInfo: ts.server.ScriptInfo,
+): lsp.DocumentSymbol[] {
+  const result: lsp.DocumentSymbol[] = [];
+
+  for (const symbol of symbols) {
+    const converted = convertTemplateSymbol(symbol, scriptInfo);
+    if (converted) {
+      result.push(converted);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Converts a single Angular template symbol to an LSP DocumentSymbol.
+ */
+function convertTemplateSymbol(
+  symbol: TemplateDocumentSymbol,
+  scriptInfo: ts.server.ScriptInfo,
+): lsp.DocumentSymbol | null {
+  if (!symbol.spans || symbol.spans.length === 0) {
+    return null;
+  }
+
+  const range = tsTextSpanToLspRange(scriptInfo, symbol.spans[0]);
+  const selectionRange = symbol.nameSpan
+    ? tsTextSpanToLspRange(scriptInfo, symbol.nameSpan)
+    : range;
+
+  const children: lsp.DocumentSymbol[] = [];
+  if (symbol.childItems) {
+    for (const child of symbol.childItems) {
+      const childSymbol = convertTemplateSymbol(child, scriptInfo);
+      if (childSymbol) {
+        children.push(childSymbol);
+      }
+    }
+  }
+
+  // Use lspKind if available, otherwise fall back to ScriptElementKind mapping
+  const kind =
+    symbol.lspKind !== undefined
+      ? (symbol.lspKind as lsp.SymbolKind)
+      : scriptElementKindToSymbolKind(symbol.kind);
+
+  return {
+    name: symbol.text,
+    kind,
+    range,
+    selectionRange,
+    children: children.length > 0 ? children : undefined,
+  };
+}

--- a/vscode-ng-language-service/server/src/handlers/initialization.ts
+++ b/vscode-ng-language-service/server/src/handlers/initialization.ts
@@ -19,6 +19,7 @@ export function onInitialize(session: Session, params: lsp.InitializeParams): ls
   return {
     capabilities: {
       foldingRangeProvider: true,
+      documentSymbolProvider: true,
       codeLensProvider: {resolveProvider: true},
       textDocumentSync: lsp.TextDocumentSyncKind.Incremental,
       completionProvider: {

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -24,6 +24,7 @@ import {
   IsInAngularProject,
 } from '../../common/requests';
 
+import {clearWorkspaceConfigurationCache} from './config';
 import {tsDiagnosticToLspDiagnostic} from './diagnostic';
 import {ServerHost} from './server_host';
 import {
@@ -231,6 +232,9 @@ export class Session {
     conn.onDidCloseTextDocument((p) => this.onDidCloseTextDocument(p));
     conn.onDidChangeTextDocument((p) => this.onDidChangeTextDocument(p));
     conn.onDidSaveTextDocument((p) => this.onDidSaveTextDocument(p));
+    conn.onDidChangeConfiguration(() => {
+      clearWorkspaceConfigurationCache(this.connection);
+    });
     conn.onDefinition((p) => onDefinition(this, p));
     conn.onTypeDefinition((p) => onTypeDefinition(this, p));
     conn.onReferences((p) => onReferences(this, p));

--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -42,6 +42,7 @@ import {onFoldingRanges} from './handlers/folding';
 import {onHover} from './handlers/hover';
 import {onInitialize} from './handlers/initialization';
 import {onLinkedEditingRange} from './handlers/linked_editing_range';
+import {onDocumentSymbol} from './handlers/document_symbols';
 import {onRenameRequest, onPrepareRename} from './handlers/rename';
 import {onSignatureHelp} from './handlers/signature';
 import {onGetTcb} from './handlers/tcb';
@@ -238,6 +239,7 @@ export class Session {
     conn.onHover((p) => onHover(this, p));
     conn.onFoldingRanges((p) => onFoldingRanges(this, p));
     conn.languages.onLinkedEditingRange((p) => onLinkedEditingRange(this, p));
+    conn.onDocumentSymbol(async (p) => await onDocumentSymbol(this, p));
     conn.onCompletion((p) => onCompletion(this, p));
     conn.onCompletionResolve((p) => onCompletionResolve(this, p));
     conn.onRequest(GetComponentsWithTemplateFile, (p) => getComponentsWithTemplateFile(this, p));

--- a/vscode-ng-language-service/server/src/tests/config_spec.ts
+++ b/vscode-ng-language-service/server/src/tests/config_spec.ts
@@ -1,0 +1,120 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  clearWorkspaceConfigurationCache,
+  flattenConfiguration,
+  getWorkspaceConfigurationCached,
+} from '../config';
+
+describe('flattenConfiguration', () => {
+  it('should flatten a simple nested object', () => {
+    const config = {
+      enabled: 'all',
+      suppressWhenArgumentMatchesName: true,
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints.parameterNames');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+    });
+  });
+
+  it('should flatten deeply nested objects', () => {
+    const config = {
+      parameterNames: {
+        enabled: 'all',
+        suppressWhenArgumentMatchesName: true,
+      },
+      variableTypes: {
+        enabled: true,
+      },
+    };
+    const result = flattenConfiguration(config, 'typescript.inlayHints');
+    expect(result).toEqual({
+      'typescript.inlayHints.parameterNames.enabled': 'all',
+      'typescript.inlayHints.parameterNames.suppressWhenArgumentMatchesName': true,
+      'typescript.inlayHints.variableTypes.enabled': true,
+    });
+  });
+
+  it('should handle arrays as leaf values', () => {
+    const config = {
+      items: ['a', 'b', 'c'],
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.items': ['a', 'b', 'c'],
+    });
+  });
+
+  it('should handle null values', () => {
+    const config = {
+      value: null,
+    };
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({
+      'prefix.value': null,
+    });
+  });
+
+  it('should handle empty objects', () => {
+    const config = {};
+    const result = flattenConfiguration(config, 'prefix');
+    expect(result).toEqual({});
+  });
+
+  it('should handle mixed value types', () => {
+    const config = {
+      stringVal: 'test',
+      numberVal: 42,
+      boolVal: false,
+      nested: {
+        deep: 'value',
+      },
+    };
+    const result = flattenConfiguration(config, 'config');
+    expect(result).toEqual({
+      'config.stringVal': 'test',
+      'config.numberVal': 42,
+      'config.boolVal': false,
+      'config.nested.deep': 'value',
+    });
+  });
+
+  it('should memoize workspace configuration requests for identical items', async () => {
+    const getConfiguration = jasmine.createSpy().and.resolveTo([{}, {}]);
+    const connection = {
+      workspace: {
+        getConfiguration,
+      },
+    } as any;
+
+    const items = [{section: 'angular.inlayHints'}, {section: 'editor.inlayHints'}];
+    await getWorkspaceConfigurationCached(connection, items);
+    await getWorkspaceConfigurationCached(connection, items);
+
+    expect(getConfiguration).toHaveBeenCalledTimes(1);
+  });
+
+  it('should invalidate cached workspace configuration entries', async () => {
+    const getConfiguration = jasmine.createSpy().and.resolveTo([{}]);
+    const connection = {
+      workspace: {
+        getConfiguration,
+      },
+    } as any;
+
+    const items = [{section: 'angular.inlayHints', scopeUri: 'file:///workspace/app.component.ts'}];
+    await getWorkspaceConfigurationCached(connection, items);
+    clearWorkspaceConfigurationCache(connection);
+    await getWorkspaceConfigurationCached(connection, items);
+
+    expect(getConfiguration).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Scope and Branch Position

- Built on top of `feat/document-symbols-templates` as a stacked branch for iteration speed.
- This PR is intentionally scoped to inline template/style bridge behavior in the VS Code integration layer.
- Before final merge, this branch should be rebased/split so inline-style bridge changes can be reviewed independently.

## Exact Feature Additions (one by one)

- Inline-style **Definition bridge**.
  Example: on `$color` usage inside `@Component({ styles: [...] })`, `vscode.executeDefinitionProvider` runs on the scoped virtual style document and returns a definition remapped to the source `app.component.ts` declaration (`$color: #ff0000;`).

- Inline-style **References bridge** with same-block scoping.
  Example: on `$color` in the first style block, `vscode.executeReferenceProvider` returns declaration+usage in that block; on `$color` in the second block, results stay in that second block and do not leak to the first block.

- Inline-style **Document Symbols merge** into TS symbols.
  Example: `vscode.executeDocumentSymbolProvider` output includes `(styles)` containers for each inline style block, with child symbols such as `.red` and `.blue`, and ranges mapped to source `.ts` positions.

- Inline-style **Selection Range bridge**.
  Example: `vscode.executeSelectionRangeProvider` on `$color` positions from two separate inline style blocks returns two independent selection chains, each anchored to its own source TS range.

- Inline-style **Document Color bridge**.
  Example: `vscode.executeDocumentColorProvider` returns a color info for `#ff0000` in inline styles with the range mapped to the source `.ts` file, and does not report color ranges from template text.

- Inline-style **Color Presentation bridge** with normalized edits.
  Example: `vscode.executeColorPresentationProvider` returns presentations whose `textEdit.range` is normalized to the original inline-style source range; when no provider presentation is returned, a fallback RGB presentation is produced for that range.

- Inline-style **Code Action bridge** with source remap.
  Example: quick fix for SCSS typo `dispay` is provided through `vscode.executeCodeActionProvider`, and resulting `WorkspaceEdit` entries are remapped to `app.component.ts` with the expected replacement `display` at the original typo range.

- Inline-style **Prepare Rename + Rename bridge**.
  Example: `vscode.prepareRename` and `vscode.executeDocumentRenameProvider` run against the scoped virtual style document, then remap resulting rename ranges/edits back to source TypeScript URIs/ranges.

- Inline-style **Document Highlights bridge** (explicit provider path).
  Example: for `$color` in the first style block, `vscode.executeDocumentHighlights` returns two highlights (declaration + first usage) mapped to source TS ranges and excludes the `$color` occurrence in the second style block; fallback uses `vscode.executeReferenceProvider` when highlight results are empty.

## Strict E2E Command and Result

- Command: `pnpm bazel test //vscode-ng-language-service/integration/e2e:test --test_output=errors --test_env=PATH=/opt/X11/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin --nocache_test_results`
- Result: `PASSED` (`//vscode-ng-language-service/integration/e2e:test`, 1/1 target).

## Disclosure

- AI disclosure: AI-assisted implementation and PR drafting, orchestrated by the user.
