### PR TITLE
docs: fix documentation links and formatting

### DIFF
--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -60,7 +60,7 @@ All expression values are converted to a string. Objects and arrays are converte
 
 Angular supports binding dynamic values into object properties and HTML attributes with square brackets.
 
-You can bind to properties on an HTML element's DOM instance, a [component](guide/components) instance, or a [directive](guide/directives) instance.
+You can bind to properties on an HTML element's DOM instance, a [component](/guide/components) instance, or a [directive](/guide/directives) instance.
 
 ### Native element properties
 
@@ -192,7 +192,7 @@ When binding `class` to an array or an object, Angular compares the previous val
 
 If an element has multiple bindings for the same CSS class, Angular resolves collisions by following its style precedence order.
 
-NOTE: Class bindings do not support space-separated class names in a single key. They also don't support mutations on objects as the reference of the binding remains the same. If you need one or the other, use the [ngClass](/api/common/NgClass) directive.
+> **Note:** Class bindings do not support space-separated class names in a single key. They also don't support mutations on objects as the reference of the binding remains the same. If you need one or the other, use the [ngClass](/api/common/NgClass) directive.
 
 ### CSS style properties
 
@@ -260,4 +260,4 @@ Angular supports binding string values to ARIA attributes.
 
 Angular writes the string value to the element’s `aria-label` attribute and removes it when the bound value is `null`.
 
-Some ARIA features expose DOM properties or directive inputs that accept structured values (such as element references). Use standard property bindings for those cases. See the [accessibility guide](best-practices/a11y#aria-attributes-and-properties) for examples and additional guidance.
+Some ARIA features expose DOM properties or directive inputs that accept structured values (such as element references). Use standard property bindings for those cases. See the [accessibility guide](/best-practices/a11y#aria-attributes-and-properties) for examples and additional guidance.

--- a/adev/src/content/guide/templates/ng-container.md
+++ b/adev/src/content/guide/templates/ng-container.md
@@ -91,7 +91,7 @@ You can also apply structural directives to `<ng-container>` elements. Common ex
 
 ## Using `<ng-container>` for injection
 
-See the Dependency Injection guide for more information on Angular's dependency injection system.
+See the [Dependency Injection guide](/guide/di) for more information on Angular's dependency injection system.
 
 When you apply a directive to `<ng-container>`, descendant elements can inject the directive or anything that the directive provides. Use this when you want to declaratively provide a value to a specific part of your template.
 


### PR DESCRIPTION
Fix multiple documentation issues across Angular.

## Changes

1. **binding.md** - Fixed broken markdown links
   - Component guide link: \(guide/components)\ → \(/guide/components)\
   - Directive guide link: \(guide/directives)\ → \(/guide/directives)\
   - Accessibility guide link: \(best-practices/a11y#...)\ → \(/best-practices/a11y#...)\

2. **binding.md** - Updated formatting
   - NOTE block converted to markdown blockquote style: \NOTE:\ → \> **Note:**\

3. **ng-container.md** - Added missing link
   - Dependency Injection guide: Added \[Dependency Injection guide](/guide/di)\ link

## Type of change

Documentation improvements only. No functional code changes.