### PR TITLE
feat(compiler): Enable `strictTemplates` by default

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -102,7 +102,7 @@ export interface TypeCheckingOptions {
    *
    * This flag is a superset of the deprecated `fullTemplateTypeCheck` option.
    *
-   * Defaults to `false`, even if "fullTemplateTypeCheck" is `true`.
+   * Defaults to `true`
    */
   strictTemplates?: boolean;
 

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {R3Identifiers} from '@angular/compiler';
 import ts from 'typescript';
 
 import {
@@ -65,10 +64,10 @@ import {
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
 import {
-  DirectiveResources,
   CompoundMetadataReader,
   CompoundMetadataRegistry,
   DirectiveMeta,
+  DirectiveResources,
   DtsMetadataReader,
   ExportedProviderStatusResolver,
   HostDirectivesResolver,
@@ -106,8 +105,8 @@ import {
   DecoratorHandler,
   DtsTransformRegistry,
   ivyTransformFactory,
-  TraitCompiler,
   signalMetadataTransform,
+  TraitCompiler,
 } from '../../transform';
 import {TemplateTypeCheckerImpl} from '../../typecheck';
 import {OptimizeFor, TemplateTypeChecker, TypeCheckingConfig} from '../../typecheck/api';
@@ -124,10 +123,10 @@ import {SourceFileValidator} from '../../validation';
 import {Xi18nContext} from '../../xi18n';
 import {DiagnosticCategoryLabel, NgCompilerAdapter, NgCompilerOptions} from '../api';
 
-import {coreVersionSupportsFeature} from './feature_detection';
-import {angularJitApplicationTransform} from '../../transform/jit';
-import {untagAllTsFiles} from '../../shims';
 import {DOC_PAGE_BASE_URL} from '../../diagnostics/src/error_details_base_url';
+import {untagAllTsFiles} from '../../shims';
+import {angularJitApplicationTransform} from '../../transform/jit';
+import {coreVersionSupportsFeature} from './feature_detection';
 
 /**
  * State information about a compilation which is only generated once some data is requested from
@@ -658,7 +657,7 @@ export class NgCompiler {
       if (templateSemanticsChecker !== null) {
         diagnostics.push(...templateSemanticsChecker.getDiagnosticsForComponent(component));
       }
-      if (this.options.strictTemplates && extendedTemplateChecker !== null) {
+      if (this.strictTemplates && extendedTemplateChecker !== null) {
         diagnostics.push(...extendedTemplateChecker.getDiagnosticsForComponent(component));
       }
     } catch (err: unknown) {
@@ -1037,13 +1036,20 @@ export class NgCompiler {
     });
   }
 
+  /**
+   * strictTemplate is `true` by default.
+   * Explicit opt-out is required to disable strictness
+   */
+  private get strictTemplates(): boolean {
+    return this.options.strictTemplates !== false;
+  }
+
   private get fullTemplateTypeCheck(): boolean {
     // Determine the strictness level of type checking based on compiler options. As
     // `strictTemplates` is a superset of `fullTemplateTypeCheck`, the former implies the latter.
     // Also see `verifyCompatibleTypeCheckOptions` where it is verified that `fullTemplateTypeCheck`
     // is not disabled when `strictTemplates` is enabled.
-    const strictTemplates = !!this.options.strictTemplates;
-    return strictTemplates || !!this.options.fullTemplateTypeCheck;
+    return this.strictTemplates || !!this.options.fullTemplateTypeCheck;
   }
 
   private getTypeCheckingConfig(): TypeCheckingConfig {
@@ -1051,7 +1057,7 @@ export class NgCompiler {
     // `strictTemplates` is a superset of `fullTemplateTypeCheck`, the former implies the latter.
     // Also see `verifyCompatibleTypeCheckOptions` where it is verified that `fullTemplateTypeCheck`
     // is not disabled when `strictTemplates` is enabled.
-    const strictTemplates = !!this.options.strictTemplates;
+    const strictTemplates = this.strictTemplates;
 
     const useInlineTypeConstructors = this.programDriver.supportsInlineOperations;
     const checkTwoWayBoundEvents = this.options['_checkTwoWayBoundEvents'] ?? false;
@@ -1278,7 +1284,7 @@ export class NgCompiler {
           }),
         );
       }
-      if (this.options.strictTemplates && extendedTemplateChecker !== null) {
+      if (this.strictTemplates && extendedTemplateChecker !== null) {
         diagnostics.push(
           ...compilation.traitCompiler.runAdditionalChecks(sf, (clazz, handler) => {
             return handler.extendedTemplateCheck?.(clazz, extendedTemplateChecker) || null;
@@ -1765,7 +1771,7 @@ function getR3SymbolsFile(program: ts.Program): ts.SourceFile | null {
 function* verifyCompatibleTypeCheckOptions(
   options: NgCompilerOptions,
 ): Generator<ts.Diagnostic, void, void> {
-  if (options.fullTemplateTypeCheck === false && options.strictTemplates === true) {
+  if (options.fullTemplateTypeCheck === false && options.strictTemplates !== false) {
     yield makeConfigDiagnostic({
       category: ts.DiagnosticCategory.Error,
       code: ErrorCode.CONFIG_STRICT_TEMPLATES_IMPLIES_FULL_TEMPLATE_TYPECHECK,
@@ -1777,7 +1783,7 @@ the latter can not be explicitly disabled.
 
 One of the following actions is required:
 1. Remove the "fullTemplateTypeCheck" option.
-2. Remove "strictTemplates" or set it to 'false'.
+2. Set "strictTemplates" to 'false'.
 
 More information about the template type checking compiler options can be found in the documentation:
 ${DOC_PAGE_BASE_URL}/tools/cli/template-typecheck

--- a/packages/compiler-cli/test/compliance/codegen/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/codegen/BUILD.bazel
@@ -17,6 +17,7 @@ jasmine_test(
     name = "codegen",
     data = [
         ":test_lib",
+        "//packages/animations:npm_package",
         "//packages/compiler-cli/test/compliance/test_cases",
         "//packages/core:npm_package",
     ],

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
@@ -76,7 +76,7 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                 }]
         }] });
 class MyForwardPipe {
-    transform() { }
+    transform(param) { }
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyForwardPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
     static ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyForwardPipe, isStandalone: false, name: "my_forward_pipe" });
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/forward_referenced_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/forward_referenced_pipe.ts
@@ -1,4 +1,4 @@
-import {Component, NgModule, Pipe} from '@angular/core';
+import { Component, NgModule, Pipe } from '@angular/core';
 
 @Component({
     selector: 'host-binding-comp',
@@ -15,7 +15,7 @@ export class HostBindingComp {
     standalone: false
 })
 class MyForwardPipe {
-  transform() {}
+  transform(param:unknown) {}
 }
 
 @NgModule({declarations: [HostBindingComp, MyForwardPipe]})

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -62,7 +62,11 @@ export function compileTest(
 ): CompileResult {
   const rootDir = getRootDirectory(fs);
   const outDir = getBuildOutputDirectory(fs);
-  const options = getOptions(rootDir, outDir, compilerOptions, angularCompilerOptions);
+  const options = getOptions(rootDir, outDir, compilerOptions, {
+    ...angularCompilerOptions,
+    // TODO: Do we want to enable strictTemplates for compliance tests?
+    strictTemplates: false,
+  });
   const rootNames = files.map((f) => fs.resolve(f));
   const host = new NgtscTestCompilerHost(fs, options);
   const {diagnostics, emitResult} = performCompilation({rootNames, host, options});

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import ts from 'typescript';
 import {
+  createCompilerHost,
+  createProgram,
   CustomTransformers,
   defaultGatherDiagnostics,
   Program,
-  createCompilerHost,
-  createProgram,
 } from '../../index';
 import {DocEntry} from '../../src/ngtsc/docs';
 import * as api from '../../src/transformers/api';
-import ts from 'typescript';
 
 import {mainXi18n} from '../../src/extract_i18n';
 import {main, mainDiagnosticsForTest, readNgcCommandLineAndConfiguration} from '../../src/main';
@@ -229,6 +229,11 @@ export class NgtscTestEnvironment {
     compilerOptions?: TsCompilerOptions,
     files?: string[],
   ): void {
+    // TODO: all tests should have template that pass strictness
+    if (!('strictTemplates' in extraOpts)) {
+      extraOpts['strictTemplates'] = false;
+    }
+
     let tsconfig: {[key: string]: any} = {
       extends: './tsconfig-base.json',
       angularCompilerOptions: extraOpts,

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -4178,6 +4178,7 @@ runInEachFileSystem(() => {
 
       it('should error if "extendedDiagnostics.defaultCategory" is set to an unknown value', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             defaultCategory: 'does-not-exist',
           },
@@ -4199,6 +4200,7 @@ suppress
       });
       it('should not error if "extendedDiagnostics.defaultCategory" is set to a known value', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             defaultCategory: DiagnosticCategoryLabel.Error,
           },
@@ -4210,6 +4212,7 @@ suppress
 
       it('should error if "extendedDiagnostics.checks" contains an unknown check', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               doesNotExist: DiagnosticCategoryLabel.Error,
@@ -4225,6 +4228,7 @@ suppress
       });
       it('should not error if "extendedDiagnostics.checks" contains all known checks', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               [invalidBananaInBoxFactory.name]: DiagnosticCategoryLabel.Error,
@@ -4238,6 +4242,7 @@ suppress
 
       it('should error if "extendedDiagnostics.checks" contains an unknown diagnostic category', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               [invalidBananaInBoxFactory.name]: 'does-not-exist',
@@ -4261,6 +4266,7 @@ suppress
       });
       it('should not error if "extendedDiagnostics.checks" contains all known diagnostic categories', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               [invalidBananaInBoxFactory.name]: DiagnosticCategoryLabel.Error,
@@ -7044,6 +7050,7 @@ suppress
 
       it('should allow the content projection diagnostic to be disabled individually', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               controlFlowPreventingContentProjection: DiagnosticCategoryLabel.Suppress,
@@ -7082,6 +7089,7 @@ suppress
 
       it('should allow the content projection diagnostic to be disabled via `defaultCategory`', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             defaultCategory: DiagnosticCategoryLabel.Suppress,
           },
@@ -8232,6 +8240,7 @@ suppress
 
       it('should be able to opt out for checking for unused imports via the tsconfig', () => {
         env.tsconfig({
+          strictTemplates: true,
           extendedDiagnostics: {
             checks: {
               unusedStandaloneImports: DiagnosticCategoryLabel.Suppress,


### PR DESCRIPTION
Typesafety is a must and Angular will enable its strictness on templates by default.
