### PR TITLE
docs(docs-infra): fix essentials next-step navigation pills

### DIFF
--- a/adev/src/content/introduction/essentials/signal-forms.md
+++ b/adev/src/content/introduction/essentials/signal-forms.md
@@ -269,3 +269,7 @@ To learn more about Signal Forms and how it works, check out the in-depth guides
 - [Form models](guide/forms/signals/models) - Creating and managing form data with signals
 - [Field state management](guide/forms/signals/field-state-management) - Working with validation state, interaction tracking, and field visibility
 - [Validation](guide/forms/signals/validation) - Built-in validators, custom validation rules, and async validation
+
+<docs-pill-row>
+  <docs-pill title="Modular design with dependency injection" href="essentials/dependency-injection" />
+</docs-pill-row>

--- a/adev/src/content/introduction/essentials/templates.md
+++ b/adev/src/content/introduction/essentials/templates.md
@@ -147,6 +147,6 @@ TIP: Want to know more about Angular templates? See the [In-depth Templates guid
 Now that you have dynamic data and templates in the application, it's time to learn how to enhance templates by conditionally hiding or showing certain elements, looping over elements, and more.
 
 <docs-pill-row>
-  <docs-pill title="Modular design with dependency injection" href="essentials/dependency-injection" />
+  <docs-pill title="Forms with Signals" href="essentials/signal-forms" />
   <docs-pill title="In-depth template guide" href="guide/templates" />
 </docs-pill-row>


### PR DESCRIPTION
Update the "Next step" pill in templates to point to signal-forms instead of skipping it, and add a next-step pill in signal-forms linking to dependency-injection.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The "Next step" navigation pill at the bottom of the Templates essentials page links directly to Dependency Injection, skipping the Signal Forms page. The Signal Forms page has no next-step pill at all, breaking the sequential reading flow.

<img width="1115" height="434" alt="Screenshot 2026-04-05 at 22 51 51" src="https://github.com/user-attachments/assets/f4fd7a53-a85d-44bd-8495-78011ef9b2b9" />
<img width="1135" height="535" alt="Screenshot 2026-04-05 at 22 55 16" src="https://github.com/user-attachments/assets/91f91a9e-f71d-4396-ab68-1fe1df4f5eed" />

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The Templates page now links to Signal Forms as the next step, and Signal Forms links to Dependency Injection, matching the intended essentials guide order.

<img width="1095" height="467" alt="Screenshot 2026-04-05 at 23 00 06" src="https://github.com/user-attachments/assets/ef7ec993-e561-40a6-92c3-ce4226fcf4d5" />
<img width="1099" height="429" alt="Screenshot 2026-04-05 at 23 00 35" src="https://github.com/user-attachments/assets/12d2053a-35fd-40e4-9989-511613907b6b" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
