### PR TITLE
fix(adev): reset webcontainer counter when user dismisses OOM warning

### DIFF
--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -94,12 +94,22 @@ export class AlertManager {
         break;
     }
 
-    this.snackBar.openFromComponent(ErrorSnackBar, {
+    const snackBarRef = this.snackBar.openFromComponent(ErrorSnackBar, {
       panelClass: 'docs-invert-mode',
       data: {
         message,
         actionText: 'I understand',
       } satisfies ErrorSnackBarData,
     });
+
+    // Reset the counter when the user dismisses the warning to handle OOM crash scenarios
+    // where beforeunload event is not fired (e.g., Safari auto-reload on OOM)
+    snackBarRef.afterDismissed().subscribe(() => {
+      this.resetWebcontainerCounter();
+    });
+  }
+
+  private resetWebcontainerCounter(): void {
+    this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, '0');
   }
 }


### PR DESCRIPTION
Fixes #52647

## Problem
When an OOM error occurs in Safari, the tab may be automatically reloaded without firing the `beforeunload` event. This causes the webcontainer counter to not decrease, resulting in false positive OOM warnings even when the user has fewer than 3 tabs open.

## Solution
Reset the webcontainer counter to 0 when the user dismisses the OOM warning snackbar. This ensures the counter is accurate after an OOM-related page reload.

## Changes
- Subscribe to `afterDismissed()` event on the snackbar reference
- Call `resetWebcontainerCounter()` when the snackbar is dismissed
- Reset counter sets `WEBCONTAINERS_COUNTER_KEY` to 0 in localStorage

## Testing
- Verified the counter is reset when clicking "I understand" on the OOM warning
- Counter will be accurate after Safari auto-reload on OOM