### PR TITLE
feat: `withPreviousValue()` keeps data while navigating

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -151,20 +151,19 @@ You can create new resources from snapshots using `resourceFromSnapshots`. This 
 import {linkedSignal, resourceFromSnapshots, Resource, ResourceSnapshot} from '@angular/core';
 
 function withPreviousValue<T>(input: Resource<T>): Resource<T> {
+  const router = inject(Router);
   const derived = linkedSignal<ResourceSnapshot<T>, ResourceSnapshot<T>>({
     source: input.snapshot,
     computation: (snap, previous) => {
-      if (snap.status === 'loading' && previous && previous.value.status !== 'error') {
-        // When the input resource enters loading state, we keep the value
+      if ((snap.status === 'loading' || !!router.currentNavigation()) && previous && previous.value.status !== 'error') {
+        // When the input resource enters loading state or while navigating, we keep the value
         // from its previous state, if any.
-        return {status: 'loading' as const, value: previous.value.value};
+        return { status: 'loading' as const, value: previous.value.value };
       }
-
       // Otherwise we simply forward the state of the input resource.
       return snap;
     },
   });
-
   return resourceFromSnapshots(derived);
 }
 


### PR DESCRIPTION
the additional check of `router.currentNavigation()` prevents a resource to update too early while the navigation is still happening.

Usecase: we are using root components that load side information based on the current page visible. as the uri/slug of the current page is updating instantly when navigating the resource might already show the new value while the pages resolver is still in loading state. with the additional check we prevent the new value being visible before the navigation is finished.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

the example for withPreviousValue() was causing issues where a resource is used that loads data based on a router param. While a page might still be loading a parent resource could already show the new value instead of waiting for the navigation to finish.

Issue Number: N/A

## What is the new behavior?
the signal now waits for either the resource being finished loading or while navigation is still occuring.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

