### PR TITLE
docs(docs-infra): fix v21 event video not responsive on mobile

### DIFF
--- a/adev/src/content/events/v21.md
+++ b/adev/src/content/events/v21.md
@@ -22,16 +22,4 @@ Angular v21 is being delivered to you as a brand new release adventure. With mod
 - Your first look at Signal Forms, our new streamlined, signal-based approach to forms in Angular
 - Exciting new details about the Angular Aria package
 
-<div style="display: block; width: 80%; margin: 0 auto; margin-top: 20px;">
-  <iframe
-    credentialless
-    width="560"
-    height="315"
-    src="https://www.youtube.com/embed/DDAHORVzQ5g?si=B9Uv5vXzIKJfcLGr"
-    title="YouTube video player"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    referrerpolicy="strict-origin-when-cross-origin"
-    allowfullscreen
-  ></iframe>
-</div>
+<docs-video src="https://www.youtube.com/embed/DDAHORVzQ5g?si=B9Uv5vXzIKJfcLGr" title="Angular v21 Developer Event"/>


### PR DESCRIPTION
Replace raw iframe with docs-video component to fix YouTube embed overflowing on mobile viewports.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The v21 event page embeds the YouTube developer event video using a raw `<iframe>` with a fixed `width="560"`, causing the video to overflow and get clipped on mobile viewports.

https://github.com/user-attachments/assets/dcc1dfb3-7777-4168-b492-0a60536764ce


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Uses the `<docs-video>` component, which applies `width: 100%` and `aspect-ratio: 16/9` , making the embed responsive and consistent with every other YouTube video across the docs.

<img width="747" height="832" alt="image" src="https://github.com/user-attachments/assets/406d9068-6555-499e-8db5-f9a204458441" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
