### PR TITLE
Improve Defer Trigger Misconfiguration

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
@@ -12,6 +12,7 @@ import {
   TmplAstDeferredBlock,
   TmplAstDeferredTrigger,
   TmplAstHoverDeferredTrigger,
+  TmplAstIdleDeferredTrigger,
   TmplAstImmediateDeferredTrigger,
   TmplAstInteractionDeferredTrigger,
   TmplAstTimerDeferredTrigger,
@@ -58,6 +59,26 @@ function areLiteralMapsEqual(a: LiteralMap | null, b: LiteralMap | null): boolea
   }
 
   return true;
+}
+
+function getTimedTriggerValue(
+  trigger: TmplAstTimerDeferredTrigger | TmplAstIdleDeferredTrigger,
+): number | null {
+  if (trigger instanceof TmplAstTimerDeferredTrigger) {
+    return trigger.delay;
+  }
+
+  return trigger.timeout;
+}
+
+function formatTimedTrigger(
+  trigger: TmplAstTimerDeferredTrigger | TmplAstIdleDeferredTrigger,
+): string {
+  if (trigger instanceof TmplAstTimerDeferredTrigger) {
+    return `timer(${trigger.delay}ms)`;
+  }
+
+  return trigger.timeout === null ? 'idle' : `idle(${trigger.timeout}ms)`;
 }
 
 /**
@@ -119,21 +140,36 @@ class DeferTriggerMisconfiguration extends TemplateCheckWithVisitor<ErrorCode.DE
       const main = mains[0];
 
       for (const pre of prefetches) {
-        // Timer vs Timer: warn when prefetch delay >= main delay
-        const isTimerTriggger =
+        // Delay-based pairs (timer/idle): warn when prefetch fires no sooner than main.
+
+        const isTimerPair =
           main instanceof TmplAstTimerDeferredTrigger && pre instanceof TmplAstTimerDeferredTrigger;
-        if (isTimerTriggger) {
-          const mainDelay = main.delay;
-          const preDelay = pre.delay;
-          if (preDelay >= mainDelay) {
-            const msg = `The Prefetch 'timer(${preDelay}ms)' is not scheduled before the main 'timer(${mainDelay}ms)', so it won’t run prior to rendering. Lower the prefetch delay or remove it.`;
-            diags.push(
-              ctx.makeTemplateDiagnostic(
-                pre.sourceSpan ?? node.sourceSpan,
-                formatExtendedError(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION, msg),
-              ),
-            );
+
+        const isIdlePair =
+          main instanceof TmplAstIdleDeferredTrigger && pre instanceof TmplAstIdleDeferredTrigger;
+
+        if (isTimerPair || isIdlePair) {
+          const mainVal = getTimedTriggerValue(main);
+          const preVal = getTimedTriggerValue(pre);
+          const sameUntimedIdle = mainVal == null && preVal == null;
+          const comparableTimedPair = mainVal != null && preVal != null && preVal >= mainVal;
+
+          if (!sameUntimedIdle && !comparableTimedPair) {
+            continue;
           }
+
+          const msg =
+            `The Prefetch '${formatTimedTrigger(pre)}' is not scheduled before the main '${formatTimedTrigger(main)}',` +
+            ` so it won't run prior to rendering. Lower the prefetch timing or remove it.`;
+
+          diags.push(
+            ctx.makeTemplateDiagnostic(
+              pre.sourceSpan ?? node.sourceSpan,
+              formatExtendedError(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION, msg),
+            ),
+          );
+
+          continue;
         }
 
         // Reference-based triggers (hover/interaction/viewport): warn if both

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration/index.ts
@@ -135,6 +135,19 @@ class DeferTriggerMisconfiguration extends TemplateCheckWithVisitor<ErrorCode.DE
       }
     }
 
+    // `prefetch` without an explicit main trigger defaults the main trigger to `idle`,
+    if (mains.length === 0 && prefetches.length > 0) {
+      const msg =
+        `Define a main trigger when using 'prefetch' triggers. ` +
+        `Without an explicit main trigger, @defer defaults to 'idle' and prefetch may have no effect.`;
+      diags.push(
+        ctx.makeTemplateDiagnostic(
+          node.sourceSpan,
+          formatExtendedError(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION, msg),
+        ),
+      );
+    }
+
     // If there is exactly one main and at least one prefetch, compare them.
     if (mains.length === 1 && prefetches.length > 0) {
       const main = mains[0];

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
@@ -67,6 +67,35 @@ runInEachFileSystem(() => {
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
 
+    it('should emit when prefetch idle timeout >= main idle timeout', () => {
+      const diags = getDiags(`@defer (on idle(1s); prefetch on idle(2s)) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should not emit when prefetch idle timeout < main idle timeout', () => {
+      const diags = getDiags(`@defer (on idle(2s); prefetch on idle(1s)) { <div></div> }`);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should emit when prefetch idle matches main idle with no timeout', () => {
+      const diags = getDiags(`@defer (on idle; prefetch on idle) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should not emit when only main idle has timeout', () => {
+      const diags = getDiags(`@defer (on idle(1s); prefetch on idle) { <div></div> }`);
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not emit when only prefetch idle has timeout', () => {
+      const diags = getDiags(`@defer (on idle; prefetch on idle(1s)) { <div></div> }`);
+      expect(diags.length).toBe(0);
+    });
+
     it('should emit when prefetch identical to main viewport/interaction/hover', () => {
       const diags = getDiags(
         `@defer (on viewport(ref); prefetch on viewport(ref)) { <div></div> }`,

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/defer_trigger_misconfiguration/defer_trigger_misconfiguration_spec.ts
@@ -180,5 +180,33 @@ runInEachFileSystem(() => {
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
     });
+
+    it('should emit when prefetch trigger is configured without a main trigger', () => {
+      const diags = getDiags(`@defer (prefetch on viewport(ref)) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should emit when prefetch timer is configured without a main trigger', () => {
+      const diags = getDiags(`@defer (prefetch on timer(500ms)) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should emit when prefetch idle is configured without a main trigger', () => {
+      const diags = getDiags(`@defer (prefetch on idle(500)) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
+
+    it('should emit when prefetch when is configured without a main trigger', () => {
+      const diags = getDiags(`@defer (prefetch when true) { <div></div> }`);
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.DEFER_TRIGGER_MISCONFIGURATION));
+    });
   });
 });

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -770,7 +770,7 @@ describe('quick info', () => {
 
           it('prefetch (when)', () => {
             expectQuickInfo({
-              templateOverride: `@defer (prefet¦ch when title) { }`,
+              templateOverride: `@defer (on idle; prefet¦ch when title) { }`,
               expectedSpanText: 'prefetch',
               expectedDisplayString: '(keyword) prefetch',
             });
@@ -794,7 +794,7 @@ describe('quick info', () => {
 
           it('prefetch (on)', () => {
             expectQuickInfo({
-              templateOverride: `@defer (prefet¦ch on immediate) { }`,
+              templateOverride: `@defer (on idle; prefet¦ch on immediate) { }`,
               expectedSpanText: 'prefetch',
               expectedDisplayString: '(keyword) prefetch',
             });


### PR DESCRIPTION
 On top #65553

Add two commits 

### Add diagnostics for idle prefetch triggers

Since adding support for `@defer (on idle(500ms))`, some `idle` + `prefetch` timing combinations are not detected correctly.

```html
@defer (on idle(500ms); prefetch on idle(200ms) ) {
    <heavy-comp />
}
```
Currently, this throws an error that is actually incorrect
 
> NG8021: Prefetch 'idle' matches the main trigger and provides no benefit. Remove the prefetch modifier.
 

### Adds warning for prefetch without main defer trigger

Relative to https://github.com/angular/angular/issues/52746 and according examples in [documentation](https://angular.dev/guide/templates/defer#prefetching-data-with-prefetch)

For example 

```html
@defer (prefetch when someFlag) {
  <heavy-comp />
}
```

This configuration may suggest that the prefetch will only run when someFlag becomes true.
However, since the main trigger still defaults to on idle, the deferred content can be fetched earlier during the browser’s idle period, effectively bypassing the intended condition.

Closes https://github.com/angular/angular/issues/52746