### PR TITLE
docs: combine multiple documentation typo fixes

### DIFF
--- a/adev/src/content/ecosystem/custom-build-pipeline.md
+++ b/adev/src/content/ecosystem/custom-build-pipeline.md
@@ -10,7 +10,7 @@ There are some niche use cases when you may want to maintain a custom build pipe
 
 - You have an existing app using a different toolchain and you’d like to add Angular to it
 - You’re strongly coupled to [module federation](https://module-federation.io/) and unable to adopt bundler-agnostic [native federation](https://www.npmjs.com/package/@angular-architects/native-federation)
-- You’d like to create an short-lived experiment using your favorite build tool
+- You’d like to create a short-lived experiment using your favorite build tool
 
 ## What are the options?
 

--- a/adev/src/content/guide/directives/structural-directives.md
+++ b/adev/src/content/guide/directives/structural-directives.md
@@ -56,7 +56,7 @@ The second piece of syntax is a key-expression pair, `from source`. `from` is a 
 
 ## One structural directive per element
 
-You can only apply one structural directive per element when using the shorthand syntax. This is because there is only one `<ng-template>` element onto which that directive gets unwrapped. Multiple directives would require multiple nested `<ng-template>`, and it's unclear which directive should be first. `<ng-container>` can be used when to create wrapper layers when multiple structural directives need to be applied around the same physical DOM element or component, which allows the user to define the nested structure.
+You can only apply one structural directive per element when using the shorthand syntax. This is because there is only one `<ng-template>` element onto which that directive gets unwrapped. Multiple directives would require multiple nested `<ng-template>`, and it's unclear which directive should be first. `<ng-container>` can be used to create wrapper layers when multiple structural directives need to be applied around the same physical DOM element or component, which allows the user to define the nested structure.
 
 ## Creating a structural directive
 

--- a/adev/src/content/guide/drag-drop.md
+++ b/adev/src/content/guide/drag-drop.md
@@ -329,7 +329,7 @@ Combining `cdkDropListHasAnchor` with `cdkDropListSortingDisabled` makes it poss
 
 Drag and drop supports animations for both:
 
-- Sorting an draggable element inside a list
+- Sorting a draggable element inside a list
 - Moving the draggable element from the position that the user dropped it to the final position inside the list
 
 To set up your animations, define a CSS transition that targets the transform property. The following classes can be used for animations:

--- a/adev/src/content/guide/routing/define-routes.md
+++ b/adev/src/content/guide/routing/define-routes.md
@@ -211,7 +211,7 @@ const routes: Routes = [
 ];
 ```
 
-The page `title` property can be set dynamincally to a resolver function using [`ResolveFn`](/api/router/ResolveFn).
+The page `title` property can be set dynamically to a resolver function using [`ResolveFn`](/api/router/ResolveFn).
 
 ```ts
 const titleResolver: ResolveFn<string> = (route) => route.queryParams['id'];

--- a/adev/src/content/guide/templates/binding.md
+++ b/adev/src/content/guide/templates/binding.md
@@ -60,7 +60,7 @@ All expression values are converted to a string. Objects and arrays are converte
 
 Angular supports binding dynamic values into object properties and HTML attributes with square brackets.
 
-You can bind to properties on an HTML element's DOM instance, a [component](guide/components) instance, or a [directive](guide/directives) instance.
+You can bind to properties on an HTML element's DOM instance, a [component](/guide/components) instance, or a [directive](/guide/directives) instance.
 
 ### Native element properties
 
@@ -192,7 +192,7 @@ When binding `class` to an array or an object, Angular compares the previous val
 
 If an element has multiple bindings for the same CSS class, Angular resolves collisions by following its style precedence order.
 
-NOTE: Class bindings do not support space-separated class names in a single key. They also don't support mutations on objects as the reference of the binding remains the same. If you need one or the other, use the [ngClass](/api/common/NgClass) directive.
+> **Note:** Class bindings do not support space-separated class names in a single key. They also don't support mutations on objects as the reference of the binding remains the same. If you need one or the other, use the [ngClass](/api/common/NgClass) directive.
 
 ### CSS style properties
 
@@ -260,4 +260,4 @@ Angular supports binding string values to ARIA attributes.
 
 Angular writes the string value to the element’s `aria-label` attribute and removes it when the bound value is `null`.
 
-Some ARIA features expose DOM properties or directive inputs that accept structured values (such as element references). Use standard property bindings for those cases. See the [accessibility guide](best-practices/a11y#aria-attributes-and-properties) for examples and additional guidance.
+Some ARIA features expose DOM properties or directive inputs that accept structured values (such as element references). Use standard property bindings for those cases. See the [accessibility guide](/best-practices/a11y#aria-attributes-and-properties) for examples and additional guidance.

--- a/adev/src/content/guide/templates/ng-container.md
+++ b/adev/src/content/guide/templates/ng-container.md
@@ -91,7 +91,7 @@ You can also apply structural directives to `<ng-container>` elements. Common ex
 
 ## Using `<ng-container>` for injection
 
-See the Dependency Injection guide for more information on Angular's dependency injection system.
+See the [Dependency Injection guide](/guide/di) for more information on Angular's dependency injection system.
 
 When you apply a directive to `<ng-container>`, descendant elements can inject the directive or anything that the directive provides. Use this when you want to declaratively provide a value to a specific part of your template.
 

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -863,7 +863,7 @@ beforeEach(() => {
 });
 ```
 
-HELPFUL: The `set` key in this example replaces all the exisiting imports on your component, make sure to imports all dependencies, not only the stubs. Alternatively you can use the `remove`/`add` keys to selectively remove and add imports.
+HELPFUL: The `set` key in this example replaces all the existing imports on your component, make sure to import all dependencies, not only the stubs. Alternatively you can use the `remove`/`add` keys to selectively remove and add imports.
 
 ### `NO_ERRORS_SCHEMA`
 

--- a/adev/src/content/guide/zoneless.md
+++ b/adev/src/content/guide/zoneless.md
@@ -60,7 +60,7 @@ use [ChangeDetectionStrategy.OnPush](/best-practices/skipping-subtrees#using-onp
 
 The `OnPush` change detection strategy is not required, but it is a recommended step towards zoneless compatibility for application components. It is not always possible for library components to use `ChangeDetectionStrategy.OnPush`.
 When a library component is a host for user-components which might use `ChangeDetectionStrategy.Eager`/`Default`, it cannot use `OnPush` because that would prevent the child component from being refreshed if it is not `OnPush` compatible and relies on ZoneJS to trigger change detection. Components can use the `Default` strategy as long as they notify Angular when change detection needs to run (calling `markForCheck`, using signals, `AsyncPipe`, etc.).
-Being a host for a user component means using an API such as `ViewContainerRef.createComponent` and not just hosting a portion of a template from a user component (i.e. content projection or a using a template ref input).
+Being a host for a user component means using an API such as `ViewContainerRef.createComponent` and not just hosting a portion of a template from a user component (i.e. content projection or using a template ref input).
 
 ### Remove `NgZone.onMicrotaskEmpty`, `NgZone.onUnstable`, `NgZone.isStable`, or `NgZone.onStable`
 

--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -138,7 +138,7 @@ You can repeat part of a template multiple times with Angular's `@for` block:
 </ul>
 ```
 
-Angular's uses the `track` keyword, shown in the example above, to associate data with the DOM elements created by `@for`. See [_Why is track in @for blocks important?_](guide/templates/control-flow#why-is-track-in-for-blocks-important) for more info.
+Angular uses the `track` keyword, shown in the example above, to associate data with the DOM elements created by `@for`. See [_Why is track in @for blocks important?_](guide/templates/control-flow#why-is-track-in-for-blocks-important) for more info.
 
 TIP: Want to know more about Angular templates? See the [In-depth Templates guide](guide/templates) for the full details.
 

--- a/adev/src/content/reference/migrations/outputs.md
+++ b/adev/src/content/reference/migrations/outputs.md
@@ -17,7 +17,7 @@ ng generate @angular/core:output-migration
 
 1. `@Output()` class members are updated to their `output()` equivalent.
 2. Imports in the file of components or directives, at Typescript module level, are updated as well.
-3. Migrates the APIs functions like `event.next()`, which use is not recommended, to `event.emit()` and removes `event.complete()` calls.
+3. Migrates API calls like `event.next()`, whose use is not recommended, to `event.emit()` and removes `event.complete()` calls.
 
 **Before**
 

--- a/adev/src/content/reference/migrations/route-lazy-loading.md
+++ b/adev/src/content/reference/migrations/route-lazy-loading.md
@@ -1,6 +1,6 @@
 # Migration to lazy-loaded routes
 
-This schematic helps developers to convert eagerly loaded component routes to lazy loaded routes. This allows the build process to split the production bundle into smaller chunks, to avoid big JS bundle that includes all routes, which negatively affects initial page load of an application.
+This schematic helps developers to convert eagerly loaded component routes to lazy loaded routes. This allows the build process to split the production bundle into smaller chunks, to avoid a big JS bundle that includes all routes, which negatively affects initial page load of an application.
 
 Run the schematic using the following command:
 

--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
@@ -14,7 +14,7 @@ When working in the browser playground, you do not need to `ng serve` to run the
 <docs-workflow>
 
 <docs-step title="Download the default app">
-Start by clicking the "Download" icon in the top right pan of the code editor. This will download a `.zip` file containing the source code for this tutorial. Open this in your local Terminal and IDE then move on to testing the default app.
+Start by clicking the "Download" icon in the top right pane of the code editor. This will download a `.zip` file containing the source code for this tutorial. Open this in your local Terminal and IDE then move on to testing the default app.
 
 At any step in the tutorial, you can click this icon to download the step's source code and start from there.
 </docs-step>


### PR DESCRIPTION
This PR combines several small documentation and comment typo fixes that were previously submitted as separate pull requests.

As suggested by the maintainer, these changes are consolidated into a single PR to simplify the review process.

Included changes from:

#67664
#67663
#67662
#67661

All fixes are documentation or comment typos and do not change functionality.