### PR TITLE
refactor(localize): replace `any` with `unknown` in messages and translations utils

### DIFF
--- a/packages/localize/src/utils/src/messages.ts
+++ b/packages/localize/src/utils/src/messages.ts
@@ -138,7 +138,7 @@ export interface ParsedMessage extends MessageMetadata {
   /**
    * A mapping of placeholder names to substitution values.
    */
-  substitutions: Record<string, any>;
+  substitutions: Record<string, unknown>;
   /**
    * An optional mapping of placeholder names to associated MessageIds.
    * This can be used to match ICU placeholders to the message that contains the ICU.
@@ -170,12 +170,12 @@ export interface ParsedMessage extends MessageMetadata {
  */
 export function parseMessage(
   messageParts: TemplateStringsArray,
-  expressions?: readonly any[],
+  expressions?: readonly unknown[],
   location?: SourceLocation,
   messagePartLocations?: (SourceLocation | undefined)[],
   expressionLocations: (SourceLocation | undefined)[] = [],
 ): ParsedMessage {
-  const substitutions: {[placeholderName: string]: any} = {};
+  const substitutions: Record<string, unknown> = {};
   const substitutionLocations: {[placeholderName: string]: SourceLocation | undefined} = {};
   const associatedMessageIds: {[placeholderName: string]: MessageId} = {};
   const metadata = parseMetadata(messageParts[0], messageParts.raw[0]);

--- a/packages/localize/src/utils/src/translations.ts
+++ b/packages/localize/src/utils/src/translations.ts
@@ -22,14 +22,18 @@ export interface ParsedTranslation extends MessageMetadata {
 export type ParsedTranslations = Record<MessageId, ParsedTranslation>;
 
 export class MissingTranslationError extends Error {
-  private readonly type = 'MissingTranslationError';
+  readonly type = 'MissingTranslationError';
   constructor(readonly parsedMessage: ParsedMessage) {
     super(`No translation found for ${describeMessage(parsedMessage)}.`);
   }
 }
 
-export function isMissingTranslationError(e: any): e is MissingTranslationError {
-  return e.type === 'MissingTranslationError';
+export function isMissingTranslationError(e: unknown): e is MissingTranslationError {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    (e as MissingTranslationError).type === 'MissingTranslationError'
+  );
 }
 
 /**
@@ -51,8 +55,8 @@ export function isMissingTranslationError(e: any): e is MissingTranslationError 
 export function translate(
   translations: Record<string, ParsedTranslation>,
   messageParts: TemplateStringsArray,
-  substitutions: readonly any[],
-): [TemplateStringsArray, readonly any[]] {
+  substitutions: readonly unknown[],
+): [TemplateStringsArray, readonly unknown[]] {
   const message = parseMessage(messageParts, substitutions);
   // Look up the translation using the messageId, and then the legacyId if available.
   let translation = translations[message.id];
@@ -137,7 +141,7 @@ export function makeParsedTranslation(
  */
 export function makeTemplateObject(cooked: string[], raw: string[]): TemplateStringsArray {
   Object.defineProperty(cooked, 'raw', {value: raw});
-  return cooked as any;
+  return cooked as unknown as TemplateStringsArray;
 }
 
 function describeMessage(message: ParsedMessage): string {

--- a/packages/localize/tools/test/extract/translation_files/mock_message.ts
+++ b/packages/localize/tools/test/extract/translation_files/mock_message.ts
@@ -35,7 +35,7 @@ export function mockMessage(
     text += `{$${placeholderNames[i - 1]}}${messageParts[i]}`;
   }
   return {
-    substitutions: [],
+    substitutions: {},
     ...options,
     id: options.customId || id, // customId trumps id
     text,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?


Replace unsafe `any` type annotations with `unknown` across the localize utility layer to improve type safety and catch potential type errors at compile time rather than at runtime.

Changes in `messages.ts`:
- `ParsedMessage.substitutions`: `Record<string, any>` => `Record<string, unknown>`
- `parseMessage` parameter `expressions`: `readonly any[]` => `readonly unknown[]`
- Local `substitutions` variable: `{[key: string]: any}` => `Record<string, unknown>`

Changes in `translations.ts`:
- `isMissingTranslationError` parameter: `any` => `unknown`, with proper narrowing (`typeof e === 'object' && e !== null`) before property access
- `MissingTranslationError.type` visibility: `private` => `readonly` to allow access through the narrowed `unknown` type in the type guard
- `translate` parameter and return type: `readonly any[]` => `readonly unknown[]`
- `makeTemplateObject` cast: `cooked as any` => `cooked as unknown as TemplateStringsArray`

Fix in `mock_message.ts` (test helper):
- `substitutions: []` => `substitutions: {}` — the array literal was only assignable because the field was typed as `any`; the correct empty value for a `Record<string, unknown>` is an object literal
- 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

