### PR TITLE
fix(forms): clear native date inputs correctly in signal forms when changed via native UI

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -20,7 +20,14 @@ import {
   type ControlBindingKey,
 } from './bindings';
 import type {FormField} from './form_field_directive';
-import {getNativeControlValue, setNativeControlValue, setNativeDomProperty} from './native';
+import {InputValidityMonitor} from './input_validity_monitor';
+import {
+  getNativeControlValue,
+  isInput,
+  inputRequiresValidityTracking,
+  setNativeControlValue,
+  setNativeDomProperty,
+} from './native';
 import {observeSelectMutations} from './select';
 
 export function nativeControlCreate(
@@ -29,6 +36,7 @@ export function nativeControlCreate(
   parseErrorsSource: WritableSignal<
     Signal<readonly ValidationError.WithoutFieldTree[]> | undefined
   >,
+  validityMonitor: InputValidityMonitor,
 ): () => void {
   let updateMode = false;
   const input = parent.nativeFormElement;
@@ -41,13 +49,18 @@ export function nativeControlCreate(
     (rawValue: unknown) => parent.state().controlValue.set(rawValue),
     // Our parse function doesn't care about the raw value that gets passed in,
     // It just reads the newly parsed value directly off the input element.
-    () => getNativeControlValue(input, parent.state().value),
+    (_rawValue: unknown) => getNativeControlValue(input, parent.state().value, validityMonitor),
   );
 
   parseErrorsSource.set(parser.errors);
   // Pass undefined as the raw value since the parse function doesn't care about it.
   host.listenToDom('input', () => parser.setRawValue(undefined));
   host.listenToDom('blur', () => parent.state().markAsTouched());
+
+  // TODO: move extraction to first update pass?
+  if (isInput(input) && inputRequiresValidityTracking(input)) {
+    validityMonitor.watchValidity(input, () => parser.setRawValue(undefined));
+  }
 
   parent.registerAsBinding();
 

--- a/packages/forms/signals/src/directive/form_field_directive.ts
+++ b/packages/forms/signals/src/directive/form_field_directive.ts
@@ -47,6 +47,7 @@ import {
   isTextualFormElement,
   type NativeFormControl,
 } from './native';
+import {InputValidityMonitor} from './input_validity_monitor';
 
 export const ɵNgFieldDirective: unique symbol = Symbol();
 
@@ -152,6 +153,7 @@ export class FormField<T> {
   private readonly controlValueAccessors = inject(NG_VALUE_ACCESSOR, {optional: true, self: true});
 
   private readonly config = inject(SIGNAL_FORMS_CONFIG, {optional: true});
+  private readonly validityMonitor = inject(InputValidityMonitor);
 
   private readonly parseErrorsSource = signal<
     Signal<readonly ValidationError.WithoutFieldTree[]> | undefined
@@ -329,6 +331,7 @@ export class FormField<T> {
         host,
         this as FormField<unknown>,
         this.parseErrorsSource,
+        this.validityMonitor,
       );
     } else {
       throw new RuntimeError(

--- a/packages/forms/signals/src/directive/input_validity_monitor.ts
+++ b/packages/forms/signals/src/directive/input_validity_monitor.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {DOCUMENT, isPlatformBrowser} from '@angular/common';
+import {Injectable, CSP_NONCE, inject, OnDestroy, PLATFORM_ID, forwardRef} from '@angular/core';
+
+/**
+ * Service that monitors validity state changes on native form elements.
+ *
+ * It works by dynamically installing a CSS transition on `input, textarea` `:valid`
+ * and `:invalid` states, which allows us to intercept a `transitionstart` event
+ * whenever the native validity state changes without an `input` event (e.g. clearing a date input).
+ */
+@Injectable({providedIn: 'root', useClass: forwardRef(() => AnimationInputValidityMonitor)})
+export abstract class InputValidityMonitor {
+  abstract watchValidity(element: HTMLInputElement, callback: () => void): void;
+  abstract isBadInput(element: HTMLInputElement): boolean;
+}
+
+@Injectable()
+export class AnimationInputValidityMonitor extends InputValidityMonitor implements OnDestroy {
+  private readonly document = inject(DOCUMENT);
+  private readonly cspNonce = inject(CSP_NONCE, {optional: true});
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly injectedStyles = new WeakMap<Document | ShadowRoot, HTMLStyleElement>();
+
+  /** Starts watching the given element for validity state changes. */
+  override watchValidity(element: HTMLInputElement, callback: () => void): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    const rootNode = element.getRootNode() as Document | ShadowRoot;
+    if (!this.injectedStyles.has(rootNode)) {
+      this.injectedStyles.set(rootNode, this.createTransitionStyle(rootNode));
+    }
+
+    element.addEventListener('animationstart', (event: Event) => {
+      const animationEvent = event as AnimationEvent;
+      if (
+        animationEvent.animationName === 'ng-valid' ||
+        animationEvent.animationName === 'ng-invalid'
+      ) {
+        callback();
+      }
+    });
+  }
+
+  override isBadInput(element: HTMLInputElement): boolean {
+    return element.validity?.badInput ?? false;
+  }
+
+  private createTransitionStyle(rootNode: Document | ShadowRoot): HTMLStyleElement {
+    const element = this.document.createElement('style');
+    if (this.cspNonce) {
+      element.nonce = this.cspNonce;
+    }
+    element.textContent = `
+      @keyframes ng-valid {}
+      @keyframes ng-invalid {}
+      input:valid, textarea:valid {
+        animation: ng-valid 0.001s;
+      }
+      input:invalid, textarea:invalid {
+        animation: ng-invalid 0.001s;
+      }
+    `;
+    if (rootNode.nodeType === 9 /* Node.DOCUMENT_NODE */) {
+      (rootNode as Document).head?.appendChild(element);
+    } else {
+      rootNode.appendChild(element);
+    }
+    return element;
+  }
+
+  ngOnDestroy(): void {
+    // We explicitly clean up the main document's injected style wrapper.
+    this.injectedStyles.get(this.document)?.remove();
+
+    // We do not need to iterate over ShadowRoots to clean them up.
+    // The WeakMap drops the reference when the ShadowRoot is destroyed,
+    // and the DOM subtree takes care of its own garbage collection.
+  }
+}

--- a/packages/forms/signals/src/directive/native.ts
+++ b/packages/forms/signals/src/directive/native.ts
@@ -9,6 +9,7 @@
 import {untracked} from '@angular/core';
 import {NativeInputParseError, WithoutFieldTree} from '../api/rules';
 import type {ParseResult} from '../api/transformed_value';
+import type {InputValidityMonitor} from './input_validity_monitor';
 
 // Re-export shared native utilities from main forms package
 export {
@@ -36,10 +37,11 @@ import type {ɵNativeFormControl as NativeFormControl} from '@angular/forms';
 export function getNativeControlValue(
   element: NativeFormControl,
   currentValue: () => unknown,
+  validityMonitor: InputValidityMonitor,
 ): ParseResult<unknown> {
   let modelValue: unknown;
 
-  if (element.validity.badInput) {
+  if (isInput(element) && validityMonitor.isBadInput(element)) {
     return {
       error: new NativeInputParseError() as WithoutFieldTree<NativeInputParseError>,
     };
@@ -134,4 +136,17 @@ export function setNativeNumberControlValue(element: HTMLInputElement, value: nu
   } else {
     element.valueAsNumber = value;
   }
+}
+export function isInput(element: HTMLElement): element is HTMLInputElement {
+  return element.tagName === 'INPUT';
+}
+
+export function inputRequiresValidityTracking(input: HTMLInputElement): boolean {
+  return (
+    input.type === 'date' ||
+    input.type === 'datetime-local' ||
+    input.type === 'month' ||
+    input.type === 'time' ||
+    input.type === 'week'
+  );
 }

--- a/packages/forms/signals/test/web/BUILD.bazel
+++ b/packages/forms/signals/test/web/BUILD.bazel
@@ -3,7 +3,10 @@ load("//tools:defaults.bzl", "ng_project", "zoneless_web_test_suite")
 ng_project(
     name = "test_lib",
     testonly = True,
-    srcs = glob(["**/*.spec.ts"]),
+    srcs = glob([
+        "**/*.spec.ts",
+        "**/*.ts",
+    ]),
     deps = [
         "//:node_modules/zod",
         "//packages/core",

--- a/packages/forms/signals/test/web/form_field_directive.spec.ts
+++ b/packages/forms/signals/test/web/form_field_directive.spec.ts
@@ -14,6 +14,7 @@ import {
   ElementRef,
   EventEmitter,
   inject,
+  Injectable,
   Injector,
   input,
   Input,
@@ -24,11 +25,22 @@ import {
   Output,
   resource,
   signal,
+  Type,
   viewChild,
   viewChildren,
   ViewContainerRef,
+  ViewEncapsulation,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+
+function isFirefox() {
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.indexOf('firefox') != -1) {
+    return true;
+  }
+  return false;
+}
+
 import {NG_STATUS_CLASSES} from '../../compat/public_api';
 import {
   debounce,
@@ -53,6 +65,18 @@ import {
   type ValidationError,
   type WithOptionalFieldTree,
 } from '../../public_api';
+import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
+import {TestInputValidityMonitor} from './test_input_validity_monitor';
+
+function configureTestValidityMonitor() {
+  TestBed.configureTestingModule({
+    providers: [
+      TestInputValidityMonitor,
+      {provide: InputValidityMonitor, useExisting: TestInputValidityMonitor},
+    ],
+  });
+  return TestBed.inject(TestInputValidityMonitor);
+}
 
 @Component({
   selector: 'string-control',
@@ -4347,6 +4371,223 @@ describe('field directive', () => {
         input.dispatchEvent(new Event('input'));
       });
       expect(cmp.f().value()).toBe(newDateTimestamp);
+    });
+
+    it('should work inside a Shadow DOM component', () => {
+      @Component({
+        imports: [FormField],
+        selector: 'shadow-cmp',
+        encapsulation: ViewEncapsulation.ShadowDom,
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class ShadowCmp {
+        f = form(signal('2024-01-01'));
+      }
+
+      const fix = act(() => TestBed.createComponent(ShadowCmp));
+      const input = fix.nativeElement.shadowRoot.querySelector('input') as HTMLInputElement;
+      const cmp = fix.componentInstance as ShadowCmp;
+
+      act(() => {
+        input.value = '';
+        input.dispatchEvent(
+          new AnimationEvent('animationstart', {animationName: 'ng-invalid', bubbles: true}),
+        );
+      });
+      expect(cmp.f().value()).toBe('');
+    });
+
+    it('should re-evaluate validity and value when native UI clears date input without input event', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="date" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('2024-01-01'));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // 1. Start in valid input state
+      expect(input.value).toBe('2024-01-01');
+      // 2. Field should be valid
+      expect(cmp.f().errors()).toEqual([]);
+
+      // 3. Transition to bad input state (invalid input from the user keyboard)
+      act(() => {
+        validityMonitor.setInputState(input, '', true);
+      });
+
+      // 4. Field should be invalid (parse error)
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+
+      // 5. Transition to empty input state (native UI clears date input without input event)
+      act(() => {
+        validityMonitor.setInputState(input, '', false);
+      });
+
+      // 6. Field should be valid again (parse error gone)
+      expect(cmp.f().errors()).toEqual([]);
+      expect(cmp.f().value()).toBe('');
+    });
+
+    it('should re-evaluate validity and value when native UI clears time input without input event', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="time" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('12:00'));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // 1. Start in valid input state
+      expect(input.value).toBe('12:00');
+      // 2. Field should be valid
+      expect(cmp.f().errors()).toEqual([]);
+
+      // 3. Transition to bad input state (invalid input from the user keyboard)
+      act(() => {
+        validityMonitor.setInputState(input, '', true);
+      });
+
+      // 4. Field should be invalid (parse error)
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+
+      // 5. Transition to empty input state (native UI clears time input without input event)
+      act(() => {
+        validityMonitor.setInputState(input, '', false);
+      });
+
+      // 6. Field should be valid again (parse error gone)
+      expect(cmp.f().errors()).toEqual([]);
+      expect(cmp.f().value()).toBe('');
+    });
+
+    // Firefox doesn't support <input type="month">
+    (!isFirefox() ? it : xit)(
+      'should re-evaluate validity and value when native UI clears month input without input event',
+      () => {
+        @Component({
+          imports: [FormField],
+          template: `<input type="month" [formField]="f" />`,
+        })
+        class TestCmp {
+          f = form(signal('2024-01'));
+        }
+
+        const validityMonitor = configureTestValidityMonitor();
+        const fix = act(() => TestBed.createComponent(TestCmp));
+        const input = fix.nativeElement.firstChild as HTMLInputElement;
+        const cmp = fix.componentInstance as TestCmp;
+
+        // 1. Start in valid input state
+        expect(input.value).toBe('2024-01');
+        // 2. Field should be valid
+        expect(cmp.f().errors()).toEqual([]);
+
+        // 3. Transition to bad input state (invalid input from the user keyboard)
+        act(() => {
+          validityMonitor.setInputState(input, '', true);
+        });
+
+        // 4. Field should be invalid (parse error)
+        expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+
+        // 5. Transition to empty input state (native UI clears month input without input event)
+        act(() => {
+          validityMonitor.setInputState(input, '', false);
+        });
+
+        // 6. Field should be valid again (parse error gone)
+        expect(cmp.f().errors()).toEqual([]);
+        expect(cmp.f().value()).toBe('');
+      },
+    );
+
+    // Firefox doesn't support <input type="week">
+    (!isFirefox() ? it : xit)(
+      'should re-evaluate validity and value when native UI clears week input without input event',
+      () => {
+        @Component({
+          imports: [FormField],
+          template: `<input type="week" [formField]="f" />`,
+        })
+        class TestCmp {
+          f = form(signal('2024-W01'));
+        }
+
+        const validityMonitor = configureTestValidityMonitor();
+        const fix = act(() => TestBed.createComponent(TestCmp));
+        const input = fix.nativeElement.firstChild as HTMLInputElement;
+        const cmp = fix.componentInstance as TestCmp;
+
+        // 1. Start in valid input state
+        expect(input.value).toBe('2024-W01');
+        // 2. Field should be valid
+        expect(cmp.f().errors()).toEqual([]);
+
+        // 3. Transition to bad input state (invalid input from the user keyboard)
+        act(() => {
+          validityMonitor.setInputState(input, '', true);
+        });
+
+        // 4. Field should be invalid (parse error)
+        expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+
+        // 5. Transition to empty input state (native UI clears week input without input event)
+        act(() => {
+          validityMonitor.setInputState(input, '', false);
+        });
+
+        // 6. Field should be valid again (parse error gone)
+        expect(cmp.f().errors()).toEqual([]);
+        expect(cmp.f().value()).toBe('');
+      },
+    );
+
+    it('should re-evaluate validity and value when native UI clears datetime-local input without input event', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="datetime-local" [formField]="f" />`,
+      })
+      class TestCmp {
+        f = form(signal('2024-01-01T12:00'));
+      }
+
+      const validityMonitor = configureTestValidityMonitor();
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // 1. Start in valid input state
+      expect(input.value).toBe('2024-01-01T12:00');
+      // 2. Field should be valid
+      expect(cmp.f().errors()).toEqual([]);
+
+      // 3. Transition to bad input state (invalid input from the user keyboard)
+      act(() => {
+        validityMonitor.setInputState(input, '', true);
+      });
+
+      // 4. Field should be invalid (parse error)
+      expect(cmp.f().errors()).toEqual([jasmine.objectContaining({kind: 'parse'})]);
+
+      // 5. Transition to empty input state (native UI clears datetime-local input without input event)
+      act(() => {
+        validityMonitor.setInputState(input, '', false);
+      });
+
+      // 6. Field should be valid again (parse error gone)
+      expect(cmp.f().errors()).toEqual([]);
+      expect(cmp.f().value()).toBe('');
     });
 
     it('should sync string field with color type input', () => {

--- a/packages/forms/signals/test/web/input_validity_monitor.spec.ts
+++ b/packages/forms/signals/test/web/input_validity_monitor.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
+
+describe('InputValidityMonitor', () => {
+  let monitor: InputValidityMonitor;
+
+  beforeEach(() => {
+    monitor = TestBed.inject(InputValidityMonitor);
+  });
+
+  describe('Document injected styles', () => {
+    it('appends exactly one <style> tag to document.head when tracking multiple inputs', () => {
+      const input1 = document.createElement('input');
+      const input2 = document.createElement('input');
+
+      // Add to body so element.getRootNode() === document
+      document.body.appendChild(input1);
+      document.body.appendChild(input2);
+
+      const initialStyleCount = document.head.querySelectorAll('style').length;
+
+      monitor.watchValidity(input1, () => {});
+      const stylesAfterFirst = document.head.querySelectorAll('style').length;
+      expect(stylesAfterFirst).toBe(initialStyleCount + 1);
+
+      monitor.watchValidity(input2, () => {});
+      const stylesAfterSecond = document.head.querySelectorAll('style').length;
+      expect(stylesAfterSecond).toBe(initialStyleCount + 1); // Deduped, count should not increase
+
+      document.body.removeChild(input1);
+      document.body.removeChild(input2);
+    });
+
+    it('removes the <style> from document.head upon destruction', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+
+      const initialStyleCount = document.head.querySelectorAll('style').length;
+
+      monitor.watchValidity(input, () => {});
+      expect(document.head.querySelectorAll('style').length).toBe(initialStyleCount + 1);
+
+      (monitor as any).ngOnDestroy();
+      expect(document.head.querySelectorAll('style').length).toBe(initialStyleCount);
+
+      document.body.removeChild(input);
+    });
+  });
+
+  describe('Shadow DOM injected styles', () => {
+    it('appends exactly one <style> tag to a ShadowRoot when tracking multiple inputs inside it', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const targetShadowRoot = host.attachShadow({mode: 'open'});
+
+      const input1 = document.createElement('input');
+      const input2 = document.createElement('input');
+      targetShadowRoot.appendChild(input1);
+      targetShadowRoot.appendChild(input2);
+
+      // Verify no styles are present
+      expect(targetShadowRoot.querySelectorAll('style').length).toBe(0);
+
+      monitor.watchValidity(input1, () => {});
+      expect(targetShadowRoot.querySelectorAll('style').length).toBe(1);
+
+      monitor.watchValidity(input2, () => {});
+      expect(targetShadowRoot.querySelectorAll('style').length).toBe(1); // Deduped
+
+      document.body.removeChild(host);
+    });
+
+    it('tracks styles across different ShadowRoots independently without duplicating', () => {
+      const host1 = document.createElement('div');
+      const targetShadowRoot1 = host1.attachShadow({mode: 'open'});
+      const input1 = document.createElement('input');
+      targetShadowRoot1.appendChild(input1);
+
+      const host2 = document.createElement('div');
+      const targetShadowRoot2 = host2.attachShadow({mode: 'open'});
+      const input2 = document.createElement('input');
+      targetShadowRoot2.appendChild(input2);
+
+      document.body.appendChild(host1);
+      document.body.appendChild(host2);
+
+      monitor.watchValidity(input1, () => {});
+      monitor.watchValidity(input2, () => {});
+
+      expect(targetShadowRoot1.querySelectorAll('style').length).toBe(1);
+      expect(targetShadowRoot2.querySelectorAll('style').length).toBe(1);
+
+      document.body.removeChild(host1);
+      document.body.removeChild(host2);
+    });
+  });
+  describe('isBadInput', () => {
+    it('should return false when validity.badInput is not set or false', () => {
+      const element = document.createElement('input');
+      expect(monitor.isBadInput(element)).toBe(false);
+
+      const input = document.createElement('input');
+      expect(monitor.isBadInput(input)).toBe(false);
+    });
+
+    it('should return value of validity.badInput when available', () => {
+      // Create a fake element that simulates the `validity` property
+      // since we cannot programmatically set `.validity.badInput` on a real DOM node here without an actual user event
+      const fakeInput = {
+        validity: {
+          badInput: true,
+        },
+      } as unknown as HTMLInputElement;
+      expect(monitor.isBadInput(fakeInput)).toBe(true);
+    });
+  });
+});

--- a/packages/forms/signals/test/web/number_input.spec.ts
+++ b/packages/forms/signals/test/web/number_input.spec.ts
@@ -6,11 +6,25 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, signal, viewChildren} from '@angular/core';
+import {Component, signal, viewChildren, Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormField, form} from '../../public_api';
+import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
+import {TestInputValidityMonitor} from './test_input_validity_monitor';
 
 describe('numeric inputs', () => {
+  let validityMonitor: TestInputValidityMonitor;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TestInputValidityMonitor,
+        {provide: InputValidityMonitor, useExisting: TestInputValidityMonitor},
+      ],
+    });
+    validityMonitor = TestBed.inject(TestInputValidityMonitor);
+  });
+
   describe('parsing logic', () => {
     it('should not change the model when user enters un-parsable input', () => {
       @Component({
@@ -24,13 +38,11 @@ describe('numeric inputs', () => {
 
       const fixture = act(() => TestBed.createComponent(TestCmp));
       const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
-      patchNumberInput(input);
 
       expect(input.value).toBe('42');
 
       act(() => {
-        input.value = '42e';
-        input.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input, '42e', true);
       });
 
       expect(fixture.componentInstance.f().value()).toBe(42);
@@ -39,8 +51,7 @@ describe('numeric inputs', () => {
       ]);
 
       act(() => {
-        input.value = '42e1';
-        input.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input, '42e1', false);
       });
 
       expect(fixture.componentInstance.f().value()).toBe(420);
@@ -64,16 +75,13 @@ describe('numeric inputs', () => {
       const fixture = act(() => TestBed.createComponent(TestCmp));
       const input1 = fixture.nativeElement.querySelector('#input1') as HTMLInputElement;
       const input2 = fixture.nativeElement.querySelector('#input2') as HTMLInputElement;
-      patchNumberInput(input1);
-      patchNumberInput(input2);
 
       expect(input1.value).toBe('5');
       expect(input2.value).toBe('5');
 
       // Trigger parse error on input1
       act(() => {
-        input1.value = '5e';
-        input1.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input1, '5e', true);
       });
 
       expect(fixture.componentInstance.bindings()[0].errors()).toEqual([
@@ -82,8 +90,7 @@ describe('numeric inputs', () => {
 
       // Update model via input2
       act(() => {
-        input2.value = '42';
-        input2.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input2, '42', false);
       });
 
       expect(fixture.componentInstance.bindings()[0].errors()).toEqual([]);
@@ -143,18 +150,15 @@ describe('numeric inputs', () => {
 
       const fixture = act(() => TestBed.createComponent(TestCmp));
       const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
-      patchNumberInput(input);
 
       act(() => {
-        input.value = '4';
-        input.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input, '4', false);
       });
 
       expect(fixture.componentInstance.f().value()).toBe(4);
 
       act(() => {
-        input.value = '';
-        input.dispatchEvent(new Event('input'));
+        validityMonitor.setInputState(input, '', false);
       });
 
       expect(fixture.componentInstance.f().value()).toBeNull();
@@ -168,35 +172,4 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
-}
-
-/**
- * Patch a number input to make its validity work as it would if the user was actually typing.
- *
- * `validity.badInput` is updated when the user types in the `<input>`, but when we simulate it
- * by setting the value and dispatching an event, that flag is not updated. To work around this
- * we patch the input.
- */
-function patchNumberInput(input: HTMLInputElement) {
-  let value = input.value;
-  Object.defineProperties(input, {
-    value: {
-      set: (v) => {
-        value = v;
-      },
-      get: () => {
-        const num = Number(value);
-        return Number.isNaN(num) ? '' : value;
-      },
-    },
-    valueAsNumber: {
-      get: () => Number(value),
-      set: (v) => {
-        value = String(v);
-      },
-    },
-  });
-  Object.defineProperties(input.validity, {
-    badInput: {get: () => Number.isNaN(Number(value))},
-  });
 }

--- a/packages/forms/signals/test/web/test_input_validity_monitor.ts
+++ b/packages/forms/signals/test/web/test_input_validity_monitor.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injectable} from '@angular/core';
+import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
+
+@Injectable()
+export class TestInputValidityMonitor extends InputValidityMonitor {
+  private state = new Map<HTMLInputElement, {badInput?: boolean; callback?: () => void}>();
+
+  override watchValidity(element: HTMLInputElement, callback: () => void): void {
+    const currentState = this.state.get(element) ?? {};
+    this.state.set(element, {...currentState, callback});
+  }
+
+  override isBadInput(element: HTMLInputElement): boolean {
+    return this.state.get(element)?.badInput ?? false;
+  }
+
+  setInputState(element: HTMLInputElement, value: string, badInput: boolean) {
+    const currentState = this.state.get(element);
+    const previousBadInput = currentState?.badInput ?? false;
+    const valueChanged = element.value !== value;
+
+    this.state.set(element, {...currentState, badInput});
+    element.value = value;
+
+    if (valueChanged) {
+      element.dispatchEvent(new Event('input'));
+    }
+    if (previousBadInput !== badInput) {
+      currentState?.callback?.();
+    }
+  }
+}


### PR DESCRIPTION
When a native date input gets cleared manually by a user via the internal browser UI, the element changes from invalid to valid, but no `input` event is emitted.

This commit introduces `InputValidityMonitor`, an injectable service that intercepts these edge-case native status changes. The monitor dynamically installs CSP-compliant styles appending a specific `--ng-validity` CSS variable to `:valid` and `:invalid` pseudoclasses on native form controls as a property transition. By attaching a `transitionstart` listener, Angular intercepts these changes immediately and re-invokes the parser.

Fixes #67300