### PR TITLE
fix(forms): deduplicate writeValue calls in CVA interop

### DIFF
--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -21,16 +21,22 @@ export function cvaControlCreate(
   host: ControlDirectiveHost,
   parent: FormField<unknown>,
 ): () => void {
-  parent.controlValueAccessor!.registerOnChange((value: unknown) =>
-    parent.state().controlValue.set(value as any),
-  );
+  const bindings = createBindings<ControlBindingKey | 'controlValue'>();
+
+  parent.controlValueAccessor!.registerOnChange((value: unknown) => {
+    // Update tracking for 'controlValue' here so that when the effect runs,
+    // `bindingUpdated` sees that the model value matches the last seen view value.
+    // This prevents the framework from writing the same value back to the CVA (CVA loopback).
+    bindings['controlValue'] = value;
+    parent.state().controlValue.set(value as any);
+  });
   parent.controlValueAccessor!.registerOnTouched(() => parent.state().markAsTouched());
   parent.registerAsBinding();
 
-  const bindings = createBindings<ControlBindingKey | 'controlValue'>();
   return () => {
     const fieldState = parent.state();
     const value = fieldState.value();
+
     if (bindingUpdated(bindings, 'controlValue', value)) {
       // We don't know if the interop control has underlying signals, so we must use `untracked` to
       // prevent writing to a signal in a reactive context.

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -30,6 +30,7 @@ import {
   NG_VALUE_ACCESSOR,
   NgControl,
   ɵFORM_FIELD_PARSE_ERRORS as FORM_FIELD_PARSE_ERRORS,
+  ɵselectValueAccessor as selectValueAccessor,
 } from '@angular/forms';
 import {type ValidationError} from '../api/rules';
 import type {Field, FieldState} from '../api/types';
@@ -193,7 +194,18 @@ export class FormField<T> {
    * @internal
    */
   get controlValueAccessor(): ControlValueAccessor | undefined {
-    return this.controlValueAccessors?.[0] ?? this.interopNgControl?.valueAccessor ?? undefined;
+    if (!this.controlValueAccessors || this.controlValueAccessors.length === 0) {
+      return this.interopNgControl?.valueAccessor ?? undefined;
+    }
+
+    // Rely on the exact logic in `@angular/forms` to pick the accessors with correct priority,
+    // passing our fake `InteropNgControl` to fulfill its first parameter requirement.
+    return (
+      selectValueAccessor(
+        this.interopNgControl as unknown as NgControl,
+        this.controlValueAccessors,
+      ) ?? undefined
+    );
   }
 
   /**

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -18,7 +18,13 @@ import {
   viewChild,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl} from '@angular/forms';
+import {
+  ControlValueAccessor,
+  DefaultValueAccessor,
+  NG_VALUE_ACCESSOR,
+  NgControl,
+  ReactiveFormsModule,
+} from '@angular/forms';
 import {
   debounce,
   disabled,
@@ -371,6 +377,25 @@ describe('ControlValueAccessor', () => {
     expect(() => fixture.detectChanges()).not.toThrowError(/NG0600/);
 
     expect(() => fixture.componentInstance.disabled.set(true)).not.toThrowError(/NG0600/);
+  });
+
+  it('should pick custom CVA over default CVA when both are present', () => {
+    @Component({
+      selector: 'app-root',
+      // Import ReactiveFormsModule to provide the non-standalone DefaultValueAccessor directive.
+      // The selector for DefaultValueAccessor matches `[ngDefaultControl]`.
+      imports: [FormField, CustomControl, ReactiveFormsModule],
+      template: `<custom-control [formField]="f" ngDefaultControl />`,
+    })
+    class App {
+      f = form<string>(signal(''));
+    }
+
+    const fixture = act(() => TestBed.createComponent(App));
+    const customControlInstance = fixture.debugElement.children[0].injector.get(CustomControl);
+
+    act(() => fixture.componentInstance.f().value.set('updated'));
+    expect(customControlInstance.writeCount).toBe(2); // 1 initial + 1 update
   });
 
   describe('properties', () => {

--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -61,6 +61,7 @@ describe('ControlValueAccessor', () => {
   })
   class CustomControl implements ControlValueAccessor {
     value = '';
+    writeCount = 0;
     disabled = false;
 
     private onChangeFn?: (value: string) => void;
@@ -68,6 +69,7 @@ describe('ControlValueAccessor', () => {
 
     writeValue(newValue: string): void {
       this.value = newValue;
+      this.writeCount++;
     }
 
     registerOnChange(fn: (value: string) => void): void {
@@ -130,6 +132,31 @@ describe('ControlValueAccessor', () => {
       input.dispatchEvent(new Event('input'));
     });
     expect(fixture.componentInstance.f().value()).toBe('typing');
+  });
+
+  it('should not write back to CVA on view change', () => {
+    @Component({
+      imports: [CustomControl, FormField],
+      template: `<custom-control [formField]="f" />`,
+    })
+    class TestCmp {
+      readonly f = form(signal('test'));
+      readonly control = viewChild.required(CustomControl);
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const control = fixture.componentInstance.control();
+    const input = fixture.nativeElement.querySelector('input');
+
+    expect(control.writeCount).toBe(1); // Initial write
+
+    act(() => {
+      input.value = 'typing';
+      input.dispatchEvent(new Event('input'));
+    });
+
+    expect(fixture.componentInstance.f().value()).toBe('typing');
+    expect(control.writeCount).toBe(1); // Should still be 1 (No write-back!)
   });
 
   it('should support debounce', async () => {

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -393,7 +393,7 @@ export function syncPendingControls(
 // TODO: vsavkin remove it once https://github.com/angular/angular/issues/3011 is implemented
 export function selectValueAccessor(
   dir: NgControl,
-  valueAccessors: ControlValueAccessor[] | null | undefined,
+  valueAccessors: readonly ControlValueAccessor[] | null | undefined,
 ): ControlValueAccessor | null {
   if (!valueAccessors) return null;
 

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -48,7 +48,11 @@ export {
   SelectMultipleControlValueAccessor,
   ɵNgSelectMultipleOption,
 } from './directives/select_multiple_control_value_accessor';
-export {SetDisabledStateOption, ɵFORM_FIELD_PARSE_ERRORS} from './directives/shared';
+export {
+  selectValueAccessor as ɵselectValueAccessor,
+  SetDisabledStateOption,
+  ɵFORM_FIELD_PARSE_ERRORS,
+} from './directives/shared';
 export {
   AsyncValidator,
   AsyncValidatorFn,


### PR DESCRIPTION
Update bindings['controlValue'] during onChange to track the view value. This allows bindingUpdated to skip writeValue if the model value matches the last seen view value, preventing redundant writes.

Fixes #67847
