### PR TITLE
fix(service-worker): bypass CSP violation reports

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -241,6 +241,21 @@ export class Driver implements Debuggable, UpdateSource {
       return;
     }
 
+    // CSP violation reports and Reporting API reports are POST requests that should not be
+    // intercepted by the ServiceWorker. The browser sends these autonomously and handling them
+    // in the SW can cause errors (e.g. due to CORS restrictions or redirect mode mismatches).
+    // Let such requests pass through to the network directly.
+    // See https://github.com/angular/angular/issues/31477 for more details.
+    const contentType = req.headers.get('content-type');
+    if (
+      req.method === 'POST' &&
+      contentType != null &&
+      (contentType.startsWith('application/csp-report') ||
+        contentType.startsWith('application/reports+json'))
+    ) {
+      return;
+    }
+
     // The only thing that is served unconditionally is the debug page.
     if (requestUrlObj.path === this.ngswStatePath) {
       // Allow the debugger to handle the request, but don't affect SW state in any other way.

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -1385,6 +1385,48 @@ import {envIsSupported} from '../testing/utils';
       server.assertSawRequestFor('/some/url');
     });
 
+    it('bypasses the ServiceWorker on CSP violation report requests', async () => {
+      // NOTE:
+      // Requests that bypass the SW are not handled at all in the mock implementation of `scope`,
+      // therefore no requests reach the server.
+
+      // CSP violation report (application/csp-report)
+      await makeRequest(scope, '/csp-report-endpoint', undefined, {
+        method: 'POST',
+        headers: {'content-type': 'application/csp-report'},
+      });
+      server.assertNoRequestFor('/csp-report-endpoint');
+
+      // Reporting API report (application/reports+json)
+      await makeRequest(scope, '/reporting-endpoint', undefined, {
+        method: 'POST',
+        headers: {'content-type': 'application/reports+json'},
+      });
+      server.assertNoRequestFor('/reporting-endpoint');
+
+      // CSP report with charset parameter should also be bypassed
+      await makeRequest(scope, '/csp-report-endpoint', undefined, {
+        method: 'POST',
+        headers: {'content-type': 'application/csp-report; charset=utf-8'},
+      });
+      server.assertNoRequestFor('/csp-report-endpoint');
+
+      // GET request with CSP report content type should NOT be bypassed (not a real CSP report)
+      await makeRequest(scope, '/foo.txt', undefined, {
+        headers: {'content-type': 'application/csp-report'},
+      });
+      server.assertSawRequestFor('/foo.txt');
+
+      server.clearRequests();
+
+      // POST request with a different content type should NOT be bypassed
+      await makeRequest(scope, '/api/endpoint', undefined, {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+      });
+      server.assertSawRequestFor('/api/endpoint');
+    });
+
     it('unregisters when manifest 404s', async () => {
       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
       await driver.initialized;


### PR DESCRIPTION
## Summary

The Angular service worker intercepts all fetch events, including CSP violation reports (`Content-Type: application/csp-report`) and Reporting API reports (`Content-Type: application/reports+json`). These are POST requests sent autonomously by the browser, and intercepting them causes errors due to CORS restrictions or redirect mode mismatches.

This PR adds an early check in the SW `onFetch` handler: if the request is a POST with a CSP/Reporting API content-type, the SW returns immediately without calling `event.respondWith()`, letting the browser handle the request natively.

### Changes

- `packages/service-worker/worker/src/driver.ts`: Added content-type check after existing `ngsw-bypass` check
- `packages/service-worker/worker/test/happy_spec.ts`: Added 5 tests (positive + negative cases)

Fixes #31477