### PR TITLE
ci: correct capitalization of MarkTechson in pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -434,7 +434,7 @@ groups:
         ])
     reviewers:
       users:
-        - marktechson
+        - MarkTechson
         - kirjs
         - ~JeanMeche
         - ~dgp1130


### PR DESCRIPTION
Correct the capitalization of MarkTechson's username to match their GitHub profile, ensuring proper evaluation by PullApprove.