### PR TITLE
build: no longer require release mode for releases

### DIFF
--- a/.ng-dev/github.mjs
+++ b/.ng-dev/github.mjs
@@ -9,5 +9,5 @@ export const github = {
   name: 'angular',
   mainBranchName: 'main',
   mergeMode: 'caretaker-only',
-  requireReleaseModeForRelease: true,
+  requireReleaseModeForRelease: false,
 };


### PR DESCRIPTION
This PR updates the github.mjs configuration to set requireReleaseModeForRelease to false, removing the requirement to use release mode for releases in the angular/angular repository.