### PR TITLE
fix(docs-infra): prevent inline code wrapping in CLI reference table

### DIFF
--- a/adev/shared-docs/styles/docs/_table.scss
+++ b/adev/shared-docs/styles/docs/_table.scss
@@ -35,6 +35,9 @@
         vertical-align: top;
         min-width: 10ch;
       }
+      td:has(code) {
+        min-width: 8ch;
+      }
       &:not(:last-child) {
         border-block-end: 1px solid var(--senary-contrast);
       }


### PR DESCRIPTION
Inline code elements inside table cells inherited `width: 100%` from the global code styles, causing short codes like `s`, `dev` to stack vertically instead of rendering on the same line. Add `min-width` to table cells containing code to ensure proper inline layout.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<img width="821" height="100" alt="image" src="https://github.com/user-attachments/assets/87873295-2447-4c8d-b512-a9336d938614" />

Inline `<code>` elements inside table cells inherit `width: 100%` from the global inline code styles (`_code.scss`), combined with `display: inline-block`. This causes short codes like `s`, `dev` in the `/reference/cli` table's Alias column to stack vertically — each code element takes the full cell width and forces a line break.

[reference/cli](https://angular.dev/cli)

Issue Number: N/A

## What is the new behavior?

<img width="814" height="76" alt="image" src="https://github.com/user-attachments/assets/8307c167-4b0c-4da3-a730-e39e7ad15e72" />

Added `min-width: 8ch` to `td:has(code)` in `_table.scss`, giving table cells containing inline code enough horizontal space for short codes to render on the same line.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
