### PR TITLE
refactor(compiler): deprecate most of the strict `TypeCheckingOptions` options

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -47,8 +47,6 @@ export interface I18nOptions {
 
 // @public
 export interface LegacyNgcOptions {
-    // @deprecated
-    allowEmptyCodegenFiles?: boolean;
     flatModuleId?: string;
     flatModuleOutFile?: string;
     preserveWhitespaces?: boolean;
@@ -69,15 +67,24 @@ export interface TargetOptions {
 
 // @public
 export interface TypeCheckingOptions {
+    // @deprecated
     strictAttributeTypes?: boolean;
+    // @deprecated
     strictContextGenerics?: boolean;
+    // @deprecated
     strictDomEventTypes?: boolean;
+    // @deprecated
     strictDomLocalRefTypes?: boolean;
     strictInputAccessModifiers?: boolean;
+    // @deprecated
     strictInputTypes?: boolean;
+    // @deprecated
     strictLiteralTypes?: boolean;
+    // @deprecated
     strictNullInputTypes?: boolean;
+    // @deprecated
     strictOutputEventTypes?: boolean;
+    // @deprecated
     strictSafeNavigationTypes?: boolean;
     strictTemplates?: boolean;
     typeCheckHostBindings?: boolean;

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -78,7 +78,10 @@ export interface LegacyNgcOptions {
  * @publicApi
  */
 export interface TypeCheckingOptions {
-  /** Whether type checking of host bindings is enabled. */
+  /** Whether type checking of host bindings is enabled.
+   *
+   * Defaults to `true`
+   */
   typeCheckHostBindings?: boolean;
 
   /**
@@ -97,7 +100,10 @@ export interface TypeCheckingOptions {
    * directive or component is receiving the binding. If set to `true`, both sides of the assignment
    * are checked.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictInputTypes?: boolean;
 
@@ -105,7 +111,7 @@ export interface TypeCheckingOptions {
    * Whether to check if the input binding attempts to assign to a restricted field (readonly,
    * private, or protected) on the directive/component.
    *
-   * Defaults to `false`, even if "strictTemplates" and/or
+   * Defaults to `false` even if "strictTemplates" and/or
    * "strictInputTypes" is set. Note that if `strictInputTypes` is not set, or set to `false`, this
    * flag has no effect.
    *
@@ -122,8 +128,11 @@ export interface TypeCheckingOptions {
    * binding expressions are wrapped in a non-null assertion operator to effectively disable strict
    * null checks.
    *
-   * Defaults to `false`. Note that if `strictInputTypes` is
-   * not set, or set to `false`, this flag has no effect.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   * Note that if `strictInputTypes` is not set, or set to `false`, this flag has no effect.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictNullInputTypes?: boolean;
 
@@ -136,8 +145,11 @@ export interface TypeCheckingOptions {
    * without a value, so with this flag set to `true`, an error would be reported. If set to
    * `false`, text attributes will never report an error.
    *
-   * Defaults to `false`. Note that if `strictInputTypes` is
-   * not set, or set to `false`, this flag has no effect.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   * Note that if `strictInputTypes` is not set, or set to `false`, this flag has no effect.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictAttributeTypes?: boolean;
 
@@ -148,7 +160,10 @@ export interface TypeCheckingOptions {
    * then the return type of `a?.b` for example will be the same as the type of the ternary
    * expression `a != null ? a.b : a`.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictSafeNavigationTypes?: boolean;
 
@@ -159,7 +174,10 @@ export interface TypeCheckingOptions {
    * determined by the type of `document.createElement` for the given DOM node. If set to `false`,
    * the type of `ref` for DOM nodes will be `any`.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictDomLocalRefTypes?: boolean;
 
@@ -171,7 +189,10 @@ export interface TypeCheckingOptions {
    * `EventEmitter`/`Subject` of the output. If set to `false`, the `$event` variable will be of
    * type `any`.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictOutputEventTypes?: boolean;
 
@@ -182,7 +203,10 @@ export interface TypeCheckingOptions {
    * `HTMLElementEventMap`, with a fallback to the native `Event` type. If set to `false`, the
    * `$event` variable will be of type `any`.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictDomEventTypes?: boolean;
 
@@ -195,7 +219,10 @@ export interface TypeCheckingOptions {
    * will be included in the context type for the template. If `false`, any generic parameters will
    * be set to `any` in the template context type.
    *
-   * Defaults to `false`.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictContextGenerics?: boolean;
 
@@ -203,7 +230,10 @@ export interface TypeCheckingOptions {
    * Whether object or array literals defined in templates use their inferred type, or are
    * interpreted as `any`.
    *
-   * Defaults to `false` unless `strictTemplates` is set.
+   * Defaults to `true` unless `strictTemplates` is set to `false`.
+   *
+   * @deprecated 22.0
+   * This option is deprecated and will be removed in a future major release.
    */
   strictLiteralTypes?: boolean;
 }

--- a/vscode-ng-language-service/schemas/tsconfig-ng.schema.json
+++ b/vscode-ng-language-service/schemas/tsconfig-ng.schema.json
@@ -12,11 +12,6 @@
     "angularCompilerOptions": {
       "type": "object",
       "properties": {
-        "allowEmptyCodegenFiles": {
-          "type": "boolean",
-          "description": "Generate all possible generated files. This option is not used anymore.",
-          "deprecated": true
-        },
         "annotateForClosureCompiler": {
           "type": "boolean",
           "description": "Insert JSDoc type annotations needed by Closure Compiler."


### PR DESCRIPTION
This is overdue. Strictness is the way to go.

This commit also removes `allowEmptyCodegenFiles` which was deprecated and unused.
