### PR TITLE
docs: add dev-app section to contributing docs

### DIFF
--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -6,6 +6,7 @@ It also explains the basic mechanics of using `git`, `node`, and `pnpm`.
 - [Building and Testing Angular](#building-and-testing-angular)
   - [Prerequisite Software](#prerequisite-software)
   - [Development in a Container](#development-in-a-container)
+  - [Experimenting in dev-app](#experimenting-in-dev-app)
   - [Getting the Sources](#getting-the-sources)
   - [Installing NPM Modules](#installing-npm-modules)
   - [Building](#building)
@@ -56,6 +57,10 @@ following on your development machine:
 ## Development in a Container
 
 You can also use the provided [Dev Container](https://containers.dev/) configuration to set up a development environment. This approach uses Docker to create a container with all the necessary tools (Node.js, pnpm, etc.) pre-installed.
+
+## Experimenting in dev-app
+
+For experimentation while developing Angular, consider running the [dev-app](../dev-app/README.md) in this repository.
 
 **Prerequisites:**
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

As someone wanting to run a build of the source in a project, I tried to follow the guide on linking to your own project. I had some friction doing all the symlink particulars, and have had issues in the past.

Issue Number: N/A

## What is the new behavior?

The convenient dev-app is now mentioned in the contributing docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Learned about this thanks to @SkyZeroZx 
