### PR TITLE
fix(forms): preserve precision of key type in stateOf()

### DIFF
--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -123,7 +123,7 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
   RESOURCE[IS_ASYNC_VALIDATION_RESOURCE] = true;
 
   metadata(path, RESOURCE, (ctx) => {
-    const node = ctx.stateOf(path) as FieldNode;
+    const node = ctx.stateOf(path) as unknown as FieldNode;
     const validationState = node.validationState;
     if (validationState.shouldSkipValidation() || !validationState.syncValid()) {
       return undefined;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -893,6 +893,18 @@ export type FieldContext<
     : RootFieldContext<TValue>;
 
 /**
+ * Maps a PathKind to its corresponding key type in its parent.
+ * - PathKind.Item -> number
+ * - PathKind.Child -> string
+ * - PathKind.Root -> never
+ */
+export type PathKindToKey<T extends PathKind> = T[typeof ɵɵTYPE] extends 'item'
+  ? number
+  : T[typeof ɵɵTYPE] extends 'child' | 'item'
+    ? string
+    : never;
+
+/**
  * The base field context that is available for all fields.
  *
  * @experimental 21.0
@@ -916,12 +928,14 @@ export interface RootFieldContext<TValue> {
   // signature is a deferred conditional. This tautological wrapper mimics the deferred
   // structure so that TypeScript accepts the assignment gracefully.
   /** Gets the state of the field represented by the given path. */
-  stateOf<PControl extends AbstractControl>(
-    p: CompatSchemaPath<PControl>,
-  ): [PControl] extends [any] ? ReadonlyCompatFieldState<PControl> : never;
-  stateOf<PValue>(
-    p: SchemaPath<PValue, SchemaPathRules>,
-  ): [PValue] extends [any] ? ReadonlyFieldState<PValue> : never;
+  stateOf<PControl extends AbstractControl, TPathKind extends PathKind>(
+    p: CompatSchemaPath<PControl, TPathKind>,
+  ): [PControl] extends [any]
+    ? ReadonlyCompatFieldState<PControl, PathKindToKey<TPathKind>>
+    : never;
+  stateOf<PValue, TPathKind extends PathKind>(
+    p: SchemaPath<PValue, SchemaPathRules, TPathKind>,
+  ): [PValue] extends [any] ? ReadonlyFieldState<PValue, PathKindToKey<TPathKind>> : never;
   /** Gets the field represented by the given path. */
   fieldTreeOf<PModel>(
     p: SchemaPathTree<PModel>,

--- a/packages/forms/signals/src/field/context.ts
+++ b/packages/forms/signals/src/field/context.ts
@@ -19,6 +19,8 @@ import {
   CompatSchemaPath,
   CompatFieldState,
   FieldContext,
+  PathKind,
+  PathKindToKey,
   ReadonlyCompatFieldState,
   ReadonlyFieldState,
   ReadonlyFieldTree,
@@ -156,12 +158,14 @@ export class FieldNodeContext implements FieldContext<unknown> {
     return this.resolve<PModel>(p) as any;
   }
 
-  stateOf<PControl extends AbstractControl>(
-    p: CompatSchemaPath<PControl>,
-  ): [PControl] extends [any] ? ReadonlyCompatFieldState<PControl> : never;
-  stateOf<PValue>(
-    p: SchemaPath<PValue, SchemaPathRules>,
-  ): [PValue] extends [any] ? ReadonlyFieldState<PValue> : never;
+  stateOf<PControl extends AbstractControl, TPathKind extends PathKind>(
+    p: CompatSchemaPath<PControl, TPathKind>,
+  ): [PControl] extends [any]
+    ? ReadonlyCompatFieldState<PControl, PathKindToKey<TPathKind>>
+    : never;
+  stateOf<PValue, TPathKind extends PathKind>(
+    p: SchemaPath<PValue, SchemaPathRules, TPathKind>,
+  ): [PValue] extends [any] ? ReadonlyFieldState<PValue, PathKindToKey<TPathKind>> : never;
   stateOf<TModel>(p: SchemaPath<TModel, SchemaPathRules> | CompatSchemaPath<any>): any {
     return this.resolve<TModel>(p as any)();
   }

--- a/packages/forms/signals/src/schema/logic.ts
+++ b/packages/forms/signals/src/schema/logic.ts
@@ -227,7 +227,7 @@ function wrapWithPredicates<TValue, TReturn>(
   }
   return (arg: FieldContext<any>): TReturn | typeof IGNORED => {
     for (const predicate of predicates) {
-      let predicateField = arg.stateOf(predicate.path) as FieldNode;
+      let predicateField = arg.stateOf(predicate.path) as unknown as FieldNode;
       // Check the depth of the current field vs the depth this predicate is supposed to be
       // evaluated at. If necessary, walk up the field tree to grab the correct context field.
       // We can check the pathKeys as an untracked read since we know the structure of our fields

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -163,5 +163,17 @@ function typeVerificationOnlyDoNotRunMe() {
         },
       });
     });
+
+    it('should infer precise key type for object children in stateOf', () => {
+      schema<{user: {name: string}}>((p) => {
+        validate(p.user, (ctx) => {
+          const state = ctx.stateOf(p.user.name);
+          const key: string = state.keyInParent(); // Should compile
+          // @ts-expect-error
+          const keyNumber: number = state.keyInParent();
+          return null;
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Ensure that FieldContext.stateOf() captures the generic TPathKind from SchemaPath to correctly infer the TKey type of the returned FieldState.

