### PR TITLE
test(http): disable XSRF and mock location in HttpClient tests to avoid Domino failures and state leakage

### DIFF
--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -9,7 +9,8 @@
 import {HttpClient} from '../src/client';
 import {HttpErrorResponse, HttpEventType, HttpResponse, HttpStatusCode} from '../src/response';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
-import {provideHttpClient} from '../src/provider';
+import {provideHttpClient, withNoXsrfProtection} from '../src/provider';
+import {ɵprovideFakePlatformNavigation} from '@angular/common/testing';
 import {TestBed} from '@angular/core/testing';
 import {toArray} from 'rxjs/operators';
 
@@ -18,7 +19,11 @@ describe('HttpClient', () => {
   let backend: HttpTestingController;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideHttpClient(withNoXsrfProtection()),
+        provideHttpClientTesting(),
+        ɵprovideFakePlatformNavigation(),
+      ],
     });
     client = TestBed.inject(HttpClient);
     backend = TestBed.inject(HttpTestingController);


### PR DESCRIPTION
The `HttpClient` tests in `client_spec.ts` were failing intermittently in Node/Domino environment because `MockPlatformLocation` defaults to `http://_empty_/`. This valid URL satisfied the URL parser in `xsrfInterceptorFn`, causing it to proceed to cookie extraction which throws `NotYetImplemented` in Domino.

To fix this:
1. Disabled XSRF protection in `client_spec.ts` using `withNoXsrfProtection()`, as these tests are not for XSRF.
2. Provided `ɵprovideFakePlatformNavigation` to remove state leakage effects and ensure consistency.