### PR TITLE
fix(core): bind global context to idle callback shims in @defer's idle service

### DIFF
--- a/packages/core/src/defer/idle_service.ts
+++ b/packages/core/src/defer/idle_service.ts
@@ -19,9 +19,9 @@ import {makeEnvironmentProviders} from '../di/provider_collection';
  * overridden/mocked in test environment and picked up by the runtime code.
  */
 const _requestIdleCallback = () =>
-  typeof requestIdleCallback !== 'undefined' ? requestIdleCallback.bind(globalThis) : setTimeout;
+  (typeof requestIdleCallback !== 'undefined' ? requestIdleCallback : setTimeout).bind(globalThis);
 const _cancelIdleCallback = () =>
-  typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback.bind(globalThis) : clearTimeout;
+  (typeof requestIdleCallback !== 'undefined' ? cancelIdleCallback : clearTimeout).bind(globalThis);
 
 /**
  * Service which configures custom 'on idle' behavior for Angular features like `@defer`.


### PR DESCRIPTION
Fix a Safari regression caused by [`a5981b8`](https://github.com/angular/angular/commit/a5981b83a60577d9068d2429bcbed969edca581b) where the browser is unable to properly assign the `window` context to idle callback shims in `@defer` 'on idle' configuration service.