### PR TITLE
fix(core): add 'object' to SRC_RESOURCE_TAGS for stricter URL sanitization

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -214,7 +214,14 @@ export function ɵɵtrustConstantResourceUrl(url: TemplateStringsArray): Trusted
 }
 
 // Define sets outside the function for O(1) lookups and memory efficiency
-const SRC_RESOURCE_TAGS = new Set(['embed', 'frame', 'iframe', 'media', 'script']);
+const SRC_RESOURCE_TAGS = new Set([
+  'embed',
+  'frame',
+  'iframe',
+  'media',
+  'object', //data attribute
+  'script',
+]);
 const HREF_RESOURCE_TAGS = new Set(['base', 'link', 'script']);
 
 /**


### PR DESCRIPTION
## Problem
The `<object data="...">` element can load external executable resources
similar to `<iframe src="...">` and `<embed src="...">`, but it was missing
from `SRC_RESOURCE_TAGS` in `sanitization.ts`.

This caused `getUrlSanitizer()` to use the weaker `ɵɵsanitizeUrl` instead
of the stricter `ɵɵsanitizeResourceUrl` for `<object>` elements.

## Fix

Added `'object'` to `SRC_RESOURCE_TAGS` so that bindings like
`<object [attr.data]="url">` are treated as resource URLs and
sanitized accordingly.
## Related

- Similar to how `embed`, `iframe`, and `script` are handled