### PR TITLE
refactor(core): account for shadow roots in animations

### DIFF
--- a/packages/core/src/animation/utils.ts
+++ b/packages/core/src/animation/utils.ts
@@ -255,6 +255,13 @@ export function elementHasClassList(element: HTMLElement, classList: string[]): 
   return false;
 }
 
+/** Gets the target of an event while accounting for Shadow DOM. */
+export function getEventTarget<T extends EventTarget>(event: Event): T | null {
+  // If an event is bound outside the Shadow DOM, the `event.target` will
+  // point to the shadow root so we have to use `composedPath` instead.
+  return (event.composedPath ? event.composedPath()[0] : event.target) as T | null;
+}
+
 /**
  * Determines if the animation or transition event is currently the expected longest animation
  * based on earlier determined data in `longestAnimations`
@@ -272,7 +279,7 @@ export function isLongestAnimation(
   // block the animationend/transitionend event from doing its work.
   if (longestAnimation === undefined) return true;
   return (
-    nativeElement === event.target &&
+    nativeElement === getEventTarget(event) &&
     ((longestAnimation.animationName !== undefined &&
       (event as AnimationEvent).animationName === longestAnimation.animationName) ||
       (longestAnimation.propertyName !== undefined &&

--- a/packages/core/src/render3/instructions/animation.ts
+++ b/packages/core/src/render3/instructions/animation.ts
@@ -35,6 +35,7 @@ import {
   clearLViewNodeAnimationResolvers,
   enterClassMap,
   getClassListFromValue,
+  getEventTarget,
   getLViewEnterAnimations,
   getLViewLeaveAnimations,
   isLongestAnimation,
@@ -114,7 +115,7 @@ export function runEnterAnimation(
   // gets removed early.
   const handleEnterAnimationStart = (event: AnimationEvent | TransitionEvent) => {
     // this early exit case is to prevent issues with bubbling events that are from child element animations
-    if (event.target !== nativeElement) return;
+    if (getEventTarget(event) !== nativeElement) return;
 
     const eventName = event instanceof AnimationEvent ? 'animationend' : 'transitionend';
     ngZone.runOutsideAngular(() => {
@@ -125,7 +126,7 @@ export function runEnterAnimation(
   // When the longest animation ends, we can remove all the classes
   const handleEnterAnimationEnd = (event: AnimationEvent | TransitionEvent) => {
     // this early exit case is to prevent issues with bubbling events that are from child element animations
-    if (event.target !== nativeElement) return;
+    if (getEventTarget(event) !== nativeElement) return;
 
     if (isLongestAnimation(event, nativeElement)) {
       hasCompleted = true;
@@ -171,7 +172,7 @@ function enterAnimationEnd(
 ) {
   const elementData = enterClassMap.get(nativeElement);
   // this event.target check is to prevent issues with bubbling events that are from child element animations
-  if (event.target !== nativeElement || !elementData) return;
+  if (getEventTarget(event) !== nativeElement || !elementData) return;
   if (isLongestAnimation(event, nativeElement)) {
     // Now that we've found the longest animation, there's no need
     // to keep bubbling up this event as it's not going to apply to
@@ -327,8 +328,9 @@ function animateLeaveClassRunner(
   let hasCompleted = false;
 
   const handleOutAnimationEnd = (event: AnimationEvent | TransitionEvent | CustomEvent) => {
+    const target = getEventTarget(event as Event);
     // Custom fallback events don't have a target, so we bypass this check for them.
-    if (event.target !== el && event.type !== 'animation-fallback') return;
+    if (target !== el && event.type !== 'animation-fallback') return;
 
     if (
       event.type === 'animation-fallback' ||


### PR DESCRIPTION
This adds a util function to get the proper target, properly accounting for shadow roots.
