### PR TITLE
docs(docs-infra): replace non-interactive buttons with spans

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/cli-reference.tsx
@@ -27,14 +27,14 @@ export function CliCommandReference(entry: CliCommandRenderable) {
                 <div className={'shiki line cli'}>
                   ng {commandName(entry, command)}
                   {entry.argumentsLabel && (
-                    <button member-id={'Arguments'} className="shiki-ln-line-argument">
+                    <span member-id={'Arguments'} className="shiki-ln-line-argument">
                       {entry.argumentsLabel}
-                    </button>
+                    </span>
                   )}
                   {entry.optionsLabel && (
-                    <button member-id={'Options'} className="shiki-ln-line-option">
+                    <span member-id={'Options'} className="shiki-ln-line-option">
                       {entry.optionsLabel}
-                    </button>
+                    </span>
                   )}
                 </div>
               </code>

--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -36,6 +36,15 @@ $code-font-size: 0.875rem;
     }
   }
 
+  .shiki.line.cli {
+    span {
+      color: var(--quaternary-contrast);
+      font-family: var(--inter-font);
+      font-weight: 600;
+      font-size: 13px;
+    }
+  }
+
   .docs-light-mode .shiki {
     color: var(--shiki-light);
     background-color: var(--shiki-light-bg);


### PR DESCRIPTION
These elements are not interactive, so using `<button>` is misleading for accessibility (screen readers and keyboard navigation expect an action).
 

## What is the current behavior?

 

https://github.com/user-attachments/assets/5e56f69b-f382-4a23-a60b-ac7feff4ece8


## What is the new behavior?

 

https://github.com/user-attachments/assets/95ae8122-d400-4812-872b-fcbd0969085f

