### PR TITLE
feat(devtools): Add preview for childSignalProp nodes to the signals-…

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signal-details/signal-details.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signal-details/signal-details.component.html
@@ -110,7 +110,10 @@
 
 @let isPreviewable =
   isSignalNode &&
-  (node.kind === 'signal' || node.kind === 'computed' || node.kind === 'linkedSignal');
+  (node.kind === 'signal' ||
+    node.kind === 'computed' ||
+    node.kind === 'linkedSignal' ||
+    node.kind === 'childSignalProp');
 
 @if (isPreviewable || resourceCluster()) {
   @if (previewableNode(); as previewableNode) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signals-visualizer/signals-visualizer.ts
@@ -745,7 +745,12 @@ function getBodyText(node: DevtoolsSignalGraphNode, graph: DevtoolsSignalGraph):
     return '[nodes]';
   }
 
-  if (node.kind === 'signal' || node.kind === 'computed' || node.kind === 'linkedSignal') {
+  if (
+    node.kind === 'signal' ||
+    node.kind === 'computed' ||
+    node.kind === 'linkedSignal' ||
+    node.kind === 'childSignalProp'
+  ) {
     return node.preview.preview;
   }
 


### PR DESCRIPTION
…visualizer and signal-details components.

The childSignalProp nodes were added to make it easier for users to visualize and understand when signals were being passed between components. Adding the preview for the new nodes makes the data being displayed equivalent to that of other reactive nodes in the signal graph.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
