### PR TITLE
Prevent context capturing `hostElement` in onRendererDestroy

### DIFF
--- a/packages/animations/browser/src/render/animation_renderer.ts
+++ b/packages/animations/browser/src/render/animation_renderer.ts
@@ -46,7 +46,7 @@ export class AnimationRendererFactory implements RendererFactory2 {
       if (!renderer) {
         // Ensure that the renderer is removed from the cache on destroy
         // since it may contain references to detached DOM nodes.
-        const onRendererDestroy = () => cache.delete(delegate);
+        const onRendererDestroy = cache.delete.bind(cache, delegate);
         renderer = new BaseAnimationRenderer(
           EMPTY_NAMESPACE_ID,
           delegate,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

hostElement is retained by the onRendererDestroy callback, so if for some reason the renderer is not destroyed or is just retained without calling onRendererDestroy (bug in Angular? Possible but could just be a quirk of how we're using it in our app) hostElement is retained.

My best guess as to _why_ the callback itself is retained is that we hold on to a destroyed Renderer somewhere in our own code, but it is not in the retainer tree so seems unlikely. 

My heap snapshots show this retention path and ignoring it resolves the entire retention tree for the detached nodes.
<img width="1478" height="706" alt="image" src="https://github.com/user-attachments/assets/b4fcbd18-8e2a-48d1-ae43-8a5ad76cb0a4" />
<img width="1630" height="880" alt="image" src="https://github.com/user-attachments/assets/6b338d07-e577-481d-9dc6-0d0d51ce01a8" />

I want to note that I uncovered this while doing a great deal of refactoring on our application to figure out why we were leaking so many DOM nodes, so it's possible what I've proposed here is a red herring.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I dug into the v8 source to explain why this happens, and it seems likely to me that this is a true retainer due to how arrow functions capture scope. If someone is more hot on v8 scopes/contexts I'd love to use this as a chance to learn where I've gone astray in my reasoning.

===

V8 does per-variable context allocation, not whole-scope. A variable only gets heap-allocated (context slot) if an inner function actually references it across a function boundary: see [MustAllocateInContext](https://github.com/nicknisi/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/ast/scopes.cc#L2582-L2599) and [ForceContextAllocation](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/ast/variables.h#L80-L87). 

but all closures in the same function activation share ONE Context object per scope level. the Context has a slot for every variable that ANY inner function in that scope caused to be context-allocated — [scope-info.h comment](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/objects/scope-info.h#L74-L80)

In registerTrigger (the else branch for animated components) we reference hostElement, which forces it into the function-scope Context. the original onRendererDestroy arrow (the if branch for non-animated components) is a JSFunction whose [context field](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/objects/js-function.tq#L33-L38) points up through that same shared Context, so it transitively retains hostElement even though it never uses it and the two branches are mutually exclusive

Why use bind?

.bind() prevents capturing scope (this is well known!) JSBoundFunction [has no context field](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/objects/js-function.tq#L8-L18) — just bound_target_function, bound_this, bound_arguments. so the function-scope Context (with hostElement in it) gets GC'd after createRenderer returns

name resolution is where the force-allocation happens — when lookup crosses a function boundary, force_context_allocation flips to true: [scopes.cc L2287](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/ast/scopes.cc#L2287-L2288), and when the var is found it gets marked: [scopes.cc L2249-L2267](https://github.com/v8/v8/blob/d91f86417722e786787bc754717354f5384312cb/src/ast/scopes.cc#L2249-L2267)

