### PR TITLE
fix(migrations): fix NgClass leaving trailing comma after removal

### DIFF
--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
@@ -178,14 +178,23 @@ function getPropertyRemovalRange(property: ts.ObjectLiteralElementLike): {
 
   const properties = parent.properties;
   const propertyIndex = properties.indexOf(property);
-  const end = property.getEnd();
 
-  if (propertyIndex < properties.length - 1) {
-    const nextProperty = properties[propertyIndex + 1];
-    return {start: property.getStart(), end: nextProperty.getStart()};
+  if (propertyIndex === 0) {
+    return {start: property.getFullStart(), end: properties[1].getFullStart()};
   }
 
-  return {start: property.getStart(), end};
+  if (properties.length === 1) {
+    const sourceFile = property.getSourceFile();
+    let end = property.getEnd();
+    const textAfter = sourceFile.text.substring(end, parent.getEnd());
+    const commaIndex = textAfter.indexOf(',');
+    if (commaIndex !== -1) {
+      end += commaIndex + 1;
+    }
+    return {start: property.getFullStart(), end};
+  }
+
+  return {start: properties[propertyIndex - 1].getEnd(), end: property.getEnd()};
 }
 
 export function calculateImportReplacements(

--- a/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngclass-to-class-migration/util.ts
@@ -179,10 +179,6 @@ function getPropertyRemovalRange(property: ts.ObjectLiteralElementLike): {
   const properties = parent.properties;
   const propertyIndex = properties.indexOf(property);
 
-  if (propertyIndex === 0) {
-    return {start: property.getFullStart(), end: properties[1].getFullStart()};
-  }
-
   if (properties.length === 1) {
     const sourceFile = property.getSourceFile();
     let end = property.getEnd();
@@ -192,6 +188,10 @@ function getPropertyRemovalRange(property: ts.ObjectLiteralElementLike): {
       end += commaIndex + 1;
     }
     return {start: property.getFullStart(), end};
+  }
+
+  if (propertyIndex === 0) {
+    return {start: property.getFullStart(), end: properties[1].getFullStart()};
   }
 
   return {start: properties[propertyIndex - 1].getEnd(), end: property.getEnd()};

--- a/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
+++ b/packages/core/schematics/test/ngclass_to_class_migration_spec.ts
@@ -519,6 +519,31 @@ describe('NgClass migration', () => {
       expect(content).not.toContain('imports: [NgFor, NgIf,]'); // No trailing comma
     });
 
+    it('should handle multiline imports array formatting with NgClass at the end', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgClass} from '@angular/common';
+
+        @Component({
+        template: \`<div [ngClass]="{'admin': isAdmin}"></div>\`,
+        imports: [NgClass],
+        })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+
+      expect(content).toContain(`@Component({
+        template: \`<div [class.admin]="isAdmin"></div>\`,
+        })
+        export class Cmp {}`);
+    });
+
     it('should handle multiline imports array formatting', async () => {
       writeFile(
         '/app.component.ts',


### PR DESCRIPTION
This fixes an issue where when removing NgClass from the imports array of a component, an extra trailing comma would be left behind if it was the last element.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: https://github.com/angular/angular/issues/67631

## What is the new behavior?

Fixed the migration where imports is the last.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
N/A