### PR TITLE
refactor: export symbols for external use

### DIFF
--- a/packages/compiler-cli/private/hybrid_analysis.ts
+++ b/packages/compiler-cli/private/hybrid_analysis.ts
@@ -42,3 +42,4 @@ export {
   ExpressionIdentifier,
   hasExpressionIdentifier,
 } from '../src/ngtsc/typecheck/src/comments';
+export {SymbolBuilder} from '../src/ngtsc/typecheck/src/template_symbol_builder';

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -831,6 +831,10 @@ export class SymbolBuilder {
       return node.argumentExpression.getStart();
     } else if (ts.isCallExpression(node)) {
       return this.getTcbPositionForNode(node.expression);
+    } else if (ts.isAsExpression(node)) {
+      return this.getTcbPositionForNode(node.expression);
+    } else if (ts.isNonNullExpression(node)) {
+      return this.getTcbPositionForNode(node.expression);
     } else {
       return node.getStart();
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -28,6 +28,7 @@ import {
   ParseTemplateOptions,
   TmplAstComponent,
   MatchSource,
+  SafePropertyRead,
 } from '@angular/compiler';
 import ts from 'typescript';
 
@@ -841,6 +842,38 @@ runInEachFileSystem(() => {
               .getTypeChecker()
               .typeToString(templateTypeChecker.getTypeOfSymbol(keyedReadSymbol)!),
           ).toEqual('string');
+        });
+
+        it('safe property reads with as any (failure case)', () => {
+          const fileName = absoluteFrom('/main.ts');
+          const templateString = `<div [inputA]="route?.data?.icon"></div>`;
+          const {templateTypeChecker, program} = setup(
+            [
+              {
+                fileName,
+                templates: {'Cmp': templateString},
+                source: `
+                interface Route {
+                  data: { icon: string; };
+                }
+                export class Cmp { route?: Route; }
+              `,
+              },
+            ],
+            {strictSafeNavigationTypes: false},
+          );
+          const sf = getSourceFileOrError(program, fileName);
+          const cmp = getClass(sf, 'Cmp');
+          const nodes = getAstElements(templateTypeChecker, cmp);
+          const ast = (nodes[0].inputs[0].value as ASTWithSource).ast as PropertyRead;
+          const dataRead = ast.receiver as SafePropertyRead;
+          const dataSymbol = templateTypeChecker.getSymbolOfNode(dataRead, cmp)!;
+          assertExpressionSymbol(dataSymbol);
+          expect(
+            program
+              .getTypeChecker()
+              .symbolToString(templateTypeChecker.getTsSymbolOfSymbol(dataSymbol)!),
+          ).toEqual('data');
         });
 
         it('ternary expressions', () => {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -52,7 +52,13 @@ export {publishFacade} from './jit_compiler_facade';
 export * from './ml_parser/ast';
 export * from './ml_parser/html_parser';
 export * from './ml_parser/html_tags';
-export * from './property_mapping';
+export {
+  ClassPropertyMapping,
+  ClassPropertyName,
+  InputOrOutput,
+  BindingPropertyName,
+} from './property_mapping';
+export {MatchSource} from './render3/view/t2_api';
 export {LexerRange} from './ml_parser/lexer';
 export {ParseTreeResult, TreeError} from './ml_parser/parser';
 export * from './ml_parser/tags';


### PR DESCRIPTION
export symbols for sharing in environments outside of angular monorepo
