### PR TITLE
fix(core): sanitize namespaced SVG attributes and missing elements

### DIFF
--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -442,6 +442,9 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
     if (isAttribute) {
       // NB: For security purposes, use the mapped property name, not the attribute name.
       propName = this.getMappedPropName(propName);
+      if (propName.indexOf(':') > -1) {
+        propName = propName.split(':').pop()!;
+      }
     }
 
     // Make sure comparisons are case insensitive, so that case differences between attribute and

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -105,6 +105,11 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'none|href',
       'none|xlink:href',
 
+      'use|href',
+      'use|xlink:href',
+
+      '*|xml:base',
+
       // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
       'img|src',
       'video|src',

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -225,10 +225,12 @@ const HREF_RESOURCE_TAGS = new Set(['base', 'link', 'script']);
  * If tag and prop names don't match Resource URL schema, use URL sanitizer.
  */
 export function getUrlSanitizer(tag: string, prop: string) {
+  if (prop.indexOf(':') > -1) {
+    prop = prop.split(':').pop()!;
+  }
   const isResource =
     (prop === 'src' && SRC_RESOURCE_TAGS.has(tag)) ||
-    (prop === 'href' && HREF_RESOURCE_TAGS.has(tag)) ||
-    (prop === 'xlink:href' && tag === 'script');
+    (prop === 'href' && (HREF_RESOURCE_TAGS.has(tag) || tag === 'script'));
 
   return isResource ? ɵɵsanitizeResourceUrl : ɵɵsanitizeUrl;
 }


### PR DESCRIPTION
This PR fixes bypasses in SVG sanitization (CVE-2026-22610). It normalizes attribute prefixes in the compiler and runtime, and adds missing SVG elements like <use> to the security schema. This is an incomplete fix for the original issue where custom prefixes (e.g., s:href) could bypass literal string matching.