### PR TITLE
docs(docs-infra): improve angular-new-app skill

### DIFF
--- a/skills/dev-skills/angular-new-app/SKILL.md
+++ b/skills/dev-skills/angular-new-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: angular-new-app
-description: Creates a new Angular app using the Angular CLI. This skill should be used whenver a user wants to create a new Angular application and contains important guidelines for how to effectively create a modern Angular application.
+description: Creates a new Angular app using the Angular CLI. This skill should be used whenever a user wants to create a new Angular application and contains important guidelines for how to effectively create a modern Angular application.
 license: MIT
 compatibility: Requires node, npm, and access to the internet
 metadata:
@@ -10,9 +10,7 @@ metadata:
 
 # Angular New App
 
-You are an expert Angular developer and have access to tools to create new Angular apps.
-
-You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, performant, and accessible code following Angular and TypeScript best practices.
+You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, performant, and accessible code following Angular and TypeScript best practices. You have access to tools to create new Angular apps.
 
 When creating a new Angular application for a user, always follow the following steps:
 
@@ -32,7 +30,14 @@ When creating a new Angular application for a user, always follow the following 
 
    _Important_: Prefer agent for `--ai-config`, or use the option that best suits the environment, for example if the user is using Gemini, use `--ai-config=gemini`.
 
-   Load the contents of that ai configuration into memory so that you can refer to it when generating code for the user. This will help you to generate code that is consistent with modern Angular best practices.
+   Load the contents of that AI configuration into memory so that you can refer to it when generating code for the user. This will help you generate code that is consistent with modern Angular best practices.
+
+   Consider these commonly useful flags based on the user's requirements:
+   - `--style=scss|css|less` — stylesheet format
+   - `--routing` — add routing module
+   - `--ssr` — enable server-side rendering
+   - `--prefix=<prefix>` — component selector prefix
+   - `--skip-tests` — only if the user explicitly requests it
 
 3. Do not start the app until you've built some features, ask the user if they want to start the app. You can always run `npx ng build` to check for errors and repair them.
 
@@ -42,6 +47,11 @@ When creating a new Angular application for a user, always follow the following 
    - To generate pipes, use the Angular CLI `npx ng generate pipe <pipe-name>`
    - To generate directives, use the Angular CLI `npx ng generate directive <directive-name>`
    - To generate interfaces, use the Angular CLI `npx ng generate interface <interface-name>`
+   - To generate guards, use the Angular CLI `npx ng generate guard <guard-name>`
+   - To generate interceptors, use the Angular CLI `npx ng generate interceptor <interceptor-name>`
+   - To generate resolvers, use the Angular CLI `npx ng generate resolver <resolver-name>`
+   - To generate enums, use the Angular CLI `npx ng generate enum <enum-name>`
+   - To generate classes, use the Angular CLI `npx ng generate class <class-name>`
 
    _IMPORTANT_: Take note of the path returned from running the generate commands so that you know exactly where the new files are.
 


### PR DESCRIPTION
Consolidate duplicate persona intro, add commonly useful ng new flags and missing generators to scaffolding guidelines.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The angular-new-app SKILL.md has a redundant persona intro, missing commonly useful ng new flags, and is missing several generators (guard, interceptor, resolver, enum, class).

Issue Number: #67965

## What is the new behavior?

Consolidated intro, added commonly useful flags (--style, --routing, --ssr, --prefix, --skip-tests) to step 2, and added missing generators to step 4.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
