### PR TITLE
refactor: replace `any` with stricter types in common and core

### DIFF
--- a/goldens/public-api/common/index.api.md
+++ b/goldens/public-api/common/index.api.md
@@ -358,7 +358,7 @@ export function isPlatformServer(platformId: Object): boolean;
 // @public
 export class JsonPipe implements PipeTransform {
     // (undocumented)
-    transform(value: any): string;
+    transform(value: unknown): string;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<JsonPipe, never>;
     // (undocumented)
@@ -594,7 +594,7 @@ export class NgIfContext<T = unknown> {
 export class NgLocaleLocalization extends NgLocalization {
     constructor(locale: string);
     // (undocumented)
-    getPluralCategory(value: any, locale?: string): string;
+    getPluralCategory(value: number, locale?: string): string;
     // (undocumented)
     protected locale: string;
     // (undocumented)
@@ -606,7 +606,7 @@ export class NgLocaleLocalization extends NgLocalization {
 // @public (undocumented)
 export abstract class NgLocalization {
     // (undocumented)
-    abstract getPluralCategory(value: any, locale?: string): string;
+    abstract getPluralCategory(value: number, locale?: string): string;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgLocalization, never>;
     // (undocumented)

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -19,7 +19,7 @@ import {RuntimeErrorCode} from '../errors';
   useFactory: () => new NgLocaleLocalization(inject(LOCALE_ID)),
 })
 export abstract class NgLocalization {
-  abstract getPluralCategory(value: any, locale?: string): string;
+  abstract getPluralCategory(value: number, locale?: string): string;
 }
 
 /**
@@ -66,7 +66,7 @@ export class NgLocaleLocalization extends NgLocalization {
     super();
   }
 
-  override getPluralCategory(value: any, locale?: string): string {
+  override getPluralCategory(value: number, locale?: string): string {
     const plural = getLocalePluralCase(locale || this.locale)(value);
 
     switch (plural) {

--- a/packages/common/src/pipes/json_pipe.ts
+++ b/packages/common/src/pipes/json_pipe.ts
@@ -34,7 +34,7 @@ export class JsonPipe implements PipeTransform {
   /**
    * @param value A value of any type to convert into a JSON-format string.
    */
-  transform(value: any): string {
+  transform(value: unknown): string {
     ngDevMode && warnIfSignal('JsonPipe', value);
 
     return JSON.stringify(value, null, 2);

--- a/packages/core/src/render3/util/stringify_utils.ts
+++ b/packages/core/src/render3/util/stringify_utils.ts
@@ -16,7 +16,7 @@ import type {ClassDebugInfo} from '../interfaces/definition';
  * be extra careful not to introduce megamorphic reads in it.
  * Check `core/test/render3/perf/render_stringify` for benchmarks and alternate implementations.
  */
-export function renderStringify(value: any): string {
+export function renderStringify(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value == null) return '';
   // Use `String` so that it invokes the `toString` method of the value. Note that this


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?


- `JsonPipe.transform`: `any` → `unknown`
- `renderStringify`: `any` → `unknown`
- `NgLocalization.getPluralCategory`: `any` → `number`

Replace unsafe any types with more precise alternatives.                                    

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
