### PR TITLE
Codegen fixes

### DIFF
--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -396,7 +396,15 @@ export abstract class AbstractEmitterVisitor
 
   visitDynamicImportExpr(ast: o.DynamicImportExpr, ctx: EmitterVisitorContext): void {
     this.printLeadingComments(ast, ctx);
-    ctx.print(ast, `import(${ast.url})`);
+    ctx.print(ast, `import(`);
+
+    if (typeof ast.url === 'string') {
+      ctx.print(ast, escapeIdentifier(ast.url, true)!);
+    } else {
+      ast.url.visitExpression(this, ctx);
+    }
+
+    ctx.print(ast, `)`);
   }
 
   visitNotExpr(ast: o.NotExpr, ctx: EmitterVisitorContext): void {
@@ -409,13 +417,14 @@ export abstract class AbstractEmitterVisitor
     this.printLeadingComments(ast, ctx);
     ctx.print(ast, `function${ast.name ? ' ' + ast.name : ''}(`);
     this.visitParams(ast.params, ctx);
-    ctx.println(ast, `)`);
+    ctx.print(ast, `)`);
     ast.type?.visitType(this, ctx);
-    ctx.println(ast, ` {`);
+    ctx.print(ast, ` {`);
+    ctx.println(ast);
     ctx.incIndent();
     this.visitAllStatements(ast.statements, ctx);
     ctx.decIndent();
-    ctx.print(ast, `}`);
+    ctx.println(ast, `}`);
   }
 
   visitArrowFunctionExpr(ast: o.ArrowFunctionExpr, ctx: EmitterVisitorContext): void {
@@ -424,14 +433,15 @@ export abstract class AbstractEmitterVisitor
     this.visitParams(ast.params, ctx);
     ctx.print(ast, ')');
     ast.type?.visitType(this, ctx);
-    ctx.print(ast, ' =>');
+    ctx.print(ast, ' => ');
 
     if (Array.isArray(ast.body)) {
-      ctx.println(ast, `{`);
+      ctx.print(ast, `{`);
+      ctx.println(ast);
       ctx.incIndent();
       this.visitAllStatements(ast.body, ctx);
       ctx.decIndent();
-      ctx.print(ast, `}`);
+      ctx.println(ast, `}`);
     } else {
       const shouldParenthesize = this.shouldParenthesize(ast.body, ast);
 
@@ -451,9 +461,10 @@ export abstract class AbstractEmitterVisitor
     this.printLeadingComments(stmt, ctx);
     ctx.print(stmt, `function ${stmt.name}(`);
     this.visitParams(stmt.params, ctx);
-    ctx.println(stmt, `)`);
+    ctx.print(stmt, `)`);
     stmt.type?.visitType(this, ctx);
-    ctx.println(stmt, ` {`);
+    ctx.print(stmt, ` {`);
+    ctx.println(stmt);
     ctx.incIndent();
     this.visitAllStatements(stmt.statements, ctx);
     ctx.decIndent();

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -247,7 +247,7 @@ function locateRNodeByPath(path: string, lView: LView): RNode {
   } else if (referenceNode === REFERENCE_NODE_BODY) {
     ref = ɵɵresolveBody(
       lView[DECLARATION_COMPONENT_VIEW][HOST] as RElement & {ownerDocument: Document},
-    );
+    ) as Element;
   } else {
     const parentElementId = Number(referenceNode);
     ref = unwrapRNode((lView as any)[parentElementId + HEADER_OFFSET]) as Element;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -98,18 +98,20 @@ import {StandaloneService} from './standalone_service';
  *  - The reason why this API and `outputs` API is not the same is that `NgOnChanges` has
  *    inconsistent behavior in that it uses declared names rather than minified or public.
  */
-type DirectiveInputs<T> = {
-  [P in keyof T]?:  // Basic case. Mapping minified name to public name.
-    | string
-    // Complex input when there are flags, or differing public name and declared name, or there
-    // is a transform. Such inputs are not as common, so the array form is only generated then.
-    | [
-        flags: InputFlags,
-        publicName: string,
-        declaredName?: string,
-        transform?: InputTransformFunction,
-      ];
-};
+type DirectiveInputs = Record<
+  string,
+  // Basic case. Mapping minified name to public name.
+  | string
+  // Complex input when there are flags, or differing public name and declared name, or there
+  // is a transform. Such inputs are not as common, so the array form is only generated then.
+  | [
+      flags: InputFlags,
+      publicName: string,
+      declaredName?: string,
+      transform?: InputTransformFunction,
+    ]
+  | undefined
+>;
 
 interface DirectiveDefinition<T> {
   /**
@@ -123,7 +125,7 @@ interface DirectiveDefinition<T> {
   /**
    * A map of input names.
    */
-  inputs?: DirectiveInputs<T>;
+  inputs?: DirectiveInputs;
 
   /**
    * A map of output names.
@@ -135,7 +137,7 @@ interface DirectiveDefinition<T> {
    * This allows the render to re-construct the minified and non-minified names
    * of properties.
    */
-  outputs?: {[P in keyof T]?: string};
+  outputs?: Record<string, string | undefined>;
 
   /**
    * A list of optional features to apply.

--- a/packages/core/src/render3/util/misc_utils.ts
+++ b/packages/core/src/render3/util/misc_utils.ts
@@ -12,15 +12,15 @@ import {RElement} from '../interfaces/renderer_dom';
  *
  * @codeGenApi
  */
-export function ɵɵresolveWindow(element: RElement & {ownerDocument: Document}) {
-  return element.ownerDocument.defaultView;
+export function ɵɵresolveWindow(element: RElement & {ownerDocument: Document}): EventTarget {
+  return element.ownerDocument.defaultView!;
 }
 
 /**
  *
  * @codeGenApi
  */
-export function ɵɵresolveDocument(element: RElement & {ownerDocument: Document}) {
+export function ɵɵresolveDocument(element: RElement & {ownerDocument: Document}): EventTarget {
   return element.ownerDocument;
 }
 
@@ -28,7 +28,7 @@ export function ɵɵresolveDocument(element: RElement & {ownerDocument: Document
  *
  * @codeGenApi
  */
-export function ɵɵresolveBody(element: RElement & {ownerDocument: Document}) {
+export function ɵɵresolveBody(element: RElement & {ownerDocument: Document}): EventTarget {
   return element.ownerDocument.body;
 }
 


### PR DESCRIPTION
Fixes the following issues that were found when inspecting generated code:

## fix(core): resolver function not matching expected type 

Fixes that the `ɵɵresolveWindow` function wasn't match the type expected by `ɵɵlistener`. I've also added explicit type annotations to make cases like this easier to catch.

## fix(core): widen type for directive inputs/outputs 

Currently the directive inputs and outputs are typed to match the members of the class. We can't guarantee that when generating code, because of cases like `model` where an output is generated implicitly.

These changes widen the type to be any string.

## fix(compiler): abstract emitter producing incorrect code for dynamic imports

Fixes that the abstract emitter wasn't adding quotes around the URL of a dynamic import.