### PR TITLE
ci: update the path to the labeling github actions

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: angular/dev-infra/github-actions/pull-request-labeling@90e509ff1244bbc119ab3c5fd660f6e20694e3a8
+      - uses: angular/dev-infra/github-actions/labeling/pull-request@90e509ff1244bbc119ab3c5fd660f6e20694e3a8
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
           labels: '{"requires: TGP": ["packages/core/primitives/**/{*,.*}"]}'
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/issue-labeling@90e509ff1244bbc119ab3c5fd660f6e20694e3a8
+      - uses: angular/dev-infra/github-actions/labeling/issue@90e509ff1244bbc119ab3c5fd660f6e20694e3a8
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
           google-generative-ai-key: ${{ secrets.GOOGLE_GENERATIVE_AI_KEY }}


### PR DESCRIPTION
Update the paths to the labeling github actions after the refactor in dev-infra
