### PR TITLE
refactor: correct typos in comments, docs, and error messages

### DIFF
--- a/adev/src/app/features/home/animation/parser/utils.spec.ts
+++ b/adev/src/app/features/home/animation/parser/utils.spec.ts
@@ -90,7 +90,7 @@ describe('CSS Value Parser Utils', () => {
       expect(output).toEqual('translate(42px)');
     });
 
-    it('should stringify a transform value with a function with multiple paramters', () => {
+    it('should stringify a transform value with a function with multiple parameters', () => {
       const output = stringifyParsedValue({
         type: 'transform',
         values: new Map([

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
@@ -53,7 +53,7 @@ export interface TreeVisualizerConfig<T extends TreeNode> {
   d3LinkModifier: (link: SvgD3Link<T>) => void;
 }
 
-// For easier compatability with d3 v5
+// For easier compatibility with d3 v5
 // Inspired by https://www.mulberryhousesoftware.com/articles/supporting-two-major-versions-of-d3
 function wrapEvent<E, V>(fn: (e: E) => void): (e: E) => void;
 function wrapEvent<E, V>(fn: (e: E, node: V) => void): (e: E, node: V) => void;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -713,7 +713,7 @@ class InlineTcbOp implements Op {
   ) {}
 
   /**
-   * Type check blocks are inserted immediately after the end of the directve class.
+   * Type check blocks are inserted immediately after the end of the directive class.
    */
   get splitPoint(): number {
     return this.ref.node.end + 1;

--- a/packages/compiler-cli/test/compliance/test_helpers/i18n_helpers.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/i18n_helpers.ts
@@ -81,7 +81,7 @@ export function i18nIcuMsg(message: string, placeholders: Placeholder[], options
  * - The third (optional) items is the id of the message that this placeholder references.
  *   This is used for matching ICU placeholders to ICU messages.
  */
-export type Placeholder = [name: string, indentifier: string, associatedId: string];
+export type Placeholder = [name: string, identifier: string, associatedId: string];
 
 /**
  * Describes message metadata object.

--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -31,7 +31,7 @@ import {
 } from './util';
 
 /**
- * Function that can be used to prcess the dependencies that
+ * Function that can be used to process the dependencies that
  * are going to be added to the imports of a declaration.
  */
 export type DeclarationImportsRemapper = (imports: PotentialImport[]) => PotentialImport[];

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -402,7 +402,7 @@ export type ɵTokenize<S extends string, D extends string> = string extends S
   ? string[] /* S must be a literal */
   : S extends `${infer T}${D}${infer U}`
     ? [T, ...ɵTokenize<U, D>]
-    : [S] /* Base case */;
+    : [S]; /* Base case */
 
 /**
  * CoerceStrArrToNumArr accepts an array of strings, and converts any numeric string to a number.
@@ -433,7 +433,7 @@ export type ɵNavigate<
         : any /* tail(K) was not an array, give up */
       : never /* head(K) does not index T, give up */
     : any /* K cannot be split, give up */
-  : any /* T is not indexable, give up */;
+  : any; /* T is not indexable, give up */
 
 /**
  * ɵWriteable removes readonly from all keys.
@@ -1462,7 +1462,7 @@ export abstract class AbstractControl<
     if (this._asyncValidationSubscription) {
       this._asyncValidationSubscription.unsubscribe();
 
-      // we're cancelling the validator subscribtion, we keep if it should have emitted
+      // we're cancelling the validator subscription, we keep if it should have emitted
       // because we want to emit eventually if it was required at least once.
       const shouldHaveEmitted =
         (this._hasOwnPendingAsyncValidator?.emitEvent ||

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -57,7 +57,7 @@ function createStyleElement(style: string, doc: Document): HTMLStyleElement {
  * Searches a DOM document's head element for style elements with a matching application
  * identifier attribute (`ng-app-id`) to the provide identifier and adds usage records for each.
  * @param doc An HTML DOM document instance.
- * @param appId A string containing an Angular application identifer.
+ * @param appId A string containing an Angular application identifier.
  * @param inline A Map object for tracking inline (defined via `styles` in component decorator) style usage.
  * @param external A Map object for tracking external (defined via `styleUrls` in component decorator) style usage.
  * @returns Whether or not styles were added.

--- a/packages/zone.js/test/rxjs/rxjs.fromEvent.spec.ts
+++ b/packages/zone.js/test/rxjs/rxjs.fromEvent.spec.ts
@@ -86,7 +86,7 @@ describe('Observable.fromEvent', () => {
       const clickEvent = document.createEvent('Event');
       clickEvent.initEvent('click', false, false);
 
-      const subscriper: any = subscriptionZone.run(() => {
+      const subscriber: any = subscriptionZone.run(() => {
         return observable1.subscribe(
           (result: any) => {
             expect(Zone.current.name).toEqual(subscriptionZone.name);
@@ -104,7 +104,7 @@ describe('Observable.fromEvent', () => {
 
       triggerZone.run(() => {
         button.dispatchEvent(clickEvent);
-        subscriper.complete();
+        subscriber.complete();
       });
       expect(log).toEqual(['addListener', clickEvent, 'completed', 'removeListener']);
     }),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Fix misspellings found across multiple packages:

- `paramters` => `parameters` (utils.spec.ts)
- `directve` => `directive` (typecheck/context.ts)
- `subscriper` => `subscriber` (zone.js rxjs test)
- `swich` => `switch` (adev animation parser test)
- `subscribtion` => `subscription` (forms/abstract_model.ts)
- `lifecyle` => `lifecycle` (ng-devtools-backend hooks)
- `compatability` => `compatibility` (tree-visualizer.ts)
- `indentifier(s)` => `identifier(s)` (compiler-cli shared.ts, i18n_helpers.ts, declaration_only_emission_spec.ts)
- `identifer` => `identifier` (platform-browser shared_styles_host.ts)
- `prcess` => `process` (standalone-migration to-standalone.ts)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
