### PR TITLE
refactor(http): Make Fetch API the default in `HttpBackend`

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -42,7 +42,7 @@ import {
  *
  * @publicApi
  */
-@Injectable({providedIn: 'root', useExisting: HttpXhrBackend})
+@Injectable({providedIn: 'root', useExisting: FetchBackend})
 export abstract class HttpBackend implements HttpHandler {
   abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
 }
@@ -90,8 +90,7 @@ export class HttpInterceptorHandler implements HttpHandler {
                 "to use `fetch` APIs. It's strongly recommended to " +
                 'enable `fetch` for applications that use Server-Side Rendering ' +
                 'for better performance and compatibility. ' +
-                'To enable `fetch`, add the `withFetch()` to the `provideHttpClient()` ' +
-                'call at the root of the application.',
+                'To enable `fetch`, remove the `withXhr()` feature from the `provideHttpClient()` call',
             ),
           );
       }

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -45,7 +45,7 @@ const XSSI_PREFIX = /^\)\]\}',?\n/;
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class FetchBackend implements HttpBackend {
   // We use an arrow function to always reference the current global implementation of `fetch`.
   // This is helpful for cases when the global `fetch` implementation is modified by external code,

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -66,6 +66,8 @@ function makeHttpFeature<KindT extends HttpFeatureKind>(
 /**
  * Configures Angular's `HttpClient` service to be available for injection.
  *
+ * The `HttpClient` service is provided in the root by default.
+ *
  * By default, `HttpClient` will be configured for injection with its default options for XSRF
  * protection of outgoing requests. Additional configuration options can be provided by passing
  * feature functions to `provideHttpClient`. For example, HTTP interceptors can be added using the
@@ -73,16 +75,18 @@ function makeHttpFeature<KindT extends HttpFeatureKind>(
  *
  * <div class="docs-alert docs-alert-helpful">
  *
- * It's strongly recommended to enable
- * [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for applications that use
- * Server-Side Rendering for better performance and compatibility. To enable `fetch`, add
- * `withFetch()` feature to the `provideHttpClient()` call at the root of the application:
+ * By default, `HttpClient` uses the
+ * [`fetch` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make requests.
+ * This is strongly recommended for applications that use
+ * Server-Side Rendering for better performance and compatibility.
+ * To use the `XMLHttpRequest` API instead, add the {@link withXhr} feature:
  *
  * ```ts
- * provideHttpClient(withFetch());
+ * provideHttpClient(withXhr());
  * ```
  *
  * </div>
+ *
  * @see [HTTP Client](guide/http/setup)
  * @see {@link withInterceptors}
  * @see {@link withInterceptorsFromDi}

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -90,7 +90,7 @@ function validateXhrCompatibility(req: HttpRequest<any>) {
       console.warn(
         formatRuntimeError(
           errorCode,
-          `Angular detected that a \`HttpClient\` request with the \`${property}\` option was sent using XHR, which does not support it. To use the \`${property}\` option, enable Fetch API support by passing \`withFetch()\` as an argument to \`provideHttpClient()\`.`,
+          `Angular detected that a \`HttpClient\` request with the \`${property}\` option was sent using XHR, which does not support it. To use the \`${property}\` option, use the Fetch API by removing \`withXhr()\` from the \`provideHttpClient()\` call.`,
         ),
       );
     }

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -601,7 +601,7 @@ describe('without providers', () => {
     const backend = TestBed.inject(HttpBackend);
 
     expect(client).toBeInstanceOf(HttpClient);
-    expect(backend).toBeInstanceOf(HttpXhrBackend);
+    expect(backend).toBeInstanceOf(FetchBackend);
   });
 
   it('should not use legacy interceptors by default', () => {


### PR DESCRIPTION
Updates the `HttpBackend` default provider to `FetchBackend`.

Also updates related warning messages to reflect the new default behavior.
 

## What is the current behavior?
 
Currently, the default behavior of `HttpClient` ( provide in root by default ) is to use the XHR backend.

## What is the new behavior?

Use `FetchBackend`, since it is the intended default behavior and is somewhat counterintuitive otherwise.
  