### PR TITLE
fix(router): use null-prototype objects for parsed URL params

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -626,7 +626,10 @@ class UrlParser {
   }
 
   parseQueryParams(): Params {
-    const params: Params = {};
+    // A null-prototype object is used so that query param names like
+    // `hasOwnProperty` don't shadow Object.prototype methods and cause
+    // TypeErrors when the parser checks for duplicate keys.
+    const params: Params = Object.create(null);
     if (this.consumeOptional('?')) {
       do {
         this.parseQueryParam(params);
@@ -697,7 +700,7 @@ class UrlParser {
   }
 
   private parseMatrixParams(): {[key: string]: string} {
-    const params: {[key: string]: string} = {};
+    const params: {[key: string]: string} = Object.create(null);
     while (this.consumeOptional(';')) {
       this.parseParam(params);
     }
@@ -741,7 +744,7 @@ class UrlParser {
     const decodedKey = decodeQuery(key);
     const decodedVal = decodeQuery(value);
 
-    if (params.hasOwnProperty(decodedKey)) {
+    if (Object.prototype.hasOwnProperty.call(params, decodedKey)) {
       // Append to existing values
       let currentVal = params[decodedKey];
       if (!Array.isArray(currentVal)) {

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -208,6 +208,12 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual('/one?a=foo&a=bar&a=swaz');
   });
 
+  it('should parse query params named hasOwnProperty without throwing', () => {
+    const tree = url.parse('/one?hasOwnProperty=x&next=1');
+    expect(tree.queryParams).toEqual({hasOwnProperty: 'x', next: '1'});
+    expect(url.serialize(tree)).toEqual('/one?hasOwnProperty=x&next=1');
+  });
+
   it('should parse fragment', () => {
     const tree = url.parse('/one#two');
     expect(tree.fragment).toEqual('two');


### PR DESCRIPTION
A query parameter named `hasOwnProperty` overwrites the inherited Object method on the params accumulator, causing a TypeError on the next parameter. Use `Object.prototype.hasOwnProperty.call()` instead, consistent with the safe pattern already used in `ParamsAsMap` (`shared.ts` line 83).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- N/A - Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No