### PR TITLE
refactor(devtools): fix browser-specific styles infra

### DIFF
--- a/devtools/projects/ng-devtools/src/styles/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/styles/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "npm_sass_library", "sass_library")
+load("//devtools/tools:defaults.bzl", "npm_sass_library", "sass_binary", "sass_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -75,4 +75,14 @@ sass_library(
         ":material_sass_deps",
         ":typography",
     ],
+)
+
+sass_binary(
+    name = "firefox",
+    src = "firefox.scss",
+)
+
+sass_binary(
+    name = "chrome",
+    src = "chrome.scss",
 )

--- a/devtools/projects/ng-devtools/src/styles/chrome.scss
+++ b/devtools/projects/ng-devtools/src/styles/chrome.scss
@@ -1,0 +1,1 @@
+/* Chrome-specific global styles */

--- a/devtools/projects/ng-devtools/src/styles/firefox.scss
+++ b/devtools/projects/ng-devtools/src/styles/firefox.scss
@@ -1,0 +1,1 @@
+/* Firefox-specific global styles */

--- a/devtools/projects/shell-browser/src/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "esbuild", "extension_package", "ng_project", "sass_binary", "string_flag", "ts_project")
+load("//devtools/tools:defaults.bzl", "copy_to_directory", "esbuild", "extension_package", "ng_project", "sass_binary", "string_flag", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,6 +8,18 @@ sass_binary(
     include_paths = ["external/_main/node_modules"],
     sourcemap = False,
     deps = ["//devtools/projects/ng-devtools/src/styles:global"],
+)
+
+copy_to_directory(
+    name = "browser_specific_styles",
+    srcs = [
+        "//devtools/projects/ng-devtools/src/styles:chrome",
+        "//devtools/projects/ng-devtools/src/styles:firefox",
+    ],
+    out = "styles",
+    replace_prefixes = {
+        "devtools/projects/ng-devtools/src/styles": "",
+    },
 )
 
 ts_project(
@@ -72,6 +84,7 @@ exports_files(["index.html"])
 filegroup(
     name = "prod_app_static_files",
     srcs = [
+        ":browser_specific_styles",
         ":index.html",
         ":shell_common_styles",
     ],

--- a/devtools/src/BUILD.bazel
+++ b/devtools/src/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "esbuild", "http_server", "ng_project", "sass_binary")
+load("//devtools/tools:defaults.bzl", "copy_to_directory", "esbuild", "http_server", "ng_project", "sass_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,6 +7,18 @@ sass_binary(
     src = "styles.scss",
     sourcemap = False,
     deps = ["//devtools/projects/ng-devtools/src/styles:global"],
+)
+
+copy_to_directory(
+    name = "browser_specific_styles",
+    srcs = [
+        "//devtools/projects/ng-devtools/src/styles:chrome",
+        "//devtools/projects/ng-devtools/src/styles:firefox",
+    ],
+    out = "styles",
+    replace_prefixes = {
+        "devtools/projects/ng-devtools/src/styles": "",
+    },
 )
 
 ng_project(
@@ -43,6 +55,7 @@ exports_files(["index.html"])
 filegroup(
     name = "dev_app_static_files",
     srcs = [
+        ":browser_specific_styles",
         ":demo_styles",
         ":index.html",
         "//devtools/src/assets",


### PR DESCRIPTION
Fix browser-specific styles infrastructure. PR #62786 cleans up part of the code, but there are still services that attempt to load these stylesheets on `main`.