### PR TITLE
docs(docs-infra): scroll home features section into view on tab change

### DIFF
--- a/adev/src/app/features/home/home.component.html
+++ b/adev/src/app/features/home/home.component.html
@@ -36,20 +36,20 @@
     </div>
   </section>
 
-  <section class="features-section">
+  <section class="features-section" #featuresSection>
     <h2 id="features">Features that actually <br />help you solve problems</h2>
 
     <div ngTabs class="material-tabs">
-      <div ngTabList selectionMode="follow" selectedTab="signals">
+      <div ngTabList selectionMode="follow" [(selectedTab)]="selectedFeatureTab">
         <div class="tab-background"></div>
-        <div ngTab value="signals">Signals</div>
-        <div ngTab value="control-flow">Control Flow</div>
-        <div ngTab value="deferrable-views">Deferrable Views</div>
-        <div ngTab value="hydration">Hydration</div>
+        <div ngTab [value]="FEATURE_TAB.signals">Signals</div>
+        <div ngTab [value]="FEATURE_TAB.controlFlow">Control Flow</div>
+        <div ngTab [value]="FEATURE_TAB.deferrableViews">Deferrable Views</div>
+        <div ngTab [value]="FEATURE_TAB.hydration">Hydration</div>
       </div>
 
       <div class="sliding-window">
-        <div ngTabPanel [preserveContent]="true" value="signals">
+        <div ngTabPanel [preserveContent]="true" [value]="FEATURE_TAB.signals">
           @defer (on idle) {
             <ng-template ngTabContent>
               <adev-signals-demo />
@@ -57,7 +57,7 @@
           }
         </div>
 
-        <div ngTabPanel [preserveContent]="true" value="control-flow">
+        <div ngTabPanel [preserveContent]="true" [value]="FEATURE_TAB.controlFlow">
           @defer (on idle) {
             <ng-template ngTabContent>
               <adev-control-flow-example />
@@ -65,7 +65,7 @@
           }
         </div>
 
-        <div ngTabPanel [preserveContent]="true" value="deferrable-views">
+        <div ngTabPanel [preserveContent]="true" [value]="FEATURE_TAB.deferrableViews">
           @defer (on idle) {
             <ng-template ngTabContent>
               <adev-defer-example />
@@ -73,7 +73,7 @@
           }
         </div>
 
-        <div ngTabPanel [preserveContent]="true" value="hydration">
+        <div ngTabPanel [preserveContent]="true" [value]="FEATURE_TAB.hydration">
           @defer (on idle) {
             <ng-template ngTabContent>
               <adev-hydration-example />

--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -98,6 +98,11 @@ section {
   }
 }
 
+#features {
+  margin: 0;
+  padding: 2.5rem 1rem;
+}
+
 @property --gradient-angle {
   syntax: '<angle>';
   initial-value: 90deg;

--- a/adev/src/app/features/home/home.component.ts
+++ b/adev/src/app/features/home/home.component.ts
@@ -8,14 +8,28 @@
 
 import {Tab, TabContent, TabList, TabPanel, Tabs} from '@angular/aria/tabs';
 import {A11yModule} from '@angular/cdk/a11y';
-import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {
+  afterRenderEffect,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
 import {IS_SEARCH_DIALOG_OPEN, IconComponent, TextField} from '@angular/docs';
 import {ActivatedRoute, RouterLink} from '@angular/router';
-import {CodeHighligher} from './code-highlighting/code-highlighter';
 import {ControlFlowExample} from './components/control-flow/control-flow-example';
 import {DeferrableViewsExample} from './components/deferrable-views-example/deferrable-views-example';
 import {HydrationExample} from './components/hydration-example/hydration-example';
 import {SignalsDemo} from './components/signals-demo/signals-demo';
+
+const FEATURE_TAB = {
+  signals: 'signals',
+  controlFlow: 'control-flow',
+  deferrableViews: 'deferrable-views',
+  hydration: 'hydration',
+} as const;
 
 @Component({
   selector: 'adev-home',
@@ -41,9 +55,26 @@ import {SignalsDemo} from './components/signals-demo/signals-demo';
 export default class Home {
   private readonly activatedRoute = inject(ActivatedRoute);
   protected readonly isUwu = 'uwu' in this.activatedRoute.snapshot.queryParams;
-  private readonly codeHighlighter = inject(CodeHighligher);
 
   protected readonly displaySearchDialog = inject(IS_SEARCH_DIALOG_OPEN);
+
+  protected readonly FEATURE_TAB = FEATURE_TAB;
+  protected readonly selectedFeatureTab = signal<keyof typeof FEATURE_TAB>(FEATURE_TAB.signals);
+  protected readonly featuresSection = viewChild<ElementRef>('featuresSection');
+
+  constructor() {
+    let lastFeatureTab = this.selectedFeatureTab();
+
+    afterRenderEffect({
+      read: () => {
+        const featureTab = this.selectedFeatureTab();
+        if (lastFeatureTab !== featureTab) {
+          this.featuresSection()?.nativeElement.scrollIntoView();
+          lastFeatureTab = featureTab;
+        }
+      },
+    });
+  }
 
   openSearch() {
     this.displaySearchDialog.set(true);


### PR DESCRIPTION
A small UX improvement where the Features section on the home page is scrolled into view when you change the feature tab.

If you happen to randomly explore the page and click on the various buttons, in the case of the features tabs and depending on your screen size, the actual action happens outside of the viewport. 

<img width="1456" height="1093" alt="Screenshot 2026-02-25 at 13 45 09" src="https://github.com/user-attachments/assets/1322f190-28b7-4e48-8028-5a26e90fc29d" />

