### PR TITLE
Resource state key

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -186,6 +186,7 @@ export interface BaseResourceOptions<T, R> {
     equal?: ValueEqualityFn<T>;
     injector?: Injector;
     params?: (ctx: ResourceParamsContext) => R;
+    transferCacheKey?: (params: R) => StateKey<T>;
 }
 
 // @public

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1725,7 +1725,7 @@ export type ResourceSnapshot<T> = {
 export type ResourceStatus = 'idle' | 'error' | 'loading' | 'reloading' | 'resolved' | 'local';
 
 // @public
-export type ResourceStreamingLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<Signal<ResourceStreamItem<T>>>;
+export type ResourceStreamingLoader<T, R> = (param: ResourceLoaderParams<R>) => Signal<ResourceStreamItem<T>> | PromiseLike<Signal<ResourceStreamItem<T>>> | undefined;
 
 // @public (undocumented)
 export type ResourceStreamItem<T> = {

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -434,6 +434,7 @@ class HttpResourceImpl<T>
       equal,
       debugName,
       injector,
+      undefined,
       getInitialStream,
     );
     this.client = injector.get(HttpClient);

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Observable, Subscription} from 'rxjs';
 import {
   assertInInjectionContext,
+  BaseResourceOptions,
   resource,
   ResourceLoaderParams,
   ResourceRef,
+  ResourceStreamItem,
   Signal,
   signal,
-  BaseResourceOptions,
   ɵRuntimeError,
   ɵRuntimeErrorCode,
-  ResourceStreamItem,
 } from '../../src/core';
-import {Observable, Subscription} from 'rxjs';
 import {encapsulateResourceError} from '../../src/resource/resource';
 
 /**
@@ -75,8 +75,7 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
         resolve = undefined;
       }
 
-      // TODO(alxhub): remove after g3 updated to rename loader -> stream
-      const streamFn = opts.stream ?? (opts as {loader?: RxResourceOptions<T, R>['stream']}).loader;
+      const streamFn = opts.stream;
       if (streamFn === undefined) {
         throw new ɵRuntimeError(
           ɵRuntimeErrorCode.MUST_PROVIDE_STREAM_OPTION,
@@ -102,6 +101,10 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
           params.abortSignal.removeEventListener('abort', onAbort);
         },
       });
+
+      if (resolve === undefined) {
+        return stream;
+      }
 
       return promise;
     },

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {BehaviorSubject, EMPTY, Observable, of, Subscriber, throwError} from 'rxjs';
-import {ApplicationRef, Injector, signal} from '../../src/core';
+import {ApplicationRef, Injector, makeStateKey, signal, TransferState} from '../../src/core';
 import {TestBed} from '../../testing';
 import {rxResource} from '../src';
 
@@ -175,10 +175,110 @@ describe('rxResource()', () => {
     expect(res.error()).toBeInstanceOf(Error);
     expect(() => res.value()).toThrowError(/bad news/);
   });
+
+  describe('with TransferState', () => {
+    let transferState: TransferState;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({providers: [TransferState]});
+      transferState = TestBed.inject(TransferState);
+    });
+
+    afterEach(() => {
+      (globalThis as any).ngServerMode = undefined;
+    });
+
+    it('should read from TransferState if a key is present', async () => {
+      const key = makeStateKey<number>('test-key');
+      transferState.set(key, 123);
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(456),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      // Should be synchronously resolved from cache
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(123);
+
+      // Should prevent loader from running
+      await flushMicrotasks();
+      expect(testResource.value()).toBe(123);
+    });
+
+    it('should write to TransferState on server when resolved (sync)', async () => {
+      (globalThis as any).ngServerMode = true;
+      const key = makeStateKey<number>('server-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(789),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      expect(testResource.status()).toBe('loading');
+
+      await flushMicrotasks();
+
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(789);
+      expect(transferState.get(key, null!)).toBe(789);
+    });
+
+    it('should write to TransferState on server when resolved (async)', async () => {
+      (globalThis as any).ngServerMode = true;
+      const key = makeStateKey<number>('server-async-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () =>
+          new Observable<number>((sub) => {
+            Promise.resolve().then(() => {
+              sub.next(101112);
+              sub.complete();
+            });
+          }),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      expect(testResource.status()).toBe('loading');
+
+      await waitFor(() => testResource.status() === 'resolved');
+
+      expect(testResource.value()).toBe(101112);
+      expect(transferState.get(key, null!)).toBe(101112);
+    });
+
+    it('should not write to TransferState on client when resolved', async () => {
+      (globalThis as any).ngServerMode = false;
+      const key = makeStateKey<number>('client-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(131415),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      await flushMicrotasks();
+
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(131415);
+      expect(transferState.hasKey(key)).toBeFalse();
+    });
+  });
 });
 
 async function waitFor(fn: () => boolean): Promise<void> {
   while (!fn()) {
     await new Promise((resolve) => setTimeout(resolve, 1));
   }
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -6,21 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {of, Observable, BehaviorSubject, throwError} from 'rxjs';
-import {TestBed} from '../../testing';
+import {BehaviorSubject, EMPTY, Observable, of, Subscriber, throwError} from 'rxjs';
 import {ApplicationRef, Injector, signal} from '../../src/core';
+import {TestBed} from '../../testing';
 import {rxResource} from '../src';
 
 describe('rxResource()', () => {
   it('should fetch data using an observable loader', async () => {
     const injector = TestBed.inject(Injector);
-    const appRef = TestBed.inject(ApplicationRef);
     const res = rxResource({
       stream: () => of(1),
       injector,
     });
-    await appRef.whenStable();
+
+    TestBed.tick();
+
+    // Value should be available synchronously (because the observable emits synchronously)
     expect(res.value()).toBe(1);
+    expect(res.status()).toBe('resolved');
   });
 
   it('should cancel the fetch when a new request comes in', async () => {
@@ -29,7 +32,7 @@ describe('rxResource()', () => {
     const request = signal(1);
     let unsub = false;
     let lastSeenRequest: number = 0;
-    rxResource({
+    const res = rxResource({
       params: request,
       stream: ({params: request}) => {
         lastSeenRequest = request;
@@ -47,12 +50,23 @@ describe('rxResource()', () => {
       injector,
     });
 
+    // The stream isn't evaluated eagerly. We have to wait for the effect to run to see the first request.
+    expect(lastSeenRequest).toBe(0);
+
+    TestBed.tick();
+
+    expect(res.status()).toBe('loading');
+    expect(lastSeenRequest).toBe(1);
+
     // Wait for the resource to reach loading state.
     await waitFor(() => lastSeenRequest === 1);
 
     // Setting request = 2 should cancel request = 1
     request.set(2);
+    // The stream is updated asynchronously because we're waiting for the effect to fire.
+    expect(lastSeenRequest).toBe(1);
     await appRef.whenStable();
+    expect(lastSeenRequest).toBe(2);
     expect(unsub).toBe(true);
   });
 
@@ -112,6 +126,54 @@ describe('rxResource()', () => {
     expect(rxRes.error()).toBeInstanceOf(FooError);
 
     expect(() => rxRes.value()).toThrowError(/This is a FooError/);
+  });
+
+  it('should reuse observable', async () => {
+    let count = 0;
+    let sub!: Subscriber<number>;
+    const obs = new Observable<number>((s) => {
+      sub = s;
+      count++;
+    });
+
+    const res = rxResource({
+      stream: () => obs,
+      injector: TestBed.inject(Injector),
+    });
+    // Hasn't subscribed to the observable yet
+    expect(count).toBe(0);
+
+    TestBed.tick();
+    expect(count).toBe(1);
+    expect(res.status()).toBe('loading');
+    sub.next(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(count).toBe(1);
+  });
+
+  it('should report error synchronously (after tick)', () => {
+    const injector = TestBed.inject(Injector);
+    const res = rxResource({
+      stream: () => EMPTY,
+      injector,
+    });
+    TestBed.tick();
+    expect(res.status()).toBe('error');
+    expect(res.error()).toBeInstanceOf(Error);
+    expect(() => res.value()).toThrowError(/Resource completed before producing a value/);
+  });
+
+  it('should report sync error synchronously (after tick) ', () => {
+    const injector = TestBed.inject(Injector);
+    const res = rxResource({
+      stream: () => throwError(() => new Error('bad news')),
+      injector,
+    });
+    TestBed.tick();
+    expect(res.status()).toBe('error');
+    expect(res.error()).toBeInstanceOf(Error);
+    expect(() => res.value()).toThrowError(/bad news/);
   });
 });
 

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -200,7 +200,7 @@ export type ResourceLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLi
  */
 export type ResourceStreamingLoader<T, R> = (
   param: ResourceLoaderParams<R>,
-) => PromiseLike<Signal<ResourceStreamItem<T>>>;
+) => Signal<ResourceStreamItem<T>> | PromiseLike<Signal<ResourceStreamItem<T>>> | undefined;
 
 /**
  * Options to the `resource` function, for creating a resource.

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -9,6 +9,7 @@
 import {Injector} from '../di/injector';
 import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {WritableSignal} from '../render3/reactivity/signal';
+import {StateKey} from '../transfer_state';
 
 /** Error thrown when a `Resource` dependency of another resource errors. */
 export class ResourceDependencyError extends Error {
@@ -231,6 +232,11 @@ export interface BaseResourceOptions<T, R> {
    * Overrides the `Injector` used by `resource`.
    */
   injector?: Injector;
+
+  /**
+   * The transfer cache key used to cache the resource data in the `TransferState` during server-side rendering and to retrieve it on the client side.
+   */
+  transferCacheKey?: (params: R) => StateKey<T>;
 }
 
 /**

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
+import {isSignal, Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {computed} from '../render3/reactivity/computed';
 import {effect, EffectRef} from '../render3/reactivity/effect';
 import {signal, signalAsReadonlyFn, WritableSignal} from '../render3/reactivity/signal';
@@ -14,7 +14,6 @@ import {untracked} from '../render3/reactivity/untracked';
 import {
   Resource,
   ResourceDependencyError,
-  ResourceLoaderParams,
   ResourceOptions,
   ResourceParamsStatus,
   ResourceRef,
@@ -413,30 +412,44 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       // The actual loading is run through `untracked` - only the request side of `resource` is
       // reactive. This avoids any confusion with signals tracking or not tracking depending on
       // which side of the `await` they are.
-      const stream = await untracked(() => {
+      const stream = untracked(() => {
         return this.loaderFn({
           params: extRequest.request as Exclude<R, undefined>,
-          // TODO(alxhub): cleanup after g3 removal of `request` alias.
-          request: extRequest.request as Exclude<R, undefined>,
           abortSignal,
           previous: {
             status: previousStatus,
           },
-        } as ResourceLoaderParams<R>);
+        });
       });
 
       // If this request has been aborted, or the current request no longer
       // matches this load, then we should ignore this resolution.
-      if (abortSignal.aborted || untracked(this.extRequest) !== extRequest) {
-        return;
-      }
+      const shouldDiscard = () => abortSignal.aborted || untracked(this.extRequest) !== extRequest;
 
-      this.state.set({
-        extRequest,
-        status: 'resolved',
-        previousStatus: 'resolved',
-        stream,
-      });
+      if (isSignal(stream)) {
+        if (shouldDiscard()) {
+          return;
+        }
+
+        this.state.set({
+          extRequest,
+          status: 'resolved',
+          previousStatus: 'resolved',
+          stream,
+        });
+      } else {
+        const resolvedStream = await stream;
+        if (shouldDiscard()) {
+          return;
+        }
+
+        this.state.set({
+          extRequest,
+          status: 'resolved',
+          previousStatus: 'resolved',
+          stream: resolvedStream,
+        });
+      }
     } catch (err) {
       if (abortSignal.aborted || untracked(this.extRequest) !== extRequest) {
         return;

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -32,6 +32,7 @@ import {inject} from '../di/injector_compatibility';
 import {DestroyRef} from '../linker/destroy_ref';
 import {PendingTasks} from '../pending_tasks';
 import {linkedSignal} from '../render3/reactivity/linked_signal';
+import {StateKey, TransferState} from '../transfer_state';
 
 /**
  * Constructs a `Resource` that projects a reactive request to an asynchronous operation defined by
@@ -77,6 +78,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
     options.injector ?? inject(Injector),
+    options.transferCacheKey,
   );
 }
 
@@ -194,6 +196,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
 
   override readonly status: Signal<ResourceStatus>;
   override readonly error: Signal<Error | undefined>;
+  private readonly transferState: TransferState | undefined;
 
   constructor(
     request: (ctx: ResourceParamsContext) => R,
@@ -202,6 +205,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     private readonly equal: ValueEqualityFn<T> | undefined,
     private readonly debugName: string | undefined,
     injector: Injector,
+    private transferCacheKey: ((request: R) => StateKey<T>) | undefined,
     getInitialStream?: (request: R) => Signal<ResourceStreamItem<T>> | undefined,
   ) {
     super(
@@ -230,6 +234,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       ),
       debugName,
     );
+
+    this.transferState = injector.get(TransferState, undefined, {optional: true}) ?? undefined;
 
     this.extRequest = linkedSignal<WrappedRequest>(
       () => {
@@ -265,7 +271,19 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           );
         } else if (!status) {
           if (!previous) {
-            stream = getInitialStream?.(extRequest.request as R);
+            if (this.transferCacheKey && this.transferState && request !== undefined) {
+              const key = this.transferCacheKey(request as R);
+              if (this.transferState.hasKey(key)) {
+                stream = signal(
+                  {value: this.transferState.get(key, null!)},
+                  ngDevMode ? createDebugNameObject(this.debugName, 'stream') : undefined,
+                );
+              }
+            }
+
+            if (!stream) {
+              stream = getInitialStream?.(extRequest.request as R);
+            }
             // Clear getInitialStream so it doesn't hold onto memory
             getInitialStream = undefined;
             status = request === undefined ? 'idle' : stream ? 'resolved' : 'loading';
@@ -437,6 +455,18 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           previousStatus: 'resolved',
           stream,
         });
+
+        const result = untracked(stream);
+        if (
+          typeof ngServerMode !== 'undefined' &&
+          ngServerMode &&
+          this.transferCacheKey &&
+          this.transferState &&
+          isResolved(result)
+        ) {
+          const key = this.transferCacheKey(extRequest.request as R);
+          this.transferState.set(key, result.value);
+        }
       } else {
         const resolvedStream = await stream;
         if (shouldDiscard()) {
@@ -449,6 +479,20 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           previousStatus: 'resolved',
           stream: resolvedStream,
         });
+
+        // Use a local variable for the result so TypeScript can narrow `resolvedStream` correctly.
+        const result = resolvedStream ? untracked(resolvedStream) : undefined;
+        if (
+          typeof ngServerMode !== 'undefined' &&
+          ngServerMode &&
+          this.transferCacheKey &&
+          this.transferState &&
+          result &&
+          isResolved(result)
+        ) {
+          const key = this.transferCacheKey(extRequest.request as R);
+          this.transferState.set(key, result.value);
+        }
       }
     } catch (err) {
       if (abortSignal.aborted || untracked(this.extRequest) !== extRequest) {

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -8,18 +8,21 @@
 
 import {
   ApplicationRef,
+  Component,
   computed,
   createEnvironmentInjector,
   effect,
   EnvironmentInjector,
   Injector,
+  Input,
+  inputBinding,
   resource,
   ResourceRef,
   ResourceStatus,
   signal,
 } from '../../src/core';
-import {TestBed} from '../../testing';
 import {promiseWithResolvers} from '../../src/util/promise_with_resolvers';
+import {TestBed} from '../../testing';
 
 abstract class MockBackend<T, R> {
   protected pending = new Map<
@@ -744,15 +747,98 @@ describe('resource', () => {
   });
 
   it('should allow streaming', async () => {
+    const res = resource({
+      stream: () => signal({value: 'done'}),
+      injector: TestBed.inject(Injector),
+    });
+
+    // We rely an a synchronous tick to ensure that the stream is properly initialized, as it runs inside an effect.
+    TestBed.tick();
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('done');
+  });
+
+  it('should allow streaming with param & sync stream', async () => {
+    const param = signal('a');
+    const res = resource({
+      params: param,
+      stream: ({params}) => signal({value: params + ' done'}),
+      injector: TestBed.inject(Injector),
+    });
+
+    // We rely an a synchronous tick to ensure that the stream is properly initialized, as it runs inside an effect.
+    TestBed.tick();
+
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('a done');
+  });
+
+  it('should allow async streaming', async () => {
     const appRef = TestBed.inject(ApplicationRef);
     const res = resource({
       stream: async () => signal({value: 'done'}),
       injector: TestBed.inject(Injector),
     });
 
+    expect(res.status()).toBe('loading');
+    TestBed.tick();
+    // We're still loading, the promise hasn't resolved yet.
+    expect(res.status()).toBe('loading');
+
     await appRef.whenStable();
     expect(res.status()).toBe('resolved');
     expect(res.value()).toBe('done');
+  });
+
+  it('should allow streaming & cancelling with param & sync stream', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    const param = signal('a');
+    let streamCount = 0;
+    const res = resource({
+      params: param,
+      stream: ({params}) => {
+        streamCount++;
+        return signal({value: params + ' done'});
+      },
+      injector: TestBed.inject(Injector),
+    });
+
+    // The stream is not evaluated eagerly, because we have to wait for init (in case we read inputs)
+    expect(streamCount).toBe(0);
+
+    TestBed.tick();
+
+    expect(streamCount).toBe(1);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('a done');
+    param.set('b');
+    await appRef.whenStable();
+    expect(streamCount).toBe(2);
+    expect(res.status()).toBe('resolved');
+    expect(res.value()).toBe('b done');
+  });
+
+  it('should allow stream from input()', async () => {
+    @Component({
+      selector: 'test',
+      template: `{{ res.value() }}`,
+    })
+    class TestComponent {
+      @Input() value = '';
+      res = resource({
+        params: () => this.value,
+        stream: ({params}) => signal({value: params + ' done'}),
+      });
+    }
+
+    const fixture = TestBed.createComponent(TestComponent, {
+      bindings: [inputBinding('value', signal('a'))],
+    });
+
+    TestBed.tick();
+
+    expect(fixture.componentInstance.res.value()).toEqual('a done');
   });
 
   it('should error via error()', async () => {

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -16,10 +16,12 @@ import {
   Injector,
   Input,
   inputBinding,
+  makeStateKey,
   resource,
   ResourceRef,
   ResourceStatus,
   signal,
+  TransferState,
 } from '../../src/core';
 import {promiseWithResolvers} from '../../src/util/promise_with_resolvers';
 import {TestBed} from '../../testing';
@@ -1117,3 +1119,67 @@ function extractError(fn: () => unknown): Error | undefined {
     return err as Error;
   }
 }
+
+describe('with TransferState', () => {
+  let transferState: TransferState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [TransferState]});
+    transferState = TestBed.inject(TransferState);
+  });
+
+  it('should read from TransferState if a key is present', async () => {
+    const key = makeStateKey<number>('test-key');
+    transferState.set(key, 123);
+
+    const testResource = resource({
+      loader: async () => 456,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    // Should be synchronously resolved from cache
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(123);
+
+    // Should prevent loader from running
+    await flushMicrotasks();
+    expect(testResource.value()).toBe(123);
+  });
+
+  it('should write to TransferState on server when resolved', async () => {
+    (globalThis as any).ngServerMode = true;
+    const key = makeStateKey<number>('server-key');
+
+    const testResource = resource({
+      loader: async () => 789,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    expect(testResource.status()).toBe('loading');
+
+    await flushMicrotasks();
+
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(789);
+    expect(transferState.get(key, null!)).toBe(789);
+    (globalThis as any).ngServerMode = undefined;
+  });
+
+  it('should not write to TransferState on client when resolved', async () => {
+    const key = makeStateKey<number>('client-key');
+
+    const testResource = resource({
+      loader: async () => 101112,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    await flushMicrotasks();
+
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(101112);
+    expect(transferState.hasKey(key)).toBeFalse();
+  });
+});


### PR DESCRIPTION
On top of #67382
---- 

feat(core): add ability to cache resources for SSR

This commit adds a `transferCacheKey` option to enable easy caching for `resource`/ `rxResource`. 

By caching resource data we make sure that resources are not in a loading state during hydration on the client side and responsible for destroying server hydrated DOM. 

fixes #62897 