### PR TITLE
fix(compiler): sanitize SVG animation values/to/from attrs and add mi…

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -105,6 +105,25 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'none|href',
       'none|xlink:href',
 
+      // SVG elements that support href but were missing from the schema.
+      // See: https://issuetracker.google.com/issues/494429770
+      'image|href',
+      'image|xlink:href',
+      'use|href',
+      'use|xlink:href',
+      'feImage|href',
+      'feImage|xlink:href',
+      'textPath|href',
+      'textPath|xlink:href',
+      'pattern|href',
+      'pattern|xlink:href',
+      'linearGradient|href',
+      'linearGradient|xlink:href',
+      'radialGradient|href',
+      'radialGradient|xlink:href',
+      'mpath|href',
+      'mpath|xlink:href',
+
       // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
       'img|src',
       'video|src',
@@ -135,6 +154,20 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'set|attributeName',
       'animateMotion|attributeName',
       'animateTransform|attributeName',
+
+      // SVG animation value-carrying attributes that can inject javascript: URIs
+      // into security-sensitive target attributes (e.g., href) via browser animation engine.
+      // See: https://issuetracker.google.com/issues/494429770
+      'animate|values',
+      'animate|from',
+      'animate|to',
+      'set|to',
+      'animateMotion|values',
+      'animateMotion|from',
+      'animateMotion|to',
+      'animateTransform|values',
+      'animateTransform|from',
+      'animateTransform|to',
 
       'unknown|attributeName',
 


### PR DESCRIPTION
Missing SVG href entries

The dom_security_schema.ts did not classify the values, from, and to attributes on SVG animation elements (animate, set, animateMotion, animateTransform) as security-sensitive. An attacker could bind a javascript: URI to these attributes, which the browser's SVG animation engine then applies to a target element's href after Angular's sanitization phase, enabling same-origin XSS.

Additionally, the href and xlink:href attributes on several SVG elements (image, use, feImage, textPath, pattern, linearGradient, radialGradient, mpath) were not registered in the security schema, allowing unsanitized javascript: URIs in the DOM.

This commit adds:
- animate|values, animate|from, animate|to to ATTRIBUTE_NO_BINDING
- set|to to ATTRIBUTE_NO_BINDING
- animateMotion and animateTransform values/from/to to ATTRIBUTE_NO_BINDING
- Missing SVG element href/xlink:href entries to SecurityContext.URL

Fixes https://issuetracker.google.com/issues/494429770

## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix (Security)

## What is the current behavior?

SVG animation attributes (`values`, `from`, `to`) on `<animate>`, `<set>`, `<animateMotion>`, `<animateTransform>` are not classified as security-sensitive in `dom_security_schema.ts`. An attacker can bind `javascript:` URIs to these attributes. The browser's SVG animation engine then applies the payload to a target element's `href` **after** Angular's sanitization phase, resulting in same-origin XSS.

Additionally, `href`/`xlink:href` on `<image>`, `<use>`, `<feImage>`, `<textPath>`, `<pattern>`, `<linearGradient>`, `<radialGradient>`, `<mpath>` are not registered in the security schema, allowing unsanitized `javascript:` URIs in the DOM.

Same vulnerability class as CVE-2025-66412 (GHSA-v4hv-rgfq-gp49).

Issue: https://issuetracker.google.com/issues/494429770

## What is the new behavior?

- Animation value-carrying attributes (`values`, `from`, `to`) blocked from dynamic binding via `ATTRIBUTE_NO_BINDING`
- Missing SVG element `href`/`xlink:href` entries sanitized via `SecurityContext.URL`

## Does this PR introduce a breaking change?

- [x] No

## Other information

Confirmed same-origin XSS execution on Angular 21.2.5 (latest patched version). `alert(document.domain)` returns the application's domain, confirming JavaScript runs in the application's security context.