### PR TITLE
refactor(compiler-cli): update old angular.io references to angular.dev

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -672,7 +672,7 @@ export class NgCompiler {
   }
 
   /**
-   * Add Angular.io error guide links to diagnostics for this compilation.
+   * Add https://angular.dev/errors error guide links to diagnostics for this compilation.
    */
   private addMessageTextDetails(diagnostics: ts.Diagnostic[]): ts.Diagnostic[] {
     return diagnostics.map((diag) => {

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
@@ -9,7 +9,7 @@
 import {ErrorCode} from './error_code';
 
 /**
- * Contains a set of error messages that have detailed guides at angular.io.
+ * Contains a set of error messages that have detailed guides at angular.dev.
  * Full list of available error guides can be found at https://angular.dev/errors
  */
 export const COMPILER_ERRORS_WITH_GUIDES = new Set([


### PR DESCRIPTION
Update comment references from the old site angular.io to the new site angular.dev.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
There was one other reference in compiler-cli within `packages\compiler-cli\src\ngtsc\annotations\directive\src\handler.ts` on line 199, however, I couldn't find a migrated version of that topic (https://v9.angular.io/guide/migration-undecorated-classes) so I left it alone.