### PR TITLE
fix(docs-infra): align search result icon with text on mobile

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -27,14 +27,16 @@
                     </i>
                   </span>
 
-                  <!-- Page title -->
-                  <span [innerHtml]="result.labelHtml"></span>
-                  @if (result.package) {
-                    <span
-                      [innerHTML]="result.package"
-                      class="docs-search-result__label__package"
-                    ></span>
-                  }
+                  <!-- Page title and package badge -->
+                  <span class="docs-search-result__label__text">
+                    <span [innerHtml]="result.labelHtml"></span>
+                    @if (result.package) {
+                      <span
+                        [innerHTML]="result.package"
+                        class="docs-search-result__label__package"
+                      ></span>
+                    }
+                  </span>
                 </p>
 
                 @if (result.subLabelHtml) {

--- a/adev/shared-docs/components/search-dialog/search-dialog.component.scss
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.scss
@@ -46,6 +46,7 @@ dialog {
 
       .docs-search-result-icon {
         display: inline-block;
+        flex-shrink: 0;
 
         i {
           display: flex;
@@ -91,7 +92,20 @@ dialog {
 
       &__label {
         font-weight: 600;
-        flex-wrap: wrap;
+
+        &__text {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: baseline;
+          gap: 0.25rem 0.5rem;
+          flex: 1;
+          min-width: 0;
+          overflow-wrap: break-word;
+
+          > * {
+            min-width: 0;
+          }
+        }
 
         &__package {
           font-size: 0.75rem;


### PR DESCRIPTION
## Summary

Fixes the vertically misaligned icon in search result items on mobile viewports.

Closes https://github.com/angular/angular/issues/68005

## Problem

On narrow (mobile) viewports, the search result icon was pushed to its own flex line when the title text was too long. This caused the icon to appear at the top of the item, visually disconnected from the title text.

The root cause: `.docs-search-result__label` uses `display: flex` with `flex-wrap: wrap`. When the title span's min-content width (longest unbreakable word) plus the icon exceeded the container width, the title wrapped to the next flex line — leaving the icon orphaned on the first line.

## Fix

An HTML structure change in `search-dialog.component.html` and corresponding CSS update in `search-dialog.component.scss`:

The title text and package badge are wrapped in a new `<span class="docs-search-result__label__text">` container, while the icon stays as a direct sibling. This gives two flex children in `__label`:

1. **Icon** (`flex-shrink: 0`) — fixed-size, never squeezed or separated.
2. **Text wrapper** (`flex: 1; min-width: 0; display: flex; flex-wrap: wrap`) — takes remaining space; title text and badge flow inside it.

Since `__label` no longer has `flex-wrap: wrap`, the icon and text wrapper are always on the same flex line. Long title text word-wraps internally (`overflow-wrap: break-word` + `min-width: 0`). When the package badge doesn't fit, it wraps to the next line *within the text wrapper* — staying indented past the icon rather than dropping underneath it.