### PR TITLE
fix(compiler-cli): improve error for non-exported standalone imports

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -231,10 +231,12 @@ const isUsedPipe = (decl: AnyUsedType): decl is UsedPipe =>
 /**
  * `DecoratorHandler` which handles the `@Component` annotation.
  */
-export class ComponentDecoratorHandler
-  implements
-    DecoratorHandler<Decorator, ComponentAnalysisData, ComponentSymbol, ComponentResolutionData>
-{
+export class ComponentDecoratorHandler implements DecoratorHandler<
+  Decorator,
+  ComponentAnalysisData,
+  ComponentSymbol,
+  ComponentResolutionData
+> {
   constructor(
     private reflector: ReflectionHost,
     private evaluator: PartialEvaluator,
@@ -2077,6 +2079,7 @@ export class ComponentDecoratorHandler
         this.metaReader,
         this.scopeReader,
         false /* isDeferredImport */,
+        this.reflector,
       );
       diagnostics ??= [];
       diagnostics.push(...importDiagnostics);
@@ -2088,6 +2091,7 @@ export class ComponentDecoratorHandler
         this.metaReader,
         this.scopeReader,
         true /* isDeferredImport */,
+        this.reflector,
       );
       diagnostics ??= [];
       diagnostics.push(...importDiagnostics);
@@ -2589,6 +2593,7 @@ function validateStandaloneImports(
   metaReader: MetadataReader,
   scopeReader: ComponentScopeReader,
   isDeferredImport: boolean,
+  reflector: ReflectionHost,
 ): ts.Diagnostic[] {
   const diagnostics: ts.Diagnostic[] = [];
   for (const ref of importRefs) {
@@ -2624,6 +2629,13 @@ function validateStandaloneImports(
     }
 
     // Make an error?
+
+    // If this decorated class isn’t exported, it may be skipped when `compileNonExportedClasses` is disabled (e.g. in the language service).
+    // Suppress this diagnostic so TypeScript’s “Cannot find name” error can surface instead.
+    if (!reflector.isStaticallyExported(ref.node) && hasAngularCoreDecorator(ref.node, reflector)) {
+      continue;
+    }
+
     const error = isDeferredImport
       ? makeUnknownComponentDeferredImportDiagnostic(ref, importExpr)
       : makeUnknownComponentImportDiagnostic(ref, importExpr);
@@ -2636,4 +2648,14 @@ function validateStandaloneImports(
 /** Returns whether an ImportDeclaration is a default import. */
 function isDefaultImport(node: ts.ImportDeclaration): boolean {
   return node.importClause !== undefined && node.importClause.namedBindings === undefined;
+}
+
+/** Checks whether a class declaration has at least one decorator imported from `@angular/core`.*/
+function hasAngularCoreDecorator(node: ClassDeclaration, reflector: ReflectionHost): boolean {
+  const decorators = reflector.getDecoratorsOfDeclaration(node);
+
+  return (
+    decorators !== null &&
+    decorators.some((d) => d.import !== null && d.import.from === '@angular/core')
+  );
 }

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -528,6 +528,82 @@ runInEachFileSystem(() => {
         );
       });
 
+      it('should silence the Angular import diagnostic for a non-exported class', () => {
+        env.tsconfig({compileNonExportedClasses: false});
+        env.write(
+          'test.ts',
+          `
+            import {Component, Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[dir]',
+            })
+            class TestDir {}
+
+            @Component({
+              selector: 'test-cmp',
+              template: '',
+              imports: [TestDir],
+            })
+            export class TestCmp {}
+          `,
+        );
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should silence the Angular import diagnostic when both the importing and imported classes are non-exported', () => {
+        // Simulates the common test-file pattern where both the component under test
+        env.tsconfig({compileNonExportedClasses: false});
+        env.write(
+          'test.ts',
+          `
+            import {Component, Directive} from '@angular/core';
+
+            @Directive({
+              selector: '[dir]',
+            })
+            class TestDir {}
+
+            @Component({
+              selector: 'test-cmp',
+              template: '',
+              imports: [TestDir],
+            })
+            class TestCmp {}
+          `,
+        );
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+
+      it('should surface a TypeScript used-before-declaration error when a non-exported directive is imported before its definition', () => {
+        // When a non-exported Angular class is referenced in `imports` before it is declared in the file
+        // TypeScript reports TS2449 ("Class 'X' used before its declaration")
+        env.tsconfig({compileNonExportedClasses: false});
+        env.write(
+          'test.ts',
+          `
+            import {Component, Directive} from '@angular/core';
+
+            @Component({
+              selector: 'test-cmp',
+              template: '',
+              imports: [TestDir],
+            })
+            export class TestCmp {}
+
+            @Directive({
+              selector: '[dir]',
+            })
+            class TestDir {}
+          `,
+        );
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].code).toBe(2449);
+      });
+
       it('should type-check standalone component templates', () => {
         env.write(
           'test.ts',


### PR DESCRIPTION
Add diagnostic when a standalone imports entry references a non-exported directive/component/pipe.

Fixes #49874

 
## What is the current behavior?
<img width="909" height="226" alt="image" src="https://github.com/user-attachments/assets/e4b4894c-7efd-44c3-879e-36128e8d1849" />

Misleading message shown

```
Component imports must be standalone components, directives, pipes, or must be NgModules.
```

## What is the new behavior?

<img width="1207" height="289" alt="image" src="https://github.com/user-attachments/assets/18818d81-b4c2-4cc4-b93f-0712adaaa2ef" />

Now language service should be show : 

```text
'Dir' is used in 'imports' but is not exported from its file. Component imports must be exported to be resolved by the Angular compiler.
```