### PR TITLE
feat(service-worker): add `typedMessages()` and typed push event interfaces

### DIFF
--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -8,6 +8,10 @@
 
 export {
   NoNewVersionDetectedEvent,
+  NotificationClickEvent,
+  NotificationCloseEvent,
+  PushEvent,
+  PushSubscriptionChangeEvent,
   UnrecoverableStateEvent,
   VersionDetectedEvent,
   VersionEvent,

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -104,9 +104,42 @@ export interface UnrecoverableStateEvent {
 /**
  * An event emitted when a `PushEvent` is received by the service worker.
  */
-export interface PushEvent {
+export interface PushEvent<T = any> {
   type: 'PUSH';
-  data: any;
+  data: T;
+}
+
+/**
+ * An event emitted when the user clicks on a notification.
+ */
+export interface NotificationClickEvent {
+  type: 'NOTIFICATION_CLICK';
+  data: {
+    action: string;
+    notification: NotificationOptions & {title: string};
+  };
+}
+
+/**
+ * An event emitted when the user closes a notification.
+ */
+export interface NotificationCloseEvent {
+  type: 'NOTIFICATION_CLOSE';
+  data: {
+    action: string;
+    notification: NotificationOptions & {title: string};
+  };
+}
+
+/**
+ * An event emitted when the push subscription changes (e.g. due to expiration or key rotation).
+ */
+export interface PushSubscriptionChangeEvent {
+  type: 'PUSH_SUBSCRIPTION_CHANGE';
+  data: {
+    oldSubscription: PushSubscription | null;
+    newSubscription: PushSubscription | null;
+  };
 }
 
 export type IncomingEvent = UnrecoverableStateEvent | VersionEvent;

--- a/packages/service-worker/src/push.ts
+++ b/packages/service-worker/src/push.ts
@@ -11,7 +11,14 @@ import {NEVER, Observable, Subject} from 'rxjs';
 import {map, switchMap, take} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from './errors';
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
+import {
+  ERR_SW_NOT_SUPPORTED,
+  NgswCommChannel,
+  NotificationClickEvent,
+  NotificationCloseEvent,
+  PushEvent,
+  PushSubscriptionChangeEvent,
+} from './low_level';
 
 /**
  * Subscribe and listen to
@@ -47,7 +54,7 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, PushEvent} from './low_level';
  *     "actions": NotificationAction[],
  *     "badge": USVString,
  *     "body": DOMString,
- *     "data": any,
+ *     "data": unknown,
  *     "dir": "auto"|"ltr"|"rtl",
  *     "icon": USVString,
  *     "image": USVString,
@@ -99,6 +106,21 @@ export class SwPush {
    * Emits the payloads of the received push notification messages.
    */
   readonly messages: Observable<object>;
+
+  /**
+   * Returns an observable that emits push notification payloads cast to the provided type `T`.
+   * Use this when you know the shape of your push notification data and want type-safe access
+   * without casting at every subscription site.
+   *
+   * @usageNotes
+   * ```ts
+   * interface MyPushPayload { title: string; body: string; }
+   * swPush.typedMessages<MyPushPayload>().subscribe(({title, body}) => { ... });
+   * ```
+   */
+  typedMessages<T>(): Observable<T> {
+    return this.messages as Observable<T>;
+  }
 
   /**
    * Emits the payloads of the received push notification messages as well as the action the user
@@ -189,16 +211,16 @@ export class SwPush {
     this.messages = this.sw.eventsOfType<PushEvent>('PUSH').pipe(map((message) => message.data));
 
     this.notificationClicks = this.sw
-      .eventsOfType('NOTIFICATION_CLICK')
-      .pipe(map((message: any) => message.data));
+      .eventsOfType<NotificationClickEvent>('NOTIFICATION_CLICK')
+      .pipe(map((message) => message.data));
 
     this.notificationCloses = this.sw
-      .eventsOfType('NOTIFICATION_CLOSE')
-      .pipe(map((message: any) => message.data));
+      .eventsOfType<NotificationCloseEvent>('NOTIFICATION_CLOSE')
+      .pipe(map((message) => message.data));
 
     this.pushSubscriptionChanges = this.sw
-      .eventsOfType('PUSH_SUBSCRIPTION_CHANGE')
-      .pipe(map((message: any) => message.data));
+      .eventsOfType<PushSubscriptionChangeEvent>('PUSH_SUBSCRIPTION_CHANGE')
+      .pipe(map((message) => message.data));
 
     this.pushManager = this.sw.registration.pipe(
       map(

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -314,13 +314,60 @@ describe('ServiceWorker library', () => {
       });
     });
 
+    describe('typedMessages', () => {
+      it('receives typed push messages', () => {
+        interface MyPayload {
+          title: string;
+          count: number;
+        }
+        const sendMessage = (data: MyPayload) => mock.sendMessage({type: 'PUSH', data});
+
+        const received: MyPayload[] = [];
+        push.typedMessages<MyPayload>().subscribe((msg) => received.push(msg));
+
+        sendMessage({title: 'hello', count: 1});
+        sendMessage({title: 'world', count: 2});
+
+        expect(received).toEqual([
+          {title: 'hello', count: 1},
+          {title: 'world', count: 2},
+        ]);
+      });
+
+      it('ignores non-PUSH messages', () => {
+        const received: unknown[] = [];
+        push.typedMessages<unknown>().subscribe((msg) => received.push(msg));
+
+        mock.sendMessage({type: 'PUSH', data: 'a'});
+        mock.sendMessage({type: 'NOT_PUSH', data: 'b'});
+        mock.sendMessage({type: 'PUSH', data: 'c'});
+
+        expect(received).toEqual(['a', 'c']);
+      });
+
+      it('each call returns an independent observable', () => {
+        const first: unknown[] = [];
+        const second: unknown[] = [];
+
+        push.typedMessages<string>().subscribe((msg) => first.push(msg));
+        push.typedMessages<number>().subscribe((msg) => second.push(msg));
+
+        mock.sendMessage({type: 'PUSH', data: 'x'});
+
+        expect(first).toEqual(['x']);
+        expect(second).toEqual(['x']);
+      });
+    });
+
     describe('messages', () => {
       it('receives push messages', () => {
         const sendMessage = (type: string, message: string) =>
           mock.sendMessage({type, data: {message}});
 
         const receivedMessages: string[] = [];
-        push.messages.subscribe((msg: any) => receivedMessages.push(msg.message));
+        push
+          .typedMessages<{message: string}>()
+          .subscribe((msg) => receivedMessages.push(msg.message));
 
         sendMessage('PUSH', 'this was a push message');
         sendMessage('NOTPUSH', 'this was not a push message');
@@ -366,6 +413,38 @@ describe('ServiceWorker library', () => {
         sendMessage('NOTIFICATION_CLOSE', 'empty_string');
 
         expect(receivedMessages).toEqual(['empty_string']);
+      });
+    });
+
+    describe('pushSubscriptionChanges', () => {
+      it('receives push subscription change messages', () => {
+        const sendMessage = (
+          type: string,
+          data: {
+            oldSubscription: PushSubscription | null;
+            newSubscription: PushSubscription | null;
+          },
+        ) => mock.sendMessage({type, data});
+
+        const received: Array<{
+          oldSubscription: PushSubscription | null;
+          newSubscription: PushSubscription | null;
+        }> = [];
+        push.pushSubscriptionChanges.subscribe((msg) => received.push(msg));
+
+        const fakeOld = {endpoint: 'old'} as unknown as PushSubscription;
+        const fakeNew = {endpoint: 'new'} as unknown as PushSubscription;
+
+        sendMessage('PUSH_SUBSCRIPTION_CHANGE', {
+          oldSubscription: fakeOld,
+          newSubscription: fakeNew,
+        });
+        sendMessage('NOT_PUSH_SUBSCRIPTION_CHANGE', {oldSubscription: null, newSubscription: null});
+        sendMessage('PUSH_SUBSCRIPTION_CHANGE', {oldSubscription: fakeNew, newSubscription: null});
+
+        expect(received.length).toBe(2);
+        expect(received[0]).toEqual({oldSubscription: fakeOld, newSubscription: fakeNew});
+        expect(received[1]).toEqual({oldSubscription: fakeNew, newSubscription: null});
       });
     });
 


### PR DESCRIPTION
## PR Checklist          

Please check if your PR fulfills the following requirements:                                                                                                                    
 
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md                                    
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)                                                                                                                 
                                                                                                                                                                                
## PR Type
                                                                                                                                                                                
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes                                                                                                                                                     
- [ ] CI related changes
- [ ] Documentation content changes                                                                                                                                             
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?                       
                                                                                                                         
`SwPush.messages` is typed as `Observable<object>`, giving consumers no way to access push notification payload properties without casting at every subscription site. The internal event types for `NOTIFICATION_CLICK`, `NOTIFICATION_CLOSE`, and `PUSH_SUBSCRIPTION_CHANGE` were also untyped (`any`), making it impossible to leverage TypeScript's type checking when working with these events.  Additionally, `pushSubscriptionChanges` had no test coverage.                                                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                
## What is the new behavior?

- Added `SwPush.typedMessages<T>(): Observable<T>` — a generic method that                                                                                                      
  returns the push message stream cast to a user-provided type, eliminating
  repeated `as MyType` casts at every subscription site.                                                                                                                        
- Added typed event interfaces exported from `@angular/service-worker`:                                                                                                         
  - `PushEvent<T = any>` — now generic, allowing `eventsOfType<PushEvent<MyPayload>>()`                                                                                         
  - `NotificationClickEvent`                                                                                                                                                    
  - `NotificationCloseEvent`                                                                                                                                                    
  - `PushSubscriptionChangeEvent`                                                                                                                                               
- Replaced three internal `map((message: any) => message.data)` casts in                                                                                                        
  `SwPush` with properly typed `eventsOfType<T>()` calls.                                                                                                                       
- Added tests for `typedMessages()` (typed payloads, non-PUSH filtering,                                                                                                        
  independent observables) and `pushSubscriptionChanges`.                                                                                                                       
                                                                                                                                                                                
## Does this PR introduce a breaking change?                                                                                                                                    
                
- [ ] Yes                                                                                                                                                                       
- [x] No        

## Other information

`SwPush.messages` intentionally remains `Observable<object>` for backward                                                                                                       
compatibility. `typedMessages<T>()` is the opt-in typed alternative.