### PR TITLE
refactor(core): ignore infinite animations in animate api

### DIFF
--- a/packages/core/src/animation/longest_animation.ts
+++ b/packages/core/src/animation/longest_animation.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LView} from '../render3/interfaces/view';
 import {LongestAnimation} from './interfaces';
 
 /** Parses a CSS time value to milliseconds. */
@@ -43,10 +42,12 @@ function getLongestComputedAnimation(computedStyle: CSSStyleDeclaration): Longes
   const rawNames = parseCssPropertyValue(computedStyle, 'animation-name');
   const rawDelays = parseCssPropertyValue(computedStyle, 'animation-delay');
   const rawDurations = parseCssPropertyValue(computedStyle, 'animation-duration');
+  const rawIterationCounts = parseCssPropertyValue(computedStyle, 'animation-iteration-count');
   const longest: LongestAnimation = {animationName: '', propertyName: undefined, duration: 0};
   for (let i = 0; i < rawNames.length; i++) {
     const duration = parseCssTimeUnitsToMs(rawDelays[i]) + parseCssTimeUnitsToMs(rawDurations[i]);
-    if (duration > longest.duration) {
+    const iterationCount = rawIterationCounts[i];
+    if (duration > longest.duration && iterationCount !== 'infinite') {
       longest.animationName = rawNames[i];
       longest.duration = duration;
     }
@@ -123,6 +124,9 @@ function determineLongestAnimationFromElementAnimations(
   };
   for (const animation of animations) {
     const timing = animation.effect?.getTiming();
+    if (timing?.iterations === Infinity) {
+      continue;
+    }
     // duration can be a string 'auto' or a number.
     const animDuration = typeof timing?.duration === 'number' ? timing.duration : 0;
     let duration = (timing?.delay ?? 0) + animDuration;

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -2493,4 +2493,84 @@ describe('Animation', () => {
       document.querySelectorAll('.overlay-pane').forEach((p) => p.remove());
     }));
   });
+
+  describe('infinite animations', () => {
+    const styles = `
+      .infinite-anim {
+        animation: infinite-anim 1s infinite;
+      }
+      @keyframes infinite-anim {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+    `;
+
+    it('should ignore infinite animations during animate.leave and remove element immediately', fakeAsync(() => {
+      @Component({
+        selector: 'test-cmp',
+        styles: styles,
+        template:
+          '<div>@if (show()) {<p animate.leave="infinite-anim" #el>I should leave</p>}</div>',
+        encapsulation: ViewEncapsulation.None,
+      })
+      class TestComponent {
+        show = signal(true);
+        @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
+      }
+
+      TestBed.configureTestingModule({animationsEnabled: true});
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const cmp = fixture.componentInstance;
+      fixture.detectChanges();
+      const paragraph = fixture.debugElement.query(By.css('p'));
+      expect(paragraph).toBeTruthy();
+
+      cmp.show.set(false);
+      fixture.detectChanges();
+
+      // Simulate a frame. If the animation is ignored, it should be removed already.
+      // If it's NOT ignored, it will wait for the animation (forever).
+      tickAnimationFrames(1);
+      fixture.detectChanges();
+
+      // The element should be removed if infinite animations are ignored.
+      expect(cmp.show()).toBeFalsy();
+      expect(fixture.debugElement.query(By.css('p'))).toBeNull();
+    }));
+
+    it('should ignore infinite animations during animate.enter and remove classes immediately', fakeAsync(() => {
+      @Component({
+        selector: 'test-cmp',
+        styles: styles,
+        template:
+          '<div>@if (show()) {<p animate.enter="infinite-anim" #el>I should enter</p>}</div>',
+        encapsulation: ViewEncapsulation.None,
+      })
+      class TestComponent {
+        show = signal(false);
+        @ViewChild('el', {read: ElementRef}) el!: ElementRef<HTMLParagraphElement>;
+      }
+
+      TestBed.configureTestingModule({animationsEnabled: true});
+
+      const fixture = TestBed.createComponent(TestComponent);
+      const cmp = fixture.componentInstance;
+      fixture.detectChanges();
+
+      cmp.show.set(true);
+      fixture.detectChanges();
+
+      // Check that class is added initially (maybe?)
+      let paragraph = fixture.debugElement.query(By.css('p'));
+      expect(paragraph.nativeElement.classList.contains('infinite-anim')).toBe(true);
+
+      // Simulate a frame. If ignored, class should be removed immediately.
+      tickAnimationFrames(1);
+      fixture.detectChanges();
+
+      paragraph = fixture.debugElement.query(By.css('p'));
+      expect(paragraph.nativeElement.classList.contains('infinite-anim')).toBe(false);
+    }));
+  });
 });


### PR DESCRIPTION
This ensures that when calculating longest animations, we completely ignore infinite animations. This will prevent mistakes with using the API and hopefully catch any unexpected bugs.

fixes: #67350
