### PR TITLE
docs(router): clarify command array interpretation for relative navigation

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -140,6 +140,9 @@ export class UserDetail {
 }
 ```
 
+NOTE: When using `router.navigate()` with a command array and `relativeTo`, Angular resolves the commands as a single navigation path. Splitting relative traversal across multiple array entries (for example `['..', 'child']`) may not behave as expected.
+
+
 ### `router.navigateByUrl()`
 
 The `router.navigateByUrl()` method provides a direct way to programmatically navigate using URL path strings rather than array segments. This method is ideal when you have a full URL path and need to perform absolute navigation, especially when working with externally provided URLs or deep linking scenarios.


### PR DESCRIPTION
Adds a clarification explaining how command arrays passed to `router.navigate()` are interpreted during relative navigation.

The documentation may suggest that relative traversal can be split across multiple command array entries. In practice, commands are resolved as a single navigation path, which can lead to confusion.

This change adds a NOTE callout near the existing relative navigation examples to clarify the expected behavior.

Scope:
- Documentation only
- No behavioral changes