### PR TITLE
fix(core): allow undefined value for SimpleChange.previousValue

### DIFF
--- a/packages/core/src/change_detection/simple_change.ts
+++ b/packages/core/src/change_detection/simple_change.ts
@@ -19,7 +19,7 @@ import type {ɵINPUT_SIGNAL_BRAND_READ_TYPE} from '../authoring/input/input_sign
  */
 export class SimpleChange<T = any> {
   constructor(
-    public previousValue: T,
+    public previousValue: T | undefined,
     public currentValue: T,
     public firstChange: boolean,
   ) {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: Inaccurate typing fixed

## What is the current behavior?

The current typing does not allow `undefined` as a value for `previousValue`. However, for the first change, this is always set to `undefined`.

Issue Number: N/A

## What is the new behavior?

The new typing allows `undefined` which is already used during runtime for the first change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
