### PR TITLE
fix(core): ensure definitions compile

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -1042,7 +1042,7 @@ export abstract class ViewportScroller {
     abstract setHistoryScrollRestoration(scrollRestoration: 'auto' | 'manual'): void;
     abstract setOffset(offset: [number, number] | (() => [number, number])): void;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: i0.ɵɵInjectableDeclaration<NullViewportScroller | BrowserViewportScroller>;
 }
 
 // @public @deprecated

--- a/goldens/public-api/core/global_utils.api.md
+++ b/goldens/public-api/core/global_utils.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { ɵɵInjectableDeclaration } from '@angular/core';
+
 // @public
 export function applyChanges(component: {}): void;
 

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import * as _angular_core from '@angular/core';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
@@ -989,7 +990,7 @@ export abstract class Injector {
     // (undocumented)
     static THROW_IF_NOT_FOUND: {};
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<Injector>;
 }
 
 // @public
@@ -1118,7 +1119,7 @@ export class IterableDiffers {
     // (undocumented)
     find(iterable: any): IterableDifferFactory;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<IterableDiffers>;
 }
 
 // @public
@@ -1160,7 +1161,7 @@ export class KeyValueDiffers {
     // (undocumented)
     find(kv: any): KeyValueDifferFactory;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<KeyValueDiffers>;
 }
 
 // @public
@@ -1417,7 +1418,7 @@ export class PendingTasks {
     add(): () => void;
     run(fn: () => Promise<unknown>): void;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<PendingTasks>;
 }
 
 // @public
@@ -1757,7 +1758,7 @@ export abstract class Sanitizer {
     // (undocumented)
     abstract sanitize(context: SecurityContext, value: {} | string | null): string | null;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<null>;
 }
 
 // @public
@@ -1918,7 +1919,7 @@ export class TransferState {
     set<T>(key: StateKey<T>, value: T): void;
     toJson(): string;
     // (undocumented)
-    static ɵprov: unknown;
+    static ɵprov: _angular_core.ɵɵInjectableDeclaration<TransferState>;
 }
 
 // @public

--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import * as _angular_core from '@angular/core';
 import { MonoTypeOperatorFunction } from 'rxjs';
 import { Observable } from 'rxjs';
 import { Subscribable } from 'rxjs';

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import * as _angular_core from '@angular/core';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -167,14 +167,14 @@ export interface InjectorTypeWithProviders<T> {
 export function ɵɵdefineInjectable<T>(opts: {
   token: unknown;
   providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'environment' | null;
-  factory: () => T;
-}): unknown {
+  factory: (parent?: Type<any>) => T;
+}): ɵɵInjectableDeclaration<T> {
   return {
     token: opts.token,
     providedIn: (opts.providedIn as any) || null,
     factory: opts.factory,
     value: undefined,
-  } as ɵɵInjectableDeclaration<T>;
+  };
 }
 
 /**

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -419,7 +419,7 @@ export function ɵɵdefineNgModule<T>(def: {
 
   /** Unique ID for the module that is used with `getModuleFactory`. */
   id?: string | null;
-}): unknown {
+}): NgModuleDef<T> {
   return noSideEffects(() => {
     const res: NgModuleDef<T> = {
       type: def.type,
@@ -608,8 +608,8 @@ export function ɵɵdefinePipe<T>(pipeDef: {
    * Whether the pipe is standalone.
    */
   standalone?: boolean;
-}): unknown {
-  return <PipeDef<T>>{
+}): PipeDef<T> {
+  return {
     type: pipeDef.type,
     name: pipeDef.name,
     factory: null,

--- a/packages/core/src/render3/interfaces/public_definitions.ts
+++ b/packages/core/src/render3/interfaces/public_definitions.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Type} from '../../interface/type';
+
 // This file contains types that will be published to npm in library typings files.
 
 // Formatting does horrible things to these declarations.
@@ -78,7 +80,9 @@ export type ɵɵInjectorDeclaration<T> = unknown;
 /**
  * @publicApi
  */
-export type ɵɵFactoryDeclaration<T, CtorDependencies extends CtorDependency[]> = unknown;
+export type ɵɵFactoryDeclaration<T, CtorDependencies extends CtorDependency[]> = (
+  parent?: Type<any>,
+) => T;
 
 /**
  * An object literal of this type is used to represent the metadata of a constructor dependency.


### PR DESCRIPTION
Includes the following changes to make sure the definitions for injectable compiler:
1. The types for the `factory` function now include the `parent` parameter.
2. `ɵɵFactoryDeclaration` is now defined as a function. We need this since the provider definition gets passed into the inejctable definition by reference.
3. `ɵɵdefineInjectable`, `ɵɵdefineNgModule` and `ɵɵdefinePipe` now return the typed definition, rather than `unknown`. This aligns with what we do for components and directives.
