### PR TITLE
refactor: prepare for required `changeDetection` prop on G3.

### DIFF
--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -665,6 +665,8 @@ export interface Component extends Directive {
  */
 export const Component: ComponentDecorator = makeDecorator(
   'Component',
+  // TODO(jeanmeche): remove the ts-ignore when OnPush is the default
+  // @ts-ignore
   (c: Component = {}) => ({changeDetection: ChangeDetectionStrategy.Eager, ...c}),
   Directive,
   undefined,

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -8,66 +8,70 @@
 
 import {ResourceLoader} from '@angular/compiler';
 import {
+  ɵANIMATIONS_DISABLED as ANIMATIONS_DISABLED,
   ApplicationInitStatus,
-  ɵINTERNAL_APPLICATION_ERROR_HANDLER as INTERNAL_APPLICATION_ERROR_HANDLER,
-  Compiler,
-  COMPILER_OPTIONS,
-  Component,
-  Directive,
-  Injector,
-  inject,
-  InjectorType,
-  LOCALE_ID,
-  ModuleWithComponentFactories,
-  ModuleWithProviders,
-  NgModule,
-  NgModuleFactory,
-  Pipe,
-  PlatformRef,
-  Provider,
-  resolveForwardRef,
-  StaticProvider,
-  Type,
-  ɵclearResolutionOfComponentResourcesQueue,
   ɵcompileComponent as compileComponent,
   ɵcompileDirective as compileDirective,
   ɵcompileNgModuleDefs as compileNgModuleDefs,
   ɵcompilePipe as compilePipe,
+  Compiler,
+  COMPILER_OPTIONS,
+  Component,
+  ɵRender3ComponentFactory as ComponentFactory,
   ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID,
   ɵDEFER_BLOCK_CONFIG as DEFER_BLOCK_CONFIG,
   ɵdepsTracker as depsTracker,
+  Directive,
   ɵDirectiveDef as DirectiveDef,
-  ɵgenerateStandaloneInDeclarationsError,
+  ENVIRONMENT_INITIALIZER,
+  ErrorHandler,
   ɵgetAsyncClassMetadataFn as getAsyncClassMetadataFn,
   ɵgetInjectableDef as getInjectableDef,
+  inject,
+  ɵɵInjectableDeclaration as InjectableDeclaration,
+  Injector,
+  InjectorType,
+  ɵINTERNAL_APPLICATION_ERROR_HANDLER as INTERNAL_APPLICATION_ERROR_HANDLER,
   ɵInternalEnvironmentProviders as InternalEnvironmentProviders,
-  ɵprovideZonelessChangeDetectionInternal as provideZonelessChangeDetectionInternal,
-  ɵisComponentDefPendingResolution,
   ɵisEnvironmentProviders as isEnvironmentProviders,
+  LOCALE_ID,
+  ModuleWithComponentFactories,
+  ModuleWithProviders,
   ɵNG_COMP_DEF as NG_COMP_DEF,
   ɵNG_DIR_DEF as NG_DIR_DEF,
   ɵNG_INJ_DEF as NG_INJ_DEF,
   ɵNG_MOD_DEF as NG_MOD_DEF,
   ɵNG_PIPE_DEF as NG_PIPE_DEF,
-  ɵNgModuleFactory as R3NgModuleFactory,
+  NgModule,
+  NgModuleFactory,
+  ɵRender3NgModuleRef as NgModuleRef,
   ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes,
   ɵNgModuleType as NgModuleType,
+  NgZone,
   ɵpatchComponentDefWithScope as patchComponentDefWithScope,
-  ɵRender3ComponentFactory as ComponentFactory,
-  ɵRender3NgModuleRef as NgModuleRef,
+  Pipe,
+  PlatformRef,
+  Provider,
+  ɵprovideZonelessChangeDetectionInternal as provideZonelessChangeDetectionInternal,
+  ɵNgModuleFactory as R3NgModuleFactory,
+  resolveForwardRef,
+  ɵsetLocaleId as setLocaleId,
+  StaticProvider,
+  ɵtransitiveScopesFor as transitiveScopesFor,
+  Type,
+  ɵclearResolutionOfComponentResourcesQueue,
+  ɵgenerateStandaloneInDeclarationsError,
+  ɵisComponentDefPendingResolution,
   ɵresolveComponentResources,
   ɵrestoreComponentResolutionQueue,
-  ɵsetLocaleId as setLocaleId,
-  ɵtransitiveScopesFor as transitiveScopesFor,
-  ɵɵInjectableDeclaration as InjectableDeclaration,
-  NgZone,
-  ErrorHandler,
-  ENVIRONMENT_INITIALIZER,
-  ɵANIMATIONS_DISABLED as ANIMATIONS_DISABLED,
 } from '../../src/core';
 
 import {ComponentDef, ComponentType} from '../../src/render3';
 
+import {
+  RETHROW_APPLICATION_ERRORS_DEFAULT,
+  TestBedApplicationErrorHandler,
+} from './application_error_handler';
 import {MetadataOverride} from './metadata_override';
 import {
   ComponentResolver,
@@ -81,10 +85,6 @@ import {
   DEFER_BLOCK_DEFAULT_BEHAVIOR,
   TestModuleMetadata,
 } from './test_bed_common';
-import {
-  RETHROW_APPLICATION_ERRORS_DEFAULT,
-  TestBedApplicationErrorHandler,
-} from './application_error_handler';
 
 enum TestingModuleOverride {
   DECLARATION,
@@ -115,8 +115,8 @@ function assertNoStandaloneComponents(
 // Resolvers for Angular decorators
 type Resolvers = {
   module: Resolver<NgModule>;
-  component: Resolver<Directive>;
-  directive: Resolver<Component>;
+  component: Resolver<Component>;
+  directive: Resolver<Directive>;
   pipe: Resolver<Pipe>;
 };
 

--- a/packages/router/src/components/empty_outlet.ts
+++ b/packages/router/src/components/empty_outlet.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 import {RouterOutlet} from '../directives/router_outlet';
-import {PRIMARY_OUTLET} from '../shared';
 import {Route} from '../models';
+import {PRIMARY_OUTLET} from '../shared';
 export {ɵEmptyOutletComponent as EmptyOutletComponent};
 
 /**
@@ -27,6 +27,7 @@ export {ɵEmptyOutletComponent as EmptyOutletComponent};
   imports: [RouterOutlet],
   // Used to avoid component ID collisions with user code.
   exportAs: 'emptyRouterOutlet',
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class ɵEmptyOutletComponent {}
 

--- a/packages/router/testing/src/router_testing_harness.ts
+++ b/packages/router/testing/src/router_testing_harness.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   DebugElement,
   Injectable,
@@ -44,6 +45,7 @@ export class RootFixtureService {
 @Component({
   template: '<router-outlet [routerOutletData]="routerOutletData()"></router-outlet>',
   imports: [RouterOutlet],
+  changeDetection: ChangeDetectionStrategy.Eager,
 })
 export class RootCmp {
   @ViewChild(RouterOutlet) outlet?: RouterOutlet;


### PR DESCRIPTION
We'll make this a G3 only change to prevent backsliding during the transition period.
