### PR TITLE
fix(ci): use immutable SHA for checkout reference

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -34,7 +34,7 @@ jobs:
           repository: ${{steps.comment-branch.outputs.head_owner}}/${{steps.comment-branch.outputs.head_repo}}
           # Checkout the pull request and assume it being trusted given we've checked
           # that the action was triggered by a team member.
-          ref: ${{steps.comment-branch.outputs.head_ref}}
+          ref: ${{steps.comment-branch.outputs.head_sha}}
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## PR Type
- [x] CI related changes

## What is the current behavior?

The workflow checks out the pull request using a mutable branch reference (`head_ref`). This can lead to non-deterministic behavior if the branch is updated between the triggering event and the checkout step.

## What is the new behavior?

The workflow now uses the immutable commit SHA (`head_sha`) for checkout, ensuring that the exact commit at the time of resolution is used.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This change improves reproducibility and consistency of benchmark runs by ensuring deterministic code checkout.