### PR TITLE
fix(docs-infra): reset webcontainer counter on OOM warning action

### DIFF
--- a/adev/src/app/editor/alert-manager.service.spec.ts
+++ b/adev/src/app/editor/alert-manager.service.spec.ts
@@ -1,0 +1,67 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {LOCAL_STORAGE, MockLocalStorage, WINDOW} from '@angular/docs';
+import {MatSnackBar, MatSnackBarRef} from '@angular/material/snack-bar';
+import {Subject} from 'rxjs';
+
+import {AlertManager, AlertReason, WEBCONTAINERS_COUNTER_KEY} from './alert-manager.service';
+
+describe('AlertManager', () => {
+  let service: AlertManager;
+  let action$ = new Subject<void>();
+  let mockWindow: jasmine.SpyObj<Window>;
+  let mockLocalStorage: MockLocalStorage;
+  let snackBarRef: Pick<MatSnackBarRef<unknown>, 'onAction'>;
+  let mockSnackBar: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    action$ = new Subject<void>();
+    mockWindow = jasmine.createSpyObj<Window>('Window', ['addEventListener']);
+    mockLocalStorage = new MockLocalStorage();
+
+    snackBarRef = {
+      onAction: () => action$.asObservable(),
+    };
+
+    mockSnackBar = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['openFromComponent']);
+    mockSnackBar.openFromComponent.and.returnValue(snackBarRef as MatSnackBarRef<unknown>);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AlertManager,
+        {provide: WINDOW, useValue: mockWindow},
+        {provide: LOCAL_STORAGE, useValue: mockLocalStorage},
+        {provide: MatSnackBar, useValue: mockSnackBar},
+      ],
+    });
+
+    service = TestBed.inject(AlertManager);
+  });
+
+  it('should reset webcontainers counter when out-of-memory warning is acknowledged', () => {
+    mockLocalStorage.setItem(WEBCONTAINERS_COUNTER_KEY, '5');
+
+    service['openSnackBar'](AlertReason.OUT_OF_MEMORY);
+    action$.next();
+    action$.complete();
+
+    expect(mockLocalStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('0');
+  });
+
+  it('should not reset webcontainers counter when mobile warning is acknowledged', () => {
+    mockLocalStorage.setItem(WEBCONTAINERS_COUNTER_KEY, '5');
+
+    service['openSnackBar'](AlertReason.MOBILE);
+    action$.next();
+    action$.complete();
+
+    expect(mockLocalStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('5');
+  });
+});

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -94,12 +94,18 @@ export class AlertManager {
         break;
     }
 
-    this.snackBar.openFromComponent(ErrorSnackBar, {
+    const snackBarRef = this.snackBar.openFromComponent(ErrorSnackBar, {
       panelClass: 'docs-invert-mode',
       data: {
         message,
         actionText: 'I understand',
       } satisfies ErrorSnackBarData,
     });
+
+    if (reason === AlertReason.OUT_OF_MEMORY) {
+      snackBarRef.onAction().subscribe(() => {
+        this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, '0');
+      });
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a browser tab crashes due to OOM, the `beforeunload` handler may not fire. As a result, the `numberOfWebcontainers` counter can remain stale in local storage and repeatedly trigger the out-of-memory warning.

Issue Number: #52647

## What is the new behavior?

When the out-of-memory warning snackbar action (`I understand`) is acknowledged, the webcontainer counter is reset to `0`.

This also adds unit tests to verify:
- OOM warning acknowledgment resets the counter.
- Mobile warning acknowledgment does not reset the counter.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No docs-content changes are needed for this behavior fix.

Local checks run:
- `pnpm exec tslint -c tslint.json --project tsconfig-tslint.json adev/src/app/editor/alert-manager.service.ts adev/src/app/editor/alert-manager.service.spec.ts`

Note: full `pnpm test //adev:test --test_arg=--include=src/app/editor/alert-manager.service.spec.ts` could not complete in this environment due disk-space limits during Bazel sandboxing.