### PR TITLE
docs: clarify CSS variable usage in ARIA multiselect examples

### DIFF
--- a/adev/src/content/guide/aria/multiselect.md
+++ b/adev/src/content/guide/aria/multiselect.md
@@ -63,6 +63,14 @@ The multiselect pattern combines [Combobox](guide/aria/combobox) and [Listbox](g
 
 ## Examples
 
+### Note on styling
+
+The examples in this guide rely on CSS variables defined in the Angular documentation stylesheets.
+
+If you copy these examples into your own project, the styles may not appear as expected unless these variables are also included or defined in your application.
+
+You may need to inspect the documentation source styles or define equivalent CSS variables manually.
+
 ### Basic multiselect
 
 Users need to select multiple items from a list of options. A readonly combobox paired with a multi-enabled listbox provides familiar multiselect functionality with full accessibility support.


### PR DESCRIPTION
This PR adds a note in the ARIA multiselect guide to clarify that the examples rely on CSS variables defined in the Angular documentation stylesheets.

When these examples are copied outside the docs environment, styles may not work as expected unless the required CSS variables are included or defined.

This improves developer experience by making the dependency explicit and reducing confusion when using these examples independently.

No functional changes.