### PR TITLE
docs(docs-infra): Enhances update guide layout responsiveness

### DIFF
--- a/adev/src/app/features/update/update.component.scss
+++ b/adev/src/app/features/update/update.component.scss
@@ -1,12 +1,12 @@
 @use '@angular/docs/styles/media-queries' as mq;
 
-$ver-dropdown-width: 200px;
+$ver-dropdown-width: clamp(165px, 20vw, 200px);
 
 :host {
   display: flex;
   flex-flow: column;
   align-items: center;
-  padding: var(--layout-padding) 0px;
+  padding: var(--layout-padding);
   container: update-guide-page / inline-size;
 
   .docs-viewer {


### PR DESCRIPTION
The version dropdown width now uses `clamp()` for better responsiveness.
 
## What is the current behavior?

 See on mobile https://next.angular.dev/update-guide
<img width="588" height="650" alt="image" src="https://github.com/user-attachments/assets/7f594056-2156-468d-a1d6-333ddea5b6df" />



## What is the new behavior?

 
<img width="387" height="509" alt="image" src="https://github.com/user-attachments/assets/5b979100-474d-4d72-a8ff-3724dc88afb7" />
