### PR TITLE
docs(docs-infra): use signals & improve types

### DIFF
--- a/adev/shared-docs/components/search-dialog/BUILD.bazel
+++ b/adev/shared-docs/components/search-dialog/BUILD.bazel
@@ -29,6 +29,7 @@ ng_project(
         "//adev/shared-docs/pipes",
         "//adev/shared-docs/providers",
         "//adev/shared-docs/services",
+        "//adev/shared-docs/utils",
     ],
 )
 

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.ts
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.ts
@@ -32,6 +32,7 @@ import {RelativeLink} from '../../pipes';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
 import {SearchHistoryComponent} from '../search-history/search-history.component';
 import {TextField} from '../text-field/text-field.component';
+import {getRelativeUrl} from '../../utils';
 
 @Component({
   selector: 'docs-search-dialog',
@@ -55,7 +56,7 @@ export class SearchDialog {
 
   readonly history = inject(SearchHistory);
   private readonly search = inject(Search);
-  private readonly relativeLink = new RelativeLink();
+
   private readonly router = inject(Router);
   private readonly window = inject(WINDOW);
   private readonly injector = inject(Injector);
@@ -120,7 +121,7 @@ export class SearchDialog {
       return;
     }
 
-    this.router.navigateByUrl(this.relativeLink.transform(activeItemLink));
+    this.router.navigateByUrl(getRelativeUrl(activeItemLink));
     this.onClose.emit();
   }
 }

--- a/adev/shared-docs/components/search-history/BUILD.bazel
+++ b/adev/shared-docs/components/search-history/BUILD.bazel
@@ -28,6 +28,7 @@ ng_project(
         "//adev/shared-docs/directives",
         "//adev/shared-docs/pipes",
         "//adev/shared-docs/services",
+        "//adev/shared-docs/utils",
     ],
 )
 

--- a/adev/shared-docs/components/search-history/search-history.component.ts
+++ b/adev/shared-docs/components/search-history/search-history.component.ts
@@ -23,6 +23,7 @@ import {Router, RouterLink} from '@angular/router';
 import {SearchItem} from '../../directives';
 import {RelativeLink} from '../../pipes';
 import {SearchHistory} from '../../services';
+import {getRelativeUrl} from '../../utils';
 
 @Component({
   selector: 'docs-search-history',
@@ -41,7 +42,6 @@ export class SearchHistoryComponent {
   private readonly injector = inject(Injector);
   private readonly router = inject(Router);
 
-  private readonly relativeLink = new RelativeLink();
   private readonly keyManager = new ActiveDescendantKeyManager(
     this.items,
     this.injector,
@@ -99,7 +99,7 @@ export class SearchHistoryComponent {
     const activeItemLink = this.keyManager.activeItem?.item()?.url;
 
     if (activeItemLink) {
-      const url = this.relativeLink.transform(activeItemLink);
+      const url = getRelativeUrl(activeItemLink);
       this.router.navigateByUrl(url);
     }
   }

--- a/adev/shared-docs/directives/external-link/external-link.directive.ts
+++ b/adev/shared-docs/directives/external-link/external-link.directive.ts
@@ -22,7 +22,7 @@ import {isExternalLink} from '../../utils/index';
   },
 })
 export class ExternalLink {
-  private readonly anchor: ElementRef<HTMLAnchorElement> = inject(ElementRef);
+  private readonly anchor = inject<ElementRef<HTMLAnchorElement>>(ElementRef);
   private readonly platformId = inject(PLATFORM_ID);
 
   target?: '_blank' | '_self' | '_parent' | '_top' | '';

--- a/adev/shared-docs/directives/search-item/search-item.directive.ts
+++ b/adev/shared-docs/directives/search-item/search-item.directive.ts
@@ -23,7 +23,7 @@ export class SearchItem implements Highlightable {
 
   readonly item = input<SearchResultItem | undefined>();
 
-  private readonly elementRef = inject(ElementRef<HTMLLIElement>);
+  private readonly elementRef = inject<ElementRef<HTMLLIElement>>(ElementRef);
 
   private _isActive = signal(false);
 

--- a/adev/shared-docs/pipes/relative-link.pipe.ts
+++ b/adev/shared-docs/pipes/relative-link.pipe.ts
@@ -7,21 +7,11 @@
  */
 
 import {Pipe, PipeTransform} from '@angular/core';
-import {normalizePath, removeTrailingSlash} from '../utils/index';
+import {getRelativeUrl} from '../utils/index';
 
 @Pipe({
   name: 'relativeLink',
 })
 export class RelativeLink implements PipeTransform {
-  transform(absoluteUrl: string, result: 'relative' | 'pathname' | 'hash' = 'relative'): string {
-    const url = new URL(normalizePath(absoluteUrl));
-
-    if (result === 'hash') {
-      return url.hash?.substring(1) ?? '';
-    }
-    if (result === 'pathname') {
-      return `${removeTrailingSlash(normalizePath(url.pathname))}`;
-    }
-    return `${removeTrailingSlash(normalizePath(url.pathname))}${url.hash ?? ''}`;
-  }
+  transform = getRelativeUrl;
 }

--- a/adev/shared-docs/utils/url.utils.ts
+++ b/adev/shared-docs/utils/url.utils.ts
@@ -6,6 +6,23 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {normalizePath} from './navigation.utils';
+
+export function getRelativeUrl(
+  absoluteUrl: string,
+  result: 'relative' | 'pathname' | 'hash' = 'relative',
+): string {
+  const url = new URL(normalizePath(absoluteUrl));
+
+  if (result === 'hash') {
+    return url.hash?.substring(1) ?? '';
+  }
+  if (result === 'pathname') {
+    return `${removeTrailingSlash(normalizePath(url.pathname))}`;
+  }
+  return `${removeTrailingSlash(normalizePath(url.pathname))}${url.hash ?? ''}`;
+}
+
 export const removeTrailingSlash = (url: string): string => {
   if (url.endsWith('/')) {
     return url.slice(0, -1);

--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -9,7 +9,7 @@
 import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 import {ConnectionPositionPair} from '@angular/cdk/overlay';
 import {DOCUMENT, Location, isPlatformBrowser} from '@angular/common';
-import {Component, DestroyRef, PLATFORM_ID, inject, signal} from '@angular/core';
+import {Component, PLATFORM_ID, inject, signal} from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {
   ClickOutside,
@@ -38,7 +38,6 @@ type MenuType = 'social' | 'theme-picker' | 'version-picker';
   styleUrls: ['./navigation.component.scss', './mini-menu.scss', './nav-item.scss'],
 })
 export class Navigation {
-  private readonly destroyRef = inject(DestroyRef);
   private readonly document = inject(DOCUMENT);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly navigationState = inject(NavigationState);
@@ -134,7 +133,7 @@ export class Navigation {
   }
 
   private closeMobileNavOnPrimaryRouteChange(): void {
-    this.primaryRouteChanged$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+    this.primaryRouteChanged$.pipe(takeUntilDestroyed()).subscribe(() => {
       this.closeMobileNav();
     });
   }
@@ -146,7 +145,7 @@ export class Navigation {
         map((event) => (event as NavigationEnd).urlAfterRedirects),
       )
       .pipe(
-        takeUntilDestroyed(this.destroyRef),
+        takeUntilDestroyed(),
         //using location because router.url will only return "/" here
         startWith(this.location.path()),
       )
@@ -189,7 +188,7 @@ export class Navigation {
   }
 
   private preventToScrollContentWhenSecondaryNavIsOpened(): void {
-    this.isMobileNavigationOpened$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((opened) => {
+    this.isMobileNavigationOpened$.pipe(takeUntilDestroyed()).subscribe((opened) => {
       if (opened) {
         this.document.body.style.overflowY = 'hidden';
       } else {

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {isPlatformBrowser} from '@angular/common';
-import {Component, DestroyRef, PLATFORM_ID, computed, inject, signal} from '@angular/core';
+import {Component, PLATFORM_ID, computed, inject, signal} from '@angular/core';
 import {takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
 import {
   ClickOutside,
@@ -35,7 +35,6 @@ export const ANIMATION_DURATION = 500;
   styleUrls: ['./secondary-navigation.component.scss'],
 })
 export class SecondaryNavigation {
-  private readonly destroyRef = inject(DestroyRef);
   private readonly navigationState = inject(NavigationState);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
@@ -69,15 +68,15 @@ export class SecondaryNavigation {
 
   private readonly primaryActiveRouteChanged$ = toObservable(this.primaryActiveRouteItem).pipe(
     distinctUntilChanged(),
-    takeUntilDestroyed(this.destroyRef),
+    takeUntilDestroyed(),
   );
 
   private readonly urlAfterRedirects$ = this.router.events.pipe(
     filter((event) => event instanceof NavigationEnd),
-    map((event) => (event as NavigationEnd).urlAfterRedirects),
-    filter((url): url is string => url !== undefined),
+    map((event) => event.urlAfterRedirects),
+    filter((url) => url !== undefined),
     startWith(this.getInitialPath(this.router.routerState.snapshot)),
-    takeUntilDestroyed(this.destroyRef),
+    takeUntilDestroyed(),
   );
 
   constructor() {

--- a/adev/src/app/features/playground/playground.component.html
+++ b/adev/src/app/features/playground/playground.component.html
@@ -10,9 +10,9 @@
   </div>
 </div>
 
-@if (embeddedEditorComponent) {
+@if (embeddedEditorComponent()) {
   <div class="adev-embedded-editor-wrapper">
-    <ng-container *ngComponentOutlet="embeddedEditorComponent" />
+    <ng-container *ngComponentOutlet="embeddedEditorComponent()" />
   </div>
 }
 

--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -9,7 +9,6 @@
 import {CdkMenu, CdkMenuItem, CdkMenuTrigger} from '@angular/cdk/menu';
 import {isPlatformServer, NgComponentOutlet} from '@angular/common';
 import {
-  ChangeDetectorRef,
   Component,
   DestroyRef,
   effect,
@@ -17,6 +16,7 @@ import {
   inject,
   input,
   PLATFORM_ID,
+  signal,
   Type,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -39,7 +39,6 @@ import PLAYGROUND_ROUTE_DATA_JSON from '../../../../src/assets/tutorials/playgro
 export default class PlaygroundComponent {
   readonly templateId = input<string | undefined>();
 
-  private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly environmentInjector = inject(EnvironmentInjector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly isServer = isPlatformServer(inject(PLATFORM_ID));
@@ -51,7 +50,7 @@ export default class PlaygroundComponent {
   readonly starterTemplate = PLAYGROUND_ROUTE_DATA_JSON.starterTemplate;
 
   protected nodeRuntimeSandbox?: NodeRuntimeSandbox;
-  protected embeddedEditorComponent?: Type<unknown>;
+  protected embeddedEditorComponent = signal<Type<unknown> | null>(null);
   protected selectedTemplate: PlaygroundTemplate = this.defaultTemplate;
 
   constructor() {
@@ -74,13 +73,12 @@ export default class PlaygroundComponent {
       .pipe(
         tap(({nodeRuntimeSandbox, embeddedEditorComponent}) => {
           this.nodeRuntimeSandbox = nodeRuntimeSandbox;
-          this.embeddedEditorComponent = embeddedEditorComponent;
+          this.embeddedEditorComponent.set(embeddedEditorComponent);
         }),
         switchMap(() => this.loadTemplate(this.selectedTemplate.path)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => {
-        this.changeDetectorRef.markForCheck();
         this.nodeRuntimeSandbox?.init();
       });
   }

--- a/adev/src/app/features/tutorial/tutorial.component.html
+++ b/adev/src/app/features/tutorial/tutorial.component.html
@@ -28,9 +28,9 @@
   <!-- Embedded Editor -->
   @if (shouldRenderEmbeddedEditor()) {
     <div #editor class="docs-tutorial-editor" [class.adev-split-tutorial]="shouldRenderContent()">
-      @if (embeddedEditorComponent) {
+      @if (embeddedEditorComponent()) {
         <ng-container
-          *ngComponentOutlet="embeddedEditorComponent; inputs: {restrictedMode: restrictedMode()}"
+          *ngComponentOutlet="embeddedEditorComponent(); inputs: {restrictedMode: restrictedMode()}"
         />
       }
     </div>

--- a/adev/src/app/features/tutorial/tutorial.component.ts
+++ b/adev/src/app/features/tutorial/tutorial.component.ts
@@ -9,7 +9,6 @@
 import {isPlatformBrowser, NgComponentOutlet, NgTemplateOutlet} from '@angular/common';
 import {
   afterNextRender,
-  ChangeDetectorRef,
   Component,
   computed,
   DestroyRef,
@@ -71,7 +70,6 @@ export default class Tutorial {
   readonly resizer = viewChild.required<ElementRef<HTMLDivElement>>('resizer');
   readonly revealAnswerButton = viewChild<ElementRef<HTMLButtonElement>>('revealAnswerButton');
 
-  private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly environmentInjector = inject(EnvironmentInjector);
   private readonly elementRef = inject(ElementRef<unknown>);
   private readonly embeddedTutorialManager = inject(EmbeddedTutorialManager);
@@ -97,7 +95,7 @@ export default class Tutorial {
   nextStepPath: string | undefined;
   previousStepPath: string | undefined;
 
-  embeddedEditorComponent?: Type<unknown>;
+  embeddedEditorComponent = signal<Type<unknown> | null>(null);
 
   canRevealAnswer: Signal<boolean> = signal(false);
   readonly answerRevealed = signal<boolean>(false);
@@ -128,8 +126,7 @@ export default class Tutorial {
       from(this.loadEmbeddedEditorComponent())
         .pipe(takeUntilDestroyed(destroyRef))
         .subscribe((editorComponent) => {
-          this.embeddedEditorComponent = editorComponent;
-          this.changeDetectorRef.markForCheck();
+          this.embeddedEditorComponent.set(editorComponent);
         });
     });
   }


### PR DESCRIPTION
Use signals to avoid markForCheck.

Simplify takeUntilDestroyed usage by relying on implicit DestroyRef.

Improve type safety by typing inject(ElementRef).
 