### PR TITLE
fix(service-worker): bypass cache for requests with Range header to fix video/audio seeking

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -288,6 +288,15 @@ export class Driver implements Debuggable, UpdateSource {
       return;
     }
 
+    // Range requests (e.g. for seeking in video/audio elements) cannot be served from the
+    // ServiceWorker cache, since the SW cache does not support partial content (206) responses.
+    // Returning without calling `event.respondWith()` lets the browser handle the request
+    // directly from the network.
+    // See https://github.com/angular/angular/issues/25865
+    if (req.headers.has('range')) {
+      return;
+    }
+
     // Past this point, the SW commits to handling the request itself. This could still
     // fail (and result in `state` being set to `SAFE_MODE`), but even in that case the
     // SW will still deliver a response.

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1385,6 +1385,30 @@ import {envIsSupported} from '../testing/utils';
       server.assertSawRequestFor('/some/url');
     });
 
+    it('bypasses the ServiceWorker for requests with a `Range` header', async () => {
+      // NOTE:
+      // Range requests (e.g. for seeking in video/audio) bypass the SW entirely.
+      // Requests that bypass the SW are not handled at all in the mock implementation of `scope`,
+      // therefore no requests reach the server.
+
+      // Range requests should be bypassed regardless of value.
+      await makeRequest(scope, '/some/url', undefined, {headers: {'range': 'bytes=0-'}});
+      server.assertNoRequestFor('/some/url');
+
+      await makeRequest(scope, '/some/url', undefined, {headers: {'range': 'bytes=100-200'}});
+      server.assertNoRequestFor('/some/url');
+
+      // Case-insensitive header check: `Range` and `RANGE` should also be bypassed.
+      await makeRequest(scope, '/some/url', undefined, {headers: {'Range': 'bytes=0-'}});
+      server.assertNoRequestFor('/some/url');
+
+      server.clearRequests();
+
+      // Without a Range header, normal requests are still served by the SW.
+      await makeRequest(scope, '/some/url');
+      server.assertSawRequestFor('/some/url');
+    });
+
     it('unregisters when manifest 404s', async () => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;


### PR DESCRIPTION
## Problem

When an Angular PWA with a Service Worker intercepts fetch requests, it does not handle `Range` headers. Requests with `Range` headers are used by browsers for:
- **Video/audio seeking**: When a user scrubs through a video, the browser sends range requests to fetch specific byte ranges
- **Progressive media loading**: Audio elements preloading non-contiguous chunks

The SW intercepts these requests but the Cache API cannot return `206 Partial Content` responses, causing the browser to fail or fallback incorrectly.

## Root Cause

In `driver.ts`, `onFetch()` calls `event.respondWith(this.handleFetch(event))` for all requests. The cache only stores `200 OK` responses and cannot fulfil range requests, resulting in broken video/audio seeking in PWAs.

## Fix

Add an early-return check in `onFetch()` for requests that include a `Range` header. This follows the existing pattern used for `ngsw-bypass` and `only-if-cached` — returning without calling `event.respondWith()` lets the browser handle the request unintercepted via the network.

```typescript
// Range requests (e.g. for seeking in video/audio elements) cannot be served from the
// ServiceWorker cache, since the SW cache does not support partial content (206) responses.
if (req.headers.has('range')) {
  return;
}
```

## Testing

- Added unit test in `happy_spec.ts` verifying that range requests bypass the SW
- Regular (non-range) requests continue to be served by the SW as before

## Workaround before this fix

Users have been working around this by appending `?ngsw-bypass=true` to media URLs, or by manually patching the built `ngsw-worker.js`. This fix eliminates the need for those workarounds.

Fixes #25865