### PR TITLE
fix(core): allow explicit read generic with signal input transforms

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1017,6 +1017,8 @@ export interface InputFunction {
     <T>(initialValue: undefined, opts: InputOptionsWithoutTransform<T>): InputSignal<T | undefined>;
     <T, TransformT>(initialValue: T, opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;
     <T, TransformT>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, TransformT>): InputSignalWithTransform<T | undefined, TransformT>;
+    <T>(initialValue: T, opts: InputOptionsWithTransform<T, unknown>): InputSignalWithTransform<T, T>;
+    <T>(initialValue: undefined, opts: InputOptionsWithTransform<T | undefined, unknown>): InputSignalWithTransform<T | undefined, T | undefined>;
     required: {
         <T>(opts?: InputOptionsWithoutTransform<T>): InputSignal<T>;
         <T, TransformT>(opts: InputOptionsWithTransform<T, TransformT>): InputSignalWithTransform<T, TransformT>;

--- a/packages/core/src/authoring/input/input.ts
+++ b/packages/core/src/authoring/input/input.ts
@@ -77,6 +77,19 @@ export interface InputFunction {
     initialValue: undefined,
     opts: InputOptionsWithTransform<T | undefined, TransformT>,
   ): InputSignalWithTransform<T | undefined, TransformT>;
+  /**
+   * Declares an input of type `T` with an initial value and a transform function
+   * that accepts values of the same type.
+   */
+  <T>(initialValue: T, opts: InputOptionsWithTransform<T, unknown>): InputSignalWithTransform<T, T>;
+  /**
+   * Declares an input of type `T|undefined` without an initial value and with a transform
+   * function that accepts values of the same type.
+   */
+  <T>(
+    initialValue: undefined,
+    opts: InputOptionsWithTransform<T | undefined, unknown>,
+  ): InputSignalWithTransform<T | undefined, T | undefined>;
 
   /**
    * Initializes a required input.

--- a/packages/core/test/authoring/signal_input_signature_test.ts
+++ b/packages/core/test/authoring/signal_input_signature_test.ts
@@ -12,7 +12,7 @@
  * the resulting types match our expectations (via comments asserting the `.d.ts`).
  */
 
-import {input} from '../../src/core';
+import {booleanAttribute, input, numberAttribute} from '../../src/core';
 // import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
 // tslint:disable-next-line no-duplicate-imports
 import {InputSignal, InputSignalWithTransform} from '../../src/core';
@@ -100,6 +100,19 @@ export class InputSignatureTest {
   __requiredWithTransformButNoWriteT = input.required<string>({
     // @ts-expect-error
     transform: (v: string | boolean) => '',
+  });
+
+  /** boolean, boolean */
+  explicitReadWithBooleanAttributeTransform = input<boolean>(false, {transform: booleanAttribute});
+  /** number, number */
+  explicitReadWithNumberAttributeTransform = input<number>(0, {transform: numberAttribute});
+  /** boolean | undefined, boolean | undefined */
+  explicitReadWithUndefinedInitialBooleanAttributeTransform = input<boolean>(undefined, {
+    transform: booleanAttribute,
+  });
+  /** number | undefined, number | undefined */
+  explicitReadWithUndefinedInitialNumberAttributeTransform = input<number>(undefined, {
+    transform: numberAttribute,
   });
 
   /** string, string | boolean */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Using explicit single generic arguments with transforms, e.g. `input<boolean>(false, {transform: booleanAttribute})`, failed overload resolution.

Before this fix, type-checking produced:
```ts
✘ [ERROR] TS2769: No overload matches this call.
  Overload 1 of 5, '(initialValue: boolean, opts?: InputOptionsWithoutTransform<boolean> | undefined): InputSignal<boolean>', gave the following error.
    Type '(value: unknown) => boolean' is not assignable to type 'undefined'.
  Overload 2 of 5, '(initialValue: undefined, opts: InputOptionsWithoutTransform<boolean>): InputSignal<boolean | undefined>', gave the following error.
    Argument of type 'true' is not assignable to parameter of type 'undefined'. [plugin angular-compiler]
```

## What is the new behavior?

Add specialized overloads for `input(...)` with transform write type equal to read type, and add signature tests for `booleanAttribute`/`numberAttribute` with both defined and undefined initial values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
