### PR TITLE
feat(compiler): support JS-valid unicode identifiers and improve unicode diagnostics in template parsing

### DIFF
--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -115,6 +115,10 @@ describe('HtmlLexer', () => {
       expect(tokenizeAndHumanizeErrors('<!-a')).toEqual([['Unexpected character "a"', '0:3']]);
     });
 
+    it('should report non-BMP characters without replacement glyphs', () => {
+      expect(tokenizeAndHumanizeErrors('<!-😀')).toEqual([['Unexpected character "😀"', '0:3']]);
+    });
+
     it('should report missing end comment', () => {
       expect(tokenizeAndHumanizeErrors('<!--')).toEqual([['Unexpected character "EOF"', '0:4']]);
     });

--- a/packages/core/src/render3/styling/styling_parser.ts
+++ b/packages/core/src/render3/styling/styling_parser.ts
@@ -320,13 +320,28 @@ export function consumeQuotedText(
 
 function malformedStyleError(text: string, expecting: string, index: number): never {
   ngDevMode && assertEqual(typeof text === 'string', true, 'String expected here');
+  const charLength = getCodePointLengthAt(text, index);
   throw throwError(
     `Malformed style at location ${index} in string '` +
       text.substring(0, index) +
       '[>>' +
-      text.substring(index, index + 1) +
+      text.substring(index, index + charLength) +
       '<<]' +
-      text.slice(index + 1) +
+      text.slice(index + charLength) +
       `'. Expecting '${expecting}'.`,
   );
+}
+
+function getCodePointLengthAt(text: string, index: number): number {
+  if (index < 0 || index >= text.length) {
+    return 1;
+  }
+
+  const code = text.charCodeAt(index);
+  if (code < 0xd800 || code > 0xdbff || index + 1 >= text.length) {
+    return 1;
+  }
+
+  const next = text.charCodeAt(index + 1);
+  return next >= 0xdc00 && next <= 0xdfff ? 2 : 1;
 }

--- a/packages/core/test/render3/instructions/styling_parser_spec.ts
+++ b/packages/core/test/render3/instructions/styling_parser_spec.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {consumeQuotedText} from '../../../src/render3/styling/styling_parser';
+import {CharCode} from '../../../src/util/char_code';
+
+describe('styling parser', () => {
+  it('should not split surrogate pairs in malformed style diagnostics', () => {
+    expect(() => consumeQuotedText('"😀', CharCode.DOUBLE_QUOTE, 1, 1)).toThrowError(
+      /Malformed style at location 1 in string '"\[>>😀<<\]'.*Expecting '"'\./,
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [x] Feature

## What is the current behavior?

In short:
```ts
Component({
  selector: 'app-child',
  imports: [],
  host: {'[style.color]': '我a的() ? "green" : "red"'},
  template: `<div>{{ 我a的() ? 'Angular 🚀' : '😔' }}</div>`,
  styles: ``,
})
export class UnicodeLibChild {
  我a的 = input<string>();
}
```
will cause 
`NG5002: Parser Error: Lexer Error: Unexpected character [我]`

Angular template expression lexing currently has gaps around Unicode handling and diagnostics quality:
- Non-ASCII identifier support needed stricter JS-valid semantics and stronger coverage.
- Some unexpected-character diagnostics could render replacement/ambiguous characters for surrogate/non-BMP cases.
- Some user-facing diagnostic snippets could split surrogate pairs.

Issue Number: #517

## What is the new behavior?

This PR hardens Unicode handling and diagnostics across relevant compiler paths.

```ts
@Component({
  selector: 'app-child',
  imports: [],
  host: {'[style.color]': '我a的() ? "green" : "red"'},
  template: `<div>{{ 我a的() ? 'Angular 🚀' : '😔' }}</div>`,
  styles: ``,
})
export class UnicodeLibChild {
  我a的 = input<string>();
}
```

```ts
import {Component} from '@angular/core';
import {UnicodeLibChild} from 'unicode-lib';

@Component({
	selector: 'app-root',
	imports: [UnicodeLibChild],
	template: `<app-child [我a的]="我a的"></app-child>`,
})
export class App {
	我a的 = '我a的';
}
```
produces :
<img width="109" height="42" alt="image" src="https://github.com/user-attachments/assets/ed4f7243-0f15-46cc-a053-6f45e3ee57bf" />

### Risk assessment 
- Risk matrix in the comment below

### Prior Attempts / Addressed Concerns
- Previous related attempt: `#46194`.
- @alexhub concerns from prior attempt and how this PR addresses them:
  - Concern: broad acceptance via `codePoint >= 0x80` was over-permissive.
    - Addressed: this PR uses ECMAScript-aligned `ID_Start`/`ID_Continue`
  - Concern: "how multi-byte characters may affect source positions and any operation that relies on them".
    -Addressed: this PR adds code-point-aware advancement where identifier scanning depends on character width, adds diagnostic-formatting tests for Unicode/surrogate behavior, and captures remaining formatter/terminal-width caveats in comments below to be addressed if required.

### Implementation
- `packages/compiler/src/expression_parser/lexer.ts`
  - Supports Unicode identifiers using JS-valid `ID_Start` / `ID_Continue` checks.
  - Uses surrogate-aware code point scanning for identifiers.
  - Formats unexpected non-ASCII characters in diagnostics as escaped `\u{...}` for deterministic output.

- `packages/compiler/src/ml_parser/lexer.ts`
  - Improves unexpected-character diagnostics with codepoint-aware rendering and surrogate-safe fallback.

- `packages/core/src/render3/styling/styling_parser.ts`
  - Prevents malformed-style marker rendering from splitting surrogate pairs.

### Test coverage added/expanded
- `packages/compiler/test/expression_parser/lexer_spec.ts`
  - Astral identifiers, private identifiers, combining mark / ZWJ / ZWNJ behavior, malformed surrogates, out-of-range code points, escaped-diagnostic format guard.

- `packages/compiler/test/expression_parser/parser_spec.ts`
  - Unicode across broader expression contexts (calls, keyed read/write, safe access, assignments, object/array literals), astral/private diagnostics.

- `packages/compiler/test/ml_parser/lexer_spec.ts`
  - Non-BMP unexpected-character diagnostic regression.

- `packages/core/test/render3/instructions/styling_parser_spec.ts`
  - Surrogate-safe malformed-style diagnostic marker regression.

- `packages/compiler-cli/test/ngtsc/ngtsc_spec.ts`
  - Partial/full declaration emission coverage for unicode input aliases.
  - External declaration consumption coverage for unicode input aliases.

- Also properly handled now by builders/diagnostics
<img width="703" height="94" alt="image" src="https://github.com/user-attachments/assets/86f22b30-141b-4288-b738-d1690dded144" />
 - Underline is 2 characters too short. I've explained this in the comment below.
  

### Local validation performed
- `pnpm bazel test //packages/compiler/test/expression_parser:expression_parser --test_output=errors`
- `pnpm bazel test //packages/compiler/test/ml_parser:ml_parser --test_output=errors`
- `pnpm bazel test //packages/core/test/render3:render3 --test_filter='styling parser' --test_output=errors`
- `pnpm bazel test //packages/compiler-cli/test/ngtsc:ngtsc --test_filter='unicode input' --test_output=errors`

### Related demo artifacts (optional reviewer experimentation)
- Demo repo: https://github.com/kbrilla/angular-unicode-input-demo
- StackBlitz import: https://stackblitz.com/github/kbrilla/angular-unicode-input-demo
- VSIX artifact in demo repo: `artifacts/ng-template-new-features.vsix`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This approach intentionally avoids broad/non-spec Unicode acceptance and instead aligns with JS identifier classes, addressing concerns from earlier attempts (e.g. broad `>= 0x80` acceptance and insufficient surrogate/multi-byte diagnostics coverage).

### AI disclosure
AI assisted with implementation and drafting under user direction; all changes were reviewed and validated with local tests before opening this PR.

