### PR TITLE
docs(router): clarify relative navigation note with example

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -137,6 +137,13 @@ export class UserDetail {
     // To:   /users
     this.router.navigate(['..'], {relativeTo: this.route});
   }
+
+  navigateToList() {
+    // Angular resolves the commands array as a single navigation path relative to the current route.
+    // From: /users/123
+    // Result: /users/list
+    this.router.navigate(['..', 'list'], {relativeTo: this.route});
+  }
 }
 ```
 


### PR DESCRIPTION
Adds a clarification explaining how command arrays passed to `router.navigate()` are interpreted during relative navigation.

Includes an example showing how `['..']` resolves relative to the current route.

This addresses reviewer feedback requesting a concrete example instead of a descriptive paragraph.

Scope:
- Documentation only
- No behavioral changes