### PR TITLE
fix(core): prevent aggressive removal of items in a for loop

### DIFF
--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -348,7 +348,7 @@ function animateLeaveClassRunner(
     cleanupFns.push(renderer.listen(el, 'animationend', handleOutAnimationEnd));
     cleanupFns.push(renderer.listen(el, 'transitionend', handleOutAnimationEnd));
   });
-  trackLeavingNodes(tNode, el);
+  trackLeavingNodes(tNode, el, lView);
   for (const item of classList) {
     renderer.addClass(el, item);
   }
@@ -467,7 +467,7 @@ function runLeaveAnimationFunction(
         clearTimeout(timeoutId);
       },
     };
-    trackLeavingNodes(tNode, nativeElement as HTMLElement);
+    trackLeavingNodes(tNode, nativeElement as HTMLElement, lView);
 
     ngZone.runOutsideAngular(() => {
       cleanupFns.push(

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -145,10 +145,10 @@ function applyToElementOrContainer(
     } else if (action === WalkTNodeTreeAction.Insert && parent !== null) {
       maybeQueueEnterAnimation(parentLView, parent, tNode, injector);
       nativeInsertBefore(renderer, parent, rNode, beforeNode || null, true);
-      cancelLeavingNodes(tNode, rNode as HTMLElement);
+      cancelLeavingNodes(tNode, rNode as HTMLElement, parentLView ?? null);
     } else if (action === WalkTNodeTreeAction.Detach) {
       if (parentLView?.[ANIMATIONS]?.leave?.has(tNode.index)) {
-        trackLeavingNodes(tNode, rNode as HTMLElement);
+        trackLeavingNodes(tNode, rNode as HTMLElement, parentLView!);
       }
       runLeaveAnimationsWithCallback(
         parentLView,


### PR DESCRIPTION
This addresses the reported animation issue with drag and drop where dom nodes would disappear after being dropped.

fixes: #67257
