### PR TITLE
refactor(forms): use strict equality for pending status getter

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -658,7 +658,7 @@ export abstract class AbstractControl<
    * false otherwise.
    */
   get pending(): boolean {
-    return this.status == PENDING;
+    return this.status === PENDING;
   }
 
   /**


### PR DESCRIPTION
The `pending` getter in `AbstractControl` used loose equality (`==`) while all other status getters (`valid`, `invalid`, `disabled`) use strict equality (`===`). Both sides are strings so behavior is identical, but this inconsistency would fail strict linting rules.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `pending` getter in `AbstractControl` uses loose equality (`==`) while `valid`, `invalid`, and `disabled` getters all use strict equality (`===`).

Issue Number: #67931

## What is the new behavior?

The `pending` getter now uses strict equality (`===`) to match all other status getters in the class. No behavioral change since both operands are always strings.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

File: `packages/forms/src/model/abstract_model.ts`, line 661
