### PR TITLE
docs(router): clarify router.navigate() behavior with relativeTo and commands array

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -111,7 +111,6 @@ export class AppDashboard {
 You can also build dynamic navigation paths relative to your component’s location in the routing tree using the `relativeTo` option.
 
 When navigating to parent routes using `relativeTo`, parent segments should be provided as a single command (for example `'../../path'`). Splitting them into multiple entries (e.g. `'..', '..', 'path'`) may not produce the expected navigation result.
-
 ```angular-ts
 import {Router, ActivatedRoute} from '@angular/router';
 

--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -110,7 +110,12 @@ export class AppDashboard {
 
 You can also build dynamic navigation paths relative to your component’s location in the routing tree using the `relativeTo` option.
 
+When using the commands array with `relativeTo`, be aware that navigation behavior depends on how the commands are interpreted. In some cases, combining segments into a single string (for example `'../../path'`) may produce the expected result, while splitting them into multiple entries (e.g. `'..', '..', 'path'`) can lead to unexpected navigation behavior.
+
+Also, if the first segment starts with `/`, the navigation becomes absolute and `relativeTo` is ignored.
+
 ```angular-ts
+
 import {Router, ActivatedRoute} from '@angular/router';
 
 @Component({

--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -110,7 +110,7 @@ export class AppDashboard {
 
 You can also build dynamic navigation paths relative to your component’s location in the routing tree using the `relativeTo` option.
 
-When navigating to parent routes using `relativeTo`, parent segments should be provided as a single command (for example `'../../path'`). Splitting them into multiple entries (e.g. `'..', '..', 'path'`) may not produce the expected navigation result.
+When navigating to parent routes using `relativeTo`, parent segments should be provided as a single command (for example `'../../path'`). Splitting them into multiple entries (e.g. `'..', '..', 'path'`) results in incorrect navigation.
 ```angular-ts
 import {Router, ActivatedRoute} from '@angular/router';
 

--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -110,12 +110,9 @@ export class AppDashboard {
 
 You can also build dynamic navigation paths relative to your component’s location in the routing tree using the `relativeTo` option.
 
-When using the commands array with `relativeTo`, be aware that navigation behavior depends on how the commands are interpreted. In some cases, combining segments into a single string (for example `'../../path'`) may produce the expected result, while splitting them into multiple entries (e.g. `'..', '..', 'path'`) can lead to unexpected navigation behavior.
-
-Also, if the first segment starts with `/`, the navigation becomes absolute and `relativeTo` is ignored.
+When navigating to parent routes using `relativeTo`, parent segments should be provided as a single command (for example `'../../path'`). Splitting them into multiple entries (e.g. `'..', '..', 'path'`) may not produce the expected navigation result.
 
 ```angular-ts
-
 import {Router, ActivatedRoute} from '@angular/router';
 
 @Component({


### PR DESCRIPTION
## Summary

Adds a small clarification to the `router.navigate()` documentation to address confusion when using the commands array with `relativeTo`.

## Changes

- Clarified how command arrays may behave differently when split vs combined
- Added note about absolute navigation when using `/` with `relativeTo`

## Notes

- Change is minimal and placed within the existing section
- No structural or conceptual changes introduced

Fixes #65657