### PR TITLE
build: use different default port for dev-app

### DIFF
--- a/dev-app/BUILD.bazel
+++ b/dev-app/BUILD.bazel
@@ -43,6 +43,10 @@ ng_application(
     ng_config = ":ng_config",
     node_modules = ":node_modules",
     project_name = "dev-app",
+    serve_args = [
+        "--port",
+        "4201",
+    ],
     tags = [
         # Tagged as manual as both build and build.production use the same output directory.
         "manual",


### PR DESCRIPTION
Same as ADEV, currently the CLI prompts for another port if 4200 is busy but the toolchain doesn't support prompts.

By defaulting to 4201 we avoid regular CLI apps from preventing to run the dev-app
