### PR TITLE
docs(docs-infra): fix aria-label parsing breaking headings

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/test/heading/heading.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/heading/heading.spec.mts
@@ -135,4 +135,29 @@ describe('markdown to html', () => {
     // We ensure that we still style the heading content
     expect(markdownDocument.querySelector('strong')).toBeDefined();
   });
+
+  it('should strip all HTML tags from the aria-label attribute', () => {
+    const markdownDocument = JSDOM.fragment(
+      parseMarkdown(
+        '## **Phase 5: Experimental Signal Forms (⚠️ WARNING: Subject to Change)**',
+        rendererContext,
+      ),
+    );
+    const h2Anchor = markdownDocument.querySelector('h2 > a');
+
+    expect(h2Anchor!.innerHTML).toBe(
+      '<strong><span class="docs-emoji">Phase 5: Experimental Signal Forms (⚠️ WARNING: Subject to Change)</span></strong>',
+    );
+    expect(h2Anchor!.getAttribute('aria-label')).toBe(
+      'Link to Phase 5: Experimental Signal Forms (⚠️ WARNING: Subject to Change)',
+    );
+  });
+
+  it('should escape double quotes from the aria-label attribute', () => {
+    const markdownDocument = JSDOM.fragment(parseMarkdown('## "Special" heading', rendererContext));
+    const h2Anchor = markdownDocument.querySelector('h2 > a');
+
+    expect(h2Anchor!.innerHTML).toBe('"Special" heading');
+    expect(h2Anchor!.getAttribute('aria-label')).toBe('Link to "Special" heading');
+  });
 });

--- a/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
+++ b/adev/shared-docs/pipeline/shared/marked/transformations/heading.mts
@@ -31,7 +31,7 @@ export function headingRender(
   // Replace code backticks and remove custom ID syntax from the displayed label
   let label = parsedText.replace(/`(.*?)`/g, '<code>$1</code>');
   label = label.replace(/{#\s*[\w-]+\s*}/g, '').trim();
-  const normalizedLabel = label.replace(/<\/?code>/g, '');
+  const normalizedLabel = label.replace(/<[^>]+>/g, '').replace(/"/g, '&quot;');
 
   return `
   <h${depth} id="${link}">


### PR DESCRIPTION
Strip all HTML tags and escape quotes in aria-label to avoid breakage

 ## What is the current behavior?
 See https://next.angular.dev/ai/ai-tutor#phase-5-experimental-signal-forms--warning-subject-to-change

 
<img width="713" height="315" alt="image" src="https://github.com/user-attachments/assets/0ecfb49a-0026-44d8-b5b2-d2afaba092cc" />

<img width="765" height="234" alt="image" src="https://github.com/user-attachments/assets/201d93a9-25ef-4168-a60a-e7e2df9d5c68" />


## What is the new behavior?

 
<img width="708" height="287" alt="image" src="https://github.com/user-attachments/assets/c88f0787-8a80-4102-9f80-c2706f6f93ba" />

<img width="770" height="253" alt="image" src="https://github.com/user-attachments/assets/0ae48a74-c37f-46ae-ab55-8fd8e0ce3bdf" />
