### PR TITLE
refactor(core): expand input flags type

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -35,8 +35,7 @@ import type {
   ViewQueriesFunction,
 } from './interfaces/definition';
 import {InputFlags} from './interfaces/input_flags';
-import type {TAttributes, TConstantsOrFactory} from './interfaces/node';
-import {CssSelectorList} from './interfaces/projection';
+import type {TAttributes} from './interfaces/node';
 import {stringifyCSSSelectorList} from './node_selector_matcher';
 import {StandaloneService} from './standalone_service';
 
@@ -104,12 +103,7 @@ type DirectiveInputs = Record<
   | string
   // Complex input when there are flags, or differing public name and declared name, or there
   // is a transform. Such inputs are not as common, so the array form is only generated then.
-  | [
-      flags: InputFlags,
-      publicName: string,
-      declaredName?: string,
-      transform?: InputTransformFunction,
-    ]
+  | [flags: number, publicName: string, declaredName?: string, transform?: InputTransformFunction]
   | undefined
 >;
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -17,7 +17,6 @@ import {FactoryFn} from '../definition_factory';
 import {TAttributes, TConstantsOrFactory} from './node';
 import {CssSelectorList} from './projection';
 import type {TView} from './view';
-import {InputFlags} from './input_flags';
 import type {ControlDirectiveDef} from './control';
 
 /**
@@ -119,7 +118,7 @@ export interface DirectiveDef<T> {
    */
   readonly inputs: Record<
     string,
-    [minifiedName: string, flags: InputFlags, transform: InputTransformFunction | null]
+    [minifiedName: string, flags: number, transform: InputTransformFunction | null]
   >;
 
   /**
@@ -127,7 +126,7 @@ export interface DirectiveDef<T> {
    * used to do further processing after the `inputs` have been inverted.
    */
   readonly inputConfig: {
-    [P in keyof T]?: string | [InputFlags, string, string?, InputTransformFunction?];
+    [P in keyof T]?: string | [number, string, string?, InputTransformFunction?];
   };
 
   /**


### PR DESCRIPTION
Expands the type for the input flags in definitions since the current one prevents some of the generated code from compiling.
