### PR TITLE
refactor(core): remove `checkNoChanges` from the public API.

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -217,8 +217,6 @@ export enum ChangeDetectionStrategy {
 
 // @public
 export abstract class ChangeDetectorRef {
-    // @deprecated
-    abstract checkNoChanges(): void;
     abstract detach(): void;
     abstract detectChanges(): void;
     abstract markForCheck(): void;

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -98,18 +98,6 @@ export abstract class ChangeDetectorRef {
   abstract detectChanges(): void;
 
   /**
-   * Checks the change detector and its children, and throws if any changes are detected.
-   *
-   * Use in development mode to verify that running change detection doesn't introduce
-   * other changes. Calling it in production mode is a noop.
-   *
-   * @deprecated This is a test-only API that does not have a place in production interface.
-   * `checkNoChanges` is already part of an `ApplicationRef` tick when the app is running in dev
-   * mode. For more granular `checkNoChanges` validation, use `ComponentFixture`.
-   */
-  abstract checkNoChanges(): void;
-
-  /**
    * Re-attaches the previously detached view to the change detection tree.
    * Views are attached to the tree by default.
    *

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -23,6 +23,7 @@ import {
   EventEmitter,
   inject,
   Input,
+  ɵViewRef as InternalViewRef,
   OnInit,
   Output,
   provideCheckNoChangesConfig,
@@ -1398,7 +1399,7 @@ describe('change detection', () => {
         const fixture = TestBed.createComponent(NoChangesComp);
 
         expect(() => {
-          fixture.componentInstance.cdr.checkNoChanges();
+          (fixture.componentInstance.cdr as InternalViewRef<unknown>).checkNoChanges();
         }).toThrowError(
           /ExpressionChangedAfterItHasBeenCheckedError: .+ Previous value: '.*undefined'. Current value: '.*1'/gi,
         );
@@ -1411,7 +1412,9 @@ describe('change detection', () => {
         });
         const fixture = TestBed.createComponent(AppComp);
 
-        expect(() => fixture.componentInstance.cdr.checkNoChanges()).toThrowError(
+        expect(() =>
+          (fixture.componentInstance.cdr as InternalViewRef<unknown>).checkNoChanges(),
+        ).toThrowError(
           /ExpressionChangedAfterItHasBeenCheckedError: .+ Previous value: '.*undefined'. Current value: '.*1'/gi,
         );
       });
@@ -1433,7 +1436,9 @@ describe('change detection', () => {
         });
         const fixture = TestBed.createComponent(EmbeddedViewApp);
 
-        expect(() => fixture.componentInstance.cdr.checkNoChanges()).toThrowError(
+        expect(() =>
+          (fixture.componentInstance.cdr as InternalViewRef<unknown>).checkNoChanges(),
+        ).toThrowError(
           /ExpressionChangedAfterItHasBeenCheckedError: .+ Previous value: '.*undefined'. Current value: '.*true'/gi,
         );
       });
@@ -1452,7 +1457,9 @@ describe('change detection', () => {
         expect(comp.viewCheckCount).toEqual(1);
 
         comp.value = 2;
-        expect(() => fixture.componentInstance.cdr.checkNoChanges()).toThrow();
+        expect(() =>
+          (fixture.componentInstance.cdr as InternalViewRef<unknown>).checkNoChanges(),
+        ).toThrow();
         expect(comp.doCheckCount).toEqual(1);
         expect(comp.contentCheckCount).toEqual(1);
         expect(comp.viewCheckCount).toEqual(1);

--- a/packages/core/testing/src/component_fixture.ts
+++ b/packages/core/testing/src/component_fixture.ts
@@ -18,6 +18,7 @@ import {
   getDebugNode,
   ɵgetDeferBlocks as getDeferBlocks,
   inject,
+  ɵViewRef as InternalViewRef,
   NgZone,
   ɵNoopNgZone as NoopNgZone,
   RendererFactory2,
@@ -145,10 +146,11 @@ export class ComponentFixture<T> {
    * Trigger a change detection cycle for the component.
    */
   detectChanges(checkNoChanges = true): void {
-    const originalCheckNoChanges = this.componentRef.changeDetectorRef.checkNoChanges;
+    const originalCheckNoChanges = (this.componentRef.changeDetectorRef as InternalViewRef<unknown>)
+      .checkNoChanges;
     try {
       if (!checkNoChanges) {
-        this.componentRef.changeDetectorRef.checkNoChanges = () => {};
+        (this.componentRef.changeDetectorRef as InternalViewRef<unknown>).checkNoChanges = () => {};
       }
 
       if (this.zonelessEnabled) {
@@ -169,7 +171,8 @@ export class ComponentFixture<T> {
         });
       }
     } finally {
-      this.componentRef.changeDetectorRef.checkNoChanges = originalCheckNoChanges;
+      (this.componentRef.changeDetectorRef as InternalViewRef<unknown>).checkNoChanges =
+        originalCheckNoChanges;
     }
   }
 
@@ -177,7 +180,7 @@ export class ComponentFixture<T> {
    * Do a change detection run to make sure there were no changes.
    */
   checkNoChanges(): void {
-    this.changeDetectorRef.checkNoChanges();
+    (this.changeDetectorRef as InternalViewRef<unknown>).checkNoChanges();
   }
 
   /**


### PR DESCRIPTION
It's an internal API.

BREAKING CHANGE: `ChangeDetectorRef.checkNoChanges` was removed.  In tests use `fixture.detectChanges()` instead.
