### PR TITLE
fix(docs): warning about upgrading to v21

### DIFF
--- a/adev/src/app/features/update/update.component.ts
+++ b/adev/src/app/features/update/update.component.ts
@@ -107,7 +107,7 @@ export default class UpdateComponent {
   ];
   protected from = this.versions.find((version) => version.name === '20.0')!;
   protected to = this.versions.find((version) => version.name === '21.0')!;
-  protected futureVersion = 2100;
+  protected futureVersion = 2200;
 
   protected readonly steps: Step[] = RECOMMENDATIONS;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## What is the current behavior?

Users are shown a warning when trying to upgrade to v21 from v20 (the default selection). This warning should only be shown when users are exploring updating to prerelease versions.

<img width="1362" height="530" alt="image" src="https://github.com/user-attachments/assets/68bd431e-d0d2-4756-b4cc-e72e1469fc75" />


## What is the new behavior?

## Does this PR introduce a breaking change?
- [x] No

