### PR TITLE
fix(http): add CSP nonce support to JsonpClientBackend

### DIFF
--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -8,6 +8,7 @@
 
 import {DOCUMENT} from '../../index';
 import {
+  CSP_NONCE,
   EnvironmentInjector,
   Inject,
   inject,
@@ -94,6 +95,7 @@ export class JsonpClientBackend implements HttpBackend {
    * A resolved promise that can be used to schedule microtasks in the event handlers.
    */
   private readonly resolvedPromise = Promise.resolve();
+  private readonly nonce = inject(CSP_NONCE, {optional: true});
 
   constructor(
     private callbackMap: JsonpCallbackContext,
@@ -148,6 +150,12 @@ export class JsonpClientBackend implements HttpBackend {
       // Construct the <script> tag and point it at the URL.
       const node = this.document.createElement('script');
       node.src = url;
+
+      // Set the nonce for Content Security Policy compatibility. Without this,
+      // JSONP requests will be blocked by strict-dynamic CSP policies.
+      if (this.nonce) {
+        node.setAttribute('nonce', this.nonce);
+      }
 
       // A JSONP request requires waiting for multiple callbacks. These variables
       // are closed over and track state across those callbacks.

--- a/packages/common/http/test/jsonp_mock.ts
+++ b/packages/common/http/test/jsonp_mock.ts
@@ -25,6 +25,16 @@ export class MockScriptElement {
   remove() {
     this.ownerDocument.removeNode(this);
   }
+
+  private attrs: Record<string, string> = {};
+
+  setAttribute(name: string, value: string): void {
+    this.attrs[name] = value;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs.hasOwnProperty(name) ? this.attrs[name] : null;
+  }
 }
 
 export class MockDocument {

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {DOCUMENT} from '../..';
+import {CSP_NONCE} from '@angular/core';
 import {HttpHeaders} from '../src/headers';
 import {
   JSONP_ERR_HEADERS_NOT_SUPPORTED,
@@ -43,6 +44,7 @@ describe('JsonpClientBackend', () => {
         JsonpClientBackend,
         {provide: JsonpCallbackContext, useValue: {}},
         {provide: DOCUMENT, useValue: mockDoc},
+        {provide: CSP_NONCE, useValue: null},
       ],
     });
     backend = TestBed.inject(JsonpClientBackend);
@@ -98,6 +100,33 @@ describe('JsonpClientBackend', () => {
     // executing.
     expect(document.mock!.ownerDocument).not.toEqual(document);
   });
+  describe('CSP nonce', () => {
+    it('sets nonce attribute on script element when CSP_NONCE token is provided', (done) => {
+      TestBed.resetTestingModule();
+      const mockDoc = new MockDocument();
+      TestBed.configureTestingModule({
+        providers: [
+          JsonpClientBackend,
+          {provide: JsonpCallbackContext, useValue: {}},
+          {provide: DOCUMENT, useValue: mockDoc},
+          {provide: CSP_NONCE, useValue: 'test-nonce-123'},
+        ],
+      });
+      const nonceBackend = TestBed.inject(JsonpClientBackend);
+      nonceBackend.handle(SAMPLE_REQ).subscribe();
+
+      expect(mockDoc.mock!.getAttribute('nonce')).toBe('test-nonce-123');
+      done();
+    });
+
+    it('does not set nonce attribute when CSP_NONCE token is not provided', (done) => {
+      backend.handle(SAMPLE_REQ).subscribe();
+
+      expect(document.mock!.getAttribute('nonce')).toBeNull();
+      done();
+    });
+  });
+
   describe('throws an error', () => {
     it('when request method is not JSONP', () =>
       expect(() => backend.handle(SAMPLE_REQ.clone<never>({method: 'GET'}))).toThrowError(


### PR DESCRIPTION
> This is a continuation of #67923 which was accidentally closed.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?
`JsonpClientBackend` does not set the `nonce` attribute on dynamically injected `<script>` tags. This causes JSONP requests to be blocked in applications that use Content Security Policy with `strict-dynamic`, since the browser requires a valid nonce on all dynamically created scripts.

All other places in Angular that create `<script>` or `<style>` elements already support CSP nonces via the `CSP_NONCE` injection token (e.g. `SharedStylesHost`, `DomRendererFactory2`, `TransferState`). `JsonpClientBackend` was the only exception.

Issue Number: N/A

## What is the new behavior?
`JsonpClientBackend` now optionally injects the `CSP_NONCE` token and sets it as the `nonce` attribute on the created `<script>` element. The token is injected with `@Optional()`, so existing applications that do not provide `CSP_NONCE` are unaffected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
`MockScriptElement` in `jsonp_mock.ts` has been updated to support `setAttribute`/`getAttribute` to enable nonce-related testing.