### PR TITLE
refactor(compiler-cli): produce valid typescript with TCB completion …

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/completions.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/completions.ts
@@ -26,7 +26,7 @@ export class TcbComponentContextCompletionOp extends TcbOp {
   override readonly optional = false;
 
   override execute(): null {
-    const ctx = new TcbExpr('this.');
+    const ctx = new TcbExpr('this._');
     ctx.markIgnoreDiagnostics();
     ctx.addExpressionIdentifier(ExpressionIdentifier.COMPONENT_COMPLETION);
     this.scope.addStatement(ctx);


### PR DESCRIPTION
…line

global completions are done with a line in the TCB with `this.`, which isn't valid TS. Instead, completions still work with a character after, which is also valid TS.
