### PR TITLE
Compiler emit changes

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_other_pipe_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_other_pipe_fac.js
@@ -1,5 +1,8 @@
 export class MyOtherPipe {
   …
-  static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MyOtherPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 24)); };
+  static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyOtherPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 24));
+  };
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_pipe_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/pipe_di_change_detector_ref_my_pipe_fac.js
@@ -1,5 +1,8 @@
 export class MyPipe {
   …
-  static ɵfac = function MyPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MyPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 16)); };
+  static ɵfac = function MyPipe_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyPipe)($i0$.ɵɵdirectiveInject($i0$.ChangeDetectorRef, 16));
+  };
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/for_of_def.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/for_of_def.js
@@ -1,6 +1,7 @@
 export class ForOfDirective {
   …
   static ɵfac = function ForOfDirective_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
     return new (__ngFactoryType__ || ForOfDirective)($r3$.ɵɵdirectiveInject($r3$.ViewContainerRef), $r3$.ɵɵdirectiveInject($r3$.TemplateRef));
   };
   …

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/structural_directives_if_directive_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/structural_directives_if_directive_fac.js
@@ -1,5 +1,8 @@
 export class IfDirective {
   …
-  static ɵfac = function IfDirective_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef)); };
+  static ɵfac = function IfDirective_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || IfDirective)($r3$.ɵɵdirectiveInject($i$.TemplateRef));
+  };
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/view_tokens_di_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/view_tokens_di_fac.js
@@ -1,9 +1,8 @@
 export class MyComponent {
   // ...
   static ɵfac = function MyComponent_Factory(__ngFactoryType__) {
-    return new (__ngFactoryType__ || MyComponent)(
-      $r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef),
-      $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyComponent)($r3$.ɵɵdirectiveInject($i$.ElementRef), $r3$.ɵɵdirectiveInject($i$.ViewContainerRef), $r3$.ɵɵdirectiveInject($i$.ChangeDetectorRef));
   };
   // ...
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/TEST_CASES.json
@@ -3,87 +3,57 @@
   "cases": [
     {
       "description": "should define a basic NgModule (linked)",
-      "inputFiles": [
-        "basic_linked.ts"
-      ],
+      "inputFiles": ["basic_linked.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "basic_linked.js"
-          ]
+          "files": ["basic_linked.js"]
         }
       ],
-      "compilationModeFilter": [
-        "linked compile",
-        "declaration-only emit"
-      ]
+      "compilationModeFilter": ["linked compile", "declaration-only emit"]
     },
     {
-      "description": "should define a basic NgModule (full/local)",      
-      "inputFiles": [
-        "basic_full.ts"
-      ],
+      "description": "should define a basic NgModule (full/local)",
+      "inputFiles": ["basic_full.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "basic_full.js"
-          ]
+          "files": ["basic_full.js"]
         }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile",
-        "declaration-only emit"
-      ]
+      "compilationModeFilter": ["full compile", "local compile", "declaration-only emit"]
     },
     {
       "description": "should define an NgModule with declarations and bootstrap",
-      "inputFiles": [
-        "declarations.ts"
-      ],
+      "inputFiles": ["declarations.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "declarations.js"
-          ]
+          "files": ["declarations.js"]
         }
       ]
     },
     {
       "description": "should define an NgModule with declarations and bootstrap (jit mode)",
-      "inputFiles": [
-        "declarations_jit_mode.ts"
-      ],
+      "inputFiles": ["declarations_jit_mode.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "declarations_jit_mode.js"
-          ]
+          "files": ["declarations_jit_mode.js"]
         }
       ],
-      "compilationModeFilter": [
-        "linked compile",
-        "declaration-only emit"
-      ],
+      "compilationModeFilter": ["linked compile", "declaration-only emit"],
       "angularCompilerOptions": {
         "linkerJitMode": true
       }
     },
     {
       "description": "should define an NgModule and injector with providers",
-      "inputFiles": [
-        "providers.ts"
-      ],
+      "inputFiles": ["providers.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "providers.js"
-          ]
+          "files": ["providers.js"]
         }
       ],
       "compilationModeFilter": [
@@ -95,55 +65,36 @@
     },
     {
       "description": "should define NgModules with imports and exports",
-      "inputFiles": [
-        "imports_exports.ts"
-      ],
+      "inputFiles": ["imports_exports.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "imports_exports.js"
-          ]
+          "files": ["imports_exports.js"]
         }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile",
-        "declaration-only emit"
-      ]
+      "compilationModeFilter": ["full compile", "local compile", "declaration-only emit"]
     },
     {
       "description": "should define NgModules with imports and exports (jit mode)",
-      "inputFiles": [
-        "imports_exports_jit_mode.ts"
-      ],
+      "inputFiles": ["imports_exports_jit_mode.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "imports_exports_jit_mode.js"
-          ]
+          "files": ["imports_exports_jit_mode.js"]
         }
       ],
-      "compilationModeFilter": [
-        "linked compile",
-        "declaration-only emit"
-      ],
+      "compilationModeFilter": ["linked compile", "declaration-only emit"],
       "angularCompilerOptions": {
         "linkerJitMode": true
       }
     },
     {
       "description": "should not process NgModules that are marked `jit`",
-      "inputFiles": [
-        "no_aot.ts"
-      ],
+      "inputFiles": ["no_aot.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "no_aot.js"
-          ]
+          "files": ["no_aot.js"]
         }
       ],
       "compilationModeFilter": [
@@ -155,15 +106,11 @@
     },
     {
       "description": "should handle NgModules that extend other classes",
-      "inputFiles": [
-        "inheritance.ts"
-      ],
+      "inputFiles": ["inheritance.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "inheritance.js"
-          ]
+          "files": ["inheritance.js"]
         }
       ],
       "compilationModeFilter": [
@@ -175,36 +122,25 @@
     },
     {
       "description": "should handle NgModules with forward refs",
-      "inputFiles": [
-        "forward_refs.ts"
-      ],
+      "inputFiles": ["forward_refs.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid NgModule/Injector definition",
-          "files": [
-            "forward_refs.js"
-          ]
+          "files": ["forward_refs.js"]
         }
       ],
-      "compilationModeFilter": [
-        "linked compile",
-        "declaration-only emit"
-      ],
+      "compilationModeFilter": ["linked compile", "declaration-only emit"],
       "angularCompilerOptions": {
         "linkerJitMode": true
       }
     },
     {
       "description": "should not pass along empty array fields to the declaration",
-      "inputFiles": [
-        "empty_fields.ts"
-      ],
+      "inputFiles": ["empty_fields.ts"],
       "expectations": [
         {
           "failureMessage": "Empty declaration exists",
-          "files": [
-            "empty_fields.js"
-          ]
+          "files": ["empty_fields.js"]
         }
       ],
       "compilationModeFilter": [
@@ -216,15 +152,11 @@
     },
     {
       "description": "should handle providers passed in as a variable",
-      "inputFiles": [
-        "variable_providers.ts"
-      ],
+      "inputFiles": ["variable_providers.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid injector definition",
-          "files": [
-            "variable_providers.js"
-          ]
+          "files": ["variable_providers.js"]
         }
       ],
       "compilationModeFilter": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.js
@@ -1,7 +1,10 @@
 export class BaseModule {
   // ...
   constructor(service) { this.service = service; }
-  static ɵfac = function BaseModule_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || BaseModule)(i0.ɵɵinject(Service)); };
+  static ɵfac = function BaseModule_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || BaseModule)(i0.ɵɵinject(Service));
+  };
   static ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BaseModule });
   static ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [Service] });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/inheritance.local.js
@@ -1,7 +1,10 @@
 export class BaseModule {
   …
   constructor(service) { this.service = service; }
-  static ɵfac = function BaseModule_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || BaseModule)(i0.ɵɵinject(Service)); };
+  static ɵfac = function BaseModule_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || BaseModule)(i0.ɵɵinject(Service));
+  };
   static ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: BaseModule });
   static ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [Service] });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/component_factory.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/component_factory.js
@@ -1,16 +1,8 @@
 export class MyComponent {
   // ...
   static ɵfac = function MyComponent_Factory(__ngFactoryType__) {
-    return new (__ngFactoryType__ || MyComponent)(
-      $r3$.ɵɵinjectAttribute('name'),
-      $r3$.ɵɵinjectAttribute(dynamicAttrName()),
-      $r3$.ɵɵdirectiveInject(MyService),
-      $r3$.ɵɵdirectiveInject(MyService, 1),
-      $r3$.ɵɵdirectiveInject(MyService, 2),
-      $r3$.ɵɵdirectiveInject(MyService, 4),
-      $r3$.ɵɵdirectiveInject(MyService, 8),
-      $r3$.ɵɵdirectiveInject(MyService, 10)
-    );
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyComponent)($r3$.ɵɵinjectAttribute('name'), $r3$.ɵɵinjectAttribute(dynamicAttrName()), $r3$.ɵɵdirectiveInject(MyService), $r3$.ɵɵdirectiveInject(MyService, 1), $r3$.ɵɵdirectiveInject(MyService, 2), $r3$.ɵɵdirectiveInject(MyService, 4), $r3$.ɵɵdirectiveInject(MyService, 8), $r3$.ɵɵdirectiveInject(MyService, 10));
   }
   // ...
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/ctor_overload_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/ctor_overload_fac.js
@@ -1,6 +1,7 @@
 export class MyService {
   // ...
   static ɵfac = function MyService_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
     return new (__ngFactoryType__ || MyService)($r3$.ɵɵinject(MyDependency), $r3$.ɵɵinject(MyOptionalDependency, 8));
   }
   // ...

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/injectable_factory_fac.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/injectable_factory_fac.js
@@ -1,6 +1,7 @@
 export class MyService {
   // ...
   static ɵfac = function MyService_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
     return new (__ngFactoryType__ || MyService)($r3$.ɵɵinject(MyDependency));
   }
   // ...

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_first.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_first.js
@@ -1,7 +1,10 @@
 // NOTE The prov definition must be last so MyOtherPipe.fac is defined
 export class MyOtherPipe {
   // ...
-  static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MyOtherPipe)(i0.ɵɵdirectiveInject(Service, 16)); };
+  static ɵfac = function MyOtherPipe_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyOtherPipe)(i0.ɵɵdirectiveInject(Service, 16));
+  };
   static ɵpipe = /*@__PURE__*/ i0.ɵɵdefinePipe({ name: "myOtherPipe", type: MyOtherPipe, pure: true, standalone: false });
   static ɵprov = /*@__PURE__*/ i0.ɵɵdefineInjectable({ token: MyOtherPipe, factory: MyOtherPipe.ɵfac });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_last.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/pipe_and_injectable_pipe_last.js
@@ -1,7 +1,10 @@
 // NOTE The prov definition must be last so MyPipe.fac is defined
 export class MyPipe {
   // ...
-  static ɵfac = function MyPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MyPipe)(i0.ɵɵdirectiveInject(Service, 16)); };
+  static ɵfac = function MyPipe_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || MyPipe)(i0.ɵɵdirectiveInject(Service, 16));
+  };
   static ɵpipe = /*@__PURE__*/ i0.ɵɵdefinePipe({ name: "myPipe", type: MyPipe, pure: true, standalone: false });
   static ɵprov = /*@__PURE__*/ i0.ɵɵdefineInjectable({ token: MyPipe, factory: MyPipe.ɵfac });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/providedin_forwardref.js
@@ -1,6 +1,9 @@
 export class Service {
   …
-  static ɵfac = function Service_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || Service)($i0$.ɵɵinject(Dep)); };
+  static ɵfac = function Service_Factory(__ngFactoryType__) {
+    /* @ts-ignore */
+    return new (__ngFactoryType__ || Service)($i0$.ɵɵinject(Dep));
+  };
   static ɵprov = /*@__PURE__*/ $i0$.ɵɵdefineInjectable({ token: Service, factory: Service.ɵfac, providedIn: $i0$.forwardRef(() => Mod) });
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_with_deps.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/useclass_with_deps.js
@@ -7,6 +7,7 @@ export class MyService {
       if (__ngFactoryType__) {
         __ngConditionalFactory__ = new __ngFactoryType__();
       } else {
+        /* @ts-ignore */
         __ngConditionalFactory__ = new MyAlternateService($r3$.ɵɵinject(SomeDep));
       }
       return __ngConditionalFactory__;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_di/di/usefactory_with_deps.js
@@ -7,6 +7,7 @@ export class MyService {
       if (__ngFactoryType__) {
         __ngConditionalFactory__ = new __ngFactoryType__();
       } else {
+        /* @ts-ignore */
         __ngConditionalFactory__ = ((dep, optional) => new MyAlternateService(dep, optional))($r3$.ɵɵinject(SomeDep), $r3$.ɵɵinject(SomeDep, 8));
       }
       return __ngConditionalFactory__;

--- a/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/local_compilation_spec.ts
@@ -1048,7 +1048,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainComponent.ɵfac = function MainComponent_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
+          `MainComponent.ɵfac = function MainComponent_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
         );
       });
 
@@ -1084,7 +1084,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainComponent.ɵfac = function MainComponent_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
+          `MainComponent.ɵfac = function MainComponent_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainComponent)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
         );
       });
 
@@ -1124,7 +1124,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainDirective.ɵfac = function MainDirective_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
+          `MainDirective.ɵfac = function MainDirective_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
         );
       });
 
@@ -1157,7 +1157,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainDirective.ɵfac = function MainDirective_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
+          `MainDirective.ɵfac = function MainDirective_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainDirective)(i0.ɵɵdirectiveInject(i1.SomeService1), i0.ɵɵdirectiveInject(SomeService2), i0.ɵɵdirectiveInject(i2.SomeService3), i0.ɵɵdirectiveInject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN)); };`,
         );
       });
 
@@ -1196,7 +1196,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
+          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
         );
       });
 
@@ -1229,7 +1229,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
+          `MainPipe.ɵfac = function MainPipe_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainPipe)(i0.ɵɵdirectiveInject(i1.SomeService1, 16), i0.ɵɵdirectiveInject(SomeService2, 16), i0.ɵɵdirectiveInject(i2.SomeService3, 16), i0.ɵɵdirectiveInject(i3.nested.SomeService4, 16), i0.ɵɵinjectAttribute('title'), i0.ɵɵdirectiveInject(MESSAGE_TOKEN, 16)); };`,
         );
       });
 
@@ -1264,7 +1264,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainService.ɵfac = function MainService_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainService)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`,
+          `MainService.ɵfac = function MainService_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainService)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`,
         );
       });
 
@@ -1298,7 +1298,7 @@ runInEachFileSystem(() => {
         const jsContents = env.getContents('test.js');
 
         expect(jsContents).toContain(
-          `MainModule.ɵfac = function MainModule_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || MainModule)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`,
+          `MainModule.ɵfac = function MainModule_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || MainModule)(i0.ɵɵinject(i1.SomeService1), i0.ɵɵinject(SomeService2), i0.ɵɵinject(i2.SomeService3), i0.ɵɵinject(i3.nested.SomeService4), i0.ɵɵinjectAttribute('title'), i0.ɵɵinject(MESSAGE_TOKEN)); };`,
         );
       });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -162,7 +162,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain('Dep.ɵprov =');
       expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents).toContain(
-        'Service.ɵfac = function Service_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep)); };',
+        'Service.ɵfac = function Service_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep)); };',
       );
       expect(jsContents).toContain("providedIn: 'root' })");
       expect(jsContents).not.toContain('__decorate');
@@ -494,7 +494,9 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain(
         'factory: function Service_Factory(__ngFactoryType__) { let __ngConditionalFactory__ = null; if (__ngFactoryType__) {',
       );
-      expect(jsContents).toContain('return new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep));');
+      expect(jsContents).toContain(
+        '/* @ts-ignore */\nreturn new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep));',
+      );
       expect(jsContents).toContain(
         '__ngConditionalFactory__ = ((dep) => new Service(dep))(i0.ɵɵinject(Dep));',
       );
@@ -532,7 +534,9 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain(
         'factory: function Service_Factory(__ngFactoryType__) { let __ngConditionalFactory__ = null; if (__ngFactoryType__) {',
       );
-      expect(jsContents).toContain('return new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep));');
+      expect(jsContents).toContain(
+        '/* @ts-ignore */\nreturn new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep));',
+      );
       expect(jsContents).toContain(
         '__ngConditionalFactory__ = ((dep) => new Service(dep))(i0.ɵɵinject(Dep, 10));',
       );
@@ -569,7 +573,7 @@ runInEachFileSystem((os: string) => {
       expect(jsContents).toContain('Service.ɵprov =');
       expect(jsContents).toContain('Mod.ɵmod =');
       expect(jsContents).toContain(
-        'Service.ɵfac = function Service_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep)); };',
+        'Service.ɵfac = function Service_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep)); };',
       );
       expect(jsContents).toContain('providedIn: i0.forwardRef(() => Mod) })');
       expect(jsContents).not.toContain('__decorate');
@@ -626,7 +630,7 @@ runInEachFileSystem((os: string) => {
 
       expect(jsContents).toContain(
         `Service.ɵfac = function Service_Factory(__ngFactoryType__) { ` +
-          `return new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep), i0.ɵɵinject(OptionalDep, 8)); };`,
+          `/* @ts-ignore */\nreturn new (__ngFactoryType__ || Service)(i0.ɵɵinject(Dep), i0.ɵɵinject(OptionalDep, 8)); };`,
       );
     });
 
@@ -5123,7 +5127,7 @@ runInEachFileSystem((os: string) => {
       env.driveMain();
       const jsContents = env.getContents('test.js');
       expect(jsContents).toContain(
-        `FooCmp.ɵfac = function FooCmp_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`,
+        `FooCmp.ɵfac = function FooCmp_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || FooCmp)(i0.ɵɵinjectAttribute("test"), i0.ɵɵdirectiveInject(i0.ChangeDetectorRef), i0.ɵɵdirectiveInject(i0.ElementRef), i0.ɵɵdirectiveInject(i0.Injector), i0.ɵɵdirectiveInject(i0.Renderer2), i0.ɵɵdirectiveInject(i0.TemplateRef), i0.ɵɵdirectiveInject(i0.ViewContainerRef)); }`,
       );
     });
 
@@ -6168,7 +6172,7 @@ runInEachFileSystem((os: string) => {
       const jsContents = env.getContents('test.js');
 
       expect(jsContents).toContain(
-        'function Base_Factory(__ngFactoryType__) { return new (__ngFactoryType__ || Base)(i0.ɵɵinject(Dep)); }',
+        'function Base_Factory(__ngFactoryType__) { /* @ts-ignore */\nreturn new (__ngFactoryType__ || Base)(i0.ɵɵinject(Dep)); }',
       );
       expect(jsContents).toContain(
         '(() => { let ɵChild_BaseFactory; return function Child_Factory(__ngFactoryType__) { return (ɵChild_BaseFactory || (ɵChild_BaseFactory = i0.ɵɵgetInheritedFactory(Child)))(__ngFactoryType__ || Child); }; })();',

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -57,7 +57,7 @@ export {ParseTreeResult, TreeError} from './ml_parser/parser';
 export * from './ml_parser/tags';
 export {TokenType as LexerTokenType} from './ml_parser/tokens';
 export * from './ml_parser/xml_parser';
-export {EmitterVisitorContext} from './output/abstract_emitter';
+export {EmitterVisitorContext, AbstractEmitterVisitor} from './output/abstract_emitter';
 export {
   ArrayType,
   ArrowFunctionExpr,

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -214,11 +214,13 @@ export class EmitterVisitorContext {
 export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.ExpressionVisitor {
   private lastIfCondition: o.Expression | null = null;
 
+  constructor(private readonly printComments: boolean) {}
+
   protected printLeadingComments(
     node: o.Expression | o.Statement,
     ctx: EmitterVisitorContext,
   ): void {
-    if (node.leadingComments === undefined) {
+    if (!this.printComments || node.leadingComments === undefined) {
       return;
     }
     for (const comment of node.leadingComments) {
@@ -228,9 +230,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
         if (comment.multiline) {
           ctx.print(node, `/* ${comment.text} */`, comment.trailingNewline);
         } else {
-          comment.text.split('\n').forEach((line) => {
-            ctx.println(node, `// ${line}`);
-          });
+          comment.text.split('\n').forEach((line) => ctx.println(node, `// ${line}`));
         }
       }
     }

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -11,14 +11,15 @@ import {ParseSourceSpan} from '../parse_util';
 import * as o from './output_ast';
 import {SourceMapGenerator} from './source_map';
 
-const _SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\r|\$/g;
-const _LEGAL_IDENTIFIER_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
-const _INDENT_WITH = '  ';
+const SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\r|\$/g;
+const LEGAL_IDENTIFIER_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
+const INDENT_WITH = '  ';
 
-class _EmittedLine {
+class EmittedLine {
   partsLength = 0;
-  parts: string[] = [];
-  srcSpans: (ParseSourceSpan | null)[] = [];
+  readonly parts: string[] = [];
+  readonly srcSpans: (ParseSourceSpan | null)[] = [];
+
   constructor(public indent: number) {}
 }
 
@@ -61,17 +62,17 @@ export class EmitterVisitorContext {
     return new EmitterVisitorContext(0);
   }
 
-  private _lines: _EmittedLine[];
+  private _lines: EmittedLine[];
 
   constructor(private _indent: number) {
-    this._lines = [new _EmittedLine(_indent)];
+    this._lines = [new EmittedLine(_indent)];
   }
 
   /**
    * @internal strip this from published d.ts files due to
    * https://github.com/microsoft/TypeScript/issues/36216
    */
-  private get _currentLine(): _EmittedLine {
+  private get _currentLine(): EmittedLine {
     return this._lines[this._lines.length - 1];
   }
 
@@ -84,7 +85,7 @@ export class EmitterVisitorContext {
   }
 
   lineLength(): number {
-    return this._currentLine.indent * _INDENT_WITH.length + this._currentLine.partsLength;
+    return this._currentLine.indent * INDENT_WITH.length + this._currentLine.partsLength;
   }
 
   print(from: {sourceSpan: ParseSourceSpan | null} | null, part: string, newLine: boolean = false) {
@@ -94,7 +95,7 @@ export class EmitterVisitorContext {
       this._currentLine.srcSpans.push((from && from.sourceSpan) || null);
     }
     if (newLine) {
-      this._lines.push(new _EmittedLine(this._indent));
+      this._lines.push(new EmittedLine(this._indent));
     }
   }
 
@@ -120,7 +121,7 @@ export class EmitterVisitorContext {
 
   toSource(): string {
     return this.sourceLines
-      .map((l) => (l.parts.length > 0 ? _createIndent(l.indent) + l.parts.join('') : ''))
+      .map((l) => (l.parts.length > 0 ? INDENT_WITH.repeat(l.indent) + l.parts.join('') : ''))
       .join('\n');
   }
 
@@ -148,7 +149,7 @@ export class EmitterVisitorContext {
 
       const spans = line.srcSpans;
       const parts = line.parts;
-      let col0 = line.indent * _INDENT_WITH.length;
+      let col0 = line.indent * INDENT_WITH.length;
       let spanIdx = 0;
       // skip leading parts without source spans
       while (spanIdx < spans.length && !spans[spanIdx]) {
@@ -187,7 +188,7 @@ export class EmitterVisitorContext {
   spanOf(line: number, column: number): ParseSourceSpan | null {
     const emittedLine = this._lines[line];
     if (emittedLine) {
-      let columnsLeft = column - _createIndent(emittedLine.indent).length;
+      let columnsLeft = column - INDENT_WITH.repeat(emittedLine.indent).length;
       for (let partIndex = 0; partIndex < emittedLine.parts.length; partIndex++) {
         const part = emittedLine.parts[partIndex];
         if (part.length > columnsLeft) {
@@ -203,7 +204,7 @@ export class EmitterVisitorContext {
    * @internal strip this from published d.ts files due to
    * https://github.com/microsoft/TypeScript/issues/36216
    */
-  private get sourceLines(): _EmittedLine[] {
+  private get sourceLines(): EmittedLine[] {
     if (this._lines.length && this._lines[this._lines.length - 1].parts.length === 0) {
       return this._lines.slice(0, -1);
     }
@@ -216,42 +217,23 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
 
   constructor(private readonly printComments: boolean) {}
 
-  protected printLeadingComments(
-    node: o.Expression | o.Statement,
-    ctx: EmitterVisitorContext,
-  ): void {
-    if (!this.printComments || node.leadingComments === undefined) {
-      return;
-    }
-    for (const comment of node.leadingComments) {
-      if (comment instanceof o.JSDocComment) {
-        ctx.print(node, `/*${comment.toString()}*/`, comment.trailingNewline);
-      } else {
-        if (comment.multiline) {
-          ctx.print(node, `/* ${comment.text} */`, comment.trailingNewline);
-        } else {
-          comment.text.split('\n').forEach((line) => ctx.println(node, `// ${line}`));
-        }
-      }
-    }
-  }
+  abstract visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): void;
+  abstract visitWrappedNodeExpr(ast: o.WrappedNodeExpr<unknown>, ctx: EmitterVisitorContext): void;
 
-  visitExpressionStmt(stmt: o.ExpressionStatement, ctx: EmitterVisitorContext): any {
+  visitExpressionStmt(stmt: o.ExpressionStatement, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(stmt, ctx);
     stmt.expr.visitExpression(this, ctx);
     ctx.println(stmt, ';');
-    return null;
   }
 
-  visitReturnStmt(stmt: o.ReturnStatement, ctx: EmitterVisitorContext): any {
+  visitReturnStmt(stmt: o.ReturnStatement, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(stmt, ctx);
     ctx.print(stmt, `return `);
     stmt.value.visitExpression(this, ctx);
     ctx.println(stmt, ';');
-    return null;
   }
 
-  visitIfStmt(stmt: o.IfStmt, ctx: EmitterVisitorContext): any {
+  visitIfStmt(stmt: o.IfStmt, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(stmt, ctx);
     ctx.print(stmt, `if (`);
     this.lastIfCondition = stmt.condition; // We can skip redundant parentheses for the condition.
@@ -277,14 +259,24 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       }
     }
     ctx.println(stmt, `}`);
-    return null;
   }
 
-  abstract visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any;
+  visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): void {
+    const varKind = stmt.hasModifier(o.StmtModifier.Final) ? 'const' : 'let';
 
-  visitInvokeFunctionExpr(expr: o.InvokeFunctionExpr, ctx: EmitterVisitorContext): any {
+    this.printLeadingComments(stmt, ctx);
+    ctx.print(stmt, `${varKind} ${stmt.name}`);
+    if (stmt.value) {
+      ctx.print(stmt, ' = ');
+      stmt.value.visitExpression(this, ctx);
+    }
+    ctx.println(stmt, `;`);
+  }
+
+  visitInvokeFunctionExpr(expr: o.InvokeFunctionExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(expr, ctx);
-    const shouldParenthesize = expr.fn instanceof o.ArrowFunctionExpr;
+
+    const shouldParenthesize = this.shouldParenthesize(expr.fn, expr);
 
     if (shouldParenthesize) {
       ctx.print(expr.fn, '(');
@@ -296,17 +288,17 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(expr, `(`);
     this.visitAllExpressions(expr.args, ctx, ',');
     ctx.print(expr, `)`);
-    return null;
   }
+
   visitTaggedTemplateLiteralExpr(
     expr: o.TaggedTemplateLiteralExpr,
     ctx: EmitterVisitorContext,
-  ): any {
+  ): void {
     this.printLeadingComments(expr, ctx);
     expr.tag.visitExpression(this, ctx);
     expr.template.visitExpression(this, ctx);
-    return null;
   }
+
   visitTemplateLiteralExpr(expr: o.TemplateLiteralExpr, ctx: EmitterVisitorContext) {
     this.printLeadingComments(expr, ctx);
     ctx.print(expr, '`');
@@ -321,59 +313,57 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     }
     ctx.print(expr, '`');
   }
+
   visitTemplateLiteralElementExpr(expr: o.TemplateLiteralElementExpr, ctx: EmitterVisitorContext) {
     this.printLeadingComments(expr, ctx);
     ctx.print(expr, expr.rawText);
   }
-  visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): any {
-    throw new Error('Abstract emitter cannot visit WrappedNodeExpr.');
-  }
-  visitTypeofExpr(expr: o.TypeofExpr, ctx: EmitterVisitorContext): any {
+
+  visitTypeofExpr(expr: o.TypeofExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(expr, ctx);
     ctx.print(expr, 'typeof ');
     expr.expr.visitExpression(this, ctx);
   }
-  visitVoidExpr(expr: o.VoidExpr, ctx: EmitterVisitorContext): any {
+
+  visitVoidExpr(expr: o.VoidExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(expr, ctx);
     ctx.print(expr, 'void ');
     expr.expr.visitExpression(this, ctx);
   }
-  visitReadVarExpr(ast: o.ReadVarExpr, ctx: EmitterVisitorContext): any {
+
+  visitReadVarExpr(ast: o.ReadVarExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, ast.name);
-    return null;
   }
-  visitInstantiateExpr(ast: o.InstantiateExpr, ctx: EmitterVisitorContext): any {
+
+  visitInstantiateExpr(ast: o.InstantiateExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `new `);
     ast.classExpr.visitExpression(this, ctx);
     ctx.print(ast, `(`);
     this.visitAllExpressions(ast.args, ctx, ',');
     ctx.print(ast, `)`);
-    return null;
   }
 
-  visitLiteralExpr(ast: o.LiteralExpr, ctx: EmitterVisitorContext): any {
+  visitLiteralExpr(ast: o.LiteralExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     const value = ast.value;
     if (typeof value === 'string') {
-      ctx.print(ast, escapeIdentifier(value));
+      ctx.print(ast, escapeIdentifier(value)!);
     } else {
       ctx.print(ast, `${value}`);
     }
-    return null;
   }
 
   visitRegularExpressionLiteral(
     ast: o.RegularExpressionLiteralExpr,
     ctx: EmitterVisitorContext,
-  ): any {
+  ): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `/${ast.body}/${ast.flags || ''}`);
-    return null;
   }
 
-  visitLocalizedString(ast: o.LocalizedString, ctx: EmitterVisitorContext): any {
+  visitLocalizedString(ast: o.LocalizedString, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     const head = ast.serializeI18nHead();
     ctx.print(ast, '$localize `' + head.raw);
@@ -383,12 +373,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       ctx.print(ast, `}${ast.serializeI18nTemplatePart(i).raw}`);
     }
     ctx.print(ast, '`');
-    return null;
   }
 
-  abstract visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): any;
-
-  visitConditionalExpr(ast: o.ConditionalExpr, ctx: EmitterVisitorContext): any {
+  visitConditionalExpr(ast: o.ConditionalExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `(`);
     ast.condition.visitExpression(this, ctx);
@@ -397,25 +384,69 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(ast, ': ');
     ast.falseCase!.visitExpression(this, ctx);
     ctx.print(ast, `)`);
-    return null;
   }
 
-  visitDynamicImportExpr(ast: o.DynamicImportExpr, ctx: EmitterVisitorContext) {
+  visitDynamicImportExpr(ast: o.DynamicImportExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `import(${ast.url})`);
   }
 
-  visitNotExpr(ast: o.NotExpr, ctx: EmitterVisitorContext): any {
+  visitNotExpr(ast: o.NotExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '!');
     ast.condition.visitExpression(this, ctx);
-    return null;
   }
-  abstract visitFunctionExpr(ast: o.FunctionExpr, ctx: EmitterVisitorContext): any;
-  abstract visitArrowFunctionExpr(ast: o.ArrowFunctionExpr, context: any): any;
-  abstract visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, context: any): any;
 
-  visitUnaryOperatorExpr(ast: o.UnaryOperatorExpr, ctx: EmitterVisitorContext): any {
+  visitFunctionExpr(ast: o.FunctionExpr, ctx: EmitterVisitorContext): void {
+    this.printLeadingComments(ast, ctx);
+    ctx.print(ast, `function${ast.name ? ' ' + ast.name : ''}(`);
+    this.visitParams(ast.params, ctx);
+    ctx.println(ast, `) {`);
+    ctx.incIndent();
+    this.visitAllStatements(ast.statements, ctx);
+    ctx.decIndent();
+    ctx.print(ast, `}`);
+  }
+
+  visitArrowFunctionExpr(ast: o.ArrowFunctionExpr, ctx: EmitterVisitorContext): void {
+    this.printLeadingComments(ast, ctx);
+    ctx.print(ast, '(');
+    this.visitParams(ast.params, ctx);
+    ctx.print(ast, ') =>');
+
+    if (Array.isArray(ast.body)) {
+      ctx.println(ast, `{`);
+      ctx.incIndent();
+      this.visitAllStatements(ast.body, ctx);
+      ctx.decIndent();
+      ctx.print(ast, `}`);
+    } else {
+      const shouldParenthesize = this.shouldParenthesize(ast.body, ast);
+
+      if (shouldParenthesize) {
+        ctx.print(ast, '(');
+      }
+
+      ast.body.visitExpression(this, ctx);
+
+      if (shouldParenthesize) {
+        ctx.print(ast, ')');
+      }
+    }
+  }
+
+  visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, ctx: EmitterVisitorContext): void {
+    this.printLeadingComments(stmt, ctx);
+    ctx.print(stmt, `function ${stmt.name}(`);
+    this.visitParams(stmt.params, ctx);
+    ctx.println(stmt, `) {`);
+    ctx.incIndent();
+    this.visitAllStatements(stmt.statements, ctx);
+    ctx.decIndent();
+    ctx.println(stmt, `}`);
+  }
+
+  visitUnaryOperatorExpr(ast: o.UnaryOperatorExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     let opStr: string;
     switch (ast.operator) {
@@ -433,10 +464,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(ast, opStr);
     ast.expr.visitExpression(this, ctx);
     if (parens) ctx.print(ast, `)`);
-    return null;
   }
 
-  visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: EmitterVisitorContext): any {
+  visitBinaryOperatorExpr(ast: o.BinaryOperatorExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     const operator = BINARY_OPERATORS.get(ast.operator);
     if (!operator) {
@@ -448,32 +478,31 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     ctx.print(ast, ` ${operator} `);
     ast.rhs.visitExpression(this, ctx);
     if (parens) ctx.print(ast, `)`);
-    return null;
   }
 
-  visitReadPropExpr(ast: o.ReadPropExpr, ctx: EmitterVisitorContext): any {
+  visitReadPropExpr(ast: o.ReadPropExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ast.receiver.visitExpression(this, ctx);
     ctx.print(ast, `.`);
     ctx.print(ast, ast.name);
-    return null;
   }
-  visitReadKeyExpr(ast: o.ReadKeyExpr, ctx: EmitterVisitorContext): any {
+
+  visitReadKeyExpr(ast: o.ReadKeyExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ast.receiver.visitExpression(this, ctx);
     ctx.print(ast, `[`);
     ast.index.visitExpression(this, ctx);
     ctx.print(ast, `]`);
-    return null;
   }
-  visitLiteralArrayExpr(ast: o.LiteralArrayExpr, ctx: EmitterVisitorContext): any {
+
+  visitLiteralArrayExpr(ast: o.LiteralArrayExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `[`);
     this.visitAllExpressions(ast.entries, ctx, ',');
     ctx.print(ast, `]`);
-    return null;
   }
-  visitLiteralMapExpr(ast: o.LiteralMapExpr, ctx: EmitterVisitorContext): any {
+
+  visitLiteralMapExpr(ast: o.LiteralMapExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `{`);
     this.visitAllObjects(
@@ -491,27 +520,29 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       ',',
     );
     ctx.print(ast, `}`);
-    return null;
   }
-  visitCommaExpr(ast: o.CommaExpr, ctx: EmitterVisitorContext): any {
+
+  visitCommaExpr(ast: o.CommaExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '(');
     this.visitAllExpressions(ast.parts, ctx, ',');
     ctx.print(ast, ')');
-    return null;
   }
-  visitParenthesizedExpr(ast: o.ParenthesizedExpr, ctx: EmitterVisitorContext): any {
+
+  visitParenthesizedExpr(ast: o.ParenthesizedExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     // We parenthesize everything regardless of an explicit ParenthesizedExpr, so we can just visit
     // the inner expression.
     // TODO: Do we *need* to parenthesize everything?
     ast.expr.visitExpression(this, ctx);
   }
-  visitSpreadElementExpr(ast: o.SpreadElementExpr, ctx: EmitterVisitorContext) {
+
+  visitSpreadElementExpr(ast: o.SpreadElementExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '...');
     ast.expression.visitExpression(this, ctx);
   }
+
   visitAllExpressions(
     expressions: o.Expression[],
     ctx: EmitterVisitorContext,
@@ -553,13 +584,54 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   visitAllStatements(statements: o.Statement[], ctx: EmitterVisitorContext): void {
     statements.forEach((stmt) => stmt.visitStatement(this, ctx));
   }
+
+  private visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
+    this.visitAllObjects((param) => ctx.print(null, param.name), params, ctx, ',');
+  }
+
+  protected shouldParenthesize(
+    expression: o.Expression,
+    containingExpression: o.Expression,
+  ): boolean {
+    // Note: this method is protected so consumers can override it, e.g. in case a
+    // `WrappedNodeExpr` wraps an expression that needs to be parenthesized.
+    return (
+      // e.g. `(() => foo)()` or `(function() {})()`.
+      ((expression instanceof o.ArrowFunctionExpr || expression instanceof o.FunctionExpr) &&
+        containingExpression instanceof o.InvokeFunctionExpr) ||
+      // e.g. `() => ({a: 1, b: 2})`
+      (expression instanceof o.LiteralMapExpr &&
+        containingExpression instanceof o.ArrowFunctionExpr)
+    );
+  }
+
+  protected printLeadingComments(
+    node: o.Expression | o.Statement,
+    ctx: EmitterVisitorContext,
+  ): void {
+    if (!this.printComments || node.leadingComments === undefined) {
+      return;
+    }
+    for (const comment of node.leadingComments) {
+      if (comment instanceof o.JSDocComment) {
+        ctx.print(node, `/*${comment.toString()}*/`, comment.trailingNewline);
+      } else {
+        if (comment.multiline) {
+          ctx.print(node, `/* ${comment.text} */`, comment.trailingNewline);
+        } else {
+          comment.text.split('\n').forEach((line) => ctx.println(node, `// ${line}`));
+        }
+      }
+    }
+  }
 }
 
-export function escapeIdentifier(input: string, alwaysQuote: boolean = true): any {
+export function escapeIdentifier(input: string, alwaysQuote: boolean = true): string | null {
   if (input == null) {
     return null;
   }
-  const body = input.replace(_SINGLE_QUOTE_ESCAPE_STRING_RE, (...match: string[]) => {
+
+  const body = input.replace(SINGLE_QUOTE_ESCAPE_STRING_RE, (...match: string[]) => {
     if (match[0] == '\n') {
       return '\\n';
     } else if (match[0] == '\r') {
@@ -568,14 +640,7 @@ export function escapeIdentifier(input: string, alwaysQuote: boolean = true): an
       return `\\${match[0]}`;
     }
   });
-  const requiresQuotes = alwaysQuote || !_LEGAL_IDENTIFIER_RE.test(body);
-  return requiresQuotes ? `'${body}'` : body;
-}
 
-function _createIndent(count: number): string {
-  let res = '';
-  for (let i = 0; i < count; i++) {
-    res += _INDENT_WITH;
-  }
-  return res;
+  const requiresQuotes = alwaysQuote || !LEGAL_IDENTIFIER_RE.test(body);
+  return requiresQuotes ? `'${body}'` : body;
 }

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -212,10 +212,15 @@ export class EmitterVisitorContext {
   }
 }
 
-export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.ExpressionVisitor {
+export abstract class AbstractEmitterVisitor
+  implements o.StatementVisitor, o.ExpressionVisitor, o.TypeVisitor
+{
   private lastIfCondition: o.Expression | null = null;
 
-  constructor(private readonly printComments: boolean) {}
+  constructor(
+    protected readonly printComments: boolean,
+    protected readonly printTypes: boolean,
+  ) {}
 
   abstract visitExternalExpr(ast: o.ExternalExpr, ctx: EmitterVisitorContext): void;
   abstract visitWrappedNodeExpr(ast: o.WrappedNodeExpr<unknown>, ctx: EmitterVisitorContext): void;
@@ -266,10 +271,13 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
 
     this.printLeadingComments(stmt, ctx);
     ctx.print(stmt, `${varKind} ${stmt.name}`);
+    stmt.type?.visitType(this, ctx);
+
     if (stmt.value) {
       ctx.print(stmt, ' = ');
       stmt.value.visitExpression(this, ctx);
     }
+
     ctx.println(stmt, `;`);
   }
 
@@ -379,10 +387,10 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `(`);
     ast.condition.visitExpression(this, ctx);
-    ctx.print(ast, '? ');
+    ctx.print(ast, ' ? ');
     ast.trueCase.visitExpression(this, ctx);
-    ctx.print(ast, ': ');
-    ast.falseCase!.visitExpression(this, ctx);
+    ctx.print(ast, ' : ');
+    ast.falseCase?.visitExpression(this, ctx);
     ctx.print(ast, `)`);
   }
 
@@ -401,7 +409,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `function${ast.name ? ' ' + ast.name : ''}(`);
     this.visitParams(ast.params, ctx);
-    ctx.println(ast, `) {`);
+    ctx.println(ast, `)`);
+    ast.type?.visitType(this, ctx);
+    ctx.println(ast, ` {`);
     ctx.incIndent();
     this.visitAllStatements(ast.statements, ctx);
     ctx.decIndent();
@@ -412,7 +422,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '(');
     this.visitParams(ast.params, ctx);
-    ctx.print(ast, ') =>');
+    ctx.print(ast, ')');
+    ast.type?.visitType(this, ctx);
+    ctx.print(ast, ' =>');
 
     if (Array.isArray(ast.body)) {
       ctx.println(ast, `{`);
@@ -439,7 +451,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(stmt, ctx);
     ctx.print(stmt, `function ${stmt.name}(`);
     this.visitParams(stmt.params, ctx);
-    ctx.println(stmt, `) {`);
+    ctx.println(stmt, `)`);
+    stmt.type?.visitType(this, ctx);
+    ctx.println(stmt, ` {`);
     ctx.incIndent();
     this.visitAllStatements(stmt.statements, ctx);
     ctx.decIndent();
@@ -498,7 +512,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   visitLiteralArrayExpr(ast: o.LiteralArrayExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `[`);
-    this.visitAllExpressions(ast.entries, ctx, ',');
+    this.visitAllExpressions(ast.entries, ctx, ', ');
     ctx.print(ast, `]`);
   }
 
@@ -511,13 +525,13 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
           ctx.print(ast, '...');
           entry.expression.visitExpression(this, ctx);
         } else {
-          ctx.print(ast, `${escapeIdentifier(entry.key, entry.quoted)}:`);
+          ctx.print(ast, `${escapeIdentifier(entry.key, entry.quoted)}: `);
           entry.value.visitExpression(this, ctx);
         }
       },
       ast.entries,
       ctx,
-      ',',
+      ', ',
     );
     ctx.print(ast, `}`);
   }
@@ -525,7 +539,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   visitCommaExpr(ast: o.CommaExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '(');
-    this.visitAllExpressions(ast.parts, ctx, ',');
+    this.visitAllExpressions(ast.parts, ctx, ', ');
     ctx.print(ast, ')');
   }
 
@@ -541,6 +555,85 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, '...');
     ast.expression.visitExpression(this, ctx);
+  }
+
+  visitBuiltinType(type: o.BuiltinType, ctx: EmitterVisitorContext): void {
+    if (!this.printTypes) {
+      return;
+    }
+
+    switch (type.name) {
+      case o.BuiltinTypeName.Bool:
+        ctx.print(null, ': boolean');
+        break;
+      case o.BuiltinTypeName.Dynamic:
+        ctx.print(null, ': any');
+        break;
+      case o.BuiltinTypeName.Int:
+      case o.BuiltinTypeName.Number:
+        ctx.print(null, ': number');
+        break;
+      case o.BuiltinTypeName.String:
+        ctx.print(null, ': string');
+        break;
+      case o.BuiltinTypeName.None:
+        ctx.print(null, ': void');
+        break;
+      case o.BuiltinTypeName.Inferred:
+        // Emits nothing
+        break;
+      case o.BuiltinTypeName.Function:
+        ctx.print(null, ': Function');
+        break;
+      default:
+        ctx.print(null, ': any');
+        break;
+    }
+  }
+
+  visitExpressionType(type: o.ExpressionType, ctx: EmitterVisitorContext): void {
+    if (!this.printTypes) {
+      return;
+    }
+
+    ctx.print(null, ': ');
+    type.value.visitExpression(this, ctx);
+
+    if (type.typeParams && type.typeParams.length > 0) {
+      ctx.print(null, '<');
+      this.visitAllObjects((param) => param.visitType(this, ctx), type.typeParams, ctx, ',');
+      ctx.print(null, '>');
+    }
+  }
+
+  visitArrayType(type: o.ArrayType, ctx: EmitterVisitorContext): void {
+    if (!this.printTypes) {
+      return;
+    }
+
+    ctx.print(null, ': ');
+    type.of.visitType(this, ctx);
+    ctx.print(null, '[]');
+  }
+
+  visitMapType(type: o.MapType, ctx: EmitterVisitorContext): void {
+    if (!this.printTypes) {
+      return;
+    }
+
+    ctx.print(null, ': { [key: string]: ');
+
+    if (type.valueType) {
+      type.valueType.visitType(this, ctx);
+    } else {
+      ctx.print(null, 'any');
+    }
+
+    ctx.print(null, '}');
+  }
+
+  visitTransplantedType(type: o.TransplantedType<unknown>, ctx: EmitterVisitorContext): void {
+    throw new Error('TransplantedType nodes are not supported');
   }
 
   visitAllExpressions(
@@ -585,8 +678,16 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     statements.forEach((stmt) => stmt.visitStatement(this, ctx));
   }
 
-  private visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
-    this.visitAllObjects((param) => ctx.print(null, param.name), params, ctx, ',');
+  protected visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
+    this.visitAllObjects(
+      (param) => {
+        ctx.print(null, param.name);
+        param.type?.visitType(this, ctx);
+      },
+      params,
+      ctx,
+      ', ',
+    );
   }
 
   protected shouldParenthesize(

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -214,8 +214,6 @@ export class EmitterVisitorContext {
 export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.ExpressionVisitor {
   private lastIfCondition: o.Expression | null = null;
 
-  constructor(private _escapeDollarInStrings: boolean) {}
-
   protected printLeadingComments(
     node: o.Expression | o.Statement,
     ctx: EmitterVisitorContext,
@@ -359,7 +357,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
     this.printLeadingComments(ast, ctx);
     const value = ast.value;
     if (typeof value === 'string') {
-      ctx.print(ast, escapeIdentifier(value, this._escapeDollarInStrings));
+      ctx.print(ast, escapeIdentifier(value));
     } else {
       ctx.print(ast, `${value}`);
     }
@@ -484,10 +482,7 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
           ctx.print(ast, '...');
           entry.expression.visitExpression(this, ctx);
         } else {
-          ctx.print(
-            ast,
-            `${escapeIdentifier(entry.key, this._escapeDollarInStrings, entry.quoted)}:`,
-          );
+          ctx.print(ast, `${escapeIdentifier(entry.key, entry.quoted)}:`);
           entry.value.visitExpression(this, ctx);
         }
       },
@@ -560,18 +555,12 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
   }
 }
 
-export function escapeIdentifier(
-  input: string,
-  escapeDollar: boolean,
-  alwaysQuote: boolean = true,
-): any {
+export function escapeIdentifier(input: string, alwaysQuote: boolean = true): any {
   if (input == null) {
     return null;
   }
   const body = input.replace(_SINGLE_QUOTE_ESCAPE_STRING_RE, (...match: string[]) => {
-    if (match[0] == '$') {
-      return escapeDollar ? '\\$' : '$';
-    } else if (match[0] == '\n') {
+    if (match[0] == '\n') {
       return '\\n';
     } else if (match[0] == '\r') {
       return '\\r';

--- a/packages/compiler/src/output/abstract_js_emitter.ts
+++ b/packages/compiler/src/output/abstract_js_emitter.ts
@@ -26,7 +26,7 @@ const makeTemplateObjectPolyfill =
 
 export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
   constructor() {
-    super(false /* printComments */);
+    super(false /* printComments */, false /* emitTypes */);
   }
 
   override visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): void {

--- a/packages/compiler/src/output/abstract_js_emitter.ts
+++ b/packages/compiler/src/output/abstract_js_emitter.ts
@@ -25,10 +25,6 @@ const makeTemplateObjectPolyfill =
   '(this&&this.__makeTemplateObject||function(e,t){return Object.defineProperty?Object.defineProperty(e,"raw",{value:t}):e.raw=t,e})';
 
 export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
-  constructor() {
-    super(false);
-  }
-
   override visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): any {
     throw new Error('Cannot emit a WrappedNodeExpr in Javascript.');
   }
@@ -57,11 +53,8 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
     const elements = ast.template.elements;
     ast.tag.visitExpression(this, ctx);
     ctx.print(ast, `(${makeTemplateObjectPolyfill}(`);
-    ctx.print(ast, `[${elements.map((part) => escapeIdentifier(part.text, false)).join(', ')}], `);
-    ctx.print(
-      ast,
-      `[${elements.map((part) => escapeIdentifier(part.rawText, false)).join(', ')}])`,
-    );
+    ctx.print(ast, `[${elements.map((part) => escapeIdentifier(part.text)).join(', ')}], `);
+    ctx.print(ast, `[${elements.map((part) => escapeIdentifier(part.rawText)).join(', ')}])`);
     ast.template.expressions.forEach((expression) => {
       ctx.print(ast, ', ');
       expression.visitExpression(this, ctx);
@@ -150,8 +143,8 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
     for (let i = 1; i < ast.messageParts.length; i++) {
       parts.push(ast.serializeI18nTemplatePart(i));
     }
-    ctx.print(ast, `[${parts.map((part) => escapeIdentifier(part.cooked, false)).join(', ')}], `);
-    ctx.print(ast, `[${parts.map((part) => escapeIdentifier(part.raw, false)).join(', ')}])`);
+    ctx.print(ast, `[${parts.map((part) => escapeIdentifier(part.cooked)).join(', ')}], `);
+    ctx.print(ast, `[${parts.map((part) => escapeIdentifier(part.raw)).join(', ')}])`);
     ast.expressions.forEach((expression) => {
       ctx.print(ast, ', ');
       expression.visitExpression(this, ctx);

--- a/packages/compiler/src/output/abstract_js_emitter.ts
+++ b/packages/compiler/src/output/abstract_js_emitter.ts
@@ -29,23 +29,23 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
     super(false /* printComments */);
   }
 
-  override visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): any {
+  override visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): void {
     throw new Error('Cannot emit a WrappedNodeExpr in Javascript.');
   }
 
-  override visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): any {
+  override visitDeclareVarStmt(stmt: o.DeclareVarStmt, ctx: EmitterVisitorContext): void {
     ctx.print(stmt, `var ${stmt.name}`);
     if (stmt.value) {
       ctx.print(stmt, ' = ');
       stmt.value.visitExpression(this, ctx);
     }
     ctx.println(stmt, `;`);
-    return null;
   }
+
   override visitTaggedTemplateLiteralExpr(
     ast: o.TaggedTemplateLiteralExpr,
     ctx: EmitterVisitorContext,
-  ): any {
+  ): void {
     // The following convoluted piece of code is effectively the downlevelled equivalent of
     // ```
     // tag`...`
@@ -64,9 +64,9 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
       expression.visitExpression(this, ctx);
     });
     ctx.print(ast, ')');
-    return null;
   }
-  override visitTemplateLiteralExpr(expr: o.TemplateLiteralExpr, ctx: EmitterVisitorContext): any {
+
+  override visitTemplateLiteralExpr(expr: o.TemplateLiteralExpr, ctx: EmitterVisitorContext): void {
     ctx.print(expr, '`');
     for (let i = 0; i < expr.elements.length; i++) {
       expr.elements[i].visitExpression(this, ctx);
@@ -79,61 +79,15 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
     }
     ctx.print(expr, '`');
   }
+
   override visitTemplateLiteralElementExpr(
     expr: o.TemplateLiteralElementExpr,
     ctx: EmitterVisitorContext,
-  ): any {
+  ): void {
     ctx.print(expr, expr.rawText);
-    return null;
   }
-  override visitFunctionExpr(ast: o.FunctionExpr, ctx: EmitterVisitorContext): any {
-    ctx.print(ast, `function${ast.name ? ' ' + ast.name : ''}(`);
-    this._visitParams(ast.params, ctx);
-    ctx.println(ast, `) {`);
-    ctx.incIndent();
-    this.visitAllStatements(ast.statements, ctx);
-    ctx.decIndent();
-    ctx.print(ast, `}`);
-    return null;
-  }
-  override visitArrowFunctionExpr(ast: o.ArrowFunctionExpr, ctx: EmitterVisitorContext): any {
-    ctx.print(ast, '(');
-    this._visitParams(ast.params, ctx);
-    ctx.print(ast, ') =>');
 
-    if (Array.isArray(ast.body)) {
-      ctx.println(ast, `{`);
-      ctx.incIndent();
-      this.visitAllStatements(ast.body, ctx);
-      ctx.decIndent();
-      ctx.print(ast, `}`);
-    } else {
-      const isObjectLiteral = ast.body instanceof o.LiteralMapExpr;
-
-      if (isObjectLiteral) {
-        ctx.print(ast, '(');
-      }
-
-      ast.body.visitExpression(this, ctx);
-
-      if (isObjectLiteral) {
-        ctx.print(ast, ')');
-      }
-    }
-
-    return null;
-  }
-  override visitDeclareFunctionStmt(stmt: o.DeclareFunctionStmt, ctx: EmitterVisitorContext): any {
-    ctx.print(stmt, `function ${stmt.name}(`);
-    this._visitParams(stmt.params, ctx);
-    ctx.println(stmt, `) {`);
-    ctx.incIndent();
-    this.visitAllStatements(stmt.statements, ctx);
-    ctx.decIndent();
-    ctx.println(stmt, `}`);
-    return null;
-  }
-  override visitLocalizedString(ast: o.LocalizedString, ctx: EmitterVisitorContext): any {
+  override visitLocalizedString(ast: o.LocalizedString, ctx: EmitterVisitorContext): void {
     // The following convoluted piece of code is effectively the downlevelled equivalent of
     // ```
     // $localize `...`
@@ -154,10 +108,5 @@ export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
       expression.visitExpression(this, ctx);
     });
     ctx.print(ast, ')');
-    return null;
-  }
-
-  private _visitParams(params: o.FnParam[], ctx: EmitterVisitorContext): void {
-    this.visitAllObjects((param) => ctx.print(null, param.name), params, ctx, ',');
   }
 }

--- a/packages/compiler/src/output/abstract_js_emitter.ts
+++ b/packages/compiler/src/output/abstract_js_emitter.ts
@@ -25,6 +25,10 @@ const makeTemplateObjectPolyfill =
   '(this&&this.__makeTemplateObject||function(e,t){return Object.defineProperty?Object.defineProperty(e,"raw",{value:t}):e.raw=t,e})';
 
 export abstract class AbstractJsEmitterVisitor extends AbstractEmitterVisitor {
+  constructor() {
+    super(false /* printComments */);
+  }
+
   override visitWrappedNodeExpr(ast: o.WrappedNodeExpr<any>, ctx: EmitterVisitorContext): any {
     throw new Error('Cannot emit a WrappedNodeExpr in Javascript.');
   }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -317,8 +317,8 @@ export abstract class Expression {
     return new BinaryOperatorExpr(BinaryOperator.NullishCoalesce, this, rhs, null, sourceSpan);
   }
 
-  toStmt(): Statement {
-    return new ExpressionStatement(this, null);
+  toStmt(leadingComments?: LeadingComment[]): Statement {
+    return new ExpressionStatement(this, null, leadingComments);
   }
 }
 

--- a/packages/compiler/src/render3/r3_factory.ts
+++ b/packages/compiler/src/render3/r3_factory.ts
@@ -10,7 +10,7 @@ import {InjectFlags} from '../core';
 import * as o from '../output/output_ast';
 import {Identifiers as R3} from '../render3/r3_identifiers';
 
-import {R3CompiledExpression, R3Reference, typeWithParameters} from './util';
+import {R3CompiledExpression, R3Reference, tsIgnoreComment, typeWithParameters} from './util';
 
 /**
  * Metadata required by the factory generator to generate a `factory` function for a type.
@@ -117,6 +117,19 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3CompiledExpre
     : t;
 
   let ctorExpr: o.Expression | null = null;
+
+  // If the factory has invalid dependencies (e.g. trying to inject an interface), we normally mark
+  // the `deps` as invalid so we can emit an invalid factory. In some environments we may not
+  // be able to determine if the dependency is invalid, because that depends on information in
+  // other files. To ensure that cases like that still compile, we need to add a `@ts-ignore`
+  // comment which allows the code to compile and then error at runtime. Note that it's important
+  // to put the comment on a statement, because it includes a new line which may break `return`
+  // statements if the comment is set on the expression.
+  const factoryComments =
+    meta.deps !== null && meta.deps !== 'invalid' && meta.deps.length > 0
+      ? [tsIgnoreComment()]
+      : undefined;
+
   if (meta.deps !== null) {
     // There is a constructor (either explicitly or implicitly defined).
     if (meta.deps !== 'invalid') {
@@ -136,9 +149,10 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3CompiledExpre
     body.push(new o.DeclareVarStmt(r.name, o.NULL_EXPR, o.DYNAMIC_TYPE));
     const ctorStmt =
       ctorExpr !== null
-        ? r.set(ctorExpr).toStmt()
+        ? r.set(ctorExpr).toStmt(factoryComments)
         : o.importExpr(R3.invalidFactory).callFn([]).toStmt();
-    body.push(o.ifStmt(t, [ctorStmt], [r.set(nonCtorExpr).toStmt()]));
+    // Always add a `ts-ignore` on the alternate factory.
+    body.push(o.ifStmt(t, [ctorStmt], [r.set(nonCtorExpr).toStmt([tsIgnoreComment()])]));
     return r;
   }
 
@@ -173,7 +187,7 @@ export function compileFactoryFunction(meta: R3FactoryMetadata): R3CompiledExpre
     body.push(new o.ReturnStatement(baseFactory.callFn([typeForCtor])));
   } else {
     // This is straightforward factory, just return it.
-    body.push(new o.ReturnStatement(retExpr));
+    body.push(new o.ReturnStatement(retExpr, null, factoryComments));
   }
 
   let factoryFn: o.Expression = o.fn(

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -46,7 +46,7 @@ export function prepareSyntheticListenerName(name: string, phase: string) {
 }
 
 export function getSafePropertyAccessString(accessor: string, name: string): string {
-  const escapedName = escapeIdentifier(name, false, false);
+  const escapedName = escapeIdentifier(name, false);
   return escapedName !== name ? `${accessor}[${escapedName}]` : `${accessor}.${name}`;
 }
 

--- a/packages/compiler/test/output/abstract_emitter_spec.ts
+++ b/packages/compiler/test/output/abstract_emitter_spec.ts
@@ -11,32 +11,26 @@ import {escapeIdentifier} from '../../src/output/abstract_emitter';
 describe('AbstractEmitter', () => {
   describe('escapeIdentifier', () => {
     it('should escape single quotes', () => {
-      expect(escapeIdentifier(`'`, false)).toEqual(`'\\''`);
+      expect(escapeIdentifier(`'`)).toEqual(`'\\''`);
     });
 
     it('should escape backslash', () => {
-      expect(escapeIdentifier('\\', false)).toEqual(`'\\\\'`);
+      expect(escapeIdentifier('\\')).toEqual(`'\\\\'`);
     });
 
     it('should escape newlines', () => {
-      expect(escapeIdentifier('\n', false)).toEqual(`'\\n'`);
+      expect(escapeIdentifier('\n')).toEqual(`'\\n'`);
     });
 
     it('should escape carriage returns', () => {
-      expect(escapeIdentifier('\r', false)).toEqual(`'\\r'`);
+      expect(escapeIdentifier('\r')).toEqual(`'\\r'`);
     });
 
-    it('should escape $', () => {
-      expect(escapeIdentifier('$', true)).toEqual(`'\\$'`);
-    });
-    it('should not escape $', () => {
-      expect(escapeIdentifier('$', false)).toEqual(`'$'`);
-    });
     it('should add quotes for non-identifiers', () => {
-      expect(escapeIdentifier('==', false, false)).toEqual(`'=='`);
+      expect(escapeIdentifier('==', false)).toEqual(`'=='`);
     });
     it('does not escape class (but it probably should)', () => {
-      expect(escapeIdentifier('class', false, false)).toEqual('class');
+      expect(escapeIdentifier('class', false)).toEqual('class');
     });
   });
 });


### PR DESCRIPTION
Fixes an issue where the factories we generate might not be able to compile, based on the level of analysis.

Also expands and reworks the base abstract emitter so we can reuse it in other contexts.