### PR TITLE
refactor: extract comments utilities to private

### DIFF
--- a/packages/compiler-cli/private/hybrid_analysis.ts
+++ b/packages/compiler-cli/private/hybrid_analysis.ts
@@ -37,3 +37,8 @@ export {
   type HostListenerDecorator,
   type HostBindingDecorator,
 } from '../src/ngtsc/typecheck/src/host_bindings';
+export {
+  findFirstMatchingNode,
+  ExpressionIdentifier,
+  hasExpressionIdentifier,
+} from '../src/ngtsc/typecheck/src/comments';


### PR DESCRIPTION
allows comments utils to be used in other language service packages
