### PR TITLE
refactor(compiler): remove `fullTemplateTypeCheck` compiler option.

### DIFF
--- a/adev/src/content/reference/configs/angular-compiler-options.md
+++ b/adev/src/content/reference/configs/angular-compiler-options.md
@@ -130,15 +130,6 @@ For example, if a library uses the `public_api.ts` file as the library index of 
 The `flatModuleOutFile` option could then be set, for example, to `"index.js"`, which produces `index.d.ts` and `index.metadata.json` files.
 The `module` field of the library's `package.json` would be `"index.js"` and the `typings` field would be `"index.d.ts"`.
 
-### `fullTemplateTypeCheck`
-
-When `true`, the recommended value, enables the binding expression validation phase of the template compiler. This phase uses TypeScript to verify binding expressions.
-For more information, see [Template type checking](tools/cli/template-typecheck).
-
-Default is `false`, but when you use the Angular CLI command `ng new --strict`, it is set to `true` in the new project's configuration.
-
-IMPORTANT: The `fullTemplateTypeCheck` option has been deprecated in Angular 13 in favor of the `strictTemplates` family of compiler options.
-
 ### `generateCodeForLibraries`
 
 When `true`, creates factory files \(`.ngfactory.js` and `.ngstyle.js`\) for `.d.ts` files with a corresponding `.metadata.json` file. The default value is `true`.

--- a/adev/src/content/tools/cli/aot-compiler.md
+++ b/adev/src/content/tools/cli/aot-compiler.md
@@ -369,7 +369,7 @@ And it does not interfere with the ES module's exported API.
 One of the Angular compiler's most helpful features is the ability to type-check expressions within templates, and catch any errors before they cause crashes at runtime.
 In the template type-checking phase, the Angular template compiler uses the TypeScript compiler to validate the binding expressions in templates.
 
-Enable this phase explicitly by adding the compiler option `"fullTemplateTypeCheck"` in the `"angularCompilerOptions"` of the project's TypeScript configuration file
+Enable this phase explicitly by adding the compiler option `"strictTemplates"` in the `"angularCompilerOptions"` of the project's TypeScript configuration file
 (see [Angular Compiler Options](reference/configs/angular-compiler-options)).
 
 Template validation produces error messages when a type error is detected in a template binding

--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -50,8 +50,6 @@ export interface LegacyNgcOptions {
     allowEmptyCodegenFiles?: boolean;
     flatModuleId?: string;
     flatModuleOutFile?: string;
-    // @deprecated
-    fullTemplateTypeCheck?: boolean;
     preserveWhitespaces?: boolean;
     strictInjectionParameters?: boolean;
 }

--- a/integration/cli-hello-world-ivy-i18n/tsconfig.json
+++ b/integration/cli-hello-world-ivy-i18n/tsconfig.json
@@ -14,7 +14,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/integration/cli-hello-world-lazy/tsconfig.json
+++ b/integration/cli-hello-world-lazy/tsconfig.json
@@ -14,7 +14,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/integration/defer/tsconfig.json
+++ b/integration/defer/tsconfig.json
@@ -14,7 +14,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/integration/legacy-animations-async/tsconfig.json
+++ b/integration/legacy-animations-async/tsconfig.json
@@ -15,7 +15,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/integration/legacy-animations/tsconfig.json
+++ b/integration/legacy-animations/tsconfig.json
@@ -14,7 +14,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/integration/standalone-bootstrap/tsconfig.json
+++ b/integration/standalone-bootstrap/tsconfig.json
@@ -14,7 +14,6 @@
     "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }
 }

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -24,22 +24,6 @@ export interface LegacyNgcOptions {
   allowEmptyCodegenFiles?: boolean;
 
   /**
-   * Whether to type check the entire template.
-   *
-   * This flag currently controls a couple aspects of template type-checking, including
-   * whether embedded views are checked.
-   *
-   * For maximum type-checking, set this to `true`, and set `strictTemplates` to `true`.
-   *
-   * It is an error for this flag to be `false`, while `strictTemplates` is set to `true`.
-   *
-   * @deprecated The `fullTemplateTypeCheck` option has been superseded by the more granular
-   * `strictTemplates` family of compiler options. Usage of `fullTemplateTypeCheck` is therefore
-   * deprecated, `strictTemplates` and its related options should be used instead.
-   */
-  fullTemplateTypeCheck?: boolean;
-
-  /**
    * Whether to generate a flat module index of the given name and the corresponding
    * flat module metadata. This option is intended to be used when creating flat
    * modules similar to how `@angular/core` and `@angular/common` are packaged.
@@ -100,8 +84,6 @@ export interface TypeCheckingOptions {
   /**
    * If `true`, implies all template strictness flags below (unless individually disabled).
    *
-   * This flag is a superset of the deprecated `fullTemplateTypeCheck` option.
-   *
    * Defaults to `true`
    */
   strictTemplates?: boolean;
@@ -115,7 +97,7 @@ export interface TypeCheckingOptions {
    * directive or component is receiving the binding. If set to `true`, both sides of the assignment
    * are checked.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictInputTypes?: boolean;
 
@@ -123,7 +105,7 @@ export interface TypeCheckingOptions {
    * Whether to check if the input binding attempts to assign to a restricted field (readonly,
    * private, or protected) on the directive/component.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck", "strictTemplates" and/or
+   * Defaults to `false`, even if "strictTemplates" and/or
    * "strictInputTypes" is set. Note that if `strictInputTypes` is not set, or set to `false`, this
    * flag has no effect.
    *
@@ -140,7 +122,7 @@ export interface TypeCheckingOptions {
    * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
    * null checks.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set. Note that if `strictInputTypes` is
+   * Defaults to `false`. Note that if `strictInputTypes` is
    * not set, or set to `false`, this flag has no effect.
    */
   strictNullInputTypes?: boolean;
@@ -154,7 +136,7 @@ export interface TypeCheckingOptions {
    * without a value, so with this flag set to `true`, an error would be reported. If set to
    * `false`, text attributes will never report an error.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set. Note that if `strictInputTypes` is
+   * Defaults to `false`. Note that if `strictInputTypes` is
    * not set, or set to `false`, this flag has no effect.
    */
   strictAttributeTypes?: boolean;
@@ -166,7 +148,7 @@ export interface TypeCheckingOptions {
    * then the return type of `a?.b` for example will be the same as the type of the ternary
    * expression `a != null ? a.b : a`.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictSafeNavigationTypes?: boolean;
 
@@ -177,7 +159,7 @@ export interface TypeCheckingOptions {
    * determined by the type of `document.createElement` for the given DOM node. If set to `false`,
    * the type of `ref` for DOM nodes will be `any`.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictDomLocalRefTypes?: boolean;
 
@@ -189,7 +171,7 @@ export interface TypeCheckingOptions {
    * `EventEmitter`/`Subject` of the output. If set to `false`, the `$event` variable will be of
    * type `any`.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictOutputEventTypes?: boolean;
 
@@ -200,7 +182,7 @@ export interface TypeCheckingOptions {
    * `HTMLElementEventMap`, with a fallback to the native `Event` type. If set to `false`, the
    * `$event` variable will be of type `any`.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictDomEventTypes?: boolean;
 
@@ -213,7 +195,7 @@ export interface TypeCheckingOptions {
    * will be included in the context type for the template. If `false`, any generic parameters will
    * be set to `any` in the template context type.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is set.
+   * Defaults to `false`.
    */
   strictContextGenerics?: boolean;
 
@@ -221,7 +203,7 @@ export interface TypeCheckingOptions {
    * Whether object or array literals defined in templates use their inferred type, or are
    * interpreted as `any`.
    *
-   * Defaults to `false` unless `fullTemplateTypeCheck` or `strictTemplates` are set.
+   * Defaults to `false` unless `strictTemplates` is set.
    */
   strictLiteralTypes?: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -123,7 +123,6 @@ import {SourceFileValidator} from '../../validation';
 import {Xi18nContext} from '../../xi18n';
 import {DiagnosticCategoryLabel, NgCompilerAdapter, NgCompilerOptions} from '../api';
 
-import {DOC_PAGE_BASE_URL} from '../../diagnostics/src/error_details_base_url';
 import {untagAllTsFiles} from '../../shims';
 import {angularJitApplicationTransform} from '../../transform/jit';
 import {coreVersionSupportsFeature} from './feature_detection';
@@ -1044,14 +1043,6 @@ export class NgCompiler {
     return this.options.strictTemplates !== false;
   }
 
-  private get fullTemplateTypeCheck(): boolean {
-    // Determine the strictness level of type checking based on compiler options. As
-    // `strictTemplates` is a superset of `fullTemplateTypeCheck`, the former implies the latter.
-    // Also see `verifyCompatibleTypeCheckOptions` where it is verified that `fullTemplateTypeCheck`
-    // is not disabled when `strictTemplates` is enabled.
-    return this.strictTemplates || !!this.options.fullTemplateTypeCheck;
-  }
-
   private getTypeCheckingConfig(): TypeCheckingConfig {
     // Determine the strictness level of type checking based on compiler options. As
     // `strictTemplates` is a superset of `fullTemplateTypeCheck`, the former implies the latter.
@@ -1076,7 +1067,7 @@ export class NgCompiler {
     // First select a type-checking configuration, based on whether full template type-checking is
     // requested.
     let typeCheckingConfig: TypeCheckingConfig;
-    if (this.fullTemplateTypeCheck) {
+    if (strictTemplates) {
       typeCheckingConfig = {
         applyTemplateContextGuards: strictTemplates,
         checkQueries: false,
@@ -1106,10 +1097,6 @@ export class NgCompiler {
         strictLiteralTypes: true,
         enableTemplateTypeChecker: this.enableTemplateTypeChecker,
         useInlineTypeConstructors,
-        // Warnings for suboptimal type inference are only enabled if in Language Service mode
-        // (providing the full TemplateTypeChecker API) and if strict mode is not enabled. In strict
-        // mode, the user is in full control of type inference.
-        suggestionsForSuboptimalTypeInference: this.enableTemplateTypeChecker && !strictTemplates,
         controlFlowPreventingContentProjection:
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         unusedStandaloneImports:
@@ -1143,9 +1130,6 @@ export class NgCompiler {
         strictLiteralTypes: false,
         enableTemplateTypeChecker: this.enableTemplateTypeChecker,
         useInlineTypeConstructors,
-        // In "basic" template type-checking mode, no warnings are produced since most things are
-        // not checked anyways.
-        suggestionsForSuboptimalTypeInference: false,
         controlFlowPreventingContentProjection:
           this.options.extendedDiagnostics?.defaultCategory || DiagnosticCategoryLabel.Warning,
         unusedStandaloneImports:
@@ -1157,7 +1141,7 @@ export class NgCompiler {
     }
 
     // Apply explicitly configured strictness flags on top of the default configuration
-    // based on "fullTemplateTypeCheck".
+    // based on "strictTemplates".
     if (this.options.strictInputTypes !== undefined) {
       typeCheckingConfig.checkTypeOfInputBindings = this.options.strictInputTypes;
       typeCheckingConfig.applyTemplateContextGuards = this.options.strictInputTypes;
@@ -1764,33 +1748,11 @@ function getR3SymbolsFile(program: ts.Program): ts.SourceFile | null {
 }
 
 /**
- * Since "strictTemplates" is a true superset of type checking capabilities compared to
- * "fullTemplateTypeCheck", it is required that the latter is not explicitly disabled if the
- * former is enabled.
+ * Checks compiler options compatibility with strictTemplates
  */
 function* verifyCompatibleTypeCheckOptions(
   options: NgCompilerOptions,
 ): Generator<ts.Diagnostic, void, void> {
-  if (options.fullTemplateTypeCheck === false && options.strictTemplates !== false) {
-    yield makeConfigDiagnostic({
-      category: ts.DiagnosticCategory.Error,
-      code: ErrorCode.CONFIG_STRICT_TEMPLATES_IMPLIES_FULL_TEMPLATE_TYPECHECK,
-      messageText: `
-Angular compiler option "strictTemplates" is enabled, however "fullTemplateTypeCheck" is disabled.
-
-Having the "strictTemplates" flag enabled implies that "fullTemplateTypeCheck" is also enabled, so
-the latter can not be explicitly disabled.
-
-One of the following actions is required:
-1. Remove the "fullTemplateTypeCheck" option.
-2. Set "strictTemplates" to 'false'.
-
-More information about the template type checking compiler options can be found in the documentation:
-${DOC_PAGE_BASE_URL}/tools/cli/template-typecheck
-      `.trim(),
-    });
-  }
-
   if (options.extendedDiagnostics && options.strictTemplates === false) {
     yield makeConfigDiagnostic({
       category: ts.DiagnosticCategory.Error,

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -426,20 +426,6 @@ export interface TypeCheckingConfig {
   useInlineTypeConstructors: boolean;
 
   /**
-   * Whether or not to produce diagnostic suggestions in cases where the compiler could have
-   * inferred a better type for a construct, but was prevented from doing so by the current type
-   * checking configuration.
-   *
-   * For example, if the compiler could have used a template context guard to infer a better type
-   * for a structural directive's context and `let-` variables, but the user is in
-   * `fullTemplateTypeCheck` mode and such guards are therefore disabled.
-   *
-   * This mode is useful for clients like the Language Service which want to inform users of
-   * opportunities to improve their own developer experience.
-   */
-  suggestionsForSuboptimalTypeInference: boolean;
-
-  /**
    * Whether the type of two-way bindings should be widened to allow `WritableSignal`.
    */
   allowSignalsInTwoWayBindings: boolean;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/template.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/template.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import {TmplAstBoundAttribute, TmplAstDirective, TmplAstTemplate} from '@angular/compiler';
+import {TcbDirectiveMetadata} from '../../api';
 import {TcbOp} from './base';
 import {declareVariable, getStatementsBlock, TcbExpr} from './codegen';
 import type {Context} from './context';
-import type {Scope} from './scope';
-import {TcbDirectiveMetadata} from '../../api';
 import {tcbExpression} from './expression';
+import type {Scope} from './scope';
 
 /**
  * A `TcbOp` which generates a variable for a `TmplAstTemplate`'s context.
@@ -192,15 +192,6 @@ export class TcbTemplateBodyOp extends TcbOp {
           guardInvoke.markIgnoreDiagnostics();
           guardInvoke.addParseSpanInfo(hostNode.sourceSpan);
           guards.push(guardInvoke);
-        } else if (
-          isTemplate &&
-          hostNode.variables.length > 0 &&
-          this.tcb.env.config.suggestionsForSuboptimalTypeInference
-        ) {
-          // The compiler could have inferred a better type for the variables in this template,
-          // but was prevented from doing so by the type-checking configuration. Issue a warning
-          // diagnostic.
-          this.tcb.oobRecorder.suboptimalTypeInference(this.tcb.id, hostNode.variables);
         }
       }
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1153,7 +1153,6 @@ describe('type check blocks', () => {
       strictLiteralTypes: true,
       enableTemplateTypeChecker: false,
       useInlineTypeConstructors: true,
-      suggestionsForSuboptimalTypeInference: false,
       controlFlowPreventingContentProjection: 'warning',
       unusedStandaloneImports: 'warning',
       allowSignalsInTwoWayBindings: true,

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -30,9 +30,10 @@ import {
 } from '@angular/compiler';
 import {readFileSync} from 'fs';
 import path from 'path';
-import ts from 'typescript';
 import {globSync} from 'tinyglobby';
+import ts from 'typescript';
 
+import {freshCompilationTicket, NgCompiler, NgCompilerHost} from '../../core';
 import {
   absoluteFrom,
   AbsoluteFsPath,
@@ -81,6 +82,7 @@ import {
   ScopeData,
   TypeCheckScopeRegistry,
 } from '../../scope';
+import {sfExtensionData} from '../../shims';
 import {makeProgram, resolveFromRunfiles} from '../../testing';
 import {getRootDirs} from '../../util/src/typescript';
 import {
@@ -93,18 +95,16 @@ import {
   TypeCheckContext,
 } from '../api';
 import {
-  TypeCheckId,
   TypeCheckableDirectiveMeta,
   TypeCheckBlockMetadata,
+  TypeCheckId,
   TypeCheckingConfig,
 } from '../api/api';
+import {DomSchemaChecker} from '../api/schema';
 import {TemplateTypeCheckerImpl} from '../src/checker';
+import {TcbGenericContextBehavior} from '../src/ops/context';
 import {TypeCheckShimGenerator} from '../src/shim';
 import {TypeCheckFile} from '../src/type_check_file';
-import {sfExtensionData} from '../../shims';
-import {freshCompilationTicket, NgCompiler, NgCompilerHost} from '../../core';
-import {TcbGenericContextBehavior} from '../src/ops/context';
-import {DomSchemaChecker} from '../api/schema';
 
 export function typescriptLibDts(): TestFile {
   return {
@@ -288,7 +288,6 @@ export const ALL_ENABLED_CONFIG: Readonly<TypeCheckingConfig> = {
   strictLiteralTypes: true,
   enableTemplateTypeChecker: false,
   useInlineTypeConstructors: true,
-  suggestionsForSuboptimalTypeInference: false,
   controlFlowPreventingContentProjection: 'warning',
   unusedStandaloneImports: 'warning',
   allowSignalsInTwoWayBindings: true,
@@ -446,7 +445,6 @@ export function tcb(
     strictLiteralTypes: true,
     enableTemplateTypeChecker: false,
     useInlineTypeConstructors: true,
-    suggestionsForSuboptimalTypeInference: false,
     allowSignalsInTwoWayBindings: true,
     checkTwoWayBoundEvents: true,
     allowDomEventAssertion: true,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/GOLDEN_PARTIAL.js
@@ -108,8 +108,8 @@ export class MyComponent {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-component", ngImport: i0, template: `
     <div *ngIf="showing">
-      <div (click)="onClick(foo)"></div>
-      <button (click)="onClick2(bar)"></button>
+      <div (click)="onClick(1)"></div>
+      <button (click)="onClick2(2)"></button>
     </div>
   `, isInline: true });
 }
@@ -119,8 +119,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: 'my-component',
                     template: `
     <div *ngIf="showing">
-      <div (click)="onClick(foo)"></div>
-      <button (click)="onClick2(bar)"></button>
+      <div (click)="onClick(1)"></div>
+      <button (click)="onClick2(2)"></button>
     </div>
   `,
                     standalone: false
@@ -622,7 +622,7 @@ export class MyComponent {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-component", ngImport: i0, template: `
     <ng-template #template>
-      <button (click)="this['mes' + 'sage'] = 'hello'">Click me</button>
+      <button (click)="$any(this)['mes' + 'sage'] = 'hello'">Click me</button>
     </ng-template>
   `, isInline: true });
 }
@@ -632,7 +632,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: 'my-component',
                     template: `
     <ng-template #template>
-      <button (click)="this['mes' + 'sage'] = 'hello'">Click me</button>
+      <button (click)="$any(this)['mes' + 'sage'] = 'hello'">Click me</button>
     </ng-template>
   `,
                     standalone: false
@@ -720,7 +720,7 @@ import * as i0 from "@angular/core";
 export class TestCmp {
     name = '';
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: false, selector: "test-cmp", ngImport: i0, template: 'Name: <input [(ngModel)]="name">', isInline: true, dependencies: [{ kind: "directive", type: i0.forwardRef(() => NgModelDirective), selector: "[ngModel]", inputs: ["ngModel"], outputs: ["ngModelChanges"] }] });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: false, selector: "test-cmp", ngImport: i0, template: 'Name: <input [(ngModel)]="name">', isInline: true, dependencies: [{ kind: "directive", type: i0.forwardRef(() => NgModelDirective), selector: "[ngModel]", inputs: ["ngModel"], outputs: ["ngModelChange"] }] });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, decorators: [{
             type: Component,
@@ -732,9 +732,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
         }] });
 export class NgModelDirective {
     ngModel = '';
-    ngModelChanges = new EventEmitter();
+    ngModelChange = new EventEmitter();
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
-    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: NgModelDirective, isStandalone: false, selector: "[ngModel]", inputs: { ngModel: "ngModel" }, outputs: { ngModelChanges: "ngModelChanges" }, ngImport: i0 });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: NgModelDirective, isStandalone: false, selector: "[ngModel]", inputs: { ngModel: "ngModel" }, outputs: { ngModelChange: "ngModelChange" }, ngImport: i0 });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, decorators: [{
             type: Directive,
@@ -744,7 +744,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                 }]
         }], propDecorators: { ngModel: [{
                 type: Input
-            }], ngModelChanges: [{
+            }], ngModelChange: [{
                 type: Output
             }] } });
 export class AppModule {
@@ -769,9 +769,9 @@ export declare class TestCmp {
 }
 export declare class NgModelDirective {
     ngModel: string;
-    ngModelChanges: EventEmitter<string>;
+    ngModelChange: EventEmitter<string>;
     static ɵfac: i0.ɵɵFactoryDeclaration<NgModelDirective, never>;
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgModelDirective, "[ngModel]", never, { "ngModel": { "alias": "ngModel"; "required": false; }; }, { "ngModelChanges": "ngModelChanges"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgModelDirective, "[ngModel]", never, { "ngModel": { "alias": "ngModel"; "required": false; }; }, { "ngModelChange": "ngModelChange"; }, never, never, false, never>;
 }
 export declare class AppModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<AppModule, never>;
@@ -787,7 +787,7 @@ import * as i0 from "@angular/core";
 export class TestCmp {
     name = '';
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: false, selector: "test-cmp", ngImport: i0, template: 'Name: <ng-template><input [(ngModel)]="name"></ng-template>', isInline: true, dependencies: [{ kind: "directive", type: i0.forwardRef(() => NgModelDirective), selector: "[ngModel]", inputs: ["ngModel"], outputs: ["ngModelChanges"] }] });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: false, selector: "test-cmp", ngImport: i0, template: 'Name: <ng-template><input [(ngModel)]="name"></ng-template>', isInline: true, dependencies: [{ kind: "directive", type: i0.forwardRef(() => NgModelDirective), selector: "[ngModel]", inputs: ["ngModel"], outputs: ["ngModelChange"] }] });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, decorators: [{
             type: Component,
@@ -799,9 +799,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
         }] });
 export class NgModelDirective {
     ngModel = '';
-    ngModelChanges = new EventEmitter();
+    ngModelChange = new EventEmitter();
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
-    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: NgModelDirective, isStandalone: false, selector: "[ngModel]", inputs: { ngModel: "ngModel" }, outputs: { ngModelChanges: "ngModelChanges" }, ngImport: i0 });
+    static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: NgModelDirective, isStandalone: false, selector: "[ngModel]", inputs: { ngModel: "ngModel" }, outputs: { ngModelChange: "ngModelChange" }, ngImport: i0 });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: NgModelDirective, decorators: [{
             type: Directive,
@@ -811,7 +811,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                 }]
         }], propDecorators: { ngModel: [{
                 type: Input
-            }], ngModelChanges: [{
+            }], ngModelChange: [{
                 type: Output
             }] } });
 export class AppModule {
@@ -836,9 +836,9 @@ export declare class TestCmp {
 }
 export declare class NgModelDirective {
     ngModel: string;
-    ngModelChanges: EventEmitter<string>;
+    ngModelChange: EventEmitter<string>;
     static ɵfac: i0.ɵɵFactoryDeclaration<NgModelDirective, never>;
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgModelDirective, "[ngModel]", never, { "ngModel": { "alias": "ngModel"; "required": false; }; }, { "ngModelChanges": "ngModelChanges"; }, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgModelDirective, "[ngModel]", never, { "ngModel": { "alias": "ngModel"; "required": false; }; }, { "ngModelChange": "ngModelChange"; }, never, never, false, never>;
 }
 export declare class AppModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<AppModule, never>;
@@ -853,17 +853,17 @@ import { Component } from '@angular/core';
 import * as i0 from "@angular/core";
 export class MyComponent {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
-    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", host: { listeners: { "click": "$event.preventDefault(); $event.target.blur()" } }, ngImport: i0, template: `
-    <div (click)="$event.preventDefault(); $event.target.blur()"></div>
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: true, selector: "my-component", host: { listeners: { "click": "$event.preventDefault(); $event.target" } }, ngImport: i0, template: `
+    <div (click)="$event.preventDefault(); $event.target"></div>
   `, isInline: true });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
             type: Component,
             args: [{
                     selector: 'my-component',
-                    host: { '(click)': '$event.preventDefault(); $event.target.blur()' },
+                    host: { '(click)': '$event.preventDefault(); $event.target' },
                     template: `
-    <div (click)="$event.preventDefault(); $event.target.blur()"></div>
+    <div (click)="$event.preventDefault(); $event.target"></div>
   `
                 }]
         }] });
@@ -880,15 +880,15 @@ export declare class MyComponent {
 /****************************************************************************************************
  * PARTIAL FILE: mixed_one_way_two_way_listener_order.js
  ****************************************************************************************************/
-import { Component, Directive, Input, Output } from '@angular/core';
+import { Component, Directive, EventEmitter, Input, Output } from '@angular/core';
 import * as i0 from "@angular/core";
 export class Dir {
-    a;
-    aChange;
-    b;
-    c;
-    cChange;
-    d;
+    a = '';
+    aChange = new EventEmitter();
+    b = new EventEmitter();
+    c = '';
+    cChange = new EventEmitter();
+    d = new EventEmitter();
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Dir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
     static ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: Dir, isStandalone: true, selector: "[dir]", inputs: { a: "a", c: "c" }, outputs: { aChange: "aChange", b: "b", cChange: "cChange", d: "d" }, ngImport: i0 });
 }
@@ -929,14 +929,15 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
 /****************************************************************************************************
  * PARTIAL FILE: mixed_one_way_two_way_listener_order.d.ts
  ****************************************************************************************************/
+import { EventEmitter } from '@angular/core';
 import * as i0 from "@angular/core";
 export declare class Dir {
-    a: unknown;
-    aChange: unknown;
-    b: unknown;
-    c: unknown;
-    cChange: unknown;
-    d: unknown;
+    a: string;
+    aChange: EventEmitter<string>;
+    b: EventEmitter<any>;
+    c: string;
+    cChange: EventEmitter<string>;
+    d: EventEmitter<any>;
     static ɵfac: i0.ɵɵFactoryDeclaration<Dir, never>;
     static ɵdir: i0.ɵɵDirectiveDeclaration<Dir, "[dir]", never, { "a": { "alias": "a"; "required": false; }; "c": { "alias": "c"; "required": false; }; }, { "aChange": "aChange"; "b": "b"; "cChange": "cChange"; "d": "d"; }, never, never, true, never>;
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/implicit_receiver_keyed_write_inside_template.ts
@@ -1,10 +1,10 @@
-import {Component, NgModule} from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 
 @Component({
     selector: 'my-component',
     template: `
     <ng-template #template>
-      <button (click)="this['mes' + 'sage'] = 'hello'">Click me</button>
+      <button (click)="$any(this)['mes' + 'sage'] = 'hello'">Click me</button>
     </ng-template>
   `,
     standalone: false

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/mixed_one_way_two_way_listener_order.ts
@@ -1,16 +1,16 @@
-import {Component, Directive, Input, Output} from '@angular/core';
+import { Component, Directive, EventEmitter, Input, Output } from '@angular/core';
 
 @Directive({selector: '[dir]'})
 export class Dir {
-  @Input() a: unknown;
-  @Output() aChange: unknown;
+  @Input() a: string = '';
+  @Output() aChange = new EventEmitter<string>();
 
-  @Output() b: unknown;
+  @Output() b = new EventEmitter();
 
-  @Input() c: unknown;
-  @Output() cChange: unknown;
+  @Input() c: string = '';
+  @Output() cChange = new EventEmitter<string>();
 
-  @Output() d: unknown;
+  @Output() d = new EventEmitter();
 }
 
 @Component({

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/multiple_statements.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/multiple_statements.js
@@ -1,13 +1,13 @@
 hostBindings: function MyComponent_HostBindings(rf, ctx) { 
   if (rf & 1) {
-    $r3$.ɵɵlistener("click", function MyComponent_click_HostBindingHandler($event) { $event.preventDefault(); return $event.target.blur(); });
+    $r3$.ɵɵlistener("click", function MyComponent_click_HostBindingHandler($event) { $event.preventDefault(); return $event.target; });
   }
 }
 …
 template: function MyComponent_Template(rf, ctx) { 
   if (rf & 1) {
     $r3$.ɵɵdomElementStart(0, "div", 0);
-    $r3$.ɵɵdomListener("click", function MyComponent_Template_div_click_0_listener($event) { $event.preventDefault(); return $event.target.blur(); });
+    $r3$.ɵɵdomListener("click", function MyComponent_Template_div_click_0_listener($event) { $event.preventDefault(); return $event.target; });
     $r3$.ɵɵdomElementEnd();
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/multiple_statements.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/multiple_statements.ts
@@ -1,10 +1,10 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'my-component',
-  host: {'(click)': '$event.preventDefault(); $event.target.blur()'},
+  host: {'(click)': '$event.preventDefault(); $event.target'},
   template: `
-    <div (click)="$event.preventDefault(); $event.target.blur()"></div>
+    <div (click)="$event.preventDefault(); $event.target"></div>
   `
 })
 export class MyComponent {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way.ts
@@ -1,4 +1,4 @@
-import {Component, Directive, EventEmitter, Input, NgModule, Output} from '@angular/core';
+import { Component, Directive, EventEmitter, Input, NgModule, Output } from '@angular/core';
 
 @Component({
     selector: 'test-cmp',
@@ -15,7 +15,7 @@ export class TestCmp {
 })
 export class NgModelDirective {
   @Input() ngModel: string = '';
-  @Output() ngModelChanges: EventEmitter<string> = new EventEmitter();
+  @Output() ngModelChange: EventEmitter<string> = new EventEmitter();
 }
 
 @NgModule({declarations: [TestCmp, NgModelDirective]})

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners.ts
@@ -1,11 +1,11 @@
-import {Component, NgModule} from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 
 @Component({
     selector: 'my-component',
     template: `
     <div *ngIf="showing">
-      <div (click)="onClick(foo)"></div>
-      <button (click)="onClick2(bar)"></button>
+      <div (click)="onClick(1)"></div>
+      <button (click)="onClick2(2)"></button>
     </div>
   `,
     standalone: false

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners_template.js
@@ -5,14 +5,14 @@ function MyComponent_div_0_Template(rf, ctx) {
     $r3$.ɵɵlistener("click", function MyComponent_div_0_Template_div_click_1_listener() {
       $r3$.ɵɵrestoreView($s$);
       const $comp$ = $r3$.ɵɵnextContext();
-      return $i0$.ɵɵresetView($comp$.onClick($comp$.foo));
+      return $i0$.ɵɵresetView($comp$.onClick(1));
     });
     $r3$.ɵɵelementEnd();
     $r3$.ɵɵelementStart(2, "button", 1);
     $r3$.ɵɵlistener("click", function MyComponent_div_0_Template_button_click_2_listener() {
       $r3$.ɵɵrestoreView($s$);
       const $comp2$ = $r3$.ɵɵnextContext();
-      return $i0$.ɵɵresetView($comp2$.onClick2($comp2$.bar));
+      return $i0$.ɵɵresetView($comp2$.onClick2(2));
     });
     $r3$.ɵɵelementEnd()();
   }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way.ts
@@ -1,4 +1,4 @@
-import {Component, Directive, EventEmitter, Input, NgModule, Output} from '@angular/core';
+import { Component, Directive, EventEmitter, Input, NgModule, Output } from '@angular/core';
 
 @Component({
     selector: 'test-cmp',
@@ -15,7 +15,7 @@ export class TestCmp {
 })
 export class NgModelDirective {
   @Input() ngModel: string = '';
-  @Output() ngModelChanges: EventEmitter<string> = new EventEmitter();
+  @Output() ngModelChange: EventEmitter<string> = new EventEmitter();
 }
 
 @NgModule({declarations: [TestCmp, NgModelDirective]})

--- a/packages/compiler-cli/test/ngtsc/incremental_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/incremental_spec.ts
@@ -630,7 +630,7 @@ runInEachFileSystem(() => {
     });
 
     it('should compile incrementally with template type-checking turned on', () => {
-      env.tsconfig({fullTemplateTypeCheck: true});
+      env.tsconfig({strictTemplates: true});
       env.write(
         'main.ts',
         `
@@ -652,7 +652,7 @@ runInEachFileSystem(() => {
       // This test verifies that ambient types declared in node_modules/@types are still available
       // in incremental compilations. In the below code, the usage of `require` should be valid
       // in the original program and the incremental program.
-      env.tsconfig({fullTemplateTypeCheck: true}, {types: ['node']});
+      env.tsconfig({strictTemplates: true}, {types: ['node']});
       env.write('node_modules/@types/node/index.d.ts', 'declare var require: any;');
       env.write(
         'main.ts',
@@ -673,7 +673,7 @@ runInEachFileSystem(() => {
 
     // https://github.com/angular/angular/pull/26036
     it('should handle redirected source files', () => {
-      env.tsconfig({fullTemplateTypeCheck: true});
+      env.tsconfig({strictTemplates: true});
 
       // This file structure has an identical version of "a" under the root node_modules and inside
       // of "b". Because their package.json file indicates it is the exact same version of "a",
@@ -710,7 +710,7 @@ runInEachFileSystem(() => {
     });
 
     it('should allow incremental compilation with redirected source files', () => {
-      env.tsconfig({fullTemplateTypeCheck: true});
+      env.tsconfig({strictTemplates: true});
 
       // This file structure has an identical version of "a" under the root node_modules and inside
       // of "b". Because their package.json file indicates it is the exact same version of "a",

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1053,7 +1053,7 @@ runInEachFileSystem((os: string) => {
 
         it('should still perform schema checks in embedded views', () => {
           env.tsconfig({
-            'fullTemplateTypeCheck': false,
+            'strictTemplates': false,
             'annotateForClosureCompiler': true,
           });
           env.write(

--- a/packages/compiler-cli/test/ngtsc/scope_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/scope_spec.ts
@@ -360,7 +360,7 @@ runInEachFileSystem(() => {
       });
 
       it('should not produce component template type-check errors if its module is invalid', () => {
-        env.tsconfig({'fullTemplateTypeCheck': true});
+        env.tsconfig({'strictTemplates': true});
 
         // Set up 3 files, each of which declare an NgModule that's invalid in some way. This will
         // produce a bunch of diagnostics related to the issues with the modules. Each module also

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -29,7 +29,7 @@ runInEachFileSystem(() => {
 
     beforeEach(() => {
       env = NgtscTestEnvironment.setup(testFiles);
-      env.tsconfig({fullTemplateTypeCheck: true});
+      env.tsconfig({strictTemplates: true});
       env.write(
         'node_modules/@angular/animations/index.d.ts',
         `
@@ -117,7 +117,7 @@ runInEachFileSystem(() => {
 
     it('should check regular attributes that are directive inputs', () => {
       env.tsconfig({
-        fullTemplateTypeCheck: true,
+        strictTemplates: true,
         strictInputTypes: true,
         strictAttributeTypes: true,
       });
@@ -158,7 +158,7 @@ runInEachFileSystem(() => {
     // This is not supported at runtime
     xit('should produce diagnostics when mapping to multiple fields and bound types are incorrect', () => {
       env.tsconfig({
-        fullTemplateTypeCheck: true,
+        strictTemplates: true,
         strictInputTypes: true,
         strictAttributeTypes: true,
       });
@@ -198,7 +198,7 @@ runInEachFileSystem(() => {
 
     it('should support inputs and outputs with names that are not JavaScript identifiers', () => {
       env.tsconfig({
-        fullTemplateTypeCheck: true,
+        strictTemplates: true,
         strictInputTypes: true,
         strictOutputEventTypes: true,
       });
@@ -276,7 +276,7 @@ runInEachFileSystem(() => {
     });
 
     it('should check event bindings', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
+      env.tsconfig({strictTemplates: true, strictOutputEventTypes: true});
       env.write(
         'test.ts',
         `
@@ -307,18 +307,17 @@ runInEachFileSystem(() => {
       );
 
       const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(3);
+      expect(diags.length).toBe(4);
       expect(diags[0].messageText).toEqual(
         `Argument of type 'number' is not assignable to parameter of type 'string'.`,
       );
       expect(diags[1].messageText).toEqual(
         `Property 'updated' does not exist on type 'TestCmp'. Did you mean 'update'?`,
       );
-      // Disabled because `checkTypeOfDomEvents` is disabled by default
-      // expect(diags[2].messageText)
-      //     .toEqual(
-      //         `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`);
-      expect(diags[2].messageText).toEqual(`Property 'focused' does not exist on type 'TestCmp'.`);
+      expect(diags[2].messageText).toEqual(
+        `Argument of type 'FocusEvent' is not assignable to parameter of type 'string'.`,
+      );
+      expect(diags[3].messageText).toEqual(`Property 'focused' does not exist on type 'TestCmp'.`);
     });
 
     // https://github.com/angular/angular/issues/35073
@@ -869,7 +868,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions and their type when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+        env.tsconfig({strictTemplates: true, strictInputTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -891,7 +890,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions but not their type when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true});
+        env.tsconfig({strictTemplates: true, strictInputTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -935,7 +934,7 @@ runInEachFileSystem(() => {
 
       it('should check expressions and their nullability when enabled', () => {
         env.tsconfig({
-          fullTemplateTypeCheck: true,
+          strictTemplates: true,
           strictInputTypes: true,
           strictNullInputTypes: true,
         });
@@ -964,7 +963,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions but not their nullability when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+        env.tsconfig({strictTemplates: true, strictInputTypes: true, strictNullInputTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -1008,7 +1007,7 @@ runInEachFileSystem(() => {
 
       it('should infer result type for safe navigation expressions when enabled', () => {
         env.tsconfig({
-          fullTemplateTypeCheck: true,
+          strictTemplates: true,
           strictInputTypes: true,
           strictNullInputTypes: true,
           strictSafeNavigationTypes: true,
@@ -1039,7 +1038,8 @@ runInEachFileSystem(() => {
 
       it('should not infer result type for safe navigation expressions when not enabled', () => {
         env.tsconfig({
-          fullTemplateTypeCheck: true,
+          strictTemplates: true,
+          strictSafeNavigationTypes: false,
           strictInputTypes: true,
         });
 
@@ -1084,7 +1084,7 @@ runInEachFileSystem(() => {
       });
 
       it('should expressions and infer type of $event when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
+        env.tsconfig({strictTemplates: true, strictOutputEventTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -1110,7 +1110,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions but not infer type of $event when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true});
+        env.tsconfig({strictTemplates: true, strictOutputEventTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -1145,7 +1145,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions and let $event be of type AnimationEvent when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictOutputEventTypes: true});
+        env.tsconfig({strictTemplates: true, strictOutputEventTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -1171,7 +1171,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions and let $event be of type any when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true});
+        env.tsconfig({strictTemplates: true, strictOutputEventTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -1204,7 +1204,7 @@ runInEachFileSystem(() => {
       });
 
       it('should infer the type of DOM references when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictDomLocalRefTypes: true});
+        env.tsconfig({strictTemplates: true, strictDomLocalRefTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -1224,7 +1224,7 @@ runInEachFileSystem(() => {
       });
 
       it('should let the type of DOM references be any when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true});
+        env.tsconfig({strictTemplates: true, strictDomLocalRefTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
@@ -1264,7 +1264,7 @@ runInEachFileSystem(() => {
 
       it('should produce an error for text attributes when enabled', () => {
         env.tsconfig({
-          fullTemplateTypeCheck: true,
+          strictTemplates: true,
           strictInputTypes: true,
           strictAttributeTypes: true,
         });
@@ -1285,7 +1285,7 @@ runInEachFileSystem(() => {
       });
 
       it('should not produce an error for text attributes when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+        env.tsconfig({strictTemplates: true, strictAttributeTypes: false, strictInputTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
@@ -1317,7 +1317,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions and infer type of $event when enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictDomEventTypes: true});
+        env.tsconfig({strictTemplates: true, strictDomEventTypes: true});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(2);
@@ -1343,7 +1343,7 @@ runInEachFileSystem(() => {
       });
 
       it('should check expressions but not infer type of $event when not enabled', () => {
-        env.tsconfig({fullTemplateTypeCheck: true});
+        env.tsconfig({strictTemplates: true, strictDomEventTypes: false});
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(1);
@@ -1491,7 +1491,7 @@ runInEachFileSystem(() => {
     });
 
     it('should report an error inside the NgFor template', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -1730,7 +1730,7 @@ runInEachFileSystem(() => {
     });
 
     it('should allow the implicit value of an NgFor to be invoked', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -1868,8 +1868,8 @@ runInEachFileSystem(() => {
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('unknown');
     });
 
-    it('should report an error with an unknown pipe even if `fullTemplateTypeCheck` is disabled', () => {
-      env.tsconfig({fullTemplateTypeCheck: false});
+    it('should report an error with an unknown pipe even if `strictTemplates` is disabled', () => {
+      env.tsconfig({strictTemplates: false});
       env.write(
         'test.ts',
         `
@@ -1956,7 +1956,7 @@ runInEachFileSystem(() => {
 
     it('should constrain types using type parameter bounds', () => {
       env.tsconfig({
-        fullTemplateTypeCheck: true,
+        strictTemplates: true,
         strictInputTypes: true,
         strictContextGenerics: true,
       });
@@ -2020,7 +2020,7 @@ runInEachFileSystem(() => {
       });
 
       it("should be treated as 'any' without strictTemplates", () => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictTemplates: false});
+        env.tsconfig();
 
         const diags = env.driveDiagnostics();
         expect(diags.length).toBe(0);
@@ -2038,7 +2038,7 @@ runInEachFileSystem(() => {
     });
 
     it('should properly type-check inherited directives', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -2090,7 +2090,7 @@ runInEachFileSystem(() => {
     });
 
     it('should properly type-check inherited directives from external libraries', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
 
       env.write(
         'node_modules/external/index.d.ts',
@@ -2182,8 +2182,13 @@ runInEachFileSystem(() => {
       `,
       );
       const diags = env.driveDiagnostics();
-      expect(diags.length).toEqual(1);
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('y = !y');
+      expect(diags.length).toEqual(2);
+      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('y');
+      expect(getSourceCodeForDiagnostic(diags[1])).toEqual('y = !y');
+      expect(diags[0].messageText).toEqual(`Type 'false' is not assignable to type 'true'.`);
+      expect(diags[1].messageText).toEqual(
+        `Cannot use variable 'y' as the left-hand side of an assignment expression. Template variables are read-only.`,
+      );
     });
 
     it('should detect a duplicate variable declaration', () => {
@@ -2234,7 +2239,7 @@ runInEachFileSystem(() => {
         '_useHostForImportGeneration': true,
         // Because the tsconfig is overridden, template type-checking needs to be turned back on
         // explicitly as well.
-        'fullTemplateTypeCheck': true,
+        'strictTemplates': true,
       });
 
       // 'alpha' declares the directive which will ultimately be imported.
@@ -2296,7 +2301,7 @@ runInEachFileSystem(() => {
 
     describe('input coercion', () => {
       beforeEach(() => {
-        env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+        env.tsconfig({strictTemplates: true, strictInputTypes: true});
         env.write(
           'node_modules/@angular/material/index.d.ts',
           `
@@ -3142,7 +3147,7 @@ runInEachFileSystem(() => {
       describe('with strictInputAccessModifiers', () => {
         beforeEach(() => {
           env.tsconfig({
-            fullTemplateTypeCheck: true,
+            strictTemplates: true,
             strictInputTypes: true,
             strictInputAccessModifiers: true,
           });
@@ -3207,7 +3212,7 @@ runInEachFileSystem(() => {
 
       describe('with strict inputs', () => {
         beforeEach(() => {
-          env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+          env.tsconfig({strictTemplates: true, strictInputTypes: true});
         });
 
         it('should not produce diagnostics for correct inputs which assign to readonly, private, or protected fields', () => {
@@ -3255,7 +3260,7 @@ runInEachFileSystem(() => {
     });
 
     it('should not produce diagnostics for undeclared inputs', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -3289,7 +3294,7 @@ runInEachFileSystem(() => {
     });
 
     it('should produce diagnostics for invalid expressions when assigned into an undeclared input', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -3323,7 +3328,7 @@ runInEachFileSystem(() => {
     });
 
     it('should not produce diagnostics for undeclared inputs inherited from a base class', () => {
-      env.tsconfig({fullTemplateTypeCheck: true, strictInputTypes: true});
+      env.tsconfig({strictTemplates: true, strictInputTypes: true});
       env.write(
         'test.ts',
         `
@@ -3611,7 +3616,7 @@ runInEachFileSystem(() => {
 
     describe('legacy schema checking with the DOM schema', () => {
       beforeEach(() => {
-        env.tsconfig({fullTemplateTypeCheck: false});
+        env.tsconfig({strictTemplates: false});
       });
 
       it('should check for unknown elements', () => {
@@ -4125,35 +4130,6 @@ runInEachFileSystem(() => {
 
     describe('option compatibility verification', () => {
       beforeEach(() => env.write('index.ts', `export const a = 1;`));
-
-      it('should error if "fullTemplateTypeCheck" is false when "strictTemplates" is true', () => {
-        env.tsconfig({fullTemplateTypeCheck: false, strictTemplates: true});
-
-        const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(1);
-        expect(diags[0].messageText).toContain(
-          'Angular compiler option "strictTemplates" is enabled, however "fullTemplateTypeCheck" is disabled.',
-        );
-      });
-      it('should not error if "fullTemplateTypeCheck" is false when "strictTemplates" is false', () => {
-        env.tsconfig({fullTemplateTypeCheck: false, strictTemplates: false});
-
-        const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(0);
-      });
-      it('should not error if "fullTemplateTypeCheck" is not set when "strictTemplates" is true', () => {
-        env.tsconfig({strictTemplates: true});
-
-        const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(0);
-      });
-      it('should not error if "fullTemplateTypeCheck" is true set when "strictTemplates" is true', () => {
-        env.tsconfig({strictTemplates: true});
-
-        const diags = env.driveDiagnostics();
-        expect(diags.length).toBe(0);
-      });
-
       it('should error if "strictTemplates" is false when "extendedDiagnostics" is configured', () => {
         env.tsconfig({strictTemplates: false, extendedDiagnostics: {}});
 
@@ -4302,7 +4278,7 @@ suppress
       it('should accept a program with a flat index', () => {
         // This test asserts that flat indices don't have any negative interactions with the
         // generation of template type-checking code in the program.
-        env.tsconfig({fullTemplateTypeCheck: true, flatModuleOutFile: 'flat.js'});
+        env.tsconfig({strictTemplates: true, flatModuleOutFile: 'flat.js'});
 
         expect(env.driveDiagnostics()).toEqual([]);
       });
@@ -5913,8 +5889,8 @@ suppress
 
     describe('for loop blocks', () => {
       beforeEach(() => {
-        // `fullTemplateTypeCheck: true` is necessary so content inside `ng-template` is checked.
-        env.tsconfig({fullTemplateTypeCheck: true});
+        // `strictTemplates: true` is necessary so content inside `ng-template` is checked.
+        env.tsconfig({strictTemplates: true});
       });
 
       it('should check bindings inside of for loop blocks', () => {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -22,49 +22,49 @@ import {OptimizeFor} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
 import {
+  AngularInlayHint,
   ApplyRefactoringProgressFn,
   ApplyRefactoringResult,
-  AngularInlayHint,
   GetComponentLocationsForTemplateResponse,
-  InlayHintsConfig,
   GetTcbResponse,
   GetTemplateLocationForComponentResponse,
+  InlayHintsConfig,
   LinkedEditingRanges,
   PluginConfig,
 } from '../api';
 
+import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
 import {LanguageServiceAdapter, LSParseConfigHost} from './adapters';
 import {ALL_CODE_FIXES_METAS, CodeFixes} from './codefixes';
 import {CompilerFactory} from './compiler_factory';
 import {CompletionBuilder} from './completions';
 import {DefinitionBuilder} from './definitions';
-import {getLinkedEditingRangeAtPosition} from './linked_editing_range';
 import {
   DocumentSymbolsOptions,
   getTemplateDocumentSymbols,
   TemplateDocumentSymbol,
 } from './document_symbols';
+import {getInlayHintsForTemplate} from './inlay_hints';
+import {getLinkedEditingRangeAtPosition} from './linked_editing_range';
 import {getOutliningSpans} from './outlining_spans';
 import {QuickInfoBuilder} from './quick_info';
+import {ActiveRefactoring, allRefactorings} from './refactorings/refactoring';
 import {ReferencesBuilder, RenameBuilder} from './references_and_rename';
 import {createLocationKey} from './references_and_rename_utils';
+import {getClassificationsForTemplate, TokenEncodingConsts} from './semantic_tokens';
 import {getSignatureHelp} from './signature_help';
 import {
   getTargetAtPosition,
   getTcbNodesOfTemplateAtPosition,
   TargetNodeKind,
 } from './template_target';
+import {getTypeCheckInfoAtPosition, isTypeScriptFile, TypeCheckInfo} from './utils';
 import {
   findTightestNode,
   getClassDeclFromDecoratorProp,
   getParentClassDeclaration,
   getPropertyAssignmentFromValue,
 } from './utils/ts_utils';
-import {getTypeCheckInfoAtPosition, isTypeScriptFile, TypeCheckInfo} from './utils';
-import {ActiveRefactoring, allRefactorings} from './refactorings/refactoring';
-import {getClassificationsForTemplate, TokenEncodingConsts} from './semantic_tokens';
-import {isExternalResource} from '@angular/compiler-cli/src/ngtsc/metadata';
-import {getInlayHintsForTemplate} from './inlay_hints';
 
 type LanguageServiceConfig = Omit<PluginConfig, 'angularOnly'>;
 
@@ -887,7 +887,7 @@ export class LanguageService {
         project.readFile(path),
       );
 
-      if (!this.options.strictTemplates && !this.options.fullTemplateTypeCheck) {
+      if (!this.options.strictTemplates) {
         diagnostics.push({
           messageText:
             'Some language features are not available. ' +

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -291,36 +291,6 @@ describe('getSemanticDiagnostics', () => {
     ]);
   });
 
-  it('reports a warning when the project configuration prevents good type inference', () => {
-    const files = {
-      'app.ts': `
-        import {Component, NgModule} from '@angular/core';
-        import {CommonModule} from '@angular/common';
-
-        @Component({
-          template: '<div *ngFor="let user of users">{{user}}</div>',
-          standalone: false,
-        })
-        export class MyComponent {
-          users = ['Alpha', 'Beta'];
-        }
-      `,
-    };
-
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
-      // Disable `strictTemplates`.
-      strictTemplates: false,
-      // Use `fullTemplateTypeCheck` mode instead.
-      fullTemplateTypeCheck: true,
-    });
-    const diags = project.getDiagnosticsForFile('app.ts');
-    expect(diags.length).toBe(1);
-    const diag = diags[0];
-    expect(diag.code).toBe(ngErrorCode(ErrorCode.SUGGEST_SUBOPTIMAL_TYPE_INFERENCE));
-    expect(diag.category).toBe(ts.DiagnosticCategory.Suggestion);
-    expect(getTextOfDiagnostic(diag)).toBe('user');
-  });
-
   it('should process a component that would otherwise require an inline TCB', () => {
     const files = {
       'app.ts': `

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -128,18 +128,6 @@ describe('language service adapter', () => {
       const diag = diags.find(isSuggestStrictTemplatesDiag);
       expect(diag).toBeUndefined();
     });
-
-    it('does not suggest turning on strict mode is fullTemplateTypeCheck flag is on', () => {
-      configFileFs.overwriteConfigFile(TSCONFIG, {
-        angularCompilerOptions: {
-          fullTemplateTypeCheck: true,
-        },
-      });
-      const diags = ngLS.getCompilerOptionsDiagnostics();
-      const diag = diags.find(isSuggestStrictTemplatesDiag);
-      expect(diag).toBeUndefined();
-    });
-
     function isSuggestStrictTemplatesDiag(diag: ts.Diagnostic) {
       return diag.code === ngErrorCode(ErrorCode.SUGGEST_STRICT_TEMPLATES);
     }

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -6,11 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  InternalOptions,
-  LegacyNgcOptions,
-  TypeCheckingOptions,
-} from '@angular/compiler-cli/src/ngtsc/core/api';
+import {InternalOptions, TypeCheckingOptions} from '@angular/compiler-cli/src/ngtsc/core/api';
 import {
   absoluteFrom,
   AbsoluteFsPath,
@@ -21,8 +17,8 @@ import {
 import {OptimizeFor, TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
-import {LanguageService} from '../../src/language_service';
 import {ApplyRefactoringProgressFn, ApplyRefactoringResult} from '../../api';
+import {LanguageService} from '../../src/language_service';
 
 import {OpenBuffer} from './buffer';
 import {patchLanguageServiceProjectsWithTestHost} from './language_service_test_cache';
@@ -80,8 +76,7 @@ function writeTsconfig(
 }
 
 export type TestableOptions = TypeCheckingOptions &
-  InternalOptions &
-  Pick<LegacyNgcOptions, 'fullTemplateTypeCheck'> & {
+  InternalOptions & {
     // This already exists in `InternalOptions`, but it's `internal` so it's stripped away.
     _enableSelectorless?: boolean;
   };

--- a/vscode-ng-language-service/schemas/tsconfig-ng.schema.json
+++ b/vscode-ng-language-service/schemas/tsconfig-ng.schema.json
@@ -123,11 +123,6 @@
           "type": "boolean",
           "description": "Enables the runtime check to guard against rendering a component without first loading its NgModule."
         },
-        "fullTemplateTypeCheck": {
-          "type": "boolean",
-          "description": "Whether to type check the entire template. Superseded by 'strictTemplates'.",
-          "deprecated": true
-        },
         "generateDeepReexports": {
           "type": "boolean",
           "description": "Enables the generation of alias re-exports of directives/pipes that are visible from an NgModule from that NgModule's file."


### PR DESCRIPTION
The option was deprecated back in v13. Users should use `strictTemplates: true`.
