### PR TITLE
docs(docs-infra): improve semantic HTML in update guide

### DIFF
--- a/adev/src/app/features/update/update.component.html
+++ b/adev/src/app/features/update/update.component.html
@@ -1,4 +1,4 @@
-<div class="page docs-viewer">
+<main class="page docs-viewer">
   <h1 class="page-header" tabindex="-1">Update Guide</h1>
   <div class="wizard">
     <div>
@@ -205,4 +205,4 @@
       }
     </div>
   }
-</div>
+</main>


### PR DESCRIPTION
Improves update guide's semantic HTML
 
## What is the current behavior?

https://pagespeed.web.dev/analysis/https-next-angular-dev-update-guide/lii3yve7c4?form_factor=mobile&hl=en

 
<img width="956" height="585" alt="image" src="https://github.com/user-attachments/assets/9e37ef9d-5626-4923-9b50-e86449e56d50" />


## What is the new behavior?

 Replace `div` tag with `main`
