### PR TITLE
refactor(devtools): introduce prop-actions-menu

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/BUILD.bazel
@@ -6,7 +6,6 @@ sass_binary(
     name = "property-view-body_styles",
     src = "property-view-body.component.scss",
     deps = [
-        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer:prop-action-btn",
         "//devtools/projects/ng-devtools/src/styles:typography",
     ],
 )
@@ -23,8 +22,8 @@ ng_project(
     deps = [
         "//:node_modules/@angular/core",
         "//:node_modules/@angular/material",
-        "//devtools/projects/ng-devtools/src/lib/application-providers:supported_apis",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/dependency-viewer",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-manager",
         "//devtools/projects/ng-devtools/src/lib/shared/docs-ref-button",

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/BUILD.bazel
@@ -1,0 +1,43 @@
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "sass_library")
+
+package(default_visibility = ["//devtools:__subpackages__"])
+
+sass_binary(
+    name = "prop-actions-menu_styles",
+    src = "prop-actions-menu.component.scss",
+    deps = [
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer:prop-action-btn",
+        "//devtools/projects/ng-devtools/src/styles:typography",
+    ],
+)
+
+ng_project(
+    name = "prop-actions-menu",
+    srcs = [
+        "prop-actions-menu.component.ts",
+    ],
+    angular_assets = [
+        "prop-actions-menu.component.html",
+        ":prop-actions-menu_styles",
+    ],
+    deps = [
+        "//:node_modules/@angular/aria",
+        "//:node_modules/@angular/cdk",
+        "//:node_modules/@angular/core",
+        "//:node_modules/@angular/material",
+        "//devtools/projects/ng-devtools/src/lib/application-providers:supported_apis",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-manager",
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer:types",
+        "//devtools/projects/ng-devtools/src/lib/shared/signal-graph",
+        "//devtools/projects/protocol",
+    ],
+)
+
+sass_library(
+    name = "prop-actions-menu-cdk-styles",
+    srcs = ["_prop-actions-menu-cdk.scss"],
+    deps = [
+        "//devtools/projects/ng-devtools/src/styles:typography",
+    ],
+)

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/_prop-actions-menu-cdk.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/_prop-actions-menu-cdk.scss
@@ -1,0 +1,32 @@
+@use '../../../../../../../styles/typography';
+
+/*
+ * The file contains the styles intended for the CDK Overlay content
+ * meaning they should be loaded in the global styles file.
+ */
+
+.ng-ctx-menu-item {
+  @extend %body-01;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  background: transparent;
+  border: none;
+  gap: 0.25rem;
+  text-align: left;
+  white-space: nowrap;
+  padding: 0.2rem 0.25rem;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--quinary-contrast);
+  }
+
+  mat-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.html
@@ -1,0 +1,85 @@
+@let availableActions = this.availableActions();
+
+@if (availableActionsCount() === 1) {
+  @if (availableActions.showSignalGraph) {
+    @let graphBtnTooltip = `Show '${node().prop.name}' signal graph`;
+
+    <button
+      class="prop-action-btn show-signal"
+      type="button"
+      [matTooltip]="graphBtnTooltip"
+      [aria-label]="graphBtnTooltip"
+      (click)="showInSignalGraph($event)"
+    >
+      <mat-icon>graph_2</mat-icon>
+    </button>
+  }
+
+  @if (availableActions.logToConsole) {
+    @let tooltip = "Log '" + node().prop.name + "' to console";
+
+    <button
+      class="prop-action-btn log-value"
+      type="button"
+      [matTooltip]="tooltip"
+      [aria-label]="tooltip"
+      (click)="logValue($event)"
+    >
+      <mat-icon>terminal</mat-icon>
+    </button>
+  }
+} @else if (availableActionsCount() > 1) {
+  <button
+    ngMenuTrigger
+    #ctxMenuElement
+    #ctxMenuTrigger="ngMenuTrigger"
+    [menu]="ctxMenu()"
+    class="prop-action-btn open-menu"
+    type="button"
+    aria-label="Show property actions"
+    (click)="$event.stopPropagation()"
+  >
+    <mat-icon>more_vert</mat-icon>
+  </button>
+
+  <ng-template
+    #ctxMenuOverlay="cdkConnectedOverlay"
+    cdkAttachPopoverAsChild
+    [cdkConnectedOverlayOpen]="ctxMenuTrigger.expanded()"
+    [cdkConnectedOverlayPositions]="CTX_MENU_POSITIONS"
+    [cdkConnectedOverlay]="{
+      origin: ctxMenuElement,
+      usePopover: 'inline',
+      push: false,
+      flexibleDimensions: false,
+    }"
+  >
+    <div
+      ngMenu
+      #ctxMenu="ngMenu"
+      class="ctx-menu"
+      [style.min-height.px]="CTX_MENU_ITEM_HEIGHT * availableActionsCount()"
+    >
+      <ng-template ngMenuContent>
+        @if (availableActions.showSignalGraph) {
+          <button
+            ngMenuItem
+            value="graph"
+            class="ng-ctx-menu-item"
+            (click)="showInSignalGraph($event)"
+          >
+            <mat-icon>graph_2</mat-icon>
+            <span>Show in signal graph</span>
+          </button>
+        }
+
+        @if (availableActions.logToConsole) {
+          <button ngMenuItem value="log" class="ng-ctx-menu-item" (click)="logValue($event)">
+            <mat-icon>terminal</mat-icon>
+            <span>Log to console</span>
+          </button>
+        }
+      </ng-template>
+    </div>
+  </ng-template>
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.scss
@@ -1,0 +1,25 @@
+@use '../../../../../../shared/object-tree-explorer/prop-action-btn';
+
+/* IMPORTANT: The width is based on the current longest menu item. */
+$ctx-menu-width: 145px;
+
+:host {
+  display: inline;
+
+  .show-signal {
+    mat-icon {
+      width: 14px;
+      height: 14px;
+      font-size: 14px;
+    }
+  }
+
+  .ctx-menu {
+    border: 1px solid var(--quinary-contrast);
+    background-color: var(--senary-contrast);
+    box-shadow: 0 0 5px var(--transparent-03);
+    border-radius: 0.25rem;
+    overflow: hidden;
+    min-width: $ctx-menu-width;
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  afterRenderEffect,
+  AfterRenderRef,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  ElementRef,
+  inject,
+  Injector,
+  input,
+  output,
+  Renderer2,
+  untracked,
+  viewChild,
+} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {Menu, MenuContent, MenuItem, MenuTrigger} from '@angular/aria/menu';
+import {CdkConnectedOverlay, ConnectedPosition} from '@angular/cdk/overlay';
+
+import {FlatNode} from '../../../../../../shared/object-tree-explorer/object-tree-types';
+import {SUPPORTED_APIS} from '../../../../../../application-providers/supported_apis';
+import {DirectivePropertyResolver} from '../../../../property-resolver/directive-property-resolver';
+import {SignalGraphManager} from '../../../../signal-graph-manager/signal-graph-manager';
+import {DevtoolsSignalGraphNode} from '../../../../../../shared/signal-graph';
+
+// Based on the current design.
+// Update accordingly if that changes.
+const CTX_MENU_ITEM_HEIGHT = 22;
+
+const CTX_MENU_POSITIONS: ConnectedPosition[] = [
+  {
+    // Primary: bottom-left
+    originX: 'start',
+    originY: 'bottom',
+    overlayX: 'start',
+    overlayY: 'top',
+    offsetY: 4,
+  },
+  {
+    // Fallback: bottom-right
+    originX: 'end',
+    originY: 'bottom',
+    overlayX: 'end',
+    overlayY: 'top',
+    offsetY: 4,
+  },
+  {
+    // Fallback: top-left
+    originX: 'start',
+    originY: 'top',
+    overlayX: 'start',
+    overlayY: 'bottom',
+    offsetY: -4,
+  },
+  {
+    // Fallback: top-right
+    originX: 'end',
+    originY: 'top',
+    overlayX: 'end',
+    overlayY: 'bottom',
+    offsetY: -4,
+  },
+];
+
+interface AvailableActions {
+  logToConsole: boolean;
+  showSignalGraph: boolean;
+}
+
+@Component({
+  selector: 'ng-prop-actions-menu',
+  templateUrl: './prop-actions-menu.component.html',
+  styleUrl: './prop-actions-menu.component.scss',
+  imports: [MatTooltip, MatIcon, Menu, MenuContent, MenuItem, MenuTrigger, CdkConnectedOverlay],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PropActionsMenuComponent {
+  private readonly signalGraph = inject(SignalGraphManager);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly supportedApis = inject(SUPPORTED_APIS);
+  private readonly elementRef = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly injector = inject(Injector);
+
+  protected readonly ctxMenu = viewChild<Menu<unknown>>('ctxMenu');
+  protected readonly ctxMenuTrigger = viewChild<MenuTrigger<unknown>>('ctxMenuTrigger');
+  protected readonly ctxMenuOverlay = viewChild<CdkConnectedOverlay>('ctxMenuOverlay');
+
+  protected readonly node = input.required<FlatNode>();
+  protected readonly controller = input.required<DirectivePropertyResolver>();
+  protected readonly showSignalGraph = output<DevtoolsSignalGraphNode>();
+
+  protected readonly availableActions = computed<AvailableActions>(() => {
+    const node = this.node();
+    const supportedApis = this.supportedApis();
+
+    return {
+      logToConsole: node.level === 0,
+      showSignalGraph:
+        supportedApis.signalPropertiesInspection &&
+        supportedApis.signals &&
+        !!this.getSignalNode(node),
+    };
+  });
+
+  protected readonly availableActionsCount = computed(
+    () => Object.values(this.availableActions()).filter((a) => a).length,
+  );
+
+  protected readonly CTX_MENU_POSITIONS = CTX_MENU_POSITIONS;
+  protected readonly CTX_MENU_ITEM_HEIGHT = CTX_MENU_ITEM_HEIGHT;
+
+  constructor() {
+    let preventScrollEffect: AfterRenderRef | undefined;
+
+    effect((onCleanup) => {
+      // Eligible for a context menu.
+      if (this.availableActionsCount() > 1) {
+        untracked(() => {
+          // Load the prevent scroll effect only if needed.
+          // Realistically, it should be called once.
+          preventScrollEffect = this.preventScrollOnCtxExpanded();
+        });
+      }
+
+      onCleanup(() => {
+        preventScrollEffect?.destroy();
+      });
+    });
+  }
+
+  showInSignalGraph(e: Event): void {
+    e.stopPropagation();
+
+    const signalNode = this.getSignalNode(this.node())!;
+    this.showSignalGraph.emit(signalNode);
+    this.ctxMenu()?.close();
+  }
+
+  logValue(e: Event): void {
+    e.stopPropagation();
+
+    const node = this.node();
+    this.controller().logValue();
+    this.snackBar.open(`Logged value of '${node.prop.name}' to the console`, 'Dismiss', {
+      duration: 2000,
+      horizontalPosition: 'left',
+    });
+    this.ctxMenu()?.close();
+  }
+
+  private getSignalNode(node: FlatNode): DevtoolsSignalGraphNode | null {
+    if (node.prop.descriptor.containerType?.includes('Signal')) {
+      return this.signalGraph.graph()?.nodes.find((sn) => sn.label === node.prop.name) ?? null;
+    }
+    return null;
+  }
+
+  private preventScrollOnCtxExpanded(): AfterRenderRef {
+    let scrollableAncestor: HTMLElement | null | undefined;
+
+    return afterRenderEffect(
+      {
+        earlyRead: () => {
+          if (scrollableAncestor === undefined && this.ctxMenuTrigger()?.expanded()) {
+            // Traverse the DOM for the scrollable ancestor once,
+            // only if the context menu is opened.
+            scrollableAncestor = this.getScrollableAncestor();
+          }
+        },
+        write: () => {
+          // Note: We intentially don't abort the execution with an
+          // `if (!scrollableAncestor) return` check. expanded() needs to be
+          // reachable in the very beginning to ensure that the write phase
+          // is always executed when the signal updates.
+          if (this.ctxMenuTrigger()?.expanded()) {
+            // We want to disable scrolling when the user opens the menu.
+            // Instead of setting `overflow: hidden`, we use `pointer-events`
+            // to avoid the content displacement caused by `overflow: hidden`,
+            // that is, the disappearing scroll bar.
+            // The context menu is managed by CDK Overlay outside of this component,
+            // so it's safe to do that.
+            if (scrollableAncestor) {
+              this.renderer.setStyle(scrollableAncestor, 'pointer-events', 'none');
+            }
+          } else if (scrollableAncestor) {
+            this.renderer.removeStyle(scrollableAncestor, 'pointer-events');
+          }
+        },
+      },
+      {injector: this.injector},
+    );
+  }
+
+  private getScrollableAncestor(): HTMLElement | null {
+    const el = this.elementRef.nativeElement as HTMLElement;
+    let ancestor = el.parentElement;
+
+    while (ancestor) {
+      if (ancestor.scrollHeight > ancestor.clientHeight) {
+        return ancestor;
+      }
+      ancestor = ancestor.parentElement;
+    }
+
+    return null;
+  }
+}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.html
@@ -33,36 +33,11 @@
               (propValueUpdate)="updateValue($event)"
             >
               <ng-template let-node>
-                @if (
-                  supportedApis().signalPropertiesInspection &&
-                    signalGraphEnabled() &&
-                    getSignalNode(node);
-                  as signalNode
-                ) {
-                  @let graphBtnTooltip = `Show '${node.prop.name}' signal graph`;
-                  <button
-                    class="prop-action-btn show-signal"
-                    type="button"
-                    [matTooltip]="graphBtnTooltip"
-                    [aria-label]="graphBtnTooltip"
-                    (click)="$event.stopPropagation(); showSignalGraph.emit(signalNode)"
-                  >
-                    <mat-icon>graph_2</mat-icon>
-                  </button>
-                }
-
-                @if (node.level === 0) {
-                  @let tooltip = "Log '" + node.prop.name + "' to console";
-                  <button
-                    class="prop-action-btn log-value"
-                    type="button"
-                    [matTooltip]="tooltip"
-                    [aria-label]="tooltip"
-                    (click)="logValue($event, node)"
-                  >
-                    <mat-icon>terminal</mat-icon>
-                  </button>
-                }
+                <ng-prop-actions-menu
+                  [node]="node"
+                  [controller]="controller()"
+                  (showSignalGraph)="showSignalGraph.emit($event)"
+                />
               </ng-template>
             </ng-object-tree-explorer>
           </mat-expansion-panel>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.scss
@@ -1,5 +1,4 @@
 @use '../../../../../../styles/typography';
-@use '../../../../../shared/object-tree-explorer/prop-action-btn';
 
 :host {
   ng-docs-ref-button {
@@ -20,14 +19,6 @@
 
     ng-object-tree-explorer {
       --ote-row-indent: 0.25rem;
-
-      .show-signal {
-        mat-icon {
-          width: 14px;
-          height: 14px;
-          font-size: 14px;
-        }
-      }
     }
   }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.ts
@@ -11,17 +11,13 @@ import {
   Component,
   ɵFramework as Framework,
   computed,
-  inject,
   input,
   output,
   signal,
 } from '@angular/core';
-import {MatIcon} from '@angular/material/icon';
-import {MatTooltip} from '@angular/material/tooltip';
 import {MatExpansionModule} from '@angular/material/expansion';
-import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
 
-import {DebugSignalGraphNode, DirectivePosition} from '../../../../../../../../protocol';
+import {DirectivePosition} from '../../../../../../../../protocol';
 import {
   DirectivePropertyResolver,
   DirectiveTreeData,
@@ -29,34 +25,24 @@ import {
 import {DependencyViewerComponent} from './dependency-viewer/dependency-viewer.component';
 import {DocsRefButtonComponent} from '../../../../../shared/docs-ref-button/docs-ref-button.component';
 import {ObjectTreeExplorerComponent} from '../../../../../shared/object-tree-explorer/object-tree-explorer.component';
-import {SUPPORTED_APIS} from '../../../../../application-providers/supported_apis';
-
-import {SignalGraphManager} from '../../../signal-graph-manager/signal-graph-manager';
-import {FlatNode} from '../../../../../shared/object-tree-explorer/object-tree-types';
 import {DevtoolsSignalGraphNode} from '../../../../../shared/signal-graph';
+import {FlatNode} from '../../../../../shared/object-tree-explorer/object-tree-types';
+import {PropActionsMenuComponent} from './prop-actions-menu/prop-actions-menu.component';
 
 @Component({
   selector: 'ng-property-view-body',
   templateUrl: './property-view-body.component.html',
   styleUrls: ['./property-view-body.component.scss'],
   imports: [
-    MatIcon,
-    MatTooltip,
     MatExpansionModule,
-    MatSnackBarModule,
     DocsRefButtonComponent,
     DependencyViewerComponent,
     ObjectTreeExplorerComponent,
+    PropActionsMenuComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyViewBodyComponent {
-  private readonly _snackBar = inject(MatSnackBar);
-  private readonly signalGraph = inject(SignalGraphManager);
-  protected readonly supportedApis = inject(SUPPORTED_APIS);
-
-  protected readonly signalGraphEnabled = () => this.supportedApis().signals;
-
   readonly controller = input.required<DirectivePropertyResolver>();
   readonly directiveInputControls = input.required<DirectiveTreeData>();
   readonly directivePropControls = input.required<DirectiveTreeData>();
@@ -105,26 +91,10 @@ export class PropertyViewBodyComponent {
     this.controller().updateValue(node, newValue);
   }
 
-  logValue(e: Event, node: FlatNode): void {
-    e.stopPropagation();
-    this.controller().logValue(node);
-    this._snackBar.open(`Logged value of '${node.prop.name}' to the console`, 'Dismiss', {
-      duration: 2000,
-      horizontalPosition: 'left',
-    });
-  }
-
   handleInspect(node: FlatNode): void {
     this.inspect.emit({
       node,
       directivePosition: this.controller().directivePosition,
     });
-  }
-
-  getSignalNode(node: FlatNode): DevtoolsSignalGraphNode | null {
-    if (node.prop.descriptor.containerType?.includes('Signal')) {
-      return this.signalGraph.graph()?.nodes.find((sn) => sn.label === node.prop.name) ?? null;
-    }
-    return null;
   }
 }

--- a/devtools/projects/ng-devtools/src/styles/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/styles/BUILD.bazel
@@ -21,6 +21,7 @@ sass_library(
         ":tables",
         ":theme",
         ":typography",
+        "//devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu:prop-actions-menu-cdk-styles",
     ],
 )
 

--- a/devtools/projects/ng-devtools/src/styles/_global.scss
+++ b/devtools/projects/ng-devtools/src/styles/_global.scss
@@ -8,6 +8,7 @@
 @use './theme' as th;
 @use './inputs';
 @use './tables';
+@use '../lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu-cdk';
 
 @include mat.all-component-typographies();
 @include mat.core();

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@angular-devkit/core": "22.0.0-next.1",
     "@angular-devkit/schematics": "22.0.0-next.1",
     "@angular/animations": "workspace:*",
+    "@angular/aria": "21.3.0-next.0",
     "@angular/benchpress": "workspace: *",
     "@angular/build": "22.0.0-next.1",
     "@angular/cdk": "22.0.0-next.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@angular/animations':
         specifier: workspace:*
         version: link:packages/animations
+      '@angular/aria':
+        specifier: 21.3.0-next.0
+        version: 21.3.0-next.0(@angular/cdk@22.0.0-next.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/core@packages+core)
       '@angular/benchpress':
         specifier: 'workspace: *'
         version: link:packages/benchpress
@@ -240,7 +243,7 @@ importers:
         version: 2.1.3
       karma-jasmine:
         specifier: ^5.0.0
-        version: 5.1.0(karma@6.4.4(bufferutil@4.1.0))
+        version: 5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       karma-requirejs:
         specifier: ^1.1.0
         version: 1.1.0(karma@6.4.4(bufferutil@4.1.0))
@@ -337,7 +340,7 @@ importers:
         version: 9.0.0
       '@angular/ng-dev':
         specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#ddbbfb8f2802fcfb85c8bf6b2f78a5ea120137e7
-        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/ddbbfb8f2802fcfb85c8bf6b2f78a5ea120137e7(@modelcontextprotocol/sdk@1.27.1)
+        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/ddbbfb8f2802fcfb85c8bf6b2f78a5ea120137e7(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))
       '@babel/plugin-proposal-async-generator-functions':
         specifier: 7.20.7
         version: 7.20.7(@babel/core@7.29.0)
@@ -415,7 +418,7 @@ importers:
         version: 2.2.1
       karma-jasmine-html-reporter:
         specifier: ^2.2.0
-        version: 2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)))(karma@6.4.4(bufferutil@4.1.0))
+        version: 2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       karma-sauce-launcher:
         specifier: ^4.3.6
         version: 4.3.6(bufferutil@4.1.0)(encoding@0.1.13)(typescript@6.0.1-rc)
@@ -682,10 +685,10 @@ importers:
         version: 2.2.1
       karma-jasmine:
         specifier: 5.1.0
-        version: 5.1.0(karma@6.4.4(bufferutil@4.1.0))
+        version: 5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       karma-jasmine-html-reporter:
         specifier: 2.2.0
-        version: 2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)))(karma@6.4.4(bufferutil@4.1.0))
+        version: 2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       marked:
         specifier: 17.0.4
         version: 17.0.4
@@ -1690,6 +1693,12 @@ packages:
   '@angular-devkit/schematics@22.0.0-next.1':
     resolution: {integrity: sha512-6unx5K3XP9Fd9yPldl01EMd4qBnxk6WoxB/B5QPssIWM4BdJk4mR2ae9IOe41hxJPQc+svnSBjPbg22VzdPuMw==}
     engines: {node: ^22.22.0 || >=24.13.1, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@angular/aria@21.3.0-next.0':
+    resolution: {integrity: sha512-eFlY6mof2jWvedCoxIocBUztvZsbxpDWU0RcfO7I+ySA3uvxDrAJFZ3TCuQCO+Y5WSKgt28/VkUwxw5tx8rahg==}
+    peerDependencies:
+      '@angular/cdk': 21.3.0-next.0
+      '@angular/core': ^21.0.0-0 || ^21.1.0-0 || ^21.2.0-0 || ^21.3.0-0 || ^22.0.0-0
 
   '@angular/aria@22.0.0-next.0':
     resolution: {integrity: sha512-U9RzdqsLP678Qts7agfoBSNdVllvlkCC6FldRvuFDHESfT/7aIQMKQLorI7GnQAiMgxg+s3HCVZuwQdUkhOc4Q==}
@@ -3793,6 +3802,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -13368,6 +13378,12 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@angular/aria@21.3.0-next.0(@angular/cdk@22.0.0-next.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/core@packages+core)':
+    dependencies:
+      '@angular/cdk': 22.0.0-next.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
+      '@angular/core': link:packages/core
+      tslib: 2.8.1
+
   '@angular/aria@22.0.0-next.0(@angular/cdk@22.0.0-next.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2))(@angular/core@packages+core)':
     dependencies:
       '@angular/cdk': 22.0.0-next.0(@angular/common@packages+common)(@angular/core@packages+core)(@angular/platform-browser@packages+platform-browser)(rxjs@7.8.2)
@@ -13388,7 +13404,7 @@ snapshots:
       beasties: 0.4.1
       browserslist: 4.28.1
       esbuild: 0.27.3
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       listr2: 10.2.1
@@ -13447,7 +13463,7 @@ snapshots:
       beasties: 0.4.1
       browserslist: 4.28.1
       esbuild: 0.27.3
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       listr2: 10.2.1
@@ -13506,7 +13522,7 @@ snapshots:
       beasties: 0.4.1
       browserslist: 4.28.1
       esbuild: 0.27.3
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       istanbul-lib-instrument: 6.0.3
       jsonc-parser: 3.3.1
       listr2: 10.2.1
@@ -13567,7 +13583,7 @@ snapshots:
       '@angular-devkit/schematics': 22.0.0-next.1(chokidar@5.0.0)
       '@inquirer/prompts': 8.3.0(@types/node@20.19.37)
       '@listr2/prompt-adapter-inquirer': 4.2.1(@inquirer/prompts@8.3.0(@types/node@20.19.37))(@types/node@20.19.37)(listr2@10.2.1)
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       '@schematics/angular': 22.0.0-next.1(chokidar@5.0.0)
       '@yarnpkg/lockfile': 1.1.0
       algoliasearch: 5.49.1
@@ -13593,7 +13609,7 @@ snapshots:
       '@angular-devkit/schematics': 22.0.0-next.1(chokidar@5.0.0)
       '@inquirer/prompts': 8.3.0(@types/node@24.12.0)
       '@listr2/prompt-adapter-inquirer': 4.2.1(@inquirer/prompts@8.3.0(@types/node@20.19.37))(@types/node@24.12.0)(listr2@10.2.1)
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       '@schematics/angular': 22.0.0-next.1(chokidar@5.0.0)
       '@yarnpkg/lockfile': 1.1.0
       algoliasearch: 5.49.1
@@ -13632,12 +13648,12 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/ddbbfb8f2802fcfb85c8bf6b2f78a5ea120137e7(@modelcontextprotocol/sdk@1.27.1)':
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/ddbbfb8f2802fcfb85c8bf6b2f78a5ea120137e7(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))':
     dependencies:
       '@actions/core': 3.0.0
       '@conventional-changelog/git-client': 2.6.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)
       '@google-cloud/spanner': 8.0.0(supports-color@10.2.2)
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1)(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@6.0.6)
+      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@6.0.6)
       '@inquirer/prompts': 8.3.0(@types/node@24.12.0)
       '@inquirer/type': 4.0.3(@types/node@24.12.0)
       '@octokit/auth-app': 8.2.0
@@ -13881,7 +13897,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13901,7 +13917,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13953,7 +13969,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -14644,7 +14660,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15312,8 +15328,8 @@ snapshots:
   '@google-cloud/cloud-sql-connector@1.9.1':
     dependencies:
       '@googleapis/sqladmin': 35.2.0
-      gaxios: 7.1.4(supports-color@10.2.2)
-      google-auth-library: 10.6.1(supports-color@10.2.2)
+      gaxios: 7.1.4
+      google-auth-library: 10.6.1
       p-throttle: 7.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15357,8 +15373,8 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.39.0
       arrify: 2.0.1
       extend: 3.0.2
-      google-auth-library: 10.6.1(supports-color@10.2.2)
-      google-gax: 5.0.6(supports-color@10.2.2)
+      google-auth-library: 10.6.1
+      google-gax: 5.0.6
       heap-js: 2.7.1
       is-stream-ended: 0.1.4
       lodash.snakecase: 4.1.1
@@ -15401,14 +15417,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.27.1)(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@6.0.6)':
+  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@6.0.6)':
     dependencies:
       google-auth-library: 10.6.1(supports-color@10.2.2)
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16320,7 +16336,29 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@modelcontextprotocol/sdk@1.27.1':
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.5)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.0(express@5.2.1)
+      hono: 4.12.5
+      jose: 6.2.0
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.5)
       ajv: 8.18.0
@@ -16493,7 +16531,7 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       lru-cache: 11.2.6
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -16908,8 +16946,8 @@ snapshots:
 
   '@puppeteer/browsers@2.13.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      extract-zip: 2.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      extract-zip: 2.0.1(supports-color@8.1.1)
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.7.4
@@ -17155,7 +17193,7 @@ snapshots:
       '@secretlint/resolver': 10.2.2
       '@secretlint/types': 10.2.2
       ajv: 8.18.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       rc-config-loader: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -17164,7 +17202,7 @@ snapshots:
     dependencies:
       '@secretlint/profiler': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -17177,7 +17215,7 @@ snapshots:
       '@textlint/module-interop': 15.5.2
       '@textlint/types': 15.5.2
       chalk: 5.6.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       pluralize: 8.0.0
       strip-ansi: 7.2.0
       table: 6.9.0
@@ -17193,7 +17231,7 @@ snapshots:
       '@secretlint/profiler': 10.2.2
       '@secretlint/source-creator': 10.2.2
       '@secretlint/types': 10.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -17376,7 +17414,7 @@ snapshots:
       '@textlint/resolver': 15.5.2
       '@textlint/types': 15.5.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       js-yaml: 4.1.1
       lodash: 4.17.23
       pluralize: 2.0.0
@@ -17866,7 +17904,7 @@ snapshots:
 
   '@typescript/vfs@1.6.4(typescript@6.0.1-rc)':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.1-rc
     transitivePeerDependencies:
       - supports-color
@@ -17874,7 +17912,7 @@ snapshots:
   '@typespec/ts-http-runtime@0.3.4':
     dependencies:
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -18010,7 +18048,7 @@ snapshots:
   '@vscode/test-electron@2.5.2':
     dependencies:
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.4
@@ -18245,6 +18283,12 @@ snapshots:
       es6-promisify: 5.0.0
 
   agent-base@5.1.1: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
@@ -18808,7 +18852,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -20227,7 +20271,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       engine.io-parser: 5.2.3
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
@@ -20601,7 +20645,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -20627,16 +20671,6 @@ snapshots:
       - supports-color
 
   extend@3.0.2: {}
-
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
 
   extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
@@ -20765,7 +20799,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -20815,7 +20849,7 @@ snapshots:
       '@google-cloud/cloud-sql-connector': 1.9.1
       '@google-cloud/pubsub': 5.3.0
       '@inquirer/prompts': 7.10.1(@types/node@20.19.37)
-      '@modelcontextprotocol/sdk': 1.27.1
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       abort-controller: 3.0.0
       ajv: 8.18.0
       ajv-formats: 3.0.1
@@ -20950,7 +20984,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -21059,12 +21093,21 @@ snapshots:
   gaxios@6.7.1(encoding@0.1.13):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
       - supports-color
 
   gaxios@7.1.3(supports-color@10.2.2):
@@ -21073,6 +21116,14 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
       rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
@@ -21091,6 +21142,14 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@8.1.2(supports-color@10.2.2):
@@ -21155,7 +21214,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.0
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21311,6 +21370,17 @@ snapshots:
     dependencies:
       sparkles: 2.1.0
 
+  google-auth-library@10.6.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@10.6.1(supports-color@10.2.2):
     dependencies:
       base64-js: 1.5.1
@@ -21332,6 +21402,22 @@ snapshots:
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.1
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
       - supports-color
 
   google-gax@5.0.6(supports-color@10.2.2):
@@ -21357,8 +21443,8 @@ snapshots:
   googleapis-common@8.0.1:
     dependencies:
       extend: 3.0.2
-      gaxios: 7.1.4(supports-color@10.2.2)
-      google-auth-library: 10.6.1(supports-color@10.2.2)
+      gaxios: 7.1.4
+      google-auth-library: 10.6.1
       qs: 6.15.0
       url-template: 2.0.8
     transitivePeerDependencies:
@@ -21616,6 +21702,14 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@5.0.0(supports-color@10.2.2):
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -21627,7 +21721,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21646,7 +21740,7 @@ snapshots:
   http-proxy-middleware@3.0.5:
     dependencies:
       '@types/http-proxy': 1.17.17
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -21708,7 +21802,14 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21716,6 +21817,13 @@ snapshots:
     dependencies:
       agent-base: 6.0.2(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22132,7 +22240,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22141,7 +22249,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -22553,7 +22661,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -22710,13 +22818,13 @@ snapshots:
       is-wsl: 2.2.0
       which: 3.0.1
 
-  karma-jasmine-html-reporter@2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)))(karma@6.4.4(bufferutil@4.1.0)):
+  karma-jasmine-html-reporter@2.2.0(jasmine-core@6.1.0)(karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)))(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       jasmine-core: 6.1.0
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      karma-jasmine: 5.1.0(karma@6.4.4(bufferutil@4.1.0))
+      karma-jasmine: 5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6))
 
-  karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)):
+  karma-jasmine@5.1.0(karma@6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       jasmine-core: 4.6.1
       karma: 6.4.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -23044,7 +23152,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       flatted: 3.4.0
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -23959,10 +24067,10 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -24236,7 +24344,7 @@ snapshots:
   portfinder@1.0.38:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24438,9 +24546,9 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
       pac-proxy-agent: 7.2.0
       proxy-from-env: 1.1.0
@@ -24489,7 +24597,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.13.0
       chromium-bidi: 14.0.0(devtools-protocol@0.0.1581282)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       devtools-protocol: 0.0.1581282
       typed-query-selector: 2.12.1
       webdriver-bidi-protocol: 0.4.1
@@ -24504,9 +24612,9 @@ snapshots:
 
   puppeteer-core@5.5.0(bufferutil@4.1.0)(encoding@0.1.13):
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       devtools-protocol: 0.0.818844
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
       https-proxy-agent: 4.0.0
       node-fetch: 2.7.0(encoding@0.1.13)
       pkg-dir: 4.2.0
@@ -24601,7 +24709,7 @@ snapshots:
 
   rc-config-loader@4.1.4:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       js-yaml: 4.1.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -24847,6 +24955,13 @@ snapshots:
 
   ret@0.1.15: {}
 
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   retry-request@8.0.2(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
@@ -24967,7 +25082,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -25061,7 +25176,7 @@ snapshots:
       '@secretlint/formatter': 10.2.2
       '@secretlint/node': 10.2.2
       '@secretlint/profiler': 10.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 14.1.0
       read-pkg: 9.0.1
     transitivePeerDependencies:
@@ -25144,7 +25259,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -25376,7 +25491,7 @@ snapshots:
 
   socket.io-adapter@2.5.6(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -25386,7 +25501,7 @@ snapshots:
   socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25395,7 +25510,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       engine.io: 6.6.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       socket.io-adapter: 2.5.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       socket.io-parser: 4.2.5
@@ -25413,7 +25528,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -25480,7 +25595,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -25491,7 +25606,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -25590,7 +25705,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -25879,6 +25994,15 @@ snapshots:
     dependencies:
       debug: 4.3.1
       is2: 2.0.9
+    transitivePeerDependencies:
+      - supports-color
+
+  teeny-request@10.1.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -26183,7 +26307,7 @@ snapshots:
   tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       make-fetch-happen: 15.0.4
     transitivePeerDependencies:
       - supports-color
@@ -26389,7 +26513,7 @@ snapshots:
 
   universal-analytics@0.5.3:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Implement a context menu and add it to each property in the properties pane in order to optimize the available space by consolidating the action buttons of property items with multiple of them. Property items with a single action will retain their original behavior where the action button is directly available to click right after the displayed value.


<img width="351" height="171" alt="Screenshot 2026-03-12 at 18 43 57" src="https://github.com/user-attachments/assets/ec6bb16c-4962-4b96-8ca2-1d99ff0578ea" />
<img width="348" height="180" alt="Screenshot 2026-03-12 at 18 44 05" src="https://github.com/user-attachments/assets/fd1bb6fc-46a9-4c14-969b-ff6484ff3034" />

