### PR TITLE
refactor(core): remove `createNgModuleRef`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -481,9 +481,6 @@ export function createEnvironmentInjector(providers: Array<Provider | Environmen
 // @public
 export function createNgModule<T>(ngModule: Type<T>, parentInjector?: Injector): NgModuleRef<T>;
 
-// @public @deprecated
-export const createNgModuleRef: typeof createNgModule;
-
 // @public
 export function createPlatform(injector: Injector): PlatformRef;
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -17,102 +17,93 @@ export * from './authoring';
 // JSCompiler's conformance requirement for inferred const exports. See:
 // https://docs.google.com/document/d/1RXb1wYwsbJotO1KBgSDsAtKpduGmIHod9ADxuXcAvV4/edit?tab=t.0
 export {input} from './authoring/input/input';
-export {contentChild, contentChildren, viewChild, viewChildren} from './authoring/queries';
 export {model} from './authoring/model/model';
+export {contentChild, contentChildren, viewChild, viewChildren} from './authoring/queries';
 
-export * from './metadata';
-export * from './version';
-export {TypeDecorator} from './util/decorators';
-export * from './di';
 export {
-  BootstrapOptions,
-  ApplicationRef,
-  APP_BOOTSTRAP_LISTENER,
-} from './application/application_ref';
-export {PlatformRef} from './platform/platform_ref';
-export {
-  createPlatform,
-  createPlatformFactory,
-  assertPlatform,
-  destroyPlatform,
-  getPlatform,
-  providePlatformInitializer,
-  createOrReusePlatformInjector as ɵcreateOrReusePlatformInjector,
-} from './platform/platform';
-export {
-  provideZoneChangeDetection,
-  NgZoneOptions,
-} from './change_detection/scheduling/ng_zone_scheduling';
-export {provideZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
-export {PendingTasks} from './pending_tasks';
-export {provideCheckNoChangesConfig} from './change_detection/provide_check_no_changes_config';
-export {enableProdMode, isDevMode} from './util/is_dev_mode';
-export {
-  APP_ID,
-  PLATFORM_INITIALIZER,
-  PLATFORM_ID,
-  ANIMATION_MODULE_TYPE,
-  CSP_NONCE,
-} from './application/application_tokens';
-export {provideStabilityDebugging} from './application/stability_debug_impl';
+  AnimationCallbackEvent,
+  AnimationFunction,
+  MAX_ANIMATION_TIMEOUT,
+} from './animation/interfaces';
+export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
 export {
   APP_INITIALIZER,
   ApplicationInitStatus,
   provideAppInitializer,
 } from './application/application_init';
-export * from './zone';
-export * from './render';
-export * from './linker';
-export * from './linker/ng_module_factory_loader_impl';
+export {ApplicationModule} from './application/application_module';
 export {
+  APP_BOOTSTRAP_LISTENER,
+  ApplicationRef,
+  BootstrapOptions,
+} from './application/application_ref';
+export {
+  ANIMATION_MODULE_TYPE,
+  APP_ID,
+  CSP_NONCE,
+  PLATFORM_ID,
+  PLATFORM_INITIALIZER,
+} from './application/application_tokens';
+export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT, ResponseInit} from './application/platform_tokens';
+export {provideStabilityDebugging} from './application/stability_debug_impl';
+export * from './change_detection';
+export {provideCheckNoChangesConfig} from './change_detection/provide_check_no_changes_config';
+export {
+  NgZoneOptions,
+  provideZoneChangeDetection,
+} from './change_detection/scheduling/ng_zone_scheduling';
+export {provideZonelessChangeDetection} from './change_detection/scheduling/zoneless_scheduling_impl';
+export * from './core_private_export';
+export * from './core_reactivity_export';
+export * from './core_render3_private_export';
+export {
+  asNativeElements,
   DebugElement,
   DebugEventListener,
   DebugNode,
-  asNativeElements,
   getDebugNode,
   Predicate,
 } from './debug/debug_node';
+export {IdleService, provideIdleServiceWith} from './defer/idle_service';
+export * from './di';
+export {DOCUMENT} from './document';
+export {ErrorHandler, provideBrowserGlobalErrorListeners} from './error_handler';
+export {EventEmitter} from './event_emitter';
 export {
-  GetTestability,
-  Testability,
-  TestabilityRegistry,
-  setTestabilityGetter,
-} from './testability/testability';
-export * from './change_detection';
-export * from './platform/platform_core_providers';
-export {
+  DEFAULT_CURRENCY_CODE,
+  LOCALE_ID,
+  MissingTranslationStrategy,
   TRANSLATIONS,
   TRANSLATIONS_FORMAT,
-  LOCALE_ID,
-  DEFAULT_CURRENCY_CODE,
-  MissingTranslationStrategy,
 } from './i18n/tokens';
-export {ApplicationModule} from './application/application_module';
 export {AbstractType, Type} from './interface/type';
-export {EventEmitter} from './event_emitter';
-export {ErrorHandler, provideBrowserGlobalErrorListeners} from './error_handler';
-export * from './core_private_export';
-export * from './core_render3_private_export';
-export * from './core_reactivity_export';
-export * from './resource';
-export {SecurityContext} from './sanitization/security';
-export {Sanitizer} from './sanitization/sanitizer';
+export * from './linker';
+export * from './linker/ng_module_factory_loader_impl';
+export * from './metadata';
+export {provideNgReflectAttributes} from './ng_reflect';
+export {PendingTasks} from './pending_tasks';
 export {
-  createNgModule,
-  createNgModuleRef,
-  createEnvironmentInjector,
-} from './render3/ng_module_ref';
-export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
-export {isStandalone} from './render3/def_getters';
+  assertPlatform,
+  createPlatform,
+  createPlatformFactory,
+  destroyPlatform,
+  getPlatform,
+  providePlatformInitializer,
+  createOrReusePlatformInjector as ɵcreateOrReusePlatformInjector,
+} from './platform/platform';
+export * from './platform/platform_core_providers';
+export {PlatformRef} from './platform/platform_ref';
+export * from './render';
 export {AfterRenderRef} from './render3/after_render/api';
-export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
-export {enableProfiling} from './render3/debug/chrome_dev_tools_performance';
 export {
-  AfterRenderOptions,
   afterEveryRender,
   afterNextRender,
+  AfterRenderOptions,
   ɵFirstAvailable,
 } from './render3/after_render/hooks';
+export {ComponentMirror, createComponent, reflectComponentType} from './render3/component';
+export {enableProfiling} from './render3/debug/chrome_dev_tools_performance';
+export {isStandalone} from './render3/def_getters';
 export {
   Binding,
   DirectiveWithBindings,
@@ -120,18 +111,23 @@ export {
   outputBinding,
   twoWayBinding,
 } from './render3/dynamic_bindings';
-export {ApplicationConfig, mergeApplicationConfig} from './application/application_config';
+export {createEnvironmentInjector, createNgModule} from './render3/ng_module_ref';
+export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
+export * from './resource';
+export {Sanitizer} from './sanitization/sanitizer';
+export {SecurityContext} from './sanitization/security';
+export {
+  GetTestability,
+  setTestabilityGetter,
+  Testability,
+  TestabilityRegistry,
+} from './testability/testability';
 export {makeStateKey, StateKey, TransferState} from './transfer_state';
 export {booleanAttribute, numberAttribute} from './util/coercion';
-export {REQUEST, REQUEST_CONTEXT, RESPONSE_INIT, ResponseInit} from './application/platform_tokens';
-export {DOCUMENT} from './document';
-export {provideNgReflectAttributes} from './ng_reflect';
-export {
-  AnimationCallbackEvent,
-  AnimationFunction,
-  MAX_ANIMATION_TIMEOUT,
-} from './animation/interfaces';
-export {IdleService, provideIdleServiceWith} from './defer/idle_service';
+export {TypeDecorator} from './util/decorators';
+export {enableProdMode, isDevMode} from './util/is_dev_mode';
+export * from './version';
+export * from './zone';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {


### PR DESCRIPTION
`createNgModuleRef` was aliased to `createNgModule`

BREAKING CHANGE: `createNgModuleRef` was removed, use `createNgModule` instead


Note: There is a single G3 usage, CL is pending.