### PR TITLE
docs(forms): improve guidance for large and nested signal form models

### DIFF
--- a/adev/src/content/guide/forms/signals/models.md
+++ b/adev/src/content/guide/forms/signals/models.md
@@ -283,7 +283,11 @@ When the user types in the input, `userModel().name` updates. When the button is
 
 Form models can be flat objects or contain nested objects and arrays. The structure you choose affects how you access fields and organize validation.
 
+For larger or deeply nested forms, consider separating your domain model from the form model and using mapping approaches to transform between them. This helps keep the form state focused on UI concerns while preserving the integrity of your business data.
+
 ### Flat vs nested models
+
+In large applications, choosing between flat and nested structures also affects how easily you can manage validation, updates, and data transformations between domain and form models.
 
 Flat form models keep all fields at the top level:
 
@@ -365,6 +369,8 @@ In templates, you bind nested fields the same way as top-level fields:
   `,
 })
 ```
+
+For complex nested structures, it can be helpful to map nested domain objects into simpler form models and reconstruct them when submitting, rather than directly binding deeply nested domain data.
 
 ### Working with arrays
 


### PR DESCRIPTION
### Summary

This PR improves the existing documentation for Signal Form models by adding small clarifications around handling larger and deeply nested form structures.

### Changes

* Added guidance on separating domain and form models for complex forms
* Clarified considerations when choosing between flat and nested structures
* Included a note on mapping nested domain objects to simpler form models

### Notes

* Changes are minimal and limited to existing sections in `models.md`
* No new sections or structural modifications were introduced
* The goal is to enhance clarity without expanding the scope of the documentation

Fixes #67407