### PR TITLE
test(platform-server): replace fixed timeout with polling in event replay test

### DIFF
--- a/packages/platform-server/test/event_replay_spec.ts
+++ b/packages/platform-server/test/event_replay_spec.ts
@@ -792,11 +792,11 @@ describe('event replay', () => {
       // Eventually it should be empty again.
       // Since `invokeRegisteredReplayListeners` triggers hydration directly and pushes to queue.
 
-      // We can inspect the queue if we want.
-      // But mainly we want to ensure no crash and cleanup happens.
-
       // wait for replay
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      const start = Date.now();
+      while (queue.length > 0 && Date.now() - start < 1_000) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
       expect(queue.length).toBe(0);
     });
 


### PR DESCRIPTION
This test appears to be flakey in CI, presumably because resource constrained environments can run unexpected slower and exceed the timeout. This switches to a polling approach, waiting for the queue to drain.