### PR TITLE
refactor(compiler-cli): Export hybrid analysis from bin

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -42,6 +42,7 @@ esbuild(
         "//packages/compiler-cli/linker:files",
         "//packages/compiler-cli/linker/babel:files",
         "//packages/compiler-cli/private:files",
+        "//packages/compiler-cli/private:hybrid_analysis",
     ],
     external = [
         "@angular/compiler",

--- a/packages/compiler-cli/private/BUILD.bazel
+++ b/packages/compiler-cli/private/BUILD.bazel
@@ -12,6 +12,13 @@ copy_to_bin(
     ],
 )
 
+copy_to_bin(
+    name = "hybrid_analysis",
+    srcs = [
+        "hybrid_analysis.ts",
+    ],
+)
+
 ts_project(
     name = "private",
     srcs = glob(["*.ts"]),


### PR DESCRIPTION
This is necessary to actually use the exported symbols. Verified by building locally
