### PR TITLE
fix(compiler-cli): avoid recursive scope lookups for invalid NgModule imports

### DIFF
--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -151,10 +151,12 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
   registerPipeMetadata(pipe: PipeMeta): void {}
 
   getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope | null {
-    const scope = !this.declarationToModule.has(clazz)
-      ? null
-      : this.getScopeOfModule(this.declarationToModule.get(clazz)!.ngModule);
-    return scope;
+    if (!this.declarationToModule.has(clazz)) {
+      return null;
+    }
+
+    const module = this.declarationToModule.get(clazz)!.ngModule;
+    return this.getScopeOfModule(module);
   }
 
   /**
@@ -181,9 +183,12 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
    * defined, or the string `'error'` if the scope contained errors.
    */
   getScopeOfModule(clazz: ClassDeclaration): LocalModuleScope | null {
-    return this.moduleToRef.has(clazz)
-      ? this.getScopeOfModuleReference(this.moduleToRef.get(clazz)!)
-      : null;
+    if (!this.moduleToRef.has(clazz)) {
+      return null;
+    }
+
+    const scope = this.getScopeOfModuleReference(this.moduleToRef.get(clazz)!);
+    return scope === 'cycle' ? null : scope;
   }
 
   /**
@@ -249,13 +254,17 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
   /**
    * Implementation of `getScopeOfModule` which accepts a reference to a class.
    */
-  private getScopeOfModuleReference(ref: Reference<ClassDeclaration>): LocalModuleScope | null {
+  private getScopeOfModuleReference(
+    ref: Reference<ClassDeclaration>,
+  ): LocalModuleScope | null | 'cycle' {
     if (this.cache.has(ref.node)) {
       const cachedValue = this.cache.get(ref.node);
 
-      if (cachedValue !== IN_PROGRESS_RESOLUTION) {
-        return cachedValue as LocalModuleScope | null;
+      if (cachedValue === IN_PROGRESS_RESOLUTION) {
+        return 'cycle';
       }
+
+      return cachedValue as LocalModuleScope | null;
     }
 
     this.cache.set(ref.node, IN_PROGRESS_RESOLUTION);
@@ -593,7 +602,8 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       }
       return this.dependencyScopeReader.resolve(ref);
     } else {
-      if (this.cache.get(ref.node) === IN_PROGRESS_RESOLUTION) {
+      const scope = this.getScopeOfModuleReference(ref);
+      if (scope === 'cycle') {
         diagnostics.push(
           makeDiagnostic(
             type === 'import'
@@ -603,11 +613,10 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
             `NgModule "${type}" field contains a cycle`,
           ),
         );
-        return 'cycle';
       }
 
       // The NgModule is declared locally in the current program. Resolve it from the registry.
-      return this.getScopeOfModuleReference(ref);
+      return scope;
     }
   }
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -11470,6 +11470,30 @@ runInEachFileSystem((os: string) => {
           `The pipe 'TestPipe' appears in 'imports', but is not standalone`,
         );
       });
+
+      it('should not recurse when a non-standalone component is both declared and imported', () => {
+        env.write(
+          '/test.ts',
+          `
+            import {Component, NgModule} from '@angular/core';
+
+            @Component({standalone: false, template: ''})
+            export class TestComp {}
+
+            @NgModule({
+              declarations: [TestComp],
+              imports: [TestComp],
+            })
+            export class TestModule {}
+          `,
+        );
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toContain(
+          `The component 'TestComp' appears in 'imports', but is not standalone`,
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (not needed for this bug fix)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a non-standalone component is accidentally left in both `declarations` and
`imports` of the same `NgModule`, Angular computes the "not standalone"
diagnostic while the module scope is still resolving. That diagnostic asks for
the component scope, re-enters the same scope computation, and can overflow the
stack. In the language service this surfaces as repeated server crashes.

Issue Number: #65040

## What is the new behavior?

`LocalModuleScopeRegistry.getScopeForComponent()` now returns `null` when the
declaring `NgModule` is still in progress, allowing the existing diagnostic to
fall back to its generic message instead of recursively recomputing the module
scope.

A regression test covers the case where the same non-standalone component is
present in both `declarations` and `imports`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #65040

Verified with:

`pnpm bazel test //packages/compiler-cli/test/ngtsc:ngtsc --test_filter="*should not recurse when a non-standalone component is both declared and imported*"`