### PR TITLE
feat(compiler): support `.prevent` and `.stop` modifier for event bubbling

### DIFF
--- a/adev/src/content/guide/templates/event-listeners.md
+++ b/adev/src/content/guide/templates/event-listeners.md
@@ -135,6 +135,29 @@ export class App{
 
 If the event handler statement evaluates to `false`, Angular automatically calls `preventDefault()`, similar to [native event handler attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes#event_handler_attributes). _Always prefer explicitly calling `preventDefault`_, as this approach makes the code's intent obvious.
 
+## Using event modifiers
+
+Angular also supports event modifiers in the event name:
+
+- `.prevent` calls [`event.preventDefault()`](https://developer.mozilla.org/docs/Web/API/Event/preventDefault)
+- `.stop` calls [`event.stopPropagation()`](https://developer.mozilla.org/docs/Web/API/Event/stopPropagation)
+
+```angular-html
+<a href="/dashboard" (click.prevent)="openDashboard()"> Open dashboard </a>
+```
+
+```angular-html
+<button (click.stop)="toggleMenu()">Toggle menu</button>
+```
+
+You can combine them:
+
+```angular-html
+<button (click.prevent.stop)="onAction()">Action</button>
+```
+
+In this case Angular calls `preventDefault()` and `stopPropagation()` before running your handler.
+
 ## Extend event handling
 
 Angular’s event system is extensible via custom event plugins registered with the `EVENT_MANAGER_PLUGINS` injection token.

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -39,6 +39,7 @@ import {resolveDeferTargetNames} from './phases/defer_resolve_targets';
 import {collapseEmptyInstructions} from './phases/empty_elements';
 import {expandSafeReads} from './phases/expand_safe_reads';
 import {extractI18nMessages} from './phases/extract_i18n_messages';
+import {resolveEventModifiers} from './phases/event_modifiers';
 import {generateAdvance} from './phases/generate_advance';
 import {generateLocalLetReferences} from './phases/generate_local_let_references';
 import {generateProjectionDefs} from './phases/generate_projection_def';
@@ -132,6 +133,7 @@ const phases: Phase[] = [
   {kind: Kind.Tmpl, fn: generateVariables},
   {kind: Kind.Tmpl, fn: saveAndRestoreView},
   {kind: Kind.Both, fn: deleteAnyCasts},
+  {kind: Kind.Both, fn: resolveEventModifiers},
   {kind: Kind.Both, fn: resolveDollarEvent},
   {kind: Kind.Tmpl, fn: generateTrackVariables},
   {kind: Kind.Tmpl, fn: removeIllegalLetReferences},

--- a/packages/compiler/src/template/pipeline/src/phases/event_modifiers.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/event_modifiers.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+/**
+ * Resolves known event modifiers at compile time.
+ *
+ * For example:
+ * - `click.prevent` => `click` + `event.preventDefault()`
+ * - `click.stop` => `click` + `event.stopPropagation()`
+ * - `click.prevent.stop` => `click` + both calls
+ */
+export function resolveEventModifiers(job: CompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind !== ir.OpKind.Listener || op.isLegacyAnimationListener) {
+        continue;
+      }
+
+      const parsed = parseEventModifiers(op.name);
+      if (parsed === null) {
+        continue;
+      }
+
+      op.name = parsed.eventName;
+
+      const event = new o.ReadVarExpr('$event');
+      const modifierStatements: ir.UpdateOp[] = [];
+      if (parsed.prevent) {
+        modifierStatements.push(
+          ir.createStatementOp<ir.UpdateOp>(event.prop('preventDefault').callFn([]).toStmt()),
+        );
+      }
+      if (parsed.stop) {
+        modifierStatements.push(
+          ir.createStatementOp<ir.UpdateOp>(event.prop('stopPropagation').callFn([]).toStmt()),
+        );
+      }
+
+      op.handlerOps.prepend(modifierStatements);
+      op.consumesDollarEvent = true;
+    }
+  }
+}
+
+function parseEventModifiers(
+  eventName: string,
+): {eventName: string; prevent: boolean; stop: boolean} | null {
+  const parts = eventName.split('.');
+  if (parts.length === 1) {
+    return null;
+  }
+
+  let prevent = false;
+  let stop = false;
+  while (parts.length > 1) {
+    const maybeModifier = parts[parts.length - 1];
+    if (maybeModifier === 'prevent') {
+      prevent = true;
+      parts.pop();
+    } else if (maybeModifier === 'stop') {
+      stop = true;
+      parts.pop();
+    } else {
+      break;
+    }
+  }
+
+  if (!prevent && !stop) {
+    return null;
+  }
+
+  return {
+    eventName: parts.join('.'),
+    prevent,
+    stop,
+  };
+}

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -253,6 +253,80 @@ describe('event listeners', () => {
       button.click();
       expect(fixture.componentInstance.comp).toBeInstanceOf(MyComp);
     });
+
+    it('should prevent bubbling to component host listeners with the stop modifier', () => {
+      @Component({
+        selector: 'my-component',
+        template: '<input (change.stop)="onChange($event)">',
+      })
+      class MyComponent {
+        didHandleChange = false;
+
+        onChange(_event: Event) {
+          this.didHandleChange = true;
+        }
+      }
+
+      @Component({
+        imports: [MyComponent],
+        template: '<my-component (change)="doSomething($event)"></my-component>',
+      })
+      class App {
+        events: Event[] = [];
+
+        doSomething(event: Event) {
+          this.events.push(event);
+        }
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+      input.dispatchEvent(new Event('change', {bubbles: true}));
+      fixture.detectChanges();
+
+      const myComponent = fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+      expect(myComponent.didHandleChange).toBeTrue();
+      expect(fixture.componentInstance.events).toEqual([]);
+    });
+
+    it('should allow bubbling to component host listeners with the prevent modifier', () => {
+      @Component({
+        selector: 'my-component',
+        template: '<input (change.prevent)="onChange($event)">',
+      })
+      class MyComponent {
+        didHandleChange = false;
+
+        onChange(_event: Event) {
+          this.didHandleChange = true;
+        }
+      }
+
+      @Component({
+        imports: [MyComponent],
+        template: '<my-component (change)="doSomething($event)"></my-component>',
+      })
+      class App {
+        events: Event[] = [];
+
+        doSomething(event: Event) {
+          this.events.push(event);
+        }
+      }
+
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+      input.dispatchEvent(new Event('change', {bubbles: true, cancelable: true}));
+      fixture.detectChanges();
+
+      const myComponent = fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+      expect(myComponent.didHandleChange).toBeTrue();
+      expect(fixture.componentInstance.events.length).toBe(1);
+    });
   });
 
   describe('prevent default', () => {

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -80,14 +80,8 @@ export class EventManager {
     handler: Function,
     options?: ListenerOptions,
   ): Function {
-    const parsedEvent = parseEventName(eventName);
-    const plugin = this._findPluginFor(parsedEvent.eventName);
-    return plugin.addEventListener(
-      element,
-      parsedEvent.eventName,
-      parsedEvent.prevent || parsedEvent.stop ? applyEventModifiers(handler, parsedEvent) : handler,
-      options,
-    );
+    const plugin = this._findPluginFor(eventName);
+    return plugin.addEventListener(element, eventName, handler, options);
   }
 
   /**
@@ -117,40 +111,4 @@ export class EventManager {
     this._eventNameToPlugin.set(eventName, plugin);
     return plugin;
   }
-}
-
-function parseEventName(eventName: string): {eventName: string; prevent: boolean; stop: boolean} {
-  const [name, ...modifiers] = eventName.split('.');
-  if (modifiers.length === 0) {
-    return {eventName, prevent: false, stop: false};
-  }
-
-  let prevent = false;
-  let stop = false;
-  for (const modifier of modifiers) {
-    if (modifier === 'prevent') {
-      prevent = true;
-    } else if (modifier === 'stop') {
-      stop = true;
-    } else {
-      return {eventName, prevent: false, stop: false};
-    }
-  }
-
-  return {eventName: name, prevent, stop};
-}
-
-function applyEventModifiers(
-  handler: Function,
-  {prevent, stop}: {prevent: boolean; stop: boolean},
-): Function {
-  return (event: Event) => {
-    if (prevent) {
-      event.preventDefault();
-    }
-    if (stop) {
-      event.stopPropagation();
-    }
-    return handler(event);
-  };
 }

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -80,8 +80,14 @@ export class EventManager {
     handler: Function,
     options?: ListenerOptions,
   ): Function {
-    const plugin = this._findPluginFor(eventName);
-    return plugin.addEventListener(element, eventName, handler, options);
+    const parsedEvent = parseEventName(eventName);
+    const plugin = this._findPluginFor(parsedEvent.eventName);
+    return plugin.addEventListener(
+      element,
+      parsedEvent.eventName,
+      parsedEvent.prevent || parsedEvent.stop ? applyEventModifiers(handler, parsedEvent) : handler,
+      options,
+    );
   }
 
   /**
@@ -111,4 +117,40 @@ export class EventManager {
     this._eventNameToPlugin.set(eventName, plugin);
     return plugin;
   }
+}
+
+function parseEventName(eventName: string): {eventName: string; prevent: boolean; stop: boolean} {
+  const [name, ...modifiers] = eventName.split('.');
+  if (modifiers.length === 0) {
+    return {eventName, prevent: false, stop: false};
+  }
+
+  let prevent = false;
+  let stop = false;
+  for (const modifier of modifiers) {
+    if (modifier === 'prevent') {
+      prevent = true;
+    } else if (modifier === 'stop') {
+      stop = true;
+    } else {
+      return {eventName, prevent: false, stop: false};
+    }
+  }
+
+  return {eventName: name, prevent, stop};
+}
+
+function applyEventModifiers(
+  handler: Function,
+  {prevent, stop}: {prevent: boolean; stop: boolean},
+): Function {
+  return (event: Event) => {
+    if (prevent) {
+      event.preventDefault();
+    }
+    if (stop) {
+      event.stopPropagation();
+    }
+    return handler(event);
+  };
 }

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -82,6 +82,74 @@ import type {} from 'zone.js';
       expect(receivedEvent).toBe(dispatchedEvent);
     });
 
+    it('should stop event propagation when the stop modifier is used', () => {
+      const parent = el('<div></div>');
+      const child = el('<input></input>');
+      parent.appendChild(child);
+      doc.body.appendChild(parent);
+
+      const parentHandler = jasmine.createSpy('parentHandler');
+      const childHandler = jasmine.createSpy('childHandler');
+      const manager = new EventManager([domEventPlugin], new FakeNgZone());
+
+      manager.addEventListener(parent, 'change', parentHandler);
+      manager.addEventListener(child, 'change.stop', childHandler);
+
+      const event = new Event('change', {bubbles: true, cancelable: true});
+      child.dispatchEvent(event);
+
+      expect(childHandler).toHaveBeenCalled();
+      expect(parentHandler).not.toHaveBeenCalled();
+    });
+
+    it('should call preventDefault when the prevent modifier is used', () => {
+      const element = el('<input></input>');
+      doc.body.appendChild(element);
+
+      const handler = jasmine.createSpy('handler');
+      const manager = new EventManager([domEventPlugin], new FakeNgZone());
+      manager.addEventListener(element, 'change.prevent', handler);
+
+      const event = new Event('change', {cancelable: true});
+      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
+      element.dispatchEvent(event);
+
+      expect(handler).toHaveBeenCalled();
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should apply prevent and stop modifiers together', () => {
+      const parent = el('<div></div>');
+      const child = el('<input></input>');
+      parent.appendChild(child);
+      doc.body.appendChild(parent);
+
+      const parentHandler = jasmine.createSpy('parentHandler');
+      const handler = jasmine.createSpy('handler');
+      const manager = new EventManager([domEventPlugin], new FakeNgZone());
+      manager.addEventListener(parent, 'change', parentHandler);
+      manager.addEventListener(child, 'change.prevent.stop', handler);
+
+      const event = new Event('change', {bubbles: true, cancelable: true});
+      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
+      child.dispatchEvent(event);
+
+      expect(handler).toHaveBeenCalled();
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      expect(parentHandler).not.toHaveBeenCalled();
+    });
+
+    it('should keep non-modifier dotted event names unchanged', () => {
+      const element = el('<div></div>');
+      const handler = jasmine.createSpy('handler');
+      const plugin = new FakeEventManagerPlugin(doc, ['keydown.enter']);
+      const manager = new EventManager([domEventPlugin, plugin], new FakeNgZone());
+
+      manager.addEventListener(element, 'keydown.enter', handler);
+
+      expect(plugin.eventHandler['keydown.enter']).toBe(handler);
+    });
+
     it('should keep zone when addEventListener', () => {
       const Zone = (window as any)['Zone'];
 

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -82,63 +82,6 @@ import type {} from 'zone.js';
       expect(receivedEvent).toBe(dispatchedEvent);
     });
 
-    it('should stop event propagation when the stop modifier is used', () => {
-      const parent = el('<div></div>');
-      const child = el('<input></input>');
-      parent.appendChild(child);
-      doc.body.appendChild(parent);
-
-      const parentHandler = jasmine.createSpy('parentHandler');
-      const childHandler = jasmine.createSpy('childHandler');
-      const manager = new EventManager([domEventPlugin], new FakeNgZone());
-
-      manager.addEventListener(parent, 'change', parentHandler);
-      manager.addEventListener(child, 'change.stop', childHandler);
-
-      const event = new Event('change', {bubbles: true, cancelable: true});
-      child.dispatchEvent(event);
-
-      expect(childHandler).toHaveBeenCalled();
-      expect(parentHandler).not.toHaveBeenCalled();
-    });
-
-    it('should call preventDefault when the prevent modifier is used', () => {
-      const element = el('<input></input>');
-      doc.body.appendChild(element);
-
-      const handler = jasmine.createSpy('handler');
-      const manager = new EventManager([domEventPlugin], new FakeNgZone());
-      manager.addEventListener(element, 'change.prevent', handler);
-
-      const event = new Event('change', {cancelable: true});
-      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
-      element.dispatchEvent(event);
-
-      expect(handler).toHaveBeenCalled();
-      expect(preventDefaultSpy).toHaveBeenCalled();
-    });
-
-    it('should apply prevent and stop modifiers together', () => {
-      const parent = el('<div></div>');
-      const child = el('<input></input>');
-      parent.appendChild(child);
-      doc.body.appendChild(parent);
-
-      const parentHandler = jasmine.createSpy('parentHandler');
-      const handler = jasmine.createSpy('handler');
-      const manager = new EventManager([domEventPlugin], new FakeNgZone());
-      manager.addEventListener(parent, 'change', parentHandler);
-      manager.addEventListener(child, 'change.prevent.stop', handler);
-
-      const event = new Event('change', {bubbles: true, cancelable: true});
-      const preventDefaultSpy = spyOn(event, 'preventDefault').and.callThrough();
-      child.dispatchEvent(event);
-
-      expect(handler).toHaveBeenCalled();
-      expect(preventDefaultSpy).toHaveBeenCalled();
-      expect(parentHandler).not.toHaveBeenCalled();
-    });
-
     it('should keep non-modifier dotted event names unchanged', () => {
       const element = el('<div></div>');
       const handler = jasmine.createSpy('handler');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4059

####  Motivation

Angular currently allows an ambiguous case for event binding on a component host: if an event name matches an `@Output`, but the same DOM event also bubbles from inside the component template, the parent handler may be attached as a fallback DOM listener even when the expected behavior is to subscribe only to the component output.

This makes the behavior non-obvious and harder to debug.

```html
<custom-change (change)="onChange()"></custom-change>
```

```ts
@Component({
  selector: 'custom-change',
  template: '<input>', // bubbling native `change`
})
export class CustomChange {}
```

In this case, `(change)` on the component host may work through the fallback DOM mechanism because the native `change` event bubbles, even though the component does not declare an explicit change output.

The behavior feels "magical" and does not clearly signal an API issue in the component.

## What is the new behavior?


```html
<custom-change (change)="onChange()"></custom-change>
```

```ts
@Component({
  selector: 'custom-change',
  template: '<input (change.prevent)="...">'
})
export class CustomChange {}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
