### PR TITLE
docs: fixed note on event replay

### DIFF
--- a/adev/src/content/guide/hydration.md
+++ b/adev/src/content/guide/hydration.md
@@ -92,7 +92,9 @@ Event replay supports _native browser events_, for example `click`, `mouseover`,
 
 ---
 
-This feature ensures a consistent user experience, preventing user actions performed before Hydration from being ignored. NOTE: if you have [incremental hydration](guide/incremental-hydration) enabled, event replay is automatically enabled under the hood.
+This feature ensures a consistent user experience, preventing user actions performed before Hydration from being ignored.
+
+NOTE: If you have [incremental hydration](guide/incremental-hydration) enabled, event replay is automatically enabled under the hood.
 
 ## Constraints
 


### PR DESCRIPTION

## What is the current behavior?
<img width="752" height="130" alt="image" src="https://github.com/user-attachments/assets/dfac172f-46f5-407f-bef5-da72007279fa" />




## What is the new behavior?
<img width="759" height="241" alt="image" src="https://github.com/user-attachments/assets/9342e31b-4104-4ac9-b9f3-a797147f6680" />

