### PR TITLE
fix(core): update rxResource to address hydration

### DIFF
--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -17,6 +17,10 @@ import {
   ɵRuntimeError,
   ɵRuntimeErrorCode,
   ResourceStreamItem,
+  inject,
+  Injector,
+  DestroyRef,
+  WritableSignal,
 } from '../../src/core';
 import {Observable, Subscription} from 'rxjs';
 import {encapsulateResourceError} from '../../src/resource/resource';
@@ -53,18 +57,44 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
   if (ngDevMode && !opts?.injector) {
     assertInInjectionContext(rxResource);
   }
-  return resource<T, R>({
-    ...opts,
-    loader: undefined,
-    stream: (params) => {
-      let sub: Subscription | undefined;
 
-      // Track the abort listener so it can be removed if the Observable completes (as a memory
-      // optimization).
+  const injector = opts?.injector ?? inject(Injector);
+  const destroyRef = injector.get(DestroyRef);
+
+  // TODO(alxhub): remove after g3 updated to rename loader -> stream
+  const streamFn = opts.stream ?? (opts as {loader?: RxResourceOptions<T, R>['stream']}).loader;
+  if (streamFn === undefined) {
+    throw new ɵRuntimeError(
+      ɵRuntimeErrorCode.MUST_PROVIDE_STREAM_OPTION,
+      ngDevMode && `Must provide \`stream\` option.`,
+    );
+  }
+
+  let earlySub: Subscription | undefined;
+  let earlyPromise: Promise<Signal<ResourceStreamItem<T>>> | undefined;
+  let earlyRequest: R | undefined;
+
+  const res = resource<T, R>({
+    ...opts,
+    injector,
+    loader: undefined,
+    stream: (params: ResourceLoaderParams<R>) => {
+      const currentRequest = (params as any).request ?? (params as any).params;
+      if (earlyPromise && earlyRequest === currentRequest) {
+        const onAbort = () => earlySub?.unsubscribe();
+        params.abortSignal.addEventListener('abort', onAbort);
+
+        const promise = earlyPromise;
+        earlyPromise = undefined;
+        return promise;
+      }
+
+      earlySub?.unsubscribe();
+
+      let sub: Subscription | undefined;
       const onAbort = () => sub?.unsubscribe();
       params.abortSignal.addEventListener('abort', onAbort);
 
-      // Start off stream as undefined.
       const stream = signal<ResourceStreamItem<T>>({value: undefined as T});
       let resolve: ((value: Signal<ResourceStreamItem<T>>) => void) | undefined;
       const promise = new Promise<Signal<ResourceStreamItem<T>>>((r) => (resolve = r));
@@ -73,15 +103,6 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
         stream.set(value);
         resolve?.(stream);
         resolve = undefined;
-      }
-
-      // TODO(alxhub): remove after g3 updated to rename loader -> stream
-      const streamFn = opts.stream ?? (opts as {loader?: RxResourceOptions<T, R>['stream']}).loader;
-      if (streamFn === undefined) {
-        throw new ɵRuntimeError(
-          ɵRuntimeErrorCode.MUST_PROVIDE_STREAM_OPTION,
-          ngDevMode && `Must provide \`stream\` option.`,
-        );
       }
 
       sub = streamFn(params).subscribe({
@@ -105,5 +126,99 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
 
       return promise;
     },
-  });
+    getInitialStream: (req: R) => {
+      earlyRequest = req;
+
+      let isSubscribing = true;
+      let emittedSync = false;
+      let initialValue: ResourceStreamItem<T> = {value: undefined as T};
+
+      let stream: WritableSignal<ResourceStreamItem<T>> | undefined;
+      let resolve: ((value: Signal<ResourceStreamItem<T>>) => void) | undefined;
+      earlyPromise = new Promise<Signal<ResourceStreamItem<T>>>((r) => (resolve = r));
+
+      function send(item: ResourceStreamItem<T>): void {
+        stream!.set(item);
+        resolve?.(stream!);
+        resolve = undefined;
+      }
+
+      const abortController = new AbortController();
+
+      const params = {
+        request: req,
+        params: req,
+        previous: {status: 'idle'},
+        abortSignal: abortController.signal,
+      } as unknown as ResourceLoaderParams<R>;
+
+      try {
+        earlySub = streamFn(params).subscribe({
+          next: (value) => {
+            if (isSubscribing) {
+              emittedSync = true;
+              initialValue = {value};
+            } else {
+              send({value});
+            }
+          },
+          error: (error: unknown) => {
+            if (isSubscribing) {
+              emittedSync = true;
+              initialValue = {error: encapsulateResourceError(error)};
+            } else {
+              send({error: encapsulateResourceError(error)});
+            }
+          },
+          complete: () => {
+            if (isSubscribing && !emittedSync) {
+              emittedSync = true;
+              initialValue = {
+                error: new ɵRuntimeError(
+                  ɵRuntimeErrorCode.RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE,
+                  ngDevMode && 'Resource completed before producing a value',
+                ),
+              };
+            } else if (!isSubscribing && resolve) {
+              send({
+                error: new ɵRuntimeError(
+                  ɵRuntimeErrorCode.RESOURCE_COMPLETED_BEFORE_PRODUCING_VALUE,
+                  ngDevMode && 'Resource completed before producing a value',
+                ),
+              });
+            }
+          },
+        });
+      } catch (error: unknown) {
+        emittedSync = true;
+        initialValue = {error: encapsulateResourceError(error)};
+      }
+
+      isSubscribing = false;
+      stream = signal<ResourceStreamItem<T>>(initialValue);
+
+      if (emittedSync) {
+        earlyPromise = undefined;
+        return stream;
+      }
+
+      return undefined;
+    },
+  } as any);
+
+  const originalSet = res.value.set as any;
+  (res.value as any).set = (v: any) => {
+    earlySub?.unsubscribe();
+    originalSet(v);
+  };
+
+  const originalUpdate = res.value.update as any;
+  (res.value as any).update = (fn: any) => {
+    earlySub?.unsubscribe();
+    originalUpdate(fn);
+  };
+
+  destroyRef.onDestroy(() => earlySub?.unsubscribe());
+
+  return res;
 }

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -76,6 +76,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
     options.injector ?? inject(Injector),
+    (options as any).getInitialStream,
   );
 }
 


### PR DESCRIPTION
 Fixes a hydration mismatch issue with control flow blocks when using rxResource.
 The `getInitialStream` hook is now implemented for rxResource with an eager
 subscription to the observable stream.  This allows caching layers like Http
 TransferState to instantly populate the resource to `resolved` instead of
 defaulting to `loading` during the initial tick, matching the fix applied
 for httpResource.

 Asynchronous Observables are buffered and securely reattached to the resource
 lifecycle without subscribing a second time.

 Fixes #62897
