### PR TITLE
docs: make a note regarding i18n messageIdFormat

### DIFF
--- a/adev/src/content/reference/configs/angular-compiler-options.md
+++ b/adev/src/content/reference/configs/angular-compiler-options.md
@@ -91,6 +91,10 @@ These message formats have some issues, such as whitespace handling and reliance
 The new message format is more resilient to whitespace changes, is the same across all translation file formats, and can be created directly from calls to `$localize`.
 This allows `$localize` messages in application code to use the same ID as identical `i18n` messages in component templates.
 
+IMPORTANT: This option is only supported by the `@angular-devkit/build-angular:browser` builder.
+When using the `@angular/build:application` builder (esbuild), this option has no effect and the new decimal message ID format is always used regardless of this setting.
+If your project relies on legacy message IDs, use the `@angular-devkit/build-angular:browser` builder.
+
 ### `enableResourceInlining`
 
 When `true`, replaces the `templateUrl` and `styleUrls` properties in all `@Component` decorators with inline content in the `template` and `styles` properties.

--- a/adev/src/content/reference/configs/angular-compiler-options.md
+++ b/adev/src/content/reference/configs/angular-compiler-options.md
@@ -91,6 +91,9 @@ These message formats have some issues, such as whitespace handling and reliance
 The new message format is more resilient to whitespace changes, is the same across all translation file formats, and can be created directly from calls to `$localize`.
 This allows `$localize` messages in application code to use the same ID as identical `i18n` messages in component templates.
 
+IMPORTANT: This option is only supported by the `@angular-devkit/build-angular:browser` builder.
+When using the `@angular/build:application` builder (esbuild), this option has no effect and the new decimal message ID format is always used regardless of this setting.
+
 ### `enableResourceInlining`
 
 When `true`, replaces the `templateUrl` and `styleUrls` properties in all `@Component` decorators with inline content in the `template` and `styles` properties.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Make a clear statement that angular compiler option `enableI18nLegacyMessageIdFormat` has no effect when used with `@angular/build:application` bundler 

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## Other information

Option use in webpack builder -[ useLegacyIds = wco.tsConfig.options.enableI18nLegacyMessageIdFormat ?? true;](https://github.com/angular/angular-cli/blob/8ab937536405ad458d18c67d6f222899483b0ba1/packages/angular_devkit/build_angular/src/builders/extract-i18n/webpack-extraction.ts#L75)

So I spent quite a few hours today trying to migrate application to angular 20 and it was hard to troubleshoot why IDs are being changed when `extract-i18n` is executed and how can I not lost project translations. Docs highlight that one can use `enableI18nLegacyMessageIdFormat` for backwards compatibility with old i18n ids (which were sha-like I believe). 

But it is partially true - because the option itself works only with `@angular-devkit/build-angular` webpack bundler. Hope this note will help someone