### PR TITLE
ci: exclude test files from primitives review

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -487,7 +487,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude('packages/core/primitives/**/*spec.ts'), [
           'packages/core/primitives/**/{*,.*}',
         ])
     reviewers:


### PR DESCRIPTION
Those files aren't synced into G3 and shouldn't require external reviews
