### PR TITLE
fix(core): ViewProviders are injected into projected content if new flow-syntax is used

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -567,9 +567,13 @@ function lookupTokenUsingNodeInjector<T>(
       if (parentLocation === NO_PARENT_INJECTOR || !shouldSearchParent(flags, false)) {
         injectorIndex = -1;
       } else {
+        const viewOffset = parentLocation >> RelativeInjectorLocationFlags.ViewOffsetShift;
         previousTView = lView[TVIEW];
+        for (let i = 0; i < viewOffset; i++) {
+          previousTView = lView[TVIEW];
+          lView = lView[DECLARATION_VIEW]!;
+        }
         injectorIndex = getParentInjectorIndex(parentLocation);
-        lView = getParentInjectorView(parentLocation, lView);
       }
     }
 
@@ -609,9 +613,13 @@ function lookupTokenUsingNodeInjector<T>(
       ) {
         // The def wasn't found anywhere on this node, so it was a false positive.
         // Traverse up the tree and continue searching.
-        previousTView = tView;
+        const viewOffset = parentLocation >> RelativeInjectorLocationFlags.ViewOffsetShift;
+        previousTView = lView[TVIEW];
+        for (let i = 0; i < viewOffset; i++) {
+          previousTView = lView[TVIEW];
+          lView = lView[DECLARATION_VIEW]!;
+        }
         injectorIndex = getParentInjectorIndex(parentLocation);
-        lView = getParentInjectorView(parentLocation, lView);
       } else {
         // If we should not search parent OR If the ancestor bloom filter value does not have the
         // bit corresponding to the directive we can give up on traversing up to find the specific
@@ -652,7 +660,9 @@ function searchTokensOnInjector<T>(
         // - AND the parent TNode is an Element.
         // This means that we just came from the Component's View and therefore are allowed to see
         // into the ViewProviders.
-        previousTView != currentTView && (tNode.type & TNodeType.AnyRNode) !== 0;
+        previousTView != currentTView &&
+        (tNode.type & TNodeType.Element) !== 0 &&
+        previousTView.type === TViewType.Component;
 
   // This special case happens when there is a @host on the inject and when we are searching
   // on the host element node.

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7193,4 +7193,129 @@ describe('di', () => {
       );
     });
   });
+
+  describe('control flow + viewProviders', () => {
+    it('should not allow projected content to see viewProviders when wrapped in @if', () => {
+      const token = new InjectionToken<string>('token');
+
+      @Component({
+        selector: 'app-child-component',
+        template: '{{value}}',
+      })
+      class ChildComponent {
+        value = inject(token);
+      }
+
+      @Component({
+        selector: 'app-provider-component',
+        providers: [{provide: token, useValue: 'provider'}],
+        viewProviders: [{provide: token, useValue: 'viewProvider'}],
+        template: `
+          <div>
+            Projected<br />
+            <ng-content></ng-content>
+          </div>
+        `,
+      })
+      class ProviderComponent {}
+
+      @Component({
+        selector: 'app-test-new-flow',
+        imports: [ProviderComponent, ChildComponent],
+        template: `
+          <app-provider-component>
+            @if (true) {
+              <app-child-component />
+            }
+          </app-provider-component>
+        `,
+      })
+      class TestNewFlowComponent {}
+
+      @Component({
+        selector: 'app-test-old-flow',
+        imports: [ProviderComponent, ChildComponent, CommonModule],
+        template: `
+          <app-provider-component>
+            <app-child-component *ngIf="flag" />
+          </app-provider-component>
+        `,
+      })
+      class TestOldFlowComponent {
+        flag = true;
+      }
+
+      // Test old syntax it's ok
+      const oldFixture = TestBed.createComponent(TestOldFlowComponent);
+      oldFixture.detectChanges();
+      expect(oldFixture.nativeElement.textContent).toContain('provider');
+      expect(oldFixture.nativeElement.textContent).not.toContain('viewProvider');
+
+      // Test that the new syntax behaves like the old one
+      const newFixture = TestBed.createComponent(TestNewFlowComponent);
+      newFixture.detectChanges();
+      expect(newFixture.nativeElement.textContent).toContain('provider');
+      expect(newFixture.nativeElement.textContent).not.toContain('viewProvider');
+    });
+
+    it('should allow a directive in an @if block to inject a token from viewProviders', () => {
+      const TOKEN = new InjectionToken<string>('token');
+
+      @Directive({
+        selector: '[testDir]',
+      })
+      class TestDir {
+        value = inject(TOKEN);
+      }
+
+      @Component({
+        selector: 'test-comp',
+        imports: [TestDir],
+        viewProviders: [{provide: TOKEN, useValue: 'view-value'}],
+        template: `
+          @if (true) {
+            <div testDir></div>
+          }
+        `,
+      })
+      class TestComp {
+        @ViewChild(TestDir) testDir!: TestDir;
+      }
+
+      const fixture = TestBed.createComponent(TestComp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.testDir.value).toBe('view-value');
+    });
+
+    it('should allow a directive in nested @if blocks to inject a token from viewProviders', () => {
+      const TOKEN = new InjectionToken<string>('token');
+
+      @Directive({
+        selector: '[testDir]',
+      })
+      class TestDir {
+        value = inject(TOKEN);
+      }
+
+      @Component({
+        selector: 'test-comp',
+        imports: [TestDir],
+        viewProviders: [{provide: TOKEN, useValue: 'view-value'}],
+        template: `
+          @if (true) {
+            <div testDir></div>
+          }
+        `,
+      })
+      class TestComp {
+        @ViewChild(TestDir) testDir!: TestDir;
+      }
+
+      const fixture = TestBed.createComponent(TestComp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.testDir.value).toBe('view-value');
+    });
+  });
 });


### PR DESCRIPTION
The change limits access to viewProviders to components only, isolating control flow and restoring proper encapsulation of ng-content.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

ViewProviders are injected into projected content if new flow-syntax is used

Issue Number: #63312

## What is the new behavior?

ViewProviders correct for new control-flow syntax

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
