### PR TITLE
docs: remove takeUntilDestroyed to avoid unnecessary rxjs-interop dependency

### DIFF
--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -34,6 +34,7 @@ When you want to run code during specific navigation lifecycle events, you can d
 // Example of subscribing to router events
 import {Component, inject, signal, effect} from '@angular/core';
 import {Event, Router, NavigationStart, NavigationEnd} from '@angular/router';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   /*...*/
@@ -43,7 +44,7 @@ export class RouterEvents {
 
   constructor() {
     // Subscribe to router events and react to events
-    this.router.events.subscribe((event: Event) => {
+    this.router.events.pipe(takeUntilDestroyed()).subscribe((event: Event) => {
       if (event instanceof NavigationStart) {
         // Navigation starting
         console.log('Navigation starting:', event.url);
@@ -148,6 +149,7 @@ import {
   NavigationCancel,
   NavigationCancellationCode,
 } from '@angular/router';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-error-handler',
@@ -165,7 +167,7 @@ export class ErrorHandler {
   readonly errorMessage = signal('');
 
   constructor() {
-    this.router.events.subscribe((event) => {
+    this.router.events.pipe(takeUntilDestroyed()).subscribe((event) => {
       if (event instanceof NavigationStart) {
         this.errorMessage.set('');
       } else if (event instanceof NavigationError) {

--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -43,7 +43,7 @@ export class RouterEvents {
 
   constructor() {
     // Subscribe to router events and react to events
-    this.router.events.pipe(takeUntilDestroyed()).subscribe((event: Event) => {
+    this.router.events.subscribe((event: Event) => {
       if (event instanceof NavigationStart) {
         // Navigation starting
         console.log('Navigation starting:', event.url);
@@ -148,7 +148,6 @@ import {
   NavigationCancel,
   NavigationCancellationCode,
 } from '@angular/router';
-import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-error-handler',
@@ -166,7 +165,7 @@ export class ErrorHandler {
   readonly errorMessage = signal('');
 
   constructor() {
-    this.router.events.pipe(takeUntilDestroyed()).subscribe((event) => {
+    this.router.events.subscribe((event) => {
       if (event instanceof NavigationStart) {
         this.errorMessage.set('');
       } else if (event instanceof NavigationError) {

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -783,9 +783,7 @@ The component has to _subscribe_ to the `ActivatedRoute.paramMap` observable and
 ```ts
 constructor() {
   // get hero when `id` param changes
-  this.route.paramMap
-    .pipe(takeUntilDestroyed())
-    .subscribe((pmap) => this.getHero(pmap.get('id')));
+  this.route.paramMap.subscribe((pmap) => this.getHero(pmap.get('id')));
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [X] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Routing example in the documentation use `takeUntilDestroyed()` with `ActivatedRoute`  even though router observables already complete when the component is destroyed.  

This introduces an unnecessary `@angular/core/rxjs-interop` dependency and creates inconsistency with other routing examples that correctly omit it.

Issue Number: N/A

## What is the new behavior?

The example no longer use `takeUntilDestroyed()` with ActivatedRouter observable.
The documentation becomes lighter, avoids the extra rxjs-interop dependency, and remains consistent with other routing examples where no cleanup is done.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
