### PR TITLE
docs(router): clarify router.navigate() usage with multi-segment commands array

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -137,7 +137,11 @@ export class UserDetail {
     // To:   /users
     this.router.navigate(['..'], {relativeTo: this.route});
   }
+```
 
+When passing multiple segments in the commands array, Angular resolves them together as a single navigation path relative to the current route.
+
+```ts
   navigateToList() {
     // Angular resolves the commands array as a single navigation path relative to the current route.
     // From: /users/123


### PR DESCRIPTION
## What does this PR do?

Adds a short clarification and example explaining how Angular interprets multiple segments in the command array passed to `router.navigate()`.

This helps illustrate that the segments are resolved together as a single navigation path relative to the current route.

## Why is this useful?

The current documentation shows examples using multi-segment command arrays, but it may not be immediately clear to readers that these segments are combined into a single navigation path.

The added sentence clarifies this behavior directly before the example.

## Type of change

Documentation improvement only.

No behavioral or code changes.