### PR TITLE
build: fix failing test in forms

### DIFF
--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -117,7 +117,7 @@ describe('extractValue', () => {
       const model = {a: 1, b: 2};
       const f = form(signal(model), {injector});
 
-      f().markAsTouched();
+      f().markAsTouched({skipDescendants: true});
 
       expect(extractValue(f, {touched: true})).toBeUndefined();
     });


### PR DESCRIPTION
Fixes a test that started failing after a couple of related changes landed at the same time.
