### PR TITLE
build: use TypeScript 5.9 for patch builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -117,9 +117,9 @@ use_repo(npm, "npm")
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 rules_ts_ext.deps(
     name = "angular_npm_typescript",
-    # Obtained by: curl --silent https://registry.npmjs.org/typescript/6.0.0-beta | jq -r '.dist.integrity'
-    ts_integrity = "sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q==",
-    ts_version = "6.0.0-beta",
+    # Obtained by: curl --silent https://registry.npmjs.org/typescript/5.9.3 | jq -r '.dist.integrity'
+    ts_integrity = "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+    ts_version = "5.9.3",
 )
 use_repo(rules_ts_ext, **{"npm_typescript": "angular_npm_typescript"})
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -574,7 +574,7 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "6NyLUdrb79stFKm8oWIBK2q65cT5Upbr8IR2Qwsywu8=",
-        "usagesDigest": "5Mj1S/yyTIvnEsdYZuALQNxC6YMobxr4Fp6KXO8UzDo=",
+        "usagesDigest": "ZXlhH7TrNEERA0ibuRRxAjYv2fVuXoFGNd3v+0UK1/g=",
         "recordedFileInputs": {
           "@@rules_browsers+//package.json": "772d873d450a539e2133635aeb5e63744cf1cec86e6b37aeecd9267a147fb0d7"
         },
@@ -584,8 +584,8 @@
           "angular_npm_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
-              "version": "6.0.0-beta",
-              "integrity": "sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q==",
+              "version": "5.9.3",
+              "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/adev/package.json
+++ b/adev/package.json
@@ -91,7 +91,7 @@
     "style-mod": "4.1.3",
     "tinyglobby": "0.2.15",
     "tslib": "2.8.1",
-    "typescript": "6.0.0-beta",
+    "typescript": "5.9.3",
     "w3c-keyname": "2.2.8",
     "zwitch": "^2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "todomvc-common": "^1.0.5",
     "tslib": "^2.3.0",
     "tslint": "6.1.3",
-    "typescript": "6.0.0-beta",
+    "typescript": "5.9.3",
     "webtreemap": "^2.0.1",
     "ws": "^8.15.0",
     "xhr2": "0.2.1",
@@ -204,8 +204,7 @@
   },
   "resolutions": {
     "https-proxy-agent": "7.0.6",
-    "saucelabs": "9.0.2",
-    "typescript": "6.0.0-beta"
+    "saucelabs": "9.0.2"
   },
   "pnpm": {
     "patchedDependencies": {},

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -79,7 +79,7 @@ runInEachFileSystem(() => {
         before: [addReferenceTransformer(fooId), tracker.importPreservingTransformer()],
       });
       const testContents = host.readFile('/test.js')!;
-      expect(testContents).toContain(`const dep_1 = __importDefault(require("./dep"));`);
+      expect(testContents).toContain(`var dep_1 = require("./dep");`);
       expect(testContents).toContain(`var ref = dep_1.default;`);
     });
 

--- a/packages/compiler-cli/src/ngtsc/transform/jit/test/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/jit/test/downlevel_decorators_transform_spec.ts
@@ -386,7 +386,7 @@ describe('downlevel decorator transform', () => {
      `);
 
     expect(diagnostics.length).toBe(0);
-    expect(output).toContain('const externalFile = tslib_1.__importStar(require("./other-file"));');
+    expect(output).toContain('const externalFile = require("./other-file");');
     expect(output).toContain(dedent`
        MyDir.ctorParameters = () => [
          { type: externalFile.MyOtherClass }

--- a/packages/compiler-cli/src/ngtsc/translator/test/import_manager_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/test/import_manager_spec.ts
@@ -27,7 +27,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input } from "@angular/core";
       input;
     `),
@@ -48,7 +47,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import * as i0 from "@angular/core";
       i0;
     `),
@@ -78,7 +76,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input, output } from "@angular/core";
       input;
       output;
@@ -109,7 +106,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import * as i0 from "@angular/core";
       import * as i1 from "@angular/core/rxjs-interop";
       i0;
@@ -141,7 +137,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import * as i0 from "@angular/core";
       i0;
       i0.output;
@@ -172,7 +167,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import * as i0 from "@angular/core";
       import { input } from "@angular/core";
       input;
@@ -371,7 +365,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import * as i0 from "@angular/core";
       i0.input;
       i0.output;
@@ -484,7 +477,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import "@angular/core";
     `),
     );
@@ -506,7 +498,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input as input_1 } from "@angular/core";
       input_1;
       const input = 1;
@@ -534,7 +525,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input as input_1 } from "@angular/core";
       input_1;
       function x() {
@@ -566,7 +556,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-        "use strict";
         import { input } from "@angular/core";
         input;
     `),
@@ -587,7 +576,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input } from "@angular/core";
       input;
     `),
@@ -617,7 +605,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input } from "@angular/core";
       import { input as input_1 } from "@angular/core2";
       input;
@@ -650,7 +637,6 @@ describe('import manager', () => {
     expect(inputRef).toBe(inputRef2);
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input } from "@angular/core";
       input;
       input;
@@ -805,7 +791,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-        "use strict";
         import { foo as bar } from "@angular/core";
         bar;
         bar;
@@ -838,7 +823,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-        "use strict";
         import { foo as bar, foo as baz } from "@angular/core";
         bar;
         baz;
@@ -870,7 +854,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-        "use strict";
         import { foo, bar as foo } from "@angular/core";
         foo;
         foo;
@@ -1011,7 +994,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { output } from "@angular/core";
       input;
       output;
@@ -1041,7 +1023,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       import { input } from "@angular/core";
       input;
     `),
@@ -1065,7 +1046,6 @@ describe('import manager', () => {
 
     expect(res).toBe(
       omitLeadingWhitespace(`
-      "use strict";
       foo;
     `),
     );

--- a/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
@@ -78,7 +78,7 @@ runInEachFileSystem(() => {
       const sf = getSourceFileOrError(program, _('/main.ts'));
       program.emit(sf, undefined, undefined, undefined, {before: [testTransformerFactory]});
       const main = host.readFile(_('/main.js'));
-      expect(main).toMatch(/var x = 3;\s+var A_id = 2;\s+class A {/);
+      expect(main).toMatch(/var x = 3;\s+var A_id = 2;\s+var A =/);
     });
 
     it('handles nested statements', () => {
@@ -101,8 +101,8 @@ runInEachFileSystem(() => {
       const sf = getSourceFileOrError(program, _('/main.ts'));
       program.emit(sf, undefined, undefined, undefined, {before: [testTransformerFactory]});
       const main = host.readFile(_('/main.js'));
-      expect(main).toMatch(/var A_id = 3;\s+export class A {/);
-      expect(main).toMatch(/var B_id = 4;\s+class B {/);
+      expect(main).toMatch(/var A_id = 3;\s+var A = /);
+      expect(main).toMatch(/var B_id = 4;\s+var B = /);
     });
   });
 });

--- a/packages/compiler-cli/test/compliance/isolated/isolated_compile_spec.ts
+++ b/packages/compiler-cli/test/compliance/isolated/isolated_compile_spec.ts
@@ -78,13 +78,14 @@ function compileTests(fs: FileSystem, test: ComplianceTest): {errors: string[]} 
       ...test.compilerOptions,
       noEmit: true,
       skipLibCheck: true,
+      // Ensure we can resolve the imports in the mock FS
+      baseUrl: rootDir,
       paths: {
-        '*': ['./node_modules/*'],
+        '*': ['node_modules/*'],
       },
       // Use classic Node resolution which works better with the simple mock FS structure
       // than 'Bundler' or 'NodeNext' which expect specific package.json exports.
-      moduleResolution: ts.ModuleResolutionKind.Node16,
-      module: ts.ModuleKind.Node16,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
       strict: true,
       // TODO: enable once we fix the generated code
       noImplicitAny: false,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -95,8 +95,7 @@
       "description": "should emit a valid setClassMetadata call in ES5 if a class with a custom decorator is referencing itself inside its own metadata",
       "inputFiles": ["custom_decorator_es5.ts"],
       "compilerOptions": {
-        "target": "ES5",
-        "ignoreDeprecations": "6.0"
+        "target": "ES5"
       },
       "compilationModeFilter": ["full compile"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/es5_support/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/es5_support/TEST_CASES.json
@@ -4,8 +4,7 @@
     {
       "description": "should generate ES5 compliant localized messages if the target is ES5",
       "compilerOptions": {
-        "target": "ES5",
-        "ignoreDeprecations": "6.0"
+        "target": "ES5"
       },
       "compilationModeFilter": ["full compile", "declaration-only emit"],
       "expectations": [

--- a/packages/language-service/test/grp3/quick_info_spec.ts
+++ b/packages/language-service/test/grp3/quick_info_spec.ts
@@ -357,7 +357,7 @@ describe('quick info', () => {
         expect(toText(documentation)).toContain(
           'The **`HTMLDivElement`** interface provides special properties ' +
             '(beyond the regular HTMLElement interface it also has available to it by inheritance) ' +
-            'for manipulating <div> elements.',
+            'for manipulating div elements.',
         );
       });
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -355,7 +355,7 @@ export class Driver implements Debuggable, UpdateSource {
     event.waitUntil(this.handlePushSubscriptionChange(event));
   }
 
-  private onMessageError(event: ExtendableMessageEvent): void {
+  private onMessageError(event: MessageEvent): void {
     // Handle message deserialization errors that occur when receiving messages
     // that cannot be deserialized, typically due to corrupted data or unsupported formats.
     this.debugger.log(

--- a/packages/zone.js/tools/zone_bundle.bzl
+++ b/packages/zone.js/tools/zone_bundle.bzl
@@ -87,9 +87,6 @@ def zone_bundle(
             "--skipLibCheck",
             "--target",
             "es5",
-            # Needed to target es5
-            "--ignoreDeprecations",
-            "6.0",
             "--lib",
             "es2015,dom",
             "--allowJS",
@@ -162,9 +159,6 @@ def zone_bundle(
             "--skipLibCheck",
             "--target",
             "es5",
-            # Needed to target es5
-            "--ignoreDeprecations",
-            "6.0",
             "--lib",
             "es2015,dom",
             "--allowJS",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   https-proxy-agent: 7.0.6
   saucelabs: 9.0.2
-  typescript: 6.0.0-beta
 
 packageExtensionsChecksum: sha256-3L73Fw32UVtE6x5BJxJPBtQtH/mgsr31grNpdhHP1IY=
 
@@ -19,7 +18,7 @@ importers:
     dependencies:
       '@angular-devkit/build-angular':
         specifier: 21.2.0
-        version: 21.2.0(2a7468966ec2ebdac295938578c511f9)
+        version: 21.2.0(1121d98b204b69583f04da58baf1725e)
       '@angular-devkit/core':
         specifier: 21.2.0
         version: 21.2.0(chokidar@5.0.0)
@@ -34,7 +33,7 @@ importers:
         version: link:packages/benchpress
       '@angular/build':
         specifier: 21.2.0
-        version: 21.2.0(c18a0acbe6e5136fde3fb99c9351e09f)
+        version: 21.2.0(b12a7485180546b4dc1b7963fa8727d0)
       '@angular/cdk':
         specifier: 21.2.0
         version: 21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
@@ -268,7 +267,7 @@ importers:
         version: 4.57.1
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.57.1)(typescript@6.0.0-beta)
+        version: 6.3.0(rollup@4.57.1)(typescript@5.9.3)
       rollup-plugin-preserve-shebang:
         specifier: ^1.0.1
         version: 1.0.1
@@ -310,10 +309,10 @@ importers:
         version: 2.8.1
       tslint:
         specifier: 6.1.3
-        version: 6.1.3(typescript@6.0.0-beta)
+        version: 6.1.3(typescript@5.9.3)
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
       webtreemap:
         specifier: ^2.0.1
         version: 2.0.1
@@ -398,7 +397,7 @@ importers:
         version: 15.10.0
       firebase-tools:
         specifier: ^15.0.0
-        version: 15.8.0(@types/node@20.19.35)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+        version: 15.8.0(@types/node@20.19.35)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       get-tsconfig:
         specifier: ^4.10.1
         version: 4.13.6
@@ -419,7 +418,7 @@ importers:
         version: 2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       karma-sauce-launcher:
         specifier: ^4.3.6
-        version: 4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+        version: 4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
       prettier:
         specifier: ^3.8.0
         version: 3.8.1
@@ -434,16 +433,16 @@ importers:
         version: 0.2.5
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)
+        version: 10.9.2(@types/node@20.19.35)(typescript@5.9.3)
       tsec:
         specifier: 0.2.9
-        version: 0.2.9(@bazel/bazelisk@1.28.1)(typescript@6.0.0-beta)
+        version: 0.2.9(@bazel/bazelisk@1.28.1)(typescript@5.9.3)
       tslint-eslint-rules:
         specifier: 5.4.0
-        version: 5.4.0(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta)
+        version: 5.4.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3)
       tslint-no-toplevel-property-access:
         specifier: 0.0.2
-        version: 0.0.2(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta)
+        version: 0.0.2(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3)
       typed-graphqlify:
         specifier: ^3.1.1
         version: 3.1.6
@@ -452,7 +451,7 @@ importers:
         version: 7.22.0
       vrsource-tslint-rules:
         specifier: 6.0.0
-        version: 6.0.0(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta)
+        version: 6.0.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3)
       zod:
         specifier: ^4.0.10
         version: 4.3.6
@@ -479,7 +478,7 @@ importers:
         version: 21.2.0(@angular/cdk@21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/core@packages+core)
       '@angular/build':
         specifier: 21.2.0
-        version: 21.2.0(7f055838f8045d08a055e6e13ddd30a1)
+        version: 21.2.0(5117680ee98908b510a8aada034e8d6b)
       '@angular/cdk':
         specifier: 21.2.0
         version: 21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
@@ -617,7 +616,7 @@ importers:
         version: 24.10.11
       '@typescript/vfs':
         specifier: 1.6.2
-        version: 1.6.2(typescript@6.0.0-beta)
+        version: 1.6.2(typescript@5.9.3)
       '@webcontainer/api':
         specifier: 1.6.1
         version: 1.6.1
@@ -733,8 +732,8 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
       w3c-keyname:
         specifier: 2.2.8
         version: 2.2.8
@@ -847,7 +846,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: 21.2.0
-        version: 21.2.0(0446cbaab7220f63d6d233a22dc97a6b)
+        version: 21.2.0(ca3ba11001bf1c3b89f3387a2334da70)
       '@angular/cli':
         specifier: 21.2.0
         version: 21.2.0(@types/node@24.10.13)(chokidar@5.0.0)
@@ -858,8 +857,8 @@ importers:
         specifier: ^28.0.0
         version: 28.1.0
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: ~5.9.2
+        version: 5.9.3
       vitest:
         specifier: ^4.0.0
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -919,7 +918,7 @@ importers:
         version: link:../packages/benchpress
       '@angular/build':
         specifier: 21.2.0
-        version: 21.2.0(129a98b242ce4fbf0c477f9966481d6b)
+        version: 21.2.0(4dd7ae7687d214fc395898b056b21250)
       '@angular/common':
         specifier: workspace:*
         version: link:../packages/common
@@ -1053,8 +1052,8 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
@@ -1090,7 +1089,7 @@ importers:
         version: link:../../../animations
       '@angular/build':
         specifier: 21.2.0
-        version: 21.2.0(0446cbaab7220f63d6d233a22dc97a6b)
+        version: 21.2.0(ca3ba11001bf1c3b89f3387a2334da70)
       '@angular/common':
         specifier: workspace:*
         version: link:../../../common
@@ -1318,7 +1317,7 @@ importers:
         version: 2.5.2
       jest:
         specifier: 30.2.0
-        version: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+        version: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: 30.2.0
         version: 30.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -1357,8 +1356,8 @@ importers:
         version: link:../..
     devDependencies:
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
 
   tools/bazel/rules_angular_store:
     dependencies:
@@ -1372,8 +1371,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/language-service
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
     devDependencies:
       '@types/jasmine':
         specifier: ~6.0.0
@@ -1450,10 +1449,10 @@ importers:
     devDependencies:
       ng-packagr:
         specifier: 21.2.0
-        version: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+        version: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
 
   vscode-ng-language-service/server:
     dependencies:
@@ -1461,8 +1460,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/language-service
       typescript:
-        specifier: 6.0.0-beta
-        version: 6.0.0-beta
+        specifier: 5.9.3
+        version: 5.9.3
     devDependencies:
       '@types/node':
         specifier: ^24.5.2
@@ -1650,7 +1649,7 @@ packages:
       ng-packagr: ^21.0.0
       protractor: ^7.0.0
       tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      typescript: 6.0.0-beta
+      typescript: '>=5.9 <6.0'
     peerDependenciesMeta:
       '@angular/core':
         optional: true
@@ -1725,7 +1724,7 @@ packages:
       postcss: ^8.4.0
       tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
       tslib: ^2.3.0
-      typescript: 6.0.0-beta
+      typescript: '>=5.9 <6.0'
       vitest: ^4.0.8
     peerDependenciesMeta:
       '@angular/core':
@@ -4173,7 +4172,7 @@ packages:
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
       '@angular/compiler-cli': ^21.0.0
-      typescript: 6.0.0-beta
+      typescript: '>=5.9 <6.0'
       webpack: ^5.54.0
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
@@ -5454,7 +5453,7 @@ packages:
   '@typescript/vfs@1.6.2':
     resolution: {integrity: sha512-hoBwJwcbKHmvd2QVebiytN1aELvpk9B74B4L1mFm/XT1Q/VOYAWl2vQ9AWRFtQq8zmz6enTpfTV8WRc4ATjW/g==}
     peerDependencies:
-      typescript: 6.0.0-beta
+      typescript: '*'
 
   '@typespec/ts-http-runtime@0.3.3':
     resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
@@ -6952,7 +6951,7 @@ packages:
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: 6.0.0-beta
+      typescript: '>=4.9.5'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -10142,7 +10141,7 @@ packages:
       '@angular/compiler-cli': ^21.0.0 || ^21.2.0-next
       tailwindcss: ^2.0.0 || ^3.0.0 || ^4.0.0
       tslib: ^2.3.0
-      typescript: 6.0.0-beta
+      typescript: '>=5.9 <6.0'
     peerDependenciesMeta:
       tailwindcss:
         optional: true
@@ -11032,7 +11031,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:
@@ -11330,7 +11328,7 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: 6.0.0-beta
+      typescript: ^4.5 || ^5.0
 
   rollup-plugin-preserve-shebang@1.0.1:
     resolution: {integrity: sha512-gk7ExGBqvUinhgrvldKHkAKXXwRkWMXMZymNkrtn50uBgHITlhRjhnKmbNGwAIc4Bzgl3yLv7/8Fhi/XeHhFKg==}
@@ -12245,7 +12243,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: 6.0.0-beta
+      typescript: '>=2.7'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -12258,7 +12256,7 @@ packages:
     peerDependencies:
       '@bazel/bazelisk': '>=1.7.5'
       '@bazel/concatjs': '>=5.3.0'
-      typescript: 6.0.0-beta
+      typescript: '>=3.9.2'
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -12273,13 +12271,13 @@ packages:
     resolution: {integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==}
     peerDependencies:
       tslint: ^5.0.0
-      typescript: 6.0.0-beta
+      typescript: ^2.2.0 || ^3.0.0
 
   tslint-no-toplevel-property-access@0.0.2:
     resolution: {integrity: sha512-Oc+UUurlGLBkgeUSGxMoTpRUpaXsjqzQCEAYrYQyuU8330fi5FKlye5n53y87EJ24AlfdoxMPV7DJfFOADapfg==}
     peerDependencies:
       tslint: '>=5'
-      typescript: 6.0.0-beta
+      typescript: '>=3'
 
   tslint@6.1.3:
     resolution: {integrity: sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==}
@@ -12287,7 +12285,7 @@ packages:
     deprecated: TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.
     hasBin: true
     peerDependencies:
-      typescript: 6.0.0-beta
+      typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 4.0.0-dev'
 
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -12296,13 +12294,13 @@ packages:
   tsutils@2.29.0:
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
-      typescript: 6.0.0-beta
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
 
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: 6.0.0-beta
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -12397,8 +12395,13 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@6.0.0-beta:
-    resolution: {integrity: sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12745,7 +12748,7 @@ packages:
     resolution: {integrity: sha512-pmcnJdIVziZTk1V0Cqehmh3gIabBRkBYXkv9vx+1CZDNEa41kNGUBFwQLzw21erYOd2QnD8jJeZhBGqnlT1HWw==}
     peerDependencies:
       tslint: '*'
-      typescript: 6.0.0-beta
+      typescript: '*'
 
   vscode-css-languageservice@6.3.9:
     resolution: {integrity: sha512-1tLWfp+TDM5ZuVWht3jmaY5y7O6aZmpeXLoHl5bv1QtRsRKt4xYGRMmdJa5Pqx/FTkgRbsna9R+Gn2xE+evVuA==}
@@ -13449,13 +13452,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.0(2a7468966ec2ebdac295938578c511f9)':
+  '@angular-devkit/build-angular@21.2.0(1121d98b204b69583f04da58baf1725e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.0(chokidar@5.0.0)(webpack-dev-server@5.2.3(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)(webpack@5.105.2(esbuild@0.27.3)))(webpack@5.105.2(esbuild@0.27.3))
       '@angular-devkit/core': 21.2.0(chokidar@5.0.0)
-      '@angular/build': 21.2.0(d744326b9313465deb4994539fedfa01)
+      '@angular/build': 21.2.0(c3f1575f6bb48d5409b03158e885336a)
       '@angular/compiler-cli': link:packages/compiler-cli
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -13467,7 +13470,7 @@ snapshots:
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/runtime': 7.28.6
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 21.2.0(@angular/compiler-cli@packages+compiler-cli)(typescript@6.0.0-beta)(webpack@5.105.2(esbuild@0.27.3))
+      '@ngtools/webpack': 21.2.0(@angular/compiler-cli@packages+compiler-cli)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.24(postcss@8.5.6)
       babel-loader: 10.0.0(@babel/core@7.29.0)(webpack@5.105.2(esbuild@0.27.3))
@@ -13489,7 +13492,7 @@ snapshots:
       picomatch: 4.0.3
       piscina: 5.1.4
       postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@6.0.0-beta)(webpack@5.105.2(esbuild@0.27.3))
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.2
       sass: 1.97.3
@@ -13501,7 +13504,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       webpack: 5.105.2(esbuild@0.27.3)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.27.3))
       webpack-dev-server: 5.2.3(bufferutil@4.1.0)(tslib@2.8.1)(utf-8-validate@6.0.6)(webpack@5.105.2(esbuild@0.27.3))
@@ -13515,10 +13518,10 @@ snapshots:
       '@angular/service-worker': link:packages/service-worker
       '@angular/ssr': 21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-server@packages+platform-server)(@angular/router@packages+router)
       esbuild: 0.27.3
-      jest: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      jest: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       jest-environment-jsdom: 30.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       protractor: 7.0.0
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -13580,67 +13583,7 @@ snapshots:
       '@angular/core': link:packages/core
       tslib: 2.8.1
 
-  '@angular/build@21.2.0(0446cbaab7220f63d6d233a22dc97a6b)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
-      '@angular/compiler': link:packages/compiler
-      '@angular/compiler-cli': link:packages/compiler-cli
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@24.10.13)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      beasties: 0.4.1
-      browserslist: 4.28.1
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.3
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 6.0.0-beta
-      undici: 7.22.0
-      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': link:packages/core
-      '@angular/localize': link:packages/localize
-      '@angular/platform-browser': link:packages/platform-browser
-      '@angular/platform-server': link:packages/platform-server
-      '@angular/service-worker': link:packages/service-worker
-      '@angular/ssr': 21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-server@packages+platform-server)(@angular/router@packages+router)
-      karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      less: 4.5.1
-      lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
-      postcss: 8.5.6
-      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@21.2.0(129a98b242ce4fbf0c477f9966481d6b)':
+  '@angular/build@21.2.0(4dd7ae7687d214fc395898b056b21250)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
@@ -13669,7 +13612,7 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       undici: 7.22.0
       vite: 7.3.1(@types/node@24.10.11)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       watchpack: 2.5.1
@@ -13683,7 +13626,7 @@ snapshots:
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       less: 4.5.1
       lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.11)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -13700,7 +13643,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.0(7f055838f8045d08a055e6e13ddd30a1)':
+  '@angular/build@21.2.0(5117680ee98908b510a8aada034e8d6b)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
@@ -13729,7 +13672,7 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       undici: 7.22.0
       vite: 7.3.1(@types/node@24.10.11)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       watchpack: 2.5.1
@@ -13743,7 +13686,7 @@ snapshots:
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       less: 4.5.1
       lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.11)(jiti@2.6.1)(jsdom@28.0.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -13760,7 +13703,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.0(c18a0acbe6e5136fde3fb99c9351e09f)':
+  '@angular/build@21.2.0(b12a7485180546b4dc1b7963fa8727d0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
@@ -13789,7 +13732,7 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       undici: 7.22.0
       vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       watchpack: 2.5.1
@@ -13803,7 +13746,7 @@ snapshots:
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       less: 4.5.1
       lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -13820,7 +13763,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.0(d744326b9313465deb4994539fedfa01)':
+  '@angular/build@21.2.0(c3f1575f6bb48d5409b03158e885336a)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
@@ -13849,7 +13792,7 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       undici: 7.22.0
       vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       watchpack: 2.5.1
@@ -13863,10 +13806,70 @@ snapshots:
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       less: 4.4.2
       lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta)
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.6
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@angular/build@21.2.0(ca3ba11001bf1c3b89f3387a2334da70)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
+      '@angular/compiler': link:packages/compiler
+      '@angular/compiler-cli': link:packages/compiler-cli
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.21(@types/node@24.10.13)
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      beasties: 0.4.1
+      browserslist: 4.28.1
+      esbuild: 0.27.3
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 9.0.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 8.0.0
+      picomatch: 4.0.3
+      piscina: 5.1.4
+      rolldown: 1.0.0-rc.4
+      sass: 1.97.3
+      semver: 7.7.4
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.15
+      tslib: 2.8.1
+      typescript: 5.9.3
+      undici: 7.22.0
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      watchpack: 2.5.1
+    optionalDependencies:
+      '@angular/core': link:packages/core
+      '@angular/localize': link:packages/localize
+      '@angular/platform-browser': link:packages/platform-browser
+      '@angular/platform-server': link:packages/platform-server
+      '@angular/service-worker': link:packages/service-worker
+      '@angular/ssr': 21.2.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-server@packages+platform-server)(@angular/router@packages+router)
+      karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      less: 4.5.1
+      lmdb: 3.5.1
+      ng-packagr: 21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3)
+      postcss: 8.5.6
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@28.1.0)(less@4.5.1)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -14038,7 +14041,7 @@ snapshots:
       supports-color: 10.2.2
       tsx: 4.21.0
       typed-graphqlify: 3.1.6
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       utf-8-validate: 6.0.6
       which: 6.0.1
       yaml: 2.8.2
@@ -14069,14 +14072,14 @@ snapshots:
       call-me-maybe: 1.0.2
       js-yaml: 4.1.1
 
-  '@apphosting/build@0.1.7(@types/node@20.19.35)(typescript@6.0.0-beta)':
+  '@apphosting/build@0.1.7(@types/node@20.19.35)(typescript@5.9.3)':
     dependencies:
       '@apphosting/common': 0.0.9
       '@npmcli/promise-spawn': 3.0.0
       colorette: 2.0.20
       commander: 11.1.0
       npm-pick-manifest: 9.1.0
-      ts-node: 10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)
+      ts-node: 10.9.2(@types/node@20.19.35)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -16581,7 +16584,7 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))':
+  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -16596,7 +16599,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      jest-config: 30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -16618,7 +16621,7 @@ snapshots:
       - ts-node
     optional: true
 
-  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))':
+  '@jest/core@30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.2.0
       '@jest/pattern': 30.0.1
@@ -16633,7 +16636,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+      jest-config: 30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -17073,7 +17076,7 @@ snapshots:
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 6.0.0-beta
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -17273,14 +17276,14 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/node': 22.19.13
       tinyglobby: 0.2.12
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@ngtools/webpack@21.2.0(@angular/compiler-cli@packages+compiler-cli)(typescript@6.0.0-beta)(webpack@5.105.2(esbuild@0.27.3))':
+  '@ngtools/webpack@21.2.0(@angular/compiler-cli@packages+compiler-cli)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3))':
     dependencies:
       '@angular/compiler-cli': link:packages/compiler-cli
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       webpack: 5.105.2(esbuild@0.27.3)
 
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
@@ -18546,9 +18549,9 @@ snapshots:
       '@types/duplexify': 3.6.5
       '@types/node': 24.10.11
 
-  '@types/puppeteer-core@5.4.0(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)':
+  '@types/puppeteer-core@5.4.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      '@types/puppeteer': 7.0.4(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+      '@types/puppeteer': 7.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -18558,9 +18561,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@types/puppeteer@7.0.4(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)':
+  '@types/puppeteer@7.0.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
-      puppeteer: 24.37.5(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+      puppeteer: 24.37.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -18664,10 +18667,10 @@ snapshots:
       '@types/node': 24.10.11
     optional: true
 
-  '@typescript/vfs@1.6.2(typescript@6.0.0-beta)':
+  '@typescript/vfs@1.6.2(typescript@5.9.3)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -20376,14 +20379,14 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig@9.0.0(typescript@6.0.0-beta):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
 
   crc-32@1.2.2: {}
 
@@ -21668,9 +21671,9 @@ snapshots:
       object.pick: 1.3.0
       parse-filepath: 1.0.2
 
-  firebase-tools@15.8.0(@types/node@20.19.35)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6):
+  firebase-tools@15.8.0(@types/node@20.19.35)(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
-      '@apphosting/build': 0.1.7(@types/node@20.19.35)(typescript@6.0.0-beta)
+      '@apphosting/build': 0.1.7(@types/node@20.19.35)(typescript@5.9.3)
       '@apphosting/common': 0.0.8
       '@electric-sql/pglite': 0.3.15
       '@electric-sql/pglite-tools': 0.2.20(@electric-sql/pglite@0.3.15)
@@ -23073,15 +23076,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)):
+  jest-cli@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      jest-config: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -23093,15 +23096,15 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-cli@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)):
+  jest-cli@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+      jest-config: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.2
@@ -23112,7 +23115,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)):
+  jest-config@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -23140,13 +23143,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.35
-      ts-node: 10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)
+      ts-node: 10.9.2(@types/node@20.19.35)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
     optional: true
 
-  jest-config@30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)):
+  jest-config@30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -23174,13 +23177,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.11
-      ts-node: 10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)
+      ts-node: 10.9.2(@types/node@20.19.35)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
     optional: true
 
-  jest-config@30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)):
+  jest-config@30.2.0(@types/node@24.10.11)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -23208,12 +23211,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.11
-      ts-node: 10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)):
+  jest-config@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -23241,7 +23244,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.10.13
-      ts-node: 10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)
+      ts-node: 10.9.2(@types/node@24.10.13)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23479,12 +23482,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta)):
+  jest@30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta))
+      jest-cli: 30.2.0(@types/node@20.19.35)(ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23493,12 +23496,12 @@ snapshots:
       - ts-node
     optional: true
 
-  jest@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta)):
+  jest@30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta))
+      jest-cli: 30.2.0(@types/node@24.10.13)(ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23739,11 +23742,11 @@ snapshots:
     dependencies:
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  karma-sauce-launcher@4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6):
+  karma-sauce-launcher@4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       global-agent: 2.2.0
       saucelabs: 9.0.2
-      webdriverio: 6.12.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+      webdriverio: 6.12.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -24564,7 +24567,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  ng-packagr@21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@6.0.0-beta):
+  ng-packagr@21.2.0(@angular/compiler-cli@packages+compiler-cli)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))(tslib@2.8.1)(typescript@5.9.3):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular/compiler-cli': link:packages/compiler-cli
@@ -24584,12 +24587,12 @@ snapshots:
       ora: 9.3.0
       piscina: 5.1.4
       postcss: 8.5.6
-      rollup-plugin-dts: 6.3.0(rollup@4.57.1)(typescript@6.0.0-beta)
+      rollup-plugin-dts: 6.3.0(rollup@4.57.1)(typescript@5.9.3)
       rxjs: 7.8.2
       sass: 1.97.3
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
     optionalDependencies:
       rollup: 4.57.1
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
@@ -25291,9 +25294,9 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@6.0.0-beta)(webpack@5.105.2(esbuild@0.27.3)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.2(esbuild@0.27.3)):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@6.0.0-beta)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.4
@@ -25550,11 +25553,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@24.37.5(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6):
+  puppeteer@24.37.5(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
       '@puppeteer/browsers': 2.13.0
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1566079)
-      cosmiconfig: 9.0.0(typescript@6.0.0-beta)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       devtools-protocol: 0.0.1566079
       puppeteer-core: 24.37.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       typed-query-selector: 2.12.1
@@ -25934,11 +25937,11 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.4
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.4
 
-  rollup-plugin-dts@6.3.0(rollup@4.57.1)(typescript@6.0.0-beta):
+  rollup-plugin-dts@6.3.0(rollup@4.57.1)(typescript@5.9.3):
     dependencies:
       magic-string: 0.30.21
       rollup: 4.57.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 
@@ -27091,7 +27094,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@20.19.35)(typescript@6.0.0-beta):
+  ts-node@10.9.2(@types/node@20.19.35)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -27105,11 +27108,11 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@24.10.13)(typescript@6.0.0-beta):
+  ts-node@10.9.2(@types/node@24.10.13)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -27123,17 +27126,17 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
 
-  tsec@0.2.9(@bazel/bazelisk@1.28.1)(typescript@6.0.0-beta):
+  tsec@0.2.9(@bazel/bazelisk@1.28.1)(typescript@5.9.3):
     dependencies:
       '@bazel/bazelisk': 1.28.1
       glob: 11.1.0
       minimatch: 10.2.4
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
 
   tslib@1.14.1: {}
 
@@ -27141,20 +27144,20 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tslint-eslint-rules@5.4.0(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta):
+  tslint-eslint-rules@5.4.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       doctrine: 0.7.2
       tslib: 1.9.0
-      tslint: 6.1.3(typescript@6.0.0-beta)
-      tsutils: 3.21.0(typescript@6.0.0-beta)
-      typescript: 6.0.0-beta
+      tslint: 6.1.3(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  tslint-no-toplevel-property-access@0.0.2(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta):
+  tslint-no-toplevel-property-access@0.0.2(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      tslint: 6.1.3(typescript@6.0.0-beta)
-      typescript: 6.0.0-beta
+      tslint: 6.1.3(typescript@5.9.3)
+      typescript: 5.9.3
 
-  tslint@6.1.3(typescript@6.0.0-beta):
+  tslint@6.1.3(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.29.0
       builtin-modules: 1.1.1
@@ -27168,20 +27171,20 @@ snapshots:
       resolve: 1.22.11
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@6.0.0-beta)
-      typescript: 6.0.0-beta
+      tsutils: 2.29.0(typescript@5.9.3)
+      typescript: 5.9.3
 
   tsscmp@1.0.6: {}
 
-  tsutils@2.29.0(typescript@6.0.0-beta):
+  tsutils@2.29.0(typescript@5.9.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
 
-  tsutils@3.21.0(typescript@6.0.0-beta):
+  tsutils@3.21.0(typescript@5.9.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 6.0.0-beta
+      typescript: 5.9.3
 
   tsx@4.21.0:
     dependencies:
@@ -27295,7 +27298,9 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@6.0.0-beta: {}
+  typescript@5.8.2: {}
+
+  typescript@5.9.3: {}
 
   ua-parser-js@0.7.41: {}
 
@@ -27827,10 +27832,10 @@ snapshots:
 
   void-elements@2.0.1: {}
 
-  vrsource-tslint-rules@6.0.0(tslint@6.1.3(typescript@6.0.0-beta))(typescript@6.0.0-beta):
+  vrsource-tslint-rules@6.0.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      tslint: 6.1.3(typescript@6.0.0-beta)
-      typescript: 6.0.0-beta
+      tslint: 6.1.3(typescript@5.9.3)
+      typescript: 5.9.3
 
   vscode-css-languageservice@6.3.9:
     dependencies:
@@ -27947,9 +27952,9 @@ snapshots:
       got: 11.8.6
       lodash.merge: 4.6.2
 
-  webdriverio@6.12.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.0-beta)(utf-8-validate@6.0.6):
+  webdriverio@6.12.1(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@6.0.6):
     dependencies:
-      '@types/puppeteer-core': 5.4.0(bufferutil@4.1.0)(typescript@6.0.0-beta)(utf-8-validate@6.0.6)
+      '@types/puppeteer-core': 5.4.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@wdio/config': 6.12.1
       '@wdio/logger': 6.10.10
       '@wdio/repl': 6.11.0

--- a/vscode-ng-language-service/integration/project/package.json
+++ b/vscode-ng-language-service/integration/project/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "ng-packagr": "21.2.0",
-    "typescript": "6.0.0-beta"
+    "typescript": "5.9.3"
   },
   "scripts": {
     "build": "ng-packagr -p libs/post/ng-package.json -c libs/post/tsconfig.json"

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -272,7 +272,7 @@
   },
   "dependencies": {
     "@angular/language-service": "workspace:*",
-    "typescript": "6.0.0-beta"
+    "typescript": "5.9.3"
   },
   "devDependencies": {
     "@types/jasmine": "~6.0.0",

--- a/vscode-ng-language-service/server/package.json
+++ b/vscode-ng-language-service/server/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@angular/language-service": "workspace:*",
-    "typescript": "6.0.0-beta"
+    "typescript": "5.9.3"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",


### PR DESCRIPTION
Partially rolls back to using TypeScript 5.9 for the builds on the patch branch, because we bundle our TypeScript version with the language service which can introduce unexpected breakages for users.

Note that we still allow users to install TypeScript 6.
