### PR TITLE
fix(forms): support PromiseLike return in FormSubmitOptions action

### DIFF
--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -34,7 +34,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
   action: (
     field: FieldTree<TRootModel & TSubmittedModel>,
     detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
-  ) => Promise<TreeValidationResult>;
+  ) => TreeValidationResult | PromiseLike<TreeValidationResult>;
   /**
    * Function to run when attempting to submit the form data but validation is failing.
    *

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -48,6 +48,21 @@ describe('submit', () => {
     expect(f.first().errors()).toEqual([requiredError({fieldTree: f.first})]);
   });
 
+  it('supports PromiseLike return in submit action', async () => {
+      const data = signal({first: 'John'});
+      const f = form(data);
+
+      const promiseLike = {
+        then: (resolve: any) => resolve(undefined),
+      };
+    
+      const result = await submit(f, {
+        action: () => promiseLike as PromiseLike<any>,
+      });
+
+      expect(result).toBe(true);
+    });
+
   describe('while pending', () => {
     it('should not block', async () => {
       const data = signal('');


### PR DESCRIPTION
## Description

Currently, `FormSubmitOptions.action` is typed to return a `Promise<TreeValidationResult>`, while synchronous return values already work at runtime.

This PR widens the return type to:
TreeValidationResult | PromiseLike<TreeValidationResult>

This aligns the type definition with the actual runtime behavior and allows both synchronous and asynchronous submission actions.

## Changes
- Updated `FormSubmitOptions.action` return type
- Added test to verify PromiseLike support

## Type
- [x] Bugfix (typing improvement)