### PR TITLE
fix(service-worker): preserve redirect policy on reconstructed asset requests

### DIFF
--- a/packages/service-worker/worker/src/assets.ts
+++ b/packages/service-worker/worker/src/assets.ts
@@ -501,7 +501,7 @@ export abstract class AssetGroup {
    * Create a new `Request` based on the specified URL and `RequestInit` options, preserving only
    * metadata that are known to be safe.
    *
-   * Currently, only headers are preserved.
+   * Currently, only headers and redirect policy are preserved.
    *
    * NOTE:
    *   Things like credential inclusion are intentionally omitted to avoid issues with opaque
@@ -512,7 +512,10 @@ export abstract class AssetGroup {
    *   https://github.com/angular/angular/issues/41931#issuecomment-1227601347
    */
   private newRequestWithMetadata(url: string, options: RequestInit): Request {
-    return this.adapter.newRequest(url, {headers: options.headers});
+    return this.adapter.newRequest(url, {
+      headers: options.headers,
+      redirect: options.redirect,
+    });
   }
 
   /**

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1689,6 +1689,12 @@ import {envIsSupported} from '../testing/utils';
           expect(redirectReq.mode).toBe('cors'); // The default value.
           expect((redirectReq as any).unknownOption).toBeUndefined();
         });
+
+        it('does not follow redirects when redirect policy is error', async () => {
+          await expectAsync(
+            makeRequest(scope, '/lazy/redirected.txt', undefined, {redirect: 'error'}),
+          ).toBeRejected();
+        });
       });
     });
 

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -115,7 +115,7 @@ export class MockRequest extends MockBody implements Request {
   readonly keepalive: boolean = true;
   readonly method: string = 'GET';
   readonly mode: RequestMode = 'cors';
-  readonly redirect: RequestRedirect = 'error';
+  readonly redirect: RequestRedirect = 'follow';
   readonly referrer: string = '';
   readonly referrerPolicy: ReferrerPolicy = 'no-referrer';
   readonly signal: AbortSignal = null as any;
@@ -153,6 +153,9 @@ export class MockRequest extends MockBody implements Request {
     if (init.method !== undefined) {
       this.method = init.method;
     }
+    if (init.redirect !== undefined) {
+      this.redirect = init.redirect;
+    }
     if (init.destination !== undefined) {
       this.destination = init.destination;
     }
@@ -167,6 +170,7 @@ export class MockRequest extends MockBody implements Request {
       mode: this.mode,
       credentials: this.credentials,
       headers: this.headers,
+      redirect: this.redirect,
     });
   }
 }

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -166,7 +166,7 @@ export class MockServerState {
     const url = req.url.split('?')[0];
     if (this.resources.has(url)) {
       const response = this.resources.get(url)!.clone();
-      if ((response as any).redirected && req.redirect === 'error') {
+      if (response.redirected && req.redirect === 'error') {
         throw new Error('Redirect disallowed by request policy.');
       }
       return response;

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -165,7 +165,11 @@ export class MockServerState {
     }
     const url = req.url.split('?')[0];
     if (this.resources.has(url)) {
-      return this.resources.get(url)!.clone();
+      const response = this.resources.get(url)!.clone();
+      if ((response as any).redirected && req.redirect === 'error') {
+        throw new Error('Redirect disallowed by request policy.');
+      }
+      return response;
     }
     if (this.errors.has(url)) {
       throw new Error('Intentional failure!');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`AssetGroup.newRequestWithMetadata()` reconstructs requests while preserving headers only.

In redirect handling paths (`AssetGroup.fetchFromNetwork()`), this drops an explicit `redirect` policy from the original request. As a result, a request made with `redirect: 'error'` can be reconstructed without that policy and continue through redirect-following behavior in the SW asset fetch path.

Issue Number: N/A

## What is the new behavior?

- Preserve `redirect` when reconstructing requests in `newRequestWithMetadata()`.
- Update service-worker test mocks to preserve request `redirect` semantics.
- Add a regression test that verifies redirected lazy asset requests are rejected when `redirect: 'error'` is specified.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Test plan (executed locally):

- `bazelisk test --nocache_test_results //packages/service-worker/worker/test:test --test_arg=--filter="redirect policy is error|handles redirected responses|passes headers through to the server|does not pass non-allowed metadata through to the server"`
- `bazelisk test --nocache_test_results //packages/service-worker/worker/test:test`
- `bazelisk test --nocache_test_results //packages/service-worker/test:test`

No docs were updated because this is an internal service worker request-metadata bugfix with regression coverage in existing test suites.
