### PR TITLE
docs(docs-infra): fix close button clickability and prevent layout shift

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -100,7 +100,6 @@
   &.adev-nav-primary--next,
   &.adev-nav-primary--rc {
     // change nav background to indicate this is the rc docs
-    position: relative;
     background: linear-gradient(
       140deg,
       color-mix(in srgb, var(--orange-red), transparent 60%) 0%,
@@ -116,6 +115,7 @@
       width: 100%;
       height: 100%;
       background-color: var(--octonary-contrast);
+      z-index: -1;
     }
     .adev-version-button {
       border: 1px solid var(--quinary-contrast);


### PR DESCRIPTION
Adjust the z-index to ensure the close button remains clickable.

Also remove an unnecessary `position: relative` that was causing layout shifts in the docs UI, which resulted in a visible and unintended layout movement.


## What is the current behavior?
Sidebar mobile https://next.angular.dev/

<img width="420" height="837" alt="image" src="https://github.com/user-attachments/assets/74e33b4f-2240-42fb-a291-e12c9f2d80a8" />


## What is the new behavior?
<img width="410" height="821" alt="image" src="https://github.com/user-attachments/assets/2b21402a-daac-4fec-80a3-a44b0ecd8af9" />
