### PR TITLE
fix(devtools): fix incorrect logic in destroy function for ChromeMessageBus

### DIFF
--- a/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
@@ -80,7 +80,7 @@ export class ChromeMessageBus extends MessageBus<Events> {
   }
 
   override destroy(): void {
-    this._listeners.forEach((l) => window.removeEventListener('message', l));
+    this._listeners.forEach((l) => this._port.onMessage.removeListener(l));
     this._listeners = [];
   }
 }


### PR DESCRIPTION
Destroy uses window.removeEventListener but the ChromeMessageBus doesn't actually depend on a window object.

In practice this code is unlikely to ever be reached. If a tab is closed the entire context script JS process is killed so this is not an bug that would be very common or even reachable. That being said, for correctness this should not be using window.