### PR TITLE
fix(router): make currentSnapshot required in CanMatchFn

### DIFF
--- a/adev/src/content/guide/routing/route-guards.md
+++ b/adev/src/content/guide/routing/route-guards.md
@@ -125,11 +125,16 @@ It has access to the following default arguments:
 
 - `route`: `Route` - The route configuration being evaluated
 - `segments`: `UrlSegment[]` - The URL segments that have not been consumed by previous parent route evaluations
+- `currentSnapshot: PartialMatchRouteSnapshot` - The current route snapshot up to this point in the matching process
 
 It can return the [standard return guard types](#route-guard-return-types), but when it returns `false`, Angular tries other matching routes instead of completely blocking navigation.
 
 ```ts
-export const featureToggleGuard: CanMatchFn = (route: Route, segments: UrlSegment[]) => {
+export const featureToggleGuard: CanMatchFn = (
+  route: Route,
+  segments: UrlSegment[],
+  currentSnapshot: PartialMatchRouteSnapshot,
+) => {
   const featureService = inject(FeatureService);
   return featureService.isFeatureEnabled('newDashboard');
 };

--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -149,11 +149,11 @@ export type CanLoadFn = (route: Route, segments: UrlSegment[]) => MaybeAsync<Gua
 // @public
 export interface CanMatch {
     // (undocumented)
-    canMatch(route: Route, segments: UrlSegment[], currentSnapshot?: PartialMatchRouteSnapshot): MaybeAsync<GuardResult>;
+    canMatch(route: Route, segments: UrlSegment[], currentSnapshot: PartialMatchRouteSnapshot): MaybeAsync<GuardResult>;
 }
 
 // @public
-export type CanMatchFn = (route: Route, segments: UrlSegment[], currentSnapshot?: PartialMatchRouteSnapshot) => MaybeAsync<GuardResult>;
+export type CanMatchFn = (route: Route, segments: UrlSegment[], currentSnapshot: PartialMatchRouteSnapshot) => MaybeAsync<GuardResult>;
 
 // @public
 export class ChildActivationEnd {

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -129,6 +129,10 @@ bundle_entrypoints = [
         "strict-templates",
         "packages/core/schematics/migrations/strict-template/index.js",
     ],
+    [
+        "can-match-snapshot-required",
+        "packages/core/schematics/migrations/can-match-snapshot-required/index.js",
+    ],
 ]
 
 rollup.rollup(
@@ -140,6 +144,7 @@ rollup.rollup(
         "//:node_modules/magic-string",
         "//:node_modules/semver",
         "//packages/core/schematics:tsconfig_build",
+        "//packages/core/schematics/migrations/can-match-snapshot-required",
         "//packages/core/schematics/migrations/change-detection-eager",
         "//packages/core/schematics/migrations/http-xhr-backend",
         "//packages/core/schematics/migrations/strict-template",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -14,6 +14,11 @@
       "version": "22.0.0",
       "description": "Adds 'strictTemplates: true' in tsconfig.json.",
       "factory": "./bundles/strict-templates.cjs#migrate"
+    },
+    "can-match-snapshot-required": {
+      "version": "22.0.0",
+      "description": "Adds the required third argument to canMatch callsites.",
+      "factory": "./bundles/can-match-snapshot-required.cjs#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/can-match-snapshot-required/BUILD.bazel
+++ b/packages/core/schematics/migrations/can-match-snapshot-required/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//tools:defaults.bzl", "ts_project", "zoneless_jasmine_test")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "can-match-snapshot-required",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/@types/node",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli",
+        "//packages/compiler-cli/private",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":can-match-snapshot-required",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli/private",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+zoneless_jasmine_test(
+    name = "test",
+    data = [":test_lib"],
+    env = {"FORCE_COLOR": "3"},
+)

--- a/packages/core/schematics/migrations/can-match-snapshot-required/index.ts
+++ b/packages/core/schematics/migrations/can-match-snapshot-required/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {CanMatchSnapshotRequiredMigration} from './migration';
+
+interface Options {
+  path: string;
+}
+
+export function migrate(options: Options): Rule {
+  return async (tree, context) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: (fs) => new CanMatchSnapshotRequiredMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/migrations/can-match-snapshot-required/migration.spec.ts
+++ b/packages/core/schematics/migrations/can-match-snapshot-required/migration.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {absoluteFrom} from '@angular/compiler-cli';
+import {initMockFileSystem} from '@angular/compiler-cli/private/testing';
+import {runTsurgeMigration} from '../../utils/tsurge/testing';
+import {CanMatchSnapshotRequiredMigration} from './migration';
+
+describe('CanMatchSnapshotRequired migration (Type-Based)', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  it('should add the third argument to canMatch calls in classes implementing CanMatch', async () => {
+    const {fs} = await runTsurgeMigration(new CanMatchSnapshotRequiredMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          interface CanMatch {}
+          class MyGuard implements CanMatch {
+            canMatch(route: any, segments: any) {}
+          }
+          const guard = new MyGuard();
+          guard.canMatch({}, []);
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toContain('guard.canMatch({}, [], {} as any /* added by migration */)');
+  });
+
+  it('should NOT add argument if the class does NOT implement CanMatch', async () => {
+    const {fs} = await runTsurgeMigration(new CanMatchSnapshotRequiredMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          class MyGuard {
+            canMatch(route: any, segments: any) {}
+          }
+          const guard = new MyGuard();
+          guard.canMatch({}, []);
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).not.toContain('{} as any /* added by migration */');
+  });
+
+  it('should add the third argument to canMatch calls for functions typed as CanMatchFn', async () => {
+    const {fs} = await runTsurgeMigration(new CanMatchSnapshotRequiredMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          type CanMatchFn = (route: any, segments: any) => boolean;
+          const canMatch: CanMatchFn = (route, segments) => true;
+          canMatch({}, []);
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).toContain('canMatch({}, [], {} as any /* added by migration */)');
+  });
+
+  it('should NOT add argument if the function is NOT typed as CanMatchFn', async () => {
+    const {fs} = await runTsurgeMigration(new CanMatchSnapshotRequiredMigration(), [
+      {
+        name: absoluteFrom('/index.ts'),
+        isProgramRootFile: true,
+        contents: `
+          function canMatch(route: any, segments: any) { return true; }
+          canMatch({}, []);
+        `,
+      },
+    ]);
+
+    const content = fs.readFile(absoluteFrom('/index.ts'));
+    expect(content).not.toContain('{} as any /* added by migration */');
+  });
+});

--- a/packages/core/schematics/migrations/can-match-snapshot-required/migration.ts
+++ b/packages/core/schematics/migrations/can-match-snapshot-required/migration.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+
+export interface UnitAnalysisMetadata {
+  replacements: Replacement[];
+}
+
+export class CanMatchSnapshotRequiredMigration extends TsurgeFunnelMigration<
+  UnitAnalysisMetadata,
+  UnitAnalysisMetadata
+> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<UnitAnalysisMetadata>> {
+    const replacements: Replacement[] = [];
+    const {sourceFiles, program} = info;
+    const typeChecker = program.getTypeChecker();
+
+    for (const sourceFile of sourceFiles) {
+      const walk = (node: ts.Node): void => {
+        ts.forEachChild(node, walk);
+
+        if (ts.isCallExpression(node)) {
+          let shouldMigrate = false;
+
+          // 1. Method calls objective: obj.canMatch(a, b)
+          if (
+            ts.isPropertyAccessExpression(node.expression) &&
+            node.expression.name.text === 'canMatch'
+          ) {
+            const type = typeChecker.getTypeAtLocation(node.expression.expression);
+            const classSymbol = type.getSymbol();
+            if (classSymbol && classSymbol.declarations) {
+              const decl = classSymbol.declarations[0];
+              if (ts.isClassDeclaration(decl)) {
+                if (implementsInterface(decl, 'CanMatch')) {
+                  shouldMigrate = true;
+                }
+              }
+            }
+          }
+
+          // 2. Function calls objective: canMatch(a, b)
+          if (ts.isIdentifier(node.expression) && node.expression.text === 'canMatch') {
+            const type = typeChecker.getTypeAtLocation(node.expression);
+            const typeStr = typeChecker.typeToString(type);
+            if (typeStr.includes('CanMatchFn')) {
+              shouldMigrate = true;
+            }
+          }
+
+          if (shouldMigrate && node.arguments.length === 2) {
+            const lastArg = node.arguments[1];
+            replacements.push(
+              new Replacement(
+                projectFile(sourceFile, info),
+                new TextUpdate({
+                  position: lastArg.getEnd(),
+                  end: lastArg.getEnd(),
+                  toInsert: ', {} as any /* added by migration */',
+                }),
+              ),
+            );
+          }
+        }
+      };
+
+      ts.forEachChild(sourceFile, walk);
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async combine(
+    unitA: UnitAnalysisMetadata,
+    unitB: UnitAnalysisMetadata,
+  ): Promise<Serializable<UnitAnalysisMetadata>> {
+    return confirmAsSerializable({
+      replacements: [...unitA.replacements, ...unitB.replacements],
+    });
+  }
+
+  override async globalMeta(
+    combinedData: UnitAnalysisMetadata,
+  ): Promise<Serializable<UnitAnalysisMetadata>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats(globalMetadata: UnitAnalysisMetadata): Promise<Serializable<unknown>> {
+    return confirmAsSerializable({});
+  }
+
+  override async migrate(globalData: UnitAnalysisMetadata): Promise<{replacements: Replacement[]}> {
+    return {replacements: globalData.replacements};
+  }
+}
+
+function implementsInterface(decl: ts.ClassDeclaration, interfaceName: string): boolean {
+  if (!decl.heritageClauses) return false;
+
+  for (const clause of decl.heritageClauses) {
+    if (clause.token === ts.SyntaxKind.ImplementsKeyword) {
+      for (const expr of clause.types) {
+        if (ts.isIdentifier(expr.expression) && expr.expression.text === interfaceName) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -14,7 +14,7 @@ import {
   CanActivateChildFn,
   CanActivateFn,
   CanMatchFn,
-	PartialMatchRouteSnapshot,
+  PartialMatchRouteSnapshot,
   provideRouter,
   ResolveFn,
   Route,

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -14,6 +14,7 @@ import {
   CanActivateChildFn,
   CanActivateFn,
   CanMatchFn,
+	PartialMatchRouteSnapshot,
   provideRouter,
   ResolveFn,
   Route,
@@ -111,7 +112,11 @@ bootstrapApplication(App, {
 // #enddocregion
 
 // #docregion CanMatchFn
-const canMatchTeam: CanMatchFn = (route: Route, segments: UrlSegment[]) => {
+const canMatchTeam: CanMatchFn = (
+  route: Route,
+  segments: UrlSegment[],
+  currentSnapshot: PartialMatchRouteSnapshot,
+) => {
   return inject(PermissionsService).canMatch(inject(UserToken));
 };
 

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -1113,7 +1113,11 @@ export type CanDeactivateFn<T> = (
  * class CanMatchTeamSection implements CanMatch {
  *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
  *
- *   canMatch(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
+ *   canMatch(
+ *     route: Route,
+ *     segments: UrlSegment[],
+ *     currentSnapshot: PartialMatchRouteSnapshot,
+ *   ): Observable<boolean> | Promise<boolean> | boolean {
  *     return this.permissions.canAccess(this.currentUser, route, segments);
  *   }
  * }
@@ -1154,7 +1158,7 @@ export interface CanMatch {
   canMatch(
     route: Route,
     segments: UrlSegment[],
-    currentSnapshot?: PartialMatchRouteSnapshot,
+    currentSnapshot: PartialMatchRouteSnapshot,
   ): MaybeAsync<GuardResult>;
 }
 
@@ -1172,9 +1176,7 @@ export interface CanMatch {
  *
  * @param route The route configuration.
  * @param segments The URL segments that have not been consumed by previous parent route evaluations.
- * @param currentSnapshot The current route snapshot up to this point in the matching process. While this parameter is optional,
- * it will always be defined when called by the Router. It is only optional for backwards compatibility with functions defined prior
- * to the introduction of this parameter.
+ * @param currentSnapshot The current route snapshot up to this point in the matching process.
  *
  * @publicApi
  * @see {@link Route}
@@ -1183,7 +1185,7 @@ export interface CanMatch {
 export type CanMatchFn = (
   route: Route,
   segments: UrlSegment[],
-  currentSnapshot?: PartialMatchRouteSnapshot,
+  currentSnapshot: PartialMatchRouteSnapshot,
 ) => MaybeAsync<GuardResult>;
 
 /**


### PR DESCRIPTION
it was only optional to avoid a breaking change in a minor

BREAKING CHANGE: The `currentSnapshot` parameter in `CanMatchFn` and the `canMatch` method of the `CanMatch` interface is now required. While this was already the behavior of the Router at runtime, existing class implementations of `CanMatch` must now include the third argument to satisfy the interface.
