### PR TITLE
feat(skills): improve PR review skill handling for worktrees and remote reviews

### DIFF
--- a/.agent/skills/pr_review/SKILL.md
+++ b/.agent/skills/pr_review/SKILL.md
@@ -22,7 +22,7 @@ When reviewing a pull request for the `angular` repository, follow these essenti
    - **Payload Size**: Pay attention to the impact of changes on the final client payload size.
 
 3. **Execution Workflow**:
-   Determine the appropriate review method. If the user explicitly asks for a `local` or `remote` review in their request, that takes precedence. Otherwise, use the GitHub MCP or available scripts to determine if the review should be `local` or `remote`.
+   Determine the appropriate review method. If the user explicitly asks for a `remote` or `local` review in their request, that takes precedence (e.g. "leave comments on the PR" implies `remote`). Otherwise, use the GitHub MCP or available scripts to determine if the review should be `local` or `remote`. **When in doubt, default to `remote` to avoid accidentally mutating the user's workspace.**
 
    **Common Review Practices (Applies to both Local and Remote)**
    - **Preparation & Checklist**:
@@ -35,7 +35,7 @@ When reviewing a pull request for the `angular` repository, follow these essenti
    - **Constructive Feedback**: Provide clear, actionable, and polite feedback. Explain the _why_ behind your suggestions or edits. Do **NOT** leave inline comments purely to praise, agree with, or acknowledge a correct implementation detail, as this clutters the review. If you want to praise the PR, do so in the single general PR comment.
 
    **A. Local Code Review (If the PR is owned by the author requesting the review)**
-   - **Checkout**: Check out the PR branch locally (if it doesn't already exist, fetch it).
+   - **Checkout**: Before checking out the PR branch (`gh pr checkout <PR_NUMBER>`), verify that the branch is not already checked out in a conflicting git worktree by checking `git worktree list` or reviewing checkout errors. If checking out locally causes a fatal worktree error, either resolve the conflict safely, or pivot completely to a **Remote Code Review** (fetching the diff remotely rather than checking it out). You can ask the user if they'd prefer you to resolve the conflict or just review remotely.
    - **Review & Edit**: Execute the review directly on the code. Instead of adding inline PR comments for suggestions, format the codebase or apply the edits directly to the files.
    - **Feedback**: Summarize the review findings and the concrete changes you made in a message to the user, referencing the completed items from your checklist.
    - **Do NOT Commit or Push**: Leave the changes uncommitted in the working directory so the user can easily review the pending edits locally. Let the user know the changes are ready for their review, but do not ask for approval to push.


### PR DESCRIPTION
This PR updates the PR Review skill to handle worktree conflicts gracefully and allow the user to easily enforce a remote PR review flow even when the branch belongs to them. Resolves issues with implicit checkouts breaking existing local worktrees.