### PR TITLE
fix(compiler): prevent shimCssText from adding extra blank lines per CSS comment

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -186,7 +186,7 @@ export class ShadowCss {
         // Replace non hash comments with empty lines.
         // This is done so that we do not leak any sensitive data in comments.
         const newLinesMatches = m.match(_newLinesRe);
-        comments.push((newLinesMatches?.join('') ?? '') + '\n');
+        comments.push(newLinesMatches?.join('') ?? '');
       }
 
       return COMMENT_PLACEHOLDER;

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -368,17 +368,17 @@ describe('ShadowCss', () => {
   describe('comments', () => {
     // Comments should be kept in the same position as otherwise inline sourcemaps break due to
     // shift in lines.
-    it('should replace multiline comments with newline', () => {
-      expect(shim('/* b {c} */ b {c}', 'contenta')).toBe('\n b[contenta] {c}');
+    it('should remove inline comments without adding extra lines', () => {
+      expect(shim('/* b {c} */ b {c}', 'contenta')).toBe(' b[contenta] {c}');
     });
 
-    it('should replace multiline comments with newline in the original position', () => {
-      expect(shim('/* b {c}\n */ b {c}', 'contenta')).toBe('\n\n b[contenta] {c}');
+    it('should preserve internal newlines from multiline comments', () => {
+      expect(shim('/* b {c}\n */ b {c}', 'contenta')).toBe('\n b[contenta] {c}');
     });
 
-    it('should replace comments with newline in the original position', () => {
+    it('should remove multiple inline comments without adding extra lines', () => {
       expect(shim('/* b {c} */ b {c} /* a {c} */ a {c}', 'contenta')).toBe(
-        '\n b[contenta] {c} \n a[contenta] {c}',
+        ' b[contenta] {c}  a[contenta] {c}',
       );
     });
 
@@ -392,9 +392,7 @@ describe('ShadowCss', () => {
     });
 
     it('should handle adjacent comments', () => {
-      expect(shim('/* comment 1 */ /* comment 2 */ b {c}', 'contenta')).toBe(
-        '\n \n b[contenta] {c}',
-      );
+      expect(shim('/* comment 1 */ /* comment 2 */ b {c}', 'contenta')).toBe('  b[contenta] {c}');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Component sourcemaps using emulated style encapsulation were wrong due to `encapsulateStyle` adding new lines to CSS files which makes the sourcemap line numbers incorrect, thus clicking to navigate to sourcemaps in devtools would take you to the wrong location

Issue Number: N/A

## What is the new behavior?

Component sourcemaps are correct - we patched this into our angular version and verified this does indeed fix the issue we were experiencing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
