### PR TITLE
fix(localize): validate locale in getOutputPathFn to prevent path traversal

### DIFF
--- a/packages/localize/tools/src/translate/output_path.ts
+++ b/packages/localize/tools/src/translate/output_path.ts
@@ -26,5 +26,19 @@ export function getOutputPathFn(fs: PathManipulation, outputFolder: AbsoluteFsPa
   const [pre, post] = outputFolder.split('{{LOCALE}}');
   return post === undefined
     ? (_locale, relativePath) => fs.join(pre, relativePath)
-    : (locale, relativePath) => fs.join(pre + locale + post, relativePath);
+    : (locale, relativePath) => {
+        if (/[\/\\]|\.\./.test(locale)) {
+          throw new Error(`Invalid Locale: '${locale}' is not a valid locale.`);
+        }
+
+        const outputPath = fs.join(pre + locale + post, relativePath);
+        const resolvedOutputPath = fs.resolve(outputPath);
+        const resolvedPre = fs.resolve(pre);
+
+        if (!resolvedOutputPath.startsWith(resolvedPre)) {
+          throw new Error(`Invalid Locale: '${locale}' would cause path traversal.`);
+        }
+
+        return outputPath;
+      };
 }

--- a/packages/localize/tools/test/translate/output_path_spec.ts
+++ b/packages/localize/tools/test/translate/output_path_spec.ts
@@ -42,5 +42,12 @@ runInEachFileSystem(() => {
       expect(fn('en', 'relative/path')).toEqual(absoluteFrom('/output/en/relative/path'));
       expect(fn('fr', 'relative/path')).toEqual(absoluteFrom('/output/fr/relative/path'));
     });
+
+    it('should throw if the locale contains path traversal characters', () => {
+      const fn = getOutputPathFn(fs, absoluteFrom('/output/{{LOCALE}}'));
+      expect(() => fn('../escaped', 'relative/path')).toThrowError(/Invalid Locale/);
+      expect(() => fn('foo/bar', 'relative/path')).toThrowError(/Invalid Locale/);
+      expect(() => fn('foo\\bar', 'relative/path')).toThrowError(/Invalid Locale/);
+    });
   });
 });


### PR DESCRIPTION

The `localize-translate` CLI tool uses the `locale` field from translation files to expand the `{{LOCALE}}` placeholder in the output directory. It failed to sanitize `locale` input, allowing malicious translations to write files outside of the configured output directory.

This change mitigates this issue by combining.

Closes #67906