### PR TITLE
docs: align list formatting and improve emphasis

### DIFF
--- a/adev/src/content/examples/attribute-directives/src/app/app.component.avoid.html
+++ b/adev/src/content/examples/attribute-directives/src/app/app.component.avoid.html
@@ -1,3 +1,0 @@
-<!-- #docregion unsupported -->
-<p app:Highlight>This is invalid</p>
-<!-- #enddocregion unsupported  -->

--- a/adev/src/content/examples/attribute-directives/src/app/highlight.directive.0.ts
+++ b/adev/src/content/examples/attribute-directives/src/app/highlight.directive.0.ts
@@ -1,7 +1,0 @@
-// #docregion
-import {Directive} from '@angular/core';
-
-@Directive({
-  selector: '[appHighlight]',
-})
-export class HighlightDirective {}

--- a/adev/src/content/guide/directives/attribute-directives.md
+++ b/adev/src/content/guide/directives/attribute-directives.md
@@ -14,7 +14,14 @@ This section walks you through creating a highlight directive that sets the back
 
    The CLI creates `src/app/highlight.directive.ts`, a corresponding test file `src/app/highlight.directive.spec.ts`.
 
-   <docs-code header="highlight.directive.ts" path="adev/src/content/examples/attribute-directives/src/app/highlight.directive.0.ts"/>
+   ```angular-ts
+   import {Directive} from '@angular/core';
+
+   @Directive({
+     selector: '[appHighlight]',
+   })
+   export class HighlightDirective {}
+   ```
 
    The `@Directive()` decorator's configuration property specifies the directive's CSS attribute selector, `[appHighlight]`.
 
@@ -25,11 +32,13 @@ This section walks you through creating a highlight directive that sets the back
 
 1. Add logic to the `HighlightDirective` class that sets the background to yellow.
 
-<docs-code header="highlight.directive.ts" path="adev/src/content/examples/attribute-directives/src/app/highlight.directive.1.ts"/>
+   <docs-code header="highlight.directive.ts" path="adev/src/content/examples/attribute-directives/src/app/highlight.directive.1.ts"/>
 
-HELPFUL: Directives _do not_ support namespaces.
+IMPORTANT: Directives _do not_ support namespaces.
 
-<docs-code header="app.component.avoid.html (unsupported)" path="adev/src/content/examples/attribute-directives/src/app/app.component.avoid.html" region="unsupported"/>
+```angular-html {avoid}
+<p app:Highlight>This is invalid</p>
+```
 
 ## Applying an attribute directive
 


### PR DESCRIPTION
Aligns list formatting, replaces the “Helpful” block with an IMPORTANT note for better visibility, and removes the separate example file by inlining the single relevant line directly in the documentation.

## What is the current behavior?
<img width="1754" height="1474" alt="image" src="https://github.com/user-attachments/assets/15c78fb4-3ca9-43ce-b0b5-76d6f151baf5" />

## What is the new behavior?
<img width="1804" height="1390" alt="image" src="https://github.com/user-attachments/assets/b7f89169-0bae-4e2d-9669-4a2c3b1aad2b" />
