### PR TITLE
docs(forms): clarify disabled FormArray value behavior

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -554,7 +554,8 @@ export abstract class AbstractControl<
    * with a key-value pair for each member of the group.
    * * For a disabled `FormGroup`, the values of all controls as an object
    * with a key-value pair for each member of the group.
-   * * For a `FormArray`, the values of enabled controls as an array.
+   * * For an enabled `FormArray`, the values of enabled controls as an array.
+   * * For a disabled `FormArray`, the values of all controls as an array.
    *
    */
   public readonly value!: TValue;

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -54,7 +54,8 @@ export type ɵFormArrayRawValue<T extends AbstractControl<any>> = ɵTypedOrUntyp
  *
  * A `FormArray` aggregates the values of each child `FormControl` into an array.
  * It calculates its status by reducing the status values of its children. For example, if one of
- * the controls in a `FormArray` is invalid, the entire array becomes invalid.
+ * the controls in a `FormArray` is invalid, the entire array becomes invalid. Similarly, if all
+ * controls in a `FormArray` are disabled, the entire array becomes disabled.
  *
  * `FormArray` accepts one generic argument, which is the type of the controls inside.
  * If you need a heterogenous array, use {@link UntypedFormArray}.


### PR DESCRIPTION
## Description

Clarifies the `FormArray` API docs around disabled state and aggregated values.

The current implementation includes all child values when the `FormArray` itself is disabled, but the `AbstractControl.value` docs only described the enabled-controls case for `FormArray`. This made the behavior look inconsistent, especially compared with the existing `FormGroup` wording.

This updates the docs to make two things explicit:
- an enabled `FormArray` aggregates the values of enabled child controls
- a disabled `FormArray` aggregates the values of all child controls
- if all controls in a `FormArray` are disabled, the array itself becomes disabled

Fixes #67759
