### PR TITLE
refactor(compiler-cli): Export SymbolKind for external use

### DIFF
--- a/packages/compiler-cli/private/hybrid_analysis.ts
+++ b/packages/compiler-cli/private/hybrid_analysis.ts
@@ -21,6 +21,7 @@ export {
   type OutOfBandDiagnosticRecorder,
   type DomSchemaChecker,
   OutOfBadDiagnosticCategory,
+  SymbolKind,
 } from '../src/ngtsc/typecheck/api';
 export {RegistryDomSchemaChecker} from '../src/ngtsc/typecheck/src/dom';
 export {Environment} from '../src/ngtsc/typecheck/src/environment';


### PR DESCRIPTION
exports SymbolKind for use outside of angular monorepo
