### PR TITLE
fix(compiler): report missing structural placeholders in translations

### DIFF
--- a/packages/compiler/src/i18n/translation_bundle.ts
+++ b/packages/compiler/src/i18n/translation_bundle.ts
@@ -77,6 +77,84 @@ export class TranslationBundle {
   }
 }
 
+function incrementPlaceholderCount(placeholderCounts: Map<string, number>, name: string): void {
+  placeholderCounts.set(name, (placeholderCounts.get(name) ?? 0) + 1);
+}
+
+function collectRequiredStructuralPlaceholderCounts(
+  nodes: i18n.Node[],
+  placeholderCounts: Map<string, number>,
+): void {
+  nodes.forEach((node) => {
+    if (node instanceof i18n.Container) {
+      collectRequiredStructuralPlaceholderCounts(node.children, placeholderCounts);
+      return;
+    }
+
+    if (node instanceof i18n.Icu) {
+      Object.keys(node.cases).forEach((value) =>
+        collectRequiredStructuralPlaceholderCounts([node.cases[value]], placeholderCounts),
+      );
+      return;
+    }
+
+    if (node instanceof i18n.TagPlaceholder) {
+      incrementPlaceholderCount(placeholderCounts, node.startName);
+      if (node.closeName) {
+        incrementPlaceholderCount(placeholderCounts, node.closeName);
+      }
+      collectRequiredStructuralPlaceholderCounts(node.children, placeholderCounts);
+      return;
+    }
+
+    if (node instanceof i18n.BlockPlaceholder) {
+      incrementPlaceholderCount(placeholderCounts, node.startName);
+      incrementPlaceholderCount(placeholderCounts, node.closeName);
+      collectRequiredStructuralPlaceholderCounts(node.children, placeholderCounts);
+    }
+  });
+}
+
+function collectTranslatedPlaceholderCounts(
+  nodes: i18n.Node[],
+  placeholderCounts: Map<string, number>,
+  mapName: (name: string) => string,
+): void {
+  nodes.forEach((node) => {
+    if (node instanceof i18n.Container) {
+      collectTranslatedPlaceholderCounts(node.children, placeholderCounts, mapName);
+      return;
+    }
+
+    if (node instanceof i18n.Icu) {
+      Object.keys(node.cases).forEach((value) =>
+        collectTranslatedPlaceholderCounts([node.cases[value]], placeholderCounts, mapName),
+      );
+      return;
+    }
+
+    if (node instanceof i18n.Placeholder) {
+      incrementPlaceholderCount(placeholderCounts, mapName(node.name) || node.name);
+      return;
+    }
+
+    if (node instanceof i18n.TagPlaceholder) {
+      incrementPlaceholderCount(placeholderCounts, mapName(node.startName) || node.startName);
+      if (node.closeName) {
+        incrementPlaceholderCount(placeholderCounts, mapName(node.closeName) || node.closeName);
+      }
+      collectTranslatedPlaceholderCounts(node.children, placeholderCounts, mapName);
+      return;
+    }
+
+    if (node instanceof i18n.BlockPlaceholder) {
+      incrementPlaceholderCount(placeholderCounts, mapName(node.startName) || node.startName);
+      incrementPlaceholderCount(placeholderCounts, mapName(node.closeName) || node.closeName);
+      collectTranslatedPlaceholderCounts(node.children, placeholderCounts, mapName);
+    }
+  });
+}
+
 class I18nToHtmlVisitor implements i18n.Visitor {
   // using non-null assertions because they're (re)set by convert()
   private _srcMsg!: i18n.Message;
@@ -175,6 +253,39 @@ class I18nToHtmlVisitor implements i18n.Visitor {
     return `@${ph.name}${params} {${children}}`;
   }
 
+  private _validateTranslationStructure(nodes: i18n.Node[]): void {
+    const requiredPlaceholderCounts = new Map<string, number>();
+    collectRequiredStructuralPlaceholderCounts(this._srcMsg.nodes, requiredPlaceholderCounts);
+
+    if (requiredPlaceholderCounts.size === 0) {
+      return;
+    }
+
+    const translatedPlaceholderCounts = new Map<string, number>();
+    collectTranslatedPlaceholderCounts(nodes, translatedPlaceholderCounts, this._mapper);
+
+    const missingPlaceholderNames = Array.from(requiredPlaceholderCounts.entries())
+      .filter(
+        ([name, requiredCount]) => (translatedPlaceholderCounts.get(name) ?? 0) < requiredCount,
+      )
+      .map(([name, requiredCount]) => {
+        const translatedCount = translatedPlaceholderCounts.get(name) ?? 0;
+        return requiredCount === 1 && translatedCount === 0
+          ? `"${name}"`
+          : `"${name}" (expected ${requiredCount}, found ${translatedCount})`;
+      });
+
+    if (missingPlaceholderNames.length > 0) {
+      const placeholderText = missingPlaceholderNames.join(', ');
+      const placeholderLabel =
+        missingPlaceholderNames.length === 1 ? 'placeholder' : 'placeholders';
+      this._addError(
+        this._srcMsg.nodes[0],
+        `Translation is missing required structural ${placeholderLabel}: ${placeholderText}`,
+      );
+    }
+  }
+
   /**
    * Convert a source message to a translated text string:
    * - text nodes are replaced with their translation,
@@ -194,6 +305,7 @@ class I18nToHtmlVisitor implements i18n.Visitor {
       // And create a mapper to convert serialized placeholder names to internal names
       nodes = this._i18nNodesByMsgId[id];
       this._mapper = (name: string) => (mapper ? mapper.toInternalName(name)! : name);
+      this._validateTranslationStructure(nodes);
     } else {
       // When no translation has been found
       // - report an error / a warning / nothing,

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -555,19 +555,13 @@ describe('Merger', () => {
 
     it('should merge blocks', () => {
       const HTML = `before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after`;
-      expect(fakeTranslate(HTML)).toEqual(
-        'before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph tag' +
-          ' name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
-          ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after',
-      );
+      expect(fakeTranslate(HTML)).toEqual('before**<p>foo</p><span><i>bar</i></span>**after');
     });
 
     it('should merge nested blocks', () => {
       const HTML = `<div>before<!-- i18n --><p>foo</p><span><i>bar</i></span><!-- /i18n -->after</div>`;
       expect(fakeTranslate(HTML)).toEqual(
-        '<div>before**[ph tag name="START_PARAGRAPH">foo[/ph name="CLOSE_PARAGRAPH">[ph' +
-          ' tag name="START_TAG_SPAN">[ph tag name="START_ITALIC_TEXT">bar[/ph' +
-          ' name="CLOSE_ITALIC_TEXT">[/ph name="CLOSE_TAG_SPAN">**after</div>',
+        '<div>before**<p>foo</p><span><i>bar</i></span>**after</div>',
       );
     });
   });
@@ -670,8 +664,7 @@ function fakeTranslate(
 
   messages.forEach((message) => {
     const id = digest(message);
-    const text = serializeI18nNodes(message.nodes).join('').replace(/</g, '[');
-    i18nMsgMap[id] = [new i18n.Text(`**${text}**`, null!)];
+    i18nMsgMap[id] = [new i18n.Text('**', null!), ...message.nodes, new i18n.Text('**', null!)];
   });
 
   const translationBundle = new TranslationBundle(i18nMsgMap, null, digest);

--- a/packages/compiler/test/i18n/translation_bundle_spec.ts
+++ b/packages/compiler/test/i18n/translation_bundle_spec.ts
@@ -163,6 +163,41 @@ describe('TranslationBundle', () => {
       expect(() => tb.get(msg)).toThrowError(/Missing translation for message "ref"/);
     });
 
+    it('should report missing structural placeholders in translations', () => {
+      const msg = _extractMessages(
+        '<div i18n="@@some-key">Text A @if (bool) {<ng-container>Text B</ng-container>}</div>',
+      )[0];
+      const msgMap = {
+        foo: [
+          new i18n.Text('Text A ', span),
+          new i18n.Placeholder('', 'START_TAG_NG-CONTAINER', span),
+          new i18n.Text('Text B', span),
+          new i18n.Placeholder('', 'CLOSE_TAG_NG-CONTAINER', span),
+        ],
+      };
+      const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+
+      expect(() => tb.get(msg)).toThrowError(
+        /Translation is missing required structural placeholders: "START_BLOCK_IF", "CLOSE_BLOCK_IF"/,
+      );
+    });
+
+    it('should report missing repeated structural placeholders in translations', () => {
+      const msg = _extractMessages('<div i18n><span>one</span><span>two</span></div>')[0];
+      const msgMap = {
+        foo: [
+          new i18n.Placeholder('', 'START_TAG_SPAN', span),
+          new i18n.Text('one', span),
+          new i18n.Placeholder('', 'CLOSE_TAG_SPAN', span),
+        ],
+      };
+      const tb = new TranslationBundle(msgMap, null, (_) => 'foo');
+
+      expect(() => tb.get(msg)).toThrowError(
+        /Translation is missing required structural placeholders: "START_TAG_SPAN" \(expected 2, found 1\), "CLOSE_TAG_SPAN" \(expected 2, found 1\)/,
+      );
+    });
+
     it('should report invalid translated html', () => {
       const msgMap = {
         foo: [new i18n.Text('text', null!), new i18n.Placeholder('', 'ph1', null!)],


### PR DESCRIPTION
Translations can currently pass through compilation when they drop structural placeholders introduced by control flow blocks while still keeping nested container placeholders. This allows the mismatch to surface later as a runtime DOM error instead of failing during translation merging.

Validate that translated messages preserve required structural tag and block placeholders from the source message before converting them back to HTML. Update the related tests to use structurally valid fake translations and add coverage for the @if + ng-container regression as well as repeated structural placeholders.

Fixes #60899

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Translations are currently validated for unknown placeholders and invalid translated HTML, but they are not validated for missing structural placeholders required by the source message.

As a result, a translation can drop structural placeholders introduced by control flow blocks, still pass translation merging, and only fail later at runtime when Angular tries to create the translated DOM structure. This is the case reported for messages migrated to `@if` while translations still preserve only the nested container structure.

Issue Number: #60899

## What is the new behavior?

`TranslationBundle` now validates that translated messages preserve required structural placeholders from the source message before converting them back to HTML.

The validation is intentionally narrow and focused on structural placeholders:
- tag/container placeholders
- block placeholders

It also checks placeholder counts, not only presence, so repeated structural placeholders are validated correctly.

This makes structurally invalid translations fail at build time instead of surfacing later as runtime DOM errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Added regression coverage for:
- missing `@if` block placeholders when a nested `ng-container` placeholder structure is still present
- missing repeated structural placeholders

Also updated the merger test helper to preserve structural placeholders in fake translations so that the tests continue to model valid translated message structure under the stricter validation rules.

Verified with:
- `pnpm bazel test //packages/compiler/test:test`
- `pnpm bazel test //packages/compiler-cli/test:extract_i18n`
- `pnpm bazel test //packages/compiler-cli/test/compliance/full:full`
- `pnpm bazel test //packages/compiler-cli/test/compliance/local:local`
- `pnpm bazel test //packages/compiler-cli/test/compliance/linked:linked`
- `pnpm bazel test //packages/compiler-cli/test/compliance/codegen:codegen`
- `pnpm bazel test //packages/compiler-cli/test/compliance/declaration-only:declaration-only`
- `pnpm bazel test //packages/compiler-cli/test/compliance/test_cases:r3_view_compiler_i18n.golden_test`
- `pnpm bazel test //packages/compiler-cli/test/compliance/test_cases:r3_view_compiler_i18n/blocks.golden_test`
- `pnpm bazel test //packages/compiler-cli/test/compliance/test_cases:r3_view_compiler_i18n/nested_nodes.golden_test`
- `pnpm bazel test //packages/compiler-cli/test/compliance/test_cases:r3_view_compiler_i18n/ng-container_ng-template.golden_test`
