### PR TITLE
docs: fix grammar issues in documentation

### DIFF
--- a/adev/src/content/ecosystem/custom-build-pipeline.md
+++ b/adev/src/content/ecosystem/custom-build-pipeline.md
@@ -10,7 +10,7 @@ There are some niche use cases when you may want to maintain a custom build pipe
 
 - You have an existing app using a different toolchain and you’d like to add Angular to it
 - You’re strongly coupled to [module federation](https://module-federation.io/) and unable to adopt bundler-agnostic [native federation](https://www.npmjs.com/package/@angular-architects/native-federation)
-- You’d like to create an short-lived experiment using your favorite build tool
+- You’d like to create a short-lived experiment using your favorite build tool
 
 ## What are the options?
 

--- a/adev/src/content/guide/drag-drop.md
+++ b/adev/src/content/guide/drag-drop.md
@@ -329,7 +329,7 @@ Combining `cdkDropListHasAnchor` with `cdkDropListSortingDisabled` makes it poss
 
 Drag and drop supports animations for both:
 
-- Sorting an draggable element inside a list
+- Sorting a draggable element inside a list
 - Moving the draggable element from the position that the user dropped it to the final position inside the list
 
 To set up your animations, define a CSS transition that targets the transform property. The following classes can be used for animations:

--- a/adev/src/content/guide/zoneless.md
+++ b/adev/src/content/guide/zoneless.md
@@ -60,7 +60,7 @@ use [ChangeDetectionStrategy.OnPush](/best-practices/skipping-subtrees#using-onp
 
 The `OnPush` change detection strategy is not required, but it is a recommended step towards zoneless compatibility for application components. It is not always possible for library components to use `ChangeDetectionStrategy.OnPush`.
 When a library component is a host for user-components which might use `ChangeDetectionStrategy.Eager`/`Default`, it cannot use `OnPush` because that would prevent the child component from being refreshed if it is not `OnPush` compatible and relies on ZoneJS to trigger change detection. Components can use the `Default` strategy as long as they notify Angular when change detection needs to run (calling `markForCheck`, using signals, `AsyncPipe`, etc.).
-Being a host for a user component means using an API such as `ViewContainerRef.createComponent` and not just hosting a portion of a template from a user component (i.e. content projection or a using a template ref input).
+Being a host for a user component means using an API such as `ViewContainerRef.createComponent` and not just hosting a portion of a template from a user component (i.e. content projection or using a template ref input).
 
 ### Remove `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable`
 

--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -138,7 +138,7 @@ You can repeat part of a template multiple times with Angular's `@for` block:
 </ul>
 ```
 
-Angular's uses the `track` keyword, shown in the example above, to associate data with the DOM elements created by `@for`. See [_Why is track in @for blocks important?_](guide/templates/control-flow#why-is-track-in-for-blocks-important) for more info.
+Angular uses the `track` keyword, shown in the example above, to associate data with the DOM elements created by `@for`. See [_Why is track in @for blocks important?_](guide/templates/control-flow#why-is-track-in-for-blocks-important) for more info.
 
 TIP: Want to know more about Angular templates? See the [In-depth Templates guide](guide/templates) for the full details.
 

--- a/adev/src/content/reference/migrations/outputs.md
+++ b/adev/src/content/reference/migrations/outputs.md
@@ -17,7 +17,7 @@ ng generate @angular/core:output-migration
 
 1. `@Output()` class members are updated to their `output()` equivalent.
 2. Imports in the file of components or directives, at Typescript module level, are updated as well.
-3. Migrates the APIs functions like `event.next()`, which use is not recommended, to `event.emit()` and removes `event.complete()` calls.
+3. Migrates API calls like `event.next()`, whose use is not recommended, to `event.emit()` and removes `event.complete()` calls.
 
 **Before**
 


### PR DESCRIPTION
This PR fixes 5 grammar issues in Angular documentation files:

- Fix 'an short-lived' → 'a short-lived' in custom-build-pipeline.md
- Fix 'Sorting an draggable' → 'Sorting a draggable' in drag-drop.md
- Fix 'or a using a template ref' → 'or using a template ref' in zoneless.md
- Fix 'Angular's uses' → 'Angular uses' in templates.md
- Fix 'Migrates the APIs functions ... which use is not recommended' → 'Migrates API calls ... whose use is not recommended' in outputs.md