### PR TITLE
docs: use lighter lodash isEqual import in equality example

### DIFF
--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -237,9 +237,9 @@ When you read a signal within an `OnPush` component's template, Angular tracks t
 When creating a signal, you can optionally provide an equality function, which will be used to check whether the new value is actually different than the previous one.
 
 ```ts
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
-const data = signal(['test'], {equal: _.isEqual});
+const data = signal(['test'], {equal: isEqual});
 
 // Even though this is a different array instance, the deep equality
 // function will consider the values to be equal, and the signal won't


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The documentation currently imports the whole Lodash library in the example:

`import _ from 'lodash';`

This increases the bundle size unnecessarily (~70 kB gzipped).

Issue Number: N/A

## What is the new behavior?

The example now imports only the needed function:

`import isEqual from 'lodash/isEqual';`

This reduces the bundle impact while keeping the example functional.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
