### PR TITLE
feat(core): Set default Component changeDetection strategy to OnPush

### DIFF
--- a/devtools/cypress/integration/view-component-metadata.e2e.js
+++ b/devtools/cypress/integration/view-component-metadata.e2e.js
@@ -26,7 +26,7 @@ describe('Viewing component metadata', () => {
     });
 
     it('should display change detection strategy', () => {
-      cy.contains('ng-component-metadata', 'Change Detection Strategy: Default');
+      cy.contains('ng-component-metadata', 'Change Detection Strategy: OnPush');
     });
   });
 
@@ -40,7 +40,7 @@ describe('Viewing component metadata', () => {
     });
 
     it('should display change detection strategy', () => {
-      cy.contains('ng-component-metadata', 'Change Detection Strategy: Default');
+      cy.contains('ng-component-metadata', 'Change Detection Strategy: OnPush');
     });
 
     it('should display correct set of inputs', () => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/component-metadata/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/component-metadata/component-metadata.component.ts
@@ -16,13 +16,13 @@ import {
 } from '@angular/core';
 
 import {
-  AngularDirectiveMetadata,
   AcxDirectiveMetadata,
+  AngularDirectiveMetadata,
   ComponentType,
 } from '../../../../../../../../protocol';
 
-import {ElementPropertyResolver} from '../../../property-resolver/element-property-resolver';
 import {DocsRefButtonComponent} from '../../../../../shared/docs-ref-button/docs-ref-button.component';
+import {ElementPropertyResolver} from '../../../property-resolver/element-property-resolver';
 
 @Component({
   selector: 'ng-component-metadata',
@@ -77,7 +77,7 @@ export class ComponentMetadataComponent {
 
     const meta = metadata as Partial<AcxDirectiveMetadata | AngularDirectiveMetadata>;
     if (meta.onPush !== undefined) {
-      return meta.onPush ? 'OnPush' : 'Default';
+      return meta.onPush ? 'OnPush' : 'Eager';
     } else {
       return undefined;
     }

--- a/integration/cli-signal-inputs/src/app/greet.component.spec.ts
+++ b/integration/cli-signal-inputs/src/app/greet.component.spec.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {GreetComponent} from './greet.component';
@@ -38,6 +38,7 @@ describe('greet component', () => {
     />
   `,
   imports: [GreetComponent],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestCmp {
   clickCount = 0;

--- a/integration/platform-server/projects/ngmodule/src/app/app.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/app.component.ts
@@ -1,8 +1,9 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
   template: '<router-outlet></router-outlet>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AppComponent {}

--- a/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.component.ts
@@ -7,12 +7,13 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http-on-init',
   template: ` <div class="one">{{ responseOne }}</div> `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TransferStateComponentOnInit implements OnInit {
   responseOne: string = '';

--- a/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy/http-transfer-state.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy/http-transfer-state.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http',
@@ -16,6 +16,7 @@ import {Component, OnInit} from '@angular/core';
     <div class="two">{{ responseTwo }}</div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TransferStateComponent implements OnInit {
   responseOne: string = '';

--- a/integration/platform-server/projects/standalone/src/app/app.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
 import {CommonModule} from '@angular/common';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 
 @Component({
@@ -7,5 +7,6 @@ import {RouterOutlet} from '@angular/router';
 
   imports: [CommonModule, RouterOutlet],
   template: '<router-outlet></router-outlet>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AppComponent {}

--- a/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
@@ -7,13 +7,14 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http',
   standalone: true,
   template: ` <div class="one">{{ responseOne }}</div> `,
   providers: [HttpClient],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TransferStateOnInitComponent implements OnInit {
   responseOne: string = '';

--- a/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy/http-transfer-state.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-http',
@@ -17,6 +17,7 @@ import {Component, OnInit} from '@angular/core';
     <div class="two">{{ responseTwo }}</div>
   `,
   providers: [HttpClient],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TransferStateComponent implements OnInit {
   responseOne: string = '';

--- a/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
+++ b/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
@@ -52,6 +52,7 @@ export class InsertionComponent {
     <insertion-component [template]="template" [viewCount]="viewCount"></insertion-component>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class DeclarationComponent {
   @Input() viewCount = 1;

--- a/modules/benchmarks/src/defer/baseline/app.component.ts
+++ b/modules/benchmarks/src/defer/baseline/app.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {TableCell} from '../util';
@@ -38,6 +38,7 @@ let trustedGreyColor: SafeStyle;
       </tbody>
     </table>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AppComponent {
   @Input() data: TableCell[][] = [];

--- a/modules/benchmarks/src/defer/main/app.component.ts
+++ b/modules/benchmarks/src/defer/main/app.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {TableCell} from '../util';
@@ -38,6 +38,7 @@ let trustedGreyColor: SafeStyle;
       </tbody>
     </table>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AppComponent {
   @Input() data: TableCell[][] = [];

--- a/modules/benchmarks/src/largeform/ng2/app.ts
+++ b/modules/benchmarks/src/largeform/ng2/app.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 
@@ -65,6 +70,7 @@ import {BrowserModule} from '@angular/platform-browser';
     <input type="text" [(ngModel)]="values[49]" name="value49" />
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class AppComponent {
   copies: number[] = [];

--- a/modules/benchmarks/src/largetable/ng2/table.ts
+++ b/modules/benchmarks/src/largetable/ng2/table.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, inject, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject, Input} from '@angular/core';
 import {DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {emptyTable, TableCell} from '../util';
@@ -27,6 +27,7 @@ let trustedGreyColor: SafeStyle | null = null;
       }
     </tbody>
   </table>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TableComponent {
   @Input() data: TableCell[][] = emptyTable;

--- a/modules/benchmarks/src/largetable/ng2_switch/table.ts
+++ b/modules/benchmarks/src/largetable/ng2_switch/table.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {emptyTable, TableCell} from '../util';
@@ -26,6 +32,7 @@ import {emptyTable, TableCell} from '../util';
     </tbody>
   </table>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TableComponent {
   @Input() data: TableCell[][] = emptyTable;

--- a/modules/benchmarks/src/tree/ng2/tree.ts
+++ b/modules/benchmarks/src/tree/ng2/tree.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {BrowserModule, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {emptyTree, TreeNode} from '../util';
@@ -21,6 +26,7 @@ let trustedGreyColor: SafeStyle;
     ><tree *ngIf="data.right != null" [data]="data.right"></tree
     ><tree *ngIf="data.left != null" [data]="data.left"></tree>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TreeComponent {
   data: TreeNode = emptyTree;

--- a/modules/benchmarks/src/tree/ng2_static/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_static/tree.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {BrowserModule, DomSanitizer, SafeStyle} from '@angular/platform-browser';
 
 import {emptyTree, getMaxDepth, TreeNode} from '../util';
@@ -26,6 +32,7 @@ function createTreeComponent(level: number, isLeaf: boolean) {
     template: template,
     standalone: false,
     jit: true,
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class TreeComponent {
     @Input() data!: TreeNode;
@@ -42,6 +49,7 @@ function createTreeComponent(level: number, isLeaf: boolean) {
   template: `<tree0 *ngIf="data.left != null" [data]="data"></tree0>`,
   standalone: false,
   jit: true,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class RootTreeComponent {
   @Input() data: TreeNode = emptyTree;

--- a/modules/benchmarks/src/tree/ng2_switch/tree.ts
+++ b/modules/benchmarks/src/tree/ng2_switch/tree.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {emptyTree, TreeNode} from '../util';
@@ -20,6 +26,7 @@ import {emptyTree, TreeNode} from '../util';
     ><tree *ngIf="data.left != null" [data]="data.left"></tree
   ></ng-container>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TreeComponent {
   @Input() data: TreeNode = emptyTree;

--- a/modules/playground/src/async/main.ts
+++ b/modules/playground/src/async/main.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, NgModule, provideZoneChangeDetection} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  NgModule,
+  provideZoneChangeDetection,
+} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 @Component({
@@ -43,6 +48,7 @@ import {BrowserModule, platformBrowser} from '@angular/platform-browser';
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncApplication {
   val1: number = 0;

--- a/modules/playground/src/http/app/http_comp.ts
+++ b/modules/playground/src/http/app/http_comp.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'http-app',
@@ -18,6 +18,7 @@ import {Component} from '@angular/core';
     </ul>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class HttpCmp {
   people: {name: string}[] = [];

--- a/modules/playground/src/jsonp/app/jsonp_comp.ts
+++ b/modules/playground/src/jsonp/app/jsonp_comp.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 interface Person {
   name: string;
@@ -22,6 +22,7 @@ interface Person {
     </ul>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class JsonpCmp {
   people: Person[] = [];

--- a/modules/playground/src/template_driven_forms/main.ts
+++ b/modules/playground/src/template_driven_forms/main.ts
@@ -8,7 +8,7 @@
 
 /* tslint:disable:no-console  */
 
-import {Component, Directive, Host, NgModule} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Directive, Host, NgModule} from '@angular/core';
 import {FormControl, FormGroup, FormsModule, NG_VALIDATORS, NgForm} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -71,6 +71,7 @@ export class CreditCardValidator {}
   inputs: ['controlPath: control', 'errorTypes: errors'],
   template: ` <span *ngIf="errorMessage !== null">{{ errorMessage }}</span> `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ShowError {
   formDir: NgForm;

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {NgClass} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {NgClass} from '../../index';
 
 describe('binding to CSS class list', () => {
   let fixture: ComponentFixture<any> | null;
@@ -450,6 +451,7 @@ describe('binding to CSS class list', () => {
           <div trailing-space [ngClass]="{'foo ': applyClasses}"></div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         applyClasses = true;
@@ -470,6 +472,7 @@ describe('binding to CSS class list', () => {
         selector: 'test-component',
         imports: [NgClass],
         template: `<div class="{{ 'option-' + level }}" [ngClass]="'option-' + level"></div>`,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         level = 1;
@@ -508,6 +511,7 @@ describe('binding to CSS class list', () => {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   condition: boolean = true;

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule} from '../../index';
-import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {
   Component,
   ComponentRef,
@@ -29,6 +28,8 @@ import {
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule} from '../../index';
+import {NgComponentOutlet} from '../../src/directives/ng_component_outlet';
 
 describe('insert/remove', () => {
   beforeEach(() => {
@@ -385,6 +386,7 @@ const TEST_TOKEN = new InjectionToken('TestToken');
   selector: 'injected-component',
   template: 'foo',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectedComponent {
   constructor(@Optional() @Inject(TEST_TOKEN) public testToken: any) {}
@@ -394,6 +396,7 @@ class InjectedComponent {
   selector: 'injected-component-again',
   template: 'bar',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectedComponentAgain {}
 
@@ -409,6 +412,7 @@ const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
   selector: 'test-cmp',
   template: TEST_CMP_TEMPLATE,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   currentComponent: Type<unknown> | null = null;
@@ -499,6 +503,7 @@ class AnotherComponentWithInputs {
   selector: 'test-cmp',
   imports: [NgComponentOutlet],
   template: `<ng-template *ngComponentOutlet="currentComponent; inputs: inputs"></ng-template>`,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestInputsComponent {
   currentComponent: Type<unknown> | null = null;

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgFor, NgForOf} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, NgFor, NgForOf} from '../../index';
 
 let thisArg: any;
 
@@ -439,6 +440,7 @@ class Foo {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   value: any;

--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgIf} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, NgIf} from '../../index';
 
 describe('ngIf directive', () => {
   let fixture: ComponentFixture<any>;
@@ -324,6 +325,7 @@ describe('ngIf directive', () => {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   booleanCondition: boolean = true;

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -695,6 +695,7 @@ describe('Image directive', () => {
             [loaderParams]="loaderParams"
           />`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           width = 100;
@@ -1873,6 +1874,7 @@ describe('Image directive', () => {
         selector: 'test-cmp',
         template: `<img [ngSrc]="ngSrc" width="300" height="300" />`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         ngSrc = `img.png`;
@@ -1897,6 +1899,7 @@ describe('Image directive', () => {
         selector: 'test-cmp',
         template: `<img [ngSrc]="ngSrc" width="300" height="300" sizes="100vw" />`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         ngSrc = `img.png`;

--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component, Injectable} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, NgLocalization, NgPlural, NgPluralCase} from '../../index';
 
 describe('ngPlural', () => {
   let fixture: ComponentFixture<any>;
@@ -184,6 +185,7 @@ class TestLocalization extends NgLocalization {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   switchValue: number | null = null;

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgStyle} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {CommonModule, NgStyle} from '../../index';
 
 describe('NgStyle', () => {
   let fixture: ComponentFixture<TestComponent>;
@@ -267,6 +268,7 @@ describe('NgStyle', () => {
       selector: 'test-component',
       imports: [NgStyle],
       template: `<div [ngStyle]="{'width.px': expr}"></div>`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       expr = 400;
@@ -283,6 +285,7 @@ describe('NgStyle', () => {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   expr: any;

--- a/packages/common/test/directives/ng_switch_spec.ts
+++ b/packages/common/test/directives/ng_switch_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgSwitch, NgSwitchCase, NgSwitchDefault} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Attribute, Component, Directive, TemplateRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, NgSwitch, NgSwitchCase, NgSwitchDefault} from '../../index';
 
 describe('NgSwitch', () => {
   let fixture: ComponentFixture<any>;
@@ -151,6 +152,7 @@ describe('NgSwitch', () => {
         '<li *ngSwitchCase="\'a\'">when a</li>' +
         '<li *ngSwitchDefault>when default</li>' +
         '</ul>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       switchValue = 'a';
@@ -268,6 +270,7 @@ describe('NgSwitch', () => {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   switchValue: any = null;
@@ -301,6 +304,7 @@ class TestComponent {
     </ng-template>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComplexComponent {
   @ViewChild('foo', {static: true}) foo!: TemplateRef<any>;

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {
   Component,
   ContentChildren,
@@ -426,6 +427,7 @@ describe('NgTemplateOutlet', () => {
         <ng-template #tpl let-name>Name:{{ name }}</ng-template>
         <ng-template [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="ctx"></ng-template>
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       ctx: {$implicit: string} | undefined = undefined;
@@ -477,6 +479,7 @@ class CaptureTplRefs {
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponent {
   currentTplRef?: TemplateRef<any>;
@@ -490,6 +493,7 @@ class TestComponent {
   template: '<ng-content />',
   providers: [{provide: templateToken, useValue: 'provide-value'}],
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ProvideValueComponent {}
 
@@ -497,6 +501,7 @@ class ProvideValueComponent {}
   selector: 'inject-value',
   template: 'Hello {{tokenValue}}',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InjectValueComponent {
   constructor(@Inject(templateToken) public tokenValue: string) {}
@@ -510,6 +515,7 @@ class InjectValueComponent {
     <ng-template [ngTemplateOutlet]="template" [ngTemplateOutletContext]="context2"></ng-template>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultiContextComponent {
   context1: {name: string} | undefined;
@@ -529,6 +535,7 @@ const NESTING_DEPTH = new InjectionToken<number>('NESTING_DEPTH');
     },
   ],
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestingCounter {
   depth = inject(NESTING_DEPTH);

--- a/packages/common/test/pipes/json_pipe_spec.ts
+++ b/packages/common/test/pipes/json_pipe_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, JsonPipe} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, JsonPipe} from '../../index';
 
 describe('JsonPipe', () => {
   const regNewLine = '\n';
@@ -58,6 +59,7 @@ describe('JsonPipe', () => {
       selector: 'test-comp',
       template: '{{data | json}}',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComp {
       data: any;

--- a/packages/common/test/pipes/slice_pipe_spec.ts
+++ b/packages/common/test/pipes/slice_pipe_spec.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, SlicePipe} from '../../index';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/private/testing/matchers';
+import {CommonModule, SlicePipe} from '../../index';
 
 describe('SlicePipe', () => {
   let list: number[];
@@ -94,6 +95,7 @@ describe('SlicePipe', () => {
       selector: 'test-comp',
       template: '{{(data | slice:1).join(",") }}',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComp {
       data: any;
@@ -123,6 +125,7 @@ describe('SlicePipe', () => {
       selector: 'test-component',
       imports: [SlicePipe],
       template: '{{ title | slice:0:5 }}',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       title = 'Hello World!';

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -36,10 +36,10 @@ import {AstObject, AstValue} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
 import {GetSourceFileFn} from '../get_source_file';
 
+import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system/src/types';
 import {toR3DirectiveMeta} from './partial_directive_linker_1';
 import {LinkedDefinition, PartialLinker} from './partial_linker';
 import {extractForwardRef, PLACEHOLDER_VERSION} from './util';
-import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system/src/types';
 
 function makeDirectiveMetadata<TExpression>(
   directiveExpr: AstObject<R3DeclareDirectiveDependencyMetadata, TExpression>,
@@ -68,9 +68,10 @@ function makeDirectiveMetadata<TExpression>(
 /**
  * A `PartialLinker` that is designed to process `ɵɵngDeclareComponent()` call expressions.
  */
-export class PartialComponentLinkerVersion1<TStatement, TExpression>
-  implements PartialLinker<TExpression>
-{
+export class PartialComponentLinkerVersion1<
+  TStatement,
+  TExpression,
+> implements PartialLinker<TExpression> {
   constructor(
     private readonly getSourceFile: GetSourceFileFn,
     private sourceUrl: AbsoluteFsPath,
@@ -103,6 +104,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
     const enableBlockSyntax = major >= 17 || version === PLACEHOLDER_VERSION;
     const enableLetSyntax =
       major > 18 || (major === 18 && minor >= 1) || version === PLACEHOLDER_VERSION;
+    const hasOnPushByDefault = major >= 22 || version === PLACEHOLDER_VERSION;
 
     const template = parseTemplate(templateInfo.code, templateInfo.sourceUrl, {
       escapedString: templateInfo.isEscaped,
@@ -242,7 +244,9 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression>
         : ViewEncapsulation.Emulated,
       changeDetection: metaObj.has('changeDetection')
         ? parseChangeDetectionStrategy(metaObj.getValue('changeDetection'))
-        : ChangeDetectionStrategy.Default,
+        : hasOnPushByDefault
+          ? ChangeDetectionStrategy.OnPush
+          : ChangeDetectionStrategy.Eager,
       animations: metaObj.has('animations') ? metaObj.getOpaque('animations') : null,
       relativeContextFilePath: this.sourceUrl,
       relativeTemplatePath: null,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5987,7 +5987,7 @@ runInEachFileSystem((os: string) => {
       expect(messageText).toContain("Value is of type 'string'.");
     });
 
-    it('should handle `changeDetection` field', () => {
+    it('should handle `changeDetection` field with the "default" value: OnPush', () => {
       env.write(
         `test.ts`,
         `
@@ -6003,7 +6003,27 @@ runInEachFileSystem((os: string) => {
 
       env.driveMain();
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('changeDetection: 0');
+      // because this default value is implicit
+      expect(jsContents).not.toContain('changeDetection: 0');
+    });
+
+    it('should handle `changeDetection` field', () => {
+      env.write(
+        `test.ts`,
+        `
+      import {Component, ChangeDetectionStrategy} from '@angular/core';
+      @Component({
+        selector: 'comp-a',
+        template: '...',
+        changeDetection: ChangeDetectionStrategy.Eager
+      })
+      class CompA {}
+    `,
+      );
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('changeDetection: 1');
     });
 
     it('should throw if `changeDetection` contains invalid value', () => {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -666,7 +666,7 @@ function convertDeclareComponentFacadeToMetadata(
       decl.viewProviders !== undefined ? new WrappedNodeExpr(decl.viewProviders) : null,
     animations: decl.animations !== undefined ? new WrappedNodeExpr(decl.animations) : null,
     defer,
-    changeDetection: decl.changeDetection ?? ChangeDetectionStrategy.Default,
+    changeDetection: decl.changeDetection ?? ChangeDetectionStrategy.OnPush,
     encapsulation: decl.encapsulation ?? ViewEncapsulation.Emulated,
     declarationListEmitMode: DeclarationListEmitMode.ClosureResolved,
     relativeContextFilePath: '',

--- a/packages/compiler/src/render3/partial/api.ts
+++ b/packages/compiler/src/render3/partial/api.ts
@@ -222,7 +222,7 @@ export interface R3DeclareComponentMetadata extends R3DeclareDirectiveMetadata {
 
   /**
    * Strategy used for detecting changes in the component.
-   * Defaults to `ChangeDetectionStrategy.Default`.
+   * Defaults to `ChangeDetectionStrategy.OnPush`.
    */
   changeDetection?: ChangeDetectionStrategy;
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -316,7 +316,7 @@ export function compileComponentFromMetadata(
   if (meta.changeDetection !== null) {
     if (
       typeof meta.changeDetection === 'number' &&
-      meta.changeDetection !== core.ChangeDetectionStrategy.Default
+      meta.changeDetection !== core.ChangeDetectionStrategy.OnPush
     ) {
       // changeDetection is resolved during analysis. Only set it if not the default.
       definitionMap.set('changeDetection', o.literal(meta.changeDetection));

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -355,7 +355,7 @@ export function ɵɵdefineComponent<T>(
       template: componentDefinition.template,
       consts: componentDefinition.consts || null,
       ngContentSelectors: componentDefinition.ngContentSelectors,
-      onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
+      onPush: componentDefinition.changeDetection !== ChangeDetectionStrategy.Eager,
       directiveDefs: null!, // assigned in noSideEffects
       pipeDefs: null!, // assigned in noSideEffects
       dependencies: (baseDef.standalone && componentDefinition.dependencies) || null,

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -145,7 +145,6 @@ export class ViewRef<T> implements EmbeddedViewRef<T>, ChangeDetectorRef {
    * @Component({
    *   selector: 'app-root',
    *   template: `Number of ticks: {{numberOfTicks}}`
-   *   changeDetection: ChangeDetectionStrategy.OnPush,
    * })
    * class AppComponent {
    *   numberOfTicks = 0;

--- a/packages/core/test/acceptance/animation_spec.ts
+++ b/packages/core/test/acceptance/animation_spec.ts
@@ -31,14 +31,14 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
+import {ComponentRef} from '@angular/core/src/render3';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {isNode} from '@angular/private/testing';
-import {tickAnimationFrames} from '../animation_utils/tick_animation_frames';
-import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
-import {ComponentRef} from '@angular/core/src/render3';
+import {BrowserTestingModule, platformBrowserTesting} from '@angular/platform-browser/testing';
+import {isNode} from '@angular/private/testing';
 import {reusedNodes} from '../../src/animation/utils';
+import {tickAnimationFrames} from '../animation_utils/tick_animation_frames';
 
 @NgModule({
   providers: [provideZonelessChangeDetection()],
@@ -90,6 +90,7 @@ describe('Animation', () => {
     it('should delay element removal when an animation is specified', fakeAsync(() => {
       const logSpy = jasmine.createSpy('logSpy');
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -129,6 +130,7 @@ describe('Animation', () => {
 
     it('should remove right away when animations are disabled', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.leave="fade" #el>I should fade</p>}</div>',
@@ -151,6 +153,7 @@ describe('Animation', () => {
 
     it('should remove right away when classes have no animations', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.leave="not-a-class" #el>I should fade</p>}</div>',
@@ -198,6 +201,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template:
@@ -261,6 +265,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template: `<div>
@@ -326,6 +331,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template:
@@ -364,6 +370,7 @@ describe('Animation', () => {
 
     it('should support function syntax', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -391,6 +398,7 @@ describe('Animation', () => {
 
     it('should be host bindable', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'fade-cmp',
         host: {'animate.leave': 'fade'},
         template: '<p>I should fade</p>',
@@ -399,6 +407,7 @@ describe('Animation', () => {
       class FadeComponent {}
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [FadeComponent],
@@ -431,6 +440,7 @@ describe('Animation', () => {
 
     it('should be host bindable with brackets', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'fade-cmp',
         host: {'[animate.leave]': 'fade()'},
         template: '<p>I should fade</p>',
@@ -441,6 +451,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [FadeComponent],
@@ -474,6 +485,7 @@ describe('Animation', () => {
     it('should be host bindable with events', fakeAsync(() => {
       const fadeCalled = jasmine.createSpy('fadeCalled');
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'fade-cmp',
         styles: styles,
         host: {'(animate.leave)': 'fadeIn($event)'},
@@ -489,6 +501,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         imports: [FadeComponent],
         template: '@if (show()) { <fade-cmp /> }',
@@ -592,6 +605,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'[animate.leave]': 'slide()'},
         template: '<p>I should fade</p>',
@@ -602,6 +616,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         imports: [ChildComponent],
@@ -675,6 +690,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         styles: multiple,
         template: '<p>I should fade</p>',
@@ -683,6 +699,7 @@ describe('Animation', () => {
       class ChildComponent {}
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         imports: [ChildComponent, StuffDirective],
@@ -742,6 +759,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'animate.leave': 'slide-out'},
         template: '<p>I should fade</p>',
@@ -750,6 +768,7 @@ describe('Animation', () => {
       class ChildComponent {}
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         imports: [ChildComponent],
@@ -799,6 +818,7 @@ describe('Animation', () => {
         }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template: '@if (show()) { <div animate.leave="slide-out"><p>Element with text</p></div> }',
@@ -869,6 +889,7 @@ describe('Animation', () => {
       it('should have the same exact timing when AnimationsModule is present', fakeAsync(() => {
         const logSpy = jasmine.createSpy('logSpy');
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'test-cmp',
           styles: styles,
           template:
@@ -936,6 +957,7 @@ describe('Animation', () => {
 
     it('should apply classes on entry when animation is specified with no control flow', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div><p animate.enter="slide-in" #el>I should slide in</p></div>',
@@ -955,6 +977,7 @@ describe('Animation', () => {
 
     it('should call animation function on entry when animation is specified with no control flow', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div><p (animate.enter)="slideIn($event)">I should slide in</p></div>',
@@ -978,6 +1001,7 @@ describe('Animation', () => {
 
     it('should call animation function only once on entry when animation is specified with control flow', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -1008,6 +1032,7 @@ describe('Animation', () => {
 
     it('should apply classes on entry when animation is specified', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.enter="slide-in" #el>I should slide in</p>}</div>',
@@ -1031,6 +1056,7 @@ describe('Animation', () => {
 
     it('should support binding syntax', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -1056,6 +1082,7 @@ describe('Animation', () => {
 
     it('should remove classes when animation is done', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.enter="slide-in" #el>I should slide in</p>}</div>',
@@ -1085,6 +1112,7 @@ describe('Animation', () => {
 
     it('should support function syntax', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -1142,6 +1170,7 @@ describe('Animation', () => {
       }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template:
@@ -1198,6 +1227,7 @@ describe('Animation', () => {
       }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template: `<div>
@@ -1256,6 +1286,7 @@ describe('Animation', () => {
       }
       `;
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: multiple,
         template:
@@ -1290,6 +1321,7 @@ describe('Animation', () => {
 
     it('should remove right away when animations are disabled', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.enter="slide-in" #el>I should fade</p>}</div>',
@@ -1311,6 +1343,7 @@ describe('Animation', () => {
 
     it('should remove right away when no classes have animations', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template: '<div>@if (show()) {<p animate.enter="not-a-class" #el>I should fade</p>}</div>',
@@ -1334,6 +1367,7 @@ describe('Animation', () => {
 
     it('should be host bindable', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'animate.enter': 'slide-in'},
         template: '<p>I should fade</p>',
@@ -1342,6 +1376,7 @@ describe('Animation', () => {
       class ChildComponent {}
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [ChildComponent],
@@ -1367,6 +1402,7 @@ describe('Animation', () => {
 
     it('should be host bindable with brackets', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'[animate.enter]': 'slideIn()'},
         template: '<p>I should fade</p>',
@@ -1377,6 +1413,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [ChildComponent],
@@ -1402,6 +1439,7 @@ describe('Animation', () => {
     it('should be host bindable with events', fakeAsync(() => {
       const slideInCalled = jasmine.createSpy('slideInCalled');
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'(animate.enter)': 'slideIn($event)'},
         template: '<p>I should fade</p>',
@@ -1416,6 +1454,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [ChildComponent],
@@ -1438,6 +1477,7 @@ describe('Animation', () => {
 
     it('should compose class list when host binding and regular binding', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'[animate.enter]': 'clazz'},
         template: '<p>I should fade</p>',
@@ -1448,6 +1488,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [ChildComponent],
@@ -1480,6 +1521,7 @@ describe('Animation', () => {
 
     it('should compose class list when host binding a string and regular class strings', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'child-cmp',
         host: {'animate.enter': 'slide-in'},
         template: '<p>I should fade</p>',
@@ -1488,6 +1530,7 @@ describe('Animation', () => {
       class ChildComponent {}
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         imports: [ChildComponent],
@@ -1541,6 +1584,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template:
@@ -1601,6 +1645,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template:
@@ -1659,6 +1704,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template: '<div>@if (show()) {<p animate.leave="fade">I should fade</p>}</div>',
@@ -1729,6 +1775,7 @@ describe('Animation', () => {
           </div>
         `,
         encapsulation: ViewEncapsulation.None,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -1791,6 +1838,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template: `
@@ -1877,6 +1925,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template: `
@@ -1968,6 +2017,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         imports: [NgFor],
@@ -2030,6 +2080,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template: `
@@ -2078,6 +2129,7 @@ describe('Animation', () => {
     it('should not remove elements when swapping or moving nodes', fakeAsync(() => {
       const animateSpy = jasmine.createSpy('animateSpy');
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         template: `
           <div>
@@ -2143,6 +2195,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: animateStyles,
         template: `
@@ -2253,6 +2306,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         imports: [DynamicComponent],
         template: `
@@ -2321,6 +2375,7 @@ describe('Animation', () => {
       `;
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'animated-child',
         template: `
           @if (show()) {
@@ -2501,6 +2556,7 @@ describe('Animation', () => {
       }
 
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         imports: [MenuComponent],
         template: ` <dynamic-menu /> `,
@@ -2560,6 +2616,7 @@ describe('Animation', () => {
 
     it('should ignore infinite animations during animate.leave and remove element immediately', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:
@@ -2594,6 +2651,7 @@ describe('Animation', () => {
 
     it('should ignore infinite animations during animate.enter and remove classes immediately', fakeAsync(() => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'test-cmp',
         styles: styles,
         template:

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -6,15 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, provideZoneChangeDetection} from '../../src/core';
-import {TestBed} from '../../testing';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
+import {ChangeDetectionStrategy, Component, provideZoneChangeDetection} from '../../src/core';
+import {TestBed} from '../../testing';
 
 describe('attribute creation', () => {
   it('should create an element', () => {
     @Component({
       template: `<div id="test" title="Hello"></div>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {}
 
@@ -30,6 +31,7 @@ describe('attribute creation', () => {
     @Component({
       template: `<div id="test" xlink:href="bar" title="Hello"></div>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {}
 
@@ -64,6 +66,7 @@ describe('attribute binding', () => {
     @Component({
       template: `<a [attr.href]="url"></a>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       url = 'https://angular.io/robots.txt';
@@ -82,6 +85,7 @@ describe('attribute binding', () => {
     @Component({
       template: `<a [attr.id]="id" [attr.href]="url" [attr.tabindex]="'-1'"></a>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       url = 'https://angular.io/robots.txt';
@@ -103,6 +107,7 @@ describe('attribute binding', () => {
     @Component({
       template: `<a [id]="id" [attr.href]="url" [title]="'hello'"></a>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       url = 'https://angular.io/robots.txt';
@@ -128,6 +133,7 @@ describe('attribute binding', () => {
         attr.tabindex="{{ 1 + 3 + 7 }}"
       ></button>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       title = 'hello';
@@ -153,6 +159,7 @@ describe('attribute binding', () => {
         </button>
       `,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       title = 'hello';
@@ -179,6 +186,7 @@ describe('attribute binding', () => {
     @Component({
       template: `<a [attr.href]="badUrl"></a>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       badUrl: string | SafeUrl = 'javascript:true';
@@ -221,6 +229,7 @@ describe('attribute interpolation', () => {
         <div attr.title="{{ a }}"></div>
       `,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       a = 1;

--- a/packages/core/test/acceptance/authoring/model_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/model_inputs_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   EventEmitter,
@@ -140,6 +141,7 @@ describe('model inputs', () => {
     @Component({
       template: '<div [value]="value" dir></div>',
       imports: [Dir],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) dir!: Dir;

--- a/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_inputs_spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ViewEncapsulation} from '@angular/compiler';
 import {
+  ChangeDetectionStrategy,
   Component,
   ComponentRef,
   computed,
@@ -26,13 +28,12 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import {SIGNAL} from '../../../primitives/signals';
-import {fakeAsync, TestBed, tick} from '../../../testing';
-import {ViewEncapsulation} from '@angular/compiler';
 import {By} from '@angular/platform-browser';
-import {tickAnimationFrames} from '../../animation_utils/tick_animation_frames';
 import {isNode} from '@angular/private/testing';
 import {Subscription} from 'rxjs';
+import {SIGNAL} from '../../../primitives/signals';
+import {fakeAsync, TestBed, tick} from '../../../testing';
+import {tickAnimationFrames} from '../../animation_utils/tick_animation_frames';
 
 describe('signal inputs', () => {
   beforeEach(() =>
@@ -53,6 +54,7 @@ describe('signal inputs', () => {
     @Component({
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       value = 1;
@@ -83,6 +85,7 @@ describe('signal inputs', () => {
     @Component({
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       value = 1;
@@ -120,6 +123,7 @@ describe('signal inputs', () => {
     @Component({
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       value = 1;
@@ -206,6 +210,7 @@ describe('signal inputs', () => {
     @Component({
       template: `<input-comp [input]="value" />`,
       imports: [InputComp],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       value = 1;
@@ -233,6 +238,7 @@ describe('signal inputs', () => {
     @Component({
       template: '<div [(value)]="value" dir></div>',
       imports: [Dir],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) dir!: Dir;

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   computed,
   contentChild,
@@ -20,9 +21,9 @@ import {
   ViewChildren,
   viewChildren,
 } from '@angular/core';
+import {By} from '@angular/platform-browser';
 import {SIGNAL} from '../../../primitives/signals';
 import {TestBed} from '../../../testing';
-import {By} from '@angular/platform-browser';
 
 describe('queries as signals', () => {
   describe('view', () => {
@@ -91,6 +92,7 @@ describe('queries as signals', () => {
             <div #el></div>
           }
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         show = false;
@@ -298,6 +300,7 @@ describe('queries as signals', () => {
             }
           </query-cmp>
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         show = false;
@@ -346,6 +349,7 @@ describe('queries as signals', () => {
             }
           </div>
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         show = false;
@@ -589,6 +593,7 @@ describe('queries as signals', () => {
             <div #el></div>
           }
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         show = false;
@@ -624,6 +629,7 @@ describe('queries as signals', () => {
             <div #el></div>
           }
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class BaseComponent {
         show = false;
@@ -637,6 +643,7 @@ describe('queries as signals', () => {
             <div #el></div>
           }
         `,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent extends BaseComponent {
         @ViewChildren('el') divElsDecorator!: QueryList<ElementRef<HTMLDivElement>>;

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {NgFor, NgIf} from '@angular/common';
+import {ReactiveNode, SIGNAL} from '../../primitives/signals';
 import {
   ApplicationRef,
   ChangeDetectionStrategy,
@@ -23,7 +24,6 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '../../src/core';
-import {ReactiveNode, SIGNAL} from '../../primitives/signals';
 import {TestBed} from '../../testing';
 
 describe('CheckAlways components', () => {
@@ -35,6 +35,7 @@ describe('CheckAlways components', () => {
   it('can read a signal', () => {
     @Component({
       template: `{{ value() }}`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysCmp {
       value = signal('initial');
@@ -53,6 +54,7 @@ describe('CheckAlways components', () => {
   it('should properly remove stale dependencies from the signal graph', () => {
     @Component({
       template: `{{ show() ? name() + ' aged ' + age() : 'anonymous' }}`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysCmp {
       name = signal('John');
@@ -86,6 +88,7 @@ describe('CheckAlways components', () => {
     @Component({
       template: `{{ value() }}`,
       selector: 'check-always',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysCmp {
       value = value;
@@ -113,6 +116,7 @@ describe('CheckAlways components', () => {
     @Component({
       template: '{{val()}}',
       selector: 'a-comp',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class A {
       val = aVal;
@@ -120,6 +124,7 @@ describe('CheckAlways components', () => {
     @Component({
       template: '{{val()}}',
       selector: 'b-comp',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class B {
       val = bVal;
@@ -132,7 +137,11 @@ describe('CheckAlways components', () => {
       }
     }
 
-    @Component({template: '<a-comp />-<b-comp />', imports: [A, B]})
+    @Component({
+      template: '<a-comp />-<b-comp />',
+      imports: [A, B],
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class App {}
 
     const fixture = TestBed.createComponent(App);
@@ -155,6 +164,7 @@ describe('CheckAlways components', () => {
     @Component({
       template: '',
       selector: 'child',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       ngDoCheck() {
@@ -165,7 +175,11 @@ describe('CheckAlways components', () => {
         }
       }
     }
-    @Component({template: '{{val()}}<child />', imports: [Child]})
+    @Component({
+      template: '{{val()}}<child />',
+      imports: [Child],
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class App {
       val = val;
     }
@@ -186,6 +200,7 @@ describe('CheckAlways components', () => {
     const val = signal(0);
     @Component({
       template: '{{val()}}',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = val;
@@ -318,6 +333,7 @@ describe('OnPush components with signals', () => {
     @Component({
       selector: 'with-input-setter',
       template: '{{test}}',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class WithInputSetter {
       test = '';
@@ -366,6 +382,7 @@ describe('OnPush components with signals', () => {
     @Component({
       selector: 'with-query-setter',
       template: '<div #el>child</div>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class WithQuerySetter {
       el: unknown;
@@ -550,6 +567,7 @@ describe('OnPush components with signals', () => {
         <div misunderstood></div>
         {{ 'force advance()' }}
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       counter = counter;
@@ -582,6 +600,7 @@ describe('OnPush components with signals', () => {
         {{ counter() }}
         <div misunderstood></div>
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       counter = counter;
@@ -597,6 +616,7 @@ describe('OnPush components with signals', () => {
   it('should allow writing to signals in afterViewInit', () => {
     @Component({
       template: '{{loading()}}',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       loading = signal(true);
@@ -922,6 +942,7 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '',
       selector: 'child',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       ngOnInit() {
@@ -932,6 +953,7 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '{{val()}} <child />',
       imports: [Child],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SignalComponent {
       val = val;
@@ -950,6 +972,7 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '{{double()}}',
       selector: 'child',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       double = double;
@@ -958,6 +981,7 @@ describe('OnPush components with signals', () => {
     @Component({
       template: '|{{double()}}|<child />|',
       imports: [Child],
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SignalComponent {
       double = double;

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -88,6 +88,8 @@ describe('change detection', () => {
       selector: 'test-cmp',
       template: ` <ng-template #vm="vm" viewManipulation>{{ 'change-detected' }}</ng-template> `,
       imports: [ViewManipulation],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmpt {}
 
@@ -128,7 +130,10 @@ describe('change detection', () => {
         }
       }
 
-      @Component({template: '<ng-template #template></ng-template>'})
+      @Component({
+        template: '<ng-template #template></ng-template>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class Container {
         @ViewChild('template', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
       }
@@ -159,7 +164,10 @@ describe('change detection', () => {
         }
       }
 
-      @Component({template: '<ng-template #template></ng-template>'})
+      @Component({
+        template: '<ng-template #template></ng-template>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class Container {
         @ViewChild('template', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
       }
@@ -182,6 +190,8 @@ describe('change detection', () => {
           <ng-template #vm="vm" viewManipulation>{{ increment('embeddedView') }}</ng-template>
         `,
         imports: [ViewManipulation],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         increment(counter: 'componentView' | 'embeddedView') {
@@ -365,6 +375,8 @@ describe('change detection', () => {
           '[class.x]': 'x',
         },
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasHostBinding {
         x = true;
@@ -375,6 +387,8 @@ describe('change detection', () => {
         template: '<has-host-binding></has-host-binding>',
         inputs: ['input'],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         /**
@@ -398,6 +412,8 @@ describe('change detection', () => {
         selector: 'root',
         template: '<child [input]="3"></child>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Root {}
 
@@ -431,6 +447,8 @@ describe('change detection', () => {
       selector: 'my-app',
       template: '<my-comp [name]="name"></my-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       @ViewChild(MyComponent) comp!: MyComponent;
@@ -524,6 +542,8 @@ describe('change detection', () => {
         selector: 'button-parent',
         template: '<my-comp></my-comp><button id="parent" (click)="noop()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ButtonParent {
         @ViewChild(MyComponent) comp!: MyComponent;
@@ -566,6 +586,8 @@ describe('change detection', () => {
         selector: 'my-button-app',
         template: '<button-parent></button-parent>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyButtonApp {
         @ViewChild(ButtonParent) parent!: ButtonParent;
@@ -661,6 +683,8 @@ describe('change detection', () => {
         selector: 'parent-comp',
         template: `{{ doCheckCount }} - <my-comp></my-comp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentComp implements DoCheck {
         @ViewChild(MyComp) myComp!: MyComp;
@@ -751,6 +775,8 @@ describe('change detection', () => {
         @Component({
           template: '<my-comp dir></my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild(MyComp) myComp!: MyComp;
@@ -772,6 +798,8 @@ describe('change detection', () => {
         @Component({
           template: '{{ value }}<div dir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild(MyComp) myComp!: MyComp;
@@ -796,6 +824,8 @@ describe('change detection', () => {
         @Component({
           template: '{{ name }}<div *ngIf="showing" dir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild(Dir) dir!: Dir;
@@ -818,6 +848,8 @@ describe('change detection', () => {
         @Component({
           template: '{{ value }}',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class DetectChangesComp implements OnInit {
           value = 0;
@@ -842,6 +874,8 @@ describe('change detection', () => {
           @Component({
             template: '<child-comp [inp]="true"></child-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class ParentComp {
             constructor(public cdr: ChangeDetectorRef) {}
@@ -854,6 +888,8 @@ describe('change detection', () => {
             template: '{{inp}}',
             selector: 'child-comp',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class ChildComp {
             @Input() inp: any = '';
@@ -896,6 +932,8 @@ describe('change detection', () => {
         @Component({
           template: '{{doCheckCount}}',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class DetectChangesComp {
           doCheckCount = 0;
@@ -920,6 +958,8 @@ describe('change detection', () => {
           selector: 'app',
           template: ` <div *ngIf="visible" #ref>Visible text</div> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChildren('ref') ref!: QueryList<any>;
@@ -956,6 +996,8 @@ describe('change detection', () => {
           selector: 'structural-comp',
           template: '{{ value }}',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class StructuralComp {
           @Input() tmp!: TemplateRef<any>;
@@ -973,6 +1015,8 @@ describe('change detection', () => {
             template:
               '<ng-template #foo let-ctx="ctx">{{ ctx.value }}</ng-template><structural-comp [tmp]="foo"></structural-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class App {
             @ViewChild(StructuralComp) structuralComp!: StructuralComp;
@@ -1003,6 +1047,8 @@ describe('change detection', () => {
           @Component({
             template: '<ng-template #foo>Template text</ng-template><structural-comp [tmp]="foo">',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class App {
             @ViewChild(StructuralComp) structuralComp!: StructuralComp;
@@ -1026,6 +1072,8 @@ describe('change detection', () => {
         selector: 'detached-comp',
         template: '{{ value }}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DetachedComp implements DoCheck {
         value = 'one';
@@ -1041,6 +1089,8 @@ describe('change detection', () => {
       @Component({
         template: '<detached-comp></detached-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         @ViewChild(DetachedComp) comp!: DetachedComp;
@@ -1154,6 +1204,8 @@ describe('change detection', () => {
         @Component({
           template: '<on-push-comp [value]="value"></on-push-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class OnPushApp {
           @ViewChild(OnPushComp) onPushComp!: OnPushComp;
@@ -1349,6 +1401,8 @@ describe('change detection', () => {
         selector: 'no-changes-comp',
         template: '{{ value }}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NoChangesComp {
         value = 1;
@@ -1376,6 +1430,8 @@ describe('change detection', () => {
       @Component({
         template: '{{ value }} - <no-changes-comp></no-changes-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComp {
         value = 1;
@@ -1423,6 +1479,8 @@ describe('change detection', () => {
         @Component({
           template: '<span *ngIf="showing">{{ showing }}</span>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class EmbeddedViewApp {
           showing = true;
@@ -1611,6 +1669,8 @@ describe('change detection', () => {
             @Component({
               template: `<on-push-comp></on-push-comp>`,
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class TestApp {
               @ViewChild(OnPushComp) onPushComp!: OnPushComp;
@@ -1661,6 +1721,8 @@ describe('change detection', () => {
           @Component({
             template: `<on-push-comp></on-push-comp>`,
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class TestApp {
             @ViewChild(OnPushComp) onPushComp!: OnPushComp;
@@ -1690,6 +1752,8 @@ describe('change detection', () => {
     @Component({
       template: '...',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       a: string = 'a';

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -104,6 +104,8 @@ describe('change detection for transplanted views', () => {
         <ng-template #myTmpl let-greeting> {{ greeting }} {{ logName() }}! </ng-template>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysDeclareComp extends DeclareComp {
       constructor(changeDetector: ChangeDetectorRef) {
@@ -174,6 +176,8 @@ describe('change detection for transplanted views', () => {
         <onpush-insert-comp *ngIf="showOnPushInsert" />
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComp {
       showCheckAlwaysDeclare = false;
@@ -510,6 +514,8 @@ describe('change detection for transplanted views', () => {
         <declaration></declaration>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Declaration) declaration!: Declaration;
@@ -600,6 +606,8 @@ describe('change detection for transplanted views', () => {
       selector: 'check-always-insertion',
       template: `<ng-container [ngTemplateOutlet]="template"></ng-container>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysInsertion {
       @Input() template!: TemplateRef<{}>;
@@ -645,6 +653,8 @@ describe('change detection for transplanted views', () => {
         <on-push-insertion-host [template]="template"></on-push-insertion-host>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysDeclaration {
       @ViewChild(OnPushInsertionHost) onPushInsertionHost?: OnPushInsertionHost;
@@ -733,6 +743,8 @@ describe('change detection for transplanted views', () => {
         <triple [template]="template"></triple>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       name = 'Penny';
@@ -755,6 +767,8 @@ describe('change detection for transplanted views', () => {
     @Component({
       template: '<ng-template>{{incrementChecks()}}</ng-template>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComponent {
       @ViewChild(TemplateRef) templateRef!: TemplateRef<{}>;
@@ -884,6 +898,8 @@ describe('change detection for transplanted views', () => {
       selector: 'check-always-component',
       template: ` <ng-container #vc></ng-container> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CheckAlwaysComponent {
       @ViewChild('vc', {read: ViewContainerRef}) viewContainer!: ViewContainerRef;
@@ -905,6 +921,8 @@ describe('change detection for transplanted views', () => {
         <check-always-component [template]="transplantedTemplate"></check-always-component>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(OnPushComponent) onPushComponent!: OnPushComponent;
@@ -984,6 +1002,8 @@ describe('change detection for transplanted views', () => {
       @Component({
         selector: 'insertion',
         template: `<ng-container #vc></ng-container>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Insertion {
         @ViewChild('vc', {read: ViewContainerRef, static: true}) viewContainer!: ViewContainerRef;
@@ -999,6 +1019,8 @@ describe('change detection for transplanted views', () => {
           <insertion [template]="transplantedTemplate"></insertion>
         `,
         imports: [Insertion],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Root {
         readonly cdr = inject(ChangeDetectorRef);
@@ -1026,6 +1048,8 @@ describe('change detection for transplanted views', () => {
       @Component({
         template: '<ng-template #template>{{value}}</ng-template>',
         selector: 'declaration',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Declaration {
         @ViewChild('template', {static: true}) transplantedTemplate!: TemplateRef<{}>;
@@ -1039,6 +1063,8 @@ describe('change detection for transplanted views', () => {
           {{ incrementChecks() }}
         `,
         imports: [Insertion, Declaration],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Root {
         @ViewChild(Declaration, {static: true}) declaration!: Declaration;
@@ -1071,6 +1097,8 @@ describe('change detection for transplanted views', () => {
       selector: 'insertion',
       imports: [NgTemplateOutlet],
       template: ` <ng-container [ngTemplateOutlet]="template"> </ng-container>`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Insertion {
       @Input() template!: TemplateRef<{}>;
@@ -1081,6 +1109,8 @@ describe('change detection for transplanted views', () => {
       imports: [Insertion, AsyncPipe],
       template: `<ng-template #myTmpl> {{ newObservable() | async }} </ng-template>`,
       selector: 'declaration',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Declaration {
       @ViewChild('myTmpl', {static: true}) template!: TemplateRef<{}>;
@@ -1091,6 +1121,8 @@ describe('change detection for transplanted views', () => {
     @Component({
       imports: [Declaration, Insertion],
       template: '<insertion [template]="declaration.template"/><declaration #declaration/>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1143,6 +1175,8 @@ describe('change detection for transplanted views', () => {
         <insertion [template]="transplantedTemplate"></insertion>
       `,
       imports: [Insertion],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Root {
       @ViewChild('template', {static: true}) transplantedTemplate!: TemplateRef<{}>;

--- a/packages/core/test/acceptance/common_integration_spec.ts
+++ b/packages/core/test/acceptance/common_integration_spec.ts
@@ -7,7 +7,12 @@
  */
 
 import {By} from '@angular/platform-browser';
-import {Component, Directive, provideZoneChangeDetection} from '../../src/core';
+import {
+  Component,
+  Directive,
+  provideZoneChangeDetection,
+  ChangeDetectionStrategy,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 
 describe('@angular/common integration', () => {
@@ -27,6 +32,8 @@ describe('@angular/common integration', () => {
       selector: 'app-child',
       template: '<div dir>comp text</div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComponent {}
 
@@ -34,6 +41,8 @@ describe('@angular/common integration', () => {
       selector: 'app-root',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComponent {
       items: string[] = ['first', 'second'];
@@ -150,6 +159,8 @@ describe('@angular/common integration', () => {
             <li *ngFor="let item of items">{{ item }}</li>
           </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ToggleComponent {
         private _data: number[] = [1, 2, 3];
@@ -206,6 +217,8 @@ describe('@angular/common integration', () => {
           </li>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MultiLevelComponent {
         items: any[] = [
@@ -281,6 +294,8 @@ describe('@angular/common integration', () => {
           </p>
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MultiLevelWithListenerComponent {
         items: any[] = [{data: ['1'], value: 'first'}];
@@ -321,6 +336,8 @@ describe('@angular/common integration', () => {
           </div>
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SkippingContextComponent {
         name = 'app';
@@ -379,6 +396,8 @@ describe('@angular/common integration', () => {
           </span>
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NineLevelsComponent {
         value = 'App';
@@ -516,6 +535,8 @@ describe('@angular/common integration', () => {
           <div *ngIf="showing">{{ valueTwo }}</div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SimpleConditionComponent {
         showing = true;
@@ -548,6 +569,8 @@ describe('@angular/common integration', () => {
           </div>
         </div> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedConditionsComponent {
         showing = true;
@@ -577,6 +600,8 @@ describe('@angular/common integration', () => {
         template: `<ng-template #tpl>from tpl</ng-template>
           <ng-template [ngTemplateOutlet]="showing ? tpl : null"></ng-template> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class EmbeddedViewsComponent {
         showing = false;
@@ -603,6 +628,8 @@ describe('@angular/common integration', () => {
         template: `<ng-template #tpl>from tpl</ng-template>
           <ng-container [ngTemplateOutlet]="showing ? tpl : null"></ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NgContainerComponent {
         showing = false;

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -23,6 +23,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -43,6 +44,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -50,6 +53,8 @@ describe('projection', () => {
       selector: 'parent',
       template: '<child>content</child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -65,6 +70,8 @@ describe('projection', () => {
       selector: 'child',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -72,6 +79,8 @@ describe('projection', () => {
       selector: 'parent',
       template: '<child>content</child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -87,6 +96,8 @@ describe('projection', () => {
       selector: 'child',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -95,7 +106,8 @@ describe('projection', () => {
       selector: 'parent',
       template: `<child>before<div>content</div>after</child>`,
       standalone: false,
-    })
+    
+      changeDetection: ChangeDetectionStrategy.Eager,})
     class Parent {}
 
     TestBed.configureTestingModule({declarations: [Parent, Child]});
@@ -110,6 +122,8 @@ describe('projection', () => {
       selector: 'grand-child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class GrandChild {}
 
@@ -117,6 +131,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<grand-child><ng-content></ng-content></grand-child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -124,6 +140,8 @@ describe('projection', () => {
       selector: 'parent',
       template: `<child><b>Hello</b>World!</child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -141,6 +159,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -148,6 +168,8 @@ describe('projection', () => {
       selector: 'projected-comp',
       template: 'content',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedComp {}
 
@@ -155,6 +177,8 @@ describe('projection', () => {
       selector: 'parent',
       template: `<child><projected-comp></projected-comp></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -172,6 +196,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -179,6 +205,8 @@ describe('projection', () => {
       selector: 'projected-comp',
       template: `<p><ng-content></ng-content></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedComp {}
 
@@ -190,7 +218,8 @@ describe('projection', () => {
           <projected-comp><div>Some content</div>Other content</projected-comp>
         </child>`,
       standalone: false,
-    })
+    
+      changeDetection: ChangeDetectionStrategy.Eager,})
     class Parent {}
 
     TestBed.configureTestingModule({declarations: [Parent, Child, ProjectedComp]});
@@ -207,6 +236,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -214,6 +245,8 @@ describe('projection', () => {
       selector: 'projected-comp',
       template: `Before<ng-content></ng-content>After`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedComp {}
 
@@ -230,6 +263,8 @@ describe('projection', () => {
         >
       </child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -250,6 +285,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -257,6 +294,8 @@ describe('projection', () => {
       selector: 'projected-comp',
       template: `Before<ng-content></ng-content>After`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedComp {}
 
@@ -274,6 +313,8 @@ describe('projection', () => {
         >
       </child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -284,6 +325,8 @@ describe('projection', () => {
         <parent>**DEF**</parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -309,6 +352,8 @@ describe('projection', () => {
       template: `Before-<ng-template [ngIf]="showing"><ng-content></ng-content></ng-template
         >-After`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       showing = false;
@@ -321,6 +366,8 @@ describe('projection', () => {
         Some text</child
       >`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -356,6 +403,8 @@ describe('projection', () => {
         </ng-template>
         -After`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       showing = false;
@@ -370,6 +419,8 @@ describe('projection', () => {
         </child>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -404,6 +455,8 @@ describe('projection', () => {
       selector: 'comp',
       template: `<ng-template><ng-content></ng-content></ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @ViewChild(TemplateRef, {static: true}) template!: TemplateRef<any>;
@@ -430,6 +483,8 @@ describe('projection', () => {
         <comp #comp>Some content</comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -453,6 +508,8 @@ describe('projection', () => {
       template: `<div><ng-content></ng-content></div>
         <span><ng-content></ng-content></span>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -460,6 +517,8 @@ describe('projection', () => {
       selector: 'parent',
       template: `<child>content</child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -479,6 +538,8 @@ describe('projection', () => {
       template:
         '<div *ngFor="let item of [1, 2]; let i = index">({{i}}):<ng-content></ng-content></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -486,6 +547,8 @@ describe('projection', () => {
       selector: 'parent',
       template: '<child>content</child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -503,6 +566,8 @@ describe('projection', () => {
       selector: 'nested-comp',
       template: `<div>Child content</div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class NestedComp {}
 
@@ -510,6 +575,8 @@ describe('projection', () => {
       selector: 'root-comp',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootComp {}
 
@@ -523,6 +590,8 @@ describe('projection', () => {
         </root-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       items = [1, 2];
@@ -557,6 +626,8 @@ describe('projection', () => {
         </ng-container>
       </ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootComp {
       @Input() show: boolean = true;
@@ -566,6 +637,8 @@ describe('projection', () => {
       selector: 'my-app',
       template: `<root-comp [show]="show"><div></div></root-comp> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       show = true;
@@ -587,6 +660,8 @@ describe('projection', () => {
       selector: 'root-comp',
       template: `<ng-template [ngIf]="show"><ng-content></ng-content></ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootComp {
       @Input() show: boolean = true;
@@ -598,6 +673,8 @@ describe('projection', () => {
         ><ng-container><div></div></ng-container
       ></root-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       show = true;
@@ -619,6 +696,8 @@ describe('projection', () => {
       selector: 'child',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -630,6 +709,8 @@ describe('projection', () => {
         </ng-container>
       </child> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -645,6 +726,8 @@ describe('projection', () => {
       selector: 'grand-child',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class GrandChild {}
 
@@ -654,6 +737,8 @@ describe('projection', () => {
         <ng-content></ng-content>
       </grand-child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -665,6 +750,8 @@ describe('projection', () => {
         </ng-container>
       </child> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -682,6 +769,8 @@ describe('projection', () => {
       selector: 'child-comp',
       template: `<ng-template [ngIf]="show"><ng-content></ng-content></ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp {
       @Input() show: boolean = true;
@@ -691,6 +780,8 @@ describe('projection', () => {
       selector: 'parent-comp',
       template: `<child-comp [show]="show"><ng-content></ng-content></child-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentComp {
       @Input() show: boolean = true;
@@ -700,6 +791,8 @@ describe('projection', () => {
       selector: 'my-app',
       template: `<parent-comp [show]="show"><div></div></parent-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       show = true;
@@ -722,6 +815,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content select="span[title=toFirst]"></ng-content></div>
           <div id="second"><ng-content select="span[title=toSecond]"></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -729,6 +824,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span title="toFirst">1</span><span title="toSecond">2</span></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -747,6 +844,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content select="span.toFirst"></ng-content></div>
           <div id="second"><ng-content select="span.toSecond"></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -754,6 +853,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span class="toFirst">1</span><span class="toSecond">2</span></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -772,6 +873,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content select="span.toFirst"></ng-content></div>
           <div id="second"><ng-content select="span.toSecond"></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -781,6 +884,8 @@ describe('projection', () => {
           ><span class="other toFirst">1</span><span class="noise toSecond">2</span></child
         >`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -799,6 +904,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content select="span"></ng-content></div>
           <div id="second"><ng-content select="span.toSecond"></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -806,6 +913,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span class="toFirst">1</span><span class="toSecond">2</span></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -824,6 +933,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content select="span.toFirst"></ng-content></div>
           <div id="second"><ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -833,6 +944,8 @@ describe('projection', () => {
           ><span class="toFirst">1</span><span>remaining</span>more remaining</child
         >`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -851,6 +964,8 @@ describe('projection', () => {
         template: `<div id="first"><ng-content></ng-content></div>
           <div id="second"><ng-content select="span.toSecond"></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -858,6 +973,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span>1</span><span class="toSecond">2</span>remaining</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -881,6 +998,8 @@ describe('projection', () => {
           <hr />
           <ng-content></ng-content>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class GrandChild {}
 
@@ -891,6 +1010,8 @@ describe('projection', () => {
           <span>in child template</span>
         </grand-child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -898,6 +1019,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span>parent content</span></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -917,6 +1040,8 @@ describe('projection', () => {
           <hr />
           <ng-content select="[card-content]"></ng-content>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Card {}
 
@@ -927,6 +1052,8 @@ describe('projection', () => {
           <ng-content card-content></ng-content>
         </card>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CardWithTitle {}
 
@@ -934,6 +1061,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<card-with-title>content</card-with-title>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -951,6 +1080,8 @@ describe('projection', () => {
         selector: 'child',
         template: `<ng-content select="div"></ng-content>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -961,6 +1092,8 @@ describe('projection', () => {
           <div>should project</div></child
         >`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -979,6 +1112,8 @@ describe('projection', () => {
         selector: 'child',
         template: `<ng-content select="[title]"></ng-content>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -986,6 +1121,8 @@ describe('projection', () => {
         selector: 'parent',
         template: `<child><span [title]="'Some title'">Has title</span></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -1003,12 +1140,16 @@ describe('projection', () => {
         selector: 'child',
         template: `<span><ng-content select="div"></ng-content></span>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
       @Component({
         template: `<child><div *ngIf="value">content</div></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         value = false;
@@ -1030,6 +1171,8 @@ describe('projection', () => {
       selector: 'child-comp', //
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp {}
 
@@ -1037,6 +1180,8 @@ describe('projection', () => {
       selector: 'root-comp', //
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootComp {}
 
@@ -1050,6 +1195,8 @@ describe('projection', () => {
         </root-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       items: number[] = [1, 2, 3];
@@ -1077,6 +1224,8 @@ describe('projection', () => {
       selector: 'my-comp',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(changeDetectorRef: ChangeDetectorRef) {
@@ -1092,6 +1241,8 @@ describe('projection', () => {
         </my-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -1123,6 +1274,8 @@ describe('projection', () => {
         <ng-content select="[card-footer]"></ng-content>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Card {}
 
@@ -1137,6 +1290,8 @@ describe('projection', () => {
         </card>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CardWithTitle {}
 
@@ -1156,6 +1311,8 @@ describe('projection', () => {
         <ng-content select="[card-content]"></ng-content>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Card {}
 
@@ -1168,6 +1325,8 @@ describe('projection', () => {
         </card>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CardWithTitle {}
 
@@ -1175,6 +1334,8 @@ describe('projection', () => {
       selector: 'app',
       template: ` <card-with-title>content</card-with-title> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1193,6 +1354,8 @@ describe('projection', () => {
         content
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Card {}
 
@@ -1203,6 +1366,8 @@ describe('projection', () => {
         </card>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1218,6 +1383,8 @@ describe('projection', () => {
       selector: 'projector',
       template: `<ng-content select="projectMe"></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projector {}
 
@@ -1228,6 +1395,8 @@ describe('projection', () => {
         </projector>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Root {}
 
@@ -1250,6 +1419,8 @@ describe('projection', () => {
         selector: 'selector-proj',
         template: '<ng-content select="div"></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectedNgContentComp {}
 
@@ -1267,6 +1438,8 @@ describe('projection', () => {
         selector: 'main-selector',
         template: '<selector-proj><div x="true" *ngIf="true">Hello world!</div></selector-proj>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectorMainComp {}
 
@@ -1286,6 +1459,8 @@ describe('projection', () => {
         selector: 'selector-proj',
         template: '<ng-content select="[x]"></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectedNgContentComp {}
 
@@ -1303,6 +1478,8 @@ describe('projection', () => {
         selector: 'main-selector',
         template: '<selector-proj><div x="true" *ngIf="true">Hello world!</div></selector-proj>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectorMainComp {}
 
@@ -1322,6 +1499,8 @@ describe('projection', () => {
         selector: 'selector-proj',
         template: '<ng-content select=".x"></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectedNgContentComp {}
 
@@ -1339,6 +1518,8 @@ describe('projection', () => {
         selector: 'main-selector',
         template: '<selector-proj><div class="x" *ngIf="true">Hello world!</div></selector-proj>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectorMainComp {}
 
@@ -1357,6 +1538,8 @@ describe('projection', () => {
         selector: 'selector-proj',
         template: '<ng-content select="[ngTrackBy]"></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectedNgContentComp {}
 
@@ -1366,6 +1549,8 @@ describe('projection', () => {
           'inline(<selector-proj><div *ngFor="let item of items trackBy getItemId">{{item.name}}</div></selector-proj>)' +
           'ng-template(<selector-proj><ng-template ngFor [ngForOf]="items" let-item ngTrackBy="getItemId"><div>{{item.name}}</div></ng-template></selector-proj>)',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SelectorMainComp {
         items = [
@@ -1395,6 +1580,8 @@ describe('projection', () => {
           <ng-content select=".foo"></ng-content>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ProjectorApp {}
 
@@ -1408,6 +1595,8 @@ describe('projection', () => {
           </projector-app>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {
         show = true;
@@ -1440,6 +1629,8 @@ describe('projection', () => {
           selector: 'selector-proj',
           template: '<ng-content select="[x]"></ng-content>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SelectedNgContentComp {}
 
@@ -1458,6 +1649,8 @@ describe('projection', () => {
           template:
             '<selector-proj><ng-container x="true">Hello world!</ng-container></selector-proj>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SelectorMainComp {}
 
@@ -1477,6 +1670,8 @@ describe('projection', () => {
           selector: 'selector-proj',
           template: '<ng-content select=".x"></ng-content>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SelectedNgContentComp {}
 
@@ -1495,6 +1690,8 @@ describe('projection', () => {
           template:
             '<selector-proj><ng-container class="x">Hello world!</ng-container></selector-proj>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SelectorMainComp {}
 
@@ -1513,6 +1710,8 @@ describe('projection', () => {
           selector: 'child-comp',
           template: '<ng-content select=".nomatch"></ng-content>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildComp {}
 
@@ -1520,6 +1719,8 @@ describe('projection', () => {
           selector: 'parent-comp',
           template: `<child-comp><span *ngIf="true" class="{{ 'a' }}"></span></child-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentComp {}
 
@@ -1536,6 +1737,8 @@ describe('projection', () => {
         selector: 'child-comp',
         template: '<ng-content select=".title"></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComp {}
 
@@ -1545,6 +1748,8 @@ describe('projection', () => {
           ><span *ngIf="true" id="5" jjj="class" class="{{ 'a' }}" [title]="'abc'"></span
         ></child-comp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentComp {}
 
@@ -1571,6 +1776,8 @@ describe('projection', () => {
           `<ng-content select="[two]">Two fallback</ng-content>` +
           `<ng-content select="[three]">Three fallback</ng-content>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1582,6 +1789,8 @@ describe('projection', () => {
             <div three>Three</div>
           </projection>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1596,6 +1805,8 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Fallback content</ng-content>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1608,6 +1819,8 @@ describe('projection', () => {
             <!-- Two -->
           </projection>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1623,6 +1836,8 @@ describe('projection', () => {
         template: `<ng-content select="div">I have no divs</ng-content>|<ng-content select="span"
             >I have no spans</ng-content
           >`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1633,6 +1848,8 @@ describe('projection', () => {
             <div ngProjectAs="span">div pretending to be a span</div>
           </projection>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Projection) projection!: Projection;
@@ -1651,6 +1868,8 @@ describe('projection', () => {
         template: `<ng-content>Wildcard fallback</ng-content>|<ng-content select="span"
             >Span fallback</ng-content
           >`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1663,6 +1882,8 @@ describe('projection', () => {
             }
           </projection>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showSpan = false;
@@ -1691,12 +1912,16 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Fallback</ng-content>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
       @Component({
         imports: [Projection],
         template: ` <projection><ng-container /></projection> `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showSpan = false;
@@ -1710,12 +1935,18 @@ describe('projection', () => {
       @Component({
         selector: 'projection',
         template: `<ng-content>Value: {{ value }}</ng-content>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {
         value = 0;
       }
 
-      @Component({imports: [Projection], template: `<projection />`})
+      @Component({
+        imports: [Projection],
+        template: `<projection />`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {
         @ViewChild(Projection) projection!: Projection;
       }
@@ -1739,6 +1970,8 @@ describe('projection', () => {
 
           Value: {{ value }}
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {
         value = 0;
@@ -1748,7 +1981,11 @@ describe('projection', () => {
         }
       }
 
-      @Component({imports: [Projection], template: `<projection />`})
+      @Component({
+        imports: [Projection],
+        template: `<projection />`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       const fixture = TestBed.createComponent(App);
@@ -1780,6 +2017,8 @@ describe('projection', () => {
         selector: 'projection',
         template: `<ng-content><fallback-dir /></ng-content>`,
         imports: [FallbackDir],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1790,6 +2029,8 @@ describe('projection', () => {
             <projection />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         hasProjection = true;
@@ -1820,6 +2061,8 @@ describe('projection', () => {
         selector: 'projection',
         template: `<ng-content><fallback-dir /></ng-content>`,
         imports: [FallbackDir],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {
         @ViewChild(FallbackDir) fallback!: FallbackDir;
@@ -1828,6 +2071,8 @@ describe('projection', () => {
       @Component({
         imports: [Projection],
         template: `<projection />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Projection) projection!: Projection;
@@ -1852,6 +2097,8 @@ describe('projection', () => {
         selector: 'projection',
         template: `<ng-content><fallback-dir /></ng-content>`,
         imports: [FallbackDir],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {
         @ViewChild(FallbackDir) fallback!: FallbackDir;
@@ -1860,6 +2107,8 @@ describe('projection', () => {
       @Component({
         imports: [Projection],
         template: `<projection />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Projection) projection!: Projection;
@@ -1876,6 +2125,8 @@ describe('projection', () => {
         template:
           `<ng-content>One fallback</ng-content>|` +
           `<ng-content>Two fallback</ng-content>|<ng-content>Three fallback</ng-content>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1900,6 +2151,8 @@ describe('projection', () => {
         template:
           `<ng-content>One fallback</ng-content>|` +
           `<ng-content>Two fallback</ng-content>|<ng-content>Three fallback</ng-content>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1926,6 +2179,8 @@ describe('projection', () => {
         template: `<ng-container #ref /><ng-template #template
             ><ng-content>Fallback</ng-content></ng-template
           >`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {
         @ViewChild('template') template!: TemplateRef<unknown>;
@@ -1939,6 +2194,8 @@ describe('projection', () => {
       @Component({
         imports: [Projection],
         template: `<projection />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Projection) projection!: Projection;
@@ -1960,6 +2217,8 @@ describe('projection', () => {
           <ng-content select="[inner-header]">Inner header fallback</ng-content>
           <ng-content select="[inner-footer]">Inner footer fallback</ng-content>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class InnerProjection {}
 
@@ -1972,6 +2231,8 @@ describe('projection', () => {
           </inner-projection>
         `,
         imports: [InnerProjection],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
@@ -1982,6 +2243,8 @@ describe('projection', () => {
             <span outer-header>Outer header override</span>
           </projection>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1998,6 +2261,8 @@ describe('projection', () => {
       @Component({
         selector: 'fallback',
         template: 'Fallback',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Fallback {
         constructor() {
@@ -2009,12 +2274,16 @@ describe('projection', () => {
         selector: 'projection',
         template: `<ng-content><fallback /></ng-content>`,
         imports: [Fallback],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
       @Component({
         imports: [Projection],
         template: `<projection>Hello</projection>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2030,6 +2299,8 @@ describe('projection', () => {
         @Component({
           selector: 'projection',
           template: `<ng-content>Fallback</ng-content>`,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Projection {}
 
@@ -2039,6 +2310,8 @@ describe('projection', () => {
             <projection>Content</projection>
             <projection />
           `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2056,6 +2329,8 @@ describe('projection', () => {
         @Component({
           selector: 'projection',
           template: `<ng-content>Fallback</ng-content>`,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Projection {}
 
@@ -2065,6 +2340,8 @@ describe('projection', () => {
             <projection />
             <projection>Content</projection>
           `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2083,12 +2360,16 @@ describe('projection', () => {
             <span i18n="@@MY_ID">a <b>b</b> c</span>
           </ng-content>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projection {}
 
       @Component({
         imports: [Projection],
         template: `<projection />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 

--- a/packages/core/test/acceptance/control_flow_for_spec.ts
+++ b/packages/core/test/acceptance/control_flow_for_spec.ts
@@ -34,6 +34,8 @@ describe('control flow - for', () => {
     @Component({
       template: '@for ((item of items); track item; let idx = $index) {{{item}}({{idx}})|}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -61,6 +63,8 @@ describe('control flow - for', () => {
     @Component({
       template: '@for ((item of items.keys()); track $index) {{{item}}|}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items = new Map([
@@ -79,6 +83,8 @@ describe('control flow - for', () => {
     @Component({
       template: '@for ((item of items); track idx; let idx = $index) {{{item}}({{idx}})|}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -106,6 +112,8 @@ describe('control flow - for', () => {
     @Component({
       template: '@for ((item of items); track idx; let idx = $index) {|} @empty {Empty}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items: number[] | null | undefined = [1, 2, 3];
@@ -149,6 +157,8 @@ describe('control flow - for', () => {
     @Component({
       template: '@for (item of items | test; track item;) {{{item}}|}',
       imports: [TestPipe],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -182,6 +192,8 @@ describe('control flow - for', () => {
           {{ x }}
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -195,6 +207,8 @@ describe('control flow - for', () => {
       template:
         '@for ((item of items); track item; let idx = $index) {{{item}}({{$index}}/{{idx}})|}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       items = [1, 2, 3];
@@ -216,6 +230,8 @@ describe('control flow - for', () => {
       @Component({
         template: '@for ((item of items); track $index + offset) {{{item}}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['a', 'b', 'c'];
@@ -249,6 +265,8 @@ describe('control flow - for', () => {
           {{ item }}
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['a', 'b'];
@@ -281,6 +299,8 @@ describe('control flow - for', () => {
           }
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['a', 'b'];
@@ -305,6 +325,8 @@ describe('control flow - for', () => {
           {{ item }}
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['a', 'b'];
@@ -326,6 +348,8 @@ describe('control flow - for', () => {
           {{ item }}
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['a', 'b', 'a', 'c', 'a'];
@@ -361,6 +385,8 @@ describe('control flow - for', () => {
           {{ item }}
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = new Map([
@@ -402,6 +428,8 @@ describe('control flow - for', () => {
       @Component({
         template: `@for (item of items.values(); track item) {}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = new Map([
@@ -423,6 +451,8 @@ describe('control flow - for', () => {
       @Component({
         template: `@for (item of items; track item) {}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -446,6 +476,8 @@ describe('control flow - for', () => {
           >)
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [{value: 0}, {value: 1}];
@@ -472,6 +504,8 @@ describe('control flow - for', () => {
           ({{ item.value }})
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [{value: 0}, {value: 1}];
@@ -498,6 +532,8 @@ describe('control flow - for', () => {
           ({{ item.value }})
         }`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [{value: 0}, {value: 1}];
@@ -524,6 +560,8 @@ describe('control flow - for', () => {
       @Component({
         template: '@for (item of items; track item; let idx = $index) {{{item}}({{idx}})|}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -543,6 +581,8 @@ describe('control flow - for', () => {
       @Component({
         template: '@for (item of items; track item; let idx = $index) {{{item}}({{idx}})|}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 3];
@@ -562,6 +602,8 @@ describe('control flow - for', () => {
       @Component({
         template: '@for (item of items; track item; let idx = $index) {{{item}}({{idx}})|}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 2, 3];
@@ -581,6 +623,8 @@ describe('control flow - for', () => {
       @Component({
         template: '@for (item of items; track item; let idx = $index) {{{item}}({{idx}})|}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = [1, 2, 3, 4, 5, 6];
@@ -613,6 +657,8 @@ describe('control flow - for', () => {
       @Component({
         template: ``,
         selector: 'child-cmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp {}
 
@@ -623,6 +669,8 @@ describe('control flow - for', () => {
             <child-cmp />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         tasks = BEFORE;
@@ -644,6 +692,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -658,6 +708,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -673,6 +725,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -688,6 +742,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [];
@@ -704,6 +760,8 @@ describe('control flow - for', () => {
         selector: 'test',
         template:
           'Main: <ng-content/> Loop slot: <ng-content select="[loop]"/> Empty slot: <ng-content select="[empty]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -720,6 +778,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -743,6 +803,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -758,6 +820,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2];
@@ -784,6 +848,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -798,6 +864,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -814,6 +882,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -831,6 +901,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -848,6 +920,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -864,6 +938,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -879,6 +955,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -888,6 +966,8 @@ describe('control flow - for', () => {
         // Note the whitespace due to the indentation inside @for.
         template:
           '<test>Before @for (item of items; track $index) {<span foo>{{item}}</span>} After</test>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -902,6 +982,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -918,6 +1000,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2, 3];
@@ -932,6 +1016,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -948,6 +1034,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2];
@@ -962,6 +1050,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -974,6 +1064,8 @@ describe('control flow - for', () => {
           }
           After</test
         >`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1, 2];
@@ -994,6 +1086,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1015,6 +1109,8 @@ describe('control flow - for', () => {
           }
           After</test
         > `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1];
@@ -1033,6 +1129,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1062,6 +1160,8 @@ describe('control flow - for', () => {
           }
           After</test
         > `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1];
@@ -1080,6 +1180,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1109,6 +1211,8 @@ describe('control flow - for', () => {
           }
           After</test
         > `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1];
@@ -1125,6 +1229,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1137,6 +1243,8 @@ describe('control flow - for', () => {
             }
           </test>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1];
@@ -1151,6 +1259,8 @@ describe('control flow - for', () => {
       @Component({
         selector: 'test',
         template: 'Main: <ng-content/> Slot: <ng-content select="[foo]"/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1167,6 +1277,8 @@ describe('control flow - for', () => {
             After</test
           >
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = [1];

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy} from '@angular/compiler';
 import {
+  ChangeDetectionStrategy,
   Component,
   createComponent,
   createEnvironmentInjector,
@@ -42,6 +42,8 @@ describe('createComponent', () => {
   it('should create an instance of a standalone component', () => {
     @Component({
       template: 'Hello {{ name }}!',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StandaloneComponent {
       name = 'Angular';
@@ -65,6 +67,8 @@ describe('createComponent', () => {
     @Component({
       template: 'Hello {{ name }}!',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class NgModuleBasedComponent {
       name = 'Angular';
@@ -97,6 +101,8 @@ describe('createComponent', () => {
         <ng-content></ng-content>| <ng-content></ng-content>|
         <ng-content></ng-content>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StandaloneComponent {}
 
@@ -124,6 +130,8 @@ describe('createComponent', () => {
     const A = new InjectionToken('A');
     @Component({
       template: 'Token: {{ a }}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StandaloneComponent {
       a = inject(A);
@@ -145,6 +153,8 @@ describe('createComponent', () => {
     const B = new InjectionToken('B');
     @Component({
       template: '{{ a }} and {{ b }}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildStandaloneComponent {
       a = inject(A);
@@ -154,6 +164,8 @@ describe('createComponent', () => {
     @Component({
       template: 'Tokens: <div #target></div>',
       providers: [{provide: A, useValue: 'ElementInjector(A)'}],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootStandaloneComponent {
       @ViewChild('target', {read: ElementRef}) target!: ElementRef;
@@ -192,6 +204,8 @@ describe('createComponent', () => {
     @Component({
       selector,
       template: 'Hello {{ name }}!',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StandaloneComponent {
       name = 'Angular';
@@ -218,6 +232,8 @@ describe('createComponent', () => {
       @Component({
         selector: '.some-class',
         template: 'Hello {{ name }}!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class StandaloneComponent {
         name = 'Angular';
@@ -273,6 +289,8 @@ describe('createComponent', () => {
           'class': 'host',
           'attr-three': 'host',
         },
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComponent {
         constructor() {
@@ -307,7 +325,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -389,6 +407,8 @@ describe('createComponent', () => {
         selector: 'my-comp',
         template: '',
         hostDirectives: [Chain1, Chain2, Chain3],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComponent {
         constructor() {
@@ -449,7 +469,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent implements OnDestroy {
         ngOnDestroy() {
           logs.push('HostComponent');
@@ -479,7 +499,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {
         constructor() {
           injectedInstance = inject(Dir);
@@ -511,7 +531,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {
         @Input() someInput = 0;
       }
@@ -540,7 +560,7 @@ describe('createComponent', () => {
       @Directive({})
       class Dir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -558,7 +578,7 @@ describe('createComponent', () => {
     it('should throw if a non-directive class is attached', () => {
       class NotADir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -576,7 +596,7 @@ describe('createComponent', () => {
     it('should throw if a non-directive class is attached using the DirectiveWithBinding syntax', () => {
       class NotADir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -597,10 +617,10 @@ describe('createComponent', () => {
     });
 
     it('should throw if a component class is attached', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class NotADir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -619,7 +639,7 @@ describe('createComponent', () => {
       @Directive({standalone: false})
       class Dir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class HostComponent {}
 
       const hostElement = document.createElement('div');
@@ -639,7 +659,10 @@ describe('createComponent', () => {
 
   describe('root component inputs', () => {
     it('should be able to bind to inputs of the root component', () => {
-      @Component({template: '{{one}} - {{two}} - {{other}}'})
+      @Component({
+        template: '{{one}} - {{two}} - {{other}}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class RootComp {
         @Input() one = '';
         @Input({alias: 'twoAlias'}) two = '';
@@ -684,7 +707,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() someInput = '';
       }
@@ -733,6 +756,8 @@ describe('createComponent', () => {
       @Component({
         template: '',
         hostDirectives: [{directive: RootHostDir, inputs: ['someInput']}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {
         @Input() someInput = '';
@@ -781,7 +806,7 @@ describe('createComponent', () => {
       })
       class RootDir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {}
 
       const value = signal('initial');
@@ -820,6 +845,8 @@ describe('createComponent', () => {
       @Component({
         template: '',
         hostDirectives: [{directive: RootHostDir, inputs: ['someAlias: alias']}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {}
 
@@ -861,7 +888,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() someInput = '';
         @Input() someOtherInput = '';
@@ -903,7 +930,7 @@ describe('createComponent', () => {
     it('should invoke ngOnChanges when binding to a root component input', () => {
       const changes: SimpleChange[] = [];
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp implements OnChanges {
         @Input() someInput = '';
 
@@ -946,7 +973,7 @@ describe('createComponent', () => {
     });
 
     it('should transform input bound to the root component', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input({transform: (value: string) => parseInt(value)}) someInput = -1;
       }
@@ -989,7 +1016,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() someInput = '';
       }
@@ -1031,7 +1058,7 @@ describe('createComponent', () => {
     it('should only invoke setters if the value has changed', () => {
       let setterCount = 0;
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input()
         set someInput(_: string) {
@@ -1062,7 +1089,7 @@ describe('createComponent', () => {
     });
 
     it('should throw if target does not have an input with a specific name', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() someInput = '';
       }
@@ -1091,7 +1118,7 @@ describe('createComponent', () => {
     });
 
     it('should throw when using setInput on a component already using inputBindings', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() someInput = '';
       }
@@ -1144,7 +1171,7 @@ describe('createComponent', () => {
       // This test ensures that dynamic input bindings can still target arbitrary inputs with the
       // same name.
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() formField = '';
       }
@@ -1170,7 +1197,7 @@ describe('createComponent', () => {
 
   describe('root component outputs', () => {
     it('should be able to bind to outputs of the root component', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() event = new EventEmitter<{value: number}>();
       }
@@ -1197,7 +1224,7 @@ describe('createComponent', () => {
     });
 
     it('should clean up root component output listeners', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() event = new EventEmitter<void>();
       }
@@ -1222,7 +1249,7 @@ describe('createComponent', () => {
     });
 
     it('should handle errors in root component listeners through the ErrorHandler', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() event = new EventEmitter<void>();
       }
@@ -1278,6 +1305,8 @@ describe('createComponent', () => {
             outputs: ['myEvent: event'],
           },
         ],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {
         @Output() event = new EventEmitter<string>();
@@ -1317,7 +1346,7 @@ describe('createComponent', () => {
     it('should not listen to directive outputs with the same name as outputs on the root component', () => {
       let dirInstance!: RootDir;
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() event = new EventEmitter<string>();
       }
@@ -1353,7 +1382,7 @@ describe('createComponent', () => {
     it('should not listen to root component outputs with the same name as outputs on one of the directives', () => {
       let dirInstance!: RootDir;
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() event = new EventEmitter<string>();
       }
@@ -1391,7 +1420,7 @@ describe('createComponent', () => {
     });
 
     it('should throw if root component does not have an output with the specified name', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {}
 
       const hostElement = document.createElement('div');
@@ -1407,7 +1436,7 @@ describe('createComponent', () => {
     });
 
     it('should not listen to native event when creating an output binding', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() click = new EventEmitter<void>();
       }
@@ -1428,7 +1457,7 @@ describe('createComponent', () => {
 
   describe('root component two-way bindings', () => {
     it('should be able to use a two-way binding on the root component', () => {
-      @Component({template: 'Value: {{value}}'})
+      @Component({template: 'Value: {{value}}', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();
@@ -1471,7 +1500,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();
@@ -1530,7 +1559,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();
@@ -1598,6 +1627,8 @@ describe('createComponent', () => {
       @Component({
         template: '',
         hostDirectives: [{directive: RootHostDir, inputs: ['value'], outputs: ['valueChange']}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {
         @Input() value = '';
@@ -1675,7 +1706,7 @@ describe('createComponent', () => {
       })
       class RootDir {}
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {}
 
       const value = signal('initial');
@@ -1729,6 +1760,8 @@ describe('createComponent', () => {
             outputs: ['valueAliasChange: myAliasChange'],
           },
         ],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {}
 
@@ -1780,7 +1813,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();
@@ -1882,7 +1915,7 @@ describe('createComponent', () => {
         }
       }
 
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();
@@ -1949,7 +1982,7 @@ describe('createComponent', () => {
     });
 
     it('should throw if two-way binding target does not have an input with the specific name', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Output() valueChange = new EventEmitter<string>();
       }
@@ -1969,7 +2002,7 @@ describe('createComponent', () => {
     });
 
     it('should throw if two-way binding target does not have an output with the specific name', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
       }
@@ -1988,7 +2021,7 @@ describe('createComponent', () => {
     });
 
     it('should throw when using setInput on a component already using twoWayBinding', () => {
-      @Component({template: ''})
+      @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
       class RootComp {
         @Input() value = '';
         @Output() valueChange = new EventEmitter<string>();

--- a/packages/core/test/acceptance/defer_spec.ts
+++ b/packages/core/test/acceptance/defer_spec.ts
@@ -165,6 +165,8 @@ function createFixture(template: string) {
   @Component({
     selector: 'nested-cmp',
     template: '{{ block }}',
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class NestedCmp {
     @Input() block!: string;
@@ -174,6 +176,8 @@ function createFixture(template: string) {
     selector: 'simple-app',
     imports: [NestedCmp],
     template,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class MyCmp {
     trigger = false;
@@ -237,6 +241,8 @@ describe('@defer', () => {
     @Component({
       selector: 'my-lazy-cmp',
       template: 'Hi!',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyLazyCmp {}
 
@@ -254,6 +260,8 @@ describe('@defer', () => {
           Failed to load dependencies :(
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCmp {
       isVisible = false;
@@ -280,6 +288,8 @@ describe('@defer', () => {
     @Component({
       selector: 'my-lazy-cmp',
       template: 'Hi!',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyLazyCmp {}
 
@@ -292,6 +302,8 @@ describe('@defer', () => {
           <my-lazy-cmp />
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCmp {
       isVisible = false;
@@ -327,6 +339,8 @@ describe('@defer', () => {
       template: `@defer (when isVisible | test; prefetch when isVisible | test) {
         Hello
       }`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCmp {
       isVisible = false;
@@ -389,6 +403,8 @@ describe('@defer', () => {
         }
         <div mode="eager" dirA dirB dirC></div>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCmp {
       isVisible = true;
@@ -414,6 +430,8 @@ describe('@defer', () => {
       @Component({
         selector: 'my-lazy-cmp',
         template: '{{ foo }}',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyLazyCmp {
         foo = 'bar';
@@ -459,6 +477,8 @@ describe('@defer', () => {
             <my-lazy-cmp />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -586,6 +606,8 @@ describe('@defer', () => {
             Defer block #3
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -614,6 +636,8 @@ describe('@defer', () => {
       @Component({
         selector: 'simple-app',
         template: `No defer blocks`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -637,6 +661,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -654,6 +680,8 @@ describe('@defer', () => {
             Loading
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -706,6 +734,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -723,6 +753,8 @@ describe('@defer', () => {
             Loading
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -788,6 +820,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -810,6 +844,8 @@ describe('@defer', () => {
             <nested-cmp [block]="'error'" />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -985,6 +1021,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1005,6 +1043,8 @@ describe('@defer', () => {
             <nested-cmp [block]="'error'" />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -1051,6 +1091,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'NestedCmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {}
 
@@ -1066,6 +1108,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -1120,6 +1164,8 @@ describe('@defer', () => {
       @Component({
         selector: 'cmp-with-error',
         template: 'CmpWithError',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CmpWithError {
         constructor() {
@@ -1141,6 +1187,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -1205,6 +1253,8 @@ describe('@defer', () => {
           @Component({
             selector: 'nested-cmp',
             template: 'Rendering {{ block }} block.',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class NestedCmp {
             @Input() block!: string;
@@ -1222,6 +1272,8 @@ describe('@defer', () => {
                 Placeholder!
               }
             `,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyCmp {
             isVisible = false;
@@ -1285,6 +1337,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1307,6 +1361,8 @@ describe('@defer', () => {
             <nested-cmp [block]="'error'" />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -1349,18 +1405,24 @@ describe('@defer', () => {
       @Component({
         selector: 'cmp-a',
         template: 'CmpA',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CmpA {}
 
       @Component({
         selector: 'cmp-b',
         template: 'CmpB',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CmpB {}
 
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1384,6 +1446,8 @@ describe('@defer', () => {
             <nested-cmp [block]="'error'" />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         @Input() isVisible = false;
@@ -1404,6 +1468,8 @@ describe('@defer', () => {
             }
           </my-app>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         isVisible = false;
@@ -1455,12 +1521,16 @@ describe('@defer', () => {
       @Component({
         selector: 'cmp-a',
         template: 'CmpA',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CmpA {}
 
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1482,6 +1552,8 @@ describe('@defer', () => {
             <nested-cmp [block]="'placeholder'" />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         isVisible = false;
@@ -1526,6 +1598,8 @@ describe('@defer', () => {
       @Component({
         selector: 'cmp-a',
         template: 'CmpA',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CmpA {}
 
@@ -1541,6 +1615,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1679,6 +1755,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1694,6 +1772,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -1758,6 +1838,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1775,6 +1857,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -1836,6 +1920,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1853,6 +1939,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -1902,6 +1990,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -1917,6 +2007,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -2003,6 +2095,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2020,6 +2114,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -2082,6 +2178,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2099,6 +2197,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -2172,6 +2272,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2193,6 +2295,8 @@ describe('@defer', () => {
             With Timeout Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         loadFirst = false;
@@ -2256,6 +2360,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2273,6 +2379,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         items = ['a', 'b', 'c'];
@@ -2324,6 +2432,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2339,6 +2449,8 @@ describe('@defer', () => {
             Placeholder for prefetch idle timeout test
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -2403,6 +2515,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2418,6 +2532,8 @@ describe('@defer', () => {
             Placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         deferCond = false;
@@ -2480,6 +2596,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Primary block content.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2488,6 +2606,8 @@ describe('@defer', () => {
       @Component({
         selector: 'another-nested-cmp',
         template: 'Nested block component.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnotherNestedCmp {}
 
@@ -2513,6 +2633,8 @@ describe('@defer', () => {
             Root block placeholder
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -2574,6 +2696,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -2591,6 +2715,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         items = ['a', 'b', 'c'];
@@ -2647,6 +2773,8 @@ describe('@defer', () => {
             Hello world!
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         isVisible = false;
@@ -2696,6 +2824,8 @@ describe('@defer', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2710,7 +2840,11 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger on a component outside the defer block', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>'})
+      @Component({
+        selector: 'some-comp',
+        template: '<button></button>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class SomeComp {}
 
       @Component({
@@ -2730,6 +2864,8 @@ describe('@defer', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2758,6 +2894,8 @@ describe('@defer', () => {
             </div>
           </button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2788,6 +2926,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         cond = true;
@@ -2804,7 +2944,11 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger that is on a component in a parent embedded view', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>'})
+      @Component({
+        selector: 'some-comp',
+        template: '<button></button>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class SomeComp {}
 
       @Component({
@@ -2824,6 +2968,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         cond = true;
@@ -2853,6 +2999,8 @@ describe('@defer', () => {
             </div>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2867,7 +3015,11 @@ describe('@defer', () => {
     }));
 
     it('should resolve a trigger that is a component inside the placeholder', fakeAsync(() => {
-      @Component({selector: 'some-comp', template: '<button></button>'})
+      @Component({
+        selector: 'some-comp',
+        template: '<button></button>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class SomeComp {}
 
       @Component({
@@ -2884,6 +3036,8 @@ describe('@defer', () => {
             </div>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2910,6 +3064,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2939,6 +3095,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2962,6 +3120,8 @@ describe('@defer', () => {
             <button>Placeholder</button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -2991,6 +3151,8 @@ describe('@defer', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3021,6 +3183,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3042,6 +3206,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3070,6 +3236,8 @@ describe('@defer', () => {
             <button #trigger></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -3100,6 +3268,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -3130,6 +3300,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3159,6 +3331,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -3205,6 +3379,8 @@ describe('@defer', () => {
             <button></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -3259,6 +3435,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3287,6 +3465,8 @@ describe('@defer', () => {
             <button>Placeholder</button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3324,6 +3504,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3351,6 +3533,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3385,6 +3569,8 @@ describe('@defer', () => {
             <button #trigger></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -3421,6 +3607,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -3455,6 +3643,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -3507,6 +3697,8 @@ describe('@defer', () => {
             <button></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -3550,6 +3742,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -3567,6 +3761,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         items = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
@@ -3642,6 +3838,8 @@ describe('@defer', () => {
             placeholder[top]
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -3677,6 +3875,8 @@ describe('@defer', () => {
       @Component({
         selector: 'nested-cmp',
         template: 'Rendering {{ block }} block.',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NestedCmp {
         @Input() block!: string;
@@ -3694,6 +3894,8 @@ describe('@defer', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         shouldTrigger = false;
@@ -3774,6 +3976,8 @@ describe('@defer', () => {
             Hello world!
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         isVisible = false;
@@ -3904,6 +4108,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3928,6 +4134,8 @@ describe('@defer', () => {
             <button>Placeholder</button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3955,6 +4163,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -3998,6 +4208,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4020,6 +4232,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4049,6 +4263,8 @@ describe('@defer', () => {
             <button #trigger></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -4080,6 +4296,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         renderBlock = true;
@@ -4113,6 +4331,8 @@ describe('@defer', () => {
             Two
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4148,6 +4368,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -4195,6 +4417,8 @@ describe('@defer', () => {
             <button></button>
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         // We need a `when` trigger here so that `on idle` doesn't get added automatically.
@@ -4241,7 +4465,8 @@ describe('@defer', () => {
                 @placeholder {<button>p{{item}} </button>}
               }
            `,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class MyCmp {
         items = [1, 2, 3, 4, 5, 6];
       }
@@ -4279,6 +4504,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4300,6 +4527,8 @@ describe('@defer', () => {
           }
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4334,6 +4563,8 @@ describe('@defer', () => {
 
           <button #trigger></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {}
 
@@ -4370,6 +4601,8 @@ describe('@defer', () => {
           <button #trigger></button>
           <div #prefetchTrigger></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -4417,6 +4650,8 @@ describe('@defer', () => {
           <button #trigger></button>
           <div #prefetchTrigger></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         isVisible = false;
@@ -4483,12 +4718,16 @@ describe('@defer', () => {
         selector: 'parent-cmp',
         template: '<ng-content />',
         providers: [{provide: TokenA, useValue: 'TokenA.ParentCmp'}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentCmp {}
 
       @Component({
         selector: 'child-cmp',
         template: 'Token A: {{ parentTokenA }} | Token B: {{ parentTokenB }}',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp {
         parentTokenA = inject(TokenA);
@@ -4506,6 +4745,8 @@ describe('@defer', () => {
         `,
         imports: [ChildCmp, ParentCmp],
         providers: [{provide: TokenB, useValue: 'TokenB.RootCmp'}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         isVisible = true;
@@ -4557,6 +4798,8 @@ describe('@defer', () => {
           selector: 'lazy',
           imports: [MyModule],
           template: ` Lazy Component! Token: {{ token }} `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Lazy {
           token = inject(TokenA);
@@ -4569,6 +4812,8 @@ describe('@defer', () => {
               <lazy />
             }
           `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Dialog {}
 
@@ -4576,6 +4821,8 @@ describe('@defer', () => {
           selector: 'app-root',
           providers: [{provide: TokenA, useValue: 'TokenA from RootCmp'}],
           template: ` <div #container></div> `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class RootCmp {
           injector = inject(Injector);
@@ -4647,6 +4894,8 @@ describe('@defer', () => {
         selector: 'chart',
         template: 'Service:{{ svc.id }}|TokenA:{{ tokenA }}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Chart {
         svc = inject(Service);
@@ -4664,6 +4913,8 @@ describe('@defer', () => {
         selector: 'chart-collection',
         template: '<chart />',
         imports: [ChartsModule],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChartCollectionComponent {}
 
@@ -4678,6 +4929,8 @@ describe('@defer', () => {
         `,
         imports: [ChartCollectionComponent],
         providers: [{provide: TokenA, useValue: 'MyCmp.A'}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         items = [1, 2, 3];
@@ -4739,6 +4992,8 @@ describe('@defer', () => {
       @Component({
         imports: [RouterOutlet],
         template: '<router-outlet />',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4746,6 +5001,8 @@ describe('@defer', () => {
         selector: 'another-child',
         imports: [CommonModule, MyModuleA],
         template: 'another child: {{route.snapshot.url[0]}} | token: {{tokenA}}',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnotherChild {
         route = inject(ActivatedRoute);
@@ -4763,6 +5020,8 @@ describe('@defer', () => {
             <another-child />
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         route = inject(ActivatedRoute);

--- a/packages/core/test/acceptance/destroy_ref_spec.ts
+++ b/packages/core/test/acceptance/destroy_ref_spec.ts
@@ -15,6 +15,7 @@ import {
   EnvironmentInjector,
   inject,
   provideZoneChangeDetection,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -89,6 +90,8 @@ describe('DestroyRef', () => {
       @Component({
         selector: 'test',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(destroyCtx: DestroyRef) {
@@ -122,6 +125,8 @@ describe('DestroyRef', () => {
         // listener)
         template: `<div withCleanup></div>
           <button (click)="noop()"></button>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         noop() {}
@@ -151,6 +156,8 @@ describe('DestroyRef', () => {
         selector: 'test',
         imports: [WithCleanupDirective, NgIf],
         template: `<ng-template [ngIf]="show"><div withCleanup></div></ng-template>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         show = true;
@@ -170,6 +177,8 @@ describe('DestroyRef', () => {
       @Component({
         selector: 'child',
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         constructor() {
@@ -179,6 +188,8 @@ describe('DestroyRef', () => {
       @Component({
         imports: [Child, NgIf],
         template: '<child *ngIf="showChild"></child>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         showChild = true;
@@ -198,6 +209,8 @@ describe('DestroyRef', () => {
     @Component({
       selector: 'test',
       template: ``,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       unRegFn: () => void;
@@ -223,6 +236,8 @@ describe('DestroyRef', () => {
     @Component({
       selector: 'test',
       template: ``,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       unRegFn: () => void;
@@ -250,6 +265,8 @@ describe('DestroyRef', () => {
     @Component({
       selector: 'test',
       template: ``,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       constructor(public destroyRef: DestroyRef) {}
@@ -270,6 +287,8 @@ describe('DestroyRef', () => {
     @Component({
       selector: 'test',
       template: ``,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       constructor(destroyCtx: DestroyRef) {

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -12,6 +12,7 @@ import {BehaviorSubject} from 'rxjs';
 import {
   assertInInjectionContext,
   Attribute,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ComponentRef,
@@ -286,6 +287,7 @@ describe('importProvidersFrom', () => {
         // `any[]` option.
         providers: [[importProvidersFrom(Module)]],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -313,6 +315,8 @@ describe('importProvidersFrom', () => {
     @Component({
       template: '',
       imports: [ModuleA],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StandaloneCmp {}
 
@@ -412,6 +416,8 @@ describe('EnvironmentProviders', () => {
     @Component({
       providers: [environmentProviders as any],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       readonly token = inject(TOKEN);
@@ -440,6 +446,7 @@ describe('di', () => {
       @Component({
         template: '<div dir #dir="dir">{{ dir.value }}</div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
       TestBed.configureTestingModule({declarations: [MyDirective, MyComp]});
@@ -523,6 +530,7 @@ describe('di', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -550,6 +558,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA dirB></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -579,6 +588,7 @@ describe('di', () => {
       @Component({
         template: '<div dirB></div><div dirA></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -597,6 +607,7 @@ describe('di', () => {
         selector: 'my-comp',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(dirB: DirectiveB) {
@@ -607,6 +618,7 @@ describe('di', () => {
       @Component({
         template: '<my-comp dirB></my-comp>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -631,6 +643,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA dirB *ngFor="let i of array"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         array = [1, 2, 3];
@@ -688,6 +701,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA dirB dirC></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -739,6 +753,7 @@ describe('di', () => {
         selector: 'my-comp',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(dirD: DirectiveD) {
@@ -749,6 +764,7 @@ describe('di', () => {
       @Component({
         template: '<my-comp dirA dirB dirC dirD></my-comp>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -771,6 +787,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA dirB dirC></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         value = 'App';
@@ -823,12 +840,14 @@ describe('di', () => {
         selector: 'my-comp',
         template: '<div dirA dirB></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
       @Component({
         template: '<my-comp dirB></my-comp>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -860,6 +879,7 @@ describe('di', () => {
         selector: 'my-comp',
         template: '<div dirA #dir="dirA">{{ dir.dirB.value }}</div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -867,6 +887,8 @@ describe('di', () => {
         @Component({
           template: '<my-comp dirB></my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {}
 
@@ -886,6 +908,8 @@ describe('di', () => {
             </div>
           </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           showing = false;
@@ -911,6 +935,8 @@ describe('di', () => {
             </ng-container>
           </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           skipContent = false;
@@ -952,6 +978,8 @@ describe('di', () => {
               <!-- insertion point -->
             </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(StructuralDirective) structuralDir!: StructuralDirective;
@@ -976,6 +1004,8 @@ describe('di', () => {
             <my-comp dirB></my-comp>
           </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {}
 
@@ -1001,6 +1031,8 @@ describe('di', () => {
             <p dirA #dir="dirA">{{ dir.dirB.value }}</p>
           </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild(HostBindingDirective) hostBindingDir!: HostBindingDirective;
@@ -1041,6 +1073,8 @@ describe('di', () => {
           selector: 'child',
           template: '',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Child {
           constructor(
@@ -1052,6 +1086,8 @@ describe('di', () => {
           selector: 'projector',
           template: '<ng-content></ng-content>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Projector {}
 
@@ -1063,6 +1099,8 @@ describe('di', () => {
             </div>
           </projector>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild('childOrigin', {read: ViewContainerRef, static: true})
@@ -1120,6 +1158,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -1149,6 +1188,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA></div><div dirB></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -1191,6 +1231,7 @@ describe('di', () => {
           {provide: TestB, useFactory: createTestB},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(public readonly testB: TestB) {}
@@ -1230,6 +1271,7 @@ describe('di', () => {
           {provide: TestB, useFactory: createTestB},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(public readonly testB: TestB) {}
@@ -1257,6 +1299,7 @@ describe('di', () => {
       @Component({
         template: '<div dirA></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -1290,6 +1333,8 @@ describe('di', () => {
           @Component({
             template: '<div dirA></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveA) dirA!: DirectiveA;
@@ -1315,6 +1360,8 @@ describe('di', () => {
           @Component({
             template: '<div dirC></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveC) dirC!: DirectiveC;
@@ -1340,6 +1387,8 @@ describe('di', () => {
           @Component({
             template: '<div dirB></div><div dirC></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveC) dirC!: DirectiveC;
@@ -1359,6 +1408,8 @@ describe('di', () => {
           @Component({
             template: '',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             value: string | undefined;
@@ -1387,6 +1438,8 @@ describe('di', () => {
         @Component({
           template: '<div dirB><div dirA></div></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {}
         TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
@@ -1408,6 +1461,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1421,6 +1476,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(
@@ -1455,6 +1512,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@SkipSelf() public injector: Injector) {
@@ -1500,6 +1559,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@Host() @SkipSelf() public injector: Injector) {
@@ -1542,6 +1603,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1555,6 +1618,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@Host() @SkipSelf() public injector: Injector) {}
@@ -1581,6 +1646,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1594,6 +1661,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@Host() @SkipSelf() @Optional() public injector: Injector) {}
@@ -1620,6 +1689,8 @@ describe('di', () => {
             @Component({
               template: '<div>component</div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@SkipSelf() public el: ElementRef) {
@@ -1659,6 +1730,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@SkipSelf() public el: ElementRef) {
@@ -1669,6 +1742,8 @@ describe('di', () => {
             @Component({
               template: '<child></child>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {
               constructor(public el: ElementRef) {
@@ -1713,6 +1788,8 @@ describe('di', () => {
             @Component({
               template: '<div parent>parent <span child>child</span></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -1735,6 +1812,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public elementRef: ElementRef) {
@@ -1745,6 +1824,8 @@ describe('di', () => {
               selector: 'root',
               template: '<div><child *ngIf="true"></child></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1765,6 +1846,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public elementRef: ElementRef) {
@@ -1775,6 +1858,8 @@ describe('di', () => {
               selector: 'root',
               template: '<div><ng-template [ngIf]="true"><child></child></ng-template></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1795,6 +1880,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public ref: ViewContainerRef) {
@@ -1806,6 +1893,8 @@ describe('di', () => {
               selector: 'root',
               template: '<div><child *ngIf="true"></child></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1826,6 +1915,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public changeDetectorRef: ChangeDetectorRef) {
@@ -1837,6 +1928,8 @@ describe('di', () => {
               selector: 'root',
               template: '<child *ngIf="true"></child>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {}
 
@@ -1865,6 +1958,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {
               constructor(public injector: Injector) {
@@ -1882,6 +1977,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public injector: Injector) {
@@ -1913,6 +2010,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ParentComponent {
               constructor(public injector: Injector) {
@@ -1930,6 +2029,8 @@ describe('di', () => {
                 },
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComponent {
               constructor(@SkipSelf() public injector: Injector) {
@@ -1968,6 +2069,8 @@ describe('di', () => {
               selector: '[child]',
               template: '<ng-template dir></ng-template>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComp {
               constructor(public templateRef: TemplateRef<any>) {}
@@ -1978,6 +2081,8 @@ describe('di', () => {
               selector: 'root',
               template: '<div child></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {
               @ViewChild(ChildComp) child!: ChildComp;
@@ -2008,6 +2113,8 @@ describe('di', () => {
               selector: 'root',
               template: '<ng-template dirA></ng-template>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2039,6 +2146,8 @@ describe('di', () => {
               selector: 'root',
               template: '<ng-template dirA></ng-template>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2067,6 +2176,8 @@ describe('di', () => {
               selector: 'root',
               template: '<ng-template dirA></ng-template>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2107,6 +2218,8 @@ describe('di', () => {
             @Component({
               template: '<div parent>parent <span child>child</span></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2150,6 +2263,8 @@ describe('di', () => {
             @Component({
               template: '<div parent>parent <span child>child</span></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2182,6 +2297,8 @@ describe('di', () => {
             @Component({
               template: '<div parent>parent</div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2197,6 +2314,8 @@ describe('di', () => {
             @Component({
               template: '<span>component</span>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {
               constructor(@SkipSelf() vc: ViewContainerRef) {}
@@ -2238,6 +2357,8 @@ describe('di', () => {
             @Component({
               template: '<div parent>parent <span child>child</span></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2260,6 +2381,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class ChildComp {
               constructor(@SkipSelf() cdr: ChangeDetectorRef) {
@@ -2270,6 +2393,8 @@ describe('di', () => {
             @Component({
               template: '<div><child></child></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {
               constructor(public cdr: ChangeDetectorRef) {}
@@ -2289,6 +2414,8 @@ describe('di', () => {
             @Component({
               template: '<div></div>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@SkipSelf() public injector: ChangeDetectorRef) {}
@@ -2315,6 +2442,8 @@ describe('di', () => {
               selector: 'child',
               template: '...',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComponent {
               constructor(@SkipSelf() public injector: ChangeDetectorRef) {
@@ -2359,6 +2488,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Child {
               constructor(
@@ -2380,6 +2511,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Parent {}
 
@@ -2387,6 +2520,8 @@ describe('di', () => {
               selector: 'my-app',
               template: '<parent><child></child></parent>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyApp {
               @ViewChild(Parent) parent!: Parent;
@@ -2411,6 +2546,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Child {
               constructor(
@@ -2429,6 +2566,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Parent {}
 
@@ -2436,6 +2575,8 @@ describe('di', () => {
               selector: 'my-app',
               template: '<parent><child></child></parent>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyApp {}
 
@@ -2456,6 +2597,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Child {
               constructor(
@@ -2474,6 +2617,8 @@ describe('di', () => {
                 {provide: 'Bar', useValue: 'Bar as ViewProvider'},
               ],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class Parent {}
 
@@ -2481,6 +2626,8 @@ describe('di', () => {
               selector: 'my-app',
               template: '<parent><child></child></parent>',
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyApp {}
 
@@ -2516,6 +2663,8 @@ describe('di', () => {
             template: '<div dirString></div>',
             viewProviders: [{provide: String, useValue: 'Foo'}],
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveString) dirString!: DirectiveString;
@@ -2524,6 +2673,8 @@ describe('di', () => {
           @Component({
             template: '<my-comp></my-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {
             @ViewChild(MyComp) myComp!: MyComp;
@@ -2543,12 +2694,16 @@ describe('di', () => {
             template: '<div dirString></div>',
             providers: [{provide: String, useValue: 'Foo'}],
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {}
 
           @Component({
             template: '<my-comp></my-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {}
 
@@ -2563,12 +2718,16 @@ describe('di', () => {
             selector: 'my-comp',
             template: '<div dirA></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {}
 
           @Component({
             template: '<my-comp dirB></my-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {}
 
@@ -2583,6 +2742,8 @@ describe('di', () => {
             selector: 'my-comp',
             template: '<ng-container *ngIf="showing"><div dirA></div></ng-container>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             showing = false;
@@ -2591,6 +2752,8 @@ describe('di', () => {
           @Component({
             template: '<my-comp dirB></my-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {
             @ViewChild(MyComp) myComp!: MyComp;
@@ -2609,6 +2772,8 @@ describe('di', () => {
           @Component({
             template: '<div dirB><div *ngIf="showing" dirA></div></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {
             showing = false;
@@ -2632,6 +2797,8 @@ describe('di', () => {
           @Component({
             template: '<my-comp></my-comp>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyApp {}
 
@@ -2647,6 +2814,8 @@ describe('di', () => {
             selector: 'my-comp',
             template: '<div dirComp></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {}
 
@@ -2689,6 +2858,8 @@ describe('di', () => {
               template: '<input control>',
               viewProviders: [{provide: ControlContainer, useExisting: GroupDirective}],
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyComp {}
 
@@ -2699,6 +2870,8 @@ describe('di', () => {
                 </div>
               `,
               standalone: false,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class MyApp {}
 
@@ -2720,6 +2893,8 @@ describe('di', () => {
           @Component({
             template: '...',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             tokenViaInjector;
@@ -2752,6 +2927,8 @@ describe('di', () => {
               },
             ],
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class ParentComponent {}
 
@@ -2765,6 +2942,8 @@ describe('di', () => {
               },
             ],
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class ChildComponent {
             tokenViaInjector;
@@ -2808,6 +2987,8 @@ describe('di', () => {
             template: '<div dirString></div>',
             viewProviders: [{provide: TOKEN, useValue: 'Foo'}],
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveString) dirString!: DirectiveString;
@@ -2853,6 +3034,8 @@ describe('di', () => {
           @Component({
             template: '<div dirB></div>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MyComp {
             @ViewChild(DirectiveB) dirB!: DirectiveB;
@@ -2921,6 +3104,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         constructor(public provider: Provider) {}
@@ -2944,6 +3128,7 @@ describe('di', () => {
       @Component({
         template: '<div>{{myService.value}}</div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(public myService: MyService) {}
@@ -2972,6 +3157,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(public myService: SuperClass) {}
@@ -3004,6 +3190,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3033,6 +3220,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(myService: MyService);
@@ -3083,6 +3271,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(service: FooService) {
@@ -3104,6 +3293,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(service: FooService) {
@@ -3128,6 +3318,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(@Inject('stringToken') overriddenService: FooService, service: FooService) {
@@ -3155,6 +3346,7 @@ describe('di', () => {
       @Component({
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(service: FooService) {
@@ -3212,6 +3404,7 @@ describe('di', () => {
           </ng-container>
         </div>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         showing = true;
@@ -3252,6 +3445,8 @@ describe('di', () => {
         @Component({
           template: '<div injectorDir otherInjectorDir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(InjectorDir) injectorDir!: InjectorDir;
@@ -3284,6 +3479,8 @@ describe('di', () => {
         @Component({
           template: '<div injectorDir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(InjectorDir) injectorDir!: InjectorDir;
@@ -3332,6 +3529,8 @@ describe('di', () => {
         @Component({
           template: '<div dir otherDir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(MyDir) directive!: MyDir;
@@ -3369,6 +3568,8 @@ describe('di', () => {
         @Component({
           template: '<ng-template dir></ng-template>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(MyDir) directive!: MyDir;
@@ -3413,6 +3614,8 @@ describe('di', () => {
           selector: 'child',
           template: `<div id="test-id" dir></div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildComp {
           @ViewChild(DirectiveA) directive!: DirectiveA;
@@ -3422,6 +3625,8 @@ describe('di', () => {
           selector: 'root',
           template: '...',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class RootComp {
           public childCompRef!: ComponentRef<ChildComp>;
@@ -3481,6 +3686,8 @@ describe('di', () => {
         @Component({
           template: '<ng-template dir otherDir #dir="dir" #otherDir="otherDir"></ng-template>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(MyDir) directive!: MyDir;
@@ -3506,6 +3713,8 @@ describe('di', () => {
         @Component({
           template: '<div dir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {}
 
@@ -3517,6 +3726,8 @@ describe('di', () => {
         @Component({
           template: '<ng-container dir></ng-container>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {}
 
@@ -3536,6 +3747,8 @@ describe('di', () => {
         @Component({
           template: '<div optionalDir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(OptionalDir) directive!: OptionalDir;
@@ -3578,6 +3791,8 @@ describe('di', () => {
         @Component({
           template: '<div dir otherDir #dir="dir" #otherDir="otherDir"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild(MyDir) directive!: MyDir;
@@ -3604,6 +3819,8 @@ describe('di', () => {
           selector: 'root',
           template: `<ng-template #tmpl>Test</ng-template>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Root {
           @ViewChild(TemplateRef, {static: true}) tmpl!: TemplateRef<any>;
@@ -3660,6 +3877,7 @@ describe('di', () => {
         selector: 'my-comp',
         template: '<ng-content></ng-content>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(public cdr: ChangeDetectorRef) {}
@@ -3686,6 +3904,8 @@ describe('di', () => {
           selector: 'my-app',
           template: `<div *ngIf="showing | pipe">Visible</div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           showing = true;
@@ -3706,6 +3926,8 @@ describe('di', () => {
           selector: 'my-app',
           template: '<my-comp dir otherDir #dir="dir"></my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           @ViewChild(MyComp) component!: MyComp;
@@ -3731,6 +3953,8 @@ describe('di', () => {
           selector: 'my-comp',
           template: '<div dir otherDir #dir="dir"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           constructor(public cdr: ChangeDetectorRef) {}
@@ -3757,6 +3981,8 @@ describe('di', () => {
             <div dir otherDir #dir="dir"></div>
           </my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           constructor(public cdr: ChangeDetectorRef) {}
@@ -3785,6 +4011,8 @@ describe('di', () => {
             <div dir otherDir #dir="dir" *ngIf="showing"></div>
           </ng-container>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           showing = true;
@@ -3811,6 +4039,8 @@ describe('di', () => {
           selector: 'my-comp',
           template: '<div dir otherDir #dir="dir" *ngIf="showing"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           showing = true;
@@ -3849,6 +4079,8 @@ describe('di', () => {
           selector: 'my-app',
           template: `<ng-container getCDR>Visible</ng-container>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           constructor(public cdr: ChangeDetectorRef) {}
@@ -3878,6 +4110,7 @@ describe('di', () => {
       @Component({
         template: '<div injectorDir></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(InjectorDir) injectorDirInstance!: InjectorDir;
@@ -3910,6 +4143,7 @@ describe('di', () => {
           },
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(@Inject(TOKEN) readonly token: string) {}
@@ -3918,6 +4152,7 @@ describe('di', () => {
       @Component({
         template: `<my-comp token="token"></my-comp>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class WrapperComp {
         @ViewChild(MyComp) myComp!: MyComp;
@@ -3939,6 +4174,7 @@ describe('di', () => {
         selector: 'test-cmp',
         template: '{{value}}',
         providers: [{provide: TOKEN, useValue: 'injected value'}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         value: string;
@@ -3967,6 +4203,7 @@ describe('di', () => {
         selector: 'test-cmp',
         template: '{{service.value}}',
         providers: [Service, {provide: TOKEN, useValue: 'injected value'}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(readonly service: Service) {}
@@ -3983,6 +4220,7 @@ describe('di', () => {
       @Component({
         selector: 'test-cmp',
         template: '{{value}}',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         cdr = inject(ChangeDetectorRef);
@@ -4060,6 +4298,7 @@ describe('di', () => {
         selector: 'test-cmp',
         template: '{{service.value}}',
         providers: [{provide: TOKEN, useValue: 'injected value'}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         service: Service;
@@ -4083,6 +4322,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           value = inject(TOKEN, {optional: true});
@@ -4099,6 +4340,8 @@ describe('di', () => {
         @Component({
           template: '',
           providers: [{provide: TOKEN, useValue: 'from component'}],
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           value = inject(TOKEN, {skipSelf: true});
@@ -4115,6 +4358,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           value = inject(TOKEN, {self: true, optional: true});
@@ -4129,6 +4374,8 @@ describe('di', () => {
         @Component({
           selector: 'child',
           template: '{{value}}',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           value = inject(TOKEN, {host: true, optional: true}) ?? 'not found';
@@ -4139,6 +4386,8 @@ describe('di', () => {
           template: '<child></child>',
           providers: [{provide: TOKEN, useValue: 'from parent'}],
           encapsulation: ViewEncapsulation.None,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {}
 
@@ -4155,6 +4404,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           // TypeScript will check if this assignment is legal, which won't be the case if
@@ -4174,6 +4425,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           nodeInjector = inject(Injector);
@@ -4190,6 +4443,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           nodeInjector = inject(Injector);
@@ -4225,6 +4480,8 @@ describe('di', () => {
         @Component({
           template: '',
           providers: [{provide: TOKEN, useValue: 'from component'}],
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           nodeInjector = inject(Injector);
@@ -4252,6 +4509,8 @@ describe('di', () => {
 
         @Component({
           template: '',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           nodeInjector = inject(Injector);
@@ -4276,6 +4535,8 @@ describe('di', () => {
         @Component({
           selector: 'child',
           template: '{{ value }}',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           nodeInjector = inject(Injector);
@@ -4287,6 +4548,8 @@ describe('di', () => {
           template: '<child></child>',
           providers: [{provide: TOKEN, useValue: 'from parent'}],
           encapsulation: ViewEncapsulation.None,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {}
 
@@ -4355,6 +4618,7 @@ describe('di', () => {
       @Component({
         template: '',
         providers: [{provide: TOKEN, useValue: 'from component'}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         envInjector = inject(EnvironmentInjector);
@@ -4378,6 +4642,7 @@ describe('di', () => {
     it('should support node injectors', () => {
       @Component({
         template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         injector = inject(Injector);
@@ -4445,6 +4710,8 @@ describe('di', () => {
         @Component({
           template: '',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class EmptyCmp {}
 
@@ -4474,6 +4741,7 @@ describe('di', () => {
         template: '<div dir></div>',
         imports: [Dir],
         providers: [{provide: token, useExisting: existing}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4493,6 +4761,7 @@ describe('di', () => {
         template: '<div dir></div>',
         imports: [Dir],
         providers: [{provide: token, useExisting: existing}],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4511,7 +4780,11 @@ describe('di', () => {
         }
       }
 
-      @Component({template: '<div dir></div>', standalone: false})
+      @Component({
+        template: '<div dir></div>',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       TestBed.configureTestingModule({
@@ -4530,7 +4803,11 @@ describe('di', () => {
         }
       }
 
-      @Component({template: '<div dir></div>', standalone: false})
+      @Component({
+        template: '<div dir></div>',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       TestBed.configureTestingModule({
@@ -4560,6 +4837,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Root {}
 
@@ -4574,6 +4853,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       constructor(@Inject('B') readonly token: string) {}
@@ -4582,6 +4863,8 @@ describe('di', () => {
     @Component({
       template: `<root></root>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -4611,6 +4894,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Root {}
 
@@ -4618,6 +4903,8 @@ describe('di', () => {
       selector: 'intermediate',
       template: '<comp></comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Intermediate {}
 
@@ -4633,6 +4920,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       constructor(@Inject('B') readonly token: string) {}
@@ -4641,6 +4930,8 @@ describe('di', () => {
     @Component({
       template: `<root></root>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -4669,6 +4960,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(@Inject(LOCALE_ID) public localeId: string) {}
@@ -4691,6 +4984,8 @@ describe('di', () => {
         },
       ],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(@Inject(LOCALE_ID) public localeId: string) {}
@@ -4718,6 +5013,8 @@ describe('di', () => {
       template: '...',
       providers: [{provide: LOCALE_ID, useFactory: () => 'en-GB'}],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(@SkipSelf() @Inject(LOCALE_ID) public localeId: string) {}
@@ -4744,6 +5041,8 @@ describe('di', () => {
       template: '<div dir></div>',
       providers: [{provide: LOCALE_ID, useValue: 'en-GB'}],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       @ViewChild(MyDir) myDir!: MyDir;
@@ -4772,6 +5071,7 @@ describe('di', () => {
       @Component({
         template: '<div dir exist="existValue" other="ignore"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4802,6 +5102,7 @@ describe('di', () => {
       @Component({
         template: '<ng-template dir="initial" exist="existValue" other="ignore"></ng-template>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4832,6 +5133,7 @@ describe('di', () => {
       @Component({
         template: '<ng-container dir="initial" exist="existValue" other="ignore"></ng-container>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4864,6 +5166,7 @@ describe('di', () => {
         template:
           '<div dir style="margin: 1px; color: red;" class="hello there" other-attr="value"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4898,6 +5201,7 @@ describe('di', () => {
         template:
           '<div dir exist="existValue" svg:exist="testExistValue" other="otherValue"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4934,6 +5238,7 @@ describe('di', () => {
         template:
           '<div dir exist="existValue" [binding]="bindingValue" (output)="outputValue" other="otherValue" ignore="ignoreValue"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4963,6 +5268,7 @@ describe('di', () => {
       @Component({
         template: '<div dir title="title {{ value }}"></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @ViewChild(MyDir) directiveInstance!: MyDir;
@@ -4988,6 +5294,7 @@ describe('di', () => {
       @Component({
         template: '<div dir some-attr="foo" other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5007,6 +5314,7 @@ describe('di', () => {
       @Component({
         template: '<ng-template dir some-attr="foo" other="ignore"></ng-template>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5026,6 +5334,7 @@ describe('di', () => {
       @Component({
         template: '<ng-container dir some-attr="foo" other="ignore"></ng-container>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5055,6 +5364,7 @@ describe('di', () => {
           ></div>
         `,
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5079,6 +5389,7 @@ describe('di', () => {
       @Component({
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5098,6 +5409,7 @@ describe('di', () => {
       @Component({
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5121,6 +5433,7 @@ describe('di', () => {
           <div dir some-attr="foo" svg:exists="testExistValue" other="otherValue"></div>
         `,
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5157,6 +5470,7 @@ describe('di', () => {
           other="otherValue"
           ignore="ignoreValue"
         ></div>`,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5183,6 +5497,7 @@ describe('di', () => {
       @Component({
         template: '<div dir title="foo {{value}}" other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5207,6 +5522,7 @@ describe('di', () => {
       @Component({
         template: '<div dir some-attr="foo" other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5228,6 +5544,7 @@ describe('di', () => {
       @Component({
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5249,6 +5566,7 @@ describe('di', () => {
       @Component({
         template: '<div dir other="ignore"></div>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5276,6 +5594,7 @@ describe('di', () => {
           <video dir #v5></video>
         `,
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild('v1', {read: Dir}) value1!: Dir;
@@ -5303,6 +5622,7 @@ describe('di', () => {
       @Component({
         template: '<ng-container dir></ng-container>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestNgContainer {
         @ViewChild(Dir) dir!: Dir;
@@ -5311,6 +5631,7 @@ describe('di', () => {
       @Component({
         template: '<ng-template dir></ng-template>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestNgTemplate {
         @ViewChild(Dir) dir!: Dir;
@@ -5334,6 +5655,7 @@ describe('di', () => {
       @Component({
         template: '<ng-container dir></ng-container>',
         imports: [Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(Dir) dir!: Dir;
@@ -5369,6 +5691,8 @@ describe('di', () => {
         <div i18n>{count, select, =1 {One} other {Other value is: {{count | somePipe}}}}</div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       count = '2';
@@ -5409,6 +5733,8 @@ describe('di', () => {
         <ng-container #target></ng-container>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       count = '2';
@@ -5455,6 +5781,8 @@ describe('di', () => {
       template: '',
       providers: [PROVIDER],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       constructor(readonly base: Base) {}
@@ -5463,6 +5791,8 @@ describe('di', () => {
     @Component({
       template: `<div dirA><child></child></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(DirA) dirA!: DirA;
@@ -5500,6 +5830,7 @@ describe('di', () => {
         template: '{{value}}',
         providers: [{provide: token, useValue: 'child'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComp {
         @Input() value: any;
@@ -5509,6 +5840,7 @@ describe('di', () => {
         template: `<child-comp [value]="'' | token"></child-comp>`,
         providers: [{provide: token, useValue: 'parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -5537,6 +5869,7 @@ describe('di', () => {
         template: '{{value}}',
         viewProviders: [{provide: token, useValue: 'child'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComp {
         @Input() value: any;
@@ -5546,6 +5879,7 @@ describe('di', () => {
         template: `<child-comp [value]="'' | token"></child-comp>`,
         viewProviders: [{provide: token, useValue: 'parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -5570,6 +5904,7 @@ describe('di', () => {
         template: '',
         providers: [{provide: token, useValue: 'child'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComp {}
 
@@ -5577,6 +5912,7 @@ describe('di', () => {
         template: '<child-comp dir></child-comp>',
         providers: [{provide: token, useValue: 'parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dir!: Dir;
@@ -5603,6 +5939,7 @@ describe('di', () => {
         template: '',
         viewProviders: [{provide: token, useValue: 'child'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComp {}
 
@@ -5610,6 +5947,7 @@ describe('di', () => {
         template: '<child-comp dir></child-comp>',
         viewProviders: [{provide: token, useValue: 'parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dir!: Dir;
@@ -5627,6 +5965,8 @@ describe('di', () => {
     @Component({
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       constructor(_viewRef: ViewRef) {}
@@ -5672,6 +6012,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5707,6 +6048,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'root'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5746,6 +6088,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('outerTrigger', {read: MenuTrigger}) outerTrigger!: MenuTrigger;
@@ -5795,6 +6138,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('grandparentTrigger', {read: MenuTrigger}) grandparentTrigger!: MenuTrigger;
@@ -5840,6 +6184,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Wrapper {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5854,6 +6199,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5892,6 +6238,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5933,6 +6280,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -5977,6 +6325,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6022,6 +6371,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6060,6 +6410,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6110,6 +6461,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6157,6 +6509,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6167,6 +6520,7 @@ describe('di', () => {
         template: '<parent></parent>',
         providers: [{provide: token, useValue: 'hello from grandparent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class GrandParent {
         @ViewChild(Parent) parent!: Parent;
@@ -6203,6 +6557,7 @@ describe('di', () => {
           </ng-template>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TemplateRef) template!: TemplateRef<unknown>;
@@ -6249,6 +6604,7 @@ describe('di', () => {
         template: '<ng-template><menu></menu></ng-template>',
         providers: [{provide: declarerToken, useValue: 'hello from declarer'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Declarer {
         @ViewChild(Menu) menu!: Menu;
@@ -6260,6 +6616,7 @@ describe('di', () => {
         template: '<menu-trigger></menu-trigger>',
         providers: [{provide: creatorToken, useValue: 'hello from creator'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Creator {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6271,6 +6628,7 @@ describe('di', () => {
           <creator></creator>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Declarer) declarer!: Declarer;
@@ -6321,6 +6679,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6373,6 +6732,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6418,6 +6778,7 @@ describe('di', () => {
         selector: 'wrapper',
         template: `<div><menu></menu></div>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Wrapper {
         @ViewChild(Menu) menu!: Menu;
@@ -6434,6 +6795,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6479,6 +6841,7 @@ describe('di', () => {
         selector: 'wrapper',
         template: `<div><menu></menu></div>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Wrapper {
         @ViewChild(Menu) menu!: Menu;
@@ -6495,6 +6858,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6548,6 +6912,7 @@ describe('di', () => {
         `,
         providers: [{provide: token, useValue: 'hello from parent'}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuTrigger) trigger!: MenuTrigger;
@@ -6625,6 +6990,7 @@ describe('di', () => {
       @Component({
         selector: 'my-comp',
         template: '...',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(@Inject(A) svc: any) {}
@@ -6661,6 +7027,7 @@ describe('di', () => {
       @Component({
         selector: 'my-comp',
         template: '...',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         a = inject(A);
@@ -6697,6 +7064,7 @@ describe('di', () => {
       @Component({
         selector: 'my-comp',
         template: '...',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(private injector: Injector) {}
@@ -6758,6 +7126,7 @@ describe('di', () => {
       @Component({
         selector: 'my-comp',
         template: '...',
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         constructor(private injector: Injector) {}
@@ -6811,6 +7180,7 @@ describe('di', () => {
           {provide: B, useClass: BService, multi: true},
         ],
         template: ``,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         a = inject(A);

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -23,6 +23,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -51,6 +52,8 @@ describe('directives', () => {
       selector: 'test-cmpt',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -169,6 +172,8 @@ describe('directives', () => {
           <span>Some content</span>
         </ng-container>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         visible = true;
@@ -272,6 +277,8 @@ describe('directives', () => {
         selector: 'test-cmp',
         template: `<div *ngIf="condition" class="titleDir"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         condition = false;
@@ -372,6 +379,8 @@ describe('directives', () => {
         template: `<p [attr.dir]="direction"></p>
           <p dir="rtl"></p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         direction = 'auto';
@@ -403,6 +412,8 @@ describe('directives', () => {
         selector: `my-comp`,
         template: `<svg dir><text dir></text></svg>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -431,6 +442,8 @@ describe('directives', () => {
         selector: `my-comp`,
         template: `<svg dir><text dir></text></svg>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -465,6 +478,8 @@ describe('directives', () => {
           <div class="a" style="font-size: 10px;" [disabled]="true" [test]="test"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         test = '';
@@ -497,6 +512,8 @@ describe('directives', () => {
         selector: 'my-app',
         template: '<ng-template [dir]="message"></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         message = 'Hello';
@@ -526,6 +543,8 @@ describe('directives', () => {
         selector: 'my-app',
         template: '<ng-template dir="{{ message }}"></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         message = 'Hello';
@@ -555,6 +574,8 @@ describe('directives', () => {
         selector: 'my-app',
         template: '<ng-template *ngIf="true" dir="{{ message }}"></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         message = 'Hello';
@@ -593,6 +614,8 @@ describe('directives', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items: number[] = [1, 2, 3];
@@ -641,6 +664,8 @@ describe('directives', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items: number[] = [1, 2, 3];
@@ -675,6 +700,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [plainInput]="plainValue" [alias]="aliasedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dirInstance!: Dir;
@@ -705,6 +732,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [plainInput]="plainValue" [alias]="aliasedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dirInstance!: Dir;
@@ -733,6 +762,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [value]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -764,6 +795,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [value]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -794,6 +827,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir value="staticValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -818,6 +853,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [valueAlias]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -851,6 +888,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [value]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -885,6 +924,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [valueAlias]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -923,6 +964,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir [value]="assignedValue"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -965,6 +1008,8 @@ describe('directives', () => {
       @Component({
         template: '<div dir value="foo"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(Dir) dir!: Dir;
@@ -982,6 +1027,8 @@ describe('directives', () => {
         selector: 'comp',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @Input({transform: (value: string) => (value ? 1 : 0)}) value = -1;
@@ -990,6 +1037,8 @@ describe('directives', () => {
       @Component({
         template: '<ng-container #location/>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild('location', {read: ViewContainerRef}) vcr!: ViewContainerRef;
@@ -1012,6 +1061,8 @@ describe('directives', () => {
       @Component({
         selector: 'app-test[value]',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @Input() value = 'unset';
@@ -1020,6 +1071,8 @@ describe('directives', () => {
       @Component({
         selector: 'app-root',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(vcr: ViewContainerRef) {
@@ -1040,6 +1093,8 @@ describe('directives', () => {
       @Component({
         selector: 'app-test',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @Input() value = 'unset';
@@ -1048,6 +1103,8 @@ describe('directives', () => {
       @Component({
         selector: 'app-root',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(vcr: ViewContainerRef) {
@@ -1076,6 +1133,8 @@ describe('directives', () => {
       @Component({
         template: `<ng-template (out)="value = true"></ng-template>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(TestDir, {static: true}) testDir: TestDir | undefined;
@@ -1100,6 +1159,8 @@ describe('directives', () => {
           <span>Hello</span>
         </ng-container>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         value = false;
@@ -1134,6 +1195,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title title="a"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1155,6 +1218,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title [title]="value"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1181,6 +1246,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title [title]="value" attr.title="test"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1205,6 +1272,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title [title]="value1" [attr.title]="value2"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value1 = 'a';
@@ -1229,6 +1298,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title [title]="value1" attr.title="{{ value2 }}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value1 = 'a';
@@ -1253,6 +1324,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title title="{{ value }}" attr.title="test"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1277,6 +1350,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title title="{{ value1 }}" [attr.title]="value2"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value1 = 'a';
@@ -1301,6 +1376,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title title="{{ value1 }}" attr.title="{{ value2 }}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value1 = 'a';
@@ -1325,6 +1402,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title title="{{ value }}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1348,6 +1427,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title attr.title="{{ value }}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1371,6 +1452,8 @@ describe('directives', () => {
       @Component({
         template: `<div dir-with-title [attr.title]="value"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'a';
@@ -1430,6 +1513,8 @@ describe('directives', () => {
         selector: 'app',
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1492,6 +1577,8 @@ describe('directives', () => {
         selector: 'app',
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -77,6 +77,8 @@ describe('discovery utils', () => {
     template: '<p></p>',
     providers: [{provide: String, useValue: 'Child'}],
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class Child {
     constructor() {
@@ -109,6 +111,8 @@ describe('discovery utils', () => {
       <b *ngIf="visible">Bold</b>
     `,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class MyApp {
     text: string = 'INIT';
@@ -411,6 +415,8 @@ describe('discovery utils deprecated', () => {
         selector: 'inner-comp',
         template: '<div></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class InnerComp {}
 
@@ -418,6 +424,8 @@ describe('discovery utils deprecated', () => {
         selector: 'comp',
         template: '<inner-comp></inner-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -463,6 +471,8 @@ describe('discovery utils deprecated', () => {
           <div my-dir-3></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @ViewChild(MyDir1) myDir1Instance!: MyDir1;
@@ -503,6 +513,8 @@ describe('discovery utils deprecated', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -516,6 +528,8 @@ describe('discovery utils deprecated', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -544,6 +558,8 @@ describe('discovery utils deprecated', () => {
       @Component({
         template: '<div myDir #elRef #dirRef="myDir"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -562,6 +578,8 @@ describe('discovery utils deprecated', () => {
       @Component({
         template: '<div #elRef class="fooClass" [style.color]="color"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         color = 'red';

--- a/packages/core/test/acceptance/exports_spec.ts
+++ b/packages/core/test/acceptance/exports_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   DoCheck,
@@ -230,7 +231,12 @@ describe('exports', () => {
 });
 
 function initWithTemplate(compType: Type<any>, template: string) {
-  TestBed.overrideComponent(compType, {set: new Component({template})});
+  TestBed.overrideComponent(compType, {
+    set: new Component({
+      template,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    }),
+  });
   return TestBed.createComponent(compType);
 }
 
@@ -238,6 +244,8 @@ function initWithTemplate(compType: Type<any>, template: string) {
   selector: 'comp-to-ref',
   template: '',
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentToReference {
   name = 'Nancy';
@@ -247,6 +255,8 @@ class ComponentToReference {
   selector: 'app-comp',
   template: ``,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AppComp {
   outer = false;

--- a/packages/core/test/acceptance/hmr_spec.ts
+++ b/packages/core/test/acceptance/hmr_spec.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {computeMsgId} from '@angular/compiler';
+import {TestBed} from '@angular/core/testing';
+import {clearTranslations, loadTranslations} from '@angular/localize';
+import {EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
+import {isNode} from '@angular/private/testing';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   DoCheck,
@@ -32,19 +38,14 @@ import {
   ɵɵreplaceMetadata,
   ɵɵsetComponentScope,
 } from '../../src/core';
-import {TestBed} from '../../testing';
+import {NUM_ROOT_NODES} from '../../src/hydration/interfaces';
+import {ComponentType} from '../../src/render3';
+import {DEHYDRATED_VIEWS} from '../../src/render3/interfaces/container';
+import {isLContainer} from '../../src/render3/interfaces/type_checks';
+import {HEADER_OFFSET, TVIEW} from '../../src/render3/interfaces/view';
 import {compileComponent} from '../../src/render3/jit/directive';
 import {angularCoreEnv} from '../../src/render3/jit/environment';
-import {clearTranslations, loadTranslations} from '@angular/localize';
-import {computeMsgId} from '@angular/compiler';
-import {EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
-import {ComponentType} from '../../src/render3';
 import {getComponentLView} from '../../src/render3/util/discovery_utils';
-import {DEHYDRATED_VIEWS} from '../../src/render3/interfaces/container';
-import {HEADER_OFFSET, TVIEW} from '../../src/render3/interfaces/view';
-import {isLContainer} from '../../src/render3/interfaces/type_checks';
-import {NUM_ROOT_NODES} from '../../src/hydration/interfaces';
-import {isNode} from '@angular/private/testing';
 
 describe('hot module replacement', () => {
   beforeEach(() => {
@@ -57,6 +58,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: 'Hello <strong>{{state}}</strong>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -71,6 +73,8 @@ describe('hot module replacement', () => {
     @Component({
       imports: [ChildCmp],
       template: '<child-cmp/>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {}
 
@@ -101,6 +105,7 @@ describe('hot module replacement', () => {
     replaceMetadata(ChildCmp, {
       ...initialMetadata,
       template: `Changed <strong>{{state}}</strong>!`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -122,6 +127,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: '<span>ChildCmp (orig)</span><h1>{{ text }}</h1>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -141,6 +147,8 @@ describe('hot module replacement', () => {
           <child-cmp text="C" />
         </main>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {}
 
@@ -175,6 +183,7 @@ describe('hot module replacement', () => {
         <h2>{{ text }}</h2>
         <div>Extra node!</div>
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -213,6 +222,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: 'Base class',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -221,12 +231,16 @@ describe('hot module replacement', () => {
     @Component({
       selector: 'child-sub-cmp',
       template: 'Sub class',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildSubCmp extends ChildCmp {}
 
     @Component({
       imports: [ChildCmp, ChildSubCmp],
       template: `<child-cmp />|<child-sub-cmp />`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {}
 
@@ -244,6 +258,7 @@ describe('hot module replacement', () => {
     replaceMetadata(ChildCmp, {
       ...initialMetadata,
       template: `Replaced!`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -268,6 +283,7 @@ describe('hot module replacement', () => {
       selector: 'child-cmp',
       template: 'Hello <strong>{{state}}</strong>',
       styles: `strong {color: red;}`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -282,6 +298,8 @@ describe('hot module replacement', () => {
     @Component({
       imports: [ChildCmp],
       template: '<child-cmp/>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {}
 
@@ -300,6 +318,7 @@ describe('hot module replacement', () => {
       ...initialMetadata,
       template: `Changed <strong>{{state}}</strong>!`,
       styles: `strong {background: pink;}`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -318,6 +337,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: '<span>{{staticValue}}</span><strong>{{dynamicValue}}</strong>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -329,6 +349,8 @@ describe('hot module replacement', () => {
     @Component({
       imports: [ChildCmp],
       template: `<child-cmp staticValue="1" [dynamicValue]="dynamicValue" />`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {
       dynamicValue = '1';
@@ -367,6 +389,7 @@ describe('hot module replacement', () => {
           <strong>{{dynamicValue}}</strong>
         </main>
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
     expectHTML(
@@ -400,6 +423,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: 'Hello <strong>{{value}}</strong>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -415,6 +439,8 @@ describe('hot module replacement', () => {
           <hr />
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {
       items = [
@@ -443,6 +469,7 @@ describe('hot module replacement', () => {
     replaceMetadata(ChildCmp, {
       ...initialMetadata,
       template: `Changed <strong>{{value}}</strong>!`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -483,6 +510,7 @@ describe('hot module replacement', () => {
     const initialMetadata: Component = {
       selector: 'child-cmp',
       template: 'Hello <strong>world</strong>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     };
 
     @Component(initialMetadata)
@@ -493,6 +521,8 @@ describe('hot module replacement', () => {
     @Component({
       imports: [ChildCmp],
       template: '<child-cmp/>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class RootCmp {}
 
@@ -512,6 +542,7 @@ describe('hot module replacement', () => {
     replaceMetadata(ChildCmp, {
       ...initialMetadata,
       template: `Hello <i>Bob</i>!`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -533,10 +564,19 @@ describe('hot module replacement', () => {
     // In some cases the AoT compiler produces a `setComponentScope` for non-standalone
     // components. We simulate it here by declaring two components that are not standalone
     // and manually calling `setComponentScope`.
-    @Component({selector: 'child-cmp', template: 'hello', standalone: false})
+    @Component({
+      selector: 'child-cmp',
+      template: 'hello',
+      standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class ChildCmp {}
 
-    @Component({template: 'Initial <child-cmp/>', standalone: false})
+    @Component({
+      template: 'Initial <child-cmp/>',
+      standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class RootCmp {}
 
     ɵɵsetComponentScope(RootCmp as ComponentType<RootCmp>, [ChildCmp], []);
@@ -549,6 +589,7 @@ describe('hot module replacement', () => {
     replaceMetadata(RootCmp, {
       standalone: false,
       template: 'Changed <child-cmp/>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     });
     fixture.detectChanges();
 
@@ -564,6 +605,8 @@ describe('hot module replacement', () => {
       @Component({
         selector: 'child-cmp',
         template: '<span>ChildCmp {{ text }}</span>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp {
         @Input() text = '[empty]';
@@ -577,6 +620,8 @@ describe('hot module replacement', () => {
           <child-cmp text="A"/>
           <child-cmp text="B"/>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -591,6 +636,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ParentCmp],
         template: `<parent-cmp />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -608,6 +655,8 @@ describe('hot module replacement', () => {
           <child-cmp text="C"/>
           <child-cmp text="D"/>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -626,6 +675,8 @@ describe('hot module replacement', () => {
             </span>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -640,6 +691,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ParentCmp],
         template: `<parent-cmp />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -660,6 +713,8 @@ describe('hot module replacement', () => {
             <span #ref></span>
           </main>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -686,6 +741,8 @@ describe('hot module replacement', () => {
         selector: 'parent-cmp',
         imports: [DirA, DirB],
         template: `<div #ref dir-a></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -700,6 +757,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ParentCmp],
         template: `<parent-cmp />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -714,6 +773,8 @@ describe('hot module replacement', () => {
             <div #ref dir-b></div>
           </section>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -734,6 +795,8 @@ describe('hot module replacement', () => {
         selector: 'parent-cmp',
         imports: [Dir],
         template: `<div #ref dir></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -748,6 +811,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ParentCmp],
         template: `<parent-cmp />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -758,6 +823,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ParentCmp, {
         ...initialMetadata,
         template: `<div #ref></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -770,6 +837,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'parent-cmp',
         template: `<ng-content/>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -783,6 +852,8 @@ describe('hot module replacement', () => {
             <h2>Projected H2</h2>
           </parent-cmp>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -807,6 +878,8 @@ describe('hot module replacement', () => {
             <ng-content/>
           </section>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -834,6 +907,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'parent-cmp',
         template: `<ng-content/>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -847,6 +922,8 @@ describe('hot module replacement', () => {
             <div two="2">two</div>
           </parent-cmp>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -871,6 +948,8 @@ describe('hot module replacement', () => {
           <section><ng-content select="[two]"/></section>
           <main><ng-content select="[one]"/></main>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -891,6 +970,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ParentCmp, {
         ...initialMetadata,
         template: `<ng-content select="does-not-match"/>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<parent-cmp></parent-cmp>');
@@ -899,6 +980,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ParentCmp, {
         ...initialMetadata,
         template: `<span><ng-content select="[one]"/></span>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -922,6 +1005,8 @@ describe('hot module replacement', () => {
             <div class="default-content">Default content</div>
           </ng-content>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -934,6 +1019,8 @@ describe('hot module replacement', () => {
             <span>Some content</span>
           </parent-cmp>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -956,6 +1043,8 @@ describe('hot module replacement', () => {
             <div class="default-content">Default content</div>
           </ng-content>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expectHTML(
@@ -974,6 +1063,8 @@ describe('hot module replacement', () => {
       @Component({
         template: '',
         selector: 'child-cmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp implements OnInit, OnDestroy {
         @Input() text = '[empty]';
@@ -994,6 +1085,8 @@ describe('hot module replacement', () => {
         `,
         imports: [ChildCmp],
         selector: 'parent-cmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
       let logs: string[] = [];
 
@@ -1018,6 +1111,8 @@ describe('hot module replacement', () => {
           <parent-cmp text="B" />
         `,
         imports: [ParentCmp],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1041,6 +1136,8 @@ describe('hot module replacement', () => {
           <child-cmp text="D"/>
           <child-cmp text="E"/>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1061,6 +1158,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ParentCmp, {
         ...initialMetadata,
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expect(logs).toEqual([
@@ -1077,6 +1176,8 @@ describe('hot module replacement', () => {
       @Component({
         template: '',
         selector: 'child-cmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp implements DoCheck {
         @Input() text = '[empty]';
@@ -1090,6 +1191,8 @@ describe('hot module replacement', () => {
         template: `<child-cmp text="A"/>`,
         imports: [ChildCmp],
         selector: 'parent-cmp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
       let logs: string[] = [];
 
@@ -1103,6 +1206,8 @@ describe('hot module replacement', () => {
       @Component({
         template: `<parent-cmp />`,
         imports: [ParentCmp],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1122,6 +1227,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ParentCmp, {
         ...initialMetadata,
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expect(logs).toEqual(['ParentCmp checked']);
@@ -1135,6 +1242,8 @@ describe('hot module replacement', () => {
           <child-cmp text="A"/>
           <child-cmp text="B"/>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expect(logs).toEqual([
@@ -1162,6 +1271,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1179,6 +1290,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp [value]="value" />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         value = 1;
@@ -1195,6 +1308,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'Changed',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1214,6 +1329,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'Changed!!!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       fixture.componentInstance.value++;
@@ -1234,6 +1351,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<button (click)="clicked()"></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1248,6 +1367,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp (changed)="onChange()" />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         onChange() {
@@ -1267,6 +1388,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<button class="replacement" (click)="clicked()"></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1284,6 +1407,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<button (click)="clicked()"></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1298,6 +1423,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp (changed)="onChange()" />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         onChange() {
@@ -1317,6 +1444,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<button (click)="clicked()"></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1332,7 +1461,10 @@ describe('hot module replacement', () => {
     it('should bind events inside the NgZone after a replacement', () => {
       const calls: {name: string; inZone: boolean}[] = [];
 
-      @Component({template: `<button (click)="clicked()"></button>`})
+      @Component({
+        template: `<button (click)="clicked()"></button>`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {
         clicked() {}
       }
@@ -1361,7 +1493,10 @@ describe('hot module replacement', () => {
       fixture.detectChanges();
       expect(calls).toEqual([{name: 'click', inZone: true}]);
 
-      replaceMetadata(App, {template: '<button class="foo" (click)="clicked()"></button>'});
+      replaceMetadata(App, {
+        template: '<button class="foo" (click)="clicked()"></button>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
 
       expect(calls).toEqual([
@@ -1378,6 +1513,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1416,6 +1553,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp, DirA, DirB],
         template: `<child-cmp dir-a dir-b />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1428,6 +1567,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'Hello!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expect(initLog).toEqual(['ChildCmp init', 'DirA init', 'DirB init']);
@@ -1464,6 +1605,8 @@ describe('hot module replacement', () => {
         selector: 'child-cmp',
         template: '',
         hostDirectives: [DirA, DirB],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1480,6 +1623,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1492,6 +1637,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'Hello!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expect(initLog).toEqual(['DirA init', 'DirB init', 'ChildCmp init']);
@@ -1522,6 +1669,8 @@ describe('hot module replacement', () => {
         selector: 'child-cmp',
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1534,6 +1683,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1545,6 +1696,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<div dir-b></div>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1577,6 +1730,8 @@ describe('hot module replacement', () => {
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
         providers: [{provide: token, useValue: 'provided value'}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1585,6 +1740,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1595,6 +1752,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<div dir-b></div>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1627,6 +1786,8 @@ describe('hot module replacement', () => {
         template: '<div dir-a></div>',
         imports: [DirA, DirB],
         viewProviders: [{provide: token, useValue: 'provided value'}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1635,6 +1796,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1645,6 +1808,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<div dir-b></div>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1663,6 +1828,8 @@ describe('hot module replacement', () => {
         host: {
           '[attr.bar]': 'state',
         },
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1673,6 +1840,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp [state]="state" [attr.foo]="'The state is ' + state" />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         state = 0;
@@ -1693,7 +1862,11 @@ describe('hot module replacement', () => {
         `<child-cmp foo="The state is 1" bar="1">Hello</child-cmp>`,
       );
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: `Changed`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(
         fixture.nativeElement,
@@ -1715,6 +1888,8 @@ describe('hot module replacement', () => {
         host: {
           '[class.bar]': 'state',
         },
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1725,6 +1900,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp class="static" [state]="state" [class.foo]="state" />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         state = false;
@@ -1738,7 +1915,11 @@ describe('hot module replacement', () => {
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, `<child-cmp class="static foo bar">Hello</child-cmp>`);
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: `Changed`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, `<child-cmp class="static foo bar">Changed</child-cmp>`);
 
@@ -1754,6 +1935,8 @@ describe('hot module replacement', () => {
         host: {
           '[style.height]': 'state ? "5px" : "20px"',
         },
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1768,6 +1951,8 @@ describe('hot module replacement', () => {
           [state]="state"
           [style.width]="state ? '3px' : '12px'"
         />`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         state = false;
@@ -1787,7 +1972,11 @@ describe('hot module replacement', () => {
         `<child-cmp style="opacity: 0.5; width: 3px; height: 5px;">Hello</child-cmp>`,
       );
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: `Changed`});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: `Changed`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(
         fixture.nativeElement,
@@ -1817,6 +2006,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<span i18n>hello</span>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1825,6 +2016,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1832,7 +2025,11 @@ describe('hot module replacement', () => {
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><span>здравей</span></child-cmp>');
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>goodbye</strong>!'});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<strong i18n>goodbye</strong>!',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><strong>довиждане</strong>!</child-cmp>');
     });
@@ -1843,6 +2040,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<ng-content/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1851,6 +2050,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp i18n>hello</child-cmp>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1862,6 +2063,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'Hello translates to <strong><ng-content/></strong>!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 
@@ -1884,6 +2087,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<span i18n>Hello {{name}}!</span>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1898,6 +2103,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -1905,13 +2112,19 @@ describe('hot module replacement', () => {
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><span>Здравей Frodo!</span></child-cmp>');
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>hello</strong>'});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<strong i18n>hello</strong>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><strong>здравей</strong></child-cmp>');
 
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: '<main><section i18n>Hello {{name}}!</section></main>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expectHTML(
@@ -1935,6 +2148,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<ng-content/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -1943,6 +2158,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp i18n>Hello {{name}}!</child-cmp>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         name = 'Frodo';
@@ -1956,6 +2173,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'The text translates to <strong><ng-content/></strong>!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expectHTML(
@@ -1986,6 +2205,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<span i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</span>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -2000,6 +2221,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {}
 
@@ -2007,7 +2230,11 @@ describe('hot module replacement', () => {
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><span>десет</span></child-cmp>');
 
-      replaceMetadata(ChildCmp, {...initialMetadata, template: '<strong i18n>hello</strong>'});
+      replaceMetadata(ChildCmp, {
+        ...initialMetadata,
+        template: '<strong i18n>hello</strong>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      });
       fixture.detectChanges();
       expectHTML(fixture.nativeElement, '<child-cmp><strong>здравей</strong></child-cmp>');
 
@@ -2015,6 +2242,8 @@ describe('hot module replacement', () => {
         ...initialMetadata,
         template:
           '<main><section i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</section></main>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
       expectHTML(
@@ -2039,6 +2268,8 @@ describe('hot module replacement', () => {
       const initialMetadata: Component = {
         selector: 'child-cmp',
         template: '<ng-content/>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       };
 
       @Component(initialMetadata)
@@ -2047,6 +2278,8 @@ describe('hot module replacement', () => {
       @Component({
         imports: [ChildCmp],
         template: '<child-cmp i18n>{count, select, 10 {ten} 20 {twenty} other {other}}</child-cmp>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootCmp {
         count = 10;
@@ -2060,6 +2293,8 @@ describe('hot module replacement', () => {
       replaceMetadata(ChildCmp, {
         ...initialMetadata,
         template: 'The text translates to <strong><ng-content/></strong>!',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       });
       fixture.detectChanges();
 

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -28,6 +28,7 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {
   bypassSanitizationTrustHtml,
@@ -46,6 +47,8 @@ describe('host bindings', () => {
     @Component({
       template: '...',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       @HostBinding('style') myStylesExp = {};
@@ -80,6 +83,8 @@ describe('host bindings', () => {
         template: '...',
         host: {'class': 'foo bar'},
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentCmp {}
 
@@ -87,6 +92,8 @@ describe('host bindings', () => {
         template: '...',
         host: {'class': 'foo baz'},
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp extends ParentCmp {}
 
@@ -105,6 +112,8 @@ describe('host bindings', () => {
         template: '...',
         host: {class: 'foo', style: 'color: red'},
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -139,6 +148,8 @@ describe('host bindings', () => {
         selector: 'child',
         template: `...`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp {}
 
@@ -155,6 +166,8 @@ describe('host bindings', () => {
           '[style.color]': 'color',
         },
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentCmp {
         private _prop = '';
@@ -188,6 +201,8 @@ describe('host bindings', () => {
       @Component({
         template: `<parent [prop]="prop" [prop2]="prop2"></parent>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         prop = 'a';
@@ -219,6 +234,8 @@ describe('host bindings', () => {
         template: '<div animationPropDir>Some content</div>',
         animations: [trigger('myAnimation', [state('color', style({color: 'red'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -246,6 +263,8 @@ describe('host bindings', () => {
         template: 'Some content',
         animations: [trigger('myAnimation', [state('color', style({color: 'red'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -254,6 +273,8 @@ describe('host bindings', () => {
         template: '<my-comp animationPropDir></my-comp>',
         animations: [trigger('myAnimation', [state('color', style({color: 'green'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -273,6 +294,8 @@ describe('host bindings', () => {
         template: '<div>Some content/div>',
         animations: [trigger('myAnimation', [state('color', style({color: 'red'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @HostBinding('@myAnimation') myAnimation: string = 'color';
@@ -293,6 +316,8 @@ describe('host bindings', () => {
         template: '<div>Some content/div>',
         animations: [trigger('myAnimation', [state('color', style({color: 'red'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @HostBinding('@myAnimation') myAnimation: string = 'color';
@@ -301,6 +326,8 @@ describe('host bindings', () => {
       @Component({
         template: '<my-comp></my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -328,6 +355,8 @@ describe('host bindings', () => {
         template: '<div>Some content</div>',
         animations: [trigger('myAnimation', [state('color', style({color: 'red'}))])],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp extends AnimationDir {}
 
@@ -368,6 +397,8 @@ describe('host bindings', () => {
           trigger('myAnimation', [state('a', style({color: 'yellow'})), transition('* => a', [])]),
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -393,6 +424,8 @@ describe('host bindings', () => {
           trigger('myAnimation', [state('a', style({color: 'yellow'})), transition('* => a', [])]),
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @HostBinding('@myAnimation') myAnimation: string = 'a';
@@ -429,6 +462,8 @@ describe('host bindings', () => {
           trigger('myAnimation', [state('a', style({color: 'yellow'})), transition('* => a', [])]),
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @HostBinding('@myAnimation') myAnimation: string = 'a';
@@ -447,6 +482,8 @@ describe('host bindings', () => {
       @Component({
         template: '<my-comp></my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -490,6 +527,8 @@ describe('host bindings', () => {
           trigger('myAnimation', [state('a', style({color: 'yellow'})), transition('* => a', [])]),
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp extends AnimationDir {}
 
@@ -510,12 +549,16 @@ describe('host bindings', () => {
       @Component({
         template: ` <child-and-parent-cmp></child-and-parent-cmp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
       @Component({
         template: '...',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentCmp {
         @HostBinding('style.width') width1 = '100px';
@@ -527,6 +570,8 @@ describe('host bindings', () => {
         selector: 'child-and-parent-cmp',
         template: '...',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp extends ParentCmp {
         @HostBinding('style.width') width2 = '200px';
@@ -548,6 +593,8 @@ describe('host bindings', () => {
       @Component({
         template: '<div child-dir sibling-dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -641,6 +688,8 @@ describe('host bindings', () => {
           <ng-container [class.foo]="true" dir-that-adds-other-classes>...</ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -680,6 +729,8 @@ describe('host bindings', () => {
     @Component({
       template: '<span dir></span>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) directiveInstance!: Dir;
@@ -702,6 +753,8 @@ describe('host bindings', () => {
     @Component({
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       @HostBinding() title = 'my-title';
@@ -735,6 +788,8 @@ describe('host bindings', () => {
       template: '',
       providers: [ServiceOne, ServiceTwo],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       constructor(
@@ -770,6 +825,8 @@ describe('host bindings', () => {
       selector: 'host-title-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostTitleComp {
       @HostBinding() title = 'my-title';
@@ -782,6 +839,8 @@ describe('host bindings', () => {
         <host-title-comp></host-title-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingDir) hostBindingDir!: HostBindingDir;
@@ -807,6 +866,8 @@ describe('host bindings', () => {
       selector: 'host-binding-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       @HostBinding() id = 'blue';
@@ -818,6 +879,8 @@ describe('host bindings', () => {
         <host-binding-comp></host-binding-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChildren(HostBindingComp) hostBindingComp!: QueryList<HostBindingComp>;
@@ -858,6 +921,8 @@ describe('host bindings', () => {
     @Component({
       template: '<div someDir hostBindingDir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingDir) hostBindingDir!: HostBindingDir;
@@ -880,6 +945,8 @@ describe('host bindings', () => {
       template: '',
       selector: 'init-hook-comp',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class InitHookComp implements OnInit, OnChanges, DoCheck {
       @Input() inputValue = '';
@@ -909,6 +976,8 @@ describe('host bindings', () => {
     @Component({
       template: '<init-hook-comp [inputValue]="value"></init-hook-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 'input';
@@ -940,6 +1009,8 @@ describe('host bindings', () => {
     @Component({
       template: '<input hostBindingDir [disabled]="isDisabled">',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingInputDir) hostBindingInputDir!: HostBindingInputDir;
@@ -971,6 +1042,8 @@ describe('host bindings', () => {
       selector: 'parent',
       template: '<div hostBindingDir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
@@ -980,6 +1053,8 @@ describe('host bindings', () => {
         <parent></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1000,6 +1075,8 @@ describe('host bindings', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       rows: number[] = [];
@@ -1021,6 +1098,8 @@ describe('host bindings', () => {
       selector: 'host-binding-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       @HostBinding() id = 'my-id';
@@ -1030,6 +1109,8 @@ describe('host bindings', () => {
       selector: 'name-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class NameComp {
       @Input() names!: string[];
@@ -1041,6 +1122,8 @@ describe('host bindings', () => {
         <host-binding-comp></host-binding-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(NameComp) nameComp!: NameComp;
@@ -1077,6 +1160,8 @@ describe('host bindings', () => {
       selector: 'name-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class NameComp {
       @Input() names!: string[];
@@ -1087,6 +1172,8 @@ describe('host bindings', () => {
       host: {'[id]': `['red', id]`, '[dir]': `dir`, '[title]': `[title, otherTitle]`},
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       id = 'blue';
@@ -1101,6 +1188,8 @@ describe('host bindings', () => {
         <host-binding-comp></host-binding-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingComp) hostBindingComp!: HostBindingComp;
@@ -1163,6 +1252,8 @@ describe('host bindings', () => {
     @Component({
       template: '<button hostListenerDir hostDir>Click</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1182,6 +1273,8 @@ describe('host bindings', () => {
       host: {'[id]': `['red', id]`},
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       id = 'blue';
@@ -1199,6 +1292,8 @@ describe('host bindings', () => {
     @Component({
       template: '<host-binding-comp hostDir></host-binding-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingComp) hostBindingComp!: HostBindingComp;
@@ -1231,6 +1326,8 @@ describe('host bindings', () => {
         '[attr.title]': `otherCondition ? [title] : 'other title'`,
       },
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingComp {
       condition = true;
@@ -1242,6 +1339,8 @@ describe('host bindings', () => {
     @Component({
       template: `<host-binding-comp></host-binding-comp>{{ name }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(HostBindingComp) hostBindingComp!: HostBindingComp;
@@ -1289,6 +1388,8 @@ describe('host bindings', () => {
     @Component({
       template: `<div dir1 dir2 id="tmpl"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -1324,6 +1425,8 @@ describe('host bindings', () => {
         <div superDir></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(SubDirective) subDir!: SubDirective;
@@ -1371,6 +1474,8 @@ describe('host bindings', () => {
     @Component({
       template: '<div hostAttributeDir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1385,6 +1490,8 @@ describe('host bindings', () => {
       template: '<ng-content></ng-content>',
       host: {'[id]': 'foos.length'},
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingWithContentChildren {
       @ContentChildren('foo') foos!: QueryList<any>;
@@ -1398,6 +1505,8 @@ describe('host bindings', () => {
         </host-binding-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1415,6 +1524,8 @@ describe('host bindings', () => {
       template: '',
       host: {'[id]': 'myValue'},
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class HostBindingWithContentHooks implements AfterContentInit {
       myValue = 'initial';
@@ -1427,6 +1538,8 @@ describe('host bindings', () => {
     @Component({
       template: '<host-binding-comp></host-binding-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1445,6 +1558,8 @@ describe('host bindings', () => {
         host: {'[style.width.px]': 'width'},
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostBindingToStyles {
         width = 2;
@@ -1453,6 +1568,8 @@ describe('host bindings', () => {
       @Component({
         template: '<host-binding-to-styles></host-binding-to-styles>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostBindingToStyles) hostBindingDir!: HostBindingToStyles;
@@ -1493,6 +1610,8 @@ describe('host bindings', () => {
       @Component({
         template: '<div hostStyles containerDir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostBindingToStyles) hostBindingDir!: HostBindingToStyles;
@@ -1516,12 +1635,16 @@ describe('host bindings', () => {
         host: {'class': 'mat-toolbar'},
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class StaticHostClass {}
 
       @Component({
         template: '<static-host-class></static-host-class>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1562,6 +1685,8 @@ describe('host bindings', () => {
         @Component({
           template: `<${tag} unsafeUrlHostBindingDir></${tag}>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(UnsafeDir) unsafeDir!: UnsafeDir;
@@ -1641,6 +1766,8 @@ describe('host bindings', () => {
           <ng-container [ngTemplateOutlet]="ref" staticHostAtt dynamicHostAtt></ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1658,6 +1785,8 @@ describe('host bindings', () => {
         selector: 'my-app',
         template: ` <ng-template staticHostAtt dynamicHostAtt></ng-template> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1689,6 +1818,8 @@ describe('host bindings', () => {
       @Component({
         template: '<span dir></span>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         @ViewChild(MyDirective) dir!: MyDirective;
@@ -1721,6 +1852,8 @@ describe('host bindings', () => {
       @Component({
         template: '<span dir></span>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         @ViewChild(MyDirective) dir!: MyDirective;

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -28,6 +28,7 @@ import {
   ViewContainerRef,
   ɵɵdefineDirective,
   ɵɵHostDirectivesFeature,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
@@ -68,6 +69,8 @@ describe('host directives', () => {
     @Component({
       template: '<div dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -124,6 +127,8 @@ describe('host directives', () => {
     @Component({
       template: '<div dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -172,6 +177,8 @@ describe('host directives', () => {
     @Component({
       template: '<div dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -270,6 +277,8 @@ describe('host directives', () => {
       hostDirectives: [Chain1, Chain2, Chain3],
       providers: [{provide: token, useValue: 'host value'}],
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor() {
@@ -298,6 +307,8 @@ describe('host directives', () => {
     @Component({
       template: '<my-comp selector-matched-dir></my-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -356,6 +367,8 @@ describe('host directives', () => {
     @Component({
       template: '<div dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(FirstHostDir) firstHost!: FirstHostDir;
@@ -399,6 +412,8 @@ describe('host directives', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -484,6 +499,8 @@ describe('host directives', () => {
     @Component({
       template: '<div dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -560,6 +577,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -614,6 +633,8 @@ describe('host directives', () => {
         selector: 'child',
         hostDirectives: [ChildHostDir, OtherChildHostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child extends LogsLifecycles {
         override name = 'Child';
@@ -634,6 +655,8 @@ describe('host directives', () => {
         hostDirectives: [ParentHostDir, OtherParentHostDir],
         template: '<child plain-dir="PlainDir on child"></child>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent extends LogsLifecycles {
         override name = 'Parent';
@@ -650,6 +673,8 @@ describe('host directives', () => {
       @Component({
         template: '<parent plain-dir="PlainDir on parent"></parent>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -708,6 +733,8 @@ describe('host directives', () => {
           {directive: OtherHostDir, inputs: ['someInput']},
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComp extends LogsLifecycles {
         override name = 'HostComp';
@@ -724,6 +751,8 @@ describe('host directives', () => {
       @Component({
         template: '<host-comp plain-dir="PlainDir" [someInput]="inputValue"></host-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         inputValue = 'hello';
@@ -788,6 +817,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -825,6 +856,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -873,6 +906,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -895,6 +930,8 @@ describe('host directives', () => {
         selector: 'child',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         hostDir = inject(HostDir);
@@ -912,6 +949,8 @@ describe('host directives', () => {
         template: '<child></child>',
         hostDirectives: [HostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Host {
         @ViewChild(Child) child!: Child;
@@ -920,6 +959,8 @@ describe('host directives', () => {
       @Component({
         template: '<host></host>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Host) host!: Host;
@@ -971,6 +1012,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1030,6 +1073,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1072,6 +1117,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Host) host!: Host;
@@ -1098,6 +1145,8 @@ describe('host directives', () => {
         providers: [{provide: token, useValue: 'host'}],
         template: '<span child></span>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Host {}
 
@@ -1114,6 +1163,8 @@ describe('host directives', () => {
       @Component({
         template: '<host></host>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1141,12 +1192,16 @@ describe('host directives', () => {
         viewProviders: [{provide: token, useValue: 'host'}],
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Host {}
 
       @Component({
         template: '<host></host>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1175,6 +1230,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1197,6 +1254,8 @@ describe('host directives', () => {
         hostDirectives: [HostDir],
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         changeDetectorRef = inject(ChangeDetectorRef) as InternalChangeDetectorRef;
@@ -1205,6 +1264,8 @@ describe('host directives', () => {
       @Component({
         template: '<my-comp></my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -1257,6 +1318,8 @@ describe('host directives', () => {
         imports: [InjectsExisting],
         hostDirectives: [HostDirective],
         viewProviders: [{provide: token, useExisting: ProvidesExisting}],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CompWithHostDirective {}
 
@@ -1264,6 +1327,8 @@ describe('host directives', () => {
         selector: 'app-root',
         template: '<comp-with-host-directive providesExisting/>',
         imports: [ProvidesExisting, CompWithHostDirective],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1298,6 +1363,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1335,6 +1402,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1370,6 +1439,8 @@ describe('host directives', () => {
           (hasBeenClicked)="invalidSpy($event)"
         ></button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         validSpy = jasmine.createSpy('valid spy');
@@ -1407,6 +1478,8 @@ describe('host directives', () => {
           (hasBeenClicked)="invalidSpy($event)"
         ></button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         validSpy = jasmine.createSpy('valid spy');
@@ -1443,6 +1516,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1477,6 +1552,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1513,6 +1590,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (wasClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1546,6 +1625,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1583,6 +1664,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1622,6 +1705,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1666,6 +1751,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (wasClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1709,6 +1796,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir (hasBeenClicked)="spy($event)"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spy = jasmine.createSpy('click spy');
@@ -1742,6 +1831,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         color = 'red';
@@ -1771,6 +1862,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -1803,6 +1896,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [buttonColor]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -1835,6 +1930,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [buttonColor]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -1869,6 +1966,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dir!: Dir;
@@ -1909,6 +2008,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dir!: Dir;
@@ -1949,6 +2050,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [buttonColor]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) dir!: Dir;
@@ -1990,6 +2093,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2029,6 +2134,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(ExposedHostDir) exposedHostDir!: ExposedHostDir;
@@ -2075,6 +2182,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [buttonColor]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(FirstHostDir) firstHostDir!: FirstHostDir;
@@ -2113,6 +2222,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir color="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2141,6 +2252,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir color="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2168,6 +2281,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2195,6 +2310,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2227,6 +2344,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir color="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(ExposedHostDir) exposedHostDir!: ExposedHostDir;
@@ -2265,6 +2384,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(FirstHostDir) firstHostDir!: FirstHostDir;
@@ -2306,6 +2427,8 @@ describe('host directives', () => {
           <span dir [buttonColor]="spanValue"></span>
           <button host-dir [buttonColor]="buttonValue"></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         spanValue = 'spanValue';
@@ -2344,6 +2467,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HostDir) hostDir!: HostDir;
@@ -2397,6 +2522,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         color = 'red';
@@ -2484,6 +2611,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [buttonColor]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         color = 'red';
@@ -2568,6 +2697,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir [color]="color"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         color = 'red';
@@ -2625,6 +2756,8 @@ describe('host directives', () => {
       @Component({
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2679,12 +2812,16 @@ describe('host directives', () => {
         template: '',
         hostDirectives: [HostDir, OtherHostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
       @Component({
         template: '<comp plain-dir></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2714,6 +2851,8 @@ describe('host directives', () => {
         template: '',
         hostDirectives: [HostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         constructor() {
@@ -2724,6 +2863,8 @@ describe('host directives', () => {
       @Component({
         template: '<comp></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2747,6 +2888,8 @@ describe('host directives', () => {
         template: '',
         hostDirectives: [HostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         constructor() {
@@ -2757,6 +2900,8 @@ describe('host directives', () => {
       @Component({
         template: '<comp></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2778,6 +2923,8 @@ describe('host directives', () => {
         template: '',
         hostDirectives: [HostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         constructor(public elementRef: ElementRef<HTMLElement>) {}
@@ -2786,6 +2933,8 @@ describe('host directives', () => {
       @Component({
         template: '<comp></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Comp) compInstance!: Comp;
@@ -2806,6 +2955,8 @@ describe('host directives', () => {
       @Component({
         template: '<ng-container #insertionPoint></ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('insertionPoint', {read: ViewContainerRef}) insertionPoint!: ViewContainerRef;
@@ -2841,6 +2992,8 @@ describe('host directives', () => {
         hostDirectives: [HostDir],
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComp {
         constructor() {
@@ -2894,6 +3047,8 @@ describe('host directives', () => {
         template: '',
         hostDirectives: [HostDir, OtherHostDir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComp implements OnInit, AfterViewInit, AfterViewChecked {
         ngOnInit() {
@@ -2954,6 +3109,8 @@ describe('host directives', () => {
           },
           hostDirectives: [HostDir, OtherHostDir],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           value = 'host';
@@ -3002,6 +3159,8 @@ describe('host directives', () => {
           host: {'(click)': 'handleClick()'},
           hostDirectives: [HostDir, OtherHostDir],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           handleClick() {
@@ -3029,6 +3188,8 @@ describe('host directives', () => {
           host: {'id': 'host'},
           hostDirectives: [HostDir, OtherHostDir],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {}
 
@@ -3055,6 +3216,8 @@ describe('host directives', () => {
           hostDirectives: [HostDir],
           template: '',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {}
 
@@ -3078,6 +3241,8 @@ describe('host directives', () => {
           hostDirectives: [HostDir],
           template: '',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           hostDir = inject(HostDir);
@@ -3120,6 +3285,8 @@ describe('host directives', () => {
           hostDirectives: [FirstHostDir],
           providers: [{provide: token, useValue: 'HostDir'}],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           tokenValue = inject(token);
@@ -3157,6 +3324,8 @@ describe('host directives', () => {
           template: '',
           hostDirectives: [FirstHostDir],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           firstTokenValue = inject(firstToken);
@@ -3205,6 +3374,8 @@ describe('host directives', () => {
             },
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           @Input() color?: string;
@@ -3245,6 +3416,8 @@ describe('host directives', () => {
             },
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           color?: string; // Note: intentionally not marked as @Input.
@@ -3277,6 +3450,8 @@ describe('host directives', () => {
           selector: 'host-comp',
           hostDirectives: [HostDir],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {
           @Input() color?: string;
@@ -3315,6 +3490,8 @@ describe('host directives', () => {
             },
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {}
 
@@ -3353,6 +3530,8 @@ describe('host directives', () => {
           selector: 'host-comp',
           hostDirectives: [{directive: HostDir, inputs: ['alias: customAlias']}],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComp {}
 
@@ -3401,6 +3580,8 @@ describe('host directives', () => {
       @Component({
         hostDirectives: [Dir],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostComp {}
 
@@ -3424,6 +3605,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3449,6 +3632,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3469,7 +3654,11 @@ describe('host directives', () => {
       })
       class Dir {}
 
-      @Component({template: '<div dir></div>', imports: [HostDir, Dir]})
+      @Component({
+        template: '<div dir></div>',
+        imports: [HostDir, Dir],
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       expect(() => TestBed.createComponent(App)).toThrowError(
@@ -3485,6 +3674,8 @@ describe('host directives', () => {
         selector: 'comp',
         hostDirectives: [HostDir],
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -3501,6 +3692,8 @@ describe('host directives', () => {
         @Component({
           ...baseAppMetadata,
           imports: [Comp, HostDir],
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
         TestBed.createComponent(App);
@@ -3510,6 +3703,8 @@ describe('host directives', () => {
         @Component({
           ...baseAppMetadata,
           imports: [HostDir, Comp],
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
         TestBed.createComponent(App);
@@ -3533,6 +3728,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3544,7 +3741,11 @@ describe('host directives', () => {
     });
 
     it('should throw an error if a host directive is a component', () => {
-      @Component({template: '', selector: 'host-comp'})
+      @Component({
+        template: '',
+        selector: 'host-comp',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class HostComp {}
 
       @Directive({
@@ -3557,6 +3758,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3588,6 +3791,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3619,6 +3824,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3650,6 +3857,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3676,6 +3885,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3704,6 +3915,8 @@ describe('host directives', () => {
         imports: [Dir, HostDir],
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3736,6 +3949,8 @@ describe('host directives', () => {
         imports: [Dir, HostDir],
         template: '<button dir buttonColorAlias="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3767,6 +3982,8 @@ describe('host directives', () => {
         imports: [Dir, HostDir],
         template: '<button dir buttonColor="red"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3796,6 +4013,8 @@ describe('host directives', () => {
         imports: [Dir, HostDir],
         template: '<button dir (tappedAlias)="handleTap()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         handleTap() {}
@@ -3829,6 +4048,8 @@ describe('host directives', () => {
         imports: [Dir, HostDir],
         template: '<button dir (wasClicked)="handleClick()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         handleClick() {}
@@ -3857,7 +4078,11 @@ describe('host directives', () => {
       })
       class Host {}
 
-      @Component({template: '<div host></div>', imports: [Host]})
+      @Component({
+        template: '<div host></div>',
+        imports: [Host],
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       expect(() => {
@@ -3884,7 +4109,11 @@ describe('host directives', () => {
       })
       class Host {}
 
-      @Component({template: '<div host></div>', imports: [Host]})
+      @Component({
+        template: '<div host></div>',
+        imports: [Host],
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class App {}
 
       expect(() => {
@@ -3913,6 +4142,8 @@ describe('host directives', () => {
       @Component({
         template: '<div dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -34,6 +34,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ɵsetDocument,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {HEADER_OFFSET} from '../../src/render3/interfaces/view';
 import {getComponentLView} from '../../src/render3/util/discovery_utils';
@@ -349,6 +350,8 @@ describe('runtime i18n', () => {
       selector: 'app-comp',
       template: `<div i18n (click)="onClick()">Hello {{ name }}</div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ListenerComp {
       name = `Angular`;
@@ -561,6 +564,8 @@ describe('runtime i18n', () => {
       template:
         '<div i18n>Content: @defer (when isLoaded) {before<span>middle</span>after} ' +
         '@placeholder {before<div>placeholder</div>after}!</div>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class DeferComp {
       isLoaded = false;
@@ -787,6 +792,8 @@ describe('runtime i18n', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         isLogged = false;
@@ -1380,6 +1387,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<div><ng-content></ng-content></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -1390,6 +1399,8 @@ describe('runtime i18n', () => {
           other {at least {{value}} .}
         }</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         value = 3;
@@ -1441,6 +1452,8 @@ describe('runtime i18n', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -1450,6 +1463,8 @@ describe('runtime i18n', () => {
           <my-cmp i18n="test" *ngIf="condition">{count, plural, =1 {ONE} other {OTHER}}</my-cmp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         count = 1;
@@ -1521,6 +1536,8 @@ describe('runtime i18n', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -1533,6 +1550,8 @@ describe('runtime i18n', () => {
           }</my-cmp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         count = 1;
@@ -1584,6 +1603,8 @@ describe('runtime i18n', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         type = 'A';
@@ -1626,6 +1647,8 @@ describe('runtime i18n', () => {
           }</ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         type = 'A';
@@ -1667,6 +1690,8 @@ describe('runtime i18n', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         types = ['A', 'B', 'C'];
@@ -1688,6 +1713,8 @@ describe('runtime i18n', () => {
         selector: 'app',
         template: ` <div i18n="@@idA">{count, select, 1 {one} other {more than one}}</div> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         count = 2;
@@ -1714,6 +1741,8 @@ describe('runtime i18n', () => {
           <div i18n="@@idB">{count, plural, =1 {one (plural)} =2 {two (plural)}}</div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         count = 1;
@@ -1773,7 +1802,8 @@ describe('runtime i18n', () => {
           }</div>
         `,
         standalone: false,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class AppComponent {
         type = 'A';
         count = 1;
@@ -1825,7 +1855,8 @@ describe('runtime i18n', () => {
           <div i18n="@@idA">{count$ | async, select, 1 {{{count$ | async}} item} 2 {two items}}</div>
         `,
         standalone: false,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class AppComponent {
         count$ = new BehaviorSubject<number>(1);
       }
@@ -2010,6 +2041,8 @@ describe('runtime i18n', () => {
         selector: 'comp',
         template: '<ng-template i18n-title title="Hello"></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {}
 
@@ -2045,6 +2078,8 @@ describe('runtime i18n', () => {
         selector: 'my-cmp',
         template: ` <button *ngIf="true" i18n-title title="Hello"></button> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -2068,6 +2103,8 @@ describe('runtime i18n', () => {
         selector: 'my-cmp',
         template: ` <div *ngIf="true" i18n-title title="Hello"></div> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -2100,6 +2137,8 @@ describe('runtime i18n', () => {
         selector: 'my-app',
         template: '<ng-template i18n-dir dir="Hello {{ name }}"></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         name = 'Angular';
@@ -2134,6 +2173,8 @@ describe('runtime i18n', () => {
           selector: 'my-app',
           template: '<ng-template *ngIf="true" i18n-dir dir="Hello {{ name }}"></ng-template>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComp {
           name = 'Angular';
@@ -2161,6 +2202,8 @@ describe('runtime i18n', () => {
         selector: 'other',
         template: `<div i18n #ref="dir" test="Set" i18n-test="This is also a test"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Other {}
 
@@ -2171,6 +2214,8 @@ describe('runtime i18n', () => {
           <other></other>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -2222,6 +2267,8 @@ describe('runtime i18n', () => {
         selector: 'my-cmp',
         template: ` <ng-container i18n-mydir="meaning|description" mydir="Hello"></ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -2305,6 +2352,8 @@ describe('runtime i18n', () => {
         </div>
         <div test inner></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       exp1 = 1;
@@ -2354,6 +2403,8 @@ describe('runtime i18n', () => {
       selector: 'my-comp',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       t!: string;
@@ -2437,6 +2488,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<p><ng-content></ng-content></p>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2451,6 +2504,8 @@ describe('runtime i18n', () => {
           <remove-me-3></remove-me-3>
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2479,6 +2534,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<p><ng-content></ng-content></p>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2492,6 +2549,8 @@ describe('runtime i18n', () => {
           </child>
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2528,6 +2587,8 @@ describe('runtime i18n', () => {
         selector: 'grand-child',
         template: '<div><ng-content></ng-content></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class GrandChild {}
 
@@ -2535,6 +2596,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<grand-child><ng-content></ng-content></grand-child>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2542,6 +2605,8 @@ describe('runtime i18n', () => {
         selector: 'parent',
         template: `<child i18n><b>Hello</b> World!</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2564,6 +2629,8 @@ describe('runtime i18n', () => {
         selector: 'grand-child',
         template: '<div><ng-content></ng-content></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class GrandChild {}
 
@@ -2571,6 +2638,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<grand-child><ng-content></ng-content></grand-child>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2578,6 +2647,8 @@ describe('runtime i18n', () => {
         selector: 'parent',
         template: `<child i18n><b>Hello</b> World!</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2599,6 +2670,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<ng-content select="span"></ng-content>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2611,6 +2684,8 @@ describe('runtime i18n', () => {
           </child>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {}
 
@@ -2631,6 +2706,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<div i18n>Content projected from <ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2638,6 +2715,8 @@ describe('runtime i18n', () => {
         selector: 'parent',
         template: `<child>{{ name }}</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2666,6 +2745,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<div i18n>Content projected from <ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2675,6 +2756,8 @@ describe('runtime i18n', () => {
           ><b>{{ name }}</b></child
         >`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2696,6 +2779,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<div i18n>Child content <ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2703,6 +2788,8 @@ describe('runtime i18n', () => {
         selector: 'parent',
         template: `<child i18n>and projection from {{ name }}</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2730,6 +2817,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: '<div><ng-content></ng-content></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2740,6 +2829,8 @@ describe('runtime i18n', () => {
           other {at least {{value}} .}
         }</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         value = 3;
@@ -2757,6 +2848,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<div i18n>Child content <ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2766,6 +2859,8 @@ describe('runtime i18n', () => {
           >and projection from {name, select, angular {Angular} other {{{name}}}}</child
         >`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2800,6 +2895,8 @@ describe('runtime i18n', () => {
         selector: 'child',
         template: `<div i18n>Child content <ng-content></ng-content></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2807,6 +2904,8 @@ describe('runtime i18n', () => {
         selector: 'parent',
         template: `<child i18n>and projection from {{ name }}</child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'Parent';
@@ -2832,6 +2931,8 @@ describe('runtime i18n', () => {
         selector: 'app',
         template: ` <ng-container>(<ng-content></ng-content>)</ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyContentApp {}
 
@@ -2839,6 +2940,8 @@ describe('runtime i18n', () => {
         selector: 'my-app',
         template: ` <app i18n *ngIf="condition">{type, select, A {A} B {B} other {other}}</app> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         type = 'A';
@@ -2892,6 +2995,8 @@ describe('runtime i18n', () => {
         selector: 'div-query',
         template: '<ng-container #vc></ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DivQuery {
         @ContentChild(TemplateRef, {static: true}) template!: TemplateRef<any>;
@@ -3026,6 +3131,8 @@ describe('runtime i18n', () => {
         <div i18n>{{ myinput.value }}</div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -3055,6 +3162,8 @@ describe('runtime i18n', () => {
         <div i18n-title title="{{ myinput.value }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -3085,6 +3194,8 @@ describe('runtime i18n', () => {
         <button [close]="true">Button label</button>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ContentElementDialog {
       data = false;
@@ -3155,6 +3266,8 @@ describe('runtime i18n', () => {
           <ng-template #tmpl i18n> <ng-content></ng-content> B </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Projector {}
 
@@ -3162,6 +3275,8 @@ describe('runtime i18n', () => {
         selector: 'app',
         template: ` <projector>a</projector> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {}
 
@@ -3186,7 +3301,8 @@ describe('runtime i18n', () => {
             <div i18n>before|<div myDir>inside</div>|after</div>
           `,
         standalone: false,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class MyApp {}
 
       @Directive({
@@ -3220,6 +3336,8 @@ describe('runtime i18n', () => {
         }
       </h1>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       registerItemCount = 1;
@@ -3237,6 +3355,8 @@ describe('runtime i18n', () => {
     @Component({
       template: `<div i18n>before|<child>TextNotProjected</child>|after</div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -3244,6 +3364,8 @@ describe('runtime i18n', () => {
       selector: 'child',
       template: 'CHILD',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -3264,7 +3386,8 @@ describe('runtime i18n', () => {
       <div i18n [title]="null | async"><div>A</div></div>
       <div i18n>{{(null | async)||'B'}}<div></div></div>`,
       standalone: false,
-    })
+    
+      changeDetection: ChangeDetectionStrategy.Eager,})
     class MyApp {}
 
     TestBed.configureTestingModule({declarations: [MyApp]});
@@ -3285,23 +3408,30 @@ describe('runtime i18n', () => {
           </middle>
         </parent>`,
       standalone: false,
-    })
+    
+      changeDetection: ChangeDetectionStrategy.Eager,})
     class MyApp {}
 
     @Component({
       selector: 'parent',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {}
 
     @Component({
       selector: 'middle',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Middle {}
     @Component({
       selector: 'child',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       constructor(public middle: Middle) {
@@ -3325,6 +3455,8 @@ describe('runtime i18n', () => {
         <span [ngTemplateOutlet]="tmpl"></span>
       </div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -3362,6 +3494,8 @@ describe('runtime i18n', () => {
         </ng-container>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -3412,6 +3546,8 @@ describe('runtime i18n', () => {
         |after.
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       retention = {
@@ -3445,6 +3581,8 @@ describe('runtime i18n', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       parameters = [{name: 'void_abt_param'}];
@@ -3464,6 +3602,8 @@ describe('runtime i18n', () => {
         <li *ngFor="let item of items">{item, plural, =1 {<b>one</b>} =2 {<i>two</i>}},</li>
       </ul>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       items = [1, 2];
@@ -3493,6 +3633,8 @@ describe('runtime i18n', () => {
     @Component({
       template: `<div i18n-title title="text" injectTitle></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(InjectTitleDir) dir!: InjectTitleDir;
@@ -3520,6 +3662,8 @@ describe('runtime i18n', () => {
     @Component({
       template: `<div i18n-title title="text {{ value }}" injectTitle></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(InjectTitleDir) dir!: InjectTitleDir;
@@ -3537,7 +3681,7 @@ describe('runtime i18n', () => {
   });
 
   describe('attribute sanitization', () => {
-    @Component({template: ''})
+    @Component({template: '', changeDetection: ChangeDetectionStrategy.Eager})
     class SanitizeAppComp {
       url = 'javascript:alert("oh no")';
       count = 0;
@@ -3634,6 +3778,8 @@ function initWithTemplate(compType: Type<any>, template: string) {
   selector: 'app-comp',
   template: ``,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AppComp {
   name = `Angular`;
@@ -3648,6 +3794,8 @@ class AppComp {
   template: ``,
   preserveWhitespaces: true,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AppCompWithWhitespaces {}
 

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -7,7 +7,10 @@
  */
 
 import {state, style, trigger} from '@angular/animations';
+import {By} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
+  ChangeDetectionStrategy,
   Component,
   ContentChildren,
   Directive,
@@ -23,8 +26,6 @@ import {
 } from '../../src/core';
 import {getDirectiveDef} from '../../src/render3/def_getters';
 import {TestBed} from '../../testing';
-import {By} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('inheritance', () => {
   beforeEach(() => {
@@ -37,6 +38,8 @@ describe('inheritance', () => {
       selector: 'my-comp',
       template: '<div></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComponent {}
 
@@ -49,6 +52,8 @@ describe('inheritance', () => {
     @Component({
       template: `<div my-dir></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -134,6 +139,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir1 subDir2></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -184,6 +191,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -216,6 +225,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -258,6 +269,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -296,6 +309,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -334,6 +349,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -368,6 +385,8 @@ describe('inheritance', () => {
       @Component({
         template: `<div subDir [someInput]="1"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -400,6 +419,8 @@ describe('inheritance', () => {
         selector: 'my-comp',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp extends UndecoratedBase {
         @Input() override input: any;
@@ -408,6 +429,8 @@ describe('inheritance', () => {
       @Component({
         template: '<my-comp [input]="value"></my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value = 'hello';
@@ -468,6 +491,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -509,6 +534,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -550,6 +577,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -591,6 +620,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -632,6 +663,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -673,6 +706,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -714,6 +749,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -769,6 +806,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p sub-dir [foo]="a" [bar]="b" [baz]="c" [qux]="d"></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -808,6 +847,8 @@ describe('inheritance', () => {
         @Component({
           imports: [ActualDir],
           template: `<dir someInput="newValue"></dir>`,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {}
 
@@ -836,6 +877,8 @@ describe('inheritance', () => {
         @Component({
           imports: [ActualDir],
           template: `<dir publicName="newValue"></dir>`,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {}
 
@@ -874,6 +917,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <div sub-dir (foo)="handleFoo($event)"></div> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -913,6 +958,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir>test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -950,6 +997,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir superTitle="test">test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -998,6 +1047,8 @@ describe('inheritance', () => {
             </ul>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -1085,6 +1136,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1126,6 +1179,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1167,6 +1222,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1208,6 +1265,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1249,6 +1308,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1290,6 +1351,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1331,6 +1394,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1390,6 +1455,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p sub-dir [foo]="a" [bar]="b" [baz]="c" [qux]="d"></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -1443,6 +1510,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <div sub-dir (foo)="handleFoo($event)"></div> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -1486,6 +1555,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir>test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -1527,6 +1598,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir superTitle="test">test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -1576,6 +1649,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1663,6 +1738,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1704,6 +1781,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1745,6 +1824,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1786,6 +1867,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1827,6 +1910,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1868,6 +1953,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1909,6 +1996,8 @@ describe('inheritance', () => {
         @Component({
           template: `<p *ngIf="showing" subDir></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -1971,6 +2060,8 @@ describe('inheritance', () => {
           selector: 'my-app',
           template: `<p sub-dir [foo]="a" [bar]="b" [baz]="c" [qux]="d"></p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -2029,6 +2120,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <div sub-dir (foo)="handleFoo($event)" (bar)="handleBar($event)"></div> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -2081,6 +2174,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir>test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2131,6 +2226,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <p sub-dir superTitle="test1" superAccessKey="test2">test</p> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2196,6 +2293,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2269,6 +2368,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnInit() {
@@ -2279,6 +2379,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2320,6 +2421,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2352,6 +2454,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentInit() {
@@ -2362,6 +2465,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2394,6 +2498,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentChecked() {
@@ -2404,6 +2509,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2436,6 +2542,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewInit() {
@@ -2446,6 +2553,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2478,6 +2586,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewChecked() {
@@ -2488,6 +2597,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2520,6 +2630,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnDestroy() {
@@ -2530,6 +2641,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2576,6 +2688,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           @Input() override baz = '';
@@ -2586,6 +2699,8 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp [foo]="a" [bar]="b" [baz]="c" [qux]="d"></my-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -2626,6 +2741,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           ngOnInit() {
@@ -2636,6 +2752,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <my-comp (foo)="handleFoo($event)"></my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -2670,12 +2788,15 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
 
         @Component({
           template: ` <my-comp>test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2709,11 +2830,14 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
         @Component({
           template: ` <my-comp superTitle="test">test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -2747,6 +2871,8 @@ describe('inheritance', () => {
           <ng-content></ng-content>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperComponent {
         ngAfterViewInit() {
@@ -2762,6 +2888,8 @@ describe('inheritance', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -2838,6 +2966,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngOnInit() {
@@ -2848,6 +2977,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2880,6 +3010,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngDoCheck() {
@@ -2890,6 +3021,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2922,6 +3054,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngAfterContentInit() {
@@ -2932,6 +3065,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -2964,6 +3098,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngAfterContentChecked() {
@@ -2974,6 +3109,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3006,6 +3142,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngAfterViewInit() {
@@ -3016,6 +3153,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3048,6 +3186,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngAfterViewChecked() {
@@ -3058,6 +3197,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3090,6 +3230,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           override ngOnDestroy() {
@@ -3100,6 +3241,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3150,6 +3292,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           @Input() override baz = '';
@@ -3160,6 +3303,8 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp [foo]="a" [bar]="b" [baz]="c" [qux]="d"></my-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -3204,6 +3349,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {
           ngOnInit() {
@@ -3214,6 +3360,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <my-comp (foo)="handleFoo($event)"></my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -3252,12 +3400,15 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {}
 
         @Component({
           template: ` <my-comp>test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -3295,11 +3446,14 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperDirective {}
         @Component({
           template: ` <my-comp superTitle="test">test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -3337,6 +3491,8 @@ describe('inheritance', () => {
           <ng-content></ng-content>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperDirective {
         ngAfterViewInit() {
@@ -3352,6 +3508,8 @@ describe('inheritance', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3389,6 +3547,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperDirective {
         items = [1, 2, 3, 4, 5];
@@ -3400,6 +3560,8 @@ describe('inheritance', () => {
       @Component({
         template: ` <my-comp></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3478,6 +3640,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngOnInit() {
@@ -3488,6 +3651,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3529,6 +3693,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3561,6 +3726,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngAfterContentInit() {
@@ -3571,6 +3737,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3603,6 +3770,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngAfterContentChecked() {
@@ -3613,6 +3781,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3645,6 +3814,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngAfterViewInit() {
@@ -3655,6 +3825,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3687,6 +3858,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngAfterViewChecked() {
@@ -3697,6 +3869,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3729,6 +3902,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           override ngOnDestroy() {
@@ -3739,6 +3913,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -3791,6 +3966,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           @Input() override baz = '';
@@ -3801,6 +3977,8 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp [foo]="a" [bar]="b" [baz]="c" [qux]="d"></my-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -3847,6 +4025,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           ngOnInit() {
@@ -3857,6 +4036,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <my-comp (foo)="handleFoo($event)"></my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -3897,12 +4078,15 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {}
 
         @Component({
           template: ` <my-comp>test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -3949,11 +4133,14 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {}
         @Component({
           template: ` <my-comp superTitle="test1" superAccessKey="test2">test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -3994,6 +4181,8 @@ describe('inheritance', () => {
           <ng-content></ng-content>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends BareClass {
         ngAfterViewInit() {
@@ -4009,6 +4198,8 @@ describe('inheritance', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4048,6 +4239,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends BareClass {
         items = [1, 2, 3, 4, 5];
@@ -4059,6 +4252,8 @@ describe('inheritance', () => {
       @Component({
         template: ` <my-comp></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4104,6 +4299,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperComponent {
         ngOnInit() {
@@ -4136,6 +4333,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnInit() {
@@ -4146,6 +4344,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4178,6 +4377,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngDoCheck() {
@@ -4188,6 +4388,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4220,6 +4421,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentInit() {
@@ -4230,6 +4432,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4262,6 +4465,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentChecked() {
@@ -4272,6 +4476,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4304,6 +4509,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewInit() {
@@ -4314,6 +4520,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4346,6 +4553,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewChecked() {
@@ -4356,6 +4564,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4388,6 +4597,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnDestroy() {
@@ -4398,6 +4608,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4436,6 +4647,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           @Input() foo = '';
@@ -4449,6 +4662,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           @Input() override baz = '';
@@ -4459,6 +4673,8 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp [foo]="a" [bar]="b" [baz]="c" [qux]="d"></my-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -4495,6 +4711,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           @Output() foo = new EventEmitter<string>();
@@ -4504,6 +4722,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           ngOnInit() {
@@ -4514,6 +4733,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <my-comp (foo)="handleFoo($event)"></my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -4544,6 +4765,8 @@ describe('inheritance', () => {
           },
           animations: [trigger('animation', [state('color', style({color: 'red'}))])],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           colorExp = 'color';
@@ -4553,12 +4776,16 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<div>my-comp</div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
 
         @Component({
           template: '<my-comp>app</my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -4582,6 +4809,8 @@ describe('inheritance', () => {
             trigger('animation2', [state('opacity', style({opacity: '0.5'}))]),
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {}
 
@@ -4598,6 +4827,8 @@ describe('inheritance', () => {
             trigger('animation3', [state('bg', style({backgroundColor: 'green'}))]),
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           colorExp = 'color';
@@ -4608,6 +4839,8 @@ describe('inheritance', () => {
         @Component({
           template: '<my-comp>app</my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -4633,6 +4866,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           @HostBinding('style.color') color = 'red';
@@ -4644,12 +4879,15 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
 
         @Component({
           template: ` <my-comp>test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -4674,6 +4912,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           @HostBinding('title')
@@ -4688,11 +4928,14 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
         @Component({
           template: ` <my-comp superTitle="test">test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -4720,6 +4963,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperComponent {
         @ContentChildren(ChildDir) customDirs!: QueryList<ChildDir>;
@@ -4731,6 +4976,8 @@ describe('inheritance', () => {
           <ng-content></ng-content>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperComponent {
         ngAfterViewInit() {
@@ -4746,6 +4993,8 @@ describe('inheritance', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4771,6 +5020,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperComponent {
         @ViewChildren(ChildDir) customDirs!: QueryList<ChildDir>;
@@ -4784,6 +5035,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperComponent {
         items = [1, 2, 3, 4, 5];
@@ -4795,6 +5048,8 @@ describe('inheritance', () => {
       @Component({
         template: ` <my-comp></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -4814,6 +5069,8 @@ describe('inheritance', () => {
         selector: 'app-base',
         template: 'base',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class BaseComponent {
         @HostListener('click')
@@ -4826,6 +5083,8 @@ describe('inheritance', () => {
         selector: 'app-child',
         template: 'child',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComponent extends BaseComponent {
         // additional host listeners are defined here to have `hostBindings` function generated on
@@ -4843,6 +5102,8 @@ describe('inheritance', () => {
         selector: 'app-grand-child',
         template: 'grand-child',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class GrandChildComponent extends ChildComponent {
         // additional host listeners are defined here to have `hostBindings` function generated on
@@ -4864,6 +5125,8 @@ describe('inheritance', () => {
           <app-grand-child></app-grand-child>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootApp {}
 
@@ -4917,6 +5180,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperSuperComponent {
         ngOnInit() {
@@ -4951,6 +5216,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnInit() {
@@ -4961,6 +5227,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -4993,6 +5260,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngDoCheck() {
@@ -5003,6 +5271,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5035,6 +5304,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentInit() {
@@ -5045,6 +5315,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5077,6 +5348,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterContentChecked() {
@@ -5087,6 +5359,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5119,6 +5392,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewInit() {
@@ -5129,6 +5403,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5161,6 +5436,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngAfterViewChecked() {
@@ -5171,6 +5447,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5203,6 +5480,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           override ngOnDestroy() {
@@ -5213,6 +5491,7 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp *ngIf="showing"></my-comp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showing = true;
@@ -5251,6 +5530,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperSuperComponent {
           @Input() foo = '';
@@ -5266,6 +5547,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends BareClass {
           @Input() override baz = '';
@@ -5276,6 +5558,8 @@ describe('inheritance', () => {
         @Component({
           template: `<my-comp [foo]="a" [bar]="b" [baz]="c" [qux]="d"></my-comp>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           a = 'a';
@@ -5312,6 +5596,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperSuperComponent {
           @Output() foo = new EventEmitter<string>();
@@ -5325,6 +5611,7 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {
           ngOnInit() {
@@ -5336,6 +5623,8 @@ describe('inheritance', () => {
         @Component({
           template: ` <my-comp (foo)="handleFoo($event)" (bar)="handleBar($event)"></my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           foo = '';
@@ -5377,6 +5666,8 @@ describe('inheritance', () => {
             trigger('animation2', [state('opacity', style({opacity: '0.5'}))]),
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperComponent {
           colorExp = 'color';
@@ -5387,6 +5678,8 @@ describe('inheritance', () => {
           selector: 'intermediate-comp',
           template: '...',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class IntermediateComponent extends SuperComponent {}
 
@@ -5402,6 +5695,8 @@ describe('inheritance', () => {
             trigger('animation3', [state('bg', style({backgroundColor: 'green'}))]),
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends IntermediateComponent {
           override colorExp = 'color';
@@ -5412,6 +5707,8 @@ describe('inheritance', () => {
         @Component({
           template: '<my-comp>app</my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -5436,6 +5733,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperSuperComponent {
           @HostBinding('style.color') color = 'red';
@@ -5449,12 +5748,15 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
 
         @Component({
           template: ` <my-comp>test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -5479,6 +5781,8 @@ describe('inheritance', () => {
           selector: 'super-comp',
           template: `<p>super</p>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SuperSuperComponent {
           @HostBinding('title')
@@ -5502,11 +5806,14 @@ describe('inheritance', () => {
           selector: 'my-comp',
           template: `<p>test</p>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComponent extends SuperComponent {}
         @Component({
           template: ` <my-comp superTitle="test1" superAccessKey="test2">test</my-comp> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -5536,6 +5843,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperComponent {
         @ContentChildren(ChildDir) customDirs!: QueryList<ChildDir>;
@@ -5547,6 +5856,8 @@ describe('inheritance', () => {
           <ng-content></ng-content>
         </ul>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperComponent {
         ngAfterViewInit() {
@@ -5562,6 +5873,8 @@ describe('inheritance', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -5587,6 +5900,8 @@ describe('inheritance', () => {
         selector: 'super-comp',
         template: `<p>super</p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SuperComponent {
         @ViewChildren(ChildDir) customDirs!: QueryList<ChildDir>;
@@ -5600,6 +5915,8 @@ describe('inheritance', () => {
           </ul>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent extends SuperComponent {
         items = [1, 2, 3, 4, 5];
@@ -5611,6 +5928,8 @@ describe('inheritance', () => {
       @Component({
         template: ` <my-comp></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -31,6 +31,7 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {Inject} from '../../src/di';
 import {readPatchedLView} from '../../src/render3/context_discovery';
@@ -57,6 +58,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<span title="Hello">Greetings</span>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -72,6 +75,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<div>before|<ng-container>Greetings<span></span></ng-container>|after</div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -89,6 +94,8 @@ describe('acceptance integration tests', () => {
         template:
           '<ng-template [ngIf]="render"><div><ng-container>content</ng-container></div></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         render = false;
@@ -112,6 +119,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<ng-container *ngIf="render">content</ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         render = false;
@@ -155,6 +164,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<ng-template testDirective><ng-container>content</ng-container></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDirective, {static: true}) testDirective!: TestDirective;
@@ -180,12 +191,16 @@ describe('acceptance integration tests', () => {
         selector: 'test-cmpt',
         template: '<ng-container>component template</ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
       @Component({
         template: '<test-cmpt></test-cmpt>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -203,12 +218,16 @@ describe('acceptance integration tests', () => {
         template:
           '<ng-container><ng-container><ng-container>content</ng-container></ng-container></ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
       @Component({
         template: '<test-cmpt></test-cmpt>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -244,6 +263,8 @@ describe('acceptance integration tests', () => {
         template:
           '<ng-template testDirective><ng-container><ng-container><ng-container>content</ng-container></ng-container></ng-container></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDirective, {static: true}) testDirective!: TestDirective;
@@ -280,6 +301,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<div><ng-container dir></ng-container></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDirective) testDirective!: TestDirective;
@@ -318,6 +341,8 @@ describe('acceptance integration tests', () => {
         template:
           '<ng-container dir [contentTpl]="content"><ng-template #content>Content</ng-template></ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDirective) testDirective!: TestDirective;
@@ -361,6 +386,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<ng-container><ng-template dir>Content</ng-template></ng-container>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDirective) testDirective!: TestDirective;
@@ -385,6 +412,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<div><ng-container id="foo"></ng-container></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -401,6 +430,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '{{name}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name: string | undefined = 'benoit';
@@ -422,6 +453,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '{{name}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name: string | null = 'benoit';
@@ -443,6 +476,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '{{this.$any(1, 2)}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         $any(value: number, multiplier: number) {
@@ -471,6 +506,8 @@ describe('acceptance integration tests', () => {
           {{ myRef.id }}
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -503,6 +540,8 @@ describe('acceptance integration tests', () => {
           </b>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = 'World';
@@ -538,6 +577,8 @@ describe('acceptance integration tests', () => {
           </b>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = 'World';
@@ -559,6 +600,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: 'Hello {{name}}!',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = '';
@@ -582,6 +625,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<b>Hello {{name}}!</b>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = '';
@@ -605,6 +650,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<b><b><b><b>Hello {{name}}!</b></b></b></b>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = '';
@@ -628,6 +675,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<b><span></span><span class="foo" [id]="id"></span></b>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         id = '';
@@ -653,6 +702,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<p>hello</p>{{name}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = '';
@@ -678,6 +729,8 @@ describe('acceptance integration tests', () => {
       selector: 'todo',
       template: '<p>Todo{{value}}</p>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TodoComponent {
       value = ' one';
@@ -687,6 +740,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<todo></todo>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -701,6 +756,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<todo></todo>two',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -715,6 +772,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<todo></todo><todo></todo>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -732,6 +791,8 @@ describe('acceptance integration tests', () => {
         selector: 'todo',
         template: '{{title}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TodoComponentHostBinding {
         @HostBinding() title = 'one';
@@ -740,6 +801,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<todo></todo>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TodoComponentHostBinding) todoComponentHostBinding!: TodoComponentHostBinding;
@@ -763,6 +826,8 @@ describe('acceptance integration tests', () => {
         template: '',
         host: {'role': 'button'},
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostAttributeComp {}
 
@@ -778,6 +843,8 @@ describe('acceptance integration tests', () => {
         selector: 'comp',
         template: '<p>{{ name }}</p>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         name = 'Bess';
@@ -786,6 +853,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<comp></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -801,6 +870,8 @@ describe('acceptance integration tests', () => {
         selector: 'comp',
         template: '<div *ngIf="condition">text</div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @Input() condition!: boolean;
@@ -809,6 +880,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<comp [condition]="condition"></comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         condition = false;
@@ -835,6 +908,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<button [attr.title]="title"></button>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           title: string | null = '';
@@ -862,6 +937,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<button [attr.title]="title"></button>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           title: any;
@@ -895,6 +972,8 @@ describe('acceptance integration tests', () => {
             'a8:{{c[0]}}{{c[1]}}{{c[2]}}{{c[3]}}{{c[4]}}{{c[5]}}{{c[6]}}{{c[7]}}{{c[8]}}{{c[9]}}{{c[10]}}{{c[11]}}{{c[12]}}{{c[13]}}{{c[14]}}{{c[15]}}{{c[16]}}',
           ].join('\n'),
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           c = ['(', 0, 'a', 1, 'b', 2, 'c', 3, 'd', 4, 'e', 5, 'f', 6, 'g', 7, ')'];
@@ -964,6 +1043,8 @@ describe('acceptance integration tests', () => {
             </span>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           title: string | null = '';
@@ -1010,6 +1091,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div hostBindingDir></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(HostBindingDir) hostBindingDir!: HostBindingDir;
@@ -1036,6 +1119,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<span [style.font-size]="size"></span>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           size: string | null = '';
@@ -1062,6 +1147,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<span [style.font-size.px]="size"></span>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           size: string | number | null = '';
@@ -1094,6 +1181,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<span [class.active]="value"></span>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           value: any;
@@ -1134,6 +1223,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<span class="existing" [class.active]="value"></span>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           value: any;
@@ -1155,12 +1246,16 @@ describe('acceptance integration tests', () => {
           selector: 'my-comp',
           template: 'Comp Content',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {}
 
         @Component({
           template: '<my-comp [class.active]="value"></my-comp>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           value: any;
@@ -1185,6 +1280,8 @@ describe('acceptance integration tests', () => {
           selector: 'structural-comp',
           template: 'Comp Content',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class StructuralComp {
           @Input() tmp!: TemplateRef<any>;
@@ -1202,6 +1299,8 @@ describe('acceptance integration tests', () => {
             <structural-comp [class.active]="value" [tmp]="foo"></structural-comp>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(StructuralComp) structuralComp!: StructuralComp;
@@ -1255,6 +1354,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div class="apple orange banana" DirWithClass></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(DirWithClassDirective) mockClassDirective!: DirWithClassDirective;
@@ -1275,6 +1376,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div style="width: 100px; height: 200px" DirWithStyle></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(DirWithStyleDirective) mockStyleDirective!: DirWithStyleDirective;
@@ -1293,6 +1396,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div DirWithClass [class]="value"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(DirWithClassDirective) mockClassDirective!: DirWithClassDirective;
@@ -1311,6 +1416,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div DirWithStyle [style]="value"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(DirWithStyleDirective) mockStyleDirective!: DirWithStyleDirective;
@@ -1346,6 +1453,8 @@ describe('acceptance integration tests', () => {
             <div DirWithInitialStyling class="big" style="color:black; font-size:200px"></div>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {}
 
@@ -1383,6 +1492,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: ` <div DirWithSingleStylingBindings class="abc" style="width:100px;"></div> `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(DirWithSingleStylingBindings) dirInstance!: DirWithSingleStylingBindings;
@@ -1443,6 +1554,8 @@ describe('acceptance integration tests', () => {
         @Component({
           template: '<div Dir1WithStyle Dir2WithStyle [style.width]="width"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(Dir1WithStyle) dir1Instance!: Dir1WithStyle;
@@ -1509,6 +1622,8 @@ describe('acceptance integration tests', () => {
           template:
             '<div Dir1WithStyling Dir2WithStyling [style]="stylesExp" [class]="classesExp"></div>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           @ViewChild(Dir1WithStyling) dir1Instance!: Dir1WithStyling;
@@ -1589,6 +1704,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<div class="-{{name}}-{{age}}-"></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = '';
@@ -1614,6 +1731,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FixtureComponent {}
 
@@ -1628,6 +1747,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SomeComponent {}
 
@@ -1646,6 +1767,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FixtureComponent {}
       @Pipe({
@@ -1668,6 +1791,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FixtureComponent {}
       @NgModule({})
@@ -1688,6 +1813,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FixtureComponent {}
       class SomeClass {}
@@ -1704,6 +1831,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FixtureComponent {}
       class SomeModule {}
@@ -1725,12 +1854,16 @@ describe('acceptance integration tests', () => {
         selector: 'my-comp',
         template: 'hello',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
       @Component({
         template: '<my-comp/>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1745,12 +1878,16 @@ describe('acceptance integration tests', () => {
         selector: 'my-comp',
         template: '<ng-content/>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
       @Component({
         template: '<my-comp title="a">Before<my-comp title="b"/>After</my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1769,6 +1906,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ButtonSuperClass {
       @HostListener('click')
@@ -1781,12 +1920,16 @@ describe('acceptance integration tests', () => {
       selector: 'button[custom-button]',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ButtonSubClass extends ButtonSuperClass {}
 
     @Component({
       template: '<button custom-button></button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -1811,6 +1954,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<div someDir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SuperComp {
       @ViewChildren(SomeDir) dirs!: QueryList<SomeDir>;
@@ -1820,12 +1965,16 @@ describe('acceptance integration tests', () => {
       selector: 'button[custom-button]',
       template: '<div someDir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubComp extends SuperComp {}
 
     @Component({
       template: '<button custom-button></button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -1867,6 +2016,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<div no-assign-after-destroy [value]="directiveValue"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       directiveValue = 'initial-value';
@@ -1888,6 +2039,8 @@ describe('acceptance integration tests', () => {
       template: `foo`,
       host: {'[attr.aria-disabled]': 'true'},
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       @ContentChild(TemplateRef, {static: true}) tpl!: TemplateRef<any>;
@@ -1910,12 +2063,16 @@ describe('acceptance integration tests', () => {
       selector: 'button[custom-button]',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ButtonSubClass extends ButtonSuperClass {}
 
     @Component({
       template: '<button custom-button [isDisabled]="disableButton"></button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       disableButton = false;
@@ -1948,12 +2105,16 @@ describe('acceptance integration tests', () => {
       selector: 'button[custom-button]',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ButtonSubClass extends ButtonSuperClass {}
 
     @Component({
       template: '<button custom-button (clicked)="handleClick()"></button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {
       handleClick() {
@@ -1980,12 +2141,16 @@ describe('acceptance integration tests', () => {
       selector: '[sub-button]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button sub-button>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2013,12 +2178,16 @@ describe('acceptance integration tests', () => {
       selector: '[sub-button]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button sub-button>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2049,12 +2218,16 @@ describe('acceptance integration tests', () => {
       selector: '[sub-button]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button sub-button>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2086,12 +2259,16 @@ describe('acceptance integration tests', () => {
       selector: '[subButton]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button subButton>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2129,12 +2306,16 @@ describe('acceptance integration tests', () => {
       selector: '[subButton]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button subButton>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2178,12 +2359,16 @@ describe('acceptance integration tests', () => {
       selector: '[subButton]',
       template: '<ng-content></ng-content>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubButton extends BaseButton {}
 
     @Component({
       template: '<button subButton>Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2218,6 +2403,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<div [dir]="3"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       ngAfterViewInit(): void {
@@ -2244,6 +2431,8 @@ describe('acceptance integration tests', () => {
         </span>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       firstName: string | null = null;
@@ -2272,6 +2461,8 @@ describe('acceptance integration tests', () => {
         </span>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       unknownNames: string[] | null = null;
@@ -2301,6 +2492,8 @@ describe('acceptance integration tests', () => {
         </span>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person: {
@@ -2328,6 +2521,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: `{{ safe?.()?.()?.()?.()?.() }} {{ plain()()()()() }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       plain() {
@@ -2373,6 +2568,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: `<button some-dir>Click me</button>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2397,6 +2594,8 @@ describe('acceptance integration tests', () => {
         </svg>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       condition = true;
@@ -2421,6 +2620,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: `<div [my-dir]="{a, b: 2, someProp}"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) directive!: Dir;
@@ -2439,6 +2640,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: 'Balance: ${{ 1_000_000 * multiplier }}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       multiplier = 5;
@@ -2455,6 +2658,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: ` <span>Hello, {{ person?.getName() || 'unknown' }}!</span> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = null;
@@ -2493,6 +2698,8 @@ describe('acceptance integration tests', () => {
         >
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person: Person | null = null;
@@ -2544,6 +2751,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<child></child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2551,6 +2760,8 @@ describe('acceptance integration tests', () => {
       selector: 'child',
       template: '<grand-child></grand-child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -2558,6 +2769,8 @@ describe('acceptance integration tests', () => {
       selector: 'grand-child',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class GrandChild {}
 
@@ -2588,6 +2801,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<template><strong>Hello</strong><em>World</em></template>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2610,6 +2825,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<template><strong *ngIf="render">Hello</strong></template>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       render = true;
@@ -2638,6 +2855,8 @@ describe('acceptance integration tests', () => {
     @Component({
       template: '<template><strong>Hello {{name}}</strong></template>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       name = 'Bilbo';
@@ -2671,7 +2890,8 @@ describe('acceptance integration tests', () => {
         {{ $any(val)?.foo!.bar }}
       `,
       standalone: false,
-    })
+    
+      changeDetection: ChangeDetectionStrategy.Eager,})
     class Comp {
       val: any = null;
 
@@ -2687,6 +2907,8 @@ describe('acceptance integration tests', () => {
   it('should support template literals in expressions', () => {
     @Component({
       template: 'Message: {{`Hello, ${name} - ${value}`}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       name = 'Frodo';
@@ -2706,6 +2928,8 @@ describe('acceptance integration tests', () => {
   it('should support regular expressions in templates', () => {
     @Component({
       template: 'Matches: {{/\\d+/.test(value)}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = '123';
@@ -2725,6 +2949,8 @@ describe('acceptance integration tests', () => {
       host: {
         '(click)': 'void doStuff($event)',
       },
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       e: Event | null = null;
@@ -2745,6 +2971,8 @@ describe('acceptance integration tests', () => {
   it('should support object spread assigments in templates', () => {
     @Component({
       template: '@let obj = {a: {...foo}}; Hello, {{obj.a.b}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       foo = {b: 'Frodo'};
@@ -2762,6 +2990,8 @@ describe('acceptance integration tests', () => {
   it('should support arrays with spread elements in templates', () => {
     @Component({
       template: "@let arr = [...[...[...foo]], 'Baggins']; Hello, {{arr[0]}} {{arr[1]}}",
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       foo = ['Frodo'];
@@ -2779,6 +3009,8 @@ describe('acceptance integration tests', () => {
   it('should support calls with rest arguments in templates', () => {
     @Component({
       template: "{{fn('Hello', ...foo)}}",
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       foo = ['Frodo', 'Baggins'];
@@ -2800,6 +3032,8 @@ describe('acceptance integration tests', () => {
   it('should have correct operator precedence', () => {
     @Component({
       template: '{{1 + 10 ** -2 * 3}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
     const fixture = TestBed.createComponent(TestComponent);
@@ -2810,6 +3044,8 @@ describe('acceptance integration tests', () => {
   it('should throw on ambiguous unary operator in exponentiation expression', () => {
     @Component({
       template: '{{1 + -10 ** -2 * 3}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
     expect(() => TestBed.createComponent(TestComponent)).toThrowError(
@@ -2820,6 +3056,8 @@ describe('acceptance integration tests', () => {
   it('should not throw on unambiguous unary operator in exponentiation expression', () => {
     @Component({
       template: '{{1 + (-10) ** -2 * 3}} | {{1 + -(10 ** -2) * 3}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
     const fixture = TestBed.createComponent(TestComponent);
@@ -2830,6 +3068,8 @@ describe('acceptance integration tests', () => {
   it('should have right-to-left associativity for exponentiation', () => {
     @Component({
       template: '{{2 ** 2 ** 3}}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
     const fixture = TestBed.createComponent(TestComponent);
@@ -2838,7 +3078,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support addition assignment operator in templates', () => {
-    @Component({template: '<button (click)="a += b += c"></button>'})
+    @Component({
+      template: '<button (click)="a += b += c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 2;
       b = 3;
@@ -2862,7 +3105,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support subtraction assignment operator in templates', () => {
-    @Component({template: '<button (click)="a -= b -= c"></button>'})
+    @Component({
+      template: '<button (click)="a -= b -= c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 2;
       b = 3;
@@ -2886,7 +3132,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support multiplication assignment operator in templates', () => {
-    @Component({template: '<button (click)="a *= b *= c"></button>'})
+    @Component({
+      template: '<button (click)="a *= b *= c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 2;
       b = 3;
@@ -2910,7 +3159,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support division assignment operator in templates', () => {
-    @Component({template: '<button (click)="a /= b /= c"></button>'})
+    @Component({
+      template: '<button (click)="a /= b /= c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 4;
       b = 8;
@@ -2934,7 +3186,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support remainder assignment operator in templates', () => {
-    @Component({template: '<button (click)="a %= b %= c"></button>'})
+    @Component({
+      template: '<button (click)="a %= b %= c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 4;
       b = 3;
@@ -2952,7 +3207,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support exponentiation assignment operator in templates', () => {
-    @Component({template: '<button (click)="a **= b **= c"></button>'})
+    @Component({
+      template: '<button (click)="a **= b **= c"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 0.5;
       b = 2;
@@ -2976,7 +3234,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support logical and assignment operator in templates', () => {
-    @Component({template: '<button (click)="a &&= b"></button>'})
+    @Component({
+      template: '<button (click)="a &&= b"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 0;
       b = 2;
@@ -2996,7 +3257,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support logical or assignment operator in templates', () => {
-    @Component({template: '<button (click)="a ||= b"></button>'})
+    @Component({
+      template: '<button (click)="a ||= b"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a = 0;
       b = 2;
@@ -3016,7 +3280,10 @@ describe('acceptance integration tests', () => {
   });
 
   it('should support nullish coalescing assignment operator in templates', () => {
-    @Component({template: '<button (click)="a ??= b"></button>'})
+    @Component({
+      template: '<button (click)="a ??= b"></button>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class TestComponent {
       a: number | null = 0;
       b = 1;
@@ -3041,6 +3308,8 @@ describe('acceptance integration tests', () => {
         <p>:{{ caps\`Hello, World!\` }}:{{ (excited?.caps(3))\`Uncomfortably excited\` }}:</p>
         <p>{{ greet\`Hi, I'm \${name}, and I'm \${age}\` }}</p>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       name = 'Frodo';
@@ -3071,6 +3340,8 @@ describe('acceptance integration tests', () => {
   it('should not confuse operators for template literal tags', () => {
     @Component({
       template: '{{ typeof`test` }}',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       typeof = (...args: unknown[]) => 'fail';
@@ -3084,6 +3355,8 @@ describe('acceptance integration tests', () => {
   it('should support "in" expressions', () => {
     @Component({
       template: `{{ 'foo' in obj ? 'OK' : 'KO' }}`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       obj: any = {foo: 'bar'};
@@ -3103,6 +3376,8 @@ describe('acceptance integration tests', () => {
 
     @Component({
       template: `{{ obj instanceof MyClass ? 'OK' : 'KO' }}`,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       MyClass = MyClass;
@@ -3145,6 +3420,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: '<div [attr.data-comp]="text" dir></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         get text() {
@@ -3181,6 +3458,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: ` <div *ngFor="let item of items" dir [attr.data-comp]="text">...</div> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         items = [1, 2, 3];
@@ -3225,6 +3504,8 @@ describe('acceptance integration tests', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         showWarningMessage = false;
@@ -3252,6 +3533,8 @@ describe('acceptance integration tests', () => {
         ],
         template: ` <ng-content></ng-content> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnimationComp {
         @HostBinding('@host') public hostState = '';
@@ -3330,6 +3613,8 @@ describe('acceptance integration tests', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         showRoot = true;
@@ -3347,6 +3632,8 @@ describe('acceptance integration tests', () => {
         animations: [trigger('host', [transition('* => *', [])])],
         template: ` <ng-content></ng-content> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class InnerComp {
         @HostBinding('@host') public hostState = '';
@@ -3401,6 +3688,8 @@ describe('acceptance integration tests', () => {
     it('should support a basic arrow function in an event listener', () => {
       @Component({
         template: `<button (click)="value.update(prev => prev + 1)">Increment</button>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         value = signal(0);
@@ -3433,6 +3722,8 @@ describe('acceptance integration tests', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         value = signal('initial');
@@ -3450,6 +3741,8 @@ describe('acceptance integration tests', () => {
     it('should support an arrow function in a binding', () => {
       @Component({
         template: `Result: {{((a) => a + b)(1)}}`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         b = 2;
@@ -3477,6 +3770,8 @@ describe('acceptance integration tests', () => {
       @Component({
         imports: [TestDir],
         template: '<div test></div>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDir) testDir!: TestDir;
@@ -3506,6 +3801,8 @@ describe('acceptance integration tests', () => {
       @Component({
         imports: [TestDir],
         template: '<button test></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDir) testDir!: TestDir;
@@ -3536,6 +3833,8 @@ describe('acceptance integration tests', () => {
       @Component({
         imports: [TestDir],
         template: '<button test></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDir) testDir!: TestDir;
@@ -3565,6 +3864,8 @@ describe('acceptance integration tests', () => {
             }
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         componentProp = 0;
@@ -3586,6 +3887,8 @@ describe('acceptance integration tests', () => {
             Result: {{(() => componentProp?.a?.b?.c?.()?.()?.()?.())()}}.
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         componentProp: {a?: {b?: {c?: () => () => () => () => string}}} = {};
@@ -3608,6 +3911,8 @@ describe('acceptance integration tests', () => {
 
           {{ fn('Hello ') }}
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -3629,6 +3934,8 @@ describe('acceptance integration tests', () => {
       @Component({
         template: `<button test [callback]="() => prop = prop + 1"></button> `,
         imports: [TestDir],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(TestDir) testDir!: TestDir;
@@ -3647,6 +3954,8 @@ describe('acceptance integration tests', () => {
     it('should be able to use $event in an arrow function', () => {
       @Component({
         template: `<button (click)="value.update(prev => $event.type + prev)">Click</button>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         value = signal('');
@@ -3668,6 +3977,8 @@ describe('acceptance integration tests', () => {
             {{ item }}: {{(() => prefix + ($even ? 'even' : 'odd'))()}}
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         items = ['Zero', 'One', 'Two', 'Three'];

--- a/packages/core/test/acceptance/let_spec.ts
+++ b/packages/core/test/acceptance/let_spec.ts
@@ -7,16 +7,17 @@
  */
 
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Directive,
-  Output,
-  EventEmitter,
   ErrorHandler,
+  EventEmitter,
+  Output,
   Pipe,
   PipeTransform,
-  inject,
-  ChangeDetectorRef,
   ViewChild,
+  inject,
   provideZoneChangeDetection,
 } from '../../src/core';
 import {TestBed} from '../../testing';
@@ -34,6 +35,7 @@ describe('@let declarations', () => {
         @let result = value * multiplier;
         {{ value }} times {{ multiplier }} is {{ result }}
       `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 0;
@@ -60,6 +62,8 @@ describe('@let declarations', () => {
         @let result = value * 2;
         <button (click)="log(result)"></button>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 0;
@@ -96,6 +100,8 @@ describe('@let declarations', () => {
 
         @let one = value + 1;
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 0;
@@ -121,6 +127,8 @@ describe('@let declarations', () => {
         @let multiplier = 2;
         @let result = value * multiplier;
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 0;
@@ -159,6 +167,8 @@ describe('@let declarations', () => {
         <div dir (testEvent)="callback(value)"></div>
         @let value = 1;
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       callback(_value: number) {}
@@ -201,6 +211,8 @@ describe('@let declarations', () => {
         Result: {{ result }}
       `,
       imports: [DoublePipe],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 2;
@@ -223,6 +235,8 @@ describe('@let declarations', () => {
         @let fullName = firstName.value + ' ' + lastName.value;
         Hello, {{ fullName }}
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -251,6 +265,8 @@ describe('@let declarations', () => {
           }
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -273,6 +289,8 @@ describe('@let declarations', () => {
         @let two = one + getTwo();
         @let three = two + getThree();
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       getOne(): number {
@@ -309,6 +327,8 @@ describe('@let declarations', () => {
           </div>
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 0;
@@ -332,6 +352,8 @@ describe('@let declarations', () => {
         @let value = 1;
         {{ value }}
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       @ViewChild('value') value: any;
@@ -349,12 +371,16 @@ describe('@let declarations', () => {
         @let value = 123;
         <ng-content>The value is {{ value }}</ng-content>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class InnerComponent {}
 
     @Component({
       template: '<inner/>',
       imports: [InnerComponent],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -371,6 +397,8 @@ describe('@let declarations', () => {
         <ng-content>Fallback content</ng-content>
         <ng-content select="footer">Fallback footer</ng-content>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class InnerComponent {}
 
@@ -384,6 +412,8 @@ describe('@let declarations', () => {
         </inner>
       `,
       imports: [InnerComponent],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -405,6 +435,8 @@ describe('@let declarations', () => {
           The value comes from {{ value }}
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       value = 'component';
@@ -425,6 +457,8 @@ describe('@let declarations', () => {
           The value comes from {{ value }}
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {}
 
@@ -441,6 +475,8 @@ describe('@let declarations', () => {
           {{ calculation }}|
         }
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       values = [1, 2, 3];

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -24,6 +24,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
@@ -41,6 +42,8 @@ describe('onChanges', () => {
       selector: 'child-comp',
       template: 'child',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp implements OnChanges {
       @Input() a: number = 0;
@@ -59,6 +62,8 @@ describe('onChanges', () => {
       selector: 'app-comp',
       template: '<child-comp [a]="a" [b]="b" [c]="c"></child-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComp {
       a = 0;
@@ -95,6 +100,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val1 = 'a';
@@ -109,6 +116,8 @@ describe('onChanges', () => {
     @Component({
       template: `<comp [val1]="val1" [publicVal2]="val2"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val1 = 'a2';
@@ -155,6 +164,8 @@ describe('onChanges', () => {
       selector: 'parent',
       template: `<child [val]="val"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() val = '';
@@ -168,6 +179,8 @@ describe('onChanges', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() val = '';
@@ -180,6 +193,8 @@ describe('onChanges', () => {
     @Component({
       template: `<parent [val]="val"></parent>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'foo';
@@ -233,6 +248,8 @@ describe('onChanges', () => {
       selector: 'parent',
       template: `<child [name]="name" [val]="val"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() val = '';
@@ -248,6 +265,8 @@ describe('onChanges', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() val = '';
@@ -265,6 +284,8 @@ describe('onChanges', () => {
         <parent name="2" [val]="val"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'foo';
@@ -346,6 +367,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -358,6 +381,8 @@ describe('onChanges', () => {
     @Component({
       template: `<comp *ngIf="show" [val]="val"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -407,6 +432,8 @@ describe('onChanges', () => {
       selector: 'projected',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() val = '';
@@ -420,6 +447,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -432,6 +461,8 @@ describe('onChanges', () => {
     @Component({
       template: `<comp [val]="val"><projected [val]="val"></projected></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -484,6 +515,8 @@ describe('onChanges', () => {
       selector: 'projected',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() val = '';
@@ -499,6 +532,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -520,6 +555,8 @@ describe('onChanges', () => {
         </comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -613,6 +650,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -625,6 +664,8 @@ describe('onChanges', () => {
     @Component({
       template: `<comp [dir]="val" [val]="val"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -690,6 +731,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -704,6 +747,8 @@ describe('onChanges', () => {
     @Component({
       template: `<comp [dir]="val" [val]="val"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -782,6 +827,8 @@ describe('onChanges', () => {
     @Component({
       template: `<div [injectionDir]="val" [dir]="val"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -829,6 +876,8 @@ describe('onChanges', () => {
     @Component({
       template: `<div [dir]="val1" [dir-val]="val2"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val1 = 'a';
@@ -873,6 +922,8 @@ describe('onChanges', () => {
       selector: 'comp',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() val = '';
@@ -891,6 +942,8 @@ describe('onChanges', () => {
         <comp name="1" [val]="val"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -988,6 +1041,8 @@ describe('onChanges', () => {
       selector: 'child',
       template: `<p>{{ val }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() val = '';
@@ -1003,6 +1058,8 @@ describe('onChanges', () => {
       selector: 'parent',
       template: `<child [name]="name" [val]="val"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() val = '';
@@ -1021,6 +1078,8 @@ describe('onChanges', () => {
         <parent name="1" [val]="val"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -1181,6 +1240,8 @@ describe('onChanges', () => {
     @Component({
       template: `<p>{{ value }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 'a';
@@ -1216,6 +1277,8 @@ describe('meta-programming', () => {
     @Component({
       template: `<child name="value"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1223,6 +1286,8 @@ describe('meta-programming', () => {
       selector: 'child',
       template: `empty`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name: string = '';
@@ -1268,6 +1333,8 @@ describe('meta-programming', () => {
     @Component({
       template: `<child name="value"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1277,6 +1344,8 @@ describe('meta-programming', () => {
       selector: 'child',
       template: `empty`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child extends BaseChild {
       @Input() name: string = '';
@@ -1393,6 +1462,8 @@ describe('hooks order', () => {
       selector: 'app-comp',
       template: '<div [a]="1" [b]="2" [c]="3"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComp {}
 
@@ -1471,6 +1542,8 @@ describe('hooks order', () => {
       selector: 'app-comp',
       template: '<div [a]="id" [b]="id" [c]="id"></div><div [a]="id" [b]="id" [c]="id"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComp {
       id = 0;
@@ -1514,6 +1587,8 @@ describe('onInit', () => {
       selector: 'my-comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComponent {
       @Input() input1 = '';
@@ -1529,6 +1604,8 @@ describe('onInit', () => {
     @Component({
       template: ` <my-comp [input1]="value1" [input2]="value2"></my-comp> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value1 = 'a';
@@ -1559,6 +1636,8 @@ describe('onInit', () => {
     @Component({
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -1582,6 +1661,8 @@ describe('onInit', () => {
       selector: `child-comp`,
       template: `<p>child</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp {
       ngOnInit() {
@@ -1592,6 +1673,8 @@ describe('onInit', () => {
     @Component({
       template: `<child-comp></child-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentComp {
       ngOnInit() {
@@ -1615,6 +1698,8 @@ describe('onInit', () => {
       selector: `child-comp`,
       template: `<p>child</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp {
       @Input() name = '';
@@ -1628,6 +1713,8 @@ describe('onInit', () => {
       selector: 'parent-comp',
       template: `<child-comp [name]="name"></child-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentComp {
       @Input() name = '';
@@ -1643,6 +1730,8 @@ describe('onInit', () => {
         <parent-comp name="2"></parent-comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1662,6 +1751,8 @@ describe('onInit', () => {
       selector: 'my-comp',
       template: '<p>test</p>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       ngOnInit() {
@@ -1672,6 +1763,8 @@ describe('onInit', () => {
     @Component({
       template: ` <div *ngIf="show"><my-comp></my-comp></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -1700,6 +1793,8 @@ describe('onInit', () => {
       selector: 'my-comp',
       template: '<p>test</p>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       onInitCalled = false;
@@ -1713,12 +1808,16 @@ describe('onInit', () => {
       selector: 'dynamic-comp',
       template: ` <my-comp></my-comp> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class DynamicComp {}
 
     @Component({
       template: ` <div #container></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('container', {read: ViewContainerRef}) viewContainerRef!: ViewContainerRef;
@@ -1747,6 +1846,8 @@ describe('onInit', () => {
       selector: 'projected',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       ngOnInit() {
@@ -1758,6 +1859,8 @@ describe('onInit', () => {
       selector: 'comp',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngOnInit() {
@@ -1772,6 +1875,8 @@ describe('onInit', () => {
         </comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -1795,6 +1900,8 @@ describe('onInit', () => {
       selector: 'projected',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() name = '';
@@ -1808,6 +1915,8 @@ describe('onInit', () => {
       selector: 'comp',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -1827,6 +1936,8 @@ describe('onInit', () => {
         </comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -1862,6 +1973,8 @@ describe('onInit', () => {
       selector: 'comp',
       template: `<p></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -1877,6 +1990,8 @@ describe('onInit', () => {
         <comp name="2" dir dir-name="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -1925,6 +2040,8 @@ describe('onInit', () => {
     @Component({
       template: `<div [injectionDir]="val" [dir]="val"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -1962,6 +2079,8 @@ describe('onInit', () => {
       selector: 'comp',
       template: `<p></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -1979,6 +2098,8 @@ describe('onInit', () => {
         <comp name="2" dir dir-name="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -2016,6 +2137,8 @@ describe('onInit', () => {
         <p name="2" dir dir-name="2"></p>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -2039,6 +2162,8 @@ describe('onInit', () => {
       selector: 'comp',
       template: `<p></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2055,6 +2180,8 @@ describe('onInit', () => {
         <comp name="1"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [2, 3, 4, 5, 6];
@@ -2085,6 +2212,8 @@ describe('onInit', () => {
       selector: 'child',
       template: `<p></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -2098,6 +2227,8 @@ describe('onInit', () => {
       selector: 'parent',
       template: '<child [name]="name"></child>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -2114,6 +2245,8 @@ describe('onInit', () => {
         <parent name="1"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [2, 3, 4, 5, 6];
@@ -2162,6 +2295,8 @@ describe('doCheck', () => {
     @Component({
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngDoCheck() {
@@ -2189,6 +2324,8 @@ describe('doCheck', () => {
       selector: 'parent',
       template: `<child></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       ngDoCheck() {
@@ -2200,6 +2337,8 @@ describe('doCheck', () => {
       selector: 'child',
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       ngDoCheck() {
@@ -2210,6 +2349,8 @@ describe('doCheck', () => {
     @Component({
       template: `<parent></parent>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngDoCheck() {
@@ -2231,6 +2372,8 @@ describe('doCheck', () => {
     @Component({
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngOnInit() {
@@ -2269,6 +2412,8 @@ describe('doCheck', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2284,6 +2429,8 @@ describe('doCheck', () => {
         <comp name="2" dir="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngDoCheck() {
@@ -2318,6 +2465,8 @@ describe('doCheck', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2335,6 +2484,8 @@ describe('doCheck', () => {
         <comp name="2" dir="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngDoCheck() {
@@ -2383,6 +2534,8 @@ describe('doCheck', () => {
     @Component({
       template: `<div [injectionDir]="val" [dir]="val"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       val = 'a';
@@ -2422,6 +2575,8 @@ describe('doCheck', () => {
         <p dir="2"></p>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngDoCheck() {
@@ -2452,6 +2607,8 @@ describe('afterContentinit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterContentInit() {
@@ -2461,6 +2618,8 @@ describe('afterContentinit', () => {
     @Component({
       template: `<comp></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2483,6 +2642,8 @@ describe('afterContentinit', () => {
     @Component({
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterContentInit() {
@@ -2510,6 +2671,8 @@ describe('afterContentinit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterContentInit() {
@@ -2520,6 +2683,8 @@ describe('afterContentinit', () => {
     @Component({
       template: `<comp *ngIf="show"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -2560,6 +2725,8 @@ describe('afterContentinit', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -2573,6 +2740,8 @@ describe('afterContentinit', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -2588,6 +2757,8 @@ describe('afterContentinit', () => {
         <parent name="2"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterContentInit() {
@@ -2617,6 +2788,8 @@ describe('afterContentinit', () => {
       selector: 'projected-child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedChild {
       @Input() name = '';
@@ -2630,6 +2803,8 @@ describe('afterContentinit', () => {
       selector: 'comp',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2643,6 +2818,8 @@ describe('afterContentinit', () => {
       selector: 'projected',
       template: `<projected-child [name]="name"></projected-child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() name = '';
@@ -2664,6 +2841,8 @@ describe('afterContentinit', () => {
         </comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterContentInit() {
@@ -2705,6 +2884,8 @@ describe('afterContentinit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2721,6 +2902,8 @@ describe('afterContentinit', () => {
         <comp name="5"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [0, 1, 2, 3];
@@ -2747,6 +2930,8 @@ describe('afterContentinit', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -2760,6 +2945,8 @@ describe('afterContentinit', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -2776,6 +2963,8 @@ describe('afterContentinit', () => {
         <parent name="5"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [0, 1, 2, 3];
@@ -2829,6 +3018,8 @@ describe('afterContentinit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -2844,6 +3035,8 @@ describe('afterContentinit', () => {
         <comp name="2" dir="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterContentInit() {
@@ -2874,6 +3067,8 @@ describe('afterContentChecked', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterContentInit() {
@@ -2888,6 +3083,8 @@ describe('afterContentChecked', () => {
     @Component({
       template: `<comp></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterContentInit() {
@@ -2927,6 +3124,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterViewInit() {
@@ -2937,6 +3136,8 @@ describe('afterViewInit', () => {
     @Component({
       template: `<comp></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -2959,6 +3160,8 @@ describe('afterViewInit', () => {
     @Component({
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -2986,6 +3189,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterViewInit() {
@@ -2996,6 +3201,8 @@ describe('afterViewInit', () => {
     @Component({
       template: `<comp *ngIf="show"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3031,6 +3238,8 @@ describe('afterViewInit', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -3044,6 +3253,8 @@ describe('afterViewInit', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -3059,6 +3270,8 @@ describe('afterViewInit', () => {
         <parent name="2"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -3088,6 +3301,8 @@ describe('afterViewInit', () => {
       selector: 'projected',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() name = '';
@@ -3101,6 +3316,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3116,6 +3333,8 @@ describe('afterViewInit', () => {
         <comp name="2"><projected name="2"></projected></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -3139,6 +3358,8 @@ describe('afterViewInit', () => {
       selector: 'projected-child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectedChild {
       @Input() name = '';
@@ -3152,6 +3373,8 @@ describe('afterViewInit', () => {
       selector: 'projected',
       template: `<projected-child [name]="name"></projected-child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() name = '';
@@ -3165,6 +3388,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3180,6 +3405,8 @@ describe('afterViewInit', () => {
         <comp name="2"><projected name="2"></projected></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -3211,6 +3438,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3227,6 +3456,8 @@ describe('afterViewInit', () => {
         <comp name="5"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [0, 1, 2, 3];
@@ -3253,6 +3484,8 @@ describe('afterViewInit', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -3265,6 +3498,8 @@ describe('afterViewInit', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -3281,6 +3516,8 @@ describe('afterViewInit', () => {
         <parent name="5"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [0, 1, 2, 3];
@@ -3333,6 +3570,8 @@ describe('afterViewInit', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3348,6 +3587,8 @@ describe('afterViewInit', () => {
         <comp name="2" dir="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -3385,6 +3626,8 @@ describe('afterViewInit', () => {
         <div dir="2"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewInit() {
@@ -3415,6 +3658,8 @@ describe('afterViewChecked', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngAfterViewChecked() {
@@ -3425,6 +3670,8 @@ describe('afterViewChecked', () => {
     @Component({
       template: `<comp></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -3449,6 +3696,8 @@ describe('afterViewChecked', () => {
     @Component({
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewChecked() {
@@ -3478,6 +3727,8 @@ describe('afterViewChecked', () => {
       selector: 'comp',
       template: `<p>{{ value }}</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() value = '';
@@ -3489,6 +3740,8 @@ describe('afterViewChecked', () => {
     @Component({
       template: `<comp [value]="value"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 1;
@@ -3513,6 +3766,8 @@ describe('afterViewChecked', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -3526,6 +3781,8 @@ describe('afterViewChecked', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -3542,6 +3799,8 @@ describe('afterViewChecked', () => {
         <parent name="5"></parent>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       numbers = [0, 1, 2, 3];
@@ -3593,6 +3852,8 @@ describe('afterViewChecked', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3608,6 +3869,8 @@ describe('afterViewChecked', () => {
         <comp name="2" dir="2"></comp>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewChecked() {
@@ -3645,6 +3908,8 @@ describe('afterViewChecked', () => {
         <div dir="2"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       ngAfterViewChecked() {
@@ -3675,6 +3940,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngOnDestroy() {
@@ -3685,6 +3952,8 @@ describe('onDestroy', () => {
     @Component({
       template: `<comp *ngIf="show"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3722,6 +3991,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3739,6 +4010,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3766,6 +4039,8 @@ describe('onDestroy', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -3779,6 +4054,8 @@ describe('onDestroy', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -3795,6 +4072,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3822,6 +4101,8 @@ describe('onDestroy', () => {
       selector: 'child',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() name = '';
@@ -3835,6 +4116,8 @@ describe('onDestroy', () => {
       selector: 'parent',
       template: `<child [name]="name"></child>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @Input() name = '';
@@ -3847,6 +4130,8 @@ describe('onDestroy', () => {
       selector: 'grandparent',
       template: `<parent [name]="name"></parent>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Grandparent {
       @Input() name = '';
@@ -3863,6 +4148,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3897,6 +4184,8 @@ describe('onDestroy', () => {
       selector: 'projected',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Projected {
       @Input() name = '';
@@ -3910,6 +4199,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<div><ng-content></ng-content></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3931,6 +4222,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -3957,6 +4250,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -3975,6 +4270,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       showAll = true;
@@ -4015,6 +4312,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -4031,6 +4330,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -4080,6 +4381,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       ngOnDestroy() {
@@ -4095,6 +4398,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -4140,6 +4445,8 @@ describe('onDestroy', () => {
       selector: 'child',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {}
 
@@ -4147,6 +4454,8 @@ describe('onDestroy', () => {
       selector: 'parent',
       template: `<ng-content></ng-content>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Parent {
       @ContentChildren(Child, {descendants: true}) child!: QueryList<Child>;
@@ -4163,6 +4472,8 @@ describe('onDestroy', () => {
         <div #container dir></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('container', {read: ViewContainerRef, static: true}) container!: ViewContainerRef;
@@ -4218,6 +4529,8 @@ describe('onDestroy', () => {
       selector: 'comp',
       template: `<p>test</p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() name = '';
@@ -4235,6 +4548,8 @@ describe('onDestroy', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -4271,6 +4586,8 @@ describe('onDestroy', () => {
     @Component({
       template: `<p *ngIf="show" dir></p>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -4307,6 +4624,8 @@ describe('hook order', () => {
     template: `{{ value }}
       <div><ng-content></ng-content></div>`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class Comp {
     @Input() value = '';
@@ -4352,6 +4671,8 @@ describe('hook order', () => {
       ><ng-content></ng-content
     ></comp>`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class Parent extends Comp {}
 
@@ -4359,6 +4680,8 @@ describe('hook order', () => {
     @Component({
       template: `<comp *ngIf="show" name="comp" [value]="value"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 'a';
@@ -4412,6 +4735,8 @@ describe('hook order', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 'a';
@@ -4506,6 +4831,8 @@ describe('hook order', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 'a';
@@ -4629,6 +4956,8 @@ describe('non-regression', () => {
         <ng-template onDestroyDir>content</ng-template>
       </ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       show = true;
@@ -4674,6 +5003,8 @@ describe('non-regression', () => {
     @Component({
       template: `<div [testDir]="value">{{ value }}</div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 1;
@@ -4714,6 +5045,8 @@ describe('non-regression', () => {
     @Component({
       template: `<div [testDir]="value">{{ value }}</div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       value = 1;

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -22,6 +22,7 @@ import {
   ViewChild,
   ViewChildren,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
@@ -37,6 +38,8 @@ describe('event listeners', () => {
       @Component({
         template: `<button (click)="onClick()">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         counter = 0;
@@ -59,6 +62,8 @@ describe('event listeners', () => {
       @Component({
         template: `<button (click)="onClick(); onClick2()">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         counter = 0;
@@ -86,6 +91,8 @@ describe('event listeners', () => {
       @Component({
         template: `<button (click)="showing = !showing">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         showing = false;
@@ -107,6 +114,8 @@ describe('event listeners', () => {
       @Component({
         template: `<button (click)="onClick(data.a, data.b)">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         counter = 0;
@@ -136,6 +145,8 @@ describe('event listeners', () => {
       @Component({
         template: ` <button (click)="clicked(this.$event, $event)">Click me!</button> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         $event = 10;
@@ -166,6 +177,8 @@ describe('event listeners', () => {
           <ng-container [ngTemplateOutlet]="template"></ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         message = '';
@@ -191,6 +204,8 @@ describe('event listeners', () => {
           <ng-container *ngTemplateOutlet="template; context: {$implicit: current}"></ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         one = {value: 'one'};
@@ -227,6 +242,8 @@ describe('event listeners', () => {
       @Component({
         selector: 'my-comp',
         template: ``,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -236,6 +253,8 @@ describe('event listeners', () => {
           <my-comp #comp></my-comp>
           <button (click)="onClick(comp)"></button>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         comp: MyComp | null = null;
@@ -260,6 +279,8 @@ describe('event listeners', () => {
       @Component({
         template: `<button (click)="onClick($event)">Click</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         handlerReturnValue: boolean | undefined;
@@ -304,6 +325,8 @@ describe('event listeners', () => {
       selector: 'with-clicks-cmpt',
       template: `<button likes-clicks (click)="count()" md-button>Click me!</button>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class WithClicksCmpt {
       counter = 0;
@@ -365,6 +388,8 @@ describe('event listeners', () => {
         selector: 'test-cmpt',
         template: `<with-clicks-cmpt></with-clicks-cmpt><with-clicks-cmpt></with-clicks-cmpt>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -399,6 +424,8 @@ describe('event listeners', () => {
         selector: 'test-cmpt',
         template: `<button likes-clicks (click)="counter = counter + 1">Click me!</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         counter = 0;
@@ -432,6 +459,8 @@ describe('event listeners', () => {
         selector: 'test-cmpt',
         template: `<button throws-on-clicks likes-clicks><button></button></button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -464,6 +493,8 @@ describe('event listeners', () => {
         selector: 'test-cmpt',
         template: ` <button returns-false likes-clicks></button> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -509,6 +540,8 @@ describe('event listeners', () => {
         selector: 'test-component',
         template: `<div [(foo)]="someValue" (fooChange)="fooChange($event)"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         count = 0;
@@ -543,6 +576,8 @@ describe('event listeners', () => {
         selector: 'my-comp',
         template: '<button dirA dirB (click)="count()">Click me!</button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         counter = 0;
@@ -590,6 +625,8 @@ describe('event listeners', () => {
         selector: 'my-comp',
         template: ` <button *ngIf="visible" (click)="count()">Click me!</button> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         visible = true;
@@ -622,6 +659,8 @@ describe('event listeners', () => {
         selector: 'my-comp',
         template: ` <button *ngFor="let button of buttons" (click)="count()">Click me!</button> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         buttons = [1, 2];
@@ -659,6 +698,8 @@ describe('event listeners', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         isSectionVisible = true;
@@ -699,6 +740,8 @@ describe('event listeners', () => {
       @Component({
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @HostListener('click')
@@ -725,6 +768,8 @@ describe('event listeners', () => {
       @Component({
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @HostListener('document:click')
@@ -761,6 +806,8 @@ describe('event listeners', () => {
       @Component({
         imports: [HostListenerDir],
         template: `<button hostListenerDir>Click</button>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -792,6 +839,8 @@ describe('event listeners', () => {
       @Component({
         imports: [HostListenerDir],
         template: `<button hostListenerDir>Click</button>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -830,6 +879,8 @@ describe('event listeners', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -865,6 +916,8 @@ describe('event listeners', () => {
           <ng-container [ngTemplateOutlet]="template"></ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -910,6 +963,8 @@ describe('event listeners', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 

--- a/packages/core/test/acceptance/outputs_spec.ts
+++ b/packages/core/test/acceptance/outputs_spec.ts
@@ -15,6 +15,7 @@ import {
   OnDestroy,
   Output,
   ViewChild,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -23,6 +24,8 @@ describe('outputs', () => {
     selector: 'button-toggle',
     template: '',
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class ButtonToggle {
     @Output('change') change = new EventEmitter<void>();
@@ -42,6 +45,8 @@ describe('outputs', () => {
     selector: 'destroy-comp',
     template: '',
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class DestroyComp implements OnDestroy {
     events: string[] = [];
@@ -64,6 +69,8 @@ describe('outputs', () => {
     @Component({
       template: '<button-toggle (change)="onChange()"></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -89,6 +96,8 @@ describe('outputs', () => {
     @Component({
       template: '<button-toggle (change)="onChange()" (reset)="onReset()"></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -114,6 +123,8 @@ describe('outputs', () => {
     @Component({
       template: '<button-toggle (change)="counter = counter + 1"></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -136,6 +147,8 @@ describe('outputs', () => {
     @Component({
       template: '<button-toggle *ngIf="condition" (change)="onChange()"></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -170,6 +183,8 @@ describe('outputs', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -208,6 +223,8 @@ describe('outputs', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -255,6 +272,8 @@ describe('outputs', () => {
     @Component({
       template: '<button myButton (click)="onClick()">Click me</button>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(MyButton) buttonDir!: MyButton;
@@ -282,6 +301,8 @@ describe('outputs', () => {
     @Component({
       template: '<button-toggle (change)="onChange()" otherDir></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;
@@ -316,6 +337,8 @@ describe('outputs', () => {
       template:
         '<button-toggle (change)="onChange()" otherChangeDir [change]="change"></button-toggle>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(ButtonToggle) buttonToggle!: ButtonToggle;

--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -58,6 +58,8 @@ describe('pipe', () => {
     @Component({
       template: '{{person.name | countingPipe}}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = {name: 'bob'};
@@ -92,6 +94,8 @@ describe('pipe', () => {
     @Component({
       template: `<div my-dir [dirProp]="'a' | double"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) directive!: Dir;
@@ -108,6 +112,8 @@ describe('pipe', () => {
     @Component({
       template: `{{ person.name | multiArgPipe: 'one' : person.address.city }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = {name: 'value', address: {city: 'two'}};
@@ -124,6 +130,8 @@ describe('pipe', () => {
     @Component({
       template: `{{ person.name | multiArgPipe: 'a' : 'b' }} {{ 0 | multiArgPipe: 1 : 2 : 3 }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = {name: 'value'};
@@ -167,6 +175,8 @@ describe('pipe', () => {
       selector: 'app',
       template: '{{ count | number }}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       count = 10;
@@ -219,6 +229,8 @@ describe('pipe', () => {
       selector: 'app',
       template: '{{ count | number }}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       count = 10;
@@ -251,6 +263,8 @@ describe('pipe', () => {
     @Component({
       template: `{{ person.name | identityPipe }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = {name: 'Megatron'};
@@ -291,6 +305,8 @@ describe('pipe', () => {
     @Component({
       template: '{{person.name | duplicatePipe}}',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       person = {name: 'bob'};
@@ -317,6 +333,8 @@ describe('pipe', () => {
     @Component({
       template: `{{ condition ? 'a' : ('b' | pipe) }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       condition = false;
@@ -374,6 +392,8 @@ describe('pipe', () => {
       selector: 'app',
       template: '{{ value | sayHello }}',
       imports: [SayHelloPipe],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComponent {
       value = 'test';
@@ -389,6 +409,8 @@ describe('pipe', () => {
       @Component({
         template: '{{person.name | countingPipe}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         person = {name: null as string | null};
@@ -454,6 +476,8 @@ describe('pipe', () => {
       @Component({
         template: '{{person.name | countingImpurePipe}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         person = {name: 'bob'};
@@ -483,6 +507,8 @@ describe('pipe', () => {
           <div [id]="2 | countingImpurePipe">{{ 3 | countingImpurePipe }}</div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -520,6 +546,8 @@ describe('pipe', () => {
       @Component({
         template: '{{1 | pipeWithOnDestroy}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -553,6 +581,8 @@ describe('pipe', () => {
       @Component({
         template: '{{title | myConcatPipe}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         title = 'MyComponent Title';
@@ -586,6 +616,8 @@ describe('pipe', () => {
       @Component({
         template: '{{title | myConcatPipe}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         title = 'MyComponent Title';
@@ -624,6 +656,8 @@ describe('pipe', () => {
       @Component({
         template: '{{title | myConcatPipe}}',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         title = 'MyComponent Title';
@@ -771,6 +805,8 @@ describe('pipe', () => {
       @Component({
         template: `{{ val | throwPipe }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         val = 'anything';
@@ -806,6 +842,8 @@ describe('pipe', () => {
       @Component({
         template: `{{ val | throwPipe }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         val = 'anything';
@@ -850,6 +888,8 @@ describe('pipe', () => {
           @Component({
             template: `{{ val | throw${args.slice(0, numberOfPipeArgs).join('')} }}`,
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class App {
             val = 'anything';
@@ -895,6 +935,8 @@ describe('pipe', () => {
         @Component({
           template: '{{ 1 | testMissingPipe }}',
           standalone: componentIsStandalone,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {}
 
@@ -915,6 +957,8 @@ describe('pipe', () => {
           </ng-container>`,
           standalone: componentIsStandalone,
           ...(componentIsStandalone ? {imports: [CommonModule]} : {}),
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: string = 'test';
@@ -935,6 +979,8 @@ describe('pipe', () => {
           selector: 'app-test-child',
           template: '<ng-content></ng-content>',
           standalone: componentIsStandalone,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestChildComponent {}
 
@@ -944,6 +990,8 @@ describe('pipe', () => {
           </app-test-child>`,
           standalone: componentIsStandalone,
           ...(componentIsStandalone ? {imports: [TestChildComponent]} : {}),
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: string = 'test';
@@ -964,6 +1012,8 @@ describe('pipe', () => {
           selector: 'app-test-child',
           template: '<ng-content></ng-content>',
           standalone: componentIsStandalone,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestChildComponent {}
 
@@ -975,6 +1025,8 @@ describe('pipe', () => {
           </app-test-child>`,
           standalone: componentIsStandalone,
           ...(componentIsStandalone ? {imports: [TestChildComponent, CommonModule]} : {}),
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: string = 'test';
@@ -994,6 +1046,8 @@ describe('pipe', () => {
         @Component({
           template: '<div [title]="value | testMissingPipe"></div>',
           standalone: componentIsStandalone,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: string = 'test';
@@ -1014,6 +1068,8 @@ describe('pipe', () => {
           template: '<div *ngIf="isVisible | testMissingPipe"></div>',
           standalone: componentIsStandalone,
           ...(componentIsStandalone ? {imports: [CommonModule]} : {}),
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           isVisible: boolean = true;

--- a/packages/core/test/acceptance/profiler_spec.ts
+++ b/packages/core/test/acceptance/profiler_spec.ts
@@ -16,6 +16,7 @@ import {
   afterEveryRender,
   AfterViewChecked,
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   DoCheck,
   ErrorHandler,
@@ -68,6 +69,8 @@ describe('profiler', () => {
         selector: 'my-comp',
         template: '<button (click)="onClick()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         onClick() {}
@@ -106,7 +109,12 @@ describe('profiler', () => {
     });
 
     it('should invoke the profiler when the template throws', () => {
-      @Component({selector: 'my-comp', template: '{{ throw() }}', standalone: false})
+      @Component({
+        selector: 'my-comp',
+        template: '{{ throw() }}',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {
         throw() {
           throw new Error();
@@ -142,6 +150,8 @@ describe('profiler', () => {
         selector: 'my-comp',
         template: '<button (click)="onClick()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         onClick() {}
@@ -170,6 +180,8 @@ describe('profiler', () => {
         selector: 'my-comp',
         template: '<button (click)="onClick()"></button>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         onClick() {
@@ -202,7 +214,12 @@ describe('profiler', () => {
     });
 
     it('should invoke the profiler on output handler execution', async () => {
-      @Component({selector: 'child', template: '', standalone: false})
+      @Component({
+        selector: 'child',
+        template: '',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class Child {
         @Output() childEvent = new EventEmitter();
       }
@@ -211,6 +228,8 @@ describe('profiler', () => {
         selector: 'my-comp',
         template: '<child (childEvent)="onEvent()"></child>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         @ViewChild(Child) child!: Child;
@@ -243,6 +262,8 @@ describe('profiler', () => {
         template: '{{prop}}',
         providers: [Service],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent
         implements
@@ -273,6 +294,8 @@ describe('profiler', () => {
         selector: 'my-parent',
         template: '<my-comp [prop]="prop"></my-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyParent {
         prop = 1;
@@ -410,7 +433,12 @@ describe('profiler', () => {
     });
 
     it('should call the profiler on lifecycle execution even after error', () => {
-      @Component({selector: 'my-comp', template: '', standalone: false})
+      @Component({
+        selector: 'my-comp',
+        template: '',
+        standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent implements OnInit {
         ngOnInit() {
           throw new Error();
@@ -467,7 +495,11 @@ describe('profiler', () => {
     });
 
     it('should capture component creation and change detection entry points', () => {
-      @Component({selector: 'my-comp', template: ''})
+      @Component({
+        selector: 'my-comp',
+        template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {}
 
       const fixture = TestBed.createComponent(MyComponent);
@@ -493,13 +525,22 @@ describe('profiler', () => {
     });
 
     it('should capture child component creation events when a template error occurs', () => {
-      @Component({selector: 'my-child', template: '{{ error() }}'})
+      @Component({
+        selector: 'my-child',
+        template: '{{ error() }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class ChildComponent {
         constructor() {
           throw new Error('Simulated error');
         }
       }
-      @Component({selector: 'my-comp', imports: [ChildComponent], template: '<my-child/>'})
+      @Component({
+        selector: 'my-comp',
+        imports: [ChildComponent],
+        template: '<my-child/>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {}
 
       expect(() => TestBed.createComponent(MyComponent)).toThrow();
@@ -508,13 +549,22 @@ describe('profiler', () => {
     });
 
     it('should capture child component change detection events when a template error occurs (has start & end)', () => {
-      @Component({selector: 'my-child', template: '{{ error() }}'})
+      @Component({
+        selector: 'my-child',
+        template: '{{ error() }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class ChildComponent {
         error() {
           throw new Error('Simulated error');
         }
       }
-      @Component({selector: 'my-comp', imports: [ChildComponent], template: '<my-child/>'})
+      @Component({
+        selector: 'my-comp',
+        imports: [ChildComponent],
+        template: '<my-child/>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {}
 
       const fixture = TestBed.createComponent(MyComponent);
@@ -527,13 +577,22 @@ describe('profiler', () => {
     });
 
     it('should capture child component change detection events when a template error occurs (extensive check)', () => {
-      @Component({selector: 'my-child', template: '{{ error() }}'})
+      @Component({
+        selector: 'my-child',
+        template: '{{ error() }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class ChildComponent {
         error() {
           throw new Error('Simulated error');
         }
       }
-      @Component({selector: 'my-comp', imports: [ChildComponent], template: '<my-child/>'})
+      @Component({
+        selector: 'my-comp',
+        imports: [ChildComponent],
+        template: '<my-child/>',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {}
 
       TestBed.createComponent(MyComponent);
@@ -558,7 +617,12 @@ describe('profiler', () => {
     });
 
     it('should capture host binding events when an error occurs', () => {
-      @Component({selector: 'my-comp', host: {'[a]': 'error()'}, template: ''})
+      @Component({
+        selector: 'my-comp',
+        host: {'[a]': 'error()'},
+        template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {
         error() {
           throw new Error('Simulated error');
@@ -577,7 +641,11 @@ describe('profiler', () => {
     });
 
     it('should capture symmetric tick events when incorrectly called recursively', () => {
-      @Component({selector: 'my-comp', template: '{{ illegalTick() }}'})
+      @Component({
+        selector: 'my-comp',
+        template: '{{ illegalTick() }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class MyComponent {
         illegalTick() {
           TestBed.tick();
@@ -610,6 +678,8 @@ describe('profiler', () => {
           '[id]': '"someId"',
         },
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {}
 
@@ -625,6 +695,8 @@ describe('profiler', () => {
       @Component({
         selector: 'my-comp',
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         arRef = afterEveryRender(() => {});
@@ -646,6 +718,8 @@ describe('profiler', () => {
             nothing to see here...
           }
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {}
 

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -10,6 +10,7 @@ import {CommonModule} from '@angular/common';
 import {By, DomSanitizer, SafeUrl} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   EventEmitter,
@@ -30,6 +31,8 @@ describe('property bindings', () => {
     @Component({
       template: `<span [id]="id"></span>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       id: string | undefined;
@@ -51,6 +54,8 @@ describe('property bindings', () => {
     @Component({
       template: `<a [title]="title"></a>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       title = 'Hello';
@@ -71,6 +76,8 @@ describe('property bindings', () => {
     @Component({
       template: `<a [title]="title"></a>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       title = 'Hello';
@@ -89,6 +96,8 @@ describe('property bindings', () => {
   it('should bind to properties whose names do not correspond to their attribute names', () => {
     @Component({
       template: '<label [for]="forValue"></label>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       forValue?: string;
@@ -115,6 +124,8 @@ describe('property bindings', () => {
       @Component({
         template: '',
         selector: 'my-comp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @Input() for!: string;
@@ -123,6 +134,8 @@ describe('property bindings', () => {
       @Component({
         template: '<my-comp [for]="forValue"></my-comp>',
         imports: [MyComp],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         forValue?: string;
@@ -145,6 +158,8 @@ describe('property bindings', () => {
   it('should bind ARIA properties', () => {
     @Component({
       template: '<button [ariaLabel]="label" [ariaHasPopup]="hasPopup"></button>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       label?: string;
@@ -170,6 +185,8 @@ describe('property bindings', () => {
   it('should bind interpolated ARIA attributes', () => {
     @Component({
       template: '<button aria-label="{{label}} menu"></button>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       label?: string;
@@ -193,6 +210,8 @@ describe('property bindings', () => {
     it('on HTML elements', () => {
       @Component({
         template: '<button [aria-label]="label"></button>',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         label?: string;
@@ -215,12 +234,16 @@ describe('property bindings', () => {
     it('on component elements', () => {
       @Component({
         selector: 'button[fancy]',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FancyButton {}
 
       @Component({
         template: '<button fancy [aria-label]="label"></button>',
         imports: [FancyButton],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         label?: string;
@@ -245,6 +268,8 @@ describe('property bindings', () => {
     @Component({
       template: '',
       selector: 'my-comp',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       @Input() ariaLabel?: string;
@@ -253,6 +278,8 @@ describe('property bindings', () => {
     @Component({
       template: '<my-comp [ariaLabel]="label"></my-comp>',
       imports: [MyComp],
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       label = 'a';
@@ -281,6 +308,8 @@ describe('property bindings', () => {
       @Component({
         template: '',
         selector: 'my-comp',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         @Input({alias: 'aria-label'}) myAriaLabel?: string;
@@ -289,6 +318,8 @@ describe('property bindings', () => {
       @Component({
         template: '<my-comp [aria-label]="label"></my-comp>',
         imports: [MyComp],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         label = 'a';
@@ -315,6 +346,8 @@ describe('property bindings', () => {
     @Component({
       template: ` <a [href]="url"> </a> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       url: string | SafeUrl = 'javascript:alert("haha, I am taking over your computer!!!");';
@@ -340,6 +373,8 @@ describe('property bindings', () => {
     @Component({
       template: `<input [required]="isRequired" />`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       isRequired = false;
@@ -356,6 +391,8 @@ describe('property bindings', () => {
     @Component({
       template: `<span id="{{ '_' + id + '_' }}"></span>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       id: string | undefined;
@@ -412,6 +449,8 @@ describe('property bindings', () => {
       @Component({
         template: `<button myButton otherDir [id]="id" [disabled]="isDisabled">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         id = 0;
@@ -448,6 +487,8 @@ describe('property bindings', () => {
       @Component({
         template: `<button myButton [id]="id" [disabled]="isDisabled">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         isDisabled = true;
@@ -478,6 +519,8 @@ describe('property bindings', () => {
         selector: 'comp',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @Input() id: number | undefined;
@@ -486,6 +529,8 @@ describe('property bindings', () => {
       @Component({
         template: `<comp [id]="id"></comp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         id = 1;
@@ -510,6 +555,8 @@ describe('property bindings', () => {
       @Component({
         template: `<button myButton otherDisabledDir [disabled]="isDisabled">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         isDisabled = true;
@@ -540,6 +587,8 @@ describe('property bindings', () => {
       @Component({
         template: `<button otherDir [id]="id" (click)="onClick()">Click me</button>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         id = 1;
@@ -572,6 +621,8 @@ describe('property bindings', () => {
           <button *ngIf="!condition" otherDir [id]="id3">Click me too (3)</button>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         condition = true;
@@ -622,6 +673,8 @@ describe('property bindings', () => {
       @Component({
         template: ` <div [field]="value"></div> `,
         imports: [Field],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         value?: string;
@@ -662,6 +715,8 @@ describe('property bindings', () => {
       @Component({
         template: `<div role="button" myDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -680,6 +735,8 @@ describe('property bindings', () => {
       @Component({
         template: `<div role="button" [role]="role" myDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         role = 'listbox';
@@ -703,6 +760,8 @@ describe('property bindings', () => {
       @Component({
         template: `<div role="button" myDir myDirB></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -722,6 +781,8 @@ describe('property bindings', () => {
       @Component({
         template: `<div role="button" dir="rtl" myDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -741,6 +802,8 @@ describe('property bindings', () => {
       @Component({
         template: `<div role="button" (change)="onChange()" myDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         counter = 0;
@@ -767,6 +830,8 @@ describe('property bindings', () => {
           <div role="listbox" myDirB></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -799,6 +864,8 @@ describe('property bindings', () => {
           <div role="menu" *ngIf="!condition"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         condition = true;
@@ -835,7 +902,8 @@ describe('property bindings', () => {
         selector: 'comp',
         template: `<div role="button" myDir #dir="myDir"></div>role: {{dir.role}}`,
         standalone: false,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class Comp {}
 
       // prettier-ignore
@@ -844,7 +912,8 @@ describe('property bindings', () => {
           <comp *ngFor="let i of [0, 1]"></comp>
         `,
         standalone: false,
-      })
+      
+        changeDetection: ChangeDetectionStrategy.Eager,})
       class App {}
 
       TestBed.configureTestingModule({declarations: [App, MyDir, Comp], imports: [CommonModule]});
@@ -879,6 +948,8 @@ describe('property bindings', () => {
       animations: [trigger('trigger', [state('void', style({opacity: 0}))])],
       host: {'[@trigger]': '"void"'},
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -893,6 +964,8 @@ describe('property bindings', () => {
     @Component({
       template: '<my-comp my-dir></my-comp>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -911,6 +984,8 @@ describe('property bindings', () => {
     @Component({
       template: `<span [id]="'{{ id }}'"></span>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {}
 
@@ -924,6 +999,8 @@ describe('property bindings', () => {
     @Component({
       template: `<span [id]="'{{ \\' }}'"></span>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {}
 

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -7,7 +7,10 @@
  */
 
 import {CommonModule} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {expect} from '@angular/private/testing/matchers';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   forwardRef,
@@ -20,8 +23,6 @@ import {
 } from '../../src/core';
 import {leaveView, specOnlyIsInstructionStateEmpty} from '../../src/render3/state';
 import {inject, TestBed, waitForAsync} from '../../testing';
-import {By} from '@angular/platform-browser';
-import {expect} from '@angular/private/testing/matchers';
 
 describe('providers', () => {
   describe('inheritance', () => {
@@ -54,6 +55,7 @@ describe('providers', () => {
         selector: 'app-comp',
         template: `<div other-dir sub-dir></div>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -88,6 +90,7 @@ describe('providers', () => {
         template: '',
         providers: [SubInjectableWithDestroyHook],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(foo: SubInjectableWithDestroyHook) {}
@@ -115,6 +118,7 @@ describe('providers', () => {
         template: '',
         providers: [InjectableWithDestroyHook],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -140,6 +144,7 @@ describe('providers', () => {
         selector: 'my-cmp',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComponent {
         constructor(foo: InjectableWithDestroyHook) {}
@@ -152,6 +157,7 @@ describe('providers', () => {
         `,
         providers: [InjectableWithDestroyHook],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -177,6 +183,7 @@ describe('providers', () => {
         template: '',
         providers: [{provide: InjectableWithDestroyHook, useClass: InjectableWithDestroyHook}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(foo: InjectableWithDestroyHook) {}
@@ -213,6 +220,7 @@ describe('providers', () => {
           {provide: InjectableWithDestroyHookToken, useClass: InjectableWithDestroyHookValue},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(foo: InjectableWithDestroyHookToken) {}
@@ -250,6 +258,7 @@ describe('providers', () => {
           {provide: InjectableWithDestroyHookToken, useExisting: InjectableWithDestroyHookExisting},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(
@@ -308,6 +317,7 @@ describe('providers', () => {
         template: '<div dir-one dir-two></div>',
         providers: [DestroyService],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(service: DestroyService) {
@@ -370,6 +380,7 @@ describe('providers', () => {
         template: '<div dir-one dir-two></div>',
         providers: [{provide: token, useClass: DestroyService}],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(@Inject(token) service: DestroyService) {
@@ -415,6 +426,8 @@ describe('providers', () => {
             {provide: SERVICES, useClass: OtherDestroyService, multi: true},
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           constructor(@Inject(SERVICES) s: any) {}
@@ -464,6 +477,8 @@ describe('providers', () => {
             {provide: SERVICES, useClass: Service4, multi: true},
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           constructor(@Inject(SERVICES) s: any) {}
@@ -502,6 +517,8 @@ describe('providers', () => {
             {provide: SERVICES, useFactory: () => new OtherDestroyService(), multi: true},
           ],
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           constructor(@Inject(SERVICES) s: any) {}
@@ -531,6 +548,7 @@ describe('providers', () => {
         template: '',
         providers: [InjectableWithDestroyHookToken],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class CompWithProvider {
         constructor(token: InjectableWithDestroyHookToken) {}
@@ -540,6 +558,7 @@ describe('providers', () => {
         selector: 'app',
         template: '<comp-with-provider *ngIf="condition"></comp-with-provider>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         condition = true;
@@ -570,6 +589,7 @@ describe('providers', () => {
       selector: 'my-comp',
       template: ``,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(public svc: MyService) {}
@@ -588,6 +608,7 @@ describe('providers', () => {
         selector: 'test-comp',
         template: '<my-comp></my-comp>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {}
 
@@ -607,6 +628,7 @@ describe('providers', () => {
         selector: 'test-comp',
         template: '<div some-dir></div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {}
 
@@ -655,6 +677,7 @@ describe('providers', () => {
         selector: 'app-comp',
         template: ``,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComp {
         constructor(public myService: MyService) {}
@@ -690,6 +713,7 @@ describe('providers', () => {
         selector: 'my-app',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(public foo: SomeProvider) {}
@@ -716,6 +740,7 @@ describe('providers', () => {
         selector: 'my-app',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(public foo: SomeProvider) {}
@@ -767,6 +792,7 @@ describe('providers', () => {
           {provide: Number, useValue: 2, multi: true},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         constructor(
@@ -788,6 +814,7 @@ describe('providers', () => {
         selector: 'repeated',
         template: '[{{s}}-{{n}}]',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Repeated {
         constructor(
@@ -810,6 +837,7 @@ describe('providers', () => {
           {provide: Number, useValue: 2, multi: true},
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ComponentWithProviders {
         items = [1, 2, 3];

--- a/packages/core/test/acceptance/pure_function_spec.ts
+++ b/packages/core/test/acceptance/pure_function_spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {CommonModule} from '@angular/common';
+import {By} from '@angular/platform-browser';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   Input,
@@ -16,7 +18,6 @@ import {
   ViewChildren,
 } from '../../src/core';
 import {TestBed} from '../../testing';
-import {By} from '@angular/platform-browser';
 
 describe('components using pure function instructions internally', () => {
   beforeEach(() => {
@@ -29,6 +30,8 @@ describe('components using pure function instructions internally', () => {
       selector: 'my-comp',
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       @Input() names: string[] = [];
@@ -38,6 +41,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: ` <my-comp [names]="['Nancy', customName, 'Bess']"></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showing = true;
@@ -77,6 +82,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: ` <my-comp *ngIf="showing" [names]="['Nancy', customName, 'Bess']"></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showing = true;
@@ -98,6 +105,8 @@ describe('components using pure function instructions internally', () => {
         selector: 'many-prop-comp',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ManyPropComp {
         @Input() names1: string[] = [];
@@ -111,6 +120,8 @@ describe('components using pure function instructions internally', () => {
           </many-prop-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showing = true;
@@ -140,6 +151,8 @@ describe('components using pure function instructions internally', () => {
         selector: 'parent-comp',
         template: ` <my-comp [names]="someFn(['Nancy', customName])"></my-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ParentComp {
         customName = 'Bess';
@@ -156,6 +169,8 @@ describe('components using pure function instructions internally', () => {
           <parent-comp></parent-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -187,6 +202,8 @@ describe('components using pure function instructions internally', () => {
           <my-comp *ngIf="showing" [names]="['Nancy', customName, 'Bess', customName2]"></my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         showing = true;
@@ -239,6 +256,8 @@ describe('components using pure function instructions internally', () => {
           <my-comp [names]="[v1, v2, v3, v4, v5, v6, v7, v8]"></my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         v1 = 'a';
@@ -307,6 +326,8 @@ describe('components using pure function instructions internally', () => {
           </my-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         v0 = 'a';
@@ -382,6 +403,8 @@ describe('components using pure function instructions internally', () => {
       selector: 'object-comp',
       template: ``,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ObjectComp {
       @Input() config: any = [];
@@ -391,6 +414,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: '<object-comp [config]="{duration: 500, animation: name}"></object-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = 'slide';
@@ -434,6 +459,8 @@ describe('components using pure function instructions internally', () => {
           </object-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         name = 'slide';
@@ -510,6 +537,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: ` <object-comp *ngFor="let config of configs" [config]="config"> </object-comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         configs = [
@@ -556,6 +585,8 @@ describe('components using pure function instructions internally', () => {
           <div [dir]="{}"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(Dir) directives!: QueryList<Dir>;
@@ -576,6 +607,8 @@ describe('components using pure function instructions internally', () => {
           <div [dir]="[]"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(Dir) directives!: QueryList<Dir>;
@@ -593,6 +626,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: `<div [dir]="{}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) directive!: Dir;
@@ -614,6 +649,8 @@ describe('components using pure function instructions internally', () => {
       @Component({
         template: `<div [dir]="[]"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Dir) directive!: Dir;
@@ -638,6 +675,8 @@ describe('components using pure function instructions internally', () => {
           <div [dir]="{foo: {}}"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(Dir) directives!: QueryList<Dir>;
@@ -658,6 +697,8 @@ describe('components using pure function instructions internally', () => {
           <div [dir]="{foo: []}"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(Dir) directives!: QueryList<Dir>;
@@ -678,6 +719,8 @@ describe('components using pure function instructions internally', () => {
           <div [dir]="{foo: getFoo()}"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(Dir) directives!: QueryList<Dir>;

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -26,6 +26,7 @@ import {
   ViewChildren,
   ViewContainerRef,
   ViewRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
@@ -232,6 +233,8 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<div #foo></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -253,6 +256,8 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<div #foo></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -281,6 +286,8 @@ describe('query logic', () => {
           <div some-dir></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -312,6 +319,8 @@ describe('query logic', () => {
           <div some-dir></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -328,6 +337,8 @@ describe('query logic', () => {
         selector: 'required',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Required {}
 
@@ -335,6 +346,8 @@ describe('query logic', () => {
         selector: 'insertion',
         template: `<ng-container [ngTemplateOutlet]="content"></ng-container>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Insertion {
         @Input() content!: TemplateRef<{}>;
@@ -348,6 +361,8 @@ describe('query logic', () => {
           <insertion [content]="template"></insertion>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(Required) requiredEl!: Required;
@@ -372,6 +387,8 @@ describe('query logic', () => {
         selector: 'comp-with-view-query',
         template: '<div #foo>Content</div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ComponentWithViewQuery {
         @ViewChildren('foo')
@@ -391,6 +408,8 @@ describe('query logic', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Root {
         condition = true;
@@ -653,12 +672,16 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
       @Component({
         template: '<sub-comp><div #foo></div></sub-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(SubComp) subComp!: SubComp;
@@ -682,12 +705,16 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
       @Component({
         template: '<sub-comp><div #foo></div></sub-comp>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(SubComp) subComp!: SubComp;
@@ -715,6 +742,8 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -726,6 +755,8 @@ describe('query logic', () => {
           </sub-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(SubComp) subComp!: SubComp;
@@ -756,6 +787,8 @@ describe('query logic', () => {
         selector: 'sub-comp',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SubComp extends MyComp {}
 
@@ -767,6 +800,8 @@ describe('query logic', () => {
           </sub-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(SubComp) subComp!: SubComp;
@@ -789,6 +824,8 @@ describe('query logic', () => {
           </shallow-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         showing = false;
@@ -798,6 +835,8 @@ describe('query logic', () => {
         selector: 'shallow-comp',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ShallowComp {
         @ContentChildren('foo', {descendants: false}) foos!: QueryList<ElementRef>;
@@ -859,6 +898,8 @@ describe('query logic', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Root {
         items = [1, 2, 3];
@@ -900,6 +941,8 @@ describe('query logic', () => {
       @Component({
         imports: [ContentQueryDirective],
         template: `<div content-query #foo></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(ContentQueryDirective, {static: true})
@@ -930,6 +973,8 @@ describe('query logic', () => {
             <span #baz></span>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild('in', {static: true}) in!: ContentQueryDirective;
@@ -961,6 +1006,8 @@ describe('query logic', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild('in', {static: true}) in!: ContentQueryDirective;
@@ -998,6 +1045,8 @@ describe('query logic', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild('shallow', {static: true}) shallow!: ShallowContentQueryDirective;
@@ -1031,6 +1080,8 @@ describe('query logic', () => {
             </div>
           </div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(ContentQueryDirective, {static: true}) queryDir!: ContentQueryDirective;
@@ -1059,6 +1110,8 @@ describe('query logic', () => {
           </div>
           <div id="contentOnly" #bar></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(ContentQueryDirective, {static: true}) contentQueryDir!: ContentQueryDirective;
@@ -1095,6 +1148,8 @@ describe('query logic', () => {
             </span>
           </div>
           <span text="E"></span>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(TextDirective) texts!: QueryList<TextDirective>;
@@ -1131,6 +1186,8 @@ describe('query logic', () => {
           </div>
           <span text="E"></span>
         </div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild(ContentQueryDirective, {static: true})
@@ -1178,6 +1235,8 @@ describe('query logic', () => {
         selector: 'my-container',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyContainer {
         @ContentChildren(MyDef) myDefs!: QueryList<MyDef>;
@@ -1186,6 +1245,8 @@ describe('query logic', () => {
         selector: 'test-cmpt',
         template: `<my-container><tr myDef></tr></my-container>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1202,6 +1263,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren('target') targets!: QueryList<ElementRef>;
@@ -1216,6 +1279,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1233,6 +1298,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren('target') targets!: QueryList<ElementRef>;
@@ -1252,6 +1319,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1275,6 +1344,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren(TargetDir) targets!: QueryList<HTMLElement>;
@@ -1290,6 +1361,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1313,6 +1386,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren(TargetDir) targets!: QueryList<HTMLElement>;
@@ -1332,6 +1407,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1371,6 +1448,8 @@ describe('query logic', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1394,6 +1473,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren(TargetDir) dirTargets!: QueryList<TargetDir>;
@@ -1411,6 +1492,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1436,6 +1519,8 @@ describe('query logic', () => {
         selector: 'needs-target',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NeedsTarget {
         @ContentChildren(TargetDir) targets!: QueryList<HTMLElement>;
@@ -1455,6 +1540,8 @@ describe('query logic', () => {
           </needs-target>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -1478,6 +1565,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child],
         template: `<div child></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(Child, {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1497,6 +1586,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child, OtherChild],
         template: `<div child otherChild></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(Child, {read: OtherChild}) query?: QueryList<OtherChild>;
@@ -1514,6 +1605,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child],
         template: `<div child></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(Child, {read: OtherChild}) query?: QueryList<OtherChild>;
@@ -1532,6 +1625,8 @@ describe('query logic', () => {
           <div #foo></div>
           <div></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<ElementRef>;
@@ -1554,6 +1649,8 @@ describe('query logic', () => {
           <div></div>
           <div #bar></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo,bar') query?: QueryList<ElementRef>;
@@ -1576,6 +1673,8 @@ describe('query logic', () => {
           <div #foo></div>
           <div></div>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1594,6 +1693,8 @@ describe('query logic', () => {
     it('should query for <ng-container> and read ElementRef with a native element pointing to comment node', () => {
       @Component({
         template: `<ng-container #foo></ng-container>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1610,6 +1711,8 @@ describe('query logic', () => {
     it('should query for <ng-container> and read ElementRef without explicit read option', () => {
       @Component({
         template: `<ng-container #foo></ng-container>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<ElementRef>;
@@ -1626,6 +1729,8 @@ describe('query logic', () => {
     it('should read ViewContainerRef from element nodes when explicitly asked for', () => {
       @Component({
         template: `<div #foo></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ViewContainerRef}) query?: QueryList<ViewContainerRef>;
@@ -1642,6 +1747,8 @@ describe('query logic', () => {
     it('should read ViewContainerRef from ng-template nodes when explicitly asked for', () => {
       @Component({
         template: `<ng-template #foo></ng-template>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ViewContainerRef}) query?: QueryList<ViewContainerRef>;
@@ -1658,6 +1765,8 @@ describe('query logic', () => {
     it('should read ElementRef with a native element pointing to comment DOM node from ng-template', () => {
       @Component({
         template: `<ng-template #foo></ng-template>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1674,6 +1783,8 @@ describe('query logic', () => {
     it('should read TemplateRef from ng-template by default', () => {
       @Component({
         template: `<ng-template #foo></ng-template>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<TemplateRef<unknown>>;
@@ -1690,6 +1801,8 @@ describe('query logic', () => {
     it('should read TemplateRef from ng-template when explicitly asked for', () => {
       @Component({
         template: `<ng-template #foo></ng-template>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: TemplateRef}) query?: QueryList<TemplateRef<unknown>>;
@@ -1704,12 +1817,18 @@ describe('query logic', () => {
     });
 
     it('should read component instance if element queried for is a component host', () => {
-      @Component({selector: 'child-cmp', template: ''})
+      @Component({
+        selector: 'child-cmp',
+        template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class ChildCmp {}
 
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp #foo></child-cmp>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<ChildCmp>;
@@ -1728,12 +1847,16 @@ describe('query logic', () => {
         selector: 'child-cmp',
         exportAs: 'child',
         template: '',
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildCmp {}
 
       @Component({
         imports: [ChildCmp],
         template: `<child-cmp #foo="child"></child-cmp>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<ChildCmp>;
@@ -1754,6 +1877,8 @@ describe('query logic', () => {
       @Component({
         imports: [ChildDirective],
         template: `<div #foo="child" child></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo') query?: QueryList<ChildDirective>;
@@ -1777,6 +1902,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child1Dir, Child2Dir],
         template: `<div #foo="child1" child1 #bar="child2" child2></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo, bar') query?: QueryList<unknown>;
@@ -1798,6 +1925,8 @@ describe('query logic', () => {
       @Component({
         imports: [ChildDir],
         template: `<div child #foo="child" #bar="child"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo, bar') query?: QueryList<ChildDir>;
@@ -1820,6 +1949,8 @@ describe('query logic', () => {
           <div></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MultipleLocalRefsComp {
         @ViewChildren('foo') fooQuery!: QueryList<any>;
@@ -1849,6 +1980,8 @@ describe('query logic', () => {
       @Component({
         imports: [ChildDir],
         template: `<div child #foo="child"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1869,6 +2002,8 @@ describe('query logic', () => {
       @Component({
         imports: [ChildDir],
         template: `<div #foo #bar="child" child></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo, bar') query?: QueryList<unknown>;
@@ -1890,6 +2025,8 @@ describe('query logic', () => {
       @Component({
         imports: [],
         template: `<div #foo></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: ChildDir}) query?: QueryList<ChildDir>;
@@ -1912,6 +2049,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child],
         template: `<div child></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(OtherChild, {read: Child}) query?: QueryList<ChildDir>;
@@ -1927,6 +2066,8 @@ describe('query logic', () => {
     it('should not add results to TemplateRef-based query if only read token matches', () => {
       @Component({
         template: `<div></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(TemplateRef, {read: ElementRef}) query?: QueryList<ElementRef>;
@@ -1942,6 +2083,8 @@ describe('query logic', () => {
     it('should not add results to the query in case no match found (via TemplateRef)', () => {
       @Component({
         template: `<div></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(TemplateRef) query?: QueryList<TemplateRef<unknown>>;
@@ -1961,6 +2104,8 @@ describe('query logic', () => {
           <ng-template #bar><div>Test</div></ng-template>
           <ng-template #baz><div>Test</div></ng-template>
         `,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren(TemplateRef) tplQuery?: QueryList<TemplateRef<unknown>>;
@@ -1984,6 +2129,8 @@ describe('query logic', () => {
       @Component({
         imports: [Child],
         template: `<div child #foo></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChildren('foo', {read: Child}) query?: QueryList<Child>;
@@ -2092,6 +2239,8 @@ describe('query logic', () => {
             </ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: boolean = false;
@@ -2124,6 +2273,8 @@ describe('query logic', () => {
             </ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           value: string[] | undefined;
@@ -2167,6 +2318,8 @@ describe('query logic', () => {
             <ng-template vc></ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent implements AfterViewInit {
           queryListNotificationCounter = 0;
@@ -2230,6 +2383,8 @@ describe('query logic', () => {
             </div>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           items = [1, 2];
@@ -2276,6 +2431,8 @@ describe('query logic', () => {
             <ng-template vc></ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           @ViewChild(ViewContainerManipulatorDirective) vc!: ViewContainerManipulatorDirective;
@@ -2348,6 +2505,8 @@ describe('query logic', () => {
             <ng-template vc #vi1="vc"></ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestComponent {
           @ViewChild('tpl') tpl!: TemplateRef<any>;
@@ -2400,6 +2559,8 @@ describe('query logic', () => {
             <ng-template [ngTemplateOutlet]="show ? tpl : null"></ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyApp {
           show = false;
@@ -2446,6 +2607,8 @@ describe('query logic', () => {
           ><ng-template [ngIf]="true"><div parent></div></ng-template
         ></ng-template>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChildren(Child) instances!: QueryList<Child>;
@@ -2468,6 +2631,8 @@ describe('query logic', () => {
           {provide: MyClass, useExisting: forwardRef(() => WithMultiProvider), multi: true},
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class WithMultiProvider {}
 
@@ -2475,6 +2640,8 @@ describe('query logic', () => {
         selector: 'test-cmpt',
         template: `<with-multi-provider></with-multi-provider>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChildren(MyClass) queryResults!: QueryList<WithMultiProvider>;
@@ -2498,6 +2665,8 @@ describe('query logic', () => {
           {provide: MyClass, useExisting: forwardRef(() => WithMultiProvider), multi: true},
         ],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class WithMultiProvider {}
 
@@ -2508,6 +2677,8 @@ describe('query logic', () => {
           <with-multi-provider></with-multi-provider>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChildren(MyClass) queryResults!: QueryList<WithMultiProvider>;
@@ -2544,6 +2715,8 @@ describe('query logic', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(GroupDir) group!: GroupDir;
@@ -2591,6 +2764,8 @@ describe('query logic', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren(GroupDir) groups!: QueryList<GroupDir>;
@@ -2625,6 +2800,8 @@ describe('query logic', () => {
       @Component({
         template: '<div text-token></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('Token') token: any;
@@ -2640,6 +2817,8 @@ describe('query logic', () => {
       @Component({
         template: '<div text-token #Token></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('Token') token: any;
@@ -2655,6 +2834,8 @@ describe('query logic', () => {
       @Component({
         template: '<div text-token></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren('Token') tokens!: QueryList<any>;
@@ -2673,6 +2854,8 @@ describe('query logic', () => {
       @Component({
         template: '<div text-token #Token></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChildren('Token') tokens!: QueryList<any>;
@@ -2693,6 +2876,8 @@ describe('query logic', () => {
         selector: 'has-query',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasQuery {
         @ContentChild('Token') token: any;
@@ -2701,6 +2886,8 @@ describe('query logic', () => {
       @Component({
         template: '<has-query><div text-token></div></has-query>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HasQuery) queryComp!: HasQuery;
@@ -2718,6 +2905,8 @@ describe('query logic', () => {
         selector: 'has-query',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasQuery {
         @ContentChild('Token') token: any;
@@ -2726,6 +2915,8 @@ describe('query logic', () => {
       @Component({
         template: '<has-query><div text-token #Token></div></has-query>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HasQuery) queryComp!: HasQuery;
@@ -2743,6 +2934,8 @@ describe('query logic', () => {
         selector: 'has-query',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasQuery {
         @ContentChildren('Token') tokens!: QueryList<any>;
@@ -2751,6 +2944,8 @@ describe('query logic', () => {
       @Component({
         template: '<has-query><div text-token></div></has-query>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HasQuery) queryComp!: HasQuery;
@@ -2770,6 +2965,8 @@ describe('query logic', () => {
         selector: 'has-query',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasQuery {
         @ContentChildren('Token') tokens!: QueryList<any>;
@@ -2778,6 +2975,8 @@ describe('query logic', () => {
       @Component({
         template: '<has-query><div text-token #Token></div></has-query>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HasQuery) queryComp!: HasQuery;
@@ -2797,6 +2996,8 @@ describe('query logic', () => {
       @Component({
         template: '<div text-token #Token></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('Token', {read: 'Token'}) token: any;
@@ -2813,6 +3014,8 @@ describe('query logic', () => {
         selector: 'has-query',
         template: '<ng-content></ng-content>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HasQuery {
         @ContentChild('Token', {read: 'Token'}) token: any;
@@ -2821,6 +3024,8 @@ describe('query logic', () => {
       @Component({
         template: '<has-query><div text-token #Token></div></has-query>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(HasQuery) queryComp!: HasQuery;
@@ -2846,6 +3051,8 @@ function initWithTemplate(compType: Type<any>, template: string) {
   selector: 'local-ref-query-component',
   template: '<ng-content></ng-content>',
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class QueryComp {
   @ViewChild('viewQuery') viewChild!: any;
@@ -2859,6 +3066,8 @@ class QueryComp {
   selector: 'app-comp',
   template: ``,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AppComp {}
 
@@ -2866,6 +3075,8 @@ class AppComp {}
   selector: 'simple-comp-a',
   template: '',
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCompA {}
 
@@ -2873,6 +3084,8 @@ class SimpleCompA {}
   selector: 'simple-comp-b',
   template: '',
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SimpleCompB {}
 
@@ -2891,6 +3104,8 @@ class TextDirective {
     <span #foo></span>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticViewQueryComp {
   private _textDir!: TextDirective;
@@ -2930,6 +3145,8 @@ class StaticViewQueryComp {
     <span #baz></span>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SubclassStaticViewQueryComp extends StaticViewQueryComp {
   @ViewChild('bar', {static: true}) bar!: ElementRef;
@@ -2941,6 +3158,8 @@ class SubclassStaticViewQueryComp extends StaticViewQueryComp {
   selector: 'static-content-query-comp',
   template: `<ng-content></ng-content>`,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StaticContentQueryComp {
   private _textDir!: TextDirective;
@@ -3002,6 +3221,8 @@ class StaticContentQueryDir {
   selector: 'subclass-static-content-query-comp',
   template: `<ng-content></ng-content>`,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SubclassStaticContentQueryComp extends StaticContentQueryComp {
   @ContentChild('bar', {static: true}) bar!: ElementRef;
@@ -3013,6 +3234,8 @@ class SubclassStaticContentQueryComp extends StaticContentQueryComp {
   selector: 'query-with-changes',
   template: ` <div *ngIf="showing" #foo></div> `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class QueryCompWithChanges {
   @ViewChildren('foo') foos!: QueryList<any>;
@@ -3032,6 +3255,8 @@ export class QueryCompWithChanges {
     </query-component>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class QueryCompWithNoChanges {
   showing: boolean = true;
@@ -3043,6 +3268,8 @@ export class QueryCompWithNoChanges {
   selector: 'query-component',
   template: `<ng-content></ng-content>`,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class QueryCompWithStrictChangeEmitParent {
   @ContentChildren('foo', {
@@ -3060,6 +3287,8 @@ export class QueryCompWithStrictChangeEmitParent {
   selector: 'query-target',
   template: '<ng-content></ng-content>',
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SuperDirectiveQueryTarget {}
 
@@ -3077,6 +3306,8 @@ class SuperDirective {
     <query-target>Two</query-target>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SubComponent extends SuperDirective {}
 
@@ -3087,6 +3318,8 @@ const MY_OPTION_TOKEN = new InjectionToken<TestComponentWithToken>('ComponentWit
   template: 'Option',
   providers: [{provide: MY_OPTION_TOKEN, useExisting: TestComponentWithToken}],
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestComponentWithToken {}
 
@@ -3098,6 +3331,8 @@ class TestComponentWithToken {}
     <ng-content></ng-content>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestInjectionTokenQueries {
   @ViewChild(MY_OPTION_TOKEN) viewFirstOption!: TestComponentWithToken;
@@ -3114,5 +3349,7 @@ class TestInjectionTokenQueries {
     </test-injection-token>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestInjectionTokenContentQueries {}

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -36,6 +36,7 @@ import {
   RendererStyleFlags2,
   RendererType2,
   ViewEncapsulation,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {RElement} from '../../src/render3/interfaces/renderer_dom';
 import {NoopNgZone} from '../../src/zone/ng_zone';
@@ -54,6 +55,8 @@ describe('renderer factory lifecycle', () => {
     selector: 'some-component',
     template: `foo`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SomeComponent implements DoCheck {
     ngOnInit() {
@@ -68,6 +71,8 @@ describe('renderer factory lifecycle', () => {
     selector: 'some-component-with-error',
     template: `With error`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SomeComponentWhichThrows {
     ngOnInit() {
@@ -79,6 +84,8 @@ describe('renderer factory lifecycle', () => {
     selector: 'lol',
     template: `<some-component></some-component>`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class TestComponent implements DoCheck {
     ngOnInit() {
@@ -160,6 +167,8 @@ describe('renderer factory lifecycle', () => {
       styles: ['.some-css-class { color: red; }'],
       template: '...',
       encapsulation: ViewEncapsulation.ShadowDom,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class StyledComp {}
 
@@ -177,6 +186,8 @@ describe('renderer factory lifecycle', () => {
       @Component({
         template: '',
         animations: [animA, animB],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnimComp {}
 
@@ -193,6 +204,8 @@ describe('renderer factory lifecycle', () => {
       @Component({
         template: '...',
         animations: [],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnimComp {}
 
@@ -206,6 +219,8 @@ describe('renderer factory lifecycle', () => {
       @Component({
         template: '<div @fooAnimation></div>',
         animations: [],
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AnimComp {}
 
@@ -242,6 +257,8 @@ describe('renderer factory lifecycle', () => {
         <div>Root view</div>
         <div *ngIf="visible">Child view</div>
       `,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       visible = true;
@@ -338,6 +355,8 @@ describe('animation renderer factory', () => {
       },
     ],
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SomeComponentWithAnimation {
     exp: string | undefined;
@@ -351,6 +370,8 @@ describe('animation renderer factory', () => {
     selector: 'some-component',
     template: 'foo',
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SomeComponent {}
 
@@ -430,6 +451,8 @@ describe('custom renderer', () => {
     selector: 'some-component',
     template: `<div><span></span></div>`,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SomeComponent {}
 
@@ -482,6 +505,8 @@ describe('Renderer2 destruction hooks', () => {
       <span *ngIf="isContentVisible">C</span>
     `,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class SimpleApp {
     isContentVisible = true;
@@ -491,6 +516,8 @@ describe('Renderer2 destruction hooks', () => {
     selector: 'basic-comp',
     template: 'comp(<ng-content></ng-content>)',
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class BasicComponent {}
 
@@ -502,6 +529,8 @@ describe('Renderer2 destruction hooks', () => {
       <basic-comp *ngIf="isContentVisible">C</basic-comp>
     `,
     standalone: false,
+
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class AppWithComponents {
     isContentVisible = true;

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -17,6 +17,7 @@ import {
   Type,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {RuntimeErrorCode} from '../../src/errors';
 import {global} from '../../src/util/global';
@@ -39,6 +40,8 @@ describe('comment node text escaping', () => {
             <div></div>
           </div>`,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class XSSComp {
           // ngIf serializes the `xssValue` into a comment for debugging purposes.
@@ -151,6 +154,8 @@ describe('iframe processing', () => {
               @Component({
                 selector: 'my-comp',
                 template: ` <iframe ${srcAttr}="${TEST_IFRAME_URL}" ${securityAttr}=""> </iframe>`,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -170,6 +175,8 @@ describe('iframe processing', () => {
                   ${securityAttr.toUpperCase()}=""
                 >
                 </iframe>`,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -187,6 +194,8 @@ describe('iframe processing', () => {
                   ${srcAttr}="${TEST_IFRAME_URL}"
                   [${securityAttr}]="''"
                 ></iframe>`,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -204,6 +213,8 @@ describe('iframe processing', () => {
                   ${srcAttr}="${TEST_IFRAME_URL}"
                   ${securityAttr}="{{ '' }}"
                 ></iframe>`,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -224,6 +235,8 @@ describe('iframe processing', () => {
                     [${securityAttr.toUpperCase()}]="''"
                   ></iframe>
                 `,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -240,6 +253,8 @@ describe('iframe processing', () => {
                 template: `
                   <iframe ${srcAttr}="${TEST_IFRAME_URL}" [attr.${securityAttr}]="''"></iframe>
                 `,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -260,6 +275,8 @@ describe('iframe processing', () => {
                     [attr.${securityAttr.toUpperCase()}]="''"
                   ></iframe>
                 `,
+
+                changeDetection: ChangeDetectionStrategy.Eager,
               })
               class IframeComp {}
 
@@ -271,6 +288,8 @@ describe('iframe processing', () => {
             @Component({
               selector: 'my-comp',
               template: ` <iframe ${securityAttr}="allow-forms" [${srcAttr}]="src"> </iframe> `,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class IframeComp {
               private sanitizer = inject(DomSanitizer);
@@ -308,6 +327,8 @@ describe('iframe processing', () => {
           imports: [IframeDir],
           selector: 'my-comp',
           template: '<iframe dir></iframe>',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class IframeComp {}
 
@@ -328,6 +349,8 @@ describe('iframe processing', () => {
           imports: [Dir],
           selector: 'my-comp',
           template: '<img dir>',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class NonIframeComp {}
 
@@ -345,6 +368,8 @@ describe('iframe processing', () => {
             imports: [NgIf],
             selector: 'my-comp',
             template: `<iframe *ngIf="visible" src="${TEST_IFRAME_URL}" sandbox=""></iframe>`,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {
             visible = true;
@@ -358,6 +383,8 @@ describe('iframe processing', () => {
         @Component({
           selector: 'my-comp',
           template: `<iframe src="${TEST_IFRAME_URL}" sandbox srcdoc="Hi!"></iframe>`,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class IframeComp {}
 
@@ -378,6 +405,8 @@ describe('iframe processing', () => {
           imports: [IframeDir],
           selector: 'my-comp',
           template: '<iframe dir></iframe>',
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class IframeComp {}
 
@@ -401,6 +430,8 @@ describe('iframe processing', () => {
             imports: [IframeDir],
             selector: 'my-comp',
             template: '<iframe sandbox dir></iframe>',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -424,6 +455,8 @@ describe('iframe processing', () => {
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<IFRAME dir src="${TEST_IFRAME_URL}"></IFRAME>`,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -448,6 +481,8 @@ describe('iframe processing', () => {
             imports: [IframeDir],
             selector: 'my-comp',
             template: '<iframe dir sandbox></iframe>',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -472,6 +507,8 @@ describe('iframe processing', () => {
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<iframe src="${TEST_IFRAME_URL}" dir></iframe>`,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -483,6 +520,8 @@ describe('iframe processing', () => {
         @Component({
           selector: 'my-comp',
           template: ` <iframe referrerPolicy="no-referrer" src="${TEST_IFRAME_URL}"></iframe> `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class IframeComp {}
 
@@ -501,6 +540,8 @@ describe('iframe processing', () => {
             template: ` <section>
               <iframe src="${TEST_IFRAME_URL}" [referrerPolicy]="'no-referrer'"></iframe>
             </section>`,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -525,6 +566,8 @@ describe('iframe processing', () => {
             imports: [IframeDir],
             selector: 'my-comp',
             template: `<iframe dir src="${TEST_IFRAME_URL}"></iframe>`,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -559,6 +602,8 @@ describe('iframe processing', () => {
             // the directive matching order (thus the order of host attributes) is
             // based on the imports order, so the `sandbox` gets set first and the `src` second.
             template: '<iframe set-src set-sandbox></iframe>',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -591,6 +636,8 @@ describe('iframe processing', () => {
             imports: [DirThatSetsSandbox],
             selector: 'my-comp',
             template: '<iframe dir></iframe>',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -623,6 +670,8 @@ describe('iframe processing', () => {
             imports: [DirThatSetsSrc],
             selector: 'my-comp',
             template: '<iframe dir></iframe>',
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -642,6 +691,8 @@ describe('iframe processing', () => {
                 <iframe src="${TEST_IFRAME_URL}" [sandbox]="''"></iframe>
               </ng-template>
             `,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {
             @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
@@ -676,6 +727,8 @@ describe('iframe processing', () => {
                   <iframe src="${TEST_IFRAME_URL}" [sandbox]="''"> </iframe>
                 </section>
               `,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class IframeComp {}
 
@@ -690,6 +743,8 @@ describe('iframe processing', () => {
             @Component({
               selector: 'my-comp',
               template: ` <iframe i18n src="${TEST_IFRAME_URL}" [sandbox]="''"> </iframe> `,
+
+              changeDetection: ChangeDetectionStrategy.Eager,
             })
             class IframeComp {}
 
@@ -701,6 +756,8 @@ describe('iframe processing', () => {
           @Component({
             selector: 'my-comp',
             template: ` <iframe src="${TEST_IFRAME_URL}" i18n-sandbox sandbox=""> </iframe> `,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class IframeComp {}
 
@@ -715,6 +772,8 @@ describe('SVG animation processing', () => {
   it('should error when `attributeName` is bound', () => {
     @Component({
       template: '<svg><animate [attr.attributeName]="attr"></animate></svg>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       attr = 'href';
@@ -741,6 +800,8 @@ describe('SVG animation processing', () => {
       imports: [animateAttrDir],
       selector: 'my-comp',
       template: '<svg><animate dir></animate></svg>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {}
 
@@ -757,6 +818,8 @@ describe('innerHTML processing', () => {
   it('should drop risky attributes from elements created with innerHTML', () => {
     @Component({
       template: '<div [innerHTML]="html"></div>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       html = '<div action="abc"></div>';

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -19,6 +19,7 @@ import {
   Renderer2,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {bypassSanitizationTrustStyle} from '../../src/sanitization/bypass';
 import {TestBed} from '../../testing';
@@ -40,6 +41,8 @@ describe('styling', () => {
       @Component({
         template: `<div class="STATIC" style="color: blue"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -59,6 +62,8 @@ describe('styling', () => {
           [style.width.px]="100"
         ></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -75,6 +80,8 @@ describe('styling', () => {
       @Component({
         template: `<div [class]="{dynamic: true}" [style]="{color: 'blue', width: '100px'}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -95,6 +102,8 @@ describe('styling', () => {
           style="width: {{ '100' }}px"
         ></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -116,6 +125,8 @@ describe('styling', () => {
           style="color: blue"
         ></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
       @Directive({
@@ -156,6 +167,8 @@ describe('styling', () => {
       @Component({
         template: `<div my-host-bindings class="STATIC" style="color: blue;"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
       @Directive({
@@ -192,6 +205,8 @@ describe('styling', () => {
           <div style="content: 'foo'"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -216,6 +231,8 @@ describe('styling', () => {
           ></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -238,6 +255,8 @@ describe('styling', () => {
           ></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -255,6 +274,8 @@ describe('styling', () => {
       @Component({
         template: `<div [ngClass]="['dynamic']" [ngStyle]="{'font-family': 'dynamic'}"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
       TestBed.configureTestingModule({declarations: [Cmp]});
@@ -287,6 +308,8 @@ describe('styling', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
       TestBed.configureTestingModule({declarations: [Cmp]});
@@ -306,6 +329,8 @@ describe('styling', () => {
       @Component({
         template: `<h1 style="width: var(--my-1337-var)">Hello</h1>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         @HostBinding('style') style = '--my-1337-var: 100px;';
@@ -331,6 +356,8 @@ describe('styling', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
       TestBed.configureTestingModule({declarations: [Cmp]});
@@ -346,6 +373,8 @@ describe('styling', () => {
     it('should allow null in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', null, 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -358,6 +387,8 @@ describe('styling', () => {
     it('should allow undefined in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', undefined, 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -370,6 +401,8 @@ describe('styling', () => {
     it('should allow zero in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', 0, 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -382,6 +415,8 @@ describe('styling', () => {
     it('should allow false in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', false, 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -394,6 +429,8 @@ describe('styling', () => {
     it('should ignore an empty string in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', '', 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -406,6 +443,8 @@ describe('styling', () => {
     it('should ignore a string containing spaces in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', 'hello there', 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -421,6 +460,8 @@ describe('styling', () => {
           [class]="{a: true, 'hello there': true, c: true}"
           [class.extra]="true"
         ></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -433,6 +474,8 @@ describe('styling', () => {
     it('should ignore an object literal in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', {foo: true}, 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -445,6 +488,8 @@ describe('styling', () => {
     it('should handle a string array in a class array binding', () => {
       @Component({
         template: `<div [class]="['a', ['foo', 'bar'], 'c']" [class.extra]="true"></div>`,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {}
 
@@ -462,6 +507,8 @@ describe('styling', () => {
         <div class="s2 {{ 'd2' }}" dir-shadows-class-input></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -502,6 +549,8 @@ describe('styling', () => {
         <div class="s1" [class]="'d1'" dir-shadows-class-input></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -542,6 +591,8 @@ describe('styling', () => {
         <div style="width: 1px;" [style]="'height:1px;'" dir-shadows-class-input></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -579,6 +630,8 @@ describe('styling', () => {
     @Component({
       template: ` <div class="s1" [class]="classBinding" dir-shadows-class-input></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       classBinding: any = undefined;
@@ -626,6 +679,8 @@ describe('styling', () => {
         <div style="color: red;" [style]="'width: 100px;'" dir-shadows-style-input></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -654,6 +709,8 @@ describe('styling', () => {
     @Component({
       template: `<div class="s1" dir-shadows-class-input></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -686,6 +743,8 @@ describe('styling', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       id = 'throw_id';
@@ -750,6 +809,8 @@ describe('styling', () => {
     @Component({
       template: ` <div directive-expecting-styling style="width:200px" class="abc xyz"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -780,6 +841,8 @@ describe('styling', () => {
     @Component({
       template: ` <div directive-expecting-styling style="width:200px" class="abc"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -813,6 +876,8 @@ describe('styling', () => {
         </project>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -827,6 +892,8 @@ describe('styling', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ProjectCmp {}
 
@@ -846,6 +913,8 @@ describe('styling', () => {
       selector: '[comp]',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {}
 
@@ -856,6 +925,8 @@ describe('styling', () => {
         </ng-template>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       items = [1, 2, 3];
@@ -874,6 +945,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.color]></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -888,6 +961,8 @@ describe('styling', () => {
     @Component({
       template: '<div [class.is-open]></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -902,6 +977,8 @@ describe('styling', () => {
     @Component({
       template: '<div #div [style.opacity]="opacity"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('div') div!: ElementRef<HTMLElement>;
@@ -919,6 +996,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.backgroundImage]="image"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       image!: SafeStyle;
@@ -939,6 +1018,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.width]="width"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       width!: string;
@@ -959,6 +1040,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.width]="width"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       width!: string;
@@ -979,6 +1062,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.margin-right]="marginRight"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       marginRight!: string;
@@ -999,6 +1084,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style]="styles"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       styles!: string;
@@ -1019,6 +1106,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style]="styles"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       styles!: string;
@@ -1052,6 +1141,8 @@ describe('styling', () => {
       selector: 'app-comp',
       template: `<ng-template styleDir></ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyApp {}
 
@@ -1063,6 +1154,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.clip-path]="path"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       path!: SafeStyle;
@@ -1107,6 +1200,8 @@ describe('styling', () => {
         <div class="{{ one }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       one = '1';
@@ -1195,6 +1290,8 @@ describe('styling', () => {
         <div style="{{ self }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       self = 'content: "self"';
@@ -1256,6 +1353,8 @@ describe('styling', () => {
     @Component({
       template: '<div class="zero i-{{one}} {{two}} three"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       one = 'one';
@@ -1307,6 +1406,8 @@ describe('styling', () => {
         <div style.width="{{ singleBinding }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       singleBinding: string | null = '1337px';
@@ -1368,6 +1469,8 @@ describe('styling', () => {
     @Component({
       template: '<div style.width.px="{{one}}{{three}}{{three}}7"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       one = 1;
@@ -1397,6 +1500,8 @@ describe('styling', () => {
     @Component({
       template: '<div [class]="c" [my-class-dir]="x"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       c: any = null;
@@ -1462,6 +1567,8 @@ describe('styling', () => {
     @Component({
       template: '<div [class]="c" my-class-dir></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       c: any = 'bar';
@@ -1503,6 +1610,8 @@ describe('styling', () => {
     @Component({
       template: '<div class="static-val" [my-class-dir]="x"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       x = 'foo';
@@ -1541,6 +1650,8 @@ describe('styling', () => {
       selector: 'comp',
       template: `{{ className }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input() className: string = '';
@@ -1548,6 +1659,8 @@ describe('styling', () => {
     @Component({
       template: `<comp [className]="'my-className'"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1562,6 +1675,8 @@ describe('styling', () => {
       selector: 'comp',
       template: `{{ className }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Comp {
       @Input('class') className: string = '';
@@ -1570,6 +1685,8 @@ describe('styling', () => {
     @Component({
       template: `<comp class="static" [class]="'my-className'"></comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -1588,6 +1705,8 @@ describe('styling', () => {
     @Component({
       template: '<div class="static-val" [class]="c" [my-class-dir]="x"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       c: any = null;
@@ -1646,6 +1765,8 @@ describe('styling', () => {
     @Component({
       template: ` <div dir-one dir-two></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -1685,6 +1806,8 @@ describe('styling', () => {
         ></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -1723,6 +1846,8 @@ describe('styling', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         classMap = {'with-button': true};
@@ -1760,6 +1885,8 @@ describe('styling', () => {
     @Component({
       template: '<span dir [classesInSchool]="classes" [styleOfClothing]="style"></span>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild(Dir) dir!: Dir;
@@ -1781,6 +1908,8 @@ describe('styling', () => {
     @Component({
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @HostBinding('className') klass = 'one two';
@@ -1808,6 +1937,8 @@ describe('styling', () => {
         ></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       w: string | null | undefined = '100px';
@@ -1873,6 +2004,8 @@ describe('styling', () => {
         <div [style.width]="w0" [dir-that-sets-width]="w1" [another-dir-that-sets-width]="w2"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       w0: string | null | undefined = null;
@@ -1931,6 +2064,8 @@ describe('styling', () => {
     @Component({
       selector: 'comp-with-styling',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CompWithStyling {
       @HostBinding('style.width') public width = '900px';
@@ -1943,6 +2078,8 @@ describe('styling', () => {
         <comp-with-styling [style.opacity]="opacity" dir-with-styling>...</comp-with-styling>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       opacity: string | null = '0.5';
@@ -1990,6 +2127,8 @@ describe('styling', () => {
     @Component({
       selector: 'comp-with-styling',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CompWithStyling {
       @HostBinding('style.width') public width = '900px';
@@ -2010,6 +2149,8 @@ describe('styling', () => {
         >
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       opacity: string | null | undefined = '0.5';
@@ -2071,6 +2212,8 @@ describe('styling', () => {
     @Component({
       selector: '[sub-class-dir]',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SubClassDirective extends SuperClassDirective {
       @HostBinding('style.width') public w2 = '200px';
@@ -2079,6 +2222,8 @@ describe('styling', () => {
     @Component({
       template: ` <div sub-class-dir [style.width]="w3"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       w3: string | null | undefined = '300px';
@@ -2111,6 +2256,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style]="s" [class]="c"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       public c: {[key: string]: any} | null = null;
@@ -2179,6 +2326,8 @@ describe('styling', () => {
         ></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       map: any = {width: '111px', opacity: '0.5'};
@@ -2249,6 +2398,8 @@ describe('styling', () => {
         ></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       width: string | null | undefined = '111px';
@@ -2352,6 +2503,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style.width]="widthExp" [style.background-image]="bgImageExp"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       widthExp = '';
@@ -2382,6 +2535,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style.width]="widthExp" [style]="styleMapExp"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       widthExp = '';
@@ -2414,6 +2569,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style.width.px]="widthExp" [style.height.em]="heightExp"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       widthExp: string | number | null = '';
@@ -2453,6 +2610,8 @@ describe('styling', () => {
         <span [style.color]="getColorUnsafe()"></span>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       constructor(private sanitizer: DomSanitizer) {}
@@ -2529,6 +2688,8 @@ describe('styling', () => {
     @Component({
       template: ` <div #div [style]="map" dir-with-styling dir-with-styling-part2></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       map: any = null;
@@ -2557,6 +2718,8 @@ describe('styling', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       items = [1, 2, 3];
@@ -2615,6 +2778,8 @@ describe('styling', () => {
         <footer class="footer">footer</footer>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       items = [1, 2, 3];
@@ -2671,6 +2836,8 @@ describe('styling', () => {
         <dir-two></dir-two>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -2711,6 +2878,8 @@ describe('styling', () => {
         <div class="c" [style.color]="c" two></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       w = 100;
@@ -2759,6 +2928,8 @@ describe('styling', () => {
         <p [style.height.px]="h"></p>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       items: any[] = [];
@@ -2809,6 +2980,8 @@ describe('styling', () => {
     @Component({
       template: '<div #target one two></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       @ViewChild('target', {read: DirOne, static: true}) one!: DirOne;
@@ -2838,6 +3011,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style.width]="w" style.height="{{ h }}" [style.opacity]="o"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       w: any = null;
@@ -2872,6 +3047,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [ngClass]="c" [ngStyle]="s"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       c: any = 'foo bar';
@@ -2892,6 +3069,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [ngStyle]="s"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       s: any = {opacity: '1'};
@@ -2920,6 +3099,8 @@ describe('styling', () => {
       selector: 'child',
       template: ` <div [class.ready-child]="readyTpl"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildCmp {
       readyTpl = false;
@@ -2939,6 +3120,8 @@ describe('styling', () => {
         '[style.color]': 'color',
       },
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentCmp {
       private _prop = '';
@@ -2969,6 +3152,8 @@ describe('styling', () => {
     @Component({
       template: `<parent [prop]="prop"></parent>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       prop = 'a';
@@ -2998,6 +3183,8 @@ describe('styling', () => {
       selector: 'child',
       template: ` <div [class.ready-child]="readyTpl"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildCmp {
       readyTpl = false;
@@ -3014,6 +3201,8 @@ describe('styling', () => {
         </div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentCmp {
       updateChild = false;
@@ -3038,6 +3227,8 @@ describe('styling', () => {
     @Component({
       template: `<parent #parent></parent>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('parent', {static: true}) public parent: ParentCmp | null = null;
@@ -3068,6 +3259,8 @@ describe('styling', () => {
         <div [style.width]="w" [style.height]="h" [style]="s1" [dir-with-styling]="s2"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       h = '100px';
@@ -3125,6 +3318,8 @@ describe('styling', () => {
     @Component({
       template: `<div dir></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -3158,6 +3353,8 @@ describe('styling', () => {
     @Component({
       template: `<div dir></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {}
 
@@ -3191,6 +3388,8 @@ describe('styling', () => {
         <div [style.background]="background"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComponent {
       isDisabled = false;
@@ -3223,6 +3422,8 @@ describe('styling', () => {
     @Component({
       template: `<div class="container" [ngClass]="{disabled: isDisabled}" blockStyles></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class AppComponent {
       isDisabled = false;
@@ -3244,6 +3445,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style.color]="color" [class.foo]="fooClass"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       color = 'red';
@@ -3267,6 +3470,8 @@ describe('styling', () => {
     @Component({
       template: ` <div [style]="style" [class]="klass"></div> `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       style: any = 'width: 100px';
@@ -3290,6 +3495,8 @@ describe('styling', () => {
     @Component({
       template: `<div class="zero {{ one }}" [class.two]="true" [ngClass]="'three'"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       one = 'one';
@@ -3313,6 +3520,8 @@ describe('styling', () => {
         <div id="second" [class]="'two'" class="zero {{ one }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       one = 'one';
@@ -3340,6 +3549,8 @@ describe('styling', () => {
         <div id="second" [style]="'padding: 20px;'" style="margin: {{ margin }}"></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       margin = '10px';
@@ -3362,6 +3573,8 @@ describe('styling', () => {
     @Component({
       template: '<div [style.left.px]="left"></div>',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       left = '';
@@ -3391,6 +3604,8 @@ describe('styling', () => {
     @Component({
       template: `<div [class]="exp"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       exp = '';
@@ -3425,6 +3640,8 @@ describe('styling', () => {
       @Component({
         template: `<div [style.background-image]="iconSafe"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {
         icon = 'https://i.imgur.com/4AiXzf8.jpg';
@@ -3459,6 +3676,8 @@ describe('styling', () => {
         `,
         styles: ['div { width: 100px; }'],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyComp {}
 
@@ -3483,6 +3702,8 @@ describe('styling', () => {
         [attr.data-foo]="'my-foo'"
       ></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -3511,6 +3732,8 @@ describe('styling', () => {
     @Component({
       template: '...',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       @HostBinding('class') public classes = '';
@@ -3539,6 +3762,8 @@ describe('styling', () => {
     @Component({
       template: `<div [class]="'fooBar'" [class.barFoo]="true"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -3557,6 +3782,8 @@ describe('styling', () => {
     @Component({
       template: `<div [style]="myStyles"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       myStyles = {};
@@ -3581,6 +3808,8 @@ describe('styling', () => {
     @Component({
       template: `<div [style.width]="myWidth" [style.height]="'200px'"></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       get myWidth() {
@@ -3609,6 +3838,8 @@ describe('styling', () => {
       selector: 'my-comp-with-styling',
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCompWithStyling {
       @HostBinding('style') myStyles: any = {width: '300px'};
@@ -3637,6 +3868,8 @@ describe('styling', () => {
         </my-comp-with-styling>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       myStyles: {width?: string} = {width: '100px'};
@@ -3680,6 +3913,8 @@ describe('styling', () => {
       host: {style: 'color: blue'},
       template: '',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyCompWithStyling {}
 
@@ -3693,6 +3928,8 @@ describe('styling', () => {
     @Component({
       template: `<my-comp-with-styling my-dir-with-styling></my-comp-with-styling>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -3731,6 +3968,8 @@ describe('styling', () => {
         <div #div2 [class.zero]="zero" dir-that-sets-one-two dir-that-sets-three-four></div>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       @ViewChild('div1', {static: true, read: DirThatSetsOneTwo})
@@ -3813,6 +4052,8 @@ describe('styling', () => {
       template: '',
       host: {'class': 'host'},
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CompWithClasses {
       constructor(ref: ElementRef) {
@@ -3823,6 +4064,8 @@ describe('styling', () => {
     @Component({
       template: `<comp-with-classes class="inline" *ngFor="let item of items"></comp-with-classes>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {
       items = [1, 2, 3];
@@ -3854,6 +4097,8 @@ describe('styling', () => {
     @Component({
       template: `<div single-host-style-dir></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -3877,6 +4122,8 @@ describe('styling', () => {
     @Component({
       template: `<child-comp class="template"></child-comp>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
 
@@ -3885,6 +4132,8 @@ describe('styling', () => {
       host: {'class': 'parent-comp', '[class.parent-comp-active]': 'true'},
       template: '...',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ParentComp {}
 
@@ -3898,6 +4147,8 @@ describe('styling', () => {
       },
       template: '...',
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ChildComp extends ParentComp {}
 
@@ -3933,6 +4184,8 @@ describe('styling', () => {
       // Note that we shouldn't have a `class` attribute here.
       template: `<div test></div>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MyComp {}
 
@@ -3956,6 +4209,8 @@ describe('styling', () => {
         }
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {}
     TestBed.configureTestingModule({declarations: [Cmp]});
@@ -3969,7 +4224,10 @@ describe('styling', () => {
   it('should class bindings to classes with special characters in a template', () => {
     const className = `data-active:text-green-300/80`;
 
-    @Component({template: `<div [class.${className}]="value"></div>`})
+    @Component({
+      template: `<div [class.${className}]="value"></div>`,
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class Cmp {
       value = false;
     }
@@ -3997,6 +4255,8 @@ describe('styling', () => {
       host: {
         [`[class.${className}]`]: 'value',
       },
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       value = false;
@@ -4019,6 +4279,8 @@ describe('styling', () => {
   it('should support Set in a class binding', () => {
     @Component({
       template: '<div [class]="classes" [class.extra]="true"></div>',
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Cmp {
       classes = new Set(['a', 'b', 'c']);
@@ -4035,6 +4297,8 @@ describe('styling', () => {
       @Component({
         template: `<div [style]="style"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostBindingTestComponent {
         style: SafeStyle;
@@ -4057,6 +4321,8 @@ describe('styling', () => {
           '[class.foo]': 'hostClass',
         },
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         hostClass = true;
@@ -4076,6 +4342,8 @@ describe('styling', () => {
       @Component({
         template: `<my-cmp *ngFor="let i of [1, 2]" host-styling></my-cmp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         // When the first view in the list gets CD-ed, everything works.
@@ -4101,6 +4369,8 @@ describe('styling', () => {
         selector: 'my-cmp',
         template: `className = {{ className }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         @Input() className: string = 'unbound';
@@ -4108,6 +4378,8 @@ describe('styling', () => {
       @Component({
         template: `<my-cmp [class]="'bound'"></my-cmp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 
@@ -4122,6 +4394,8 @@ describe('styling', () => {
         selector: 'my-cmp',
         template: `className = {{ className }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyCmp {
         @Input() className: string = 'unbound';
@@ -4129,6 +4403,8 @@ describe('styling', () => {
       @Component({
         template: `<my-cmp class="bound"></my-cmp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {}
 

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -13,6 +13,7 @@ import {
   TemplateRef,
   ViewChild,
   ViewContainerRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 
@@ -21,6 +22,8 @@ describe('TemplateRef', () => {
     @Component({
       template: `<ng-template #templateRef></ng-template>`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('templateRef', {static: true}) templateRef!: TemplateRef<any>;
@@ -64,6 +67,8 @@ describe('TemplateRef', () => {
         `,
         exportAs: 'menuContent',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MenuContent {
         @ViewChild(TemplateRef, {static: true}) template!: TemplateRef<any>;
@@ -78,6 +83,8 @@ describe('TemplateRef', () => {
           </menu-content>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild(MenuContent) content!: MenuContent;
@@ -196,6 +203,8 @@ describe('TemplateRef', () => {
         selector: 'dynamic',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCmp {
         @ViewChild('templateRef', {static: true}) templateRef!: TemplateRef<any>;
@@ -205,6 +214,8 @@ describe('TemplateRef', () => {
         selector: 'test',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(public vcr: ViewContainerRef) {}
@@ -275,6 +286,8 @@ describe('TemplateRef', () => {
         <ng-container #containerRef></ng-container>
       `,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       @ViewChild('templateRef') templateRef!: TemplateRef<any>;
@@ -327,6 +340,8 @@ describe('TemplateRef', () => {
           <ng-container #containerRef></ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ListenerTest {
         @ViewChild('templateRef') templateRef!: TemplateRef<any>;

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -47,6 +47,7 @@ import {
   ViewChildren,
   ViewContainerRef,
   ɵsetDocument,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {ComponentFixture, TestBed, TestComponentRenderer} from '../../testing';
 
@@ -110,6 +111,8 @@ describe('ViewContainerRef', () => {
           >after
         </div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ViewInsertionTestCmpt {}
 
@@ -123,12 +126,16 @@ describe('ViewContainerRef', () => {
       @Component({
         template: 'hello',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HelloComp {}
 
       @Component({
         template: ` <ng-container vcref></ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
@@ -169,12 +176,16 @@ describe('ViewContainerRef', () => {
         selector: '[hello]',
         template: 'Hello',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HelloComp {}
 
       @Component({
         template: ` <ng-container #container></ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild('container', {read: ViewContainerRef}) vcRef!: ViewContainerRef;
@@ -200,6 +211,8 @@ describe('ViewContainerRef', () => {
         selector: 'dynamic-cmpt-with-view-queries',
         template: `<div #foo></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCompWithViewQueries {
         @ViewChildren('foo') fooList!: QueryList<ElementRef>;
@@ -209,6 +222,8 @@ describe('ViewContainerRef', () => {
         selector: 'test-cmp',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(readonly vcRf: ViewContainerRef) {}
@@ -229,6 +244,8 @@ describe('ViewContainerRef', () => {
             selector: svgSelector,
             template: '<svg><g></g></svg>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class SvgComp {}
 
@@ -236,6 +253,8 @@ describe('ViewContainerRef', () => {
             selector: mathMLSelector,
             template: '<math><matrix></matrix></math>',
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class MathMLComp {}
 
@@ -245,6 +264,8 @@ describe('ViewContainerRef', () => {
               <ng-container #mathml></ng-container>
             `,
             standalone: false,
+
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class TestComp {
             @ViewChild('svg', {read: ViewContainerRef}) svgVCRef!: ViewContainerRef;
@@ -294,6 +315,8 @@ describe('ViewContainerRef', () => {
         selector: '[attr-a=a].class-a:not(.class-b):not([attr-b=b]).class-c[attr-c]',
         template: 'Hello',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HelloComp {}
 
@@ -305,6 +328,8 @@ describe('ViewContainerRef', () => {
           </div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         @ViewChild('container', {read: ViewContainerRef}) vcRef!: ViewContainerRef;
@@ -425,6 +450,8 @@ describe('ViewContainerRef', () => {
           before|<ng-template #c1></ng-template>|middle|<ng-template #c2></ng-template>|after
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild('t', {static: true}) t!: TemplateRef<{}>;
@@ -457,6 +484,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: `before|<ng-template #a>A</ng-template><ng-template #b>B</ng-template>|after`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         @ViewChild('a', {static: true}) ta!: TemplateRef<{}>;
@@ -800,6 +829,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
@@ -830,6 +861,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
@@ -849,6 +882,8 @@ describe('ViewContainerRef', () => {
         selector: 'header-cmp',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HeaderCmp {}
 
@@ -858,6 +893,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
@@ -934,12 +971,16 @@ describe('ViewContainerRef', () => {
       @Component({
         selector: 'dynamic-cmp',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCmp {}
 
       @Component({
         selector: 'test-cmp',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(public vcRef: ViewContainerRef) {}
@@ -1056,6 +1097,8 @@ describe('ViewContainerRef', () => {
           <ng-template #child> I am child template </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         visible = true;
@@ -1113,6 +1156,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1156,6 +1201,8 @@ describe('ViewContainerRef', () => {
         selector: 'header-cmp',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HeaderComponent {}
 
@@ -1166,6 +1213,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1213,6 +1262,8 @@ describe('ViewContainerRef', () => {
           <div vcref [tplRef]="tplRef"></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {}
 
@@ -1242,6 +1293,8 @@ describe('ViewContainerRef', () => {
           <footer></footer>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild(VCRefDirective, {static: true}) vcRef!: VCRefDirective;
@@ -1275,6 +1328,8 @@ describe('ViewContainerRef', () => {
         selector: 'child',
         template: `{{ name }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         @Input() name: string | undefined;
@@ -1299,6 +1354,8 @@ describe('ViewContainerRef', () => {
           <child [name]="'B' | starPipe"></child>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SomeComponent {}
 
@@ -1336,6 +1393,8 @@ describe('ViewContainerRef', () => {
         selector: 'embedded-cmp',
         template: `foo`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class EmbeddedComponent implements DoCheck, OnInit {
         ngOnInit() {
@@ -1384,6 +1443,8 @@ describe('ViewContainerRef', () => {
         selector: 'embedded-cmp',
         template: `foo`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class EmbeddedComponent implements DoCheck, OnInit {
         constructor(public s: String) {}
@@ -1494,6 +1555,8 @@ describe('ViewContainerRef', () => {
           ><ng-content></ng-content
         ></embedded-cmp-with-ngcontent>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Reprojector {}
 
@@ -1557,6 +1620,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -1576,6 +1641,8 @@ describe('ViewContainerRef', () => {
           <svg></svg>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         constructor(public viewContainerRef: ViewContainerRef) {}
@@ -1585,6 +1652,8 @@ describe('ViewContainerRef', () => {
         selector: 'dynamic-comp',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicComponent {}
 
@@ -1607,6 +1676,8 @@ describe('ViewContainerRef', () => {
         selector: 'child',
         template: `Child Component`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -1614,6 +1685,8 @@ describe('ViewContainerRef', () => {
         selector: 'comp',
         template: '<ng-template #ref></ng-template>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @ViewChild('ref', {read: ViewContainerRef, static: true})
@@ -1640,6 +1713,8 @@ describe('ViewContainerRef', () => {
         selector: 'dynamic-cmp',
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCmp {
         doCheckCount = 0;
@@ -1652,6 +1727,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmp {
         constructor(public viewContainerRef: ViewContainerRef) {}
@@ -1687,6 +1764,8 @@ describe('ViewContainerRef', () => {
         selector: 'child-a',
         template: `[Child Component A]`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildA {}
 
@@ -1699,6 +1778,8 @@ describe('ViewContainerRef', () => {
           {{ tokenB }}
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildB {
         constructor(
@@ -1718,6 +1799,8 @@ describe('ViewContainerRef', () => {
         template: '',
         providers: [{provide: TOKEN_B, useValue: '[TokenB - Value]'}],
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         constructor(
@@ -1822,6 +1905,8 @@ describe('ViewContainerRef', () => {
             'class': 'host',
             'attr-three': 'host',
           },
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComponent {
           constructor() {
@@ -1869,6 +1954,8 @@ describe('ViewContainerRef', () => {
         @Component({
           template: 'Value: {{hostInput}}',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class HostComponent {
           @Input() hostInput = '';
@@ -1974,6 +2061,8 @@ describe('ViewContainerRef', () => {
         selector: 'child',
         template: `<div [tplDir]="tpl">{{ name }}</div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         @Input() tpl: TemplateRef<any> | null = null;
@@ -1989,6 +2078,8 @@ describe('ViewContainerRef', () => {
           <child [tpl]="foo"></child>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name = 'Parent';
@@ -2017,6 +2108,8 @@ describe('ViewContainerRef', () => {
         selector: 'loop-comp',
         template: ` <ng-template ngFor [ngForOf]="rows" [ngForTemplate]="tpl"> </ng-template> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class LoopComp {
         @Input() tpl!: TemplateRef<any>;
@@ -2037,6 +2130,8 @@ describe('ViewContainerRef', () => {
           <loop-comp [tpl]="rowTemplate" [rows]="rows"></loop-comp>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name = 'Parent';
@@ -2077,6 +2172,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: ` <ng-container *ngFor="let item of items">|{{ item }}|</ng-container> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = ['one', 'two', 'three'];
@@ -2117,6 +2214,8 @@ describe('ViewContainerRef', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = ['one', 'two', 'three'];
@@ -2157,6 +2256,8 @@ describe('ViewContainerRef', () => {
           >
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = ['one', 'two', 'three'];
@@ -2199,6 +2300,8 @@ describe('ViewContainerRef', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = ['one', 'two', 'three'];
@@ -2240,6 +2343,8 @@ describe('ViewContainerRef', () => {
           }</ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         items = ['one', 'two', 'three'];
@@ -2281,6 +2386,8 @@ describe('ViewContainerRef', () => {
       selector: 'hooks',
       template: `{{ name }}`,
       standalone: false,
+
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ComponentWithHooks {
       @Input() name: string | undefined;
@@ -2328,6 +2435,8 @@ describe('ViewContainerRef', () => {
           <hooks [name]="'B'"></hooks>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SomeComponent {}
 
@@ -2466,6 +2575,8 @@ describe('ViewContainerRef', () => {
           <hooks [name]="'B'"></hooks>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class SomeComponent {}
 
@@ -2606,6 +2717,8 @@ describe('ViewContainerRef', () => {
         host: {'id': 'attribute', '[title]': 'title'},
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class HostBindingCmpt {
         title = 'initial';
@@ -2614,6 +2727,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: `<ng-template vcref></ng-template>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComponent {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
@@ -2656,6 +2771,8 @@ describe('ViewContainerRef', () => {
         selector: 'child',
         template: '<div><ng-content></ng-content></div>',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {}
 
@@ -2669,6 +2786,8 @@ describe('ViewContainerRef', () => {
             <header vcref [tplRef]="foo" [name]="name">blah</header>
           </child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'bar';
@@ -2697,6 +2816,8 @@ describe('ViewContainerRef', () => {
         selector: 'child-with-view',
         template: `Before (inside)-<ng-content *ngIf="show"></ng-content>-After (inside)`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildWithView {
         show: boolean = true;
@@ -2713,6 +2834,8 @@ describe('ViewContainerRef', () => {
             After projected
           </child-with-view>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Parent {
         name: string = 'bar';
@@ -2742,6 +2865,8 @@ describe('ViewContainerRef', () => {
         selector: 'root-comp',
         template: `<ng-template [ngIf]="show"><ng-content></ng-content></ng-template>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class RootComp {
         @Input() show: boolean = true;
@@ -2754,6 +2879,8 @@ describe('ViewContainerRef', () => {
           <div></div
         ></root-comp>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class MyApp {
         show = true;
@@ -2775,6 +2902,8 @@ describe('ViewContainerRef', () => {
         template: ` <p class="a"><ng-content select="header"></ng-content></p>
           <p class="b"><ng-content></ng-content></p>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildWithSelector {}
 
@@ -2790,6 +2919,8 @@ describe('ViewContainerRef', () => {
             </child-with-selector>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Parent {
           name: string = 'bar';
@@ -2819,6 +2950,8 @@ describe('ViewContainerRef', () => {
           selector: 'content-comp',
           template: '<ng-content></ng-content>',
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ContentComp {}
 
@@ -2832,6 +2965,8 @@ describe('ViewContainerRef', () => {
             <ng-template #source>My Content</ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MyComp {
           @ViewChild('source', {static: true}) source!: TemplateRef<{}>;
@@ -2861,6 +2996,8 @@ describe('ViewContainerRef', () => {
             </child-with-selector>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Parent {
           name: string = 'bar';
@@ -2924,6 +3061,8 @@ describe('ViewContainerRef', () => {
         selector: 'dynamic-cmpt-with-bindings',
         template: `check count: {{ checkCount }}`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCompWithBindings implements DoCheck {
         checkCount = 0;
@@ -2936,6 +3075,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         constructor(public vcRef: ViewContainerRef) {}
@@ -2971,6 +3112,8 @@ describe('ViewContainerRef', () => {
       @Component({
         template: ``,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestComp {
         constructor(public vcRef: ViewContainerRef) {}
@@ -2980,6 +3123,8 @@ describe('ViewContainerRef', () => {
         selector: 'child',
         template: `<div>{{ name }}</div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Child {
         name = 'text';
@@ -2989,6 +3134,8 @@ describe('ViewContainerRef', () => {
         selector: 'dynamic-cmpt-with-children',
         template: `<child></child>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicCompWithChildren {}
 
@@ -3029,6 +3176,8 @@ describe('ViewContainerRef', () => {
     <p vcref [tplRef]="tplRef"></p>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class EmbeddedViewInsertionComp {}
 
@@ -3062,6 +3211,8 @@ class VCRefDirective {
     <hr />
     <ng-content></ng-content>`,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class EmbeddedComponentWithNgContent {}
 
@@ -3073,6 +3224,8 @@ class EmbeddedComponentWithNgContent {}
     <ng-template #ref2>2</ng-template>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ViewContainerRefComp {
   @ViewChildren(TemplateRef) templates!: QueryList<TemplateRef<any>>;
@@ -3084,6 +3237,8 @@ class ViewContainerRefComp {
   selector: 'view-container-ref-app',
   template: ` <view-container-ref-comp></view-container-ref-comp> `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ViewContainerRefApp {
   @ViewChild(ViewContainerRefComp) vcrComp!: ViewContainerRefComp;
@@ -3112,6 +3267,8 @@ export class StructDir {
   selector: 'destroy-cases',
   template: ``,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class DestroyCasesComp {
   @ViewChildren(StructDir) structDirs!: QueryList<StructDir>;
@@ -3135,6 +3292,8 @@ class ConstructorDir {
     </div>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConstructorApp {
   @ViewChild('foo', {static: true}) foo!: ElementRef;
@@ -3148,6 +3307,8 @@ class ConstructorApp {
     </ng-template>
   `,
   standalone: false,
+
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConstructorAppWithQueries {
   @ViewChild('foo', {static: true}) foo!: TemplateRef<any>;

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -20,6 +20,7 @@ import {
   ViewChild,
   ViewContainerRef,
   ViewRef,
+  ChangeDetectionStrategy,
 } from '../../src/core';
 import {TestBed} from '../../testing';
 import {By} from '@angular/platform-browser';
@@ -38,6 +39,8 @@ describe('view insertion', () => {
         selector: 'increment-comp',
         template: `<span>created{{ counter }}</span>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class IncrementComp {
         counter = _counter++;
@@ -49,6 +52,8 @@ describe('view insertion', () => {
           <div #container></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('container', {read: ViewContainerRef, static: true})
@@ -107,6 +112,8 @@ describe('view insertion', () => {
           <div #container></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef = null!;
@@ -156,6 +163,8 @@ describe('view insertion', () => {
           <div #container></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Comp {
         @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef = null!;
@@ -185,6 +194,8 @@ describe('view insertion', () => {
       @Component({
         template: ` <comp>test</comp> `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -214,6 +225,8 @@ describe('view insertion', () => {
           <div #container></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('container', {read: ViewContainerRef}) container: ViewContainerRef = null!;
@@ -284,6 +297,8 @@ describe('view insertion', () => {
         selector: 'test-cmpt',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChild('before', {static: true}) beforeTpl!: TemplateRef<{}>;
@@ -420,6 +435,8 @@ describe('view insertion', () => {
             <ng-template #tpl>test</ng-template>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class AppComponent {
           insertTpl = false;
@@ -450,6 +467,8 @@ describe('view insertion', () => {
           <div><ng-template #vi="vi" viewInserting></ng-template></div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class WithContentCmpt {
         @ViewChild('insert', {static: true}) insertTpl!: TemplateRef<{}>;
@@ -468,6 +487,8 @@ describe('view insertion', () => {
         selector: 'test-cmpt',
         template: '',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChild('wc', {static: true}) withContentCmpt!: WithContentCmpt;
@@ -526,6 +547,8 @@ describe('view insertion', () => {
         selector: 'dynamic-cmpt',
         template: '|before',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicComponent {}
 
@@ -537,6 +560,8 @@ describe('view insertion', () => {
             <div><ng-template #vi="vi" viewInserting></ng-template></div>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmpt {
           @ViewChild('insert', {static: true}) insertTpl!: TemplateRef<{}>;
@@ -580,6 +605,8 @@ describe('view insertion', () => {
         selector: 'dynamic-cmpt',
         template: 'dynamic',
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class DynamicComponent {}
 
@@ -593,6 +620,8 @@ describe('view insertion', () => {
           <div (click)="click()">|click</div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
@@ -627,6 +656,8 @@ describe('view insertion', () => {
           <div (click)="click()">|click</div>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
@@ -665,6 +696,8 @@ describe('view insertion', () => {
           </ng-container>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         items = [1];
@@ -701,6 +734,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div failInConstructorAlways></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -736,6 +771,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div failInConstructorOnce>OK</div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -766,6 +803,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div failInInputAlways="static"></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {}
 
@@ -792,6 +831,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div someDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChild(SomeDirective, {static: true})
@@ -825,6 +866,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div someDir></div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         @ViewChild(SomeDirective, {static: true})
@@ -863,6 +906,8 @@ describe('view insertion', () => {
         selector: 'test',
         template: `<ng-content></ng-content>OK`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         constructor() {
@@ -878,6 +923,8 @@ describe('view insertion', () => {
           ><test><test></test></test
         ></test>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {}
 
@@ -912,6 +959,8 @@ describe('view insertion', () => {
       @Component({
         template: `<div failInConstructorOnce>{{ value }}</div>`,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class TestCmpt {
         value = 0;
@@ -958,6 +1007,8 @@ describe('view insertion', () => {
           </ng-template>
         `,
         standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         @ViewChild('broken') template!: TemplateRef<unknown>;

--- a/packages/core/test/application_ref_integration_spec.ts
+++ b/packages/core/test/application_ref_integration_spec.ts
@@ -7,21 +7,22 @@
  */
 
 import {DOCUMENT} from '@angular/common';
+import {BrowserModule} from '@angular/platform-browser';
+import {withBody} from '@angular/private/testing';
 import {
   ApplicationRef,
   Component,
   DoCheck,
   NgModule,
+  NgZone,
+  ɵNoopNgZone as NoopNgZone,
   OnInit,
   provideZoneChangeDetection,
   TestabilityRegistry,
-  NgZone,
-  ɵNoopNgZone as NoopNgZone,
 } from '../src/core';
 import {getTestBed} from '../testing';
-import {BrowserModule} from '@angular/platform-browser';
-import {withBody} from '@angular/private/testing';
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {NgModuleFactory} from '../src/render3/ng_module_ref';
 
 describe('ApplicationRef bootstrap', () => {
@@ -29,6 +30,7 @@ describe('ApplicationRef bootstrap', () => {
     selector: 'hello-world',
     template: '<div>Hello {{ name }}</div>',
     standalone: false,
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class HelloWorldComponent implements OnInit, DoCheck {
     log: string[] = [];

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -13,7 +13,6 @@ import {
   ɵDomRendererFactory2 as DomRendererFactory2,
 } from '@angular/platform-browser';
 import type {ServerModule} from '@angular/platform-server';
-import {ERROR_DETAILS_PAGE_BASE_URL} from '../src/error_details_base_url';
 import {createTemplate, dispatchEvent, getContent, isNode} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 import {
@@ -30,13 +29,14 @@ import {
   NgModule,
   NgZone,
   PlatformRef,
+  provideZoneChangeDetection,
   RendererFactory2,
   TemplateRef,
   Type,
   ViewChild,
   ViewContainerRef,
-  provideZoneChangeDetection,
 } from '../src/core';
+import {ERROR_DETAILS_PAGE_BASE_URL} from '../src/error_details_base_url';
 import {ErrorHandler} from '../src/error_handler';
 import {ComponentRef} from '../src/linker/component_factory';
 import {createEnvironmentInjector, getLocaleId} from '../src/render3';
@@ -879,6 +879,7 @@ describe('AppRef', () => {
       selector: 'micro-task-comp',
       template: `<span>{{ text }}</span>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MicroTaskComp {
       text: string = '1';
@@ -894,6 +895,7 @@ describe('AppRef', () => {
       selector: 'macro-task-comp',
       template: `<span>{{ text }}</span>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MacroTaskComp {
       text: string = '1';
@@ -909,6 +911,7 @@ describe('AppRef', () => {
       selector: 'micro-macro-task-comp',
       template: `<span>{{ text }}</span>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MicroMacroTaskComp {
       text: string = '1';
@@ -927,6 +930,7 @@ describe('AppRef', () => {
       selector: 'macro-micro-task-comp',
       template: `<span>{{ text }}</span>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class MacroMicroTaskComp {
       text: string = '1';

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgOptimizedImage} from '@angular/common';
-import {Component} from '../../../../../src/core';
+import {ChangeDetectionStrategy, Component} from '../../../../../src/core';
 
 @Component({
   selector: 'lcp-check',
@@ -32,6 +32,7 @@ import {Component} from '../../../../../src/core';
     -->
     <img ngSrc="/e2e/b.png" width="10" height="10" />
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class LcpCheckComponent {
   imageSrc = '/e2e/a.png';

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -7,9 +7,14 @@
  */
 
 import '@angular/compiler';
-import {Component, importProvidersFrom, provideZoneChangeDetection} from '../../../src/core';
 import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
 import {RouterModule} from '@angular/router';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  importProvidersFrom,
+  provideZoneChangeDetection,
+} from '../../../src/core';
 
 import {BasicComponent} from './e2e/basic/basic';
 import {FillModeFailingComponent, FillModePassingComponent} from './e2e/fill-mode/fill-mode';
@@ -20,6 +25,7 @@ import {
 import {ImagePerfWarningsLazyComponent} from './e2e/image-perf-warnings-lazy/image-perf-warnings-lazy';
 import {ImagePerfWarningsOversizedComponent} from './e2e/image-perf-warnings-oversized/image-perf-warnings-oversized';
 import {SvgNoOversizedPerfWarningsComponent} from './e2e/image-perf-warnings-oversized/svg-no-perf-oversized-warnings';
+import {LcpCheckDuplicate} from './e2e/lcp-check-duplicate/lcp-check-duplicate';
 import {LcpCheckComponent} from './e2e/lcp-check/lcp-check';
 import {
   OversizedImageComponentFailing,
@@ -27,12 +33,12 @@ import {
 } from './e2e/oversized-image/oversized-image';
 import {PreconnectCheckComponent} from './e2e/preconnect-check/preconnect-check';
 import {PlaygroundComponent} from './playground';
-import {LcpCheckDuplicate} from './e2e/lcp-check-duplicate/lcp-check-duplicate';
 
 @Component({
   selector: 'app-root',
   imports: [RouterModule],
   template: '<router-outlet></router-outlet>',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class RootComponent {}
 

--- a/packages/core/test/change_detection_scheduler_spec.ts
+++ b/packages/core/test/change_detection_scheduler_spec.ts
@@ -46,6 +46,7 @@ import {
   tick,
 } from '../testing';
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 import {isBrowser, isNode, withBody} from '@angular/private/testing';
 import {ChangeDetectionSchedulerImpl} from '../src/change_detection/scheduling/zoneless_scheduling_impl';
@@ -555,6 +556,7 @@ describe('Angular with zoneless enabled', () => {
   it('change detects embedded view when attached to a host on ApplicationRef and declaration is marked for check', async () => {
     @Component({
       template: '<ng-template #template><div>{{thing}}</div></ng-template>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class DynamicCmp {
       @ViewChild('template') templateRef!: TemplateRef<{}>;
@@ -562,6 +564,7 @@ describe('Angular with zoneless enabled', () => {
     }
     @Component({
       template: '',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Host {
       readonly vcr = inject(ViewContainerRef);
@@ -586,6 +589,7 @@ describe('Angular with zoneless enabled', () => {
   it('change detects embedded view when attached directly to ApplicationRef and declaration is marked for check', async () => {
     @Component({
       template: '<ng-template #template><div>{{thing}}</div></ng-template>',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class DynamicCmp {
       @ViewChild('template') templateRef!: TemplateRef<{}>;

--- a/packages/core/test/component_fixture_spec.ts
+++ b/packages/core/test/component_fixture_spec.ts
@@ -6,15 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
+import {dispatchEvent, isNode} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 import {
   ApplicationRef,
   Component,
+  createComponent,
   EnvironmentInjector,
   ErrorHandler,
   Injectable,
   Input,
   NgZone,
-  createComponent,
   provideZoneChangeDetection,
   provideZonelessChangeDetection,
   signal,
@@ -28,8 +31,6 @@ import {
   waitForAsync,
   withModule,
 } from '../testing';
-import {dispatchEvent, isNode} from '@angular/private/testing';
-import {expect} from '@angular/private/testing/matchers';
 
 @Component({
   selector: 'simple-comp',
@@ -60,6 +61,7 @@ class SecondDeferredComp {}
   selector: 'my-if-comp',
   template: `MyIf(<span *ngIf="showMore">More</span>)`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 @Injectable()
 class MyIfComp {
@@ -98,6 +100,7 @@ class AsyncComp {
   selector: 'async-child-comp',
   template: '<span>{{localText}}</span>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncChildComp {
   localText: string = '';
@@ -114,6 +117,7 @@ class AsyncChildComp {
   selector: 'async-change-comp',
   template: `<async-child-comp (click)="click()" [text]="text"></async-child-comp>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncChangeComp {
   text: string = '1';
@@ -127,6 +131,7 @@ class AsyncChangeComp {
   selector: 'async-timeout-comp',
   template: `<span (click)="click()">{{ text }}</span>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class AsyncTimeoutComp {
   text: string = '1';
@@ -142,6 +147,7 @@ class AsyncTimeoutComp {
   selector: 'nested-async-timeout-comp',
   template: `<span (click)="click()">{{ text }}</span>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedAsyncTimeoutComp {
   text: string = '1';
@@ -527,6 +533,7 @@ describe('ComponentFixture', () => {
     @Component({
       template: '',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       ngDoCheck() {
@@ -550,6 +557,7 @@ describe('ComponentFixture', () => {
     @Component({
       template: '{{thing}}',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestComponent {
       thing = 'initial';
@@ -581,7 +589,10 @@ describe('ComponentFixture with zoneless', () => {
   });
 
   it('will not refresh CheckAlways views when detectChanges is called if not marked dirty', () => {
-    @Component({template: '{{signalThing()}}|{{regularThing}}'})
+    @Component({
+      template: '{{signalThing()}}|{{regularThing}}',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
     class CheckAlwaysCmp {
       regularThing = 'initial';
       signalThing = signal('initial');
@@ -631,6 +642,7 @@ describe('ComponentFixture with zoneless', () => {
   it('can disable checkNoChanges', () => {
     @Component({
       template: '{{thing}}',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       thing = 1;

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CommonModule, NgIfContext, ɵgetDOM as getDOM} from '@angular/common';
+import {CommonModule, ɵgetDOM as getDOM, NgIfContext} from '@angular/common';
+import {ChangeDetectionStrategy} from '@angular/compiler';
+import {By} from '@angular/platform-browser';
+import {createMouseEvent, hasClass} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 import {
   Component,
   DebugElement,
@@ -29,9 +33,6 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {ComponentFixture, TestBed, waitForAsync} from '../../testing';
-import {By} from '@angular/platform-browser';
-import {createMouseEvent, hasClass} from '@angular/private/testing';
-import {expect} from '@angular/private/testing/matchers';
 
 @Injectable()
 class Logger {
@@ -147,6 +148,7 @@ class EventsComp {
   viewProviders: [Logger],
   template: `<div class="child" message="child" *ngIf="myBool"><ng-content></ng-content></div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConditionalContentComp {
   myBool: boolean = false;
@@ -160,6 +162,7 @@ class ConditionalContentComp {
       <span class="from-parent"></span>
     </cond-content-comp>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ConditionalParentComp {
   parentBinding: string;

--- a/packages/core/test/directive_lifecycle_integration_spec.ts
+++ b/packages/core/test/directive_lifecycle_integration_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -69,6 +70,7 @@ class LifecycleDir implements DoCheck {
   inputs: ['field'],
   template: `<div lifecycle-dir></div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LifecycleCmp
   implements
@@ -115,5 +117,6 @@ class LifecycleCmp
 @Component({
   selector: 'my-comp',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MyComp5 {}

--- a/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_integration_spec.ts
@@ -15,6 +15,7 @@ import {
   AUTO_STYLE,
   group,
   keyframes,
+  ɵPRE_STYLE as PRE_STYLE,
   query,
   sequence,
   state,
@@ -22,22 +23,9 @@ import {
   transition,
   trigger,
   useAnimation,
-  ɵPRE_STYLE as PRE_STYLE,
 } from '@angular/animations';
 import {AnimationDriver, NoopAnimationDriver, ɵAnimationEngine} from '@angular/animations/browser';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
-import {
-  ChangeDetectorRef,
-  Component,
-  HostBinding,
-  HostListener,
-  Inject,
-  RendererFactory2,
-  ViewChild,
-  ViewContainerRef,
-  provideZoneChangeDetection,
-} from '../../src/core';
-import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {ɵDomRendererFactory2} from '@angular/platform-browser';
 import {
   ANIMATION_MODULE_TYPE,
@@ -45,6 +33,19 @@ import {
   NoopAnimationsModule,
 } from '@angular/platform-browser/animations';
 import {hasStyle, isNode} from '@angular/private/testing';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  HostListener,
+  Inject,
+  provideZoneChangeDetection,
+  RendererFactory2,
+  ViewChild,
+  ViewContainerRef,
+} from '../../src/core';
+import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 
 const DEFAULT_NAMESPACE_ID = 'id';
 const DEFAULT_COMPONENT_ID = '1';
@@ -109,6 +110,7 @@ const DEFAULT_COMPONENT_ID = '1';
     });
 
     @Component({
+      changeDetection: ChangeDetectionStrategy.Eager,
       template: '<p>template text</p>',
       standalone: false,
     })
@@ -121,6 +123,7 @@ const DEFAULT_COMPONENT_ID = '1';
     describe('fakeAsync testing', () => {
       it('should only require one flushMicrotasks call to kick off animation callbacks', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: `
             <div
@@ -172,6 +175,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should always run .start callbacks before .done callbacks even for noop animations', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: `
             <div
@@ -204,6 +208,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should emit the correct totalTime value for a noop-animation', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: `
             <div
@@ -248,6 +253,7 @@ const DEFAULT_COMPONENT_ID = '1';
       describe('whenRenderingDone', () => {
         it('should wait until the animations are finished until continuing', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'cmp',
             template: ` <div [@myAnimation]="exp"></div> `,
             animations: [
@@ -284,6 +290,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should wait for a noop animation to finish before continuing', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'cmp',
             template: ` <div [@myAnimation]="exp"></div> `,
             animations: [
@@ -319,6 +326,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should wait for active animations to finish even if they have already started', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'cmp',
             template: ` <div [@myAnimation]="exp"></div> `,
             animations: [
@@ -356,6 +364,7 @@ const DEFAULT_COMPONENT_ID = '1';
     describe('animation triggers', () => {
       it('should trigger a state change animation from void => state', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div *ngIf="exp" [@myAnimation]="exp"></div> `,
           animations: [
@@ -406,6 +415,7 @@ const DEFAULT_COMPONENT_ID = '1';
         ];
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div @myAnimation></div> `,
           animations: [REUSABLE_ANIMATION],
@@ -442,6 +452,7 @@ const DEFAULT_COMPONENT_ID = '1';
         };
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: '<div #element [@myAnimation]="exp"></div>',
           animations: [
@@ -490,6 +501,7 @@ const DEFAULT_COMPONENT_ID = '1';
         };
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: '<div [@myAnimation]="{value:exp, params: {doMatch:doMatch}}"></div>',
           animations: [
@@ -527,6 +539,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should allow a state value to be `0`', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -565,6 +578,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should always cancel the previous transition if a follow-up transition is not matched', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div
@@ -652,6 +666,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should always fire inner callbacks even if no animation is fired when a view is inserted', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div *ngIf="exp">
@@ -692,6 +707,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should only turn a view removal as into `void` state transition', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div *ngIf="exp1" [@myAnimation]="exp2"></div> `,
           animations: [
@@ -832,6 +848,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should stringify boolean triggers to `1` and `0`', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -885,6 +902,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should understand boolean values as `true` and `false` for transition animations', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -926,6 +944,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should understand boolean values as `true` and `false` for transition animations and apply the corresponding state() value', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -975,6 +994,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should not throw an error if a trigger with the same name exists in separate components', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp1',
           template: '...',
           animations: [trigger('trig', [])],
@@ -983,6 +1003,7 @@ const DEFAULT_COMPONENT_ID = '1';
         class Cmp1 {}
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp2',
           template: '...',
           animations: [trigger('trig', [])],
@@ -998,6 +1019,7 @@ const DEFAULT_COMPONENT_ID = '1';
       describe('host bindings', () => {
         it('should trigger a state change animation from state => state on the component host element', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'my-cmp',
             template: '...',
             animations: [
@@ -1044,6 +1066,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should trigger a leave animation when the inner has ViewContainerRef injected', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             template: ` <child-cmp *ngIf="exp"></child-cmp> `,
             standalone: false,
@@ -1053,6 +1076,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '...',
             animations: [
@@ -1101,6 +1125,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should trigger a leave animation when the inner components host binding updates', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             template: ` <child-cmp *ngIf="exp"></child-cmp> `,
             standalone: false,
@@ -1110,6 +1135,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '...',
             animations: [
@@ -1157,6 +1183,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should wait for child animations before removing parent', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             template: '<child-cmp *ngIf="exp" @parentTrigger></child-cmp>',
             animations: [
               trigger('parentTrigger', [
@@ -1170,6 +1197,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '<p @childTrigger>Hello there</p>',
             animations: [
@@ -1216,6 +1244,7 @@ const DEFAULT_COMPONENT_ID = '1';
         // animationRenderer => nonAnimationRenderer
         it('should trigger a leave animation when the outer components element binding updates on the host component element', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             animations: [
               trigger('host', [
@@ -1230,6 +1259,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '...',
             standalone: false,
@@ -1271,6 +1301,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should trigger a leave animation when both the inner and outer components trigger on the same element', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             animations: [
               trigger('host', [
@@ -1288,6 +1319,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '...',
             animations: [
@@ -1351,6 +1383,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should not throw when the host element is removed and no animation triggers', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             template: ` <child-cmp *ngIf="exp"></child-cmp> `,
             standalone: false,
@@ -1360,6 +1393,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '...',
             animations: [trigger('host', [transition('a => b', [style({height: '100px'})])])],
@@ -1393,6 +1427,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should properly evaluate pre/auto-style values when components are inserted/removed which contain host animations', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             template: ` <child-cmp *ngFor="let item of items"></child-cmp> `,
             standalone: false,
@@ -1402,6 +1437,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: '... child ...',
             animations: [
@@ -1434,6 +1470,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should cancel and merge in mid-animation styles into the follow-up animation, but only for animation keyframes that start right away', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -1489,6 +1526,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should provide the styling of previous players that are grouped', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -1550,6 +1588,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should provide the styling of previous players that are grouped and queried and make sure match the players with the correct elements', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div class="container" [@myAnimation]="exp">
@@ -1613,6 +1652,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should properly balance styles between states even if there are no destination state styles', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div @myAnimation *ngIf="exp"></div> `,
           animations: [
@@ -1656,6 +1696,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should not apply the destination styles if the final animate step already contains styles', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div @myAnimation *ngIf="exp"></div> `,
           animations: [
@@ -1704,6 +1745,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should invoke an animation trigger that is state-less', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div *ngFor="let item of items" @myAnimation></div> `,
           animations: [
@@ -1746,6 +1788,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should retain styles on the element once the animation is complete', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div #green @green></div> `,
           animations: [
@@ -1776,6 +1819,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should retain state styles when the underlying DOM structure changes even if there are no insert/remove animations', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div class="item" *ngFor="let item of items" [@color]="colorExp">
@@ -1827,6 +1871,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should retain state styles when the underlying DOM structure changes even if there are insert/remove animations', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div class="item" *ngFor="let item of items" [@color]="colorExp">
@@ -1887,6 +1932,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should keep/restore the trigger value when there are move operations (with *ngFor + trackBy)', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div
@@ -1961,6 +2007,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should animate removals of nodes to the `void` state for each animation trigger, but treat all auto styles as pre styles', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div *ngIf="exp" class="ng-if" [@trig1]="exp2" @trig2></div> `,
           animations: [
@@ -2027,6 +2074,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should properly cancel all existing animations when a removal occurs', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div *ngIf="exp" [@myAnimation]="exp"></div> `,
           animations: [
@@ -2071,6 +2119,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should not run inner child animations when a parent is set to be removed', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div *ngIf="exp" class="parent">
@@ -2108,6 +2157,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should cancel all active inner child animations when a parent removal animation is set to go', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div *ngIf="exp1" @parent>
@@ -2163,6 +2213,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should destroy inner animations when a parent node is set for removal', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div #parent class="parent">
@@ -2223,6 +2274,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should allow inner removals to happen when a non removal-based parent animation is set to animate', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div #parent [@parent]="exp1" class="parent">
@@ -2280,6 +2332,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should make inner removals wait until a parent based removal animation has finished', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `
             <div #parent *ngIf="exp1" @parent class="parent">
@@ -2339,6 +2392,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should detect trigger changes based on object.value properties', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="{value: exp}"></div> `,
           animations: [
@@ -2377,6 +2431,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should not render animations when the object expression value is the same as it was previously', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="{value: exp, params: params}"></div> `,
           animations: [
@@ -2414,6 +2469,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it("should update the final state styles when params update even if the expression hasn't changed", fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="{value: exp, params: {color: color}}"></div> `,
           animations: [
@@ -2464,6 +2520,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should substitute in values if the provided state match is an object with values', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -2510,6 +2567,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should retain substituted styles on the element once the animation is complete if referenced in the final state', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="{value: exp, params: {color: color}}"></div> `,
           animations: [
@@ -2583,6 +2641,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should only evaluate final state param substitutions from the expression and state values and not from the transition options ', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -2654,6 +2713,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should apply default params when resolved animation value is null or undefined', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'ani-cmp',
           template: `<div [@myAnimation]="exp"></div>`,
           animations: [
@@ -2700,6 +2760,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should not flush animations twice when an inner component runs change detection', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'outer-cmp',
           template: `
             <div *ngIf="exp" @outer></div>
@@ -2728,6 +2789,7 @@ const DEFAULT_COMPONENT_ID = '1';
         }
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'inner-cmp',
           template: ` <div *ngIf="exp" @inner></div> `,
           animations: [
@@ -2765,6 +2827,7 @@ const DEFAULT_COMPONENT_ID = '1';
         describe(':increment', () => {
           it('should detect when a value has incremented', () => {
             @Component({
+              changeDetection: ChangeDetectionStrategy.Eager,
               selector: 'if-cmp',
               template: ` <div [@myAnimation]="exp"></div> `,
               animations: [
@@ -2803,6 +2866,7 @@ const DEFAULT_COMPONENT_ID = '1';
         describe(':decrement', () => {
           it('should detect when a value has decremented', () => {
             @Component({
+              changeDetection: ChangeDetectionStrategy.Eager,
               selector: 'if-cmp',
               template: ` <div [@myAnimation]="exp"></div> `,
               animations: [
@@ -2841,6 +2905,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should animate nodes properly when they have been re-ordered', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div *ngFor="let item of items" [class]="'class-' + item.value">
@@ -2905,6 +2970,7 @@ const DEFAULT_COMPONENT_ID = '1';
       // any `insertBefore` is a move and tries to animate it.
       // NOTE: This test was extracted from `g3`
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         template: `<div i18n>Hello <span>World</span>!</div>`,
         animations: [trigger('myAnimation', [transition('* => *', [animate(1000)])])],
         standalone: false,
@@ -2924,6 +2990,7 @@ const DEFAULT_COMPONENT_ID = '1';
     describe('animation listeners', () => {
       it('should trigger a `start` state change listener for when the animation changes state from void => state', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div *ngIf="exp" [@myAnimation]="exp" (@myAnimation.start)="callback($event)"></div>
@@ -2965,6 +3032,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should trigger a `done` state change listener for when the animation changes state from a => b', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div
@@ -3017,6 +3085,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should handle callbacks for multiple triggers running simultaneously', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div [@ani1]="exp1" (@ani1.done)="callback1($event)"></div>
@@ -3080,6 +3149,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should handle callbacks for multiple triggers running simultaneously on the same element', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: `
             <div
@@ -3147,6 +3217,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should handle a leave animation for multiple triggers even if not all triggers have their own leave transition specified', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'if-cmp',
           template: ` <div *ngIf="exp" @foo @bar>123</div> `,
           animations: [
@@ -3190,6 +3261,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should trigger a state change listener for when the animation changes state from void => state on the host element', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'my-cmp',
           template: `...`,
           animations: [
@@ -3231,6 +3303,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should always fire callbacks even when a transition is not detected', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'my-cmp',
           template: `
             <div
@@ -3271,6 +3344,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should fire callback events for leave animations even if there is no leave transition', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'my-cmp',
           template: `
             <div
@@ -3316,6 +3390,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should fire callbacks on a sub animation once it starts and finishes', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'my-cmp',
           template: `
             <div
@@ -3400,6 +3475,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should fire callbacks and collect the correct the totalTime and element details for any queried sub animations', fakeAsync(() => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'my-cmp',
           template: `
             <div class="parent" [@parent]="exp" (@parent.done)="cb('all', 'done', $event)">
@@ -3514,6 +3590,7 @@ const DEFAULT_COMPONENT_ID = '1';
       describe('[@.disabled]', () => {
         it('should disable child animations when set to true', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'if-cmp',
             template: `
               <div [@.disabled]="disableExp">
@@ -3557,6 +3634,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should ensure state() values are applied when an animation is disabled', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'if-cmp',
             template: `
               <div [@.disabled]="disableExp">
@@ -3611,6 +3689,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should disable animations for the element that they are disabled on', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'if-cmp',
             template: ` <div [@.disabled]="disableExp" [@myAnimation]="exp"></div> `,
             animations: [
@@ -3651,6 +3730,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should respect inner disabled nodes once a parent becomes enabled', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'if-cmp',
             template: `
               <div [@.disabled]="disableParentExp">
@@ -3717,6 +3797,7 @@ const DEFAULT_COMPONENT_ID = '1';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             @ViewChild('parent') public parentElm: any;
@@ -3747,6 +3828,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should properly resolve animation event listeners when disabled', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'if-cmp',
             template: `
               <div [@.disabled]="disableExp">
@@ -3803,6 +3885,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should work when there are no animations on the component handling the disable/enable flag', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             template: `
               <div [@.disabled]="disableExp">
@@ -3817,6 +3900,7 @@ const DEFAULT_COMPONENT_ID = '1';
           }
 
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'child-cmp',
             template: ` <div [@myAnimation]="exp"></div> `,
             animations: [
@@ -3856,6 +3940,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should treat the property as true when the expression is missing', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             animations: [
               trigger('myAnimation', [
@@ -3887,6 +3972,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should respect parent/sub animations when the respective area in the DOM is disabled', fakeAsync(() => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             selector: 'parent-cmp',
             animations: [
               trigger('parent', [
@@ -3951,6 +4037,7 @@ const DEFAULT_COMPONENT_ID = '1';
     describe('animation normalization', () => {
       it('should convert hyphenated properties to camelcase by default', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -3996,6 +4083,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
       it('should convert hyphenated properties to camelCase by default that are auto/pre style properties', () => {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div [@myAnimation]="exp"></div> `,
           animations: [
@@ -4037,6 +4125,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
     it('should throw neither state() or transition() are used inside of trigger()', () => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'if-cmp',
         template: ` <div [@myAnimation]="exp"></div> `,
         animations: [trigger('myAnimation', [animate(1000, style({width: '100px'}))])],
@@ -4063,6 +4152,7 @@ const DEFAULT_COMPONENT_ID = '1';
         );
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div @anim *ngIf="exp"></div> `,
           animations: [trigger('anim', [transition(':enter', useAnimation(animationMetaData))])],
@@ -4106,6 +4196,7 @@ const DEFAULT_COMPONENT_ID = '1';
         );
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div @anim *ngIf="exp"></div> `,
           animations: [trigger('anim', [transition(':enter', useAnimation(animationMetaData))])],
@@ -4149,6 +4240,7 @@ const DEFAULT_COMPONENT_ID = '1';
         ]);
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div @anim *ngIf="exp"></div> `,
           animations: [
@@ -4194,6 +4286,7 @@ const DEFAULT_COMPONENT_ID = '1';
         ]);
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div @anim *ngIf="exp"></div> `,
           animations: [
@@ -4247,6 +4340,7 @@ const DEFAULT_COMPONENT_ID = '1';
         );
 
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: ` <div @anim *ngIf="exp"></div> `,
           animations: [
@@ -4290,6 +4384,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
     it('should combine multiple errors together into one exception when an animation fails to be built', () => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'if-cmp',
         template: ` <div [@foo]="fooExp" [@bar]="barExp"></div> `,
         animations: [
@@ -4334,6 +4429,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
     it('should not throw an error if styles overlap in separate transitions', () => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'if-cmp',
         template: ` <div [@myAnimation]="exp"></div> `,
         animations: [
@@ -4360,6 +4456,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
     it("should add the transition provided delay to all the transition's timelines", () => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'cmp',
         template: `
           <div @parent *ngIf="exp">
@@ -4425,6 +4522,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
     it('should keep (transition from/to) styles defined in different timelines', () => {
       @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
         selector: 'cmp',
         template: '<div @animation *ngIf="exp"></div>',
         animations: [
@@ -4491,6 +4589,7 @@ const DEFAULT_COMPONENT_ID = '1';
       describe('when modules are missing', () => {
         it('should throw when using an @prop binding without the animation module', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             template: `<div [@myAnimation]="true"></div>`,
             standalone: false,
           })
@@ -4505,6 +4604,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should throw when using an @prop listener without the animation module', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             template: `<div (@myAnimation.start)="a = true"></div>`,
             standalone: false,
           })
@@ -4523,6 +4623,7 @@ const DEFAULT_COMPONENT_ID = '1';
       describe('when modules are present, but animations are missing', () => {
         it('should throw when using an @prop property, BrowserAnimationModule is imported, but there is no animation rule', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             template: `<div [@myAnimation]="true"></div>`,
             standalone: false,
           })
@@ -4537,6 +4638,7 @@ const DEFAULT_COMPONENT_ID = '1';
 
         it('should throw when using an @prop listener, BrowserAnimationModule is imported, but there is no animation rule', () => {
           @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
             template: `<div (@myAnimation.start)="(true)"></div>`,
             standalone: false,
           })
@@ -4554,6 +4656,7 @@ const DEFAULT_COMPONENT_ID = '1';
     describe('non-animatable css props', () => {
       function buildAndAnimateSimpleTestComponent(triggerAnimationData: AnimationMetadata[]) {
         @Component({
+          changeDetection: ChangeDetectionStrategy.Eager,
           selector: 'cmp',
           template: `
             <div *ngIf="exp" [@myAnimation]="exp">

--- a/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animation_query_integration_spec.ts
@@ -8,6 +8,7 @@
 import {
   animate,
   animateChild,
+  ɵAnimationGroupPlayer as AnimationGroupPlayer,
   AnimationPlayer,
   AUTO_STYLE,
   group,
@@ -18,22 +19,27 @@ import {
   style,
   transition,
   trigger,
-  ɵAnimationGroupPlayer as AnimationGroupPlayer,
 } from '@angular/animations';
 import {
   AnimationDriver,
-  ɵAnimationEngine,
-  ɵnormalizeKeyframes as normalizeKeyframes,
-  ɵTransitionAnimationPlayer as TransitionAnimationPlayer,
   ɵENTER_CLASSNAME as ENTER_CLASSNAME,
   ɵLEAVE_CLASSNAME as LEAVE_CLASSNAME,
+  ɵnormalizeKeyframes as normalizeKeyframes,
+  ɵTransitionAnimationPlayer as TransitionAnimationPlayer,
+  ɵAnimationEngine,
 } from '@angular/animations/browser';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {CommonModule} from '@angular/common';
-import {Component, HostBinding, ViewChild, provideZoneChangeDetection} from '../../src/core';
-import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {isNode} from '@angular/private/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  provideZoneChangeDetection,
+  ViewChild,
+} from '../../src/core';
+import {fakeAsync, flushMicrotasks, TestBed} from '../../testing';
 
 import {HostListener} from '../../src/metadata/directives';
 
@@ -93,6 +99,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('c', [transition('* => 1', [animate(1000, style({opacity: 0}))])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp0: any;
@@ -149,6 +156,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('c', [transition('* => 1', [animate(1000, style({opacity: 0}))])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp0: any;
@@ -222,6 +230,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp0: any;
@@ -288,6 +297,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -342,6 +352,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('child', [transition('* => *', [])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp0: any;
@@ -423,6 +434,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -536,6 +548,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -604,6 +617,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -654,6 +668,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -729,6 +744,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -773,6 +789,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -827,6 +844,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public items: any[] = [0, 1, 2];
@@ -884,6 +902,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           @ViewChild('container') public container: any;
@@ -933,6 +952,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -995,6 +1015,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1052,6 +1073,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public items: any[] | undefined;
@@ -1143,6 +1165,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1214,6 +1237,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any = '';
@@ -1278,6 +1302,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any = '';
@@ -1349,6 +1374,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1402,6 +1428,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1463,6 +1490,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -1537,6 +1565,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1593,6 +1622,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -1653,6 +1683,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: any;
@@ -1668,6 +1699,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public items: any[] = [];
@@ -1704,6 +1736,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: any;
@@ -1719,6 +1752,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public items: any[] = [];
@@ -1764,6 +1798,7 @@ import {HostListener} from '../../src/metadata/directives';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             public exp: any;
@@ -1805,6 +1840,7 @@ import {HostListener} from '../../src/metadata/directives';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             public exp: any;
@@ -1854,6 +1890,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -1944,6 +1981,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -2025,6 +2063,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: any;
@@ -2079,6 +2118,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -2142,6 +2182,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -2207,6 +2248,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -2267,6 +2309,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -2319,6 +2362,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('parent', [transition(':leave', [query(':leave', animateChild())])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: boolean = true;
@@ -2340,6 +2384,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('child', [transition(':leave', [animate(1000, style({color: 'gold'}))])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public childEvent: any;
@@ -2384,6 +2429,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('myAnimation', [transition(':leave', [query('@*', animateChild())])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: boolean = true;
@@ -2402,6 +2448,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {}
 
@@ -2451,6 +2498,7 @@ import {HostListener} from '../../src/metadata/directives';
             trigger('myAnimation', [transition(':leave', [query('@*', animateChild())])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: boolean = true;
@@ -2460,6 +2508,7 @@ import {HostListener} from '../../src/metadata/directives';
           selector: 'child-cmp',
           template: ` <nested-child-cmp></nested-child-cmp> `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {}
 
@@ -2476,6 +2525,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class NestedChildCmp {}
 
@@ -2534,6 +2584,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: boolean = true;
@@ -2581,6 +2632,7 @@ import {HostListener} from '../../src/metadata/directives';
             </section>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: boolean | undefined;
@@ -2649,6 +2701,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           get title() {
@@ -2774,6 +2827,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp: boolean | undefined;
@@ -2817,6 +2871,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@parent]="exp"><child-cmp #child></child-cmp></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: any;
@@ -2831,6 +2886,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@child]="exp"></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public exp: any;
@@ -2883,6 +2939,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           @ViewChild('child') public childCmp: any;
@@ -2910,6 +2967,7 @@ import {HostListener} from '../../src/metadata/directives';
             <div [@child]="exp" (@child.start)="track($event)" (@child.done)="track($event)"></div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public exp: any;
@@ -3003,6 +3061,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public parent1Exp = '';
@@ -3054,6 +3113,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@parent]="exp"><child-cmp #child></child-cmp></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: any;
@@ -3070,6 +3130,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@child]="exp" class="child"></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           public exp: any;
@@ -3127,6 +3188,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@parentAnimation]="exp"><child-cmp #child></child-cmp></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ParentCmp {
           public exp: any;
@@ -3138,6 +3200,7 @@ import {HostListener} from '../../src/metadata/directives';
           selector: 'child-cmp',
           template: '<grandchild-cmp #grandchild></grandchild-cmp>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ChildCmp {
           @ViewChild('grandchild') public innerCmp: any;
@@ -3155,6 +3218,7 @@ import {HostListener} from '../../src/metadata/directives';
           ],
           template: '<div [@grandChildAnimation]="exp"></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class GrandChildCmp {
           public exp: any;
@@ -3240,6 +3304,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -3303,6 +3368,7 @@ import {HostListener} from '../../src/metadata/directives';
             </div>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp1: any;
@@ -3358,6 +3424,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public childPresent = true;
@@ -3407,6 +3474,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp = true;
@@ -3467,6 +3535,7 @@ import {HostListener} from '../../src/metadata/directives';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           public exp = false;
@@ -3526,6 +3595,7 @@ import {HostListener} from '../../src/metadata/directives';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             exp: any = '';
@@ -3574,6 +3644,7 @@ import {HostListener} from '../../src/metadata/directives';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             exp: any = '';
@@ -3626,6 +3697,7 @@ import {HostListener} from '../../src/metadata/directives';
               ]),
             ],
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Cmp {
             exp: any = '';

--- a/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/legacy_animation/legacy_animations_with_web_animations_integration_spec.ts
@@ -6,25 +6,30 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {
+  ɵAnimationGroupPlayer as AnimationGroupPlayer,
   animate,
   query,
   state,
   style,
   transition,
   trigger,
-  ɵAnimationGroupPlayer as AnimationGroupPlayer,
 } from '@angular/animations';
 import {
   AnimationDriver,
+  ɵTransitionAnimationPlayer as TransitionAnimationPlayer,
   ɵAnimationEngine,
   ɵWebAnimationsDriver,
   ɵWebAnimationsPlayer,
-  ɵTransitionAnimationPlayer as TransitionAnimationPlayer,
 } from '@angular/animations/browser';
-import {Component, ViewChild, provideZoneChangeDetection} from '../../src/core';
-import {TestBed} from '../../testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {isNode} from '@angular/private/testing';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewChild,
+  provideZoneChangeDetection,
+} from '../../src/core';
+import {TestBed} from '../../testing';
 
 (function () {
   // these tests are only meant to be run within the DOM (for now)
@@ -62,6 +67,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         public exp: boolean = false;
@@ -181,6 +187,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         public exp!: number;
@@ -266,6 +273,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         exp = false;
@@ -352,6 +360,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         items: any[] = [];
@@ -443,6 +452,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         public exp: string | undefined;
@@ -498,6 +508,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         public exp: string | undefined;
@@ -563,6 +574,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         @ViewChild('elm', {static: true}) public element: any;
@@ -607,6 +619,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         @ViewChild('elm', {static: true}) public element: any;
@@ -673,6 +686,7 @@ import {isNode} from '@angular/private/testing';
           ]),
         ],
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Cmp {
         public status: 'active' | 'inactive' = 'inactive';

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -7,6 +7,9 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
+import {By} from '@angular/platform-browser';
+import {isTextNode} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 import {
   AfterContentChecked,
   AfterContentInit,
@@ -41,12 +44,9 @@ import {
   ViewContainerRef,
 } from '../../src/core';
 import {ComponentFixture, fakeAsync, TestBed} from '../../testing';
-import {By} from '@angular/platform-browser';
-import {isTextNode} from '@angular/private/testing';
-import {expect} from '@angular/private/testing/matchers';
 
-import {MockResourceLoader} from './resource_loader_mock';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {MockResourceLoader} from './resource_loader_mock';
 
 const TEST_COMPILER_PROVIDERS: Provider[] = [
   {provide: ResourceLoader, useClass: MockResourceLoader, deps: []},
@@ -62,7 +62,9 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
     template: string,
     compType: Type<T> = <any>TestComponent,
   ): ComponentFixture<T> {
-    TestBed.overrideComponent(compType, {set: new Component({template})});
+    TestBed.overrideComponent(compType, {
+      set: new Component({template, changeDetection: ChangeDetectionStrategy.Eager}),
+    });
 
     initHelpers();
 
@@ -1395,6 +1397,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
               ><ng-template><span [i]="log('tpl')"></span></ng-template
             ></outer-cmp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MainComp {
           constructor(public cdRef: ChangeDetectorRef) {}
@@ -1410,6 +1413,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
               ><ng-template><span [i]="log('tpl')"></span></ng-template
             ></inner-cmp>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class OuterComp {
           @ContentChild(TemplateRef, {static: true}) tpl!: TemplateRef<any>;
@@ -1427,6 +1431,7 @@ const TEST_COMPILER_PROVIDERS: Provider[] = [
             ></ng-container
             ><ng-container [ngTemplateOutlet]="tpl"></ng-container>`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class InnerComp {
           @ContentChild(TemplateRef, {static: true}) tpl!: TemplateRef<any>;

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -2491,6 +2491,7 @@ class PushCmpWithAsyncPipe {
   selector: 'my-comp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MyComp {
   readonly ctxProp = signal<string | undefined>(undefined);
@@ -2989,6 +2990,7 @@ function createParentBus(peb: EventBus) {
   providers: [{provide: EventBus, useFactory: createParentBus, deps: [[EventBus, new SkipSelf()]]}],
   template: `<child-consuming-event-bus></child-consuming-event-bus>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ParentProvidingEventBus {
   bus: EventBus;
@@ -3100,6 +3102,7 @@ class DirectiveThrowingAnError {
   template: `No View Decorator:
     <div *ngFor="let item of items">{{ item }}</div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ComponentWithTemplate {
   items = [1, 2, 3];
@@ -3129,6 +3132,7 @@ class DirectiveWithPropDecorators {
 @Component({
   selector: 'some-cmp',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SomeCmp {
   value: any;
@@ -3138,6 +3142,7 @@ class SomeCmp {
   selector: 'parent-cmp',
   template: `<cmp [test$]="name"></cmp>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ParentCmp {
   name: string = 'hello';
@@ -3147,6 +3152,7 @@ export class ParentCmp {
   selector: 'cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SomeCmpWithInput {
   @Input() test$: any;

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -7,7 +7,11 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
+import {By} from '@angular/platform-browser';
+import {isNode} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 import {
+  ChangeDetectionStrategy,
   Component,
   ComponentRef,
   createComponent,
@@ -24,9 +28,6 @@ import {
   ViewEncapsulation,
 } from '../../src/core';
 import {ComponentFixture, TestBed} from '../../testing';
-import {By} from '@angular/platform-browser';
-import {expect} from '@angular/private/testing/matchers';
-import {isNode} from '@angular/private/testing';
 
 describe('projection', () => {
   beforeEach(() => TestBed.configureTestingModule({declarations: [MainComp, OtherComp, Simple]}));
@@ -276,6 +277,7 @@ describe('projection', () => {
           ><ng-content select="div"></ng-content></ng-template
         >)`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class Child {
       @Input() showing!: boolean;
@@ -290,6 +292,7 @@ describe('projection', () => {
         <span>B</span>
       </child>`,
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class App {
       showing = false;

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -14,6 +14,7 @@ import {
   AfterViewChecked,
   AfterViewInit,
   asNativeElements,
+  ChangeDetectionStrategy,
   Component,
   ContentChild,
   ContentChildren,
@@ -832,6 +833,7 @@ class DirectiveNeedsContentChild {
   selector: 'needs-view-child',
   template: `<div *ngIf="shouldShow" text="foo"></div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewChild implements AfterViewInit, AfterViewChecked {
   shouldShow: boolean = true;
@@ -890,6 +892,7 @@ class InertDirective {}
   selector: 'needs-query',
   template: '<div text="ignoreme"></div><b *ngFor="let  dir of query">{{dir.text}}|</b>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsQuery {
   @ContentChildren(TextDirective) query!: QueryList<TextDirective>;
@@ -956,6 +959,7 @@ class NeedsQueryAndProject {
   selector: 'needs-view-query',
   template: '<div text="1"><div text="2"></div></div><div text="3"></div><div text="4"></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewQuery {
   @ViewChildren(TextDirective) query!: QueryList<TextDirective>;
@@ -965,6 +969,7 @@ class NeedsViewQuery {
   selector: 'needs-view-query-if',
   template: '<div *ngIf="show" text="1"></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewQueryIf {
   show: boolean = false;
@@ -974,6 +979,7 @@ class NeedsViewQueryIf {
 @Component({
   selector: 'needs-view-query-nested-if',
   template: '<div text="1"><div *ngIf="show"><div dir></div></div></div>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsViewQueryNestedIf {
@@ -988,6 +994,7 @@ class NeedsViewQueryNestedIf {
     '<div *ngFor="let  i of list" [text]="i"></div>' +
     '<div text="4"></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewQueryOrder {
   @ViewChildren(TextDirective) query!: QueryList<TextDirective>;
@@ -1001,6 +1008,7 @@ class NeedsViewQueryOrder {
     '<div *ngFor="let  i of list" [text]="i"></div>' +
     '<div text="4"></div></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewQueryOrderWithParent {
   @ViewChildren(TextDirective) query!: QueryList<TextDirective>;
@@ -1021,6 +1029,7 @@ class NeedsTpl {
 @Component({
   selector: 'needs-named-tpl',
   template: '<ng-template #tpl><div>shadow</div></ng-template>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsNamedTpl {
@@ -1032,6 +1041,7 @@ class NeedsNamedTpl {
 @Component({
   selector: 'needs-content-children-read',
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsContentChildrenWithRead {
@@ -1042,6 +1052,7 @@ class NeedsContentChildrenWithRead {
 @Component({
   selector: 'needs-content-child-read',
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsContentChildWithRead {
@@ -1052,6 +1063,7 @@ class NeedsContentChildWithRead {
 @Component({
   selector: 'needs-content-children-shallow',
   template: '',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsContentChildrenShallow {
@@ -1061,6 +1073,7 @@ class NeedsContentChildrenShallow {
 @Component({
   selector: 'needs-content-child-template-ref',
   template: '<div [ngTemplateOutlet]="templateRef"></div>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsContentChildTemplateRef {
@@ -1073,6 +1086,7 @@ class NeedsContentChildTemplateRef {
     '<needs-content-child-template-ref>' +
     '<ng-template>OUTER<ng-template>INNER</ng-template></ng-template>' +
     '</needs-content-child-template-ref>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsContentChildTemplateRefApp {}
@@ -1080,6 +1094,7 @@ class NeedsContentChildTemplateRefApp {}
 @Component({
   selector: 'needs-view-children-read',
   template: '<div #q text="va"></div><div #w text="vb"></div>',
+  changeDetection: ChangeDetectionStrategy.Eager,
   standalone: false,
 })
 class NeedsViewChildrenWithRead {
@@ -1091,6 +1106,7 @@ class NeedsViewChildrenWithRead {
   selector: 'needs-view-child-read',
   template: '<div #q text="va"></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewChildWithRead {
   @ViewChild('q', {read: TextDirective}) textDirChild!: TextDirective;
@@ -1101,6 +1117,7 @@ class NeedsViewChildWithRead {
   selector: 'needs-viewcontainer-read',
   template: '<div #q></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NeedsViewContainerWithRead {
   @ViewChild('q', {read: ViewContainerRef}) vc!: ViewContainerRef;
@@ -1116,6 +1133,7 @@ class NeedsViewContainerWithRead {
   selector: 'has-null-query-condition',
   template: '<div></div>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class HasNullQueryCondition {
   @ContentChildren(null!) errorTrigger: any;
@@ -1125,6 +1143,7 @@ class HasNullQueryCondition {
   selector: 'my-comp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MyComp0 {
   shouldShow: boolean = false;
@@ -1135,6 +1154,7 @@ class MyComp0 {
   selector: 'my-comp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MyCompBroken0 {}
 

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -6,14 +6,22 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, HostBinding, Input, NO_ERRORS_SCHEMA} from '../../src/core';
-import {ComponentFixture, getTestBed, TestBed} from '../../testing';
 import {DomSanitizer} from '@angular/platform-browser';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  HostBinding,
+  Input,
+  NO_ERRORS_SCHEMA,
+} from '../../src/core';
+import {ComponentFixture, getTestBed, TestBed} from '../../testing';
 
 @Component({
   selector: 'my-comp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class SecuredComponent {
   ctxProp: any = 'some value';

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -7,7 +7,13 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, Directive, HostBinding, provideZoneChangeDetection} from '../../src/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  HostBinding,
+  provideZoneChangeDetection,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 
 import {getLContext, readPatchedData} from '../../src/render3/context_discovery';
@@ -558,6 +564,7 @@ describe('sanitization', () => {
     @Component({
       selector: 'sanitize-this',
       template: ` <a [href]="href"></a> `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SanitizationComp {
       href = '';
@@ -611,6 +618,7 @@ describe('sanitization', () => {
       selector: 'sanitize-this',
       imports: [UnsafeUrlHostBindingDir],
       template: ` <a unsafeUrlHostBindingDir>text</a> `,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SimpleComp {}
 

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -34,6 +34,7 @@ describe('component declaration jit compilation', () => {
       version: '18.0.0',
       type: TestClass,
       template: `<div></div>`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -47,6 +48,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       selector: '[dir], test',
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -66,6 +68,7 @@ describe('component declaration jit compilation', () => {
       outputs: {
         minifiedEventName: 'eventBindingName',
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -92,6 +95,7 @@ describe('component declaration jit compilation', () => {
       inputs: {
         minifiedClassProperty: ['bindingName', 'classProperty', transformFn],
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -114,6 +118,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       exportAs: ['a', 'b'],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -127,6 +132,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       providers: [{provide: 'token', useValue: 123}],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -141,6 +147,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       viewProviders: [{provide: 'token', useValue: 123}],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -169,6 +176,7 @@ describe('component declaration jit compilation', () => {
           emitDistinctChangesOnly: false,
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -205,6 +213,7 @@ describe('component declaration jit compilation', () => {
           emitDistinctChangesOnly: false,
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -240,6 +249,7 @@ describe('component declaration jit compilation', () => {
         classAttribute: 'foo bar',
         styleAttribute: 'width: 100px;',
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -268,6 +278,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       usesInheritance: true,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -281,6 +292,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       usesOnChanges: true,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -307,6 +319,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       styles: ['div {}'],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -322,6 +335,7 @@ describe('component declaration jit compilation', () => {
       template: '<div></div>',
       styles: ['div {}'],
       encapsulation: ViewEncapsulation.ShadowDom,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -336,6 +350,7 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template: '<div></div>',
       animations: [{type: 'trigger'}],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -352,11 +367,13 @@ describe('component declaration jit compilation', () => {
       type: TestClass,
       template,
       preserveWhitespaces: true,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
     const whenOmitted = ɵɵngDeclareComponent({
       version: '18.0.0',
       type: TestClass,
       template,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(whenTrue, {
@@ -390,6 +407,7 @@ describe('component declaration jit compilation', () => {
         },
       ],
       template: `<div [dir]="'test' | test"></div>`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -410,6 +428,7 @@ describe('component declaration jit compilation', () => {
           selector: 'cmp',
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -428,6 +447,7 @@ describe('component declaration jit compilation', () => {
           selector: '[dir]',
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -452,6 +472,7 @@ describe('component declaration jit compilation', () => {
           selector: '[dir]',
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -472,6 +493,7 @@ describe('component declaration jit compilation', () => {
           selector: '[forward]',
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     @Directive({
@@ -502,6 +524,7 @@ describe('component declaration jit compilation', () => {
           selector: '[forward]',
         },
       ],
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     @Directive({
@@ -523,6 +546,7 @@ describe('component declaration jit compilation', () => {
       pipes: {
         'test': TestPipe,
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     expectComponentDef(def, {
@@ -540,6 +564,7 @@ describe('component declaration jit compilation', () => {
           return ForwardPipe;
         }),
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     @Pipe({
@@ -564,6 +589,7 @@ describe('component declaration jit compilation', () => {
           return ForwardPipe;
         }),
       },
+      changeDetection: ChangeDetectionStrategy.Eager,
     }) as ComponentDef<TestClass>;
 
     @Pipe({

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -15,8 +15,8 @@ import {
   ɵɵNgOnChangesFeature,
 } from '../../../src/render3';
 
-import {functionContaining} from './matcher';
 import {InputFlags} from '../../../src/render3/interfaces/input_flags';
+import {functionContaining} from './matcher';
 
 describe('directive declaration jit compilation', () => {
   it('should compile a minimal directive declaration', () => {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -10,6 +10,10 @@
 import type {} from 'zone.js';
 
 import {AsyncPipe} from '@angular/common';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {withBody} from '@angular/private/testing';
+import {SIGNAL} from '../../primitives/signals';
+import {toObservable} from '../../rxjs-interop';
 import {
   AfterViewInit,
   ApplicationRef,
@@ -39,12 +43,8 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '../../src/core';
-import {SIGNAL} from '../../primitives/signals';
-import {toObservable} from '../../rxjs-interop';
 import {EffectNode} from '../../src/render3/reactivity/effect';
 import {TestBed} from '../../testing';
-import {bootstrapApplication} from '@angular/platform-browser';
-import {withBody} from '@angular/private/testing';
 
 describe('reactivity', () => {
   describe('effects', () => {
@@ -815,6 +815,7 @@ describe('reactivity', () => {
         @Component({
           selector: 'test-cmp',
           template: '',
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class TestCmp {
           ngOnInitRan = false;
@@ -835,6 +836,7 @@ describe('reactivity', () => {
               <test-cmp />
             }
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class DriverCmp {
           cond = false;

--- a/packages/core/test/test_bed_effect_spec.ts
+++ b/packages/core/test/test_bed_effect_spec.ts
@@ -14,7 +14,6 @@ import {
   inject,
   Injector,
   Input,
-  NgZone,
   provideZoneChangeDetection,
   signal,
 } from '../src/core';
@@ -155,6 +154,7 @@ describe('effects in TestBed', () => {
 
     @Component({
       template: `{{ sentinel }}`,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class TestCmp {
       get sentinel(): string {

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -11,6 +11,7 @@ import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
 import {
   APP_INITIALIZER,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Compiler,
   Component,
@@ -80,6 +81,7 @@ class SimpleService {
   selector: 'hello-world',
   template: '<greeting-cmp></greeting-cmp>',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class HelloWorld {}
 
@@ -88,6 +90,7 @@ export class HelloWorld {}
   selector: 'greeting-cmp',
   template: 'Hello {{ name }}',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class GreetingCmp {
   name: string;

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -8,10 +8,10 @@
 
 import {
   ApplicationRef,
+  ChangeDetectionStrategy,
   Component,
   ComponentRef,
   Directive,
-  EnvironmentInjector,
   Injector,
   Input,
   NgZone,
@@ -378,6 +378,7 @@ export class CdTrackerDir {
     <ng-content select="content-1"></ng-content>
     <ng-content select="content-2"></ng-content>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TestComponent {
   @Output('templateOutput1') output1 = new Subject();

--- a/packages/examples/core/di/ts/contentChildren/content_children_example.ts
+++ b/packages/examples/core/di/ts/contentChildren/content_children_example.ts
@@ -7,7 +7,15 @@
  */
 
 // #docregion Component
-import {Component, ContentChildren, Directive, input, QueryList, signal} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChildren,
+  Directive,
+  input,
+  QueryList,
+  signal,
+} from '@angular/core';
 
 @Directive({
   selector: 'pane',
@@ -22,6 +30,7 @@ export class Pane {
     <div class="top-level">Top level panes: {{ serializedPanes }}</div>
     <div class="nested">Arbitrary nested panes: {{ serializedNestedPanes }}</div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class Tab {
   @ContentChildren(Pane) topLevelPanes!: QueryList<Pane>;
@@ -54,6 +63,7 @@ export class Tab {
 
     <button (click)="show()">Show 3</button>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ContentChildrenComp {
   shouldShow = signal(false);

--- a/packages/examples/core/di/ts/viewChildren/view_children_example.ts
+++ b/packages/examples/core/di/ts/viewChildren/view_children_example.ts
@@ -9,6 +9,7 @@
 // #docregion Component
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   Directive,
   input,
@@ -38,6 +39,7 @@ export class Pane {
 
     <div>panes: {{ serializedPanes }}</div>
   `,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ViewChildrenComp implements AfterViewInit {
   @ViewChildren(Pane) panes!: QueryList<Pane>;

--- a/packages/examples/core/test_app_component.ts
+++ b/packages/examples/core/test_app_component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {RouterOutlet, Routes} from '@angular/router';
 
 import * as animationDslExample from './animation/ts/dsl/module';
@@ -20,6 +20,7 @@ import * as testabilityWhenStableExample from './testability/ts/whenStable/modul
   selector: 'example-app',
   imports: [RouterOutlet],
   template: '<router-outlet />',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class TestsAppComponent {}
 

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -8,6 +8,7 @@
 
 import {
   booleanAttribute,
+  ChangeDetectionStrategy,
   Component,
   computed,
   Directive,
@@ -3475,6 +3476,7 @@ describe('field directive', () => {
     @Component({
       selector: 'my-input',
       template: '<input #i [value]="value" (input)="valueChange.emit(i.value)" />',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CustomInput {
       @Input({required: true}) value!: string;
@@ -3588,6 +3590,7 @@ describe('field directive', () => {
       selector: 'my-checkbox',
       template:
         '<input type="checkbox" #i [checked]="checked" (input)="checkedChange.emit(i.checked)" />',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CustomCheckbox {
       @Input({required: true}) checked!: boolean;

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   inject,
@@ -56,6 +57,7 @@ describe('ControlValueAccessor', () => {
       />
     `,
     providers: [{provide: NG_VALUE_ACCESSOR, useExisting: CustomControl, multi: true}],
+    changeDetection: ChangeDetectionStrategy.Eager,
   })
   class CustomControl implements ControlValueAccessor {
     value = '';

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -8,6 +8,7 @@
 
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   Directive,
   ElementRef,
@@ -23,8 +24,8 @@ import {
   dispatchEvent,
   isNode,
   sortedClassList,
-  useAutoTick,
   timeout,
+  useAutoTick,
 } from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 import {merge, NEVER, Observable, of, Subject, Subscription, timer} from 'rxjs';
@@ -395,6 +396,7 @@ describe('reactive forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         form: FormGroup;
@@ -843,6 +845,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showAsGroup = false;
@@ -906,6 +910,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showAsArray = false;
@@ -971,6 +977,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App {
           showAsArray = false;
@@ -1564,6 +1572,7 @@ describe('reactive forms integration tests', () => {
           }
         </form>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FormArrayComp {
         controls = [new FormControl('fish'), new FormControl('cat'), new FormControl('dog')];
@@ -1687,6 +1696,7 @@ describe('reactive forms integration tests', () => {
         selector: 'form-comp',
         template: ` <form></form> `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FormComp {}
 
@@ -1708,6 +1718,7 @@ describe('reactive forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FormComp {
         control = new FormControl('abc');
@@ -2216,6 +2227,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class App implements OnDestroy {
           private _subscription: Subscription;
@@ -3608,6 +3621,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MinMaxLengthComponent {
           control: FormControl = new FormControl();
@@ -3706,6 +3721,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MinMaxComponent {
           control: FormControl = new FormControl();
@@ -4160,6 +4177,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class NgModelNoOpValidation {
           validatorInput = 'bar';
@@ -4910,6 +4929,7 @@ describe('reactive forms integration tests', () => {
           <input *ngIf="visible" type="text" [formControl]="control" cva-a validators-a />
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -4990,6 +5010,7 @@ describe('reactive forms integration tests', () => {
           <input type="text" [formControl]="control" cva-b />
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5067,6 +5088,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5149,6 +5171,7 @@ describe('reactive forms integration tests', () => {
           </ng-container>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5252,6 +5275,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5335,6 +5359,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5449,6 +5474,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5548,6 +5574,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5673,6 +5700,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5806,6 +5834,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -5951,6 +5980,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -6048,6 +6078,7 @@ describe('reactive forms integration tests', () => {
           </div>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         visible = true;
@@ -6122,6 +6153,7 @@ describe('reactive forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NoCVAComponent {
         form = new FormGroup({control: new FormControl()});
@@ -6150,6 +6182,7 @@ describe('reactive forms integration tests', () => {
           }
         </form>`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class FormArrayComp {
         controls = [new FormControl('fish'), new FormControl('cat'), new FormControl('dog')];
@@ -6254,6 +6287,8 @@ describe('reactive forms integration tests', () => {
             </form>
           `,
           standalone: false,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class FormWithFormArrayName {
           public form = new FormArray([
@@ -6340,6 +6375,7 @@ class UniqLoginValidator implements AsyncValidator {
   selector: 'form-control-comp',
   template: `<input type="text" [formControl]="control" />`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlComp {
   control!: FormControl;
@@ -6351,6 +6387,7 @@ class FormControlComp {
     <input type="text" formControlName="login" />
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormGroupComp {
   control!: FormControl;
@@ -6368,6 +6405,7 @@ class FormGroupComp {
     <input *ngIf="form.contains('email')" formControlName="email" />
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedFormGroupNameComp {
   form!: FormGroup;
@@ -6383,6 +6421,7 @@ class NestedFormGroupNameComp {
     </div>
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormArrayComp {
   form!: FormGroup;
@@ -6399,6 +6438,7 @@ class FormArrayComp {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NestedFormArrayNameComp {
   form!: FormGroup;
@@ -6415,6 +6455,7 @@ class NestedFormArrayNameComp {
     </div>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormArrayNestedGroup {
   form!: FormGroup;
@@ -6428,6 +6469,7 @@ class FormArrayNestedGroup {
     <input type="text" formControlName="password" [(ngModel)]="password" />
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormGroupNgModel {
   form!: FormGroup;
@@ -6442,6 +6484,7 @@ class FormGroupNgModel {
     <input type="text" [formControl]="passwordControl" [(ngModel)]="password" />
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlNgModel {
   control!: FormControl;
@@ -6459,6 +6502,7 @@ class FormControlNgModel {
     <input type="text" formControlName="pattern" pattern=".{3,}" />
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class LoginIsEmptyWrapper {
   form!: FormGroup;
@@ -6473,6 +6517,7 @@ class LoginIsEmptyWrapper {
     <input name="pattern" type="text" formControlName="pattern" [pattern]="pattern" />
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class ValidationBindingsForm {
   form!: FormGroup;
@@ -6486,6 +6531,7 @@ class ValidationBindingsForm {
   selector: 'form-control-checkbox-validator',
   template: `<input type="checkbox" [formControl]="control" />`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlCheckboxRequiredValidator {
   control!: FormControl;
@@ -6497,6 +6543,7 @@ class FormControlCheckboxRequiredValidator {
     <input type="text" formControlName="login" uniq-login-validator="expected" />
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class UniqLoginWrapper {
   form!: FormGroup;
@@ -6510,6 +6557,7 @@ class UniqLoginWrapper {
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormGroupWithValidators {
   form = new FormGroup({login: new FormControl('INITIAL')});
@@ -6523,6 +6571,7 @@ class FormGroupWithValidators {
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlWithAsyncValidatorFn {
   control = new FormControl('INITIAL');
@@ -6543,6 +6592,7 @@ class FormControlWithAsyncValidatorFn {
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlWithValidators {
   form: FormGroup = new FormGroup({login: new FormControl('INITIAL')});
@@ -6559,6 +6609,7 @@ class FormControlWithValidators {
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MultipleFormControls {
   control = new FormControl('a');
@@ -6576,6 +6627,7 @@ class MultipleFormControls {
     </div>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgForFormControlWithValidators {
   form: FormGroup = new FormGroup({login: new FormControl('a')});
@@ -6588,6 +6640,7 @@ class NgForFormControlWithValidators {
     <input type="number" formControlName="pin" [max]="max" [min]="min" />
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MinMaxFormControlNameComp {
   control!: FormControl;
@@ -6602,6 +6655,7 @@ class MinMaxFormControlNameComp {
     <input type="number" [formControl]="control" [max]="max" [min]="min" />
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class MinMaxFormControlComp {
   control!: FormControl;
@@ -6619,6 +6673,7 @@ class MinMaxFormControlComp {
     </dialog>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeDialogForm {
   @ViewChild('form') form!: ElementRef<HTMLFormElement>;
@@ -6634,6 +6689,7 @@ class NativeDialogForm {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class RadioForm {
   form = new FormGroup({

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -7,8 +7,20 @@
  */
 
 import {CommonModule, ɵgetDOM as getDOM} from '@angular/common';
-import {Component, Directive, ElementRef, forwardRef, Input, Type, ViewChild} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Directive,
+  ElementRef,
+  forwardRef,
+  Input,
+  Type,
+  ViewChild,
+} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {dispatchEvent, sortedClassList, timeout, useAutoTick} from '@angular/private/testing';
+import {merge} from 'rxjs';
 import {
   AbstractControl,
   AsyncValidator,
@@ -25,9 +37,6 @@ import {
   NgModel,
   Validator,
 } from '../index';
-import {By} from '@angular/platform-browser';
-import {dispatchEvent, useAutoTick, timeout, sortedClassList} from '@angular/private/testing';
-import {merge} from 'rxjs';
 
 import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integration_spec';
 
@@ -82,6 +91,7 @@ describe('template-driven forms integration tests', () => {
         selector: 'app-root',
         template: `<input type="radio" value="one" [(ngModel)]="active" />`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         active = 'one';
@@ -351,6 +361,7 @@ describe('template-driven forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         private _counter = 0;
@@ -413,6 +424,7 @@ describe('template-driven forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class App {
         private _counter = 0;
@@ -2112,6 +2124,7 @@ describe('template-driven forms integration tests', () => {
           <my-custom-component name="max" ngModel [max]="max"></my-custom-component>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {}
 
@@ -2134,6 +2147,7 @@ describe('template-driven forms integration tests', () => {
       @Component({
         template: '<input type="range" min="10" max="20">',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {}
 
@@ -2160,6 +2174,7 @@ describe('template-driven forms integration tests', () => {
           template:
             '<form><input name="amount" ngModel [minlength]="minlen" [maxlength]="maxlen"></form>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MinLengthMaxLengthComponent {
           minlen: number | null = null;
@@ -2249,6 +2264,7 @@ describe('template-driven forms integration tests', () => {
           template:
             '<form><input type="number" name="minmaxinput" ngModel [min]="minlen" [max]="maxlen"></form>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class MinLengthMaxLengthComponent {
           minlen: number | null = null;
@@ -2609,6 +2625,7 @@ describe('template-driven forms integration tests', () => {
           </form>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class NgModelNoOpValidation {
         validatorInput = 'foo';
@@ -2764,6 +2781,7 @@ describe('template-driven forms integration tests', () => {
   selector: 'standalone-ng-model',
   template: ` <input type="text" [(ngModel)]="name" /> `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class StandaloneNgModel {
   name!: string;
@@ -2777,6 +2795,7 @@ class StandaloneNgModel {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelForm {
   name!: string | null;
@@ -2790,6 +2809,7 @@ class NgModelForm {
   selector: 'ng-model-native-validate-form',
   template: `<form ngNativeValidate></form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelNativeValidateForm {}
 
@@ -2805,6 +2825,7 @@ class NgModelNativeValidateForm {}
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelGroupForm {
   first!: string;
@@ -2825,6 +2846,7 @@ class NgModelGroupForm {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelValidBinding {
   first!: string;
@@ -2841,6 +2863,7 @@ class NgModelValidBinding {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelNgIfForm {
   first!: string;
@@ -2862,6 +2885,7 @@ class NgModelNgIfForm {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelNestedForm {
   first!: string;
@@ -2876,6 +2900,7 @@ class NgModelNestedForm {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgNoFormComp {}
 
@@ -2887,6 +2912,7 @@ class NgNoFormComp {}
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class InvalidNgModelNoName {}
 
@@ -2899,6 +2925,7 @@ class InvalidNgModelNoName {}
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelOptionsStandalone {
   one!: string;
@@ -2918,6 +2945,7 @@ class NgModelOptionsStandalone {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelValidationBindings {
   required!: boolean;
@@ -2940,6 +2968,7 @@ class NgModelValidationBindings {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelMultipleValidators {
   required!: boolean;
@@ -2953,6 +2982,7 @@ class NgModelMultipleValidators {
     <input type="checkbox" [(ngModel)]="accepted" [required]="required" name="checkbox" />
   </form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelCheckboxRequiredValidator {
   accepted: boolean = false;
@@ -2963,6 +2993,7 @@ class NgModelCheckboxRequiredValidator {
   selector: 'ng-model-email',
   template: `<form><input type="email" ngModel [email]="validatorEnabled" name="email" /></form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelEmailValidator {
   validatorEnabled: boolean = false;
@@ -2985,6 +3016,7 @@ class NgAsyncValidator implements AsyncValidator {
   selector: 'ng-model-async-validation',
   template: `<input name="async" ngModel ng-async-validator />`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelAsyncValidation {}
 
@@ -2996,6 +3028,7 @@ class NgModelAsyncValidation {}
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelChangesForm {
   name!: string;
@@ -3013,6 +3046,7 @@ class NgModelChangesForm {
     <input #ngModel="ngModel" ngModel [maxlength]="4" (ngModelChange)="onNgModelChange(ngModel)" />
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelChangeState {
   onNgModelChange = () => {};
@@ -3022,6 +3056,7 @@ class NgModelChangeState {
   selector: 'ng-model-max',
   template: `<form><input name="max" type="number" ngModel [max]="max" /></form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelMaxValidator {
   max!: number;
@@ -3031,6 +3066,7 @@ class NgModelMaxValidator {
   selector: 'ng-model-min',
   template: `<form><input name="min" type="number" ngModel [min]="min" /></form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelMinValidator {
   min!: number;
@@ -3040,6 +3076,7 @@ class NgModelMinValidator {
   selector: 'ng-model-min-max',
   template: ` <form><input name="min_max" type="number" ngModel [min]="min" [max]="max" /></form>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelMinMaxValidator {
   min!: number | string;
@@ -3064,6 +3101,7 @@ class CustomDirective {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelNoMinMaxValidator {
   min!: number;
@@ -3081,6 +3119,7 @@ class NgModelNoMinMaxValidator {
     </dialog>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NativeDialogForm {
   @ViewChild('form') form!: ElementRef<HTMLFormElement>;

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -24,6 +24,9 @@ import {
   ViewChild,
 } from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By, ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {dispatchEvent, isNode, timeout, useAutoTick} from '@angular/private/testing';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -38,9 +41,6 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '../index';
-import {By, ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
-import {dispatchEvent, useAutoTick, timeout, isNode} from '@angular/private/testing';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
 describe('value accessors', () => {
   useAutoTick();
@@ -1800,6 +1800,7 @@ class FormControlSelectNgValue {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectWithCompareFn {
   compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
@@ -1819,6 +1820,7 @@ class FormControlSelectWithCompareFn {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectWithComparePerfFn {
   compareFnCalls = 0;
@@ -1846,6 +1848,7 @@ class FormControlSelectWithComparePerfFn {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectWithCompareTrackByFn {
   compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
@@ -1866,6 +1869,7 @@ class FormControlSelectWithCompareTrackByFn {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectMultiple {
   cities = ['SF', 'NY'];
@@ -1880,6 +1884,7 @@ class FormControlSelectMultiple {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectMultipleNgValue {
   cities = [
@@ -1897,6 +1902,7 @@ class FormControlSelectMultipleNgValue {
     </select>
   </div>`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlSelectMultipleWithCompareFn {
   compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
@@ -1916,6 +1922,7 @@ class FormControlSelectMultipleWithCompareFn {
     </select>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelSelectForm {
   selectedCity: {[k: string]: string} = {};
@@ -1933,6 +1940,7 @@ class NgModelSelectForm {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelSelectWithPlaceholderForm {
   cities: any[] = [];
@@ -1961,6 +1969,7 @@ class NgModelSelectWithNullForm {
     </select>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelSelectWithCustomCompareFnForm {
   compareFn: (o1: any, o2: any) => boolean = (o1: any, o2: any) =>
@@ -1993,6 +2002,7 @@ class NgModelSelectMultipleWithCustomCompareFnForm {
     </select>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelSelectMultipleForm {
   selectedCities!: any[];
@@ -2003,6 +2013,7 @@ class NgModelSelectMultipleForm {
   selector: 'form-control-range-input',
   template: `<input type="range" [formControl]="control" />`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class FormControlRangeInput {
   control!: FormControl;
@@ -2012,6 +2023,7 @@ class FormControlRangeInput {
   selector: 'ng-model-range-form',
   template: '<input type="range" [(ngModel)]="val">',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelRangeForm {
   val: any;
@@ -2028,6 +2040,7 @@ class NgModelRangeForm {
     <input type="radio" [formControl]="showRadio" value="yes" />
     <input type="radio" [formControl]="showRadio" value="no" />`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class FormControlRadioButtons {
   form!: FormGroup;
@@ -2046,6 +2059,7 @@ export class FormControlRadioButtons {
     </form>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class NgModelRadioForm {
   food!: string;

--- a/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/async/test/animation_renderer_spec.ts
@@ -36,16 +36,17 @@ import {
   ViewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../../index';
-import {InjectableAnimationEngine} from '../../../animations/src/providers';
 import {el, isNode} from '@angular/private/testing';
+import {InjectableAnimationEngine} from '../../../animations/src/providers';
+import {ɵDomRendererFactory2 as DomRendererFactory2} from '../../../index';
 
+import {ChangeDetectionStrategy} from '@angular/compiler';
+import {provideAnimationsAsync} from '../public_api';
 import {
   AsyncAnimationRendererFactory,
   DynamicDelegationRenderer,
   ɵASYNC_ANIMATION_LOADING_SCHEDULER_FN,
 } from '../src/async_animation_renderer';
-import {provideAnimationsAsync} from '../public_api';
 
 type AnimationBrowserModule = typeof import('@angular/animations/browser');
 
@@ -310,6 +311,7 @@ type AnimationBrowserModule = typeof import('@angular/animations/browser');
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           exp: any;
@@ -352,6 +354,7 @@ type AnimationBrowserModule = typeof import('@angular/animations/browser');
             trigger('animation2', [transition(':leave', [])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           exp1: any = true;

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -17,6 +17,7 @@ import {
   ɵAnimationEngine as AnimationEngine,
   ɵAnimationRendererFactory as AnimationRendererFactory,
 } from '@angular/animations/browser';
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {
   APP_INITIALIZER,
   Component,
@@ -31,14 +32,14 @@ import {
   ViewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {el, isNode, withBody} from '@angular/private/testing';
 import {bootstrapApplication, platformBrowser} from '../../index';
+import {DomRendererFactory2} from '../../src/dom/dom_renderer';
+import {provideAnimationsAsync} from '../async';
 import {
   BrowserAnimationsModule,
   ɵInjectableAnimationEngine as InjectableAnimationEngine,
 } from '../index';
-import {provideAnimationsAsync} from '../async';
-import {DomRendererFactory2} from '../../src/dom/dom_renderer';
-import {withBody, isNode, el} from '@angular/private/testing';
 
 (function () {
   if (isNode) return;
@@ -214,6 +215,7 @@ import {withBody, isNode, el} from '@angular/private/testing';
             ]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           exp: any;
@@ -259,6 +261,7 @@ import {withBody, isNode, el} from '@angular/private/testing';
             trigger('animation2', [transition(':leave', [])]),
           ],
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Cmp {
           exp1: any = true;

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -7,19 +7,26 @@
  */
 
 import {animate, style, transition, trigger} from '@angular/animations';
-import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, ɵgetDOM as getDOM, isPlatformBrowser} from '@angular/common';
 import {
+  inject as _inject,
   ANIMATION_MODULE_TYPE,
+  APP_ID,
   APP_INITIALIZER,
+  ApplicationRef,
+  ChangeDetectionStrategy,
   Compiler,
   Component,
+  ComponentRef,
+  ɵConsole as Console,
+  ɵcreateOrReusePlatformInjector as createOrReusePlatformInjector,
   createPlatformFactory,
   CUSTOM_ELEMENTS_SCHEMA,
+  destroyPlatform,
   Directive,
   ErrorHandler,
   importProvidersFrom,
   Inject,
-  inject as _inject,
   InjectionToken,
   Injector,
   LOCALE_ID,
@@ -29,6 +36,7 @@ import {
   OnDestroy,
   PLATFORM_ID,
   PLATFORM_INITIALIZER,
+  providePlatformInitializer,
   Provider,
   provideZoneChangeDetection,
   Sanitizer,
@@ -38,20 +46,12 @@ import {
   TransferState,
   Type,
   VERSION,
-  EnvironmentProviders,
-  ApplicationRef,
-  ɵConsole as Console,
-  ComponentRef,
-  destroyPlatform,
-  providePlatformInitializer,
-  ɵcreateOrReusePlatformInjector as createOrReusePlatformInjector,
-  APP_ID,
 } from '@angular/core';
-import {ɵLog as Log, inject, TestBed} from '@angular/core/testing';
-import {BrowserModule} from '../../index';
-import {provideAnimations, provideNoopAnimations} from '../../animations';
-import {expect} from '@angular/private/testing/matchers';
+import {inject, ɵLog as Log, TestBed} from '@angular/core/testing';
 import {isNode, withBody} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
+import {provideAnimations, provideNoopAnimations} from '../../animations';
+import {BrowserModule} from '../../index';
 
 import {bootstrapApplication, platformBrowser} from '../../src/browser';
 
@@ -224,6 +224,7 @@ describe('bootstrap factory method', () => {
     @Component({
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SimpleComp {
       name = 'SimpleComp';
@@ -232,6 +233,7 @@ describe('bootstrap factory method', () => {
     @Component({
       selector: 'hello-app-2',
       template: 'Hello from {{ name }}!',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class SimpleComp2 {
       name = 'SimpleComp2';
@@ -240,6 +242,7 @@ describe('bootstrap factory method', () => {
     @Component({
       selector: 'hello-app',
       template: 'Hello from {{ name }}!',
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class ComponentWithDeps {
       constructor(@Inject(NAME) public name: string) {}
@@ -249,6 +252,7 @@ describe('bootstrap factory method', () => {
       selector: 'hello-app-2',
       template: 'Hello from {{ name }}!',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class NonStandaloneComp {
       name = 'NonStandaloneComp';
@@ -820,6 +824,7 @@ describe('bootstrap factory method', () => {
       selector: 'hello-app',
       template: '<div id="button-a" (click)="onClick()">{{title}}</div>',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CompA {
       title: string = '';
@@ -838,6 +843,7 @@ describe('bootstrap factory method', () => {
       selector: 'hello-app-2',
       template: '<div id="button-b" (click)="onClick()">{{title}}</div>',
       standalone: false,
+      changeDetection: ChangeDetectionStrategy.Eager,
     })
     class CompB {
       title: string = '';

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -5,16 +5,17 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import {ChangeDetectionStrategy} from '@angular/compiler';
 import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {isNode} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 import {By} from '../../src/dom/debug/by';
 import {
   addBaseHrefToCssSourceMap,
   NAMESPACE_URIS,
   REMOVE_STYLES_ON_COMPONENT_DESTROY,
 } from '../../src/dom/dom_renderer';
-import {expect} from '@angular/private/testing/matchers';
-import {isNode} from '@angular/private/testing';
 
 describe('DefaultDomRendererV2', () => {
   if (isNode) {
@@ -520,6 +521,7 @@ class CmpEncapsulationIsolatedShadowWithChildren {}
     <cmp-none></cmp-none>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class SomeApp {}
 
@@ -527,6 +529,7 @@ export class SomeApp {}
   selector: 'shadow-parent-app-with-children',
   template: ` <cmp-shadow-children></cmp-shadow-children> `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class IsolatedShadowComponentParentApp {}
 
@@ -534,6 +537,7 @@ export class IsolatedShadowComponentParentApp {}
   selector: 'test-cmp',
   template: '',
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 class TestCmp {
   constructor(public renderer: Renderer2) {}
@@ -549,6 +553,7 @@ class TestCmp {
     <cmp-none *ngIf="!componentTwoInstanceHidden && !showEmulatedComponents"></cmp-none>
   `,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class SomeAppForCleanUp {
   componentOneInstanceHidden = false;

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -8,6 +8,7 @@
 
 import {ResourceLoader} from '@angular/compiler';
 import {
+  ChangeDetectionStrategy,
   Compiler,
   Component,
   ComponentFactoryResolver,
@@ -21,8 +22,8 @@ import {
   NgModule,
   Optional,
   Pipe,
-  TransferState,
   SkipSelf,
+  TransferState,
   Type,
 } from '@angular/core';
 import {
@@ -34,8 +35,8 @@ import {
   waitForAsync,
   withModule,
 } from '@angular/core/testing';
-import {expect} from '@angular/private/testing/matchers';
 import {isBrowser} from '@angular/private/testing';
+import {expect} from '@angular/private/testing/matchers';
 
 // Services, and components for the tests.
 
@@ -72,6 +73,7 @@ class ParentComp {}
   selector: 'my-if-comp',
   template: `MyIf(<span *ngIf="showMore">More</span>)`,
   standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 @Injectable()
 class MyIfComp {

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -26,6 +26,7 @@ import {computeMsgId} from '@angular/compiler';
 import {
   afterEveryRender,
   ApplicationRef,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   ɵCLIENT_RENDER_MODE_FLAG as CLIENT_RENDER_MODE_FLAG,
   Component,
@@ -5854,6 +5855,7 @@ describe('platform-server full application hydration integration', () => {
             Project?: <span>{{ project ? 'yes' : 'no' }}</span>
             <ng-content *ngIf="project" />
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ProjectorCmp {
           @Input() project: boolean = false;
@@ -5868,6 +5870,7 @@ describe('platform-server full application hydration integration', () => {
               <h2>This node is not projected as well.</h2>
             </projector-cmp>
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           project = false;
@@ -5917,6 +5920,7 @@ describe('platform-server full application hydration integration', () => {
             Project?: <span>{{ project ? 'yes' : 'no' }}</span>
             <ng-content *ngIf="project" />
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class ProjectorCmp {
           @Input() project: boolean = false;
@@ -5931,6 +5935,7 @@ describe('platform-server full application hydration integration', () => {
               <h2>This node is projected as well.</h2>
             </projector-cmp>
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           project = true;
@@ -6858,6 +6863,7 @@ describe('platform-server full application hydration integration', () => {
               else block
             }
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           conditionA = false;
@@ -7323,6 +7329,7 @@ describe('platform-server full application hydration integration', () => {
             @let greeting = name + '!!!';
             Hello, {{ greeting }}
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           name = 'Frodo';
@@ -7359,6 +7366,7 @@ describe('platform-server full application hydration integration', () => {
             @let result = plusTwo + 1;
             Result: {{ result }}
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           value = 1;
@@ -7406,6 +7414,7 @@ describe('platform-server full application hydration integration', () => {
             @let result = value | double;
             Result: {{ result }}
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           value = 1;
@@ -7447,6 +7456,7 @@ describe('platform-server full application hydration integration', () => {
 
             @let one = value + 1;
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class SimpleComponent {
           value = 0;

--- a/packages/upgrade/static/test/integration/change_detection_spec.ts
+++ b/packages/upgrade/static/test/integration/change_detection_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   destroyPlatform,
   Directive,
@@ -40,6 +41,7 @@ withEachNg1Version(() => {
         selector: 'my-app',
         template: '',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {}
 
@@ -125,6 +127,7 @@ withEachNg1Version(() => {
         selector: 'ng2',
         template: `{{ l('2A') }}<ng1a></ng1a>{{ l('2B') }}<ng1b></ng1b>{{ l('2C') }}`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2Component {
         l = l;
@@ -163,6 +166,7 @@ withEachNg1Version(() => {
         selector: 'my-app',
         template: '<my-child [value]="value"></my-child>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class AppComponent {
         value?: number;
@@ -175,6 +179,7 @@ withEachNg1Version(() => {
         selector: 'my-child',
         template: '<div>{{ valueFromPromise }}</div>',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class ChildComponent {
         valueFromPromise?: number;

--- a/packages/upgrade/static/test/integration/downgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_component_spec.ts
@@ -70,6 +70,7 @@ withEachNg1Version(() => {
           'oneWayA: {{oneWayA}}; oneWayB: {{oneWayB}}; ' +
           'twoWayA: {{twoWayA}}; twoWayB: {{twoWayB}}; ({{ngOnChangesCount}})',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2Component implements OnChanges {
         ngOnChangesCount = 0;
@@ -182,6 +183,7 @@ withEachNg1Version(() => {
         selector: 'ng2',
         inputs: ['message'],
         template: 'Message: {{message()}}',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {
@@ -269,6 +271,7 @@ withEachNg1Version(() => {
         selector: 'ng2',
         template: `model: {{ model }};`,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2Component implements OnChanges {
         ngOnChangesCount = 0;
@@ -317,6 +320,7 @@ withEachNg1Version(() => {
         selector: 'ng2',
         template: '{{ value1 }} | {{ value2 }}',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2Component {
         @Input() value1 = -1;
@@ -385,6 +389,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '{{ value1 }} | {{ value2 }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {
@@ -450,6 +455,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '{{ value }}',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {
@@ -487,6 +493,7 @@ withEachNg1Version(() => {
         selector: 'ng2',
         template: ` ngOnChangesCount: {{ ngOnChangesCount }} | firstChangesCount:
           {{ firstChangesCount }} | initialValue: {{ initialValue }}`,
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component implements OnChanges {
@@ -548,6 +555,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '<span>{{_value}}</span>',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2 {
@@ -615,6 +623,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '<ul><li>test1</li><li>test2</li></ul>',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component implements OnDestroy {
@@ -680,6 +689,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2-outer',
         template: '<div *ngIf="!destroyIt"><ng1></ng1></div>',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2OuterComponent {
@@ -689,6 +699,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2-inner',
         template: 'test',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2InnerComponent implements OnDestroy {
@@ -738,6 +749,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '<span>NG2</span>',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {}
@@ -801,6 +813,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: 'test',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {}
@@ -846,6 +859,7 @@ withEachNg1Version(() => {
       @Component({
         selector: '[itWorks]',
         template: 'It works',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class WorksComponent {}
@@ -870,6 +884,7 @@ withEachNg1Version(() => {
       @Component({
         selector: '[itWorks]',
         template: 'It works',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class WorksComponent {}
@@ -877,6 +892,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'root-component',
         template: '<span itWorks></span>!',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class RootComponent {}
@@ -911,6 +927,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'child',
         template: 'child',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class ChildComponent {
@@ -948,6 +965,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2B',
         template: "{{ 'Ng2 template' }}",
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2ComponentB {}
@@ -978,6 +996,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {
@@ -996,6 +1015,7 @@ withEachNg1Version(() => {
 
       @Component({
         template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class LazyLoadedComponent {
@@ -1031,6 +1051,7 @@ withEachNg1Version(() => {
       @Component({
         selector: 'ng2',
         template: '',
+        changeDetection: ChangeDetectionStrategy.Eager,
         standalone: false,
       })
       class Ng2Component {}
@@ -1069,7 +1090,11 @@ withEachNg1Version(() => {
     afterEach(() => destroyPlatform());
 
     it('should downgrade a standalone component using NgModule APIs', waitForAsync(() => {
-      @Component({selector: 'ng2', template: 'Hi from Angular!'})
+      @Component({
+        selector: 'ng2',
+        template: 'Hi from Angular!',
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
       class Ng2Component {}
 
       const ng1Module = angular

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -12,6 +12,7 @@ import {
   AfterViewChecked,
   AfterViewInit,
   ApplicationRef,
+  ChangeDetectionStrategy,
   Compiler,
   Component,
   destroyPlatform,
@@ -28,10 +29,10 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  provideZoneChangeDetection,
   StaticProvider,
   Type,
   ViewRef,
-  provideZoneChangeDetection,
 } from '@angular/core';
 import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
@@ -1139,6 +1140,7 @@ withEachNg1Version(() => {
             <ng-content></ng-content>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component
           implements

--- a/packages/upgrade/static/test/integration/upgrade_component_spec.ts
+++ b/packages/upgrade/static/test/integration/upgrade_component_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   destroyPlatform,
   Directive,
@@ -107,6 +108,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -160,6 +162,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -206,6 +209,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -255,6 +259,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -311,6 +316,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -361,6 +367,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -415,6 +422,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -503,6 +511,7 @@ withEachNg1Version(() => {
             <ng1D>Ignore this</ng1D>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -575,6 +584,7 @@ withEachNg1Version(() => {
             | Outside: {{ dataA }}, {{ dataB }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           dataA = 'foo';
@@ -655,6 +665,7 @@ withEachNg1Version(() => {
             | Outside: {{ dataA.value }}, {{ dataB.value }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           dataA = {value: 'foo'};
@@ -736,6 +747,7 @@ withEachNg1Version(() => {
             <ng1 [(inputAttrA)]="dataA" [(inputB)]="dataB"></ng1>
             | Outside: {{ dataA.value }}, {{ dataB.value }}
           `,
+          changeDetection: ChangeDetectionStrategy.Eager,
           standalone: false,
         })
         class Ng2Component {
@@ -815,6 +827,7 @@ withEachNg1Version(() => {
             | Outside: {{ dataA }}, {{ dataB }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           dataA = 'foo';
@@ -914,6 +927,7 @@ withEachNg1Version(() => {
             {{ event }} - {{ last }}, {{ first }}, {{ city }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           first = 'Victor';
@@ -993,6 +1007,7 @@ withEachNg1Version(() => {
             {{ dataB.value }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           dataA = {value: 'foo'};
@@ -1087,6 +1102,7 @@ withEachNg1Version(() => {
             | {{ someText }} - Data: {{ dataA }} - Length: {{ dataA.length }}
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           someText = 'ng2';
@@ -1167,6 +1183,7 @@ withEachNg1Version(() => {
           selector: 'ng2-x',
           template: 'ng2X(<ng1A></ng1A>)',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentX {}
 
@@ -1226,6 +1243,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1278,6 +1296,7 @@ withEachNg1Version(() => {
         @Component({
           selector: 'ng2',
           template: '<ng1A></ng1A>',
+          changeDetection: ChangeDetectionStrategy.Eager,
           standalone: false,
         })
         class Ng2Component {}
@@ -1332,6 +1351,7 @@ withEachNg1Version(() => {
         @Component({
           selector: 'ng2',
           template: '<ng1A></ng1A>',
+          changeDetection: ChangeDetectionStrategy.Eager,
           standalone: false,
         })
         class Ng2Component {}
@@ -1386,6 +1406,7 @@ withEachNg1Version(() => {
         @Component({
           selector: 'ng2',
           template: '<ng1A></ng1A>',
+          changeDetection: ChangeDetectionStrategy.Eager,
           standalone: false,
         })
         class Ng2Component {}
@@ -1444,6 +1465,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1519,6 +1541,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1596,6 +1619,7 @@ withEachNg1Version(() => {
             <ng1B title="WORKS"></ng1B>
           `,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1654,6 +1678,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1 title="WORKS"></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           dataA = 'foo';
@@ -1710,6 +1735,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1 title="WORKS"></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1775,6 +1801,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -1839,6 +1866,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: '<ng1></ng1>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -1899,6 +1927,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: '<ng1A></ng1A>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -1968,6 +1997,7 @@ withEachNg1Version(() => {
             selector: 'ng2-a',
             template: '<ng1A></ng1A>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2ComponentA {}
 
@@ -1975,6 +2005,7 @@ withEachNg1Version(() => {
             selector: 'ng2-b',
             template: '<ng1B></ng1B>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2ComponentB {}
 
@@ -1982,6 +2013,7 @@ withEachNg1Version(() => {
             selector: 'ng2-c',
             template: '<ng1C></ng1C>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2ComponentC {}
 
@@ -2063,6 +2095,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: '<ng1></ng1>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -2148,6 +2181,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: 'ng2(<div><ng1B></ng1B> | <ng1C></ng1C></div>)',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -2223,6 +2257,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: 'ng2(<div><ng1B></ng1B></div>)',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -2288,6 +2323,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: '<ng1B></ng1B>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -2360,6 +2396,7 @@ withEachNg1Version(() => {
             selector: 'ng2',
             template: '<ng1C></ng1C>',
             standalone: false,
+            changeDetection: ChangeDetectionStrategy.Eager,
           })
           class Ng2Component {}
 
@@ -2417,6 +2454,7 @@ withEachNg1Version(() => {
           selector: 'ng2A',
           template: 'ng2A(<ng1>{{ value }} | <ng2B *ngIf="showB"></ng2B></ng1>)',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentA {
           value = 'foo';
@@ -2430,6 +2468,7 @@ withEachNg1Version(() => {
           selector: 'ng2B',
           template: 'ng2B({{ value }})',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentB {
           value = 'bar';
@@ -2504,6 +2543,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: 'ng2(<ng1>{{ value }}</ng1> | <ng1></ng1>)',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           value = 'from-ng2';
@@ -2574,6 +2614,7 @@ withEachNg1Version(() => {
             </ng1>
             )`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           x = 'foo';
@@ -2659,6 +2700,7 @@ withEachNg1Version(() => {
             <ng1><content-x>ignored x</content-x><content-y>ignored y</content-y></ng1>
             )`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           x = 'foo';
@@ -2748,6 +2790,7 @@ withEachNg1Version(() => {
             >
             )`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           x = 'ng2X';
@@ -2820,6 +2863,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -2884,6 +2928,7 @@ withEachNg1Version(() => {
             </ng1>
             )`,
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           x = 'foo';
@@ -2993,6 +3038,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           data = {foo: 'bar'};
@@ -3155,6 +3201,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A [inputA]="data"></ng1A> | <ng1B [inputB]="data"></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           data = {foo: 'bar'};
@@ -3304,6 +3351,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3383,6 +3431,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3463,6 +3512,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3542,6 +3592,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3620,6 +3671,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3715,6 +3767,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1A></ng1A> | <ng1B></ng1B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -3806,6 +3859,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           @Input() show: boolean = false;
@@ -3915,6 +3969,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<div *ngIf="show"><ng1A></ng1A> | <ng1B></ng1B></div>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           @Input() show: boolean = false;
@@ -4008,6 +4063,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1 value="foo"></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {}
 
@@ -4067,6 +4123,7 @@ withEachNg1Version(() => {
           selector: 'ng2A',
           template: '<ng2B *ngIf="!destroyIt"></ng2B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentA {
           destroyIt = false;
@@ -4080,6 +4137,7 @@ withEachNg1Version(() => {
           selector: 'ng2B',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentB {}
 
@@ -4143,6 +4201,7 @@ withEachNg1Version(() => {
           selector: 'ng2A',
           template: '<ng2B *ngIf="!destroyIt"></ng2B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentA {
           destroyIt = false;
@@ -4156,6 +4215,7 @@ withEachNg1Version(() => {
           selector: 'ng2B',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentB {}
 
@@ -4222,6 +4282,7 @@ withEachNg1Version(() => {
           selector: 'ng2A',
           template: '<ng2B *ngIf="!destroyIt"></ng2B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentA {
           destroyIt = false;
@@ -4235,6 +4296,7 @@ withEachNg1Version(() => {
           selector: 'ng2B',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentB {}
 
@@ -4303,6 +4365,7 @@ withEachNg1Version(() => {
           selector: 'ng2A',
           template: '<ng2B *ngIf="!destroyIt"></ng2B>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentA {
           destroyIt = false;
@@ -4316,6 +4379,7 @@ withEachNg1Version(() => {
           selector: 'ng2B',
           template: '<ng1></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2ComponentB {}
 
@@ -4378,6 +4442,7 @@ withEachNg1Version(() => {
           selector: 'ng2',
           template: '<ng1 *ngIf="doShow"></ng1>',
           standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
         })
         class Ng2Component {
           doShow: boolean = false;
@@ -4449,6 +4514,7 @@ withEachNg1Version(() => {
         selector: 'ng2-a',
         template: 'ng2A(<ng1X></ng1X>)',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentA {}
 
@@ -4456,6 +4522,7 @@ withEachNg1Version(() => {
         selector: 'ng2-b',
         template: 'ng2B',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentB {}
 
@@ -4551,6 +4618,7 @@ withEachNg1Version(() => {
           </ng1X>
         `,
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentA {
         ng2ADataA = {value: 'foo'};
@@ -4566,6 +4634,7 @@ withEachNg1Version(() => {
         selector: 'ng2-b',
         template: 'ng2B({{ ng2BInputA }}, {{ ng2BInputC }})',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentB {
         @Input('ng2BInput1') ng2BInputA: any;
@@ -4737,6 +4806,7 @@ withEachNg1Version(() => {
         selector: 'ng2-a',
         template: 'ng2A(<ng1A></ng1A>)',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentA {}
 
@@ -4744,6 +4814,7 @@ withEachNg1Version(() => {
         selector: 'ng2-b',
         template: 'ng2B(<ng1B></ng1B>)',
         standalone: false,
+        changeDetection: ChangeDetectionStrategy.Eager,
       })
       class Ng2ComponentB {}
 
@@ -4788,7 +4859,12 @@ withEachNg1Version(() => {
         }
 
         // Define `Ng2Component`
-        @Component({selector: 'ng2', template: '<ng1></ng1>', standalone: false})
+        @Component({
+          selector: 'ng2',
+          template: '<ng1></ng1>',
+          standalone: false,
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
         class Ng2Component {}
 
         // Define `ng1Module`


### PR DESCRIPTION
The default change detection strategy is now OnPush.

BREAKING CHANGE: Component with undefined `changeDetection` property are now `OnPush` by default. Specify `changeDetection: ChangeDetectionStrategy.Eager` to keep the previous behavior.
