### PR TITLE
fix(language-service): Provide support for protected signal inputs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -446,29 +446,22 @@ export class SymbolBuilder {
     });
     const bindings: BindingSymbol[] = [];
     for (const node of nodes) {
-      if (!isAccessExpression(node.left)) {
+      if (!isAccessExpression(node.left) && !ts.isIdentifier(node.left)) {
         continue;
       }
 
-      const signalInputAssignment = unwrapSignalInputWriteTAccessor(node.left);
-      let fieldAccessExpr: ts.PropertyAccessExpression | ts.ElementAccessExpression;
-      // Signal inputs need special treatment because they are generated with an extra keyed
-      // access. E.g. `_t1.prop[WriteT_ACCESSOR_SYMBOL]`. Observations:
-      //   - The keyed access for the write type needs to be resolved for the "input type".
-      //   - The definition symbol of the input should be the input class member, and not the
-      //     internal write accessor. Symbol should resolve `_t1.prop`.
+      const signalInputAssignment = isAccessExpression(node.left)
+        ? unwrapSignalInputWriteTAccessor(node.left)
+        : null;
+      let fieldAccessExpr: ts.PropertyAccessExpression | ts.ElementAccessExpression | ts.Identifier;
       let tcbLocation: TcbLocation;
-      if (signalInputAssignment !== null) {
-        // Note: If the field expression for the input binding refers to just an identifier,
-        // then we are handling the case of a temporary variable being used for the input field.
-        // This is the case with `honorAccessModifiersForInputBindings = false` and in those cases
-        // we cannot resolve the owning directive, similar to how we guard above with `isAccessExpression`.
-        if (ts.isIdentifier(signalInputAssignment.fieldExpr)) {
-          continue;
-        }
 
+      if (signalInputAssignment !== null) {
         fieldAccessExpr = signalInputAssignment.fieldExpr;
         tcbLocation = this.getTcbLocationForNode(fieldAccessExpr);
+      } else if (ts.isIdentifier(node.left)) {
+        fieldAccessExpr = node.left;
+        tcbLocation = this.getTcbLocationForNode(node.left);
       } else {
         fieldAccessExpr = node.left;
         tcbLocation = this.getTcbLocationForNode(fieldAccessExpr);
@@ -498,13 +491,15 @@ export class SymbolBuilder {
   }
 
   private getDirectiveSymbolForAccessExpression(
-    fieldAccessExpr: ts.ElementAccessExpression | ts.PropertyAccessExpression,
+    fieldAccessExpr: ts.ElementAccessExpression | ts.PropertyAccessExpression | ts.Identifier,
     meta: SymbolDirectiveMeta,
   ): DirectiveSymbol | null {
     return {
       ref: meta.getSymbolReference(),
       kind: SymbolKind.Directive,
-      tcbLocation: this.getTcbLocationForNode(fieldAccessExpr.expression),
+      tcbLocation: ts.isIdentifier(fieldAccessExpr)
+        ? this.getTcbLocationForNode(fieldAccessExpr)
+        : this.getTcbLocationForNode(fieldAccessExpr.expression),
       isComponent: meta.isComponent,
       isStructural: meta.isStructural,
       selector: meta.selector,
@@ -927,4 +922,18 @@ function extractNameFromTypeNode(node: ts.Node): string | null {
     if (ts.isIdentifier(typeName)) return typeName.text;
   }
   return null;
+}
+
+/**
+ * Extracts the type node from a TCB variable declaration, handling both direct types
+ * and types specified in an `as` expression in the initializer.
+ */
+function getTcbVariableType(declaration: ts.VariableDeclaration): ts.TypeNode | undefined {
+  if (declaration.type) {
+    return declaration.type;
+  }
+  if (declaration.initializer && ts.isAsExpression(declaration.initializer)) {
+    return declaration.initializer.type;
+  }
+  return undefined;
 }

--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -127,8 +127,101 @@ export class QuickInfoBuilder {
     const kind =
       symbol.kind === SymbolKind.Input ? DisplayInfoKind.PROPERTY : DisplayInfoKind.EVENT;
 
-    const quickInfo = this.getQuickInfoAtTcbLocation(symbol.bindings[0].tcbLocation);
-    return quickInfo === undefined ? undefined : updateQuickInfoKind(quickInfo, kind);
+    const binding = symbol.bindings[0];
+    const tcbQuickInfo = this.getQuickInfoAtTcbLocation(binding.tcbLocation);
+
+    const program = this.tsLS.getProgram();
+    if (program && binding.target && binding.target.kind === SymbolKind.Directive) {
+      const tcbFile = program.getSourceFile(binding.tcbLocation.tcbPath);
+      if (tcbFile) {
+        const node = findNodeAtPosition(tcbFile, binding.tcbLocation.positionInFile);
+        let propertyName: string | undefined;
+
+        if (node) {
+          if (ts.isIdentifier(node)) {
+            const varName = node.text;
+            const declaration = findVariableDeclaration(tcbFile, varName);
+            if (declaration) {
+              const typeNode = getTcbVariableType(declaration);
+              if (typeNode && ts.isTypeQueryNode(typeNode)) {
+                const exprName = typeNode.exprName;
+                let propName: string | undefined;
+                if (ts.isQualifiedName(exprName)) {
+                  propName = exprName.right.text;
+                } else if (ts.isIdentifier(exprName)) {
+                  propName = exprName.text;
+                }
+                if (propName && propName.startsWith('ngAcceptInputType_')) {
+                  propertyName = propName.substring('ngAcceptInputType_'.length);
+                }
+              }
+            }
+          }
+
+          if (!propertyName) {
+            let curr: ts.Node | undefined = node;
+            while (
+              curr &&
+              !ts.isPropertyAccessExpression(curr) &&
+              !ts.isElementAccessExpression(curr)
+            ) {
+              curr = curr.parent;
+            }
+            if (curr) {
+              if (ts.isPropertyAccessExpression(curr)) {
+                propertyName = curr.name.text;
+              } else if (
+                ts.isElementAccessExpression(curr) &&
+                ts.isStringLiteral(curr.argumentExpression)
+              ) {
+                propertyName = curr.argumentExpression.text;
+              }
+            }
+          }
+
+          if (!propertyName && 'name' in this.node && typeof this.node.name === 'string') {
+            propertyName = this.node.name;
+          }
+        }
+
+        if (propertyName) {
+          // Check if TCB quick info is valid and contains the property name!
+          if (tcbQuickInfo && tcbQuickInfo.displayParts) {
+            const containsProp = tcbQuickInfo.displayParts.some((p) => p.text === propertyName);
+            const isTemp = tcbQuickInfo.displayParts.some((p) => p.text.startsWith('_t'));
+
+            if (containsProp && !isTemp) {
+              const textSpan = getTextSpanOfNode(this.node);
+              return updateQuickInfoKind({...tcbQuickInfo, textSpan}, kind);
+            }
+          }
+
+          // Fallback to class property lookup!
+          const classDecl = binding.target.ref.node;
+          if (ts.isClassDeclaration(classDecl)) {
+            const member = classDecl.members.find(
+              (m: ts.ClassElement) =>
+                m.name && ts.isIdentifier(m.name) && m.name.text === propertyName,
+            );
+            if (member && member.name) {
+              const fileName = classDecl.getSourceFile().fileName;
+              const position = member.name.getStart();
+              const declInfo = this.tsLS.getQuickInfoAtPosition(fileName, position);
+              if (declInfo) {
+                if (declInfo.displayParts) {
+                  declInfo.displayParts = filterAliasImports(declInfo.displayParts);
+                }
+                const textSpan = getTextSpanOfNode(this.node);
+                return updateQuickInfoKind({...declInfo, textSpan}, kind);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Ultimate fallback to TCB QuickInfo!
+    return tcbQuickInfo === undefined ? undefined : updateQuickInfoKind(tcbQuickInfo, kind);
   }
 
   private getQuickInfoForElementSymbol(symbol: ElementSymbol): ts.QuickInfo {
@@ -330,4 +423,37 @@ function updateQuickInfoKind(quickInfo: ts.QuickInfo, kind: DisplayInfoKind): ts
 
 function displayPartsEqual(a: {text: string; kind: string}, b: {text: string; kind: string}) {
   return a.text === b.text && a.kind === b.kind;
+}
+
+function findNodeAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node | undefined {
+  function find(node: ts.Node): ts.Node | undefined {
+    if (position >= node.getStart() && position <= node.getEnd()) {
+      return ts.forEachChild(node, find) || node;
+    }
+    return undefined;
+  }
+  return find(sourceFile);
+}
+
+function getTcbVariableType(declaration: ts.VariableDeclaration): ts.TypeNode | undefined {
+  if (declaration.type) {
+    return declaration.type;
+  }
+  if (declaration.initializer && ts.isAsExpression(declaration.initializer)) {
+    return declaration.initializer.type;
+  }
+  return undefined;
+}
+
+function findVariableDeclaration(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration | undefined {
+  function find(node: ts.Node): ts.VariableDeclaration | undefined {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name) {
+      return node;
+    }
+    return ts.forEachChild(node, find);
+  }
+  return find(sourceFile);
 }

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -13,7 +13,7 @@ import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv, Project}
 function quickInfoSkeleton(): {[fileName: string]: string} {
   return {
     'app.ts': `
-        import {Component, Directive, EventEmitter, Input, NgModule, Output, Pipe, PipeTransform, model, signal} from '@angular/core';
+        import {Component, Directive, EventEmitter, Input, NgModule, Output, Pipe, PipeTransform, input, model, signal} from '@angular/core';
         import {CommonModule} from '@angular/common';
 
         export interface Address {
@@ -97,6 +97,22 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
         }
 
         @Directive({
+          selector: '[signal-input]',
+          standalone: false,
+        })
+        export class SignalInput {
+          signalInput = input<string>();
+        }
+
+        @Directive({
+          selector: '[restricted-signal-input]',
+          standalone: false,
+        })
+        export class RestrictedSignalInput {
+          protected restrictedSignalInput = input<string>();
+        }
+
+        @Directive({
           selector: 'button[custom-button][compound]',
           standalone: false,
         })
@@ -122,6 +138,8 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
             StringModel,
             TestComponent,
             SignalModel,
+            SignalInput,
+            RestrictedSignalInput,
             DeprecatedDirective
           ],
           imports: [
@@ -285,6 +303,81 @@ describe('quick info', () => {
             expectedDisplayString:
               '(property) SignalModel.signalModel: ModelSignal<string | undefined>',
           });
+        });
+
+        it('should work for signal inputs', () => {
+          expectQuickInfo({
+            templateOverride: `<div signal-input [signal¦Input]="signalValue"></div>`,
+            expectedSpanText: 'signalInput',
+            expectedDisplayString:
+              '(property) SignalInput.signalInput: InputSignal<string | undefined>',
+          });
+        });
+
+        it('should work for restricted signal inputs', () => {
+          const customEnv = LanguageServiceTestEnv.setup();
+          const customProject = customEnv.addProject('custom-test', quickInfoSkeleton());
+
+          const text = `<div restricted-signal-input [restricted¦SignalInput]="signalValue"></div>`;
+          const templateOverride = text;
+          const expectedSpanText = 'restrictedSignalInput';
+          const expectedDisplayString =
+            '(property) RestrictedSignalInput.restrictedSignalInput: InputSignal<string | undefined>';
+
+          const template = customProject.openFile('app.html');
+          template.contents = text.replace('¦', '');
+          customEnv.expectNoSourceDiagnostics();
+
+          template.moveCursorToText(templateOverride);
+          const quickInfo = template.getQuickInfoAtPosition();
+          expect(quickInfo).toBeTruthy();
+          const {textSpan, displayParts} = quickInfo!;
+          expect(
+            template.contents.substring(textSpan.start, textSpan.start + textSpan.length),
+          ).toEqual(expectedSpanText);
+          expect(toText(displayParts)).toEqual(expectedDisplayString);
+        });
+
+        it('should work for inputs with ngAcceptInputType_', () => {
+          const customEnv = LanguageServiceTestEnv.setup();
+          const files = quickInfoSkeleton();
+          files['app.ts'] = files['app.ts'].replace(
+            'declarations: [',
+            'declarations: [\n            CoercedInputDir,',
+          );
+          files['app.ts'] = files['app.ts'].replace(
+            '@NgModule({',
+            `
+            @Directive({
+              selector: '[coerced-input]',
+              standalone: false,
+            })
+            export class CoercedInputDir {
+              @Input() coerced!: boolean;
+              static ngAcceptInputType_coerced: boolean | string;
+            }
+            
+            @NgModule({`,
+          );
+          const customProject = customEnv.addProject('custom-test', files);
+
+          const text = `<div coerced-input [coerced¦]="true"></div>`;
+          const templateOverride = text;
+          const expectedSpanText = 'coerced';
+          const expectedDisplayString = '(property) CoercedInputDir.coerced: boolean';
+
+          const template = customProject.openFile('app.html');
+          template.contents = text.replace('¦', '');
+          customEnv.expectNoSourceDiagnostics();
+
+          template.moveCursorToText(templateOverride);
+          const quickInfo = template.getQuickInfoAtPosition();
+          expect(quickInfo).toBeTruthy();
+          const {textSpan, displayParts} = quickInfo!;
+          expect(
+            template.contents.substring(textSpan.start, textSpan.start + textSpan.length),
+          ).toEqual(expectedSpanText);
+          expect(toText(displayParts)).toEqual(expectedDisplayString);
         });
       });
 


### PR DESCRIPTION
built on top of https://github.com/angular/angular/pull/67961 because otherwise the solution would default to using the typechecker that we're trying to remove