### PR TITLE
docs(docs-infra): preserve navigation origin when clicking cross-category links

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.html
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.html
@@ -53,7 +53,7 @@
                   matrixParams: 'ignored',
                   fragment: 'ignored',
                 }"
-                (click)="emitClickOnLink()"
+                (click)="emitClickOnLink(item)"
                 [matTooltip]="item.label"
                 [matTooltipDisabled]="itemLabel.length < 27"
                 matTooltipPosition="after"

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.spec.ts
@@ -153,5 +153,6 @@ describe('NavigationList', () => {
 class FakeNavigationListState {
   isOpened = signal(true);
   activeNavigationItem = signal(navigationItems.at(1));
+  crossCategoryOrigin = signal<NavigationItem | undefined>(undefined);
   toggleItem(item: NavigationItem) {}
 }

--- a/adev/shared-docs/components/navigation-list/navigation-list.component.ts
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.ts
@@ -39,6 +39,7 @@ export class NavigationList {
   readonly linkClicked = output<void>();
 
   private readonly navigationState = inject(NavigationState);
+  private readonly crossCategoryOrigin = this.navigationState.crossCategoryOrigin;
 
   readonly activeItem = this.navigationState.activeNavigationItem;
 
@@ -50,10 +51,19 @@ export class NavigationList {
     ) {
       return;
     }
+    const prevParentItem = this.crossCategoryOrigin();
+    if (prevParentItem) {
+      this.crossCategoryOrigin.set(undefined);
+      this.navigationState.toggleItem(prevParentItem);
+      return;
+    }
     this.navigationState.toggleItem(item);
   }
 
-  emitClickOnLink(): void {
+  emitClickOnLink(item: NavigationItem): void {
+    if (item.isCrossReferenced) {
+      this.crossCategoryOrigin.set(item.parent);
+    }
     this.linkClicked.emit();
   }
 

--- a/adev/shared-docs/interfaces/navigation-item.ts
+++ b/adev/shared-docs/interfaces/navigation-item.ts
@@ -17,5 +17,6 @@ export interface NavigationItem {
   contentPath?: string;
   status?: 'new' | 'updated';
   category?: string;
+  isCrossReferenced?: boolean;
   preserveOtherCategoryOrder?: boolean; // true by default
 }

--- a/adev/shared-docs/services/navigation-state.service.ts
+++ b/adev/shared-docs/services/navigation-state.service.ts
@@ -21,6 +21,7 @@ export class NavigationState {
   private readonly _isMobileNavVisible = signal<boolean>(false);
   private readonly _level = linkedSignal(() => this._expandedItems().length);
 
+  readonly crossCategoryOrigin = signal<NavigationItem | undefined>(undefined);
   readonly primaryActiveRouteItem = signal<string | null>(null);
   activeNavigationItem = this._activeNavigationItem.asReadonly();
   expandedItems = this._expandedItems.asReadonly();

--- a/adev/src/app/routing/navigation-entries/index.ts
+++ b/adev/src/app/routing/navigation-entries/index.ts
@@ -660,6 +660,7 @@ export const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             path: 'guide/routing/testing',
             contentPath: 'guide/routing/testing',
             status: 'new',
+            isCrossReferenced: true,
           },
           {
             label: 'Debugging tests',
@@ -863,6 +864,7 @@ export const DOCS_SUB_NAVIGATION_DATA: NavigationItem[] = [
             label: 'Route transition animations',
             path: 'guide/routing/route-transition-animations',
             contentPath: 'guide/routing/route-transition-animations',
+            isCrossReferenced: true,
           },
         ],
       },


### PR DESCRIPTION
docs(docs-infra): preserve navigation origin when clicking cross-category links

When a sidebar item links to a page in a different category (e.g., "Route transition animations" under Animations links to a Routing page), clicking back navigates to the main menu instead of the originating category.

Store the originating category in NavigationState when clicking a cross-referenced item, so the back button returns to the correct section.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When navigating to a cross-category link in the docs sidebar (e.g., clicking
"Route transition animations" under Animations, which routes to a Routing
page), the sidebar switches to the Routing section. Pressing the back arrow
navigates to the main menu instead of returning to Animations.

The same issue affects "Testing routing and navigation" under Testing, which
routes to a Routing page.

https://github.com/user-attachments/assets/0e253e7c-9edd-4570-a992-7029b443127c


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Clicking back returns to the originating category. A `crossCategoryOrigin`
signal in `NavigationState` stores the parent section when a cross-referenced
item is clicked. The back button checks this signal and navigates to the
stored origin instead of the main menu.

Items that link across categories are marked with `isCrossReferenced: true`
in the navigation data.


https://github.com/user-attachments/assets/76961629-aabf-4de1-b39e-e5e798b53773




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information



Affected files:
- `NavigationItem` interface — added `isCrossReferenced` property
- `NavigationState` service — added `crossCategoryOrigin` signal
- `NavigationList` component — back button and link click logic
- Navigation entries — flagged 2 cross-category items
