### PR TITLE
Fix flakey `formatDate` tests

### DIFF
--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -515,13 +515,11 @@ describe('Format date', () => {
     it('should support timezones', () => {
       const isoDate = '2024-02-17T12:00:00Z';
 
-      const date1 = formatDate(isoDate, 'long', 'en', 'America/New_York');
-      const date2 = formatDate(isoDate, 'long', 'en', 'EST');
-      expect(date1).toBe('February 17, 2024, 12:00:00 PM GMT+0');
-      expect(date2).toBe('February 17, 2024, 7:00:00 AM GMT-5');
+      const dateEst = formatDate(isoDate, 'long', 'en', 'EST');
+      expect(dateEst).toBe('February 17, 2024, 7:00:00 AM GMT-5');
 
-      const date3 = formatDate(isoDate, 'long', 'en', '+0500');
-      expect(date3).toBe('February 17, 2024, 5:00:00 PM GMT+5');
+      const dateOffset = formatDate(isoDate, 'long', 'en', '+0500');
+      expect(dateOffset).toBe('February 17, 2024, 5:00:00 PM GMT+5');
     });
 
     it('should return thursday date of the same week', () => {

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -524,13 +524,13 @@ describe('Format date', () => {
 
     it('should return thursday date of the same week', () => {
       // Dec. 31st is a Sunday, last day of the last week of 2023
-      expect(getThursdayThisIsoWeek(new Date('2023-12-31'))).toEqual(new Date('2023-12-28'));
+      expect(getThursdayThisIsoWeek(new Date(2023, 11, 31))).toEqual(new Date(2023, 11, 28));
 
       // Dec. 29th is a Thursday
-      expect(getThursdayThisIsoWeek(new Date('2022-12-29'))).toEqual(new Date('2022-12-29'));
+      expect(getThursdayThisIsoWeek(new Date(2022, 11, 29))).toEqual(new Date(2022, 11, 29));
 
       // Jan 01st is a Monday
-      expect(getThursdayThisIsoWeek(new Date('2024-01-01'))).toEqual(new Date('2024-01-04'));
+      expect(getThursdayThisIsoWeek(new Date(2024, 0, 1))).toEqual(new Date(2024, 0, 4));
     });
   });
 });


### PR DESCRIPTION
Mostly generated by Gemini, fixing some flakey tests which were accidentally using device local time, which can vary for Bazel tests based on the location of RBE instances.