### PR TITLE
docs: add spam policy

### DIFF
--- a/contributing-docs/saved-issue-replies.md
+++ b/contributing-docs/saved-issue-replies.md
@@ -96,3 +96,11 @@ Once you've finished that update, you will need to force push using `git push [o
 ```
 Please rebase and squash your commits. To do this, make sure to `git fetch upstream` to get the latest changes from the angular repository. Then in your branch run `git rebase upstream/main -i` to do an interactive rebase. This should allow you to fixup or drop any unnecessary commits. After you finish the rebase, force push using `git push [origin name] [branch name] --force`.
 ```
+
+## Angular: Spam
+
+Woah, looks like you've opened a lot issues/PRs recently. While we appreciate contributions from the community, triaging and reviewing a large influx of content in a short time period takes time away from other ongoing projects. As a result, we're closing these issues/PRs to maintain the team's focus.
+
+Note that this is not necessarily a rejection of the goals or direction of any of these contributions in particular, so much as a reflection of the team's current capacity and priorities.
+
+You are welcome to open a smaller subset of issues/PRs in accordance with [our policy](/contributing-docs/spam.md) focused on the most important and impactful contributions and we will do our best to prioritize a response as soon as possible.

--- a/contributing-docs/spam.md
+++ b/contributing-docs/spam.md
@@ -1,0 +1,22 @@
+# Spam Policy
+
+Users who create excessive amounts of issues or PRs in a short time frame,
+particularly low-quality or low-value contributions may see those contributions
+automatically closed without consideration.
+
+Community contributors should limit themselves to no more than 3 open PRs at a
+single time.
+
+## Why?
+
+Reviewing and sheparding PRs as well as managing large issue counts takes time
+and energy from the core team. Triaging a PR well enough to understand its goals
+and implementation takes a significant amount of time, regardless of whether the
+PR is ultimately accepted. This policy ensures the team is able to balance its
+limited resources across all contributors and projects.
+
+## Exceptions
+
+If you plan to undertake more significant work that you anticipate will generate
+many individual PRs, please reach out to the team in a Github issue first to
+validate that Angular will be able to support and accept your contributions.


### PR DESCRIPTION
This defines an initial policy with regard to issue / PR spam as well as a saved reply for bulk-closing large issue / PR counts at once.