### PR TITLE
docs(router): fix duplicated word in UrlTree comment

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -765,7 +765,7 @@ class UrlParser {
 
       const next = this.remaining[path.length];
 
-      // if is is not one of these characters, then the segment was unescaped
+      // if is not one of these characters, then the segment was unescaped
       // or the group was not closed
       if (next !== '/' && next !== ')' && next !== ';') {
         throw new RuntimeError(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

A duplicated word appears in a router comment in `packages/router/src/url_tree.ts`:
`if is is not one of these characters, then the segment was unescaped`

Issue Number: N/A

## What is the new behavior?

Removes the duplicate word:
`if is not one of these characters, then the segment was unescaped`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a comment-only wording fix in router parsing docs/comments; no runtime behavior changes.
