### PR TITLE
feat(forms): add hasError to signal forms field state

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -501,6 +501,7 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
     readonly fieldTree: ReadonlyFieldTree<unknown, TKey>;
     focusBoundControl(options?: FocusOptions): void;
     readonly formFieldBindings: Signal<readonly FormFieldBinding[]>;
+    hasError(kind: string): boolean;
     hasMetadata(key: MetadataKey<any, any, any>): boolean;
     readonly hidden: Signal<boolean>;
     readonly invalid: Signal<boolean>;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -480,6 +480,43 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
   hasMetadata(key: MetadataKey<any, any, any>): boolean;
 
   /**
+   * @description
+   *
+   * Reports whether this field currently has a validation error of the given kind.
+   *
+   * This is a helper similar to `FormControl.hasError` for Signal Forms field state.
+   * It provides a direct way to check for a specific validation error without depending on the
+   * position of an item in the array returned by `errors()`.
+   *
+   * @param kind The kind of validation error to check, for example `'required'`, `'email'`,
+   *   or a custom validation error kind.
+   * @returns `true` if an error with the given kind is currently present on this field,
+   *   otherwise `false`.
+   *
+   * @usageNotes
+   *
+   * Use this helper in templates when rendering validation messages for specific errors.
+   *
+   * ```angular-html
+   * @if (loginForm.email().hasError('required')) {
+   *   <div>Email is required.</div>
+   * }
+   *
+   * @if (loginForm.email().hasError('email')) {
+   *   <div>Please enter a valid email address.</div>
+   * }
+   *
+   * @if (addressForm.postalCode().hasError('invalidPostalCode')) {
+   *   <div>Please enter a valid postal code.</div>
+   * }
+   * ```
+   *
+   * This is especially useful when a field may have multiple validation errors, since it avoids
+   * hard-coded positional access patterns such as `errors()[0]` or `errors()[1]`.
+   */
+  hasError(kind: string): boolean;
+
+  /**
    * Focuses the first UI control in the DOM that is bound to this field state.
    * If no UI control is bound, does nothing.
    * @param options Optional focus options to pass to the native focus() method.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -244,6 +244,10 @@ export class FieldNode implements FieldState<unknown> {
     return this.metadataState.has(key);
   }
 
+  hasError(kind: string): boolean {
+    return this.errors().some((error) => error.kind === kind);
+  }
+
   markAsTouched(options?: MarkAsTouchedOptions): void {
     untracked(() => {
       this.markAsTouchedInternal(options);

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -1207,6 +1207,47 @@ describe('FieldNode', () => {
         expect(f.age().errors()).toEqual([]);
       });
     });
+
+    describe('hasError', () => {
+      it('should return true when the field has an error of the given kind', () => {
+        const f = form(
+          signal({a: ''}),
+          (p) => {
+            required(p.a);
+          },
+          {injector: TestBed.inject(Injector)},
+        );
+
+        expect(f.a().hasError('required')).toBe(true);
+        expect(f.a().hasError('email')).toBe(false);
+      });
+
+      it('should return false when the field does not have an error of the given kind', () => {
+        const f = form(
+          signal({a: 'hello'}),
+          (p) => {
+            required(p.a);
+          },
+          {injector: TestBed.inject(Injector)},
+        );
+
+        expect(f.a().hasError('required')).toBe(false);
+      });
+
+      it('should return true for any matching error kind when multiple errors are present', () => {
+        const f = form(
+          signal({a: ''}),
+          (p) => {
+            validate(p.a, () => [{kind: 'first'}, {kind: 'second'}]);
+          },
+          {injector: TestBed.inject(Injector)},
+        );
+
+        expect(f.a().hasError('first')).toBe(true);
+        expect(f.a().hasError('second')).toBe(true);
+        expect(f.a().hasError('third')).toBe(false);
+      });
+    });
   });
 
   describe('errorSummary', () => {


### PR DESCRIPTION
Add a `hasError(kind)` helper to Signal Forms field state.

This makes it easier to check for specific validation errors in templates without
depending on positional access to `errors()`, such as `errors()[0]` or
`errors()[1]`.

The new helper helps avoid "magic numbers" when rendering validation messages.

Closes #66624
Related to #63905


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Signal Forms field state exposes `errors()`, but it does not provide a direct way to check whether a field currently has a validation error of a specific kind.

As a result, templates may need to inspect the returned error array directly, which can lead to patterns that depend on error ordering and the use of "magic numbers" such as `errors()[0]` and `errors()[1]`.

Issue Number: N/A

## What is the new behavior?

Signal Forms field state now provides a `hasError(kind)` helper that returns whether the field currently has a validation error of the given kind.

This allows templates to check for specific validation errors directly and helps avoid "magic numbers" when rendering validation messages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No