### PR TITLE
refactor: ensure modules with 'declare global' are correctly handled by Rollup

### DIFF
--- a/packages/core/primitives/event-dispatch/src/earlyeventcontract.ts
+++ b/packages/core/primitives/event-dispatch/src/earlyeventcontract.ts
@@ -140,3 +140,6 @@ function removeEventListeners(
     container.removeEventListener(eventTypes[i], earlyEventHandler, /* useCapture */ capture);
   }
 }
+
+// This fixes the RollupError: Exported variable "global" is not defined.
+export {};

--- a/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
+++ b/packages/core/primitives/event-dispatch/src/event_dispatcher.ts
@@ -190,3 +190,6 @@ export function registerDispatcher(
     dispatcher.dispatch(eventInfo);
   }, Restriction.I_AM_THE_JSACTION_FRAMEWORK);
 }
+
+// This fixes the RollupError: Exported variable "global" is not defined.
+export {};

--- a/packages/core/primitives/signals/src/formatter.ts
+++ b/packages/core/primitives/signals/src/formatter.ts
@@ -159,3 +159,6 @@ export function installDevToolsSignalFormatter() {
     globalThis.devtoolsFormatters.push(formatter);
   }
 }
+
+// This fixes the RollupError: Exported variable "global" is not defined.
+export {};

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -90,3 +90,6 @@ export function initNgDevMode(): boolean {
   }
   return false;
 }
+
+// This fixes the RollupError: Exported variable "global" is not defined.
+export {};


### PR DESCRIPTION


Explicitly adding an `export {}` to modules containing `declare global` fixes an issue where Rollup would incorrectly claim that the `global` variable is not defined in the emitted `.d.ts` files.

Needed to land the latest `rules_angular`.
