### PR TITLE
docs(forms): clarify zoneless change detection for reactive FormArray updates

### DIFF
--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -379,6 +379,26 @@ The `@for` block iterates over each form control instance provided by the aliase
 
 Each time a new alias instance is added, the new form array instance is provided its control based on the index. This lets you track each individual control when calculating the status and value of the root control.
 
+NOTE: In zoneless applications, mutating a reactive forms model (for example calling `FormArray.push()`) does not automatically schedule component change detection. If your template depends on structural model changes such as `aliases.controls`, make sure the component notifies Angular to run change detection, for example by bridging a forms observable to `ChangeDetectorRef.markForCheck()`:
+
+```ts
+import {ChangeDetectorRef, Component, inject} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+
+@Component({
+  /* ... */
+})
+export class ProfileEditor {
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  constructor() {
+    this.profileForm.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.cdr.markForCheck());
+  }
+}
+```
+
 </docs-step>
 
 ### Using `FormArrayDirective` for top-level form arrays

--- a/adev/src/content/guide/zoneless.md
+++ b/adev/src/content/guide/zoneless.md
@@ -123,6 +123,12 @@ readonly myObservableState = someObservable.pipe(pendingUntilEvent());
 The framework uses this service internally as well to prevent serialization until asynchronous tasks are complete. These include, but are not limited to,
 an ongoing Router navigation and an incomplete `HttpClient` request.
 
+### Reactive forms in zoneless applications
+
+Reactive forms model updates (`setValue`, `patchValue`, `FormArray.push`, and similar APIs) update form state and emit forms observables, but they do not automatically schedule component change detection.
+
+If a template depends on reactive forms state, connect forms observables to a change-detection notification (for example `ChangeDetectorRef.markForCheck()`), or reflect the data through signals consumed by the template.
+
 ## Testing and Debugging
 
 ### Using Zoneless in `TestBed`


### PR DESCRIPTION
## Description

This PR clarifies expected behavior for reactive forms in zoneless applications.

Reactive forms model mutations (for example `FormArray.push()`) update form state and emit forms observables, but they do not automatically schedule component change detection.

The docs now explicitly recommend connecting reactive forms observables to a change-detection notification (for example `ChangeDetectorRef.markForCheck()`), or exposing state through signals consumed by the template.

## Docs updated

- `guide/forms/reactive-forms`: added a zoneless note in the dynamic `FormArray` section with an example (`valueChanges` + `markForCheck`).
- `guide/zoneless`: added a short subsection for reactive forms expectations in zoneless mode.

Fixes #65536
