### PR TITLE
fix(core): remove obsolete iOS cursor pointer hack in event delegation

### DIFF
--- a/packages/core/primitives/event-dispatch/src/event_contract_container.ts
+++ b/packages/core/primitives/event-dispatch/src/event_contract_container.ts
@@ -24,11 +24,6 @@ export interface EventContractContainerManager {
 }
 
 /**
- * Whether the user agent is running on iOS.
- */
-const isIos = typeof navigator !== 'undefined' && /iPhone|iPad|iPod/.test(navigator.userAgent);
-
-/**
  * A class representing a container node and all the event handlers
  * installed on it. Used so that handlers can be cleaned up if the
  * container is removed from the contract.
@@ -56,20 +51,6 @@ export class EventContractContainer implements EventContractContainerManager {
     getHandler: (element: Element) => (event: Event) => void,
     passive?: boolean,
   ) {
-    // In iOS, event bubbling doesn't happen automatically in any DOM element,
-    // unless it has an onclick attribute or DOM event handler attached to it.
-    // This breaks JsAction in some cases. See "Making Elements Clickable"
-    // section at http://goo.gl/2VoGnB.
-    //
-    // A workaround for this issue is to change the CSS cursor style to 'pointer'
-    // for the container element, which magically turns on event bubbling. This
-    // solution is described in the comments section at http://goo.gl/6pEO1z.
-    //
-    // We use a navigator.userAgent check here as this problem is present both
-    // on Mobile Safari and thin WebKit wrappers, such as Chrome for iOS.
-    if (isIos) {
-      (this.element as HTMLElement).style.cursor = 'pointer';
-    }
     this.handlerInfos.push(
       eventLib.addEventListener(this.element, eventType, getHandler(this.element), passive),
     );


### PR DESCRIPTION
This removes the `cursor: pointer` injection for iOS devices in `event_contract_container.ts`.

Historically, WebKit had a quirk where `click` events wouldn't bubble from non-interactive elements (like a `<div>`) unless they had an explicit cursor style or `onclick` attribute. Angular's event delegation relied on this hack to ensure iOS Safari dispatched delegated events. See [this](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html) and [this](https://www.quirksmode.org/blog/archives/2010/09/click_event_del.html).

Apple fixed this in WebCore back in late 2018 [here](https://bugs.webkit.org/show_bug.cgi?id=151933) and [here](https://bugs.webkit.org/show_bug.cgi?id=153887). The fix shipped in Safari 12.1 and iOS 12.2, explicitly removing the "ignore onclick on body and beyond" restriction. The Pointer Events API in iOS 13 fully normalized the behavior. I confirmed this in iOS Safari. [Web Platform Tests](https://wpt.fyi/results/uievents/order-of-events/mouse-events/click-on-div.html?label=experimental&label=master&aligned) also confirm it's fixed.

Beyond cleaning up legacy code, this fixes the "blue flash" bug that affects development environments. When Chrome's mobile emulator spoofs an iOS user agent, Angular applies `cursor: pointer` to the root container. The browser interprets the entire document as an interactive button and paints a massive `-webkit-tap-highlight-color` flash across the whole screen on every tap. This shows up in confused questions like [this](https://stackoverflow.com/questions/25704650/disable-blue-highlight-when-touch-press-object-with-cursorpointer).

Developers frequently hit this and write global CSS workarounds just to suppress it. Removing the User-Agent sniff eliminates the root cause and stops us from mutating the DOM for 100% of iOS traffic to fix a bug that hasn't existed in years.