### PR TITLE
fix(forms): support generic unions in signal form schemas

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -140,7 +140,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
 export type FieldStateByMode<TValue, TKey extends string | number, TMode extends 'writable' | 'readonly'> = TMode extends 'writable' ? FieldState<TValue, TKey> : ReadonlyFieldState<TValue, TKey>;
 
 // @public
-export type FieldTree<TModel, TKey extends string | number = string | number, TMode extends 'writable' | 'readonly' = 'writable'> = (() => [TModel] extends [AbstractControl] ? CompatFieldState<TModel, TKey, TMode> : FieldStateByMode<TModel, TKey, TMode>) & ([TModel] extends [AbstractControl] ? object : [TModel] extends [ReadonlyArray<infer U>] ? ReadonlyArrayLike<MaybeFieldTree<U, number, TMode>> : TModel extends Record<string, any> ? Subfields<TModel, TMode> : object);
+export type FieldTree<TModel, TKey extends string | number = string | number, TMode extends 'writable' | 'readonly' = 'writable'> = (() => [TModel] extends [AbstractControl] ? CompatFieldState<TModel, TKey, TMode> : FieldStateByMode<TModel, TKey, TMode>) & (TModel extends AbstractControl ? object : TModel extends ReadonlyArray<infer U> ? ReadonlyArrayLike<MaybeFieldTree<U, number, TMode>> : TModel extends Record<string, any> ? Subfields<TModel, TMode> : object);
 
 // @public
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<TValue, ValidationResult<ValidationError.WithoutFieldTree>, TPathKind>;
@@ -476,7 +476,14 @@ export function provideSignalFormsConfig(config: SignalFormsConfig): Provider[];
 export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>, logic?: NoInfer<LogicFn<TValue, boolean, TPathKind>>): void;
 
 // @public
-export type ReadonlyArrayLike<T> = Pick<ReadonlyArray<T>, number | 'length' | typeof Symbol.iterator>;
+export interface ReadonlyArrayLike<T> {
+    // (undocumented)
+    [Symbol.iterator](): IterableIterator<T>;
+    // (undocumented)
+    readonly [n: number]: T;
+    // (undocumented)
+    readonly length: number;
+}
 
 // @public
 export type ReadonlyCompatFieldState<TControl extends AbstractControl, TKey extends string | number = string | number> = CompatFieldState<TControl, TKey, 'readonly'>;
@@ -543,12 +550,12 @@ export class RequiredValidationError extends BaseNgValidationError {
 // @public
 export interface RootFieldContext<TValue> {
     readonly fieldTree: ReadonlyFieldTree<TValue>;
-    fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): ReadonlyFieldTree<PModel>;
+    fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): [PModel] extends [any] ? ReadonlyFieldTree<PModel> : never;
     readonly pathKeys: Signal<readonly string[]>;
     readonly state: ReadonlyFieldState<TValue>;
-    stateOf<PControl extends AbstractControl>(p: CompatSchemaPath<PControl>): ReadonlyCompatFieldState<PControl>;
+    stateOf<PControl extends AbstractControl>(p: CompatSchemaPath<PControl>): [PControl] extends [any] ? ReadonlyCompatFieldState<PControl> : never;
     // (undocumented)
-    stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): ReadonlyFieldState<PValue>;
+    stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): [PValue] extends [any] ? ReadonlyFieldState<PValue> : never;
     readonly value: Signal<TValue>;
     valueOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): PValue;
 }
@@ -586,7 +593,9 @@ export namespace SchemaPathRules {
 }
 
 // @public
-export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = ([TModel] extends [AbstractControl] ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & (TModel extends AbstractControl ? unknown : TModel extends ReadonlyArray<any> ? unknown : TModel extends Record<string, any> ? {
+export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = ([TModel] extends [AbstractControl] ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & ([TModel] extends [AbstractControl] ? unknown : [
+TModel
+] extends [ReadonlyArray<any>] ? unknown : TModel extends Record<string, any> ? {
     [K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>;
 } : unknown);
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -232,9 +232,9 @@ export type FieldTree<
     ? CompatFieldState<TModel, TKey, TMode>
     : FieldStateByMode<TModel, TKey, TMode>) &
     // Children:
-    ([TModel] extends [AbstractControl]
+    (TModel extends AbstractControl
       ? object
-      : [TModel] extends [ReadonlyArray<infer U>]
+      : TModel extends ReadonlyArray<infer U>
         ? ReadonlyArrayLike<MaybeFieldTree<U, number, TMode>>
         : TModel extends Record<string, any>
           ? Subfields<TModel, TMode>
@@ -277,10 +277,11 @@ export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'
  *
  * @experimental 21.0
  */
-export type ReadonlyArrayLike<T> = Pick<
-  ReadonlyArray<T>,
-  number | 'length' | typeof Symbol.iterator
->;
+export interface ReadonlyArrayLike<T> {
+  readonly [n: number]: T;
+  readonly length: number;
+  [Symbol.iterator](): IterableIterator<T>;
+}
 
 /**
  * Helper type for defining `FieldTree`. Given a type `TValue` that may include `undefined`,
@@ -697,10 +698,10 @@ export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
     ? CompatSchemaPath<TModel, TPathKind>
     : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) &
     // Subpaths
-    (TModel extends AbstractControl
+    ([TModel] extends [AbstractControl]
       ? unknown
       : // Array paths have no subpaths
-        TModel extends ReadonlyArray<any>
+        [TModel] extends [ReadonlyArray<any>]
         ? unknown
         : // Object subfields
           TModel extends Record<string, any>
@@ -903,13 +904,24 @@ export interface RootFieldContext<TValue> {
   /** Gets the value of the field represented by the given path. */
   valueOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): PValue;
 
+  // Note: These methods use a tautological conditional type (`[P] extends [any] ? ... : never`).
+  // This is required because the `FieldNodeContext` implementation returns a deferred conditional
+  // type from `FieldTreeBase` (e.g. `[P] extends [AbstractControl] ? ...`).
+  // TypeScript is strictly invariant when matching generic method signatures and will throw an
+  // assignability error if the interface signature is fully resolved while the implementation
+  // signature is a deferred conditional. This tautological wrapper mimics the deferred
+  // structure so that TypeScript accepts the assignment gracefully.
   /** Gets the state of the field represented by the given path. */
   stateOf<PControl extends AbstractControl>(
     p: CompatSchemaPath<PControl>,
-  ): ReadonlyCompatFieldState<PControl>;
-  stateOf<PValue>(p: SchemaPath<PValue, SchemaPathRules>): ReadonlyFieldState<PValue>;
+  ): [PControl] extends [any] ? ReadonlyCompatFieldState<PControl> : never;
+  stateOf<PValue>(
+    p: SchemaPath<PValue, SchemaPathRules>,
+  ): [PValue] extends [any] ? ReadonlyFieldState<PValue> : never;
   /** Gets the field represented by the given path. */
-  fieldTreeOf<PModel>(p: SchemaPathTree<PModel>): ReadonlyFieldTree<PModel>;
+  fieldTreeOf<PModel>(
+    p: SchemaPathTree<PModel>,
+  ): [PModel] extends [any] ? ReadonlyFieldTree<PModel> : never;
   /** The list of keys that lead from the root field to the current field. */
   readonly pathKeys: Signal<readonly string[]>;
 }

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -16,7 +16,10 @@ import {
 import {RuntimeErrorCode} from '../errors';
 import {AbstractControl} from '@angular/forms';
 import {
+  CompatSchemaPath,
+  CompatFieldState,
   FieldContext,
+  ReadonlyCompatFieldState,
   ReadonlyFieldState,
   ReadonlyFieldTree,
   SchemaPath,
@@ -48,7 +51,13 @@ export class FieldNodeContext implements FieldContext<unknown> {
   constructor(
     /** The field node this context corresponds to. */
     private readonly node: FieldNode,
-  ) {}
+  ) {
+    // These methods are explicitly bound to the context instance so that they
+    // safely retain their `this` reference if destructured by consumers
+    // (e.g., during validation when `stateOf` or `fieldTreeOf` are extracted).
+    this.fieldTreeOf = this.fieldTreeOf.bind(this);
+    this.stateOf = this.stateOf.bind(this);
+  }
 
   /**
    * Resolves a target path relative to this context.
@@ -137,8 +146,25 @@ export class FieldNodeContext implements FieldContext<unknown> {
     return Number(key);
   });
 
-  readonly fieldTreeOf = <TModel>(p: SchemaPathTree<TModel>) => this.resolve<TModel>(p);
-  readonly stateOf = <TModel>(p: SchemaPath<TModel, SchemaPathRules>) => this.resolve<TModel>(p)();
+  // Note: `fieldTreeOf` and `stateOf` are purposefully defined as overloaded class
+  // methods rather than arrow-function properties. This allows their signatures
+  // to successfully satisfy the complex, deferred conditional generic typings
+  // required by the `RootFieldContext` interface.
+  fieldTreeOf<PModel>(
+    p: SchemaPathTree<PModel>,
+  ): [PModel] extends [any] ? ReadonlyFieldTree<PModel> : never {
+    return this.resolve<PModel>(p) as any;
+  }
+
+  stateOf<PControl extends AbstractControl>(
+    p: CompatSchemaPath<PControl>,
+  ): [PControl] extends [any] ? ReadonlyCompatFieldState<PControl> : never;
+  stateOf<PValue>(
+    p: SchemaPath<PValue, SchemaPathRules>,
+  ): [PValue] extends [any] ? ReadonlyFieldState<PValue> : never;
+  stateOf<TModel>(p: SchemaPath<TModel, SchemaPathRules> | CompatSchemaPath<any>): any {
+    return this.resolve<TModel>(p as any)();
+  }
   readonly valueOf = <TValue>(p: SchemaPath<TValue, SchemaPathRules>) => {
     const result = this.resolve(p)().value();
 

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -97,6 +97,15 @@ function typeVerificationOnlyDoNotRunMe() {
       form(signal<RecursiveType>([5]));
     });
 
+    it('should allow property access on generic type unions', () => {
+      // Validates that uninstantiated generic unions can still access shared
+      // fields via naked conditional distribution in FieldTree
+      function testGeneric<T extends {a: 1} | {a: 1; b: 2}>(f: FieldTree<T>) {
+        const x: FieldTree<1> = f.a;
+        return x;
+      }
+    });
+
     it('should allow ReadonlyArray in model and be iterable', () => {
       interface Order {
         readonly products: readonly string[];


### PR DESCRIPTION
This commit resolves an issue where using an uninstantiated generic type parameter in a signal form model caused TypeScript compilation failures due to distributive conditional types (#66596). The previous attempt to fix this issue by tuple-wrapping everything caused another bug (#65535) that prevented property access on generic unions.

This commit balances the need to resolve nested generic property access while handling infinitely recursive generic structures without depth errors.

What changed and why:
- Base State Wrappers: Tuple wrappers (`[TModel] extends [AbstractControl]`) are applied to `FieldTreeBase` to safely defer generic evaluation. This prevents primitive unions (like `boolean`) from incorrectly evaluating to `never`.
- Naked Map Over Children: Object subfield checks (`TModel extends Record`) are re-evaluated as purely naked conditionals. Eager distribution over generics allows users to directly access shared properties of unresolved union types.
- Array Interface Deflection: `ReadonlyArrayLike<T>` generic abstraction is redefined as an explicit `interface` instead of a mapped `Pick` type alias. This optimally intercepts TypeScript from eagerly evaluating infinitely recursive array structures (e.g. `RecursiveType = (number | RecursiveType)[]`).
- Overloaded Context Methods: `FieldNodeContext.stateOf` and `fieldTreeOf` are defined as explicitly overloaded class methods and lexically bound (`this`) in the constructor. These changes are required to safely align the runtime bindings with the tautological conditionals implemented in the `RootFieldContext` interface structure.

Fixes #65535