### PR TITLE
ci: fix exclusion of manual_api_docs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -243,8 +243,8 @@ groups:
       - >
         contains_any_globs(files, [
           'adev/**/{*,.*}',
-          'tools/manual_api_docs/blocks/**/*.md',
-          'tools/manual_api_docs/elements/**/*.md',
+          'tools/manual_api_docs/blocks/*.md',
+          'tools/manual_api_docs/elements/*.md',
         ])
     reviewers:
       users:
@@ -299,8 +299,8 @@ groups:
       - >
         contains_any_globs(files
             .exclude('.pullapprove.yml') 
-            .exclude('tools/manual_api_docs/blocks/**/*.md')
-            .exclude('tools/manual_api_docs/elements/**/*.md'),
+            .exclude('tools/manual_api_docs/blocks/*.md')
+            .exclude('tools/manual_api_docs/elements/*.md'),
         [
           '{*,.*}',
           '.agent/**/{*,.*}',


### PR DESCRIPTION
On top of #67253, dev-infra should be required for docs files
