### PR TITLE
build: force external sourcemaps for esbuild targets

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -84,6 +84,10 @@ have sourcemaps loaded and be unminified.
 - The background service worker is found at `chrome://extensions`.
   - Click on the "Angular DevTools" extension and the "Inspect Views > service worker" button to open a debugger.
 
+### Enabling sourcemaps
+
+To enable sourcemaps you need to add the `sourcemap = "inline"` flag to the `esbuild` macro located in `tools/defaults.bzl`.
+
 ### Running End-to-End Tests
 
 Before running end-to-end tests, you need to start the development server using:

--- a/devtools/projects/shell-browser/src/app/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/app/BUILD.bazel
@@ -214,8 +214,6 @@ esbuild(
     entry_point = "detect-angular.ts",
     format = "iife",
     platform = "browser",
-    # Need to inline sourcemaps for injected scripts as Chrome doesn't seem to load them correctly otherwise.
-    sourcemap = "inline",
     splitting = False,
     target = "esnext",
     deps = [
@@ -234,8 +232,6 @@ esbuild(
     entry_point = "backend.ts",
     format = "iife",
     platform = "browser",
-    # Need to inline sourcemaps for injected scripts as Chrome doesn't seem to load them correctly otherwise.
-    sourcemap = "inline",
     splitting = False,
     target = "esnext",
     deps = [
@@ -254,8 +250,6 @@ esbuild(
     entry_point = "ng-validate.ts",
     format = "iife",
     platform = "browser",
-    # Need to inline sourcemaps for injected scripts as Chrome doesn't seem to load them correctly otherwise.
-    sourcemap = "inline",
     splitting = False,
     target = "esnext",
     deps = [
@@ -292,8 +286,6 @@ esbuild(
     entry_point = "content-script.ts",
     format = "iife",
     platform = "browser",
-    # Need to inline sourcemaps for injected scripts as Chrome doesn't seem to load them correctly otherwise.
-    sourcemap = "inline",
     splitting = False,
     target = "esnext",
     deps = [

--- a/devtools/tools/defaults.bzl
+++ b/devtools/tools/defaults.bzl
@@ -24,14 +24,17 @@ npm_sass_library = _npm_sass_library
 http_server = _http_server
 js_library = _js_library
 
-def esbuild(minify = None, sourcemap = "linked", sources_content = True, **kwargs):
+def esbuild(minify = None, **kwargs):
     _esbuild(
         minify = minify if minify != None else select({
             "//devtools:debug_build": False,
             "//conditions:default": True,
         }),
-        sourcemap = sourcemap,
-        sources_content = sources_content,
+        # Do not change this as otherwise the sourcemaps will cause the build not to be 100% preproducable and firefox will not publish the extension.
+        # NB: Do not use `select` here either as this option is not configurable and bazel doesn't resolve to a value.
+        # TODO: Remove this once aspect_rules_esbuild supports sourcemap = False
+        # See: https://github.com/aspect-build/rules_esbuild/pull/264
+        sourcemap = "external",
         **kwargs
     )
 

--- a/devtools/tools/defaults.bzl
+++ b/devtools/tools/defaults.bzl
@@ -30,7 +30,7 @@ def esbuild(minify = None, **kwargs):
             "//devtools:debug_build": False,
             "//conditions:default": True,
         }),
-        # Do not change this as otherwise the sourcemaps will cause the build not to be 100% preproducable and firefox will not publish the extension.
+        # Do not change this as otherwise the sourcemaps will cause the build not to be reproducable and firefox will not publish the extension.
         # NB: Do not use `select` here either as this option is not configurable and bazel doesn't resolve to a value.
         # TODO: Remove this once aspect_rules_esbuild supports sourcemap = False
         # See: https://github.com/aspect-build/rules_esbuild/pull/264


### PR DESCRIPTION
Update the `esbuild` macro in devtools to use `external` sourcemaps by default and remove the ability to override the `sourcemap` and `sources_content` options. This change is necessary to ensure that the build is deterministic and 100% reproducible as otherwise Firefox will not publish the build.

