### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -56,7 +56,7 @@ export enum Plural {
 }
 
 /**
- * Context-dependant translation forms for strings.
+ * Context-dependent translation forms for strings.
  * Typically the standalone version is for the nominative form of the word,
  * and the format version is used for the genitive case.
  * @see [CLDR website](http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles)

--- a/packages/compiler/src/i18n/serializers/placeholder.ts
+++ b/packages/compiler/src/i18n/serializers/placeholder.ts
@@ -45,7 +45,7 @@ const TAG_TO_PLACEHOLDER_NAMES: {[k: string]: string} = {
  * Returns the same placeholder name when the content is identical.
  */
 export class PlaceholderRegistry {
-  // Count the occurrence of the base name top generate a unique name
+  // Count the occurrence of the base name to generate a unique name
   private _placeHolderNameCounts: {[k: string]: number} = {};
   // Maps signature to placeholder names
   private _signatureToName: {[k: string]: string} = {};

--- a/packages/compiler/src/template/pipeline/src/phases/track_fn_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/track_fn_optimization.ts
@@ -14,7 +14,7 @@ import type {CompilationJob} from '../compilation';
 
 /**
  * `track` functions in `for` repeaters can sometimes be "optimized," i.e. transformed into inline
- * expressions, in lieu of an external function call. For example, tracking by `$index` can be be
+ * expressions, in lieu of an external function call. For example, tracking by `$index` can be
  * optimized into an inline `trackByIndex` reference. This phase checks track expressions for
  * optimizable cases.
  */

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -69,7 +69,7 @@ export function ɵɵgetReplaceMetadataURL(id: string, timestamp: string, base: s
  * Replaces the metadata of a component type and re-renders all live instances of the component.
  * @param type Class whose metadata will be replaced.
  * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
- * @param environment Syntehtic namespace imports that need to be passed along to the callback.
+ * @param environment Synthetic namespace imports that need to be passed along to the callback.
  * @param locals Local symbols from the source location that have to be exposed to the callback.
  * @param importMeta `import.meta` from the call site of the replacement function. Optional since
  *   it isn't used internally.

--- a/packages/core/src/render3/instructions/text_interpolation.ts
+++ b/packages/core/src/render3/instructions/text_interpolation.ts
@@ -29,7 +29,7 @@ import {
  *
  * Update text content with a lone bound value
  *
- * Used when a text node has 1 interpolated value in it, an no additional text
+ * Used when a text node has 1 interpolated value in it, and no additional text
  * surrounds that interpolated value:
  *
  * ```html

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -156,7 +156,7 @@ export function retrieveTransferredState(
   if (script?.textContent) {
     try {
       // Avoid using any here as it triggers lint errors in google3 (any is not allowed).
-      // Decoding of `<` is done of the box by browsers and node.js, same behaviour as G3
+      // Decoding of `<` is done out of the box by browsers and node.js, same behaviour as G3
       // script_builders.
       return JSON.parse(script.textContent) as {};
     } catch (e) {


### PR DESCRIPTION
This PR fixes 6 typos in code comments across Angular packages:

- Fix 'Syntehtic' → 'Synthetic' in packages/core/src/render3/hmr.ts
- Fix 'an no additional' → 'and no additional' in packages/core/src/render3/instructions/text_interpolation.ts
- Fix 'Context-dependant' → 'Context-dependent' in packages/common/src/i18n/locale_data_api.ts
- Fix 'done of the box' → 'done out of the box' in packages/core/src/transfer_state.ts
- Fix 'can be be' → 'can be' in packages/compiler/src/template/pipeline/src/phases/track_fn_optimization.ts
- Fix 'top generate' → 'to generate' in packages/compiler/src/i18n/serializers/placeholder.ts