### PR TITLE
docs: remove duplicate aria-hidden attribute in angular aria ngTree ex…

### DIFF
--- a/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.html
+++ b/adev/src/content/examples/aria/tree/src/single-select/basic/app/app.html
@@ -27,7 +27,6 @@
         aria-hidden="true"
         class="material-symbols-outlined selected-icon"
         translate="no"
-        aria-hidden="true"
         >check</span
       >
     </li>


### PR DESCRIPTION
…ample

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is a duplicate `aria-hidden` attribute in the `ngTree` single-select example in the docs of the Angular Aria Tree Pattern.

Issue Number: N/A

## What is the new behavior?

Remove duplicate `aria-hidden` attribute.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
