### PR TITLE
docs(docs-infra): redefine /guide/pipes redirect

### DIFF
--- a/adev/src/app/routing/redirections.ts
+++ b/adev/src/app/routing/redirections.ts
@@ -128,13 +128,8 @@ export const REDIRECT_ROUTES: Route[] = [
     redirectTo: '/tools/cli/build-system-migration#hot-module-replacement',
   },
   {
-    path: 'guide',
-    children: [
-      {
-        path: 'pipes',
-        redirectTo: '/guide/templates/pipes',
-      },
-    ],
+    path: 'guide/pipes',
+    redirectTo: '/guide/templates/pipes',
   },
   {
     path: 'guide/experimental/zoneless',


### PR DESCRIPTION
Update the definition of the `/guide/pipes` redirect in order to avoid breaking the `a.dev/guide` redirect to Not Found page.

Current behavior: https://angular.dev/guide (shows a blank page)