### PR TITLE
docs(core): clarify provideZoneChangeDetection usage in v21+

### DIFF
--- a/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
+++ b/packages/core/src/change_detection/scheduling/ng_zone_scheduling.ts
@@ -134,8 +134,8 @@ export function internalProvideZoneChangeDetection({
  * Provides `NgZone`-based change detection for the application bootstrapped using
  * `bootstrapApplication`.
  *
- * `NgZone` is already provided in applications by default. This provider allows you to configure
- * options like `eventCoalescing` in the `NgZone`.
+ * Add this provider to use `NgZone`/ZoneJS-based change detection and configure options like
+ * `eventCoalescing` in the `NgZone`.
  *
  * If you need this provider function in an NgModule-based application, pass it as `applicationProviders` to `bootstrapModule()`.
  *


### PR DESCRIPTION
## Description

Clarifies the `provideZoneChangeDetection` API docs.

The previous wording said that `NgZone` is already provided by default and described this API primarily as a way to configure options like `eventCoalescing`. In Angular v21+, zoneless change detection is the default for new applications, so that wording is misleading for users who want to keep using ZoneJS-based change detection.

This updates the API JSDoc to make the behavior explicit:
- `provideZoneChangeDetection()` is used to opt the application into `NgZone`/ZoneJS-based change detection
- it can also be used to configure `NgZone` options such as `eventCoalescing`

Fixes #67498