### PR TITLE
CSS Variable Namespacing

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -55,6 +55,15 @@ export class By {
 export function createApplication(options?: ApplicationConfig, context?: BootstrapContext): Promise<ApplicationRef>;
 
 // @public
+export class CssVarNamespacer {
+    namespace(name: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<CssVarNamespacer, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<CssVarNamespacer>;
+}
+
+// @public
 export function disableDebugTools(): void;
 
 // @public

--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -199,6 +199,9 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
+export function provideCssVarNamespacing(namespace: string): EnvironmentProviders;
+
+// @public
 export function provideProtractorTestingSupport(): Provider[];
 
 // @public

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
@@ -1,1 +1,1 @@
-styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]
+styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --%NS%webkit-transition: 1s linear all; }"]

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -11,7 +11,7 @@ import * as core from '../../core';
 import {CssSelector} from '../../directive_matching';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan} from '../../parse_util';
-import {ShadowCss} from '../../shadow_css';
+import {namespaceCssVariables, ShadowCss} from '../../shadow_css';
 import {CompilationJobKind, TemplateCompilationMode} from '../../template/pipeline/src/compilation';
 import {emitHostBindingFunction, emitTemplateFn, transform} from '../../template/pipeline/src/emit';
 import {ingestComponent, ingestHostBinding} from '../../template/pipeline/src/ingest';
@@ -300,10 +300,11 @@ export function compileComponentFromMetadata(
   let hasStyles = !!meta.externalStyles?.length;
   // e.g. `styles: [str1, str2]`
   if (meta.styles && meta.styles.length) {
+    const namespacedStyles = meta.styles.map((s) => namespaceCssVariables(s));
     const styleValues =
       meta.encapsulation == core.ViewEncapsulation.Emulated
-        ? compileStyles(meta.styles, CONTENT_ATTR, HOST_ATTR)
-        : meta.styles;
+        ? compileStyles(namespacedStyles, CONTENT_ATTR, HOST_ATTR)
+        : namespacedStyles;
     const styleNodes = styleValues.reduce((result, style) => {
       if (style.trim().length > 0) {
         result.push(constantPool.getConstLiteral(o.literal(style)));

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -30,7 +30,7 @@ describe('CSP integration', () => {
     for (let i = 0; i < styles.length; i++) {
       const style = styles[i];
       const nonce = style.getAttribute('nonce');
-      if (nonce && style.textContent?.includes('--csp-test-var')) {
+      if (nonce && style.textContent?.includes('csp-test-var')) {
         nonces.push(nonce);
       }
     }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -55,6 +55,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -32,6 +32,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -14,6 +14,7 @@
       "COMPONENT_REGEX",
       "COMPONENT_VARIABLE",
       "CONTENT_ATTR",
+      "CSS_VAR_NAMESPACE",
       "DefaultDomRenderer2",
       "DomAdapter",
       "DomEventsPlugin",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -40,6 +40,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTEXT",
       "CREATE_VIEW_TRANSITION",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "CanActivate",
       "CanDeactivate",
       "ChainedInjector",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -32,6 +32,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/platform-browser/src/dom/css_var_namespacer.ts
+++ b/packages/platform-browser/src/dom/css_var_namespacer.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject, Injectable} from '@angular/core';
+import {CSS_VAR_NAMESPACE} from './dom_renderer';
+
+/**
+ * A service that can be used to manually namespace CSS variable names at runtime.
+ * This is useful when reading or setting CSS variables dynamically in JavaScript that
+ * were transformed by the compiler during the build.
+ *
+ * @publicApi
+ */
+@Injectable({providedIn: 'root'})
+export class CssVarNamespacer {
+  private readonly namespacePrefix = inject(CSS_VAR_NAMESPACE, {optional: true}) ?? '';
+
+  /**
+   * Prepends the namespace prefix to a CSS variable name.
+   *
+   * @param name The CSS variable name to namespace, including the leading `--`.
+   * @returns The namespaced CSS variable name, including the leading `--`. Returns the input
+   *     unchanged if no namespace is configured.
+   */
+  namespace(name: string): string {
+    // Validate that the whole `--foo` variable is passed in.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (!name.startsWith('--')) {
+        throw new Error(
+          `CSS variable names passed to \`CssVarNamespacer\` must start with '--', got: '${name}'`,
+        );
+      }
+    }
+
+    // We want to support libraries which might be used by applications which do and don't
+    // namespace variables. Therefore the library always needs to use `CssVarNamespacer`, even
+    // though the application may not actually be namespacing anything.
+    if (!this.namespacePrefix) return name;
+
+    return `--${this.namespacePrefix}${name.substring('--'.length)}`;
+  }
+}

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -28,6 +28,7 @@ export {
   HammerLoader,
   HammerModule,
 } from './dom/events/hammer_gestures';
+export {provideCssVarNamespacing} from './dom/dom_renderer';
 export {
   DomSanitizer,
   SafeHtml,

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -17,6 +17,7 @@ export {
 export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
+export {CssVarNamespacer} from './dom/css_var_namespacer';
 export {By} from './dom/debug/by';
 export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';

--- a/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
+++ b/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {CssVarNamespacer} from '../../src/dom/css_var_namespacer';
+import {provideCssVarNamespacing} from '../../src/dom/dom_renderer';
+
+describe('CssVarNamespacer', () => {
+  it('should namespace variables when `CSS_VAR_NAMESPACE` is provided', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer, provideCssVarNamespacing('test-app_')],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(namespacer.namespace('--my-var')).toBe('--test-app_my-var');
+  });
+
+  it('should not namespace variables when `CSS_VAR_NAMESPACE` is not provided', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(namespacer.namespace('--my-var')).toBe('--my-var');
+  });
+
+  it('throws an error when a variable is passed in without the leading `--`', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(() => namespacer.namespace('my-var')).toThrowError(/must start with '--'/);
+  });
+});


### PR DESCRIPTION
This adds CSS variable namespacing support to Angular.

This allows multiple apps to coexist on the same page with isolated CSS variables, meaning one can use `color: var(--primary-color);` without worrying about accidentally inheriting the primary color of a different app which happens to set it on an ancestor element.

To enable this feature, call `provideCssVarNamespacing` in your `app.config.ts`. Typically you want to configure this with the same value as [`APP_ID`](https://angular.dev/api/core/APP_ID), but with an additional separator at the end (a `-` or `_`):

```typescript
import {ApplicationConfig, APP_ID} from '@angular/core';
import {provideCssVarNamespacing} from '@angular/platform-browser';

export const appConfig: ApplicationConfig = {
  providers: [
    {
      provide: APP_ID,
      useValue: 'my-app',
    },
    provideCssVarNamespacing('my-app_'),
  ],
};
```

This only namespaces styles in Angular components (the `styles` or `styleUrls` properties in `@Component`). It does not namespace global styles, which are out of scope for this effort.

Namespacing does naturally break any JavaScript references to CSS variables, therefore this PR also introduces `CssVarNamespacer` which allows you to automatically namespace variables based on what is configured in the application.

```typescript
import {CssVarNamespacer} from '@angular/platform-browser';

const namespacer = inject(CssVarNamespacer);
const color = namespacer.namespace('--primary-color');
getComputedStyle(someElement).getPropertyValue(color);
```

Libraries should consider always using the namespacer when referring to CSS variables, as they may be consumed by applications which enable namespacing.

Namespacing works by having the compiler unconditionally prepend `%NS%` to CSS variables (`--foo` -> `--%NS%foo`) and then at runtime replaces `%NS%` with a namespace specified by `provideCssVarNamespacing('my-app_')` (`--%NS%foo` -> `--my-app_foo`).

Internal bug: [b/485672083](http://b/485672083)