### PR TITLE
docs(docs-infra): add spacing between reference option and description

### DIFF
--- a/adev/shared-docs/styles/_reference.scss
+++ b/adev/shared-docs/styles/_reference.scss
@@ -426,6 +426,14 @@
       .docs-ref-content {
         padding: 1rem 0;
 
+        .docs-ref-option-and-description {
+          .docs-reference-option {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+          }
+        }
+
         &:not(:first-child) {
           border-block-start: 1px solid var(--senary-contrast);
         }


### PR DESCRIPTION

## What is the current behavior?

https://next.angular.dev/cli/analytics/disable

<img width="385" height="296" alt="image" src="https://github.com/user-attachments/assets/0b6d14ed-ba7d-4933-aad7-73bc383d352e" />




## What is the new behavior?


<img width="380" height="306" alt="image" src="https://github.com/user-attachments/assets/5bba7a08-5323-49a8-8947-7d70f5ba2107" />