### PR TITLE
refactor(forms): make `markAsTouched()` touch all descendants by default

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -131,7 +131,7 @@ export interface FieldState<TValue, TKey extends string | number = string | numb
     readonly controlValue: WritableSignal<TValue>;
     readonly fieldTree: FieldTree<unknown, TKey>;
     markAsDirty(): void;
-    markAsTouched(): void;
+    markAsTouched(options?: MarkAsTouchedOptions): void;
     reset(value?: TValue): void;
     readonly value: WritableSignal<TValue>;
 }
@@ -282,6 +282,11 @@ export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root>
 
 // @public
 export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind.Root> = (result: TResult, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
+
+// @public
+export interface MarkAsTouchedOptions {
+    skipDescendants?: boolean;
+}
 
 // @public
 export const MAX: MetadataKey<Signal<number | undefined>, number | undefined, number | undefined>;

--- a/packages/forms/signals/compat/src/compat_field_adapter.ts
+++ b/packages/forms/signals/compat/src/compat_field_adapter.ts
@@ -94,7 +94,7 @@ export class CompatFieldAdapter implements FieldAdapter {
     if (!options.control) {
       return this.basicAdapter.createValidationState(node);
     }
-    return new CompatValidationState(options);
+    return new CompatValidationState(node, options);
   }
 
   /**

--- a/packages/forms/signals/compat/src/compat_validation_state.ts
+++ b/packages/forms/signals/compat/src/compat_validation_state.ts
@@ -14,12 +14,11 @@ import {
   extractNestedReactiveErrors,
   type CompatValidationError,
 } from '../../src/compat/validation_errors';
-import {getControlStatusSignal} from './compat_field_node';
+import {CompatFieldNode, getControlStatusSignal} from './compat_field_node';
 import {CompatFieldNodeOptions} from './compat_structure';
 
 // Readonly signal containing an empty array, used for optimization.
 const EMPTY_ARRAY_SIGNAL = computed(() => []);
-const TRUE_SIGNAL = computed(() => true);
 
 /**
  * Compat version of a validation state that wraps a FormControl, and proxies it's validation state.
@@ -36,7 +35,10 @@ export class CompatValidationState implements ValidationState {
 
   readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(() => []);
 
-  constructor(options: CompatFieldNodeOptions) {
+  constructor(
+    private readonly node: CompatFieldNode,
+    options: CompatFieldNodeOptions,
+  ) {
     this.syncValid = getControlStatusSignal(options, (c: AbstractControl) => c.status === 'VALID');
     this.errors = getControlStatusSignal(options, extractNestedReactiveErrors);
     this.pending = getControlStatusSignal(options, (c) => c.pending);
@@ -57,7 +59,12 @@ export class CompatValidationState implements ValidationState {
   rawSyncTreeErrors = EMPTY_ARRAY_SIGNAL;
   syncErrors = EMPTY_ARRAY_SIGNAL;
   rawAsyncErrors = EMPTY_ARRAY_SIGNAL;
-  shouldSkipValidation = TRUE_SIGNAL;
+
+  // Compat fields can't have validation rules applied to them; however, there are other
+  // features that depend on this property, such as `markAsTouched()`.
+  readonly shouldSkipValidation = computed(
+    () => this.node.hidden() || this.node.disabled() || this.node.readonly(),
+  );
 
   /**
    * Computes status based on whether the field is valid/invalid/pending.

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -408,24 +408,14 @@ export async function submit<TModel>(
     );
   }
 
+  node.markAsTouched();
+
   const onInvalid = options?.onInvalid as FormSubmitOptions<unknown, unknown>['onInvalid'];
-  const ignoreValidators = options?.ignoreValidators ?? 'pending';
-
-  // Determine whether or not to run the action based on the current validity.
-  let shouldRunAction = true;
-  untracked(() => {
-    markAllAsTouched(node);
-
-    if (ignoreValidators === 'none') {
-      shouldRunAction = node.valid();
-    } else if (ignoreValidators === 'pending') {
-      shouldRunAction = !node.invalid();
-    }
-  });
+  const shouldRun = shouldRunAction(node, options?.ignoreValidators);
 
   // Run the action (or alternatively the `onInvalid` callback)
   try {
-    if (shouldRunAction) {
+    if (shouldRun) {
       node.submitState.selfSubmitting.set(true);
       const errors = await untracked(() => action?.(field, detail));
       errors && setSubmissionErrors(node, errors);
@@ -452,17 +442,17 @@ export function schema<TValue>(fn: SchemaFn<TValue>): Schema<TValue> {
   return SchemaImpl.create(fn) as unknown as Schema<TValue>;
 }
 
-/** Marks a {@link node} and its descendants as touched. */
-function markAllAsTouched(node: FieldNode) {
-  // Don't mark hidden, disabled, or readonly fields as touched since they don't contribute to the
-  // form's validity. This also prevents errors from appearing immediately if they're later made
-  // interactive.
-  if (node.validationState.shouldSkipValidation()) {
-    return;
-  }
-  node.markAsTouched();
-  for (const child of node.structure.children()) {
-    markAllAsTouched(child);
+function shouldRunAction(
+  node: FieldNode,
+  ignoreValidators?: FormSubmitOptions<unknown, unknown>['ignoreValidators'],
+) {
+  switch (ignoreValidators) {
+    case 'all':
+      return true;
+    case 'none':
+      return untracked(node.valid);
+    default: // Ignore pending validators by default (or specified 'pending').
+      return !untracked(node.invalid);
   }
 }
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -58,6 +58,19 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
 }
 
 /**
+ * Options for the `markAsTouched` method.
+ *
+ * @experimental 21.2.0
+ */
+export interface MarkAsTouchedOptions {
+  /**
+   * If `true`, only marks the current field as touched.
+   * If `false` or not provided, marks the field and all its descendants as touched.
+   */
+  skipDescendants?: boolean;
+}
+
+/**
  * A type that represents either a single value of type `T` or a readonly array of `T`.
  * @template T The type of the value(s).
  *
@@ -516,9 +529,11 @@ export interface FieldState<
   markAsDirty(): void;
 
   /**
-   * Sets the touched status of the field to `true`.
+   * Sets the touched status of the field and its descendants to `true`.
+   *
+   * @param options Options for marking the field as touched.
    */
-  markAsTouched(): void;
+  markAsTouched(options?: MarkAsTouchedOptions): void;
 
   /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -17,7 +17,13 @@ import {
   REQUIRED,
 } from '../api/rules/metadata';
 import type {ValidationError} from '../api/rules/validation/validation_errors';
-import type {DisabledReason, FieldContext, FieldState, FieldTree} from '../api/types';
+import type {
+  DisabledReason,
+  FieldContext,
+  FieldState,
+  FieldTree,
+  MarkAsTouchedOptions,
+} from '../api/types';
 import type {FormField} from '../directive/form_field_directive';
 import {DYNAMIC} from '../schema/logic';
 import {LogicNode} from '../schema/logic_node';
@@ -238,14 +244,24 @@ export class FieldNode implements FieldState<unknown> {
     return this.metadataState.has(key);
   }
 
-  /**
-   * Marks this specific field as touched.
-   */
-  markAsTouched(): void {
+  markAsTouched(options?: MarkAsTouchedOptions): void {
     untracked(() => {
-      this.nodeState.markAsTouched();
+      this.markAsTouchedInternal(options);
       this.flushSync();
     });
+  }
+
+  markAsTouchedInternal(options?: MarkAsTouchedOptions): void {
+    if (this.validationState.shouldSkipValidation()) {
+      return;
+    }
+    this.nodeState.markAsTouched();
+    if (options?.skipDescendants) {
+      return;
+    }
+    for (const child of this.structure.children()) {
+      child.markAsTouchedInternal();
+    }
   }
 
   /**

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -417,7 +417,7 @@ describe('FieldNode', () => {
       expect(f().touched()).toBe(true);
     });
 
-    it('does not propagate down', () => {
+    it('propagates down by default', () => {
       const f = form(
         signal({
           a: 1,
@@ -426,8 +426,28 @@ describe('FieldNode', () => {
         {injector: TestBed.inject(Injector)},
       );
 
+      expect(f().touched()).toBe(false);
       expect(f.a().touched()).toBe(false);
+      expect(f.b().touched()).toBe(false);
       f().markAsTouched();
+      expect(f().touched()).toBe(true);
+      expect(f.a().touched()).toBe(true);
+      expect(f.b().touched()).toBe(true);
+    });
+
+    it('does not propagate down when skipDescendants is true', () => {
+      const f = form(
+        signal({
+          a: 1,
+          b: 2,
+        }),
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f().touched()).toBe(false);
+      expect(f.a().touched()).toBe(false);
+      f().markAsTouched({skipDescendants: true});
+      expect(f().touched()).toBe(true);
       expect(f.a().touched()).toBe(false);
     });
 


### PR DESCRIPTION
`markAsTouched()` now marks all descendants as touched. In general this method is called when controls update the model. Most controls update leaf nodes, in which case this change has no effect.

Marking all descendants allows triggering validation for subsections of a form, independently from having to call `submit()` on the entire form.

`markAsTouched()` now accepts a `MarkAsTouchedOptions` parameter, which includes a `skipDescendants` property. This can be used mark only the receiving field as touched: `node.markAsTouched({skipDescendants: true})`.