### PR TITLE
refactor(language-service): Export template target from API

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -23,6 +23,16 @@ ts_project(
 )
 
 ts_project(
+    name = "private",
+    srcs = [
+        "private.ts",
+    ],
+    deps = [
+        "//packages/language-service/src",
+    ],
+)
+
+ts_project(
     name = "factory_lib",
     srcs = ["plugin-factory.ts"],
     deps = [
@@ -46,6 +56,20 @@ esbuild(
     deps = [":api"],
 )
 
+esbuild(
+    name = "private_bundle",
+    entry_point = ":private.ts",
+    external = [
+        "typescript",
+        "@angular/compiler",
+        "@angular/compiler-cli",
+        "@angular/compiler-cli/*",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":private"],
+)
+
 npm_package(
     srcs = [
         "index.d.ts",
@@ -55,6 +79,8 @@ npm_package(
         ":api_types",
         ":factory_bundle",
         ":factory_lib_types",
+        ":private_bundle",
+        ":private_types",
         "//packages/language-service/bundles:language-service.js",
     ],
     package = "@angular/language-service",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -23,6 +23,10 @@
     "./api": {
       "types": "./api.d.ts",
       "default": "./api_bundle.js"
+    },
+    "./private": {
+      "types": "./private.d.ts",
+      "default": "./private_bundle.js"
     }
   },
   "repository": {

--- a/packages/language-service/private.ts
+++ b/packages/language-service/private.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export * from './src/template_target';

--- a/vscode-ng-language-service/BUILD.bazel
+++ b/vscode-ng-language-service/BUILD.bazel
@@ -63,6 +63,8 @@ npm_package(
     exclude_srcs_patterns = [
         "*.map",
         "**/*.map",
+        "node_modules/@angular/language-service/private_bundle.js",
+        "node_modules/@angular/language-service/private.d.ts",
     ],
     include_srcs_packages = [
         "**",


### PR DESCRIPTION
allows template target to be used in other tooling
