### PR TITLE
refactor(compiler-cli): export TCB types and methods

### DIFF
--- a/packages/compiler-cli/private/BUILD.bazel
+++ b/packages/compiler-cli/private/BUILD.bazel
@@ -33,6 +33,7 @@ ts_project(
         "//packages/compiler-cli/src/ngtsc/transform",
         "//packages/compiler-cli/src/ngtsc/transform/jit",
         "//packages/compiler-cli/src/ngtsc/translator",
+        "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "//packages/compiler-cli/src/ngtsc/util",
     ],

--- a/packages/compiler-cli/private/tooling.ts
+++ b/packages/compiler-cli/private/tooling.ts
@@ -43,3 +43,24 @@ export const constructorParametersDownlevelTransform = (
 ): ts.TransformerFactory<ts.SourceFile> => {
   return angularJitApplicationTransform(program, isCore);
 };
+
+// TCB generation exports for ng-hybrid-preprocessor
+export {generateTypeCheckBlock} from '../src/ngtsc/typecheck/src/type_check_block';
+export type {
+  TypeCheckingConfig,
+  TcbComponentMetadata,
+  TcbTypeCheckBlockMetadata,
+  TcbTypeParameter,
+  TypeCheckId,
+  TcbDirectiveMetadata,
+  TcbPipeMetadata,
+  TemplateDiagnostic,
+  TcbReferenceMetadata,
+} from '../src/ngtsc/typecheck/api';
+export type {DomSchemaChecker} from '../src/ngtsc/typecheck/src/dom';
+export {Environment} from '../src/ngtsc/typecheck/src/environment';
+export type {OutOfBandDiagnosticRecorder} from '../src/ngtsc/typecheck/src/oob';
+export {TcbGenericContextBehavior} from '../src/ngtsc/typecheck/src/ops/context';
+export {ImportManager} from '../src/ngtsc/translator';
+export type {ReferenceEmitter} from '../src/ngtsc/imports';
+export type {ReflectionHost, ClassDeclaration} from '../src/ngtsc/reflection';


### PR DESCRIPTION
exports methods and types required for TCB generation. This would allow external tools to generate TCBs using their own analysis pipelines, separate from the compiler-cli implementations.
