### PR TITLE
test(core): refactors test to use `timeout` utility

### DIFF
--- a/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
+++ b/packages/core/primitives/dom-navigation/testing/test/fake_platform_navigation.spec.ts
@@ -12,7 +12,7 @@ import {
   FakeNavigation,
   FakeNavigationCurrentEntryChangeEvent,
 } from '../fake_navigation';
-import {ensureDocument} from '@angular/private/testing';
+import {ensureDocument, timeout} from '@angular/private/testing';
 
 ensureDocument();
 
@@ -671,7 +671,7 @@ describe('navigation', () => {
           },
         });
         locals.navigation.pushState(null, '', '/pushed');
-        await new Promise((resolve) => setTimeout(resolve));
+        await timeout();
         expect(precommitHandlerCalled).toBeTrue();
         expect(locals.navigation.currentEntry.url).toBe('https://test.com/pushed');
       });
@@ -704,7 +704,7 @@ describe('navigation', () => {
         });
 
         locals.navigation.pushState(null, '', '/pushed-throw');
-        await new Promise((resolve) => setTimeout(resolve));
+        await timeout();
         expect(locals.navigation.currentEntry.url).not.toBe('https://test.com/pushed-throw');
         expect(locals.navigationCurrentEntryChangeEvents.length).toBe(0);
       });
@@ -717,7 +717,7 @@ describe('navigation', () => {
           },
         });
         locals.navigation.replaceState(null, '', '/replaced');
-        await new Promise((resolve) => setTimeout(resolve));
+        await timeout();
         expect(precommitHandlerCalled).toBeTrue();
         expect(locals.navigation.currentEntry.url).toBe('https://test.com/replaced');
       });
@@ -733,7 +733,7 @@ describe('navigation', () => {
         });
 
         locals.navigation.replaceState(null, '', '/replaced-reject');
-        await new Promise((resolve) => setTimeout(resolve));
+        await timeout();
         expect(precommitHandlerCalled).toBeTrue();
         const navigateEvent = locals.navigateEvents[locals.navigateEvents.length - 1];
         expect(navigateEvent.signal.aborted).toBeTrue();
@@ -753,7 +753,7 @@ describe('navigation', () => {
         });
 
         locals.navigation.replaceState(null, '', '/replaced-throw');
-        await new Promise((resolve) => setTimeout(resolve));
+        await timeout();
         expect(precommitHandlerCalled).toBeTrue();
         const navigateEvent = locals.navigateEvents[locals.navigateEvents.length - 1];
         expect(navigateEvent.signal.aborted).toBeTrue();
@@ -765,7 +765,7 @@ describe('navigation', () => {
         it('correctly changes URL and replaces history entry by default', async () => {
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-push');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           locals.pendingInterceptOptions.push({
             precommitHandler: async (event) => {
               event.redirect('/redirected-from-push', {history: 'push'});
@@ -773,7 +773,7 @@ describe('navigation', () => {
           });
           const originalNumEntries = locals.navigation.entries().length;
           locals.navigation.pushState(null, '', '/pushed');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.url).toBe('https://test.com/redirected-from-push');
           expect(locals.navigation.entries().length).toBe(originalNumEntries + 1);
@@ -782,7 +782,7 @@ describe('navigation', () => {
         it('correctly changes URL and replaces history entry when history: "replace"', async () => {
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-push');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           locals.pendingInterceptOptions.push({
             precommitHandler: async (event) => {
               event.redirect('/redirected-from-push', {history: 'replace'});
@@ -790,7 +790,7 @@ describe('navigation', () => {
           });
           const originalNumEntries = locals.navigation.entries().length;
           locals.navigation.pushState(null, '', '/pushed');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.url).toBe('https://test.com/redirected-from-push');
           // pushState (becomes entry) + redirect with replace (replaces that entry)
@@ -807,7 +807,7 @@ describe('navigation', () => {
           const nextEvent = locals.nextNavigateEvent();
           locals.navigation.pushState(null, '', '/pushed-for-info');
           const e = await nextEvent;
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           expect(e.info).toEqual(redirectInfo);
         });
 
@@ -819,7 +819,7 @@ describe('navigation', () => {
             },
           });
           locals.navigation.pushState(null, '', '/pushed-for-state');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.getState()).toEqual(redirectState);
         });
@@ -829,7 +829,7 @@ describe('navigation', () => {
         it('correctly changes URL and replaces history entry by default', async () => {
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-push');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           locals.navigateEvents.length = 0;
 
           locals.pendingInterceptOptions.push({
@@ -839,7 +839,7 @@ describe('navigation', () => {
           });
           const originalNumEntries = locals.navigation.entries().length;
           locals.navigation.replaceState(null, '', '/replaced-for-push');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.url).toBe(
             'https://test.com/redirected-from-replace-push',
@@ -851,7 +851,7 @@ describe('navigation', () => {
         it('correctly changes URL and replaces history entry when history: "replace"', async () => {
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-replace');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           locals.navigateEvents.length = 0;
 
           locals.pendingInterceptOptions.push({
@@ -861,7 +861,7 @@ describe('navigation', () => {
           });
           const originalNumEntries = locals.navigation.entries().length;
           locals.navigation.replaceState(null, '', '/replaced-for-replace');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.url).toBe(
             'https://test.com/redirected-from-replace-replace',
@@ -874,7 +874,7 @@ describe('navigation', () => {
           const redirectInfo = {isRedirectedReplace: true};
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-info');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
           locals.navigateEvents.length = 0;
 
           locals.pendingInterceptOptions.push({
@@ -885,7 +885,7 @@ describe('navigation', () => {
           const redirectedEvent = locals.nextNavigateEvent(); // Redirected navigation
           locals.navigation.replaceState(null, '', '/replaced-for-info');
           const e = await redirectedEvent;
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(e.info).toEqual(redirectInfo);
         });
@@ -894,7 +894,7 @@ describe('navigation', () => {
           const redirectState = {isRedirectedReplace: true};
           // First, push a state
           locals.navigation.pushState(null, '', '/initial-for-replace-state');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           locals.pendingInterceptOptions.push({
             precommitHandler: async (event) => {
@@ -902,7 +902,7 @@ describe('navigation', () => {
             },
           });
           locals.navigation.replaceState(null, '', '/replaced-for-state');
-          await new Promise((resolve) => setTimeout(resolve));
+          await timeout();
 
           expect(locals.navigation.currentEntry.getState()).toEqual(redirectState);
         });
@@ -1492,7 +1492,7 @@ describe('navigation', () => {
       // Determine if we need to await committed/finished for go() or if nextNavigateEvent is enough.
       // go() uses internal mechanism, but eventually updates currentEntry.
       // We can wait for the loop to settle.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await timeout();
       expect(locals.navigation.currentEntry.key).toBe(thirdPageEntry.key);
     });
   });

--- a/packages/core/rxjs-interop/test/pending_until_event_spec.ts
+++ b/packages/core/rxjs-interop/test/pending_until_event_spec.ts
@@ -23,6 +23,7 @@ import {
 
 import {pendingUntilEvent} from '../src';
 import {TestBed} from '../../testing';
+import {timeout} from '@angular/private/testing';
 
 describe('pendingUntilEvent', () => {
   let taskService: PendingTasksInternal;
@@ -230,21 +231,21 @@ describe('pendingUntilEvent', () => {
     sub.next();
     observable.subscribe();
     // first subscription unblocks
-    await new Promise((r) => setTimeout(r, 5));
+    await timeout(5);
     // still pending because the other subscribed after the emit
     expect(taskService.hasPendingTasks).toBe(true);
 
     sub.next();
-    await new Promise((r) => setTimeout(r, 3));
+    await timeout(3);
     observable.subscribe();
     sub.next();
     // second subscription unblocks
-    await new Promise((r) => setTimeout(r, 2));
+    await timeout(2);
     // still pending because third subscription delay not finished
     expect(taskService.hasPendingTasks).toBe(true);
 
     // finishes third subscription
-    await new Promise((r) => setTimeout(r, 3));
+    await timeout(3);
     await expectAsync(appRef.whenStable()).toBeResolved();
   });
 });

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -8,6 +8,7 @@
 
 import {of, Observable, BehaviorSubject, throwError} from 'rxjs';
 import {TestBed} from '../../testing';
+import {timeout} from '@angular/private/testing';
 import {ApplicationRef, Injector, signal} from '../../src/core';
 import {rxResource} from '../src';
 
@@ -117,6 +118,6 @@ describe('rxResource()', () => {
 
 async function waitFor(fn: () => boolean): Promise<void> {
   while (!fn()) {
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await timeout(1);
   }
 }

--- a/packages/core/test/acceptance/after_render_hook_spec.ts
+++ b/packages/core/test/acceptance/after_render_hook_spec.ts
@@ -37,6 +37,7 @@ import {TestBed} from '../../testing';
 import {firstValueFrom} from 'rxjs';
 import {filter} from 'rxjs/operators';
 import {EnvironmentInjector, Injectable} from '../../src/di';
+import {timeout} from '@angular/private/testing';
 
 function createAndAttachComponent<T>(component: Type<T>) {
   const componentRef = createComponent(component, {
@@ -1330,7 +1331,7 @@ describe('after render hooks', () => {
         counter = counter;
         async ngOnInit() {
           // push the render hook to a time outside of change detection
-          await new Promise<void>((resolve) => setTimeout(resolve));
+          await timeout();
           afterNextRender(
             () => {
               counter.set(1);

--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -9,6 +9,7 @@
 import {CommonModule} from '@angular/common';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/private/testing/matchers';
+import {timeout} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 import {
   ApplicationRef,
@@ -1575,7 +1576,7 @@ describe('change detection', () => {
           fixture.detectChanges();
 
           fixture.componentInstance.state = 'new';
-          await new Promise<void>((resolve) => setTimeout(resolve, 10));
+          await timeout(10);
 
           expect(error!.code).toEqual(RuntimeErrorCode.EXPRESSION_CHANGED_AFTER_CHECKED);
         });
@@ -1604,7 +1605,7 @@ describe('change detection', () => {
           // markForCheck schedules change detection
           fixture.componentInstance.changeDetectorRef.markForCheck();
           // wait beyond the exhaustive check interval
-          await new Promise<void>((resolve) => setTimeout(resolve, 1));
+          await timeout(1);
 
           expect(error).toBeUndefined();
         });

--- a/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
+++ b/packages/core/test/acceptance/change_detection_transplanted_view_spec.ts
@@ -32,6 +32,7 @@ import {
 import {provideCheckNoChangesConfig} from '../../src/change_detection/provide_check_no_changes_config';
 import {ComponentFixture, TestBed} from '../../testing';
 import {expect} from '@angular/private/testing/matchers';
+import {timeout} from '@angular/private/testing';
 import {of} from 'rxjs';
 
 describe('change detection for transplanted views', () => {
@@ -1185,7 +1186,7 @@ describe('change detection for transplanted views', () => {
     const fixture = TestBed.createComponent(Root);
     TestBed.inject(ApplicationRef).attachView(fixture.componentRef.hostView);
     // wait the 1 tick for exhaustive check to trigger
-    await new Promise((r) => setTimeout(r, 1));
+    await timeout(1);
     expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/test/application_init_spec.ts
+++ b/packages/core/test/application_init_spec.ts
@@ -17,6 +17,7 @@ import {ERROR_DETAILS_PAGE_BASE_URL} from '../src/error_details_base_url';
 import {EMPTY, Observable, Subscriber} from 'rxjs';
 
 import {TestBed} from '../testing';
+import {timeout} from '@angular/private/testing';
 
 describe('ApplicationInitStatus', () => {
   let status: ApplicationInitStatus;
@@ -236,7 +237,7 @@ describe('ApplicationInitStatus', () => {
       TestBed.configureTestingModule({
         providers: [
           provideAppInitializer(async () => {
-            await new Promise((resolve) => setTimeout(resolve));
+            await timeout();
             isInitialized = true;
           }),
         ],

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {fakeAsync, TestBed} from '../testing';
+import {TestBed} from '../testing';
 import {ErrorHandler, provideBrowserGlobalErrorListeners} from '../src/error_handler';
-import {isNode, withBody} from '@angular/private/testing';
+import {isNode, timeout, withBody} from '@angular/private/testing';
 import {ApplicationRef, Component, destroyPlatform, inject} from '../src/core';
 import {bootstrapApplication} from '@angular/platform-browser';
 
@@ -137,7 +137,7 @@ describe('ErrorHandler', () => {
         expect(dispatched).toEqual(true);
 
         // Wait until the error is re-thrown, so we can reset the original error handler.
-        await new Promise((resolve) => setTimeout(resolve, 1));
+        await timeout(1);
       });
 
       window.onerror = originalWindowOnError;


### PR DESCRIPTION
Replaces direct `setTimeout` wrapped in a Promise with the `timeout` helper from `@angular/private/testing`
