### PR TITLE
fix(core): auto-resolve duplicate host directive matches instead of throwing NG0309

### DIFF
--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -70,6 +70,11 @@ export function ɵɵHostDirectivesFeature(
  */
 function resolveHostDirectives(matches: DirectiveDef<unknown>[]): HostDirectiveResolution {
   const allDirectiveDefs: DirectiveDef<unknown>[] = [];
+  // Tracks directives already added to `allDirectiveDefs` so that a directive that is both
+  // a host directive of another matched directive AND directly selector-matched (or referenced
+  // multiple times in host directive chains) is only included once. The first occurrence wins,
+  // which mirrors how providers handle duplicates.
+  const seenDirectiveDefs = new Set<DirectiveDef<unknown>>();
   let hasComponent = false;
   let hostDirectiveDefs: HostDirectiveDefs | null = null;
   let hostDirectiveRanges: HostDirectiveRanges | null = null;
@@ -94,7 +99,7 @@ function resolveHostDirectives(matches: DirectiveDef<unknown>[]): HostDirectiveR
       hostDirectiveRanges ??= new Map();
 
       // TODO(pk): probably could return matches instead of taking in an array to fill in?
-      findHostDirectiveDefs(def, allDirectiveDefs, hostDirectiveDefs);
+      findHostDirectiveDefs(def, allDirectiveDefs, hostDirectiveDefs, seenDirectiveDefs);
 
       // Note that these indexes are within the offset by `directiveStart`. We can't do the
       // offsetting here, because `directiveStart` hasn't been initialized on the TNode yet.
@@ -106,11 +111,16 @@ function resolveHostDirectives(matches: DirectiveDef<unknown>[]): HostDirectiveR
     if (i === 0 && isComponentDef(def)) {
       hasComponent = true;
       allDirectiveDefs.push(def);
+      seenDirectiveDefs.add(def);
     }
   }
 
   for (let i = hasComponent ? 1 : 0; i < matches.length; i++) {
-    allDirectiveDefs.push(matches[i]);
+    const def = matches[i];
+    if (!seenDirectiveDefs.has(def)) {
+      allDirectiveDefs.push(def);
+      seenDirectiveDefs.add(def);
+    }
   }
 
   return [allDirectiveDefs, hostDirectiveDefs, hostDirectiveRanges];
@@ -120,16 +130,22 @@ function findHostDirectiveDefs(
   currentDef: DirectiveDef<unknown>,
   matchedDefs: DirectiveDef<unknown>[],
   hostDirectiveDefs: HostDirectiveDefs,
+  seenDirectiveDefs: Set<DirectiveDef<unknown>>,
 ): void {
   if (currentDef.hostDirectives !== null) {
     for (const configOrFn of currentDef.hostDirectives) {
       if (typeof configOrFn === 'function') {
         const resolved = configOrFn();
         for (const config of resolved) {
-          trackHostDirectiveDef(createHostDirectiveDef(config), matchedDefs, hostDirectiveDefs);
+          trackHostDirectiveDef(
+            createHostDirectiveDef(config),
+            matchedDefs,
+            hostDirectiveDefs,
+            seenDirectiveDefs,
+          );
         }
       } else {
-        trackHostDirectiveDef(configOrFn, matchedDefs, hostDirectiveDefs);
+        trackHostDirectiveDef(configOrFn, matchedDefs, hostDirectiveDefs, seenDirectiveDefs);
       }
     }
   }
@@ -140,6 +156,7 @@ function trackHostDirectiveDef(
   def: HostDirectiveDef,
   matchedDefs: DirectiveDef<unknown>[],
   hostDirectiveDefs: HostDirectiveDefs,
+  seenDirectiveDefs: Set<DirectiveDef<unknown>>,
 ) {
   const hostDirectiveDef = getDirectiveDef(def.directive)!;
 
@@ -147,14 +164,22 @@ function trackHostDirectiveDef(
     validateHostDirective(def, hostDirectiveDef);
   }
 
+  // If this directive was already added (e.g. it appears in multiple host directive chains
+  // or is also matched directly by a selector), skip it. The first occurrence wins, which
+  // mirrors how providers handle duplicates.
+  if (seenDirectiveDefs.has(hostDirectiveDef)) {
+    return;
+  }
+
   // We need to patch the `declaredInputs` so that
   // `ngOnChanges` can map the properties correctly.
   patchDeclaredInputs(hostDirectiveDef.declaredInputs, def.inputs);
 
   // Host directives execute before the host so that its host bindings can be overwritten.
-  findHostDirectiveDefs(hostDirectiveDef, matchedDefs, hostDirectiveDefs);
+  findHostDirectiveDefs(hostDirectiveDef, matchedDefs, hostDirectiveDefs, seenDirectiveDefs);
   hostDirectiveDefs.set(hostDirectiveDef, def);
   matchedDefs.push(hostDirectiveDef);
+  seenDirectiveDefs.add(hostDirectiveDef);
 }
 
 /** Creates a `HostDirectiveDef` from a used-defined host directive configuration. */

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -3459,9 +3459,15 @@ describe('host directives', () => {
       );
     });
 
-    it('should throw an error if a host directive matches multiple times in a template', () => {
+    it('should auto-resolve a host directive that also matches directly in a template', () => {
+      let instanceCount = 0;
+
       @Directive({selector: '[dir]'})
-      class HostDir {}
+      class HostDir {
+        constructor() {
+          instanceCount++;
+        }
+      }
 
       @Directive({
         selector: '[dir]',
@@ -3472,14 +3478,19 @@ describe('host directives', () => {
       @Component({template: '<div dir></div>', imports: [HostDir, Dir]})
       class App {}
 
-      expect(() => TestBed.createComponent(App)).toThrowError(
-        'NG0309: Directive HostDir matches multiple times on the same element. Directives can only match an element once.',
-      );
+      expect(() => TestBed.createComponent(App)).not.toThrow();
+      expect(instanceCount).toBe(1);
     });
 
-    it('should throw an error if a host directive matches multiple times on a component', () => {
+    it('should auto-resolve a host directive that also matches directly on a component', () => {
+      let instanceCount = 0;
+
       @Directive({selector: '[dir]'})
-      class HostDir {}
+      class HostDir {
+        constructor() {
+          instanceCount++;
+        }
+      }
 
       @Component({
         selector: 'comp',
@@ -3492,33 +3503,36 @@ describe('host directives', () => {
         template: '<comp dir></comp>',
       };
 
-      const expectedError =
-        'NG0309: Directive HostDir matches multiple times on the same element. Directives can only match an element once.';
+      // Note: the definition order in `imports` affects the directive matching order
+      // so we verify that both orderings deduplicate correctly.
+      instanceCount = 0;
+      @Component({
+        ...baseAppMetadata,
+        imports: [Comp, HostDir],
+      })
+      class App1 {}
+      expect(() => TestBed.createComponent(App1)).not.toThrow();
+      expect(instanceCount).toBe(1);
 
-      // Note: the definition order in `imports` seems to affect the
-      // directive matching order so we test both scenarios.
-      expect(() => {
-        @Component({
-          ...baseAppMetadata,
-          imports: [Comp, HostDir],
-        })
-        class App {}
-        TestBed.createComponent(App);
-      }).toThrowError(expectedError);
-
-      expect(() => {
-        @Component({
-          ...baseAppMetadata,
-          imports: [HostDir, Comp],
-        })
-        class App {}
-        TestBed.createComponent(App);
-      }).toThrowError(expectedError);
+      instanceCount = 0;
+      @Component({
+        ...baseAppMetadata,
+        imports: [HostDir, Comp],
+      })
+      class App2 {}
+      expect(() => TestBed.createComponent(App2)).not.toThrow();
+      expect(instanceCount).toBe(1);
     });
 
-    it('should throw an error if a host directive appears multiple times in a chain', () => {
+    it('should auto-resolve a host directive that appears multiple times in a chain', () => {
+      let instanceCount = 0;
+
       @Directive()
-      class DuplicateHostDir {}
+      class DuplicateHostDir {
+        constructor() {
+          instanceCount++;
+        }
+      }
 
       @Directive({hostDirectives: [DuplicateHostDir]})
       class HostDir {}
@@ -3538,9 +3552,8 @@ describe('host directives', () => {
 
       TestBed.configureTestingModule({declarations: [App, Dir]});
 
-      expect(() => TestBed.createComponent(App)).toThrowError(
-        'NG0309: Directive DuplicateHostDir matches multiple times on the same element. Directives can only match an element once.',
-      );
+      expect(() => TestBed.createComponent(App)).not.toThrow();
+      expect(instanceCount).toBe(1);
     });
 
     it('should throw an error if a host directive is a component', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a directive appeared on an element more than once — either because it was both selector-matched and pulled in as a hostDirective of another matched directive, or because it was referenced multiple times across nested host directive chains — Angular threw a hard runtime error:                                                                      
                                                                                                                                                                                NG0309: Directive Foo matches multiple times on the same element.                                                                                                                 Directives can only match an element once.  

Fixes #57846

## What is the new behavior?

Angular silently deduplicates instead of throwing. The first occurrence wins and all subsequent occurrences of the same directive on the same element are ignored. The directive is instantiated exactly once, regardless of how many times it appears across selector matches and host directive chains.                                                       
                                                                                                                                                                                  
This mirrors how providers behave when the same token appears in multiple providers arrays — no error, first registration is kept.                                              
                                                                                                                                                                                  
Execution order is preserved: since host directives are always inserted before their host in the directive list, a directive that enters via a hostDirective chain will still  execute before the selector-matched directive that hosts it, even if it was also independently selector-matched.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
