### PR TITLE
fix(forms): treat cleared date input as empty value

### DIFF
--- a/packages/forms/signals/src/directive/native.ts
+++ b/packages/forms/signals/src/directive/native.ts
@@ -68,6 +68,15 @@ export function getNativeControlValue(
 ): ParseResult<unknown> {
   let modelValue: unknown;
 
+  // Clearing a date input should always read as "no value", even if `badInput` is stale.
+  if (element.type === 'date' && element.value === '') {
+    modelValue = untracked(currentValue);
+    if (modelValue === null || modelValue instanceof Date) {
+      return {value: null};
+    }
+    return {value: ''};
+  }
+
   if (element.validity.badInput) {
     return {
       error: new NativeInputParseError() as WithoutFieldTree<NativeInputParseError>,

--- a/packages/forms/signals/test/node/ng_signal_form.spec.ts
+++ b/packages/forms/signals/test/node/ng_signal_form.spec.ts
@@ -10,7 +10,7 @@ import {Component, provideZonelessChangeDetection, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
-import {form, FormRoot} from '../../public_api';
+import {form, FormField, FormRoot, required, requiredError} from '../../public_api';
 
 @Component({
   template: `
@@ -117,6 +117,112 @@ describe('FormRoot', () => {
     expect(event.defaultPrevented).toBe(true);
     expect(component.submitted).toBeTrue();
   });
+
+  it('optional date field should submit after manual clear without parse error', () => {
+    @Component({
+      template: `
+        <form [formRoot]="form">
+          <input type="date" [formField]="form.birthDate" />
+          <button type="submit">Submit</button>
+        </form>
+      `,
+      imports: [FormField, FormRoot],
+    })
+    class TestCmp {
+      readonly submitCount = signal(0);
+      readonly formValue = signal({birthDate: ''});
+      readonly form = form(this.formValue, () => {}, {
+        submission: {
+          action: async () => {
+            this.submitCount.update((c) => c + 1);
+          },
+        },
+      });
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const setBadInput = patchBadInput(input);
+
+    act(() => {
+      input.value = '2026-03-03';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    act(() => formElement.dispatchEvent(new Event('submit', {cancelable: true})));
+    expect(component.submitCount()).toBe(1);
+
+    act(() => {
+      input.value = '';
+      setBadInput(true);
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(component.form.birthDate().value()).toBe('');
+    expect(component.form.birthDate().errors()).toEqual([]);
+
+    act(() => formElement.dispatchEvent(new Event('submit', {cancelable: true})));
+    expect(component.submitCount()).toBe(2);
+  });
+
+  it('required date field should return required error after manual clear, not parse error', () => {
+    @Component({
+      template: `
+        <form [formRoot]="form">
+          <input type="date" [formField]="form.birthDate" />
+          <button type="submit">Submit</button>
+        </form>
+      `,
+      imports: [FormField, FormRoot],
+    })
+    class TestCmp {
+      readonly submitCount = signal(0);
+      readonly formValue = signal({birthDate: ''});
+      readonly form = form(
+        this.formValue,
+        (p) => {
+          required(p.birthDate);
+        },
+        {
+          submission: {
+            action: async () => {
+              this.submitCount.update((c) => c + 1);
+            },
+          },
+        },
+      );
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const setBadInput = patchBadInput(input);
+
+    act(() => {
+      input.value = '2026-03-03';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    act(() => formElement.dispatchEvent(new Event('submit', {cancelable: true})));
+    expect(component.submitCount()).toBe(1);
+
+    act(() => {
+      input.value = '';
+      setBadInput(true);
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(component.form.birthDate().value()).toBe('');
+    expect(component.form.birthDate().errors()).toEqual([
+      requiredError({fieldTree: component.form.birthDate}),
+    ]);
+
+    act(() => formElement.dispatchEvent(new Event('submit', {cancelable: true})));
+    expect(component.submitCount()).toBe(1);
+  });
 });
 
 function act<T>(fn: () => T): T {
@@ -125,4 +231,20 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
+}
+
+function patchBadInput(input: HTMLInputElement): (value: boolean) => void {
+  let badInput = false;
+  if (!input.validity) {
+    Object.defineProperty(input, 'validity', {
+      value: {},
+      configurable: true,
+    });
+  }
+  Object.defineProperty(input.validity, 'badInput', {
+    get: () => badInput,
+  });
+  return (value: boolean) => {
+    badInput = value;
+  };
 }


### PR DESCRIPTION
When a date input is manually cleared, the browser can report an empty value while `badInput` is stale. Treat an empty date control as no value so signal forms update the model and clear parse errors instead of retaining the previous date. This restores submit behavior for optional fields and allows required validation to surface normally.

Fixes #67300

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

For signal forms with `<input type="date">`, after entering a valid date and then manually clearing the input, a parse error can persist and the previous valid date value is retained. Optional date fields then become impossible to submit once filled at least once.

Issue Number: #67300

## What is the new behavior?

When `input[type="date"]` has `value === ''`, signal forms treat it as a cleared value (`''` or `null` depending on model shape) and clear parse errors. Optional fields submit again after clearing, and required fields fail with required validation instead of a stuck parse error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Regression introduced in v21.2.0 by native input parsing support in #66917.
