### PR TITLE
Add DI graph AI debugging tool

### DIFF
--- a/packages/core/src/debug/ai/di_graph.ts
+++ b/packages/core/src/debug/ai/di_graph.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getLContext} from '../../render3/context_discovery';
+import {NodeInjector} from '../../render3/di';
+import {TDirectiveHostNode, TNode} from '../../render3/interfaces/node';
+import {INJECTOR, LView, T_HOST, TVIEW, TViewType} from '../../render3/interfaces/view';
+import {DiGraph, SerializedInjector, serializeInjector} from './serialized_di_graph';
+import {ChainedInjector} from '../../render3/chained_injector';
+import {Injector} from '../../di/injector';
+import {ToolDefinition} from './tool_definitions';
+import {walkLViewDirectives} from './traversal';
+import {getLViewParent} from '../../render3/util/view_utils';
+import {R3Injector} from '../../di/r3_injector';
+import {NullInjector} from '../../di/null_injector';
+
+/** Tool that exposes Angular's DI graph to AI agents. */
+export const diGraphTool: ToolDefinition<{}, DiGraph> = {
+  name: 'angular:di_graph',
+  // tslint:disable-next-line:no-toplevel-property-access
+  description: `
+Exposes the Angular Dependency Injection (DI) graph of the application.
+
+This tool extracts both the element injector tree (associated with DOM elements and components)
+and the environment injector tree (associated with modules and standalone application roots).
+It captures the relationship structure and the providers resolved at each level.
+
+Returns:
+- \`elementInjectorRoots\`: An array of root element injectors (one for each Angular application
+  root found). Each node forms a tree hierarchy:
+  - \`name\`: The constructor name of this injector.
+  - \`type\`: 'element'.
+  - \`providers\`: Array of providers configured on this injector.
+    - \`token\`: The DI token.
+    - \`value\`: The resolved value of that provider if it was instantiated.
+  - \`hostElement\`: The DOM element that this injector is associated with.
+  - \`children\`: Array of child element injectors.
+- \`environmentInjectorRoot\`: The root environment injector. It forms a tree hierarchy of nodes
+  representing all environment injectors:
+  - \`name\`: The identifier for the environment injector.
+  - \`type\`: 'environment' or 'null'.
+  - \`providers\`: Array of providers configured on this injector.
+    - \`token\`: The DI token.
+    - \`value\`: The resolved value of that provider if it was instantiated.
+  - \`children\`: Array of child environment injectors.
+  `.trim(),
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+  execute: async () => {
+    const roots = Array.from(document.querySelectorAll('[ng-version]')) as HTMLElement[];
+    if (roots.length === 0) {
+      throw new Error('Could not find Angular root element ([ng-version]) on the page.');
+    }
+    return discoverDiGraph(roots);
+  },
+};
+
+/**
+ * Traverses the Angular internal tree from the root to discover element and environment injectors.
+ */
+function discoverDiGraph(roots: HTMLElement[]): DiGraph {
+  const rootLViews = roots.map((root) => {
+    const lContext = getLContext(root);
+    if (!lContext?.lView) {
+      throw new Error(
+        `Could not find an \`LView\` for root \`<${root.tagName.toLowerCase()}>\`, is it an Angular component?`,
+      );
+    }
+    return lContext.lView;
+  });
+
+  return {
+    elementInjectorRoots: rootLViews.map((rootLView) => walkElementInjectors(rootLView)),
+    environmentInjectorRoot: collectEnvInjectors(rootLViews),
+  };
+}
+
+/**
+ * Traverses all directive-hosting nodes in the `rootLView` hierarchy and builds a tree of
+ * serialized element injectors.
+ *
+ * This function uses `walkLViewDirectives` to visit nodes in depth-first order and a stack
+ * to reconstruct the hierarchical tree of injectors, handling both same-view and cross-view
+ * relationships.
+ *
+ * @param rootLView The root view to start traversal from.
+ * @returns The root {@link SerializedInjector} object.
+ */
+function walkElementInjectors(rootLView: LView): SerializedInjector {
+  // Assert that we were given a root `LView` rather than a random component.
+  // A root component actually gets two `LView` objects, the "root `LView`" with
+  // `type === TViewType.Root` and then an `LView` for the component itself as a child.
+  if (rootLView[TVIEW].type !== TViewType.Root) {
+    throw new Error(`Expected a root LView but got type: \`${rootLView[TVIEW].type}\`.`);
+  }
+
+  // Track the injectors we're currently processing.
+  const stack: Array<[TNode, LView, SerializedInjector]> = [];
+
+  // By constraining `rootLView` to only accepting root `LView` objects, we don't have to
+  // process `rootLView` itself, knowing that it won't be a component or directive.
+  // We can just check its descendants.
+  for (const [tNode, lView] of walkLViewDirectives(rootLView)) {
+    const injector = new NodeInjector(tNode as TDirectiveHostNode, lView);
+    const serialized = serializeInjector(injector);
+
+    // Look for our nearest ancestor in the stack.
+    while (stack.length > 0) {
+      const [lastTNode, lastLView, lastInjector] = stack[stack.length - 1];
+
+      const isDescendantInSameView = isTNodeDescendant(tNode, lastTNode);
+      const isDescendantInDifferentView = isLViewDescendantOfTNode(lView, lastLView, lastTNode);
+      if (isDescendantInSameView || isDescendantInDifferentView) {
+        // This injector is a child of the current last injector in the stack.
+        lastInjector.children.push(serialized);
+        break;
+      } else {
+        stack.pop();
+      }
+    }
+
+    // Future injectors might be children of this one.
+    stack.push([tNode, lView, serialized]);
+  }
+
+  // Since all component/directive LViews are descendants of the root LView, the first
+  // item on the stack must still remain and will be the root injector.
+  if (stack.length === 0) {
+    throw new Error(`Expected at least one component/directive in the root \`LView\`.`);
+  }
+  const [, , rootInjector] = stack[0];
+  return rootInjector;
+}
+
+/**
+ * Collects and serializes all environment injectors found in the hierarchy of the given
+ * `rootLViews`.
+ *
+ * Injectors have pointers to their parents, but not their children, so walking "down" the
+ * hierarchy is not a generally supported operation.
+ *
+ * The function walks down the `LView` hierarchy to find all the component/directive descendants.
+ * For each one, it then walks back up the injector hierarchy to find the full set of environment
+ * injectors.
+ *
+ * @param rootLViews The root views to start traversal from.
+ * @returns The root {@link SerializedInjector} object containing the entire environment
+ *     injector tree.
+ */
+function collectEnvInjectors(rootLViews: LView[]): SerializedInjector {
+  const serializedEnvInjectorMap = new Map<Injector, SerializedInjector>();
+  let rootEnvInjector: SerializedInjector | undefined = undefined;
+
+  /**
+   * Serialize all the ancestors of the given injector and return
+   * its serialized version.
+   *
+   * @param injector The environment injector to start from.
+   * @returns The serialized form of the input {@link Injector}.
+   */
+  function serializeAncestors(injector: Injector): SerializedInjector {
+    const existing = serializedEnvInjectorMap.get(injector);
+    if (existing) return existing;
+
+    const serialized = serializeInjector(injector);
+    serializedEnvInjectorMap.set(injector, serialized);
+
+    const parentInjector = getParentEnvInjector(injector);
+    if (parentInjector) {
+      // Recursively process the parent and attach ourselves as a child.
+      const parentSerialized = serializeAncestors(parentInjector);
+      parentSerialized.children.push(serialized);
+    } else {
+      // If there is no parent, this is a root environment injector.
+      if (!rootEnvInjector) {
+        rootEnvInjector = serialized;
+      } else if (rootEnvInjector !== serialized) {
+        throw new Error('Expected only one root environment injector, but found multiple.', {
+          cause: {firstRoot: rootEnvInjector, secondRoot: serialized},
+        });
+      }
+    }
+
+    return serialized;
+  }
+
+  // Process all descendant environment injectors.
+  for (const rootLView of rootLViews) {
+    for (const [, lView] of walkLViewDirectives(rootLView)) {
+      serializeAncestors(lView[INJECTOR]);
+    }
+  }
+
+  if (!rootEnvInjector) {
+    throw new Error('Expected a root environment injector but did not find one.');
+  }
+
+  return rootEnvInjector;
+}
+
+/**
+ * Checks if `node` is a descendant of `ancestor` within the SAME view.
+ *
+ * Since we are in the same view, we can safely use `tNode.parent` to determine
+ * if `ancestor` is an ancestor of the current `node`.
+ */
+function isTNodeDescendant(node: TNode, ancestor: TNode): boolean {
+  let curr: TNode | null = node;
+  while (curr) {
+    if (curr === ancestor) return true;
+    curr = curr.parent;
+  }
+  return false;
+}
+
+/**
+ * Checks if `lView` is a descendant of `parentTNode` in `parentLView` (crossing view boundaries).
+ *
+ * `tNode.parent` is restricted to referring to nodes within the SAME view. When we cross
+ * view boundaries (e.g., entering a component's internal view or an embedded view like `@if`),
+ * `tNode.parent` becomes `null` or points to something inside that view, breaking the chain to the
+ * outside.
+ *
+ * To solve this, we use the `LView` hierarchy to find if the current view is a descendant of the
+ * `parentLView`.
+ */
+function isLViewDescendantOfTNode(lView: LView, parentLView: LView, parentTNode: TNode): boolean {
+  let currentLView: LView | null = lView;
+  let hostTNode: TNode | null = null;
+
+  while (currentLView && currentLView !== parentLView) {
+    hostTNode = currentLView[T_HOST];
+    currentLView = getLViewParent(currentLView);
+  }
+
+  return (
+    currentLView === parentLView && hostTNode !== null && isTNodeDescendant(hostTNode, parentTNode)
+  );
+}
+
+/** Find the parent environment injector of the given injector. */
+function getParentEnvInjector(injector: Injector): Injector | undefined {
+  if (injector instanceof ChainedInjector) {
+    // We skip `chainedInjector.injector` because that points at the parent element injector
+    // which is handled by `walkElementInjectors`.
+    const chainedInjector = injector;
+    return chainedInjector.parentInjector;
+  } else if (injector instanceof R3Injector) {
+    return injector.parent;
+  } else if (injector instanceof NullInjector) {
+    return undefined;
+  } else {
+    throw new Error(`Unknown injector type: "${injector.constructor.name}".`);
+  }
+}

--- a/packages/core/src/debug/ai/registration.ts
+++ b/packages/core/src/debug/ai/registration.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {diGraphTool} from './di_graph';
 import {signalGraphTool} from './signal_graph';
 import {DevtoolsToolDiscoveryEvent} from './tool_definitions';
 
@@ -26,7 +27,7 @@ export function registerAiTools(): () => void {
     const event = inputEvent as DevtoolsToolDiscoveryEvent;
     event.respondWith({
       name: 'Angular',
-      tools: [signalGraphTool],
+      tools: [diGraphTool, signalGraphTool],
     });
   }
 

--- a/packages/core/src/debug/ai/serialized_di_graph.ts
+++ b/packages/core/src/debug/ai/serialized_di_graph.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Injector} from '../../di/injector';
+import {getNodeInjectorTNode, NodeInjector} from '../../render3/di';
+import {TNodeProviderIndexes} from '../../render3/interfaces/node';
+import {
+  getInjectorMetadata,
+  getInjectorProviders,
+} from '../../render3/util/injector_discovery_utils';
+
+/**
+ * A serialized representation of an Angular dependency injection graph.
+ */
+export interface DiGraph {
+  /** The roots of the element injector trees starting from the requested root elements. */
+  elementInjectorRoots: SerializedInjector[];
+
+  /** The root of the environment injector tree for the application. */
+  environmentInjectorRoot: SerializedInjector;
+}
+
+/**
+ * A serialized representation of an Angular injector.
+ */
+export type SerializedInjector =
+  | ElementSerializedInjector
+  | EnvironmentSerializedInjector
+  | NullSerializedInjector;
+
+export interface ElementSerializedInjector {
+  name: string;
+  type: 'element';
+  providers: SerializedProvider[];
+  viewProviders: SerializedProvider[];
+  children: SerializedInjector[];
+  /** The host element associated with this injector. */
+  hostElement: HTMLElement;
+}
+
+export interface EnvironmentSerializedInjector {
+  name: string;
+  type: 'environment';
+  providers: SerializedProvider[];
+  children: SerializedInjector[];
+}
+
+export interface NullSerializedInjector {
+  name: string;
+  type: 'null';
+  providers: SerializedProvider[];
+  children: SerializedInjector[];
+}
+
+/**
+ * A serialized representation of a DI provider.
+ */
+export interface SerializedProvider {
+  token: any;
+  value: unknown;
+}
+
+/**
+ * Serializes an injector and its children/providers into a tree.
+ */
+export function serializeInjector(injector: Injector): SerializedInjector {
+  const metadata = getInjectorMetadata(injector);
+
+  if (metadata?.type === 'null') {
+    return {
+      name: 'Null Injector',
+      type: 'null',
+      providers: [],
+      children: [],
+    };
+  }
+
+  // Only attempt to get providers for types supported by getInjectorProviders.
+  let allProviders: SerializedProvider[] = [];
+  if (metadata?.type === 'element' || metadata?.type === 'environment') {
+    allProviders = getInjectorProviders(injector).map((record) => {
+      return {
+        token: record.token,
+        value: injector.get(record.token, null, {optional: true, self: true}),
+      };
+    });
+  }
+
+  if (metadata?.type === 'element') {
+    const tNode = getNodeInjectorTNode(injector as NodeInjector);
+    const viewProvidersCount = tNode
+      ? tNode.providerIndexes >> TNodeProviderIndexes.CptViewProvidersCountShift
+      : 0;
+
+    const viewProviders = allProviders.slice(0, viewProvidersCount);
+    const resolvedProviders = allProviders.slice(viewProvidersCount);
+
+    return {
+      name: injector.constructor.name,
+      type: 'element',
+      providers: resolvedProviders,
+      viewProviders,
+      children: [],
+      hostElement: metadata.source as HTMLElement,
+    };
+  }
+
+  return {
+    name: metadata?.source ?? injector.constructor.name ?? 'Unknown Injector',
+    type: 'environment', // Fallback for other injector types
+    providers: allProviders,
+    children: [],
+  };
+}

--- a/packages/core/src/debug/ai/traversal.ts
+++ b/packages/core/src/debug/ai/traversal.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export {walkLViewDirectives} from '../../render3/util/view_traversal_utils';

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -9,11 +9,12 @@
 import {assertDefined} from '../../util/assert';
 import {assertLView} from '../assert';
 import {readPatchedLView} from '../context_discovery';
-import {LContainer} from '../interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer} from '../interfaces/container';
+import {TNode} from '../interfaces/node';
 import {isLContainer, isLView, isRootView} from '../interfaces/type_checks';
-import {CHILD_HEAD, CONTEXT, LView, NEXT} from '../interfaces/view';
+import {CHILD_HEAD, CONTEXT, LView, NEXT, TVIEW} from '../interfaces/view';
 
-import {getLViewParent} from './view_utils';
+import {getComponentLViewByIndex, getLViewParent} from './view_utils';
 
 /**
  * Retrieve the root view from any component or `LView` by walking the parent `LView` until
@@ -64,4 +65,85 @@ function getNearestLContainer(viewOrContainer: LContainer | LView | null) {
     viewOrContainer = viewOrContainer[NEXT];
   }
   return viewOrContainer as LContainer | null;
+}
+
+/**
+ * A generator that yields the logical children of a given TNode in its LView.
+ *
+ * @param tNode The parent TNode.
+ * @param lView The current LView.
+ * @returns A generator that yields [TNode, LView] pairs for each logical child.
+ */
+function* walkLViewChildren(tNode: TNode, lView: LView): IterableIterator<[TNode, LView]> {
+  // Visit child TNodes in the current view.
+  let child = tNode.child;
+  while (child) {
+    yield [child, lView];
+    child = child.next;
+  }
+
+  // If this is a component, visit its internal view.
+  if (tNode.componentOffset > -1) {
+    const componentLView = getComponentLViewByIndex(tNode.index, lView);
+    if (isLView(componentLView)) {
+      const componentTView = componentLView[TVIEW];
+      const firstChild = componentTView.firstChild;
+      if (firstChild) yield [firstChild, componentLView];
+    }
+  }
+
+  // If this is a container (like `@if`), visit its embedded views.
+  const slot = lView[tNode.index];
+  if (isLContainer(slot)) {
+    for (let i = CONTAINER_HEADER_OFFSET; i < slot.length; i++) {
+      const embeddedLView = slot[i] as LView;
+      const embeddedTView = embeddedLView[TVIEW];
+      const firstChild = embeddedTView.firstChild;
+      if (firstChild) yield [firstChild, embeddedLView];
+    }
+  }
+}
+
+/**
+ * Recursively iterates through transitive descendants of an input view.
+ *
+ * @param lView The input LView.
+ * @returns A generator that yields [TNode, LView] pairs for all descendants.
+ */
+function* walkLViewDescendants(lView: LView): IterableIterator<[TNode, LView]> {
+  const tView = lView[TVIEW];
+  let child = tView.firstChild;
+  while (child) {
+    yield* walkTNodeDescendants(child, lView);
+    child = child.next;
+  }
+}
+
+/**
+ * Recursively iterates through the descendants of a TNode in the view tree,
+ * yielding the node itself and all its transitive descendants.
+ *
+ * @param tNode The starting TNode.
+ * @param lView The LView associated with the TNode.
+ * @returns A generator that yields [TNode, LView] pairs for the node and its descendants.
+ */
+function* walkTNodeDescendants(tNode: TNode, lView: LView): IterableIterator<[TNode, LView]> {
+  yield [tNode, lView];
+  for (const [childTNode, childLView] of walkLViewChildren(tNode, lView)) {
+    yield* walkTNodeDescendants(childTNode, childLView);
+  }
+}
+
+/**
+ * Iterates through transitive descendants of an input view and filters down to only components/directives.
+ *
+ * @param lView The input LView.
+ * @returns A generator that yields [TNode, LView] pairs for nodes with directives.
+ */
+export function* walkLViewDirectives(lView: LView): IterableIterator<[TNode, LView]> {
+  for (const [tNode, currentLView] of walkLViewDescendants(lView)) {
+    if (tNode.directiveEnd > tNode.directiveStart) {
+      yield [tNode, currentLView];
+    }
+  }
 }

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -87,8 +87,11 @@ function* walkLViewChildren(tNode: TNode, lView: LView): IterableIterator<[TNode
     const componentLView = getComponentLViewByIndex(tNode.index, lView);
     if (isLView(componentLView)) {
       const componentTView = componentLView[TVIEW];
-      const firstChild = componentTView.firstChild;
-      if (firstChild) yield [firstChild, componentLView];
+      let componentChild = componentTView.firstChild;
+      while (componentChild) {
+        yield [componentChild, componentLView];
+        componentChild = componentChild.next;
+      }
     }
   }
 
@@ -98,8 +101,11 @@ function* walkLViewChildren(tNode: TNode, lView: LView): IterableIterator<[TNode
     for (let i = CONTAINER_HEADER_OFFSET; i < slot.length; i++) {
       const embeddedLView = slot[i] as LView;
       const embeddedTView = embeddedLView[TVIEW];
-      const firstChild = embeddedTView.firstChild;
-      if (firstChild) yield [firstChild, embeddedLView];
+      let embeddedChild = embeddedTView.firstChild;
+      while (embeddedChild) {
+        yield [embeddedChild, embeddedLView];
+        embeddedChild = embeddedChild.next;
+      }
     }
   }
 }

--- a/packages/core/test/debug/di_graph_spec.ts
+++ b/packages/core/test/debug/di_graph_spec.ts
@@ -1,0 +1,652 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  Component,
+  createComponent,
+  createEnvironmentInjector,
+  destroyPlatform,
+  Directive,
+  Injectable,
+  InjectionToken,
+} from '@angular/core';
+import {bootstrapApplication, createApplication} from '@angular/platform-browser';
+import {withBody} from '@angular/private/testing';
+import {diGraphTool} from '../../src/debug/ai/di_graph';
+import {setupFrameworkInjectorProfiler} from '../../src/render3/debug/framework_injector_profiler';
+
+describe('diGraphTool', () => {
+  beforeEach(() => {
+    destroyPlatform();
+    setupFrameworkInjectorProfiler();
+  });
+  afterEach(() => void destroyPlatform());
+
+  it(
+    'should discover element injectors',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class CustomService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+        providers: [CustomService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            type: 'element',
+            providers: [
+              {
+                token: CustomService,
+                value: jasmine.any(CustomService),
+              },
+            ],
+            viewProviders: [],
+            children: [],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should build hierarchical tree of element injectors with root component',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class DirectiveService {}
+
+      @Directive({
+        selector: '[custom-dir]',
+        providers: [DirectiveService],
+      })
+      class CustomDir {}
+
+      @Injectable()
+      class ComponentService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div custom-dir>Root</div>',
+        imports: [CustomDir],
+        providers: [ComponentService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            type: 'element',
+            providers: [
+              {
+                token: ComponentService,
+                value: jasmine.any(ComponentService),
+              },
+            ],
+            children: [
+              jasmine.objectContaining({
+                type: 'element',
+                providers: [
+                  {
+                    token: DirectiveService,
+                    value: jasmine.any(DirectiveService),
+                  },
+                ],
+                children: [],
+              }),
+            ],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should discover ancestor environment injectors',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class EnvService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp, {
+        providers: [EnvService],
+      });
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.environmentInjectorRoot).toEqual(
+          jasmine.objectContaining({
+            name: 'Null Injector',
+            children: jasmine.arrayContaining([
+              jasmine.objectContaining({
+                name: 'R3Injector', // Platform
+                children: jasmine.arrayContaining([
+                  jasmine.objectContaining({
+                    name: 'Environment Injector', // Root
+                    providers: jasmine.arrayContaining([
+                      {token: EnvService, value: jasmine.any(EnvService)},
+                    ]),
+                  }),
+                ]),
+              }),
+            ]),
+          }),
+        );
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+  it(
+    'should discover element injectors from multiple roots',
+    withBody('<app-root-1></app-root-1><app-root-2></app-root-2>', async () => {
+      @Injectable()
+      class Service1 {}
+
+      @Component({
+        selector: 'app-root-1',
+        template: '<div>Root 1</div>',
+        providers: [Service1],
+      })
+      class AppRoot1 {}
+
+      @Injectable()
+      class Service2 {}
+
+      @Component({
+        selector: 'app-root-2',
+        template: '<div>Root 2</div>',
+        providers: [Service2],
+      })
+      class AppRoot2 {}
+
+      const appRef = await createApplication();
+      appRef.bootstrap(AppRoot1);
+      appRef.bootstrap(AppRoot2);
+
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            providers: [{token: Service1, value: jasmine.any(Service1)}],
+          }),
+          jasmine.objectContaining({
+            providers: [{token: Service2, value: jasmine.any(Service2)}],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle content projection',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class ProjectorService {}
+
+      @Component({
+        selector: 'projector',
+        template: '<ng-content></ng-content>',
+        providers: [ProjectorService],
+      })
+      class ProjectorCmp {}
+
+      @Injectable()
+      class ChildService {}
+
+      @Directive({
+        selector: '[child-dir]',
+        providers: [ChildService],
+      })
+      class ChildDir {}
+
+      @Injectable()
+      class TestService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<projector><div child-dir></div></projector>',
+        imports: [ProjectorCmp, ChildDir],
+        providers: [TestService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            providers: jasmine.arrayWithExactContents([
+              {
+                token: TestService,
+                value: jasmine.any(TestService),
+              },
+            ]),
+            children: [
+              jasmine.objectContaining({
+                providers: jasmine.arrayWithExactContents([
+                  {
+                    token: ProjectorService,
+                    value: jasmine.any(ProjectorService),
+                  },
+                ]),
+                children: [
+                  jasmine.objectContaining({
+                    type: 'element',
+                    providers: jasmine.arrayWithExactContents([
+                      {
+                        token: ChildService,
+                        value: jasmine.any(ChildService),
+                      },
+                    ]),
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle embedded views (`@if`)',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class DirectiveService {}
+
+      @Directive({
+        selector: '[child-dir]',
+        providers: [DirectiveService],
+      })
+      class ChildDir {}
+
+      @Injectable()
+      class ComponentService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '@if (true) { <div child-dir></div> }',
+        imports: [ChildDir],
+        providers: [ComponentService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            providers: [
+              {
+                token: ComponentService,
+                value: jasmine.any(ComponentService),
+              },
+            ],
+            children: [
+              jasmine.objectContaining({
+                type: 'element',
+                providers: [
+                  {
+                    token: DirectiveService,
+                    value: jasmine.any(DirectiveService),
+                  },
+                ],
+              }),
+            ],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle host directives',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class HostService {}
+
+      @Directive({
+        selector: '[host-dir]',
+        providers: [HostService],
+      })
+      class HostDir {}
+
+      @Injectable()
+      class TestService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+        hostDirectives: [HostDir],
+        providers: [TestService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          // Components and host directives share the same `Injector`.
+          jasmine.objectContaining({
+            providers: jasmine.arrayWithExactContents([
+              {
+                token: HostService,
+                value: jasmine.any(HostService),
+              },
+              {
+                token: TestService,
+                value: jasmine.any(TestService),
+              },
+            ]),
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle view providers',
+    withBody('<test-cmp></test-cmp>', async () => {
+      @Injectable()
+      class TestService {}
+
+      @Injectable()
+      class ViewService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+        providers: [TestService],
+        viewProviders: [ViewService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            providers: [
+              {
+                token: TestService,
+                value: jasmine.any(TestService),
+              },
+            ],
+            viewProviders: [
+              {
+                token: ViewService,
+                value: jasmine.any(ViewService),
+              },
+            ],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle dynamically created root components',
+    withBody('<test-cmp></test-cmp><div id="dynamic-host"></div>', async () => {
+      @Injectable()
+      class DynamicService {}
+
+      @Component({
+        selector: 'dynamic-cmp',
+        template: '<div>Dynamic</div>',
+        providers: [DynamicService],
+      })
+      class DynamicCmp {}
+
+      @Injectable()
+      class TestService {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+        providers: [TestService],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const hostEl = document.getElementById('dynamic-host')!;
+
+        // Use createComponent with hostElement!
+        createComponent(DynamicCmp, {
+          environmentInjector: appRef.injector,
+          hostElement: hostEl,
+        });
+
+        const result = await diGraphTool.execute({});
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            providers: [{token: TestService, value: jasmine.any(TestService)}],
+          }),
+          jasmine.objectContaining({
+            providers: [{token: DynamicService, value: jasmine.any(DynamicService)}],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+  it(
+    'should handle custom environment injectors with `createComponent`',
+    withBody('<test-cmp></test-cmp><div id="dynamic-host"></div>', async () => {
+      @Component({
+        selector: 'dynamic-cmp',
+        template: '<div>Dynamic</div>',
+      })
+      class DynamicCmp {}
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const hostEl = document.getElementById('dynamic-host')!;
+
+        // Create custom environment injector!
+        const customEnv = createEnvironmentInjector([], appRef.injector);
+
+        // NOTE: We cannot assert on the providers array here because manually created
+        // environment injectors bypass the profiler hooks that populate the providers
+        // manifest. However, we CAN assert that the injector itself was found and
+        // mapped into the hierarchy by searching the tree for its name.
+        const CustomConstructor = function () {};
+        Object.defineProperty(CustomConstructor, 'name', {value: 'CustomEnvInjector'});
+        (customEnv as any).constructor = CustomConstructor;
+
+        // Use createComponent with custom environment injector!
+        createComponent(DynamicCmp, {
+          environmentInjector: customEnv,
+          hostElement: hostEl,
+        });
+
+        const result = await diGraphTool.execute({});
+
+        expect(result.environmentInjectorRoot).toEqual(
+          jasmine.objectContaining({
+            name: 'Null Injector',
+            children: [
+              jasmine.objectContaining({
+                name: 'R3Injector', // Platform
+                children: [
+                  jasmine.objectContaining({
+                    name: 'Environment Injector', // Root
+                    children: jasmine.arrayContaining([
+                      jasmine.objectContaining({
+                        name: 'CustomEnvInjector',
+                        type: 'environment',
+                      }),
+                    ]),
+                  }),
+                ],
+              }),
+            ],
+          }),
+        );
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle multi-providers',
+    withBody('<test-cmp></test-cmp>', async () => {
+      const multiToken = new InjectionToken<string[]>('MULTI_TOKEN');
+
+      @Component({
+        selector: 'test-cmp',
+        template: '<div>Root</div>',
+        providers: [
+          {provide: multiToken, useValue: 'val1', multi: true},
+          {provide: multiToken, useValue: 'val2', multi: true},
+        ],
+      })
+      class TestCmp {}
+
+      const appRef = await bootstrapApplication(TestCmp);
+      try {
+        const result = await diGraphTool.execute({});
+
+        expect(result.elementInjectorRoots).toEqual([
+          jasmine.objectContaining({
+            // There should only be one `multiToken`, but the framework profiler currently records
+            // multi-providers once per configuration rather than aggregating them by token. This
+            // causes them to appear multiple times in the providers array.
+            providers: [
+              {token: multiToken, value: ['val1', 'val2']},
+              {token: multiToken, value: ['val1', 'val2']},
+            ],
+          }),
+        ]);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle siblings with directives',
+    withBody('<test-comp-1></test-comp-1>', async () => {
+      @Directive({
+        selector: '[dir-a]',
+        standalone: true,
+      })
+      class DirA {}
+
+      @Directive({
+        selector: '[dir-b]',
+        standalone: true,
+      })
+      class DirB {}
+
+      @Component({
+        selector: 'test-comp-1',
+        template: '<div dir-a></div><div dir-b></div>',
+        imports: [DirA, DirB],
+        standalone: true,
+      })
+      class TestComponent1 {}
+
+      const appRef = await bootstrapApplication(TestComponent1);
+      try {
+        const result = await diGraphTool.execute({});
+
+        // TestComponent should have two children
+        expect(result.elementInjectorRoots[0].children.length).toBe(2);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should handle siblings with directives inside @if',
+    withBody('<test-comp-2></test-comp-2>', async () => {
+      @Directive({
+        selector: '[dir-a]',
+        standalone: true,
+      })
+      class DirA {}
+
+      @Directive({
+        selector: '[dir-b]',
+        standalone: true,
+      })
+      class DirB {}
+
+      @Component({
+        selector: 'test-comp-2',
+        template: ' @if (true) { <div dir-a></div><div dir-b></div> }',
+        imports: [DirA, DirB],
+        standalone: true,
+      })
+      class TestComponent2 {}
+
+      const appRef = await bootstrapApplication(TestComponent2);
+      try {
+        const result = await diGraphTool.execute({});
+
+        // TestComponent should have two children
+        expect(result.elementInjectorRoots[0].children.length).toBe(2);
+      } finally {
+        appRef.destroy();
+      }
+    }),
+  );
+
+  it(
+    'should throw an error if a root is not an Angular component',
+    withBody('<div ng-version="fake"></div>', async () => {
+      await expectAsync(diGraphTool.execute({})).toBeRejectedWithError(
+        /Could not find an `LView` for root `<div>`, is it an Angular component\?/,
+      );
+    }),
+  );
+});

--- a/packages/core/test/render3/util/view_traversal_utils_spec.ts
+++ b/packages/core/test/render3/util/view_traversal_utils_spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '../../../src/metadata/directives';
+import {TestBed} from '@angular/core/testing';
+import {walkLViewDirectives} from '../../../src/render3/util/view_traversal_utils';
+import {getLContext} from '../../../src/render3/context_discovery';
+
+describe('view_traversal_utils', () => {
+  describe('walkLViewDirectives', () => {
+    it('should yield all components in the view hierarchy', async () => {
+      @Component({
+        selector: 'child-comp',
+        template: '<b>Child</b>',
+      })
+      class ChildComponent {}
+
+      @Component({
+        selector: 'test-comp',
+        template: '<div><child-comp></child-comp></div>',
+        imports: [ChildComponent],
+      })
+      class TestComponent {}
+
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const lView = getLContext(fixture.nativeElement)!.lView!;
+      const directives = Array.from(walkLViewDirectives(lView));
+      const values = directives.map(([node]) => node.value);
+
+      expect(values).toContain('child-comp');
+      expect(values).not.toContain('div');
+      expect(values).not.toContain('b');
+    });
+
+    it('should handle embedded views in a container', async () => {
+      @Component({
+        selector: 'child-comp',
+        template: '<b>Child</b>',
+      })
+      class ChildComponent {}
+
+      @Component({
+        selector: 'test-comp',
+        template: '<div>@if (show) {<child-comp></child-comp>}</div>',
+        imports: [ChildComponent],
+      })
+      class TestComponent {
+        show = true;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const lView = getLContext(fixture.nativeElement)!.lView!;
+      const directives = Array.from(walkLViewDirectives(lView));
+      const values = directives.map(([node]) => node.value);
+
+      expect(values).toContain('child-comp');
+    });
+
+    it('should handle content projection', async () => {
+      @Component({
+        selector: 'projected-comp',
+        template: '<b>Projected</b>',
+      })
+      class ProjectedComponent {}
+
+      @Component({
+        selector: 'projector-comp',
+        template: '<div class="projector"><ng-content></ng-content></div>',
+      })
+      class ProjectorComponent {}
+
+      @Component({
+        selector: 'test-comp',
+        template: '<projector-comp><projected-comp></projected-comp></projector-comp>',
+        imports: [ProjectorComponent, ProjectedComponent],
+      })
+      class TestComponent {}
+
+      const fixture = TestBed.createComponent(TestComponent);
+      await fixture.whenStable();
+
+      const lView = getLContext(fixture.nativeElement)!.lView!;
+      const directives = Array.from(walkLViewDirectives(lView));
+      const values = directives.map(([node]) => node.value);
+
+      expect(values).toContain('projector-comp');
+      expect(values).toContain('projected-comp');
+    });
+  });
+});


### PR DESCRIPTION
This is part of an experiment with chrome-devtools-mcp to expose runtime data about framework internal state such as the dependency injection graph to AI agents and see if it improves debuggability of Angular applications.

Unlike the signal graph tool, I'm far from convinced this is a good output structure for agents to consume. It misses some important edges (notably connecting elements to specific environment injectors) and is likely too much information for an AI to usefully consume. I suspect more targeted tools will be more useful for certain use cases. However, this gives us an initial implementation to experiment with and see what evals best with various agents.

/cc @wolfib

CARETAKER NOTE: g3 tests seem to be flakes/preexisting failures.