### PR TITLE
refactor(compiler-cli): narrow `FatalLinkerError` type guard to unknown

### DIFF
--- a/packages/compiler-cli/linker/src/fatal_linker_error.ts
+++ b/packages/compiler-cli/linker/src/fatal_linker_error.ts
@@ -29,6 +29,6 @@ export class FatalLinkerError extends Error {
 /**
  * Whether the given object `e` is a FatalLinkerError.
  */
-export function isFatalLinkerError(e: any): e is FatalLinkerError {
-  return e && e.type === 'FatalLinkerError';
+export function isFatalLinkerError(e: unknown): e is FatalLinkerError {
+  return typeof e === 'object' && e !== null && 'type' in e && e.type === 'FatalLinkerError';
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The guard accepted `any`, which allowed unsafe property access and weakened type safety.

## What is the new behavior?

The guard now works with unknown and verifies that the value is a non-null object with a type property before comparing it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
