### PR TITLE
Remove tap highlight for API reference list filter

### DIFF
--- a/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
+++ b/adev/src/app/features/references/api-reference-list/api-reference-list.component.scss
@@ -25,6 +25,7 @@
     border-block-end: 1px solid var(--senary-contrast);
     padding-block-end: 2rem;
     margin-block-end: 1rem;
+    -webkit-tap-highlight-color: transparent;
 
     .adev-reference-list-type-filter-label {
       margin-block: 2.5rem 1rem;


### PR DESCRIPTION
 
## What is the current behavior?

 

https://github.com/user-attachments/assets/b91a57e1-3bdd-4a2a-94ff-eb9ebacc76fc



## What is the new behavior?

 

https://github.com/user-attachments/assets/779607c1-1cdb-4205-b205-74a1055b0623

