### PR TITLE
feat(forms): add FieldState.getError()

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -130,6 +130,7 @@ export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = T
 export interface FieldState<TValue, TKey extends string | number = string | number> extends ReadonlyFieldState<TValue, TKey> {
     readonly controlValue: WritableSignal<TValue>;
     readonly fieldTree: FieldTree<unknown, TKey>;
+    getError(kind: string): ValidationError.WithFieldTree | undefined;
     markAsDirty(): void;
     markAsTouched(options?: MarkAsTouchedOptions): void;
     reloadValidation(): void;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -537,6 +537,17 @@ export interface FieldState<
   markAsTouched(options?: MarkAsTouchedOptions): void;
 
   /**
+   * Gets the first validation error of the given kind on this field.
+   *
+   * This method is reactive and will re-evaluate when the field's errors change if called
+   * within a reactive context (e.g. `computed` or `effect`).
+   *
+   * @param kind The kind of error (e.g. 'required', 'min').
+   * @returns The first matching error, or `undefined` if none.
+   */
+  getError(kind: string): ValidationError.WithFieldTree | undefined;
+
+  /**
    * Resets the {@link touched} and {@link dirty} state of the field and its descendants.
    *
    * Note this does not change the data model, which can be reset directly if desired.

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -249,6 +249,10 @@ export class FieldNode implements FieldState<unknown> {
     return this.metadataState.get(key);
   }
 
+  getError(kind: string): ValidationError.WithFieldTree | undefined {
+    return this.errors().find((e) => e.kind === kind);
+  }
+
   hasMetadata(key: MetadataKey<any, any, any>): boolean {
     return this.metadataState.has(key);
   }

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -1023,6 +1023,37 @@ describe('FieldNode', () => {
       expect(f.a().valid()).toBe(false);
     });
 
+    it('should get error by kind', () => {
+      const f = form(
+        signal({a: 1}),
+        (p) => {
+          validate(p.a, ({value}) => {
+            if (value() > 10) {
+              return [{kind: 'too-damn-high'}, {kind: 'bad'}];
+            }
+            return undefined;
+          });
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f.a().getError('too-damn-high')).toBeUndefined();
+      expect(f.a().getError('bad')).toBeUndefined();
+
+      f.a().value.set(11);
+      const errorHigh = f.a().getError('too-damn-high');
+      expect(errorHigh).toBeDefined();
+      expect(errorHigh?.kind).toBe('too-damn-high');
+      expect(errorHigh?.fieldTree).toBe(f.a);
+
+      const errorBad = f.a().getError('bad');
+      expect(errorBad).toBeDefined();
+      expect(errorBad?.kind).toBe('bad');
+      expect(errorBad?.fieldTree).toBe(f.a);
+
+      expect(f.a().getError('non-existent')).toBeUndefined();
+    });
+
     it('should validate required field', () => {
       const data = signal({first: '', last: ''});
       const f = form(


### PR DESCRIPTION
Added a `getError(kind: string)` method to `FieldState` that returns the first validation error of a given kind, or `undefined` if no such error exists. This method is reactive and will re-evaluate when errors change.

Fixes #63905

Also updated public API goldens and added unit tests.