### PR TITLE
fix(forms): allow resubmission after submission errors in signal forms

### DIFF
--- a/packages/forms/signals/src/field/submit.ts
+++ b/packages/forms/signals/src/field/submit.ts
@@ -23,6 +23,10 @@ export class FieldSubmitState {
   /** Submission errors that are associated with this field. */
   readonly submissionErrors: WritableSignal<readonly ValidationError.WithFieldTree[]>;
 
+  clearSubmissionErrors() {
+    this.submissionErrors.set([]);
+  }
+
   constructor(private readonly node: FieldNode) {
     this.submissionErrors = linkedSignal({
       source: this.node.structure.value,
@@ -35,6 +39,14 @@ export class FieldSubmitState {
    * Either because the field was submitted directly, or because a parent field was submitted.
    */
   readonly submitting: Signal<boolean> = computed(() => {
-    return this.selfSubmitting() || (this.node.structure.parent?.submitting() ?? false);
+    const isSubmitting =
+      this.selfSubmitting() ||
+      (this.node.structure.parent?.submitting() ?? false);
+
+    if (isSubmitting && this.selfSubmitting()) {
+      this.clearSubmissionErrors();
+    }
+
+    return isSubmitting;
   });
 }

--- a/packages/forms/signals/src/field/submit.ts
+++ b/packages/forms/signals/src/field/submit.ts
@@ -44,7 +44,9 @@ export class FieldSubmitState {
       (this.node.structure.parent?.submitting() ?? false);
 
     if (isSubmitting && this.selfSubmitting()) {
-      this.clearSubmissionErrors();
+      untracked(() => {
+        this.clearSubmissionErrors();
+      });
     }
 
     return isSubmitting;


### PR DESCRIPTION
### Problem

When a submission results in errors (e.g. server-side or submission errors), the form remains in an invalid state and prevents subsequent submissions unless a field value changes.

This makes it difficult to retry submissions in common scenarios like transient failures.

---

### Root Cause

`FieldSubmitState.submissionErrors` persists across submission attempts and is not cleared when a new submission starts. As a result, the form continues to be considered invalid.

---

### Solution

Clear `submissionErrors` when a new submission attempt begins by detecting when the form enters the submitting state.

This is implemented within the `submitting` computed signal by conditionally resetting errors when `selfSubmitting` becomes `true`.

---

### Design Considerations

The reset logic is placed inside the `submitting` computation to keep the change minimal and localized without introducing additional APIs or modifying submission flow across multiple files.

While this introduces a controlled side-effect within a computed signal, it is:

* Scoped only to the transition when `selfSubmitting` becomes `true`
* Guarded to avoid triggering on parent-driven recomputations
* Aligned with the existing reactive structure without expanding surface area

This approach avoids invasive changes while ensuring correct behavior for resubmission.

---

### Result

Forms can now be resubmitted after a failed submission without requiring any field changes, improving usability and aligning with expected form behavior.
