### PR TITLE
docs(docs-infra): Adds anchor links to class member headers for linking

### DIFF
--- a/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
+++ b/adev/shared-docs/pipeline/api-gen/rendering/templates/class-member.tsx
@@ -59,10 +59,16 @@ export function ClassMember(props: {member: MemberEntryRenderable}) {
   const memberName = member.name;
   const displayName = member.displayName;
   const returnType = getMemberType(member);
+  const label = displayName ?? memberName;
+
   return (
     <div id={memberName} className={REFERENCE_MEMBER_CARD}>
       <header className={REFERENCE_MEMBER_CARD_HEADER}>
-        <h3>{displayName ?? memberName}</h3>
+        <h3>
+          <a class="docs-anchor" href={'#' + memberName}>
+            {label}
+          </a>
+        </h3>
         {isClassMethodEntry(member) && member.signatures.length > 1 ? (
           <span>{member.signatures.length} overloads</span>
         ) : returnType ? (

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/renderable.spec.mts
@@ -7,8 +7,10 @@
  */
 
 import {readFile} from 'fs/promises';
+import {JSDOM} from 'jsdom';
 import {DocEntryRenderable} from '../entities/renderables.mjs';
 import {getRenderable} from '../processing.mjs';
+import {renderEntry} from '../rendering.mjs';
 import {setSymbols} from '../symbol-context.mjs';
 import {resolve} from 'path';
 import {initHighlighter} from '../../../shared/shiki.mjs';
@@ -59,5 +61,22 @@ describe('renderable', () => {
     expect(linkedSignal!.developerPreview).toEqual({version: undefined});
     expect(linkedSignal!.experimental).toBe(undefined);
     expect(linkedSignal!.stable).toBe(undefined);
+  });
+
+  it('should render docs-anchor links in class member card headers', () => {
+    const viewRef = entries.get('ViewRef')!;
+    expect(viewRef).toBeDefined();
+
+    const html = renderEntry(viewRef);
+    const fragment = JSDOM.fragment(html);
+
+    const memberCards = fragment.querySelectorAll('.docs-reference-member-card');
+    expect(memberCards.length).toBeGreaterThan(0);
+
+    for (const card of Array.from(memberCards)) {
+      const id = card.getAttribute('id')!;
+      const anchor = card.querySelector('h3 a.docs-anchor') as HTMLAnchorElement;
+      expect(anchor.getAttribute('href')).toBe(`#${id}`);
+    }
   });
 });

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/code-transforms.mts
@@ -95,6 +95,7 @@ export async function addRenderableCodeToc<T extends DocEntry & HasModuleName>(
     {
       language: 'typescript',
       apiEntries: getSymbolsAsApiEntries(),
+      removeWhitespace: false,
     },
   );
 

--- a/adev/shared-docs/pipeline/shared/shiki.mts
+++ b/adev/shared-docs/pipeline/shared/shiki.mts
@@ -42,6 +42,7 @@ export function codeToHtml(
     apiEntries?: ApiEntries;
     language?: string;
     highlight?: Set<number>;
+    removeWhitespace?: boolean;
   },
 ): string {
   const html = highlighter.codeToHtml(code, {
@@ -53,7 +54,7 @@ export function codeToHtml(
     cssVariablePrefix: '--shiki-',
     defaultColor: false,
     transformers: [
-      removeWhitespaceTransformer(),
+      ...(config.removeWhitespace ? [removeWhitespaceTransformer()] : []),
       highlightTransformer(config.highlight),
       linkApiEntriesTransformer(config.apiEntries),
     ],


### PR DESCRIPTION
Adds anchor links to class member headers for direct linking. Add test to ensure anchors render correctly.

Fixes #67970
 
## What is the current behavior?

 
See #67970
Also https://angular.dev/api/core/ApplicationRef#bootstrap

## What is the new behavior?

 

https://github.com/user-attachments/assets/b05c10a8-3c29-4514-b79c-8deb3cba723d

