### PR TITLE
refactor(devtools): drop explicit OnPush change detection strategy

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  output,
-  signal,
-} from '@angular/core';
+import {Component, computed, inject, input, output, signal} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
 import {MatSlideToggle} from '@angular/material/slide-toggle';
@@ -67,7 +59,6 @@ type Tab = 'Components' | 'Profiler' | 'Router Tree' | 'Injector Tree' | 'Transf
     ButtonComponent,
   ],
   providers: [TabUpdate],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevToolsTabsComponent {
   public readonly frameManager = inject(FrameManager);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -15,7 +15,6 @@ import {
   output,
   signal,
   viewChild,
-  ChangeDetectionStrategy,
   computed,
   DestroyRef,
 } from '@angular/core';
@@ -37,7 +36,7 @@ import {FrameManager} from '../../application-services/frame_manager';
 import {BreadcrumbsComponent} from './directive-forest/breadcrumbs/breadcrumbs.component';
 import {FlatNode} from './directive-forest/component-data-source';
 import {DirectiveForestComponent} from './directive-forest/directive-forest.component';
-import {findNodeByPosition, IndexedNode, indexForest} from './directive-forest/index-forest';
+import {IndexedNode} from './directive-forest/index-forest';
 import {constructPathOfKeysToPropertyValue} from './property-resolver/directive-property-resolver';
 import {ElementPropertyResolver} from './property-resolver/element-property-resolver';
 import {FlatNode as PropertyFlatNode} from '../../shared/object-tree-explorer/object-tree-types';
@@ -99,7 +98,6 @@ const sameDirectives = (a: IndexedNode, b: IndexedNode) => {
     SignalGraphPaneComponent,
     ResponsiveSplitDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DirectiveExplorerComponent {
   readonly showCommentNodes = input(false);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/breadcrumbs/breadcrumbs.component.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -26,7 +25,6 @@ import {MatIcon} from '@angular/material/icon';
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss'],
   imports: [MatIcon],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BreadcrumbsComponent {
   readonly parents = input.required<FlatNode[]>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/directive-forest.component.ts
@@ -14,7 +14,6 @@ import {
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {
   afterRenderEffect,
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -45,7 +44,6 @@ const RESIZE_OBSERVER_DEBOUNCE = 250; // ms
   selector: 'ng-directive-forest',
   templateUrl: './directive-forest.component.html',
   styleUrls: ['./directive-forest.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     FilterComponent,
     CdkVirtualScrollViewport,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/filter/filter.component.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  input,
-  output,
-  viewChild,
-} from '@angular/core';
+import {Component, ElementRef, input, output, viewChild} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 
@@ -52,7 +45,6 @@ const genericSearchGenerator: FilterFnGenerator = (filter: string) => {
   templateUrl: './filter.component.html',
   styleUrls: ['./filter.component.scss'],
   imports: [MatIcon, MatTooltip],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FilterComponent {
   protected readonly input = viewChild.required<ElementRef>('input');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/tree-node/tree-node.component.ts
@@ -8,7 +8,6 @@
 
 import {
   afterRenderEffect,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -39,7 +38,6 @@ export type NodeTextMatch = {
   selector: 'ng-tree-node',
   templateUrl: './tree-node.component.html',
   styleUrls: ['./tree-node.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatIcon, MatTooltip],
   host: {
     '[style.padding-left]': 'paddingLeft()',

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/defer-view/defer-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/defer-view/defer-view.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
+import {Component, computed, input} from '@angular/core';
 import {MatToolbar} from '@angular/material/toolbar';
 import {DeferBlock} from '../../../../../../../protocol';
 
@@ -15,7 +15,6 @@ import {DeferBlock} from '../../../../../../../protocol';
   selector: 'ng-defer-view',
   styleUrls: ['./defer-view.component.scss', '../styles/view-tab.scss'],
   imports: [MatToolbar],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DeferViewComponent {
   readonly defer = input.required<NonNullable<DeferBlock>>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/for-loop-view/for-loop-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/for-loop-view/for-loop-view.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
+import {Component, computed, input} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {ForLoopBlock} from '../../../../../../../protocol';
 import {ObjectTreeExplorerComponent} from '../../../../shared/object-tree-explorer/object-tree-explorer.component';
@@ -19,7 +19,6 @@ import {MatToolbar} from '@angular/material/toolbar';
   selector: 'ng-for-loop-view',
   styleUrls: ['./for-loop-view.component.scss', '../styles/view-tab.scss'],
   imports: [MatExpansionModule, ObjectTreeExplorerComponent, MatToolbar],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ForLoopViewComponent {
   protected readonly forLoop = input.required<NonNullable<ForLoopBlock>>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/component-metadata/component-metadata.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/component-metadata/component-metadata.component.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ɵFramework as Framework,
-  computed,
-  inject,
-  input,
-} from '@angular/core';
+import {Component, ɵFramework as Framework, computed, inject, input} from '@angular/core';
 
 import {
   AcxDirectiveMetadata,
@@ -29,7 +22,6 @@ import {ElementPropertyResolver} from '../../../property-resolver/element-proper
   templateUrl: './component-metadata.component.html',
   styleUrls: ['./component-metadata.component.scss'],
   imports: [DocsRefButtonComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComponentMetadataComponent {
   readonly currentSelectedComponent = input.required<ComponentType>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/property-pane-header.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane-header/property-pane-header.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input, output, signal, inject} from '@angular/core';
+import {Component, input, output, signal, inject} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 import {MatIcon} from '@angular/material/icon';
 
@@ -19,7 +19,6 @@ import {SUPPORTED_APIS} from '../../../../application-providers/supported_apis';
   templateUrl: './property-pane-header.component.html',
   selector: 'ng-property-pane-header',
   styleUrls: ['./property-pane-header.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatExpansionModule, MatIcon, ComponentMetadataComponent, ButtonComponent],
 })
 export class PropertyPaneHeaderComponent {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {DirectivePosition} from '../../../../../../protocol';
 
 import {IndexedNode} from '../directive-forest/index-forest';
@@ -28,7 +28,6 @@ import {BlockType} from '../../../shared/utils/control-flow';
     DeferViewComponent,
     ForLoopViewComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyPaneComponent {
   readonly currentSelectedElement = input.required<IndexedNode | null>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/dependency-viewer/dependency-viewer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/dependency-viewer/dependency-viewer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {Component, input} from '@angular/core';
 import {SerializedInjectedService} from '../../../../../../../../../protocol';
 import {ResolutionPathComponent} from './resolution-path/resolution-path.component';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -17,7 +17,6 @@ import {MatExpansionModule} from '@angular/material/expansion';
   templateUrl: './dependency-viewer.component.html',
   styleUrl: './dependency-viewer.component.scss',
   imports: [MatExpansionModule, MatTooltip, ResolutionPathComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DependencyViewerComponent {
   readonly dependency = input.required<SerializedInjectedService>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/dependency-viewer/resolution-path/resolution-path.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/dependency-viewer/resolution-path/resolution-path.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
+import {Component, computed, input} from '@angular/core';
 import {SerializedInjector} from '../../../../../../../../../../protocol';
 
 export const NODE_TYPE_CLASS_MAP: {[key in SerializedInjector['type']]: string} = {
@@ -21,7 +21,6 @@ export const NODE_TYPE_CLASS_MAP: {[key in SerializedInjector['type']]: string} 
   selector: 'ng-resolution-path',
   templateUrl: './resolution-path.component.html',
   styleUrl: './resolution-path.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ResolutionPathComponent {
   readonly path = input<SerializedInjector[]>([]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu.component.ts
@@ -9,7 +9,6 @@
 import {
   afterRenderEffect,
   AfterRenderRef,
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
@@ -83,7 +82,6 @@ interface AvailableActions {
   templateUrl: './prop-actions-menu.component.html',
   styleUrl: './prop-actions-menu.component.scss',
   imports: [MatTooltip, MatIcon, Menu, MenuContent, MenuItem, MenuTrigger, CdkConnectedOverlay],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropActionsMenuComponent {
   private readonly signalGraph = inject(SignalGraphManager);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/property-view-body.component.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ɵFramework as Framework,
-  computed,
-  input,
-  output,
-  signal,
-} from '@angular/core';
+import {Component, ɵFramework as Framework, computed, input, output, signal} from '@angular/core';
 import {MatExpansionModule} from '@angular/material/expansion';
 
 import {DirectivePosition} from '../../../../../../../../protocol';
@@ -40,7 +32,6 @@ import {PropActionsMenuComponent} from './prop-actions-menu/prop-actions-menu.co
     ObjectTreeExplorerComponent,
     PropActionsMenuComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyViewBodyComponent {
   readonly controller = input.required<DirectivePropertyResolver>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-header/property-view-header.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input, output} from '@angular/core';
+import {Component, computed, inject, input, output} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
 import {MatToolbar} from '@angular/material/toolbar';
@@ -18,7 +18,6 @@ import {FrameManager} from '../../../../../application-services/frame_manager';
   templateUrl: './property-view-header.component.html',
   styleUrls: ['./property-view-header.component.scss'],
   imports: [MatToolbar, MatTooltip, MatIcon],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyViewHeaderComponent {
   readonly directive = input.required<string>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input, output} from '@angular/core';
+import {Component, computed, inject, input, output} from '@angular/core';
 import {DirectivePosition} from '../../../../../../../protocol';
 
 import {ElementPropertyResolver} from '../../property-resolver/element-property-resolver';
@@ -20,7 +20,6 @@ import {DevtoolsSignalGraphNode} from '../../../../shared/signal-graph';
   templateUrl: './property-view.component.html',
   styleUrls: ['./property-view.component.scss'],
   imports: [PropertyViewHeaderComponent, PropertyViewBodyComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyViewComponent {
   readonly directive = input.required<{name: string}>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signal-graph-pane.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-pane/signal-graph-pane.component.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -38,7 +37,6 @@ type SelectedNodeSource = {
   selector: 'ng-signal-graph-pane',
   styleUrl: './signal-graph-pane.component.scss',
   imports: [SignalsVisualizerComponent, SignalDetailsComponent, MatIcon, ButtonComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SignalGraphPaneComponent {
   protected readonly visualizer = viewChild.required<SignalsVisualizerComponent>('visualizer');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-providers/injector-providers.component.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  output,
-  signal,
-} from '@angular/core';
+import {Component, computed, inject, input, output, signal} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatTableModule} from '@angular/material/table';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -31,7 +23,6 @@ import {ButtonComponent} from '../../../shared/button/button.component';
   templateUrl: './injector-providers.component.html',
   styleUrl: './injector-providers.component.scss',
   imports: [MatTableModule, MatIcon, MatTooltip, ButtonComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InjectorProvidersComponent {
   readonly injector = input.required<SerializedInjector>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/injector-tree/injector-tree.component.ts
@@ -8,7 +8,6 @@
 
 import {
   afterRenderEffect,
-  ChangeDetectionStrategy,
   Component,
   computed,
   inject,
@@ -78,7 +77,6 @@ const SNAP_ZOOM_SCALE = 0.8;
   host: {
     '[hidden]': 'hidden()',
   },
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InjectorTreeComponent {
   private readonly elementTree = viewChild<InjectorTreeVisualizer>('elementTree');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler-import-dialog/profiler-import-dialog.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler-import-dialog/profiler-import-dialog.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {Component, inject} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef, MatDialogClose} from '@angular/material/dialog';
 import {ButtonComponent} from '../../../shared/button/button.component';
 
@@ -22,7 +22,6 @@ interface DialogData {
   templateUrl: './profiler-import-dialog.component.html',
   styleUrls: ['./profiler-import-dialog.component.scss'],
   imports: [MatDialogClose, ButtonComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfilerImportDialogComponent {
   public dialogRef = inject<MatDialogRef<ProfilerImportDialogComponent>>(MatDialogRef);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/profiler.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -29,7 +29,6 @@ const PROFILER_VERSION = 1;
   templateUrl: './profiler.component.html',
   styleUrls: ['./profiler.component.scss'],
   imports: [MatTooltip, MatIcon, RecordingTimelineComponent, ButtonComponent, MatProgressBar],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfilerComponent {
   readonly state = signal<State>('idle');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/frame-selector/frame-selector.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/frame-selector/frame-selector.component.ts
@@ -13,7 +13,6 @@ import {
 } from '@angular/cdk/scrolling';
 import {
   afterRenderEffect,
-  ChangeDetectionStrategy,
   Component,
   computed,
   ElementRef,
@@ -73,7 +72,6 @@ function framesBoundSignal<T>(source: Signal<ProfilerFrame[]>, defaultValue: T) 
     ButtonComponent,
     DecimalPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FrameSelectorComponent {
   private readonly tabUpdate = inject(TabUpdate);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-timeline-controls/recording-timeline-controls.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-timeline-controls/recording-timeline-controls.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, output, signal} from '@angular/core';
+import {Component, output, signal} from '@angular/core';
 import {ButtonComponent} from '../../../../shared/button/button.component';
 
 const FILTER_PLACEHOLDER = 'Filter';
@@ -16,7 +16,6 @@ const FILTER_PLACEHOLDER = 'Filter';
   templateUrl: './recording-timeline-controls.component.html',
   styleUrls: ['./recording-timeline-controls.component.scss'],
   imports: [ButtonComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordingTimelineControlsComponent {
   protected readonly exportProfile = output<void>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-timeline.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-timeline.component.ts
@@ -6,16 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  effect,
-  input,
-  linkedSignal,
-  output,
-  signal,
-} from '@angular/core';
+import {Component, computed, effect, input, linkedSignal, output, signal} from '@angular/core';
 import {ProfilerFrame} from '../../../../../../protocol';
 import {Observable} from 'rxjs';
 
@@ -39,7 +30,6 @@ import {estimateFrameRate} from './shared/estimate-frame-rate';
     RecordingVisualizerComponent,
     VisualizerControlsComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordingTimelineComponent {
   readonly stream = input.required<Observable<ProfilerFrame[]>>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/bargraph-visualizer/bar-chart/bar-chart.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/bargraph-visualizer/bar-chart/bar-chart.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 
 import {BargraphNode} from '../../../record-formatter/bargraph-formatter/bargraph-formatter';
 
@@ -22,7 +22,6 @@ interface BarData {
   selector: 'ng-bar-chart',
   templateUrl: './bar-chart.component.html',
   styleUrls: ['./bar-chart.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BarChartComponent {
   readonly data = input<BargraphNode[]>([]);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/bargraph-visualizer/bargraph-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/bargraph-visualizer/bargraph-visualizer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {ProfilerFrame} from '../../../../../../../../protocol';
 
 import {BarGraphFormatter, BargraphNode} from '../../record-formatter/bargraph-formatter/index';
@@ -20,7 +20,6 @@ import {SelectedDirective, SelectedEntry} from '../recording-visualizer-types';
   templateUrl: './bargraph-visualizer.component.html',
   styleUrls: ['./bargraph-visualizer.component.scss'],
   imports: [BarChartComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BargraphVisualizerComponent {
   readonly nodeSelect = output<SelectedEntry>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/execution-details/execution-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/execution-details/execution-details.component.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {Component, input} from '@angular/core';
 import {SelectedDirective} from '../recording-visualizer-types';
 
 @Component({
   selector: 'ng-execution-details',
   templateUrl: './execution-details.component.html',
   styleUrls: ['./execution-details.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExecutionDetailsComponent {
   readonly data = input.required<SelectedDirective[]>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/flamegraph-visualizer/flamegraph-visualizer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input, output} from '@angular/core';
+import {Component, computed, inject, input, output} from '@angular/core';
 import {NgxFlamegraphModule, FlamegraphColor, RawData} from 'ngx-flamegraph';
 import {ProfilerFrame} from '../../../../../../../../protocol';
 
@@ -25,7 +25,6 @@ import {SelectedDirective, SelectedEntry} from '../recording-visualizer-types';
   templateUrl: './flamegraph-visualizer.component.html',
   styleUrls: ['./flamegraph-visualizer.component.scss'],
   imports: [NgxFlamegraphModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FlamegraphVisualizerComponent {
   public themeService = inject(ThemeService);

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/recording-visualizer.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input, linkedSignal} from '@angular/core';
+import {Component, computed, input, linkedSignal} from '@angular/core';
 import {DecimalPipe} from '@angular/common';
 
 import {ProfilerFrame} from '../../../../../../../protocol';
@@ -34,7 +34,6 @@ import {SplitAreaDirective} from '../../../../shared/split/splitArea.directive';
     ExecutionDetailsComponent,
     DecimalPipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordingVisualizerComponent {
   readonly visualizationMode = input.required<VisualizationMode>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/tree-map-visualizer/tree-map-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/recording-visualizer/tree-map-visualizer/tree-map-visualizer.component.ts
@@ -8,12 +8,10 @@
 
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   computed,
   effect,
   ElementRef,
-  inject,
   input,
   OnDestroy,
   viewChild,
@@ -29,7 +27,6 @@ import {TreeMapFormatter, TreeMapNode} from '../../record-formatter/tree-map-for
   selector: 'ng-tree-map-visualizer',
   templateUrl: './tree-map-visualizer.component.html',
   styleUrls: ['./tree-map-visualizer.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TreeMapVisualizerComponent implements OnDestroy {
   private _formatter = new TreeMapFormatter();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/visualizer-controls/visualizer-controls.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/recording-timeline/visualizer-controls/visualizer-controls.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input, model} from '@angular/core';
+import {Component, input, model} from '@angular/core';
 import {DecimalPipe} from '@angular/common';
 
 import {ProfilerFrame} from '../../../../../../../protocol';
@@ -17,7 +17,6 @@ import {VisualizationMode} from '../shared/visualization-mode';
   templateUrl: './visualizer-controls.component.html',
   styleUrl: './visualizer-controls.component.scss',
   imports: [DecimalPipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class VisualizerControlsComponent {
   protected readonly record = input.required<ProfilerFrame>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, computed, input, output, ChangeDetectionStrategy} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -25,7 +25,6 @@ export type ActionBtnType = 'none' | 'view-source' | 'navigate';
   templateUrl: './route-details-row.component.html',
   styleUrls: ['./route-details-row.component.scss'],
   imports: [NgTemplateOutlet, ButtonComponent, MatIcon, MatTooltip, ObjectTreeExplorerComponent],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RouteDetailsRowComponent {
   readonly label = input.required<string>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -60,7 +59,6 @@ const RUN_GUARDS_AND_RESOLVERS_OPTIONS: RunGuardsAndResolvers[] = [
     RouteDetailsRowComponent,
     ButtonComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RouterTreeComponent {
   private readonly searchInput = viewChild.required<ElementRef>('searchInput');

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Component,
-  inject,
-  signal,
-  computed,
-  linkedSignal,
-  ChangeDetectionStrategy,
-} from '@angular/core';
+import {Component, inject, signal, computed, linkedSignal} from '@angular/core';
 import {Clipboard} from '@angular/cdk/clipboard';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -66,7 +59,6 @@ export const COPY_FEEDBACK_TIMEOUT = 2000;
   ],
   templateUrl: './transfer-state.component.html',
   styleUrls: ['./transfer-state.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TransferStateComponent {
   private readonly messageBus = inject(MessageBus) as MessageBus<Events>;

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.ts
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  OnDestroy,
-  signal,
-} from '@angular/core';
+import {Component, computed, inject, OnDestroy, signal} from '@angular/core';
 import {Events, MessageBus} from '../../../protocol';
 import {interval} from 'rxjs';
 
@@ -54,7 +47,6 @@ export const LAST_SUPPORTED_VERSION = 12;
   templateUrl: './devtools.component.html',
   styleUrls: ['./devtools.component.scss'],
   imports: [DevToolsTabsComponent, MatIcon, MatTooltip, MatProgressSpinnerModule, MatTooltipModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DevToolsComponent implements OnDestroy {
   protected readonly supportedApis = inject(SUPPORTED_APIS);

--- a/devtools/projects/ng-devtools/src/lib/shared/button/button.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/button/button.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {Component, input} from '@angular/core';
 
 type ButtonType = 'primary' | 'secondary' | 'icon';
 type ButtonSize = 'standard' | 'mid' | 'compact';
@@ -15,7 +15,6 @@ type ButtonSize = 'standard' | 'mid' | 'compact';
   selector: 'button[ng-button]',
   template: '<ng-content/>',
   styleUrl: './button.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: 'ng-button',
     '[class.type-primary]': `btnType() === 'primary'`,

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.component.ts
@@ -6,15 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  ChangeDetectionStrategy,
-  Component,
-  contentChild,
-  effect,
-  input,
-  output,
-  TemplateRef,
-} from '@angular/core';
+import {Component, contentChild, effect, input, output, TemplateRef} from '@angular/core';
 import {NgTemplateOutlet} from '@angular/common';
 import {DataSource} from '@angular/cdk/collections';
 import {FlatTreeControl} from '@angular/cdk/tree';
@@ -61,7 +53,6 @@ const CHILDREN_INDENT = 14; // px
   selector: 'ng-object-tree-explorer',
   templateUrl: './object-tree-explorer.component.html',
   styleUrl: './object-tree-explorer.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgTemplateOutlet,
     MatTree,

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-editor/property-editor.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-editor/property-editor.component.ts
@@ -14,7 +14,6 @@ import {
   output,
   signal,
   viewChild,
-  ChangeDetectionStrategy,
   linkedSignal,
   computed,
 } from '@angular/core';
@@ -42,7 +41,6 @@ const parseValue = (value: EditorResult): EditorResult => {
   selector: 'ng-property-editor',
   styleUrls: ['./property-editor.component.scss'],
   imports: [FormsModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '(click)': 'onClick()',
   },

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-preview/property-preview.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-preview/property-preview.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {PropType} from '../../../../../../protocol';
 import {FlatNode} from '../object-tree-types';
 
@@ -14,7 +14,6 @@ import {FlatNode} from '../object-tree-types';
   selector: 'ng-property-preview',
   templateUrl: './property-preview.component.html',
   styleUrls: ['./property-preview.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyPreviewComponent {
   readonly node = input.required<FlatNode>();

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input, output} from '@angular/core';
+import {Component, computed, input, output} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 
 import {DebugSignalGraphNode, ElementPosition} from '../../../../../protocol';
@@ -49,7 +49,6 @@ interface ResourceCluster {
   selector: 'ng-signal-details',
   templateUrl: './signal-details.component.html',
   styleUrl: './signal-details.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [SignalValueTreeComponent, MatIcon, ButtonComponent, MatTooltip, IconComponent],
 })
 export class SignalDetailsComponent {

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-value-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-value-tree.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, computed, inject, input} from '@angular/core';
+import {Component, computed, inject, input} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {MatTreeFlattener} from '@angular/material/tree';
 import {DataSource} from '@angular/cdk/collections';
@@ -22,7 +22,6 @@ import {FlatNode, Property} from '../../object-tree-explorer/object-tree-types';
   templateUrl: './signal-value-tree.component.html',
   imports: [ObjectTreeExplorerComponent],
   styleUrl: './signal-value-tree.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SignalValueTreeComponent {
   private readonly messageBus = inject(MessageBus);

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.component.ts
@@ -8,7 +8,6 @@
 
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   computed,
   DestroyRef,
@@ -40,7 +39,6 @@ import {ButtonComponent} from '../button/button.component';
   templateUrl: './signals-visualizer.component.html',
   styleUrl: './signals-visualizer.component.scss',
   imports: [ButtonComponent, MatIcon],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SignalsVisualizerComponent {
   protected readonly svgHost = viewChild.required<ElementRef>('host');

--- a/devtools/projects/ng-devtools/src/lib/shared/split/split.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/split/split.component.ts
@@ -9,7 +9,6 @@
 import {
   afterNextRender,
   booleanAttribute,
-  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   effect,
@@ -86,7 +85,6 @@ import {
 @Component({
   selector: 'as-split',
   exportAs: 'asSplit',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: [`./split.component.scss`],
   template: `<ng-content></ng-content>
     @for (_ of displayedAreas; track $index) {

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
@@ -8,7 +8,6 @@
 
 import {
   afterNextRender,
-  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   effect,
@@ -44,7 +43,6 @@ let instanceIdx = 0;
     </svg>
   `,
   styleUrl: 'tree-visualizer.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TreeVisualizerComponent<T extends TreeNode = TreeNode> {
   protected readonly container = viewChild.required<ElementRef>('container');

--- a/devtools/src/app/demo-app/todo/home/todo.component.ts
+++ b/devtools/src/app/demo-app/todo/home/todo.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, Component, input, output} from '@angular/core';
+import {Component, input, output} from '@angular/core';
 
 import {Todo} from './todo';
 import {TooltipDirective} from './tooltip.directive';
@@ -14,7 +14,6 @@ import {TooltipDirective} from './tooltip.directive';
 @Component({
   templateUrl: 'todo.component.html',
   selector: 'app-todo',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./todo.component.scss'],
   imports: [TooltipDirective],
 })


### PR DESCRIPTION
Drop explicit `ChangeDetectionStrategy.OnPush` from the apps since it's now the default.

Related to: #67687