### PR TITLE
test(router): add test for nested empty path + named outlet behavior

### DIFF
--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -643,3 +643,51 @@ async function createRoot<T>(router: Router, type: Type<T>): Promise<ComponentFi
   await advance(f);
   return f;
 }
+
+it('should not match routes when using nested empty paths with named outlets', async () => {
+  @Component({
+    selector: 'root-cmp',
+    template: `
+      <router-outlet></router-outlet>
+      <router-outlet name="secondary"></router-outlet>
+    `,
+  })
+  class RootCmp {}
+
+  @Component({template: 'Primary'})
+  class PrimaryCmp {}
+
+  @Component({template: 'Secondary'})
+  class SecondaryCmp {}
+
+  TestBed.configureTestingModule({
+    declarations: [RootCmp, PrimaryCmp, SecondaryCmp],
+    imports: [
+      RouterTestingModule.withRoutes([
+        {
+          path: '',
+          children: [
+            {path: 'component', component: PrimaryCmp},
+          ],
+        },
+        {
+          path: '',
+          outlet: 'secondary',
+          children: [
+            {path: 'component-copy', component: SecondaryCmp},
+          ],
+        },
+      ]),
+    ],
+  });
+
+  const router = TestBed.inject(Router);
+  const fixture = TestBed.createComponent(RootCmp);
+
+  router.initialNavigation();
+  
+  fixture.detectChanges();
+
+  const result = await router.navigateByUrl('/component(secondary:component-copy)');
+
+  expect(result).toBeFalse();


### PR DESCRIPTION
## Description

This PR adds a test case demonstrating the behavior of nested empty path (`''`) routes with named outlets.

## Context

As discussed in the issue, route matching behaves differently depending on whether routes are defined at the root level or nested.

- Root-level configuration works as expected
- Nested empty path configuration fails to resolve named outlet routes

## Purpose

This test helps document and reproduce the current behavior of the Angular router, making it easier to understand and reason about.

No functional changes are introduced.