### PR TITLE
fix(migrations): avoid generating invalid code in ChangeDetectionStrategy.Eager migration

### DIFF
--- a/packages/core/schematics/migrations/change-detection-eager/BUILD.bazel
+++ b/packages/core/schematics/migrations/change-detection-eager/BUILD.bazel
@@ -22,6 +22,7 @@ ts_project(
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tsurge",
         "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+        "//packages/core/schematics/utils/tsurge/helpers/ast",
     ],
 )
 

--- a/packages/core/schematics/migrations/change-detection-eager/migration.spec.ts
+++ b/packages/core/schematics/migrations/change-detection-eager/migration.spec.ts
@@ -106,7 +106,7 @@ describe('ChangeDetectionEager migration', () => {
 
     const content = fs.readFile(absoluteFrom('/index.ts'));
     expect(content).toMatch(
-      /standalone: true,\n\s+changeDetection: ChangeDetectionStrategy\.Eager/,
+      /template: '',\n\s+changeDetection: ChangeDetectionStrategy\.Eager,\n\s+standalone: true/,
     );
   });
 

--- a/packages/core/schematics/migrations/change-detection-eager/migration.ts
+++ b/packages/core/schematics/migrations/change-detection-eager/migration.ts
@@ -19,6 +19,7 @@ import {
   TsurgeFunnelMigration,
 } from '../../utils/tsurge';
 import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+import {getLeadingLineWhitespaceOfNode} from '../../utils/tsurge/helpers/ast/leading_space';
 
 export interface ChangeDetectionEagerMigrationPhase1Data {
   replacements: Replacement[];
@@ -105,14 +106,8 @@ export class ChangeDetectionEagerMigration extends TsurgeFunnelMigration<
 
           if (properties.length > 0) {
             const lastProp = properties[properties.length - 1];
-            insertPos = lastProp.getEnd();
-
-            // Simpler approach: check comma after last property.
-            const textAfter = sf.text.substring(lastProp.getEnd());
-            const hasComma = /^\s*,/.test(textAfter);
-            const prefix = hasComma ? '' : ',';
-
-            toInsert = `${prefix}\n  changeDetection: ${exprText}.Eager`;
+            insertPos = lastProp.getStart();
+            toInsert = `changeDetection: ${exprText}.Eager,\n${getLeadingLineWhitespaceOfNode(lastProp)}`;
           } else {
             insertPos = metadata.getStart() + 1;
             toInsert = `\n  changeDetection: ${exprText}.Eager\n`;


### PR DESCRIPTION
Currently the migration that add `ChangeDetectionStrategy.Eager` to components tries to add the properties as last in the object literal. This can be tricky, because TS doesn't reflect the commas in the AST so we need have to do brittle string lookups to know where to insert it.

These changes switch to inserting the property before the last pre-existing property which should be a bit more robust.
