### PR TITLE
 ci: remove redundant `actions/checkout` steps from dev-infra workflows

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -15,7 +15,6 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: angular/dev-infra/github-actions/labeling/pull-request@9a88f495971c09574545e0ea0c2f6228b851e77a
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
@@ -24,7 +23,6 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: angular/dev-infra/github-actions/post-approval-changes@9a88f495971c09574545e0ea0c2f6228b851e77a
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
Checking out the repo is not needed for these actions.

