### PR TITLE
docs(adev): reset webcontainer counter after OOM warning dismissal

### DIFF
--- a/adev/src/app/editor/alert-manager.service.spec.ts
+++ b/adev/src/app/editor/alert-manager.service.spec.ts
@@ -77,7 +77,7 @@ describe('AlertManager', () => {
   it('should reset instances counter after dismissing out-of-memory warning', () => {
     storageMap.set(
       WEBCONTAINERS_COUNTER_KEY,
-      (MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES).toString(),
+      MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES.toString(),
     );
 
     service.init();

--- a/adev/src/app/editor/alert-manager.service.spec.ts
+++ b/adev/src/app/editor/alert-manager.service.spec.ts
@@ -1,0 +1,88 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {LOCAL_STORAGE, WINDOW} from '@angular/docs';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {Subject} from 'rxjs';
+import {
+  AlertManager,
+  MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES,
+  WEBCONTAINERS_COUNTER_KEY,
+} from './alert-manager.service';
+
+describe('AlertManager', () => {
+  let service: AlertManager;
+  let storageMap: Map<string, string>;
+  let localStorageMock: Pick<Storage, 'getItem' | 'setItem'>;
+  let beforeUnloadHandler: (() => void) | undefined;
+  let snackBarAction$: Subject<void>;
+  let snackBarMock: {openFromComponent: jasmine.Spy};
+
+  beforeEach(() => {
+    storageMap = new Map<string, string>();
+    localStorageMock = {
+      getItem: (key: string) => storageMap.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storageMap.set(key, value);
+      },
+    };
+
+    const fakeWindow = {
+      addEventListener: (eventName: string, callback: () => void) => {
+        if (eventName === 'beforeunload') {
+          beforeUnloadHandler = callback;
+        }
+      },
+    };
+
+    snackBarAction$ = new Subject<void>();
+    snackBarMock = {
+      openFromComponent: jasmine.createSpy().and.returnValue({
+        onAction: () => snackBarAction$.asObservable(),
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AlertManager,
+        {provide: LOCAL_STORAGE, useValue: localStorageMock},
+        {provide: WINDOW, useValue: fakeWindow},
+        {provide: MatSnackBar, useValue: snackBarMock},
+      ],
+    });
+
+    service = TestBed.inject(AlertManager);
+  });
+
+  it('should increment running webcontainer instances on init', () => {
+    service.init();
+
+    expect(storageMap.get(WEBCONTAINERS_COUNTER_KEY)).toBe('1');
+  });
+
+  it('should decrement running webcontainer instances on beforeunload', () => {
+    service.init();
+
+    beforeUnloadHandler?.();
+
+    expect(storageMap.get(WEBCONTAINERS_COUNTER_KEY)).toBe('0');
+  });
+
+  it('should reset instances counter after dismissing out-of-memory warning', () => {
+    storageMap.set(
+      WEBCONTAINERS_COUNTER_KEY,
+      (MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES).toString(),
+    );
+
+    service.init();
+    snackBarAction$.next();
+
+    expect(storageMap.get(WEBCONTAINERS_COUNTER_KEY)).toBe('0');
+  });
+});

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -94,12 +94,22 @@ export class AlertManager {
         break;
     }
 
-    this.snackBar.openFromComponent(ErrorSnackBar, {
+    const snackBarRef = this.snackBar.openFromComponent(ErrorSnackBar, {
       panelClass: 'docs-invert-mode',
       data: {
         message,
         actionText: 'I understand',
       } satisfies ErrorSnackBarData,
     });
+
+    if (reason === AlertReason.OUT_OF_MEMORY) {
+      snackBarRef.onAction().subscribe(() => {
+        this.resetInstancesCounter();
+      });
+    }
+  }
+
+  private resetInstancesCounter(): void {
+    this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, '0');
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes angular/angular#52647 in the docs embedded editor.

When Safari reloads a tab after OOM, `beforeunload` may not fire, so `numberOfWebcontainers` can stay stale in localStorage. That can cause the OOM warning to appear even when the user has fewer than the recommended number of tabs open.

This change resets the webcontainer instances counter when the user dismisses the OOM warning (`I understand`).

## Changes
- subscribe to the OOM snackbar action in `AlertManager`
- reset `numberOfWebcontainers` to `0` on dismissal
- add `AlertManager` unit tests for increment/decrement/reset behavior

## Testing
- Added `alert-manager.service.spec.ts` coverage for:
  - increment on init
  - decrement on `beforeunload`
  - reset on OOM warning dismissal

> Note: I could not run Bazel tests in this environment because `bazelisk` is not installed locally.
