### PR TITLE
Expose redirected and responseType

### DIFF
--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -3040,6 +3040,8 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
     hasValue(): boolean;
     readonly headers: Signal<HttpHeaders | undefined>;
     readonly progress: Signal<HttpProgressEvent | undefined>;
+    readonly redirected: Signal<boolean | undefined>;
+    readonly responseType: Signal<ResponseType | undefined>;
     readonly statusCode: Signal<number | undefined>;
 }
 

--- a/goldens/public-api/common/http/testing/index.api.md
+++ b/goldens/public-api/common/http/testing/index.api.md
@@ -59,6 +59,8 @@ export class TestRequest {
         };
         status?: number;
         statusText?: string;
+        redirected?: boolean;
+        responseType?: ResponseType;
     }): void;
     // (undocumented)
     request: HttpRequest<any>;

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -117,6 +117,8 @@ export class FetchBackend implements HttpBackend {
           statusText: error.statusText,
           url: request.urlWithParams,
           headers: error.headers,
+          redirected: response?.redirected,
+          responseType: response?.type,
         }),
       );
       return;
@@ -125,6 +127,8 @@ export class FetchBackend implements HttpBackend {
     const headers = new HttpHeaders(response.headers);
     const statusText = response.statusText;
     const url = response.url || request.urlWithParams;
+    const redirected = response.redirected;
+    const responseType = response.type;
 
     let status = response.status;
     let body: string | ArrayBuffer | Blob | object | null = null;
@@ -219,6 +223,8 @@ export class FetchBackend implements HttpBackend {
             status: response.status,
             statusText: response.statusText,
             url: response.url || request.urlWithParams,
+            redirected,
+            responseType,
           }),
         );
         return;
@@ -235,10 +241,6 @@ export class FetchBackend implements HttpBackend {
     // but a successful status code can still result in an error if the user
     // asked for JSON data and the body cannot be parsed as such.
     const ok = status >= 200 && status < 300;
-
-    const redirected = response.redirected;
-
-    const responseType = response.type;
 
     if (ok) {
       observer.next(

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -229,12 +229,12 @@ export const httpResource: HttpResourceFn = (() => {
  * This is used to parse the response appropriately before returning it to
  * the requestee.
  */
-type ResponseType = 'arraybuffer' | 'blob' | 'json' | 'text';
+type HttpResponseContentType = 'arraybuffer' | 'blob' | 'json' | 'text';
 type RawRequestType =
   | ((ctx: ResourceParamsContext) => string | undefined)
   | ((ctx: ResourceParamsContext) => HttpResourceRequest | undefined);
 
-function makeHttpResourceFn<TRaw>(responseType: ResponseType) {
+function makeHttpResourceFn<TRaw>(responseType: HttpResponseContentType) {
   return function httpResource<TResult = TRaw>(
     request: RawRequestType,
     options?: HttpResourceOptions<TResult, TRaw>,
@@ -285,7 +285,7 @@ function makeHttpResourceFn<TRaw>(responseType: ResponseType) {
 function normalizeRequest(
   ctx: ResourceParamsContext,
   request: RawRequestType,
-  responseType: ResponseType,
+  responseType: HttpResponseContentType,
 ): HttpRequest<unknown> | undefined {
   let unwrappedRequest = typeof request === 'function' ? request(ctx) : request;
   if (unwrappedRequest === undefined) {
@@ -350,12 +350,22 @@ class HttpResourceImpl<T>
     source: this.extRequest,
     computation: () => undefined as number | undefined,
   });
+  private _redirected = linkedSignal({
+    source: this.extRequest,
+    computation: () => undefined as boolean | undefined,
+  });
+  private _responseType = linkedSignal({
+    source: this.extRequest,
+    computation: () => undefined as ResponseType | undefined,
+  });
 
   readonly headers = computed(() =>
     this.status() === 'resolved' || this.status() === 'error' ? this._headers() : undefined,
   );
   readonly progress = this._progress.asReadonly();
   readonly statusCode = this._statusCode.asReadonly();
+  readonly redirected = this._redirected.asReadonly();
+  readonly responseType = this._responseType.asReadonly();
 
   constructor(
     injector: Injector,
@@ -395,6 +405,8 @@ class HttpResourceImpl<T>
               case HttpEventType.Response:
                 this._headers.set(event.headers);
                 this._statusCode.set(event.status);
+                this._redirected.set(event.redirected);
+                this._responseType.set(event.responseType);
                 try {
                   send({value: parse ? parse(event.body) : (event.body as T)});
                 } catch (error) {
@@ -410,6 +422,8 @@ class HttpResourceImpl<T>
             if (error instanceof HttpErrorResponse) {
               this._headers.set(error.headers);
               this._statusCode.set(error.status);
+              this._redirected.set(error.redirected);
+              this._responseType.set(error.responseType);
             }
 
             send({error});
@@ -445,6 +459,8 @@ class HttpResourceImpl<T>
     this._headers.set(undefined);
     this._progress.set(undefined);
     this._statusCode.set(undefined);
+    this._redirected.set(undefined);
+    this._responseType.set(undefined);
   }
 
   // This is a type only override of the method

--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -202,6 +202,22 @@ export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> 
    */
   readonly progress: Signal<HttpProgressEvent | undefined>;
 
+  /**
+   * Signal indicating whether the HTTP response was redirected during the request.
+   *
+   * This property is only available when using the Fetch API.
+   * When using the default XHR backend this value will be `undefined`.
+   */
+  readonly redirected: Signal<boolean | undefined>;
+
+  /**
+   * Signal indicating the type of the HTTP response, based on the Fetch API's `Response.type`.
+   *
+   * This property is only available when using the Fetch API.
+   * When using the default XHR backend this value will be `undefined`.
+   */
+  readonly responseType: Signal<ResponseType | undefined>;
+
   hasValue(
     this: T extends undefined ? this : never,
   ): this is HttpResourceRef<Exclude<T, undefined>>;

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -94,6 +94,8 @@ export const STATUS = 's';
 export const STATUS_TEXT = 'st';
 export const REQ_URL = 'u';
 export const RESPONSE_TYPE = 'rt';
+export const REDIRECTED = 'r';
+export const EVENT_RESPONSE_TYPE = 'ert';
 
 interface TransferHttpResponse {
   /** body */
@@ -108,6 +110,10 @@ interface TransferHttpResponse {
   [REQ_URL]?: string;
   /** responseType */
   [RESPONSE_TYPE]?: HttpRequest<unknown>['responseType'];
+  /** `Response.redirected` from the Fetch API */
+  [REDIRECTED]?: boolean;
+  /** `Response.type` value from the Fetch API */
+  [EVENT_RESPONSE_TYPE]?: ResponseType;
 }
 
 interface CacheOptions extends HttpTransferCacheOptions {
@@ -197,6 +203,8 @@ export function retrieveStateFromCache(
       [STATUS]: status,
       [STATUS_TEXT]: statusText,
       [REQ_URL]: url,
+      [REDIRECTED]: redirected,
+      [EVENT_RESPONSE_TYPE]: eventType,
     } = response;
     // Request found in cache. Respond using it.
     let body: ArrayBuffer | Blob | string | undefined = undecodedBody;
@@ -279,6 +287,8 @@ export function transferCacheInterceptorFn(
             [STATUS_TEXT]: event.statusText,
             [REQ_URL]: requestUrl,
             [RESPONSE_TYPE]: req.responseType,
+            ...(event.redirected !== undefined && {[REDIRECTED]: event.redirected}),
+            ...(event.responseType !== undefined && {[EVENT_RESPONSE_TYPE]: event.responseType}),
           });
         }
       }),

--- a/packages/common/http/test/resource_spec.ts
+++ b/packages/common/http/test/resource_spec.ts
@@ -176,6 +176,37 @@ describe('httpResource', () => {
     expect(res.statusCode()).toBe(429);
   });
 
+  it('should return response redirected & responseType when resolved', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
+    TestBed.tick();
+    const req = backend.expectOne('/data');
+    req.flush([], {
+      redirected: true,
+      responseType: 'cors',
+    });
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.value()).toEqual([]);
+    expect(res.redirected()).toBe(true);
+    expect(res.responseType()).toBe('cors');
+  });
+
+  it('should return response redirected & responseType when request errored', async () => {
+    const backend = TestBed.inject(HttpTestingController);
+    const res = httpResource(() => '/data', {injector: TestBed.inject(Injector)});
+    TestBed.tick();
+    const req = backend.expectOne('/data');
+    req.flush([], {
+      status: 429,
+      statusText: 'Too many requests',
+      redirected: false,
+      responseType: 'basic',
+    });
+    await TestBed.inject(ApplicationRef).whenStable();
+    expect(res.redirected()).toBe(false);
+    expect(res.responseType()).toBe('basic');
+  });
+
   it('should support progress events', async () => {
     const backend = TestBed.inject(HttpTestingController);
     const res = httpResource(
@@ -356,6 +387,8 @@ describe('httpResource', () => {
     expect(res.headers()).toBe(undefined);
     expect(res.progress()).toBe(undefined);
     expect(res.statusCode()).toBe(undefined);
+    expect(res.redirected()).toBe(undefined);
+    expect(res.responseType()).toBe(undefined);
   });
 
   it('should support chain', async () => {

--- a/packages/common/http/testing/src/request.ts
+++ b/packages/common/http/testing/src/request.ts
@@ -24,6 +24,8 @@ type TestRequestErrorOptions = {
   headers?: HttpHeaders | {[name: string]: string | string[]};
   status?: number;
   statusText?: string;
+  redirected?: boolean;
+  responseType?: ResponseType;
 };
 
 /**
@@ -74,6 +76,8 @@ export class TestRequest {
       headers?: HttpHeaders | {[name: string]: string | string[]};
       status?: number;
       statusText?: string;
+      redirected?: boolean;
+      responseType?: ResponseType;
     } = {},
   ): void {
     if (this.cancelled) {
@@ -85,6 +89,8 @@ export class TestRequest {
     body = _maybeConvertBody(this.request.responseType, body);
     let statusText: string | undefined = opts.statusText;
     let status: number = opts.status !== undefined ? opts.status : HttpStatusCode.Ok;
+    const responseType = opts.responseType;
+    const redirected = opts.redirected;
     if (opts.status === undefined) {
       if (body === null) {
         status = HttpStatusCode.NoContent;
@@ -97,10 +103,30 @@ export class TestRequest {
       throw new Error('statusText is required when setting a custom status.');
     }
     if (status >= 200 && status < 300) {
-      this.observer.next(new HttpResponse<any>({body, headers, status, statusText, url}));
+      this.observer.next(
+        new HttpResponse<any>({
+          body,
+          headers,
+          status,
+          statusText,
+          url,
+          redirected,
+          responseType,
+        }),
+      );
       this.observer.complete();
     } else {
-      this.observer.error(new HttpErrorResponse({error: body, headers, status, statusText, url}));
+      this.observer.error(
+        new HttpErrorResponse({
+          error: body,
+          headers,
+          status,
+          statusText,
+          url,
+          redirected,
+          responseType,
+        }),
+      );
     }
   }
 
@@ -126,6 +152,8 @@ export class TestRequest {
         status: opts.status || 0,
         statusText: opts.statusText || '',
         url: this.request.urlWithParams,
+        redirected: opts.redirected,
+        responseType: opts.responseType,
       }),
     );
   }

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -153,12 +153,19 @@ describe('HttpClient TestRequest', () => {
 
       it('should allow creating HttpErrorResponse with any status code', () => {
         const error = new ProgressEvent('error');
-        request.error(error, {status: 404, statusText: 'Not Found'});
+        request.error(error, {
+          status: 404,
+          statusText: 'Not Found',
+          responseType: 'cors',
+          redirected: true,
+        });
 
         expect(lastError).toBeDefined();
         expect(lastError).toBeInstanceOf(HttpErrorResponse);
         expect(lastError.status).toBe(404);
         expect(lastError.statusText).toBe('Not Found');
+        expect(lastError.responseType).toBe('cors');
+        expect(lastError.redirected).toBeTrue();
       });
     } else {
       it('dummy test for node tests', () => {


### PR DESCRIPTION
On top https://github.com/angular/angular/pull/64551

Expose [`redirected`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected) and [`responseType`](https://developer.mozilla.org/en-US/docs/Web/API/Response/type) on `HttpResourceRef`, aligning it with
the underlying HTTP response metadata in the Fetch API and allowing consumers
to inspect redirects and the response type used.


## What is the new behavior?
We can now access redirected and responseType

```ts
const config = httpResource(() => '/api/config');

config.redirected();
config.responseType()
```