### PR TITLE
refactor(core): declare explicit reactive node prototypes types

### DIFF
--- a/packages/core/primitives/signals/src/computed.ts
+++ b/packages/core/primitives/signals/src/computed.ts
@@ -114,7 +114,7 @@ export const ERRORED: any = /* @__PURE__ */ Symbol('ERRORED');
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-const COMPUTED_NODE = /* @__PURE__ */ (() => {
+const COMPUTED_NODE: Omit<ComputedNode<unknown>, 'computation'> = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,
     value: UNSET,

--- a/packages/core/primitives/signals/src/linked_signal.ts
+++ b/packages/core/primitives/signals/src/linked_signal.ts
@@ -123,7 +123,10 @@ export function linkedSignalUpdateFn<S, D>(
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `LINKED_SIGNAL_NODE` and `REACTIVE_NODE`.
-export const LINKED_SIGNAL_NODE: object = /* @__PURE__ */ (() => {
+export const LINKED_SIGNAL_NODE: Omit<
+  LinkedSignalNode<unknown, unknown>,
+  'computation' | 'source' | 'sourceValue'
+> = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,
     value: UNSET,

--- a/packages/core/primitives/signals/src/watch.ts
+++ b/packages/core/primitives/signals/src/watch.ts
@@ -140,7 +140,7 @@ const NOOP_CLEANUP_FN: WatchCleanupFn = () => {};
 
 // Note: Using an IIFE here to ensure that the spread assignment is not considered
 // a side-effect, ending up preserving `COMPUTED_NODE` and `REACTIVE_NODE`.
-const WATCH_NODE: Partial<WatchNode> = /* @__PURE__ */ (() => {
+const WATCH_NODE: Omit<WatchNode, 'fn' | 'schedule' | 'ref'> = /* @__PURE__ */ (() => {
   return {
     ...REACTIVE_NODE,
     consumerIsAlwaysLive: true,

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -77,7 +77,10 @@ export interface AfterRenderPhaseEffectNode extends SignalNode<unknown> {
   phaseFn(previousValue?: unknown): unknown;
 }
 
-const AFTER_RENDER_PHASE_EFFECT_NODE = /* @__PURE__ */ (() => ({
+const AFTER_RENDER_PHASE_EFFECT_NODE: Omit<
+  AfterRenderPhaseEffectNode,
+  'phase' | 'sequence' | 'userFn' | 'signal' | 'registerCleanupFn'
+> = /* @__PURE__ */ (() => ({
   ...SIGNAL_NODE,
   kind: 'afterRenderEffectPhase',
   consumerIsAlwaysLive: true,


### PR DESCRIPTION
These type annotations allow TS to associate the object's properties with their corresponding declaration in the interfaces, enabling much better code navigation. For example, "Find all implementations" for `ReactiveNode.producerRecomputeValue` now finds the implementation in `COMPUTED_NODE` and `LINKED_SIGNAL_NODE`.