### PR TITLE
docs: add 12 domain-specific Angular agent skills

### DIFF
--- a/skills/dev-skills/README.md
+++ b/skills/dev-skills/README.md
@@ -6,6 +6,18 @@ The Angular skills are designed to help coding agents create applications aligne
 
 - **`angular-developer`**: Generates Angular code and provides architectural guidance. Useful for creating components, services, or obtaining best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling, testing, or CLI tooling.
 - **`angular-new-app`**: Creates a new Angular app using the Angular CLI. Provides important guidelines for effectively setting up and structuring a modern Angular application.
+- **`angular-component`**: Standalone components, signal inputs/outputs, OnPush change detection, host bindings, content projection, and lifecycle hooks.
+- **`angular-signals`**: Signal-based reactive state with `signal()`, `computed()`, `linkedSignal()`, `effect()`, and RxJS interop.
+- **`angular-forms`**: Reactive Forms, Signal Forms (experimental), and template-driven forms with typed controls and validation.
+- **`angular-routing`**: Lazy loading, functional guards, resolvers, signal-based route parameters, and View Transitions API.
+- **`angular-http`**: Data fetching with `httpResource()`, `resource()`, `rxResource()`, HttpClient, and functional interceptors.
+- **`angular-di`**: Dependency injection with `inject()`, injection tokens, provider scopes, and hierarchical injectors.
+- **`angular-ssr`**: Server-side rendering, hydration strategies, prerendering, and browser-only API handling.
+- **`angular-testing`**: Unit/integration testing with Vitest or Jasmine, TestBed, component harnesses, and accessibility testing.
+- **`angular-tooling`**: Angular CLI usage, code generation, builds, Tailwind CSS v4 setup, and MCP server configuration.
+- **`angular-directives`**: Custom attribute and structural directives, host directives, and the directive composition API.
+- **`angular-performance`**: OnPush change detection, lazy loading, `@defer`, bundle optimization, and virtual scrolling.
+- **`angular-aria`**: Headless accessible components using `@angular/aria` (Accordion, Listbox, Combobox, Menu, Tabs, Toolbar, Tree, Grid).
 
 ## Contributions
 

--- a/skills/dev-skills/angular-aria/SKILL.md
+++ b/skills/dev-skills/angular-aria/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: angular-aria
+description: Build headless accessible components using the @angular/aria package. Use for implementing WAI-ARIA patterns like Accordion, Listbox, Select, Combobox, Menu, Menubar, Toolbar, Tabs, Tree, and Grid with full keyboard navigation, screen reader support, and focus management. Triggers on requests for accessible components, headless UI, ARIA patterns, or @angular/aria usage. Do not use for general accessibility guidance (WCAG audits, AXE checks) or Angular Material components.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Aria
+
+
+Angular Aria (`@angular/aria`) is a collection of headless, accessible directives that implement common WAI-ARIA patterns. The directives handle keyboard interactions, ARIA attributes, focus management, and screen reader support. All you have to do is provide the HTML structure, CSS styling, and business logic.
+
+**CRITICAL**: Before using this package, it must be installed via the package manager. Confirm that it has been installed in the project. Use `npm install @angular/aria` to install if necessary.
+
+## When to Use Angular Aria
+
+- **Custom design systems** — your team maintains a component library with specific visual standards
+- **Enterprise component libraries** — reusable components for multiple applications
+- **Custom brand requirements** — precise design specifications that pre-styled libraries cannot accommodate
+
+## When NOT to Use Angular Aria
+
+- **Pre-styled components needed** — use Angular Material instead
+- **Simple forms** — native HTML controls (`<button>`, `<input type="radio">`) provide built-in accessibility
+- **Rapid prototyping** — pre-styled component libraries reduce initial development time
+
+## Styling Headless Components
+
+Because Angular Aria components are headless, they do not come with default styles. You **must** use CSS to style different states based on the ARIA attributes the directives automatically apply.
+
+Common ARIA attributes to target in CSS:
+- `[aria-expanded="true"]` / `[aria-expanded="false"]`
+- `[aria-selected="true"]`
+- `[aria-disabled="true"]`
+- `[aria-pressed="true"]`
+- `[aria-checked="true"]`
+- `[aria-current="page"]` (for navigation)
+
+## Available Components
+
+### 1. Accordion
+
+Organizes related content into expandable/collapsible sections. Use for FAQs, long forms, or progressive disclosure.
+
+**Import:** `import { AccordionContent, AccordionGroup, AccordionPanel, AccordionTrigger } from '@angular/aria/accordion';`
+
+```typescript
+@Component({
+  imports: [AccordionContent, AccordionGroup, AccordionPanel, AccordionTrigger],
+  template: `
+    <div ngAccordionGroup [multiExpandable]="false">
+      <div class="accordion-item">
+        <button ngAccordionTrigger panelId="panel-1" class="accordion-header">
+          Section 1
+          <span class="icon">▼</span>
+        </button>
+        <div ngAccordionPanel panelId="panel-1" class="accordion-panel">
+          <ng-template ngAccordionContent>
+            <p>Lazy loaded content here.</p>
+          </ng-template>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class MyAccordion {}
+```
+
+```css
+.accordion-header[aria-expanded='true'] .icon {
+  transform: rotate(180deg);
+}
+.accordion-panel {
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+}
+```
+
+### 2. Listbox
+
+Single or multi-select option lists with keyboard navigation.
+
+**Import:** `import { Listbox, Option } from '@angular/aria/listbox';`
+
+```html
+<ul ngListbox [(values)]="selectedItems" orientation="horizontal" [multi]="true">
+  <li ngOption value="apple" class="option">Apple</li>
+  <li ngOption value="banana" class="option">Banana</li>
+</ul>
+```
+
+```css
+.option[aria-selected='true'] {
+  background: #e0f7fa;
+  font-weight: bold;
+}
+.option:focus-visible {
+  outline: 2px solid blue;
+}
+```
+
+### 3. Combobox, Select, and Multiselect
+
+Combine `ngCombobox` with `ngListbox` for dropdown patterns.
+
+- **Combobox**: Text input + popup (autocomplete)
+- **Select**: Readonly Combobox + single-select Listbox
+- **Multiselect**: Readonly Combobox + multi-select Listbox
+
+**Import:** `import { Combobox, ComboboxInput, ComboboxPopupContainer } from '@angular/aria/combobox';` and `import { Listbox, Option } from '@angular/aria/listbox';`
+
+```html
+<!-- Standard Select -->
+<div ngCombobox [readonly]="true">
+  <button ngComboboxInput class="select-trigger">
+    {{ selectedValue() || 'Choose an option' }}
+  </button>
+  <ng-template ngComboboxPopupContainer>
+    <ul ngListbox [(values)]="selectedValue" class="dropdown-menu">
+      <li ngOption value="option1">Option 1</li>
+      <li ngOption value="option2">Option 2</li>
+    </ul>
+  </ng-template>
+</div>
+```
+
+### 4. Menu and Menubar
+
+For actions, commands, and context menus (not for form selection).
+
+**Import:** `import { MenuBar, Menu, MenuContent, MenuItem } from '@angular/aria/menu';`
+
+```html
+<ul ngMenuBar class="menubar">
+  <li ngMenuItem value="file">
+    <button ngMenuTrigger [menu]="fileMenu">File</button>
+  </li>
+</ul>
+
+<ul ngMenu #fileMenu="ngMenu" class="menu">
+  <li ngMenuItem value="new">New</li>
+  <li ngMenuItem value="open">Open</li>
+</ul>
+```
+
+### 5. Tabs
+
+Tabbed interfaces with automatic or manual activation modes.
+
+**Import:** `import { Tab, Tabs, TabList, TabPanel, TabContent } from '@angular/aria/tabs';`
+
+```html
+<div ngTabs>
+  <ul ngTabList class="tab-list">
+    <li ngTab value="profile" class="tab-btn">Profile</li>
+    <li ngTab value="security" class="tab-btn">Security</li>
+  </ul>
+
+  <div ngTabPanel value="profile" class="tab-panel">
+    <ng-template ngTabContent>Profile Settings</ng-template>
+  </div>
+  <div ngTabPanel value="security" class="tab-panel">
+    <ng-template ngTabContent>Security Settings</ng-template>
+  </div>
+</div>
+```
+
+```css
+.tab-btn[aria-selected='true'] {
+  border-bottom: 2px solid blue;
+  font-weight: bold;
+}
+```
+
+### 6. Toolbar
+
+Groups related controls with keyboard navigation.
+
+**Import:** `import { Toolbar, ToolbarWidget, ToolbarWidgetGroup } from '@angular/aria/toolbar';`
+
+```html
+<div ngToolbar class="toolbar">
+  <div ngToolbarWidgetGroup [multi]="true" role="group" aria-label="Formatting">
+    <button ngToolbarWidget value="bold" class="tool-btn">B</button>
+    <button ngToolbarWidget value="italic" class="tool-btn">I</button>
+  </div>
+</div>
+```
+
+```css
+.tool-btn[aria-pressed='true'],
+.tool-btn[aria-checked='true'] {
+  background: #ddd;
+}
+```
+
+### 7. Tree
+
+Displays hierarchical data (file systems, nested navigation).
+
+**Import:** `import { Tree, TreeItem, TreeItemGroup } from '@angular/aria/tree';`
+
+```html
+<ul ngTree class="tree">
+  <li ngTreeItem value="documents">
+    <span class="tree-label">Documents</span>
+    <ul ngTreeGroup class="tree-group">
+      <li ngTreeItem value="resume">Resume.pdf</li>
+    </ul>
+  </li>
+</ul>
+```
+
+```css
+li[aria-expanded='true'] > .tree-label::before {
+  transform: rotate(90deg);
+}
+```
+
+### 8. Grid
+
+Two-dimensional interactive cell navigation for data tables, calendars, spreadsheets.
+
+**Import:** `import { Grid, GridRow, GridCell, GridCellWidget } from '@angular/aria/grid';`
+
+```html
+<table ngGrid [multi]="true" [enableSelection]="true" class="grid-table">
+  <tr ngGridRow>
+    <th ngGridCell role="columnheader">Name</th>
+    <th ngGridCell role="columnheader">Status</th>
+  </tr>
+  <tr ngGridRow>
+    <td ngGridCell>Project A</td>
+    <td ngGridCell [(selected)]="isSelected">
+      <button ngGridCellWidget (activated)="onActivate()">Active</button>
+    </td>
+  </tr>
+</table>
+```
+
+```css
+[ngGridCell][aria-selected='true'] {
+  background: #e3f2fd;
+}
+[ngGridCell]:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: -2px;
+}
+```
+
+## General Rules
+
+1. **Never use native HTML elements like `<select>`** when asked to implement these specific Aria patterns. Use the `ng*` directives.
+2. **Handle CSS manually**: Angular Aria does NOT provide styles. You must write the CSS, targeting the native ARIA attributes (`aria-expanded`, `aria-selected`, etc.) that the directives automatically toggle.
+3. **Lazy Loading**: Always use the provided structural directives (`ngAccordionContent`, `ngTabContent`) inside `ng-template` for heavy content panels to ensure they are lazily rendered.

--- a/skills/dev-skills/angular-component/SKILL.md
+++ b/skills/dev-skills/angular-component/SKILL.md
@@ -1,0 +1,491 @@
+---
+name: angular-component
+description: Create modern Angular standalone components following v20+ best practices. Use for building UI components with signal-based inputs/outputs, OnPush change detection, host bindings, content projection, and lifecycle hooks. Triggers on component creation, refactoring class-based inputs to signals, adding host bindings, or implementing accessible interactive components. Do not use for routing, form logic, or service architecture.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Component
+
+Create standalone components for Angular v20+. Components are standalone by default
+
+**CRITICAL** : Do NOT set `standalone: true`
+
+## Component Structure
+- Always Make the Component uses onPush Change Detection Strategy
+- Use **template** (inline): Small (<15 lines), simple templates. 
+- Use **templateUrl** (external): Large/complex templates. Use relative paths. 
+- Keep components small and focused on a single responsibility.
+
+### Dependency Injection
+
+Use `inject()` function instead of constructor injection:
+
+```typescript
+@Component({...})
+export class MyComponent {
+  // CORRECT - use inject()
+  #userService = inject(UserService);
+  #http = inject(HttpClient);
+
+  // WRONG - constructor injection is discouraged
+  // constructor(private userService: UserService) {}
+}
+```
+
+### Basic Example
+
+```typescript
+import {Component, ChangeDetectionStrategy, input, output, computed} from '@angular/core';
+
+@Component({
+    selector: 'app-user-card',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    host: {
+        'class': 'user-card',
+        '[class.active]': 'isActive()',
+        '(click)': 'handleClick()',
+    },
+    template: `
+    <img [src]="avatarUrl()" [alt]="name() + ' avatar'" />
+    <h2>{{ name() }}</h2>
+    @if (showEmail()) {
+      <p>{{ email() }}</p>
+    }
+  `,
+    styles: `
+    :host { display: block; }
+    :host.active { border: 2px solid blue; }
+  `,
+})
+export class UserCard {
+    // Required input
+    name = input.required<string>();
+
+    // Optional input with default
+    email = input<string>('');
+    showEmail = input(false);
+
+    // Input with transform
+    isActive = input(false, {transform: booleanAttribute});
+
+    // Computed from inputs
+    avatarUrl = computed(() => `https://api.example.com/avatar/${this.name()}`);
+
+    // Output
+    selected = output<string>();
+
+    handleClick() {
+        this.selected.emit(this.name());
+    }
+}
+```
+
+## Signal Inputs
+
+```typescript
+// Required - must be provided by parent
+name = input.required<string>();
+
+// Optional with default value
+count = input(0);
+
+// Optional without default (undefined allowed)
+label = input<string>();
+
+// With alias for template binding
+size = input('medium', {alias: 'buttonSize'});
+
+// With transform function
+disabled = input(false, {transform: booleanAttribute});
+value = input(0, {transform: numberAttribute});
+// with transform custom function
+interface Item {
+    key: string;
+    value: string;
+}
+
+items = input<Item[], Item[]>([], {
+    transform: (value: Item[]) => [{key: 'default', value: 'Default'}, ...value]
+});
+
+```
+
+## Signal Outputs
+
+```typescript
+import {output, outputFromObservable} from '@angular/core';
+
+// Basic output
+clicked = output<void>();
+selected = output<Item>();
+
+// With alias
+valueChange = output<number>({alias: 'change'});
+
+// From Observable (for RxJS interop)
+scroll$ = new Subject<number>();
+scrolled = outputFromObservable(this.scroll$);
+
+// Emit values
+this.clicked.emit();
+this.selected.emit(item);
+
+// **CAUTION**: For the subject, don't forget to complete it to avoid memory leaks!
+ngOnDestroy()
+{
+    this.scroll$.complete();
+}
+```
+
+## Host Bindings
+
+- **CRITICAL*** Do NOT use `@HostBinding` or `@HostListener` decorators, instead use the `host` object in `@Component`. 
+
+```typescript
+
+@Component({
+    selector: 'app-button',
+    host: {
+        // Static attributes
+        'role': 'button', // instead of @Attribute('role')
+
+        // Dynamic class bindings
+        '[class.primary]': 'variant() === "primary"', // instead of @HostBinding('.primary')
+        '[class.disabled]': 'disabled()', // instead of @HostBinding('.disabled')
+
+        // Dynamic style bindings
+        '[style.--btn-color]': 'color()', // instead of :host(.primary) [style.--btn-color]
+
+        // Attribute bindings
+        '[attr.aria-disabled]': 'disabled()', // instead of @Attribute('aria-disabled')
+        '[attr.tabindex]': 'disabled() ? -1 : 0', // instead of @Attribute('tabindex')
+
+        '[class.active]': 'isActive()',  // Instead of @HostBinding
+        
+        // Event listeners
+        '(click)': 'onClick($event)',   // Instead of @HostListener
+        '(keydown.enter)': 'onClick($event)', // Instead of @HostListener
+        '(keydown.space)': 'onClick($event)', // Instead of @HostListener
+    },
+    template: `<ng-content />`,
+})
+export class Button {
+    variant = input<'primary' | 'secondary'>('primary');
+    disabled = input(false, {transform: booleanAttribute});
+    color = input('#007bff');
+
+    clicked = output<void>();
+
+    onClick(event: Event) {
+        if (!this.disabled()) {
+            this.clicked.emit();
+        }
+    }
+}
+```
+
+## Content Projection
+
+```typescript
+
+@Component({
+    selector: 'app-card',
+    template: `
+    <header>
+      <ng-content select="[card-header]" />
+    </header>
+    <main>
+      <ng-content />
+    </main>
+    <footer>
+      <ng-content select="[card-footer]" />
+    </footer>
+  `,
+})
+export class Card {
+}
+
+// Usage:
+// <app-card>
+//   <h2 card-header>Title</h2>
+//   <p>Main content</p>
+//   <button card-footer>Action</button>
+// </app-card>
+```
+
+## Lifecycle Hooks
+
+```typescript
+import {OnInit, OnDestroy, effect, afterNextRender, afterEveryRender, afterRenderEffect} from '@angular/core';
+
+export class MyComponent implements OnInit, OnDestroy {
+    constructor() {
+        // Use effect() for non-DOM reactive logic
+        effect(() => {
+            // Reactive to signals, runs before DOM is ready
+            // Use for state synchronization and derived computations
+            const value = this.someSignal();
+            console.log('Signal changed:', value);
+        });
+
+        // Use afterNextRender() for one-time DOM initialization (SSR-safe)
+        afterNextRender(() => {
+            // Runs once after first render
+            // Perfect for third-party library initialization
+            // Browser-only APIs (ResizeObserver, IntersectionObserver)
+            // Not reactive to signals
+            this.initThirdPartyLib();
+        });
+
+        // Use afterEveryRender() for non-reactive DOM sync on every render
+        afterEveryRender(() => {
+            // Runs after every render cycle (application-level)
+            // Not reactive to signals
+            // Use for DOM synchronization that must happen every render
+            // Rarely needed - prefer afterRenderEffect() for reactive DOM
+            this.syncDOMState();
+        });
+
+        // Use afterRenderEffect() for reactive DOM operations
+        afterRenderEffect((onCleanup) => {
+            // Reactive to signals, runs after DOM updates
+            // Use when you need to read/write DOM based on signal changes
+            // Specify phase for performance (read, write, earlyRead)
+            const element = document.querySelector('.my-element');
+            element?.setAttribute('data-value', this.dynamicValue());
+
+            // Always cleanup resources
+            onCleanup(() => {
+                element?.removeAttribute('data-value');
+            });
+        });
+    }
+
+    // Example with phases
+    constructor() {
+        afterRenderEffect({
+            earlyRead: () => this.checkValueEarly(),
+            write: (value, cleanup) => {
+                const element = document.querySelector('.my-element');
+                element?.setAttribute('data-value', value);
+                cleanup(() => element?.removeAttribute('data-value'));
+            },
+            mixedReadWrite: () => {
+                // Handle mixed read/write operations
+                // **CRITICAL**: Avoid  this phase as much as possible
+            },
+            read: () => this.checkValue(),
+        })
+    }
+ 
+    ngOnInit() {
+        // Component initialized, inputs are set
+        // Use for initialization logic that doesn't require DOM
+    }
+
+    ngOnDestroy() {
+        // Cleanup subscriptions and resources
+        // effect() and afterRenderEffect() auto-cleanup
+    }
+}
+```
+- **We can define it outside the constructor**
+```typescript
+export class MyComponent {
+    // Example without constructor
+    // Need to call it in an injection context 
+    // Declare a variable to call it 
+    getUserLocation = afterNextRender(() => {
+        if (navigator.geolocation) {
+            navigator.geolocation.getCurrentPosition((position) => {
+                console.log('User location:', position.coords);
+            });
+        }
+    });
+    // it works on all of them effect, afterNextRender, afterEveryRender, afterRenderEffect 
+}
+```
+
+**Best Practices:**
+
+- **Prefer `effect()`** for most reactive needs (state sync, derived computations)
+- **Use native browser APIs** (ResizeObserver, MutationObserver, IntersectionObserver) over render hooks when possible
+- **Use `afterNextRender()`** for one-time DOM setup (library initialization, focus management)
+- **Use `afterRenderEffect()`** for reactive DOM operations (most common for signal-based DOM updates)
+- **Use `afterEveryRender()`** sparingly - only when DOM sync must happen every render regardless of signal changes
+    - **Specify phases** in `afterRenderEffect()` , `afterNextRender()` `afterEveryRender()`
+        - earlyRead Use this phase to read from the DOM before a subsequent write callback, for example to perform
+          custom layout that the browser doesn't natively support. Prefer the read phase if reading can wait until after
+          the write phase. Never write to the DOM in this phase.
+        - write Use this phase to write to the DOM. Never read from the DOM in this phase.
+        - mixedReadWrite Use this phase to read from and write to the DOM simultaneously. Never use this phase if it is
+          possible to divide the work among the other phases instead.
+        - read Use this phase to read from the DOM. Never write to the DOM in this phase.
+          You should prefer using the read and write phases over the earlyRead and
+- **Always use `onCleanup()`** for resource disposal (timers, listeners, animations)
+- **Avoid `mixedReadWrite` phase** as it may cause DOM reflows
+
+## Accessibility Requirements
+
+Components MUST:
+
+- Pass AXE accessibility checks
+- Meet WCAG AA standards
+- Include proper ARIA attributes for interactive elements
+- Support keyboard navigation
+- Maintain visible focus indicators
+
+```typescript
+
+@Component({
+    selector: 'app-toggle',
+    host: {
+        'role': 'switch',
+        '[attr.aria-checked]': 'checked()',
+        '[attr.aria-label]': 'label()',
+        'tabindex': '0',
+        '(click)': 'toggle()',
+        '(keydown.enter)': 'toggle()',
+        '(keydown.space)': 'toggle(); $event.preventDefault()',
+    },
+    template: `<span class="toggle-track"><span class="toggle-thumb"></span></span>`,
+})
+export class Toggle {
+    label = input.required<string>();
+    checked = input(false, {transform: booleanAttribute});
+    checkedChange = output<boolean>();
+
+    toggle() {
+        this.checkedChange.emit(!this.checked());
+    }
+}
+```
+
+## Template Syntax
+
+Use native control flow `@for`, `@if`, and `@switch` directives
+
+**CRITICAL**: Do NOT use `*ngIf`, `*ngFor`, `*ngSwitch`.
+
+```html
+<!-- Conditionals -->
+@if (isLoading()) {
+<app-spinner/>
+} @else if (error()) {
+<app-error [message]="error()"/>
+} @else {
+<app-content [data]="data()"/>
+}
+
+<!-- Loops -->
+@for (item of items(); track item.id) {
+<app-item [item]="item"/>
+} @empty {
+<p>No items found</p>
+}
+
+<!-- Switch -->
+@switch (status()) {
+@case ('pending') { <span>Pending</span> }
+@case ('active') { <span>Active</span> }
+@default { <span>Unknown</span> }
+}
+```
+
+### Template Best Practices
+
+**CRITICAL**: Do NOT write arrow functions in templates (they are not supported):
+
+```html
+<!-- WRONG - arrow functions not supported -->
+<button (click)="() => doSomething()">Click</button>
+
+<!-- CORRECT -->
+<button (click)="doSomething()">Click</button>
+```
+
+**CRITICAL**: Do not assume globals like `new Date()` or `window` are available in templates:
+
+```html
+<!-- WRONG -->
+<p>{{ new Date().toLocaleDateString() }}</p>
+
+<!-- CORRECT - use computed signal -->
+<p>{{ formattedDate() }}</p>
+```
+
+```typescript
+formattedDate = computed(() => new Date().toLocaleDateString());
+```
+
+### Async Pipe for Observables
+
+Use the async pipe to handle observables in templates:
+
+```typescript
+@Component({
+  template: `
+    @if (users$ | async; as users) {
+      @for (user of users; track user.id) {
+        <app-user-card [user]="user" />
+      }
+    } @else {
+      <p>Loading...</p>
+    }
+  `,
+})
+export class UserList {
+  #userService = inject(UserService);
+  users$ = this.userService.getUsers();
+}
+```
+## Class and Style Bindings
+
+Do NOT use `ngClass` or `ngStyle`. Use direct bindings:
+
+```html
+<!-- Class bindings -->
+<div [class.active]="isActive()">Single class</div>
+<div [class]="classString()">Class string</div>
+<div [class]="{class1: item.key === 'hello' , class2: item.key === 'Ahmed' }"></div>
+<!--class1 and class2 will be added conditionally-->
+<!-- Style bindings -->
+<div [style.color]="textColor()">Styled text</div>
+<div [style.width.px]="width()">With unit</div>
+```
+
+## Images
+
+Use `NgOptimizedImage` for static images:
+- **CRITICAL** Don't use it with icons, NgOptimizedImage adds overhead for tiny icons/images
+```typescript
+import {NgOptimizedImage} from '@angular/common';
+
+@Component({
+    imports: [NgOptimizedImage],
+    template: `
+    <img ngSrc="/assets/hero.jpg" width="800" height="600" priority />
+    <img [ngSrc]="imageUrl()" width="200" height="200" />
+  `,
+})
+export class Hero {
+    imageUrl = input.required<string>();
+}
+```
+
+## Animations
+
+For animating component elements entering/leaving the DOM, use native CSS with `animate.enter` and `animate.leave` (Angular v20.2+). For older projects, use the legacy `@angular/animations` DSL.
+
+See `references/angular-animations.md` for enter/leave animations, CSS transitions, staggering, and legacy DSL patterns.
+
+## Component Styling
+
+Angular components support scoped styles via view encapsulation. Use `:host` to style the host element, and avoid `::ng-deep` (deprecated).
+
+See `references/component-styling.md` for view encapsulation modes, special selectors, and style scoping best practices.
+
+See `references/component-patterns.md` for detailed component patterns and advanced examples.

--- a/skills/dev-skills/angular-component/references/angular-animations.md
+++ b/skills/dev-skills/angular-component/references/angular-animations.md
@@ -1,0 +1,144 @@
+# Angular Animations
+
+When animating elements in Angular, **first analyze the project's Angular version** in `package.json`.
+For modern applications (**Angular v20.2 and above**), prefer using native CSS with `animate.enter` and `animate.leave`. For older applications, you may need to use the deprecated `@angular/animations` package.
+
+## 1. Native CSS Animations (v20.2+ Recommended)
+
+Modern Angular provides `animate.enter` and `animate.leave` to animate elements as they enter or leave the DOM. They apply CSS classes at the appropriate times.
+
+### `animate.enter` and `animate.leave`
+
+Use these directly on elements to apply CSS classes during the enter or leave phase. Angular automatically removes the enter classes when the animation completes. For `animate.leave`, Angular waits for the animation to finish before removing the element from the DOM.
+
+`animate.enter` example:
+
+```html
+@if (isShown()) {
+<div class="enter-container" animate.enter="enter-animation">
+  <p>The box is entering.</p>
+</div>
+}
+```
+
+```css
+.enter-animation {
+  animation: slide-fade 1s;
+}
+@keyframes slide-fade {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+### Event Bindings and Third-party Libraries
+
+You can bind to `(animate.enter)` and `(animate.leave)` to call functions or use JS libraries like GSAP.
+
+```html
+@if(show()) {
+<div (animate.leave)="onLeave($event)">...</div>
+}
+```
+
+```ts
+import { AnimationCallbackEvent } from '@angular/core';
+
+onLeave(event: AnimationCallbackEvent) {
+  // Custom animation logic here
+  // CRITICAL: You MUST call animationComplete() when done so Angular removes the element!
+  event.animationComplete();
+}
+```
+
+## 2. Advanced CSS Animations
+
+### Animating State and Styles
+
+Toggle CSS classes on elements using property binding to trigger transitions.
+
+```html
+<div [class.open]="isOpen">...</div>
+```
+
+```css
+div {
+  transition: height 0.3s ease-out;
+  height: 100px;
+}
+div.open {
+  height: 200px;
+}
+```
+
+### Animating Auto Height
+
+Use `css-grid` to animate to auto height.
+
+```css
+.container {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s;
+}
+.container.open {
+  grid-template-rows: 1fr;
+}
+.container > div {
+  overflow: hidden;
+}
+```
+
+### Staggering and Parallel Animations
+
+- **Staggering**: Use `animation-delay` or `transition-delay` with different values for items in a list.
+- **Parallel**: Apply multiple animations in the `animation` shorthand (e.g., `animation: rotate 3s, fade-in 2s;`).
+
+### Programmatic Control
+
+Retrieve animations directly using standard Web APIs:
+
+```ts
+const animations = element.getAnimations();
+animations.forEach((anim) => anim.pause());
+```
+
+## 3. Legacy Animations DSL (Deprecated)
+
+For older projects (pre v20.2 or where `@angular/animations` is already heavily used), you use the component metadata DSL.
+
+**Important:** Do not mix legacy animations and `animate.enter`/`leave` in the same component.
+
+### Setup
+
+```ts
+bootstrapApplication(App, {
+  providers: [provideAnimationsAsync()],
+});
+```
+
+### Defining Transitions
+
+```ts
+import { trigger, state, style, animate, transition } from '@angular/animations';
+
+@Component({
+  animations: [
+    trigger('openClose', [
+      state('open', style({opacity: 1})),
+      state('closed', style({opacity: 0})),
+      transition('open <=> closed', [animate('0.5s')]),
+    ]),
+  ],
+  template: `<div [@openClose]="isOpen() ? 'open' : 'closed'">...</div>`,
+})
+export class OpenClose {
+  isOpen = signal(true);
+}
+```

--- a/skills/dev-skills/angular-component/references/component-patterns.md
+++ b/skills/dev-skills/angular-component/references/component-patterns.md
@@ -1,0 +1,357 @@
+# Angular Component Patterns
+## Table of Contents
+- [Model Inputs (Two-Way Binding)](#model-inputs-two-way-binding)
+- [View Queries](#view-queries)
+- [Content Queries](#content-queries)
+- [Dependency Injection in Components](#dependency-injection-in-components)
+- [Component Communication Patterns](#component-communication-patterns)
+- [Dynamic Components](#dynamic-components)
+
+## Model Inputs (Two-Way Binding)
+
+For two-way binding with `[(value)]` syntax:
+
+```typescript
+import { Component, model } from '@angular/core';
+
+@Component({
+  selector: 'app-slider',
+  host: {
+    '(input)': 'onInput($event)',
+  },
+  template: `
+    <input 
+      type="range" 
+      [value]="value()" 
+      [min]="min()" 
+      [max]="max()" 
+    />
+    <span>{{ value() }}</span>
+  `,
+})
+export class Slider {
+  // Model creates both input and output
+  value = model(0);
+  min = input(0);
+  max = input(100);
+  
+  onInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.value.set(Number(target.value));
+  }
+}
+
+// Usage: <app-slider [(value)]="sliderValue" />
+```
+
+Required model:
+
+```typescript
+value = model.required<number>();
+```
+
+## View Queries
+
+Query elements and components in the template:
+
+```typescript
+import { Component, viewChild, viewChildren, ElementRef } from '@angular/core';
+
+@Component({
+  selector: 'app-gallery',
+  template: `
+    <div #container class="gallery">
+      @for (image of images(); track image.id) {
+        <app-image-card [image]="image" />
+      }
+    </div>
+  `,
+})
+export class Gallery {
+  images = input.required<Image[]>();
+
+  // Query single element
+  container = viewChild.required<ElementRef<HTMLDivElement>>('container');
+
+  // Query single component (optional)
+  firstCard = viewChild(ImageCard);
+
+  // Query all matching components
+  allCards = viewChildren(ImageCard);
+}
+```
+
+## Content Queries
+
+Query projected content:
+
+```typescript
+import { Component, contentChild, contentChildren, effect, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-tabs',
+  template: `
+    <div class="tab-headers">
+      @for (tab of tabs(); track tab.label()) {
+        <button
+          [class.active]="tab === activeTab()"
+          (click)="selectTab(tab)"
+        >
+          {{ tab.label() }}
+        </button>
+      }
+    </div>
+    <div class="tab-content">
+      <ng-content />
+    </div>
+  `,
+})
+export class Tabs {
+  // Query all projected Tab children
+  tabs = contentChildren(Tab);
+
+  // Query single projected element
+  header = contentChild('tabHeader');
+
+  activeTab = signal<Tab | undefined>(undefined);
+
+  constructor() {
+    // Set first tab as active when tabs are available
+    effect(() => {
+      const firstTab = this.tabs()[0];
+      if (firstTab && !this.activeTab()) {
+        this.activeTab.set(firstTab);
+      }
+    });
+  }
+
+  selectTab(tab: Tab) {
+    this.activeTab.set(tab);
+  }
+}
+
+@Component({
+  selector: 'app-tab',
+  template: `<ng-content />`,
+  host: {
+    '[class.active]': 'isActive()',
+    '[style.display]': 'isActive() ? "block" : "none"',
+  },
+})
+export class Tab {
+  label = input.required<string>();
+  isActive = input(false);
+}
+```
+
+## Dependency Injection in Components
+
+Use `inject()` function instead of constructor injection:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-dashboard',
+  template: `...`,
+})
+export class Dashboard {
+  #router = inject(Router);
+  #userService = inject(User);
+  #config = inject(APP_CONFIG);
+  
+  // Optional injection
+  #analytics = inject(Analytics, { optional: true });
+  
+  // Self-only injection
+  #localService = inject(Local, { self: true });
+  
+  navigateToProfile() {
+    this.router.navigate(['/profile']);
+  }
+}
+```
+
+## Component Communication Patterns
+
+### Parent to Child (Inputs)
+
+```typescript
+// Parent
+@Component({
+  template: `<app-child [data]="parentData()" [config]="config" />`,
+})
+export class Parent {
+  parentData = signal({ name: 'Test' });
+  config = { theme: 'dark' };
+}
+
+// Child
+@Component({ selector: 'app-child' })
+export class Child {
+  data = input.required<Data>();
+  config = input<Config>();
+}
+```
+
+### Child to Parent (Outputs)
+
+```typescript
+// Child
+@Component({
+  selector: 'app-child',
+  template: `<button (click)="save()">Save</button>`,
+})
+export class Child {
+  saved = output<Data>();
+  
+  save() {
+    this.saved.emit({ id: 1, name: 'Item' });
+  }
+}
+
+// Parent
+@Component({
+  template: `<app-child (saved)="onSaved($event)" />`,
+})
+export class Parent {
+  onSaved(data: Data) {
+    console.log('Saved:', data);
+  }
+}
+```
+
+### Shared Service Pattern
+
+```typescript
+// Shared state service
+@Injectable({ providedIn: 'root' })
+export class Cart {
+  #items = signal<CartItem[]>([]);
+  
+  readonly items$ = this.items.asReadonly();
+  readonly total = computed(() => 
+    this.#items().reduce((sum, item) => sum + item.price, 0)
+  );
+  
+  addItem(item: CartItem) {
+    this.#items.update(items => [...items, item]);
+  }
+  
+  removeItem(id: string) {
+    this.#items.update(items => items.filter(i => i.id !== id));
+  }
+}
+
+// Component A
+@Component({ template: `<button (click)="add()">Add</button>` })
+export class Product {
+  #cart = inject(Cart);
+  product = input.required<Product>();
+  
+  add() {
+    this.cart.addItem({ ...this.product(), quantity: 1 });
+  }
+}
+
+// Component B
+@Component({ template: `<span>Total: {{ cart.total() }}</span>` })
+export class CartSummary {
+  cart = inject(Cart);
+}
+```
+
+## Dynamic Components
+
+Using `@defer` for lazy loading:
+
+```typescript
+@Component({
+  template: `
+    @defer (on viewport) {
+      <app-heavy-chart [data]="chartData()" />
+    } @placeholder {
+      <div class="chart-placeholder">Loading chart...</div>
+    } @loading (minimum 500ms) {
+      <app-spinner />
+    } @error {
+      <p>Failed to load chart</p>
+    }
+  `,
+})
+export class Dashboard {
+  chartData = input.required<ChartData>();
+}
+```
+
+Defer triggers:
+- `on viewport` - When element enters viewport
+- `on idle` - When browser is idle
+- `on interaction` - On user interaction (click, focus)
+- `on hover` - On mouse hover
+- `on immediate` - Immediately after non-deferred content
+- `on timer(500ms)` - After specified delay
+- `when condition` - When expression becomes true
+
+```typescript
+@Component({
+  template: `
+    @defer (on interaction; prefetch on idle) {
+      <app-comments [postId]="postId()" />
+    } @placeholder {
+      <button>Load Comments</button>
+    }
+  `,
+})
+export class Post {
+  postId = input.required<string>();
+}
+```
+
+## Attribute Directives on Components
+
+```typescript
+@Directive({
+  selector: '[appHighlight]',
+  host: {
+    '[style.backgroundColor]': 'color()',
+  },
+})
+export class Highlight {
+  color = input('yellow', { alias: 'appHighlight' });
+}
+
+// Usage on component
+@Component({
+  imports: [Highlight],
+  template: `<app-card appHighlight="lightblue" />`,
+})
+export class Page {}
+```
+
+## Error Boundaries
+
+```typescript
+@Component({
+  selector: 'app-error-boundary',
+  template: `
+    @if (hasError()) {
+      <div class="error">
+        <h3>Something went wrong</h3>
+        <button (click)="retry()">Retry</button>
+      </div>
+    } @else {
+      <ng-content />
+    }
+  `,
+})
+export class ErrorBoundary {
+  hasError = signal(false);
+  #errorHandler = inject(ErrorHandler);
+  
+  retry() {
+    this.hasError.set(false);
+  }
+}
+```

--- a/skills/dev-skills/angular-component/references/component-styling.md
+++ b/skills/dev-skills/angular-component/references/component-styling.md
@@ -1,0 +1,91 @@
+# Component Styling
+
+Angular components can define styles that apply specifically to their template, enabling encapsulation and modularity.
+
+## Defining Styles
+
+Styles can be defined inline or in separate files.
+
+```ts
+@Component({
+  selector: 'app-photo',
+  // Inline styles
+  styles: `
+    img {
+      border-radius: 50%;
+    }
+  `,
+  // OR external file
+  styleUrl: 'photo.component.css',
+})
+export class Photo {}
+```
+
+## View Encapsulation
+
+Every component has a view encapsulation setting that determines how styles are scoped.
+
+| Mode                            | Behavior                                                                                      |
+| :------------------------------ | :-------------------------------------------------------------------------------------------- |
+| `Emulated` (Default)            | Scopes styles to the component using unique HTML attributes. Global styles can still leak in. |
+| `ShadowDom`                     | Uses the browser's native Shadow DOM API to isolate styles completely.                        |
+| `None`                          | Disables encapsulation. Component styles become global.                                       |
+| `ExperimentalIsolatedShadowDom` | Strictly guarantees that only the component's styles apply.                                   |
+
+### Usage
+
+```ts
+import { ViewEncapsulation } from '@angular/core';
+
+@Component({
+  ...,
+  encapsulation: ViewEncapsulation.None,
+})
+export class GlobalStyled {}
+```
+
+## Special Selectors
+
+### `:host`
+
+Targets the component's host element (the element matching the component's selector).
+
+```css
+:host {
+  display: block;
+  border: 1px solid black;
+}
+```
+
+### `:host-context()`
+
+Targets the host element based on some condition in its ancestry.
+
+```css
+/* Apply styles if any ancestor has the 'theme-dark' class */
+:host-context(.theme-dark) {
+  background-color: #333;
+}
+```
+
+### `::ng-deep`
+
+Disables view encapsulation for a specific rule, allowing it to "leak" into child components.
+**Note: The Angular team strongly discourages the use of `::ng-deep`.** It is supported only for backwards compatibility.
+
+## Styles in Templates
+
+You can use `<style>` elements directly in a component's template. View encapsulation rules still apply.
+
+```html
+<style>
+  .dynamic-class {
+    color: red;
+  }
+</style>
+<div class="dynamic-class">Hello</div>
+```
+
+## External Styles
+
+Using `<link>` or `@import` in CSS is treated as external styles. **External styles are not affected by emulated view encapsulation.**

--- a/skills/dev-skills/angular-di/SKILL.md
+++ b/skills/dev-skills/angular-di/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: angular-di
+description: Implement dependency injection in Angular using inject(), injection tokens, and provider configuration. Use for service architecture, providing dependencies at different levels, creating injectable tokens, and managing singleton vs scoped services. Triggers on service creation, configuring providers, using injection tokens, or understanding DI hierarchy. Do not use for component templates, routing, or form handling.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Dependency Injection
+
+Configure and use dependency injection in Angular v20+ with `inject()` and providers.
+
+## Key Principles
+
+- **CRITICAL**: Use `inject()` function instead of constructor injection
+- Design services around a single responsibility
+- Use `providedIn: 'root'` for singleton services
+
+## Basic Injection
+
+### Using inject()
+
+**CRITICAL**: Use `inject()` instead of constructor injection:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { UserService } from './user.service';
+
+@Component({
+  selector: 'app-user-list',
+  template: `...`,
+})
+export class UserList {
+  // CORRECT - use inject()
+  #http = inject(HttpClient);
+  #userService = inject(UserService);
+
+  // Can use immediately
+  users = this.#userService.getUsers();
+}
+
+// WRONG - constructor injection is discouraged
+// export class UserList {
+//   constructor(
+//     #http: HttpClient,
+//     #userService: UserService
+//   ) {}
+// }
+```
+
+### Injectable Services
+
+```typescript
+import {Injectable, inject, signal} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+
+@Injectable({
+    providedIn: 'root', // Singleton at root level
+})
+export class User {
+    #http = inject(HttpClient);
+
+    #users = signal<User[]>([]);
+    readonly _users = this.#users.asReadonly();
+
+    // Working with Observables
+    loadUsers() {
+        return this.http.get<User[]>('/api/users')
+    }
+
+    // Working with Async Streams
+    async loadUsers() {
+        const users = await firstValueFrom(
+            this.#http.get<User[]>('/api/users')
+        );
+        this.#users.set(users);
+    }
+}
+```
+
+## Provider Scopes
+
+### Root Level (Singleton)
+
+```typescript
+// Recommended: providedIn
+@Injectable({
+  providedIn: 'root',
+})
+export class Auth {}
+
+// Alternative: in app.config.ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    Auth,
+  ],
+};
+```
+
+### Component Level (Instance per Component)
+
+```typescript
+@Component({
+  selector: 'app-editor',
+  providers: [EditorState], // New instance for each component
+  template: `...`,
+})
+export class Editor {
+  #editorState = inject(EditorState);
+}
+```
+
+### Route Level
+
+```typescript
+export const routes: Routes = [
+  {
+    path: 'admin',
+    providers: [Admin], // Shared within this route tree
+    children: [
+      { path: '', component: AdminDashboard },
+      { path: 'users', component: AdminUsers },
+    ],
+  },
+];
+```
+
+## Injection Tokens
+
+### Creating Tokens
+
+```typescript
+import { InjectionToken } from '@angular/core';
+
+// Simple value token
+export const API_URL = new InjectionToken<string>('API_URL');
+
+// Object token
+export interface AppConfig {
+  apiUrl: string;
+  features: {
+    darkMode: boolean;
+    analytics: boolean;
+  };
+}
+
+export const APP_CONFIG = new InjectionToken<AppConfig>('APP_CONFIG');
+
+// Token with factory (self-providing)
+export const WINDOW = new InjectionToken<Window>('Window', {
+  providedIn: 'root',
+  factory: () => window,
+});
+
+export const LOCAL_STORAGE = new InjectionToken<Storage>('LocalStorage', {
+  providedIn: 'root',
+  factory: () => localStorage,
+});
+```
+
+### Providing Token Values
+
+```typescript
+// app.config.ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    { provide: API_URL, useValue: 'https://api.example.com' },
+    {
+      provide: APP_CONFIG,
+      useValue: {
+        apiUrl: 'https://api.example.com',
+        features: { darkMode: true, analytics: true },
+      },
+    },
+  ],
+};
+```
+
+### Injecting Tokens
+
+```typescript
+
+@Injectable({providedIn: 'root'})
+export class Api {
+    #apiUrl = inject(API_URL);
+    #config = inject(APP_CONFIG);
+    #window = inject(WINDOW);
+    #httpClient = inject(HttpClient)
+
+    postData(): string {
+        return this.#httpClient.post<IUserData>(`${this.#apiUrl}`);
+    }
+}
+```
+
+## Provider Types
+
+### useClass
+
+```typescript
+// Provide implementation
+{ provide: Logger, useClass: ConsoleLogger }
+
+// Conditional implementation
+{
+  provide: Logger,
+  useClass: environment.production
+    ? ProductionLogger
+    : ConsoleLogger,
+}
+```
+
+### useValue
+
+```typescript
+// Static values
+{ provide: API_URL, useValue: 'https://api.example.com' }
+
+// Configuration objects
+{ provide: APP_CONFIG, useValue: { theme: 'dark', language: 'en' } }
+```
+
+### useFactory
+
+```typescript
+// Factory with dependencies
+{
+  provide: User,
+  useFactory : (http: HttpClient, config: AppConfig) => {
+    return new User(http, config.apiUrl);
+  },
+  deps: [HttpClient, APP_CONFIG],
+}
+
+// Async factory (not recommended - use provideAppInitializer)
+{
+  provide: CONFIG,
+  useFactory: () => fetch('/config.json').then(r => r.json()),
+}
+```
+
+### useExisting
+
+```typescript
+// Alias to existing provider
+{ provide: AbstractLogger, useExisting: ConsoleLogger }
+
+// Multiple tokens pointing to same instance
+providers: [
+  ConsoleLogger,
+  { provide: Logger, useExisting: ConsoleLogger },
+  { provide: ErrorLogger, useExisting: ConsoleLogger },
+]
+```
+
+## Injection Options
+
+### Optional Injection
+
+```typescript
+@Component({...})
+export class My {
+  // Returns null if not provided
+  #analytics = inject(Analytics, { optional: true });
+  
+  trackEvent(name: string) {
+    this.#analytics?.track(name);
+  }
+}
+```
+
+### Self, SkipSelf, Host
+
+```typescript
+@Component({
+  providers: [Local],
+})
+export class Parent {
+  // Only look in this component's injector
+  #local = inject(Local, { self: true });
+}
+
+@Component({...})
+export class Child {
+  // Skip this component, look in parent
+  #parentService = inject(ParentSvc, { skipSelf: true });
+
+  // Only look up to host component
+  #hostService = inject(Host, { host: true });
+}
+```
+
+## Multi Providers
+
+Collect multiple values for same token:
+
+```typescript
+// Token for multiple validators
+export const VALIDATORS = new InjectionToken<Validator[]>('Validators');
+
+// Provide multiple values
+providers: [
+  { provide: VALIDATORS, useClass: RequiredValidator, multi: true },
+  { provide: VALIDATORS, useClass: EmailValidator, multi: true },
+  { provide: VALIDATORS, useClass: MinLengthValidator, multi: true },
+]
+
+// Inject as array
+@Injectable()
+export class Validation {
+  #validators = inject(VALIDATORS); // Validator[]
+  
+  validate(value: string): ValidationError[] {
+    return this.#validators
+      .map(v => v.validate(value))
+      .filter(Boolean);
+  }
+}
+```
+
+### HTTP Interceptors (Multi Provider)
+
+```typescript
+// Interceptors use multi providers internally
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(
+      withInterceptors([
+        authInterceptor,
+        loggingInterceptor,
+        errorInterceptor,
+      ])
+    ),
+  ],
+};
+```
+
+## App Initializers
+
+Run async code before app starts using `provideAppInitializer`:
+
+```typescript
+import { provideAppInitializer, inject } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    Config,
+    provideAppInitializer(() => {
+      const configService = inject(Config);
+      return configService.loadConfig();
+    }),
+  ],
+};
+```
+
+### Multiple Initializers
+
+```typescript
+providers: [
+  provideAppInitializer(() => {
+    const config = inject(Config);
+    return config.load();
+  }),
+  provideAppInitializer(() => {
+    const auth = inject(Auth);
+    return auth.checkSession();
+  }),
+]
+```
+
+## Environment Injector
+
+Create injectors programmatically:
+
+```typescript
+import { createEnvironmentInjector, EnvironmentInjector, inject } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class Plugin {
+  #parentInjector = inject(EnvironmentInjector);
+  
+  loadPlugin(providers: Provider[]): EnvironmentInjector {
+    return createEnvironmentInjector(providers, this.#parentInjector);
+  }
+}
+```
+
+## runInInjectionContext
+
+Run code with injection context:
+
+```typescript
+import { runInInjectionContext, EnvironmentInjector, inject } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class Utility {
+  #injector = inject(EnvironmentInjector);
+  
+  executeWithDI<T>(fn: () => T): T {
+    return runInInjectionContext(this.#injector, fn);
+  }
+}
+
+// Usage
+utilityService.executeWithDI(() => {
+  const http = inject(HttpClient);
+  // Use http...
+});
+```
+
+See `references/di-patterns.md` for advanced DI patterns and environment injector usage.

--- a/skills/dev-skills/angular-di/references/di-patterns.md
+++ b/skills/dev-skills/angular-di/references/di-patterns.md
@@ -1,0 +1,663 @@
+# Angular Dependency Injection Patterns
+
+## Table of Contents
+- [Injector Hierarchy & Internals](#injector-hierarchy--internals)
+- [Service Patterns](#service-patterns)
+- [Abstract Classes as Tokens](#abstract-classes-as-tokens)
+- [Hierarchical Injection](#hierarchical-injection)
+- [Dynamic Providers](#dynamic-providers)
+- [Testing with DI](#testing-with-di)
+- [DestroyRef and Cleanup](#destroyref-and-cleanup)
+
+## Injector Hierarchy & Internals
+
+### Class Hierarchy
+
+Angular has two parallel injector trees with distinct class implementations:
+
+```
+Injector                         (abstract base class — @angular/core)
+├── EnvironmentInjector          (abstract, extends Injector)
+│   └── R3Injector               (concrete internal impl, extends EnvironmentInjector)
+│
+└── NodeInjector                 ![img.png](img.png)    (implements Injector — the "ElementInjector")
+```
+
+- **`Injector`** — abstract base class. Defines `get<T>(token)`. All injectors inherit or implement it.
+- **`EnvironmentInjector`** — abstract class extending `Injector`. Represents module/environment-level injectors (root, platform, lazy-loaded routes). Adds `runInContext()` (deprecated), `destroy()`, and `onDestroy()`.
+- **`R3Injector`** — the concrete class behind every `EnvironmentInjector`. The "R3" prefix means Render3 (Ivy). Created by `bootstrapApplication`, lazy routes, and `createEnvironmentInjector`. Stores providers in a `Map<ProviderToken, Record>` and tracks `ngOnDestroy` hooks.
+- **`NodeInjector`** — the element-level injector tied to the DOM/component tree. Created implicitly for each component/directive element. Uses bloom filters for fast token lookups and walks `TNode`/`LView` arrays. Does **not** extend `EnvironmentInjector`.
+
+### EnvironmentInjector vs Injector
+
+What you get when injecting these tokens depends on **where** you inject:
+
+| Context | `inject(EnvironmentInjector)` | `inject(Injector)` |
+|---|---|---|
+| `providedIn: 'root'` **service** | Root `R3Injector` | Same root `R3Injector` (identical) |
+| **Component** class | Nearest `R3Injector` (root or lazy route) | The component's `NodeInjector` |
+
+```typescript
+// In a SERVICE — both resolve to the same R3Injector instance
+@Injectable({ providedIn: 'root' })
+export class MyService {
+  #envInjector = inject(EnvironmentInjector); // root R3Injector
+  #injector = inject(Injector);               // same root R3Injector
+}
+
+// In a COMPONENT — they differ
+@Component({
+  providers: [SomeLocalService], // only visible to NodeInjector
+})
+export class MyComponent {
+  #envInjector = inject(EnvironmentInjector); // R3Injector — NO access to SomeLocalService
+  #injector = inject(Injector);               // NodeInjector — HAS access to SomeLocalService
+}
+```
+
+### Resolution Order
+
+When a component requests a dependency, Angular resolves in two phases:
+
+1. Walk **up** the `NodeInjector` (ElementInjector) hierarchy through parent components
+2. If not found, fall back to the `R3Injector` (EnvironmentInjector) hierarchy
+3. If still not found → `NullInjector` → throws error (unless `{ optional: true }`)
+
+### R3Injector Internals
+
+`R3Injector` is never instantiated directly — Angular creates it behind the scenes:
+
+```typescript
+// Angular source (packages/core/src/di/r3_injector.ts)
+export class R3Injector extends EnvironmentInjector implements PrimitivesInjector {
+  constructor(
+    providers: Array<Provider | EnvironmentProviders>,
+    readonly parent: Injector,
+    readonly source: string | null,
+    readonly scopes: Set<InjectorScope>,
+  ) { ... }
+}
+```
+
+Key internals:
+- **Provider storage**: `Map<ProviderToken, Record>` — a `null` record means "stop searching" (tree-shakable injectors)
+- **Destroy tracking**: maintains sets for `ngOnDestroy` hooks and cleanup callbacks
+- **`runInContext(fn)`**: deprecated in favor of standalone `runInInjectionContext(injector, fn)`
+- **Scopes**: tracks whether this is `root`, `platform`, or a child environment injector
+
+### NodeInjector Internals
+
+`NodeInjector` is the element-level injector tied to the Ivy rendering engine:
+
+```typescript
+// Angular source (packages/core/src/render3/di.ts)
+export class NodeInjector implements Injector {
+  constructor(
+    private _tNode: TElementNode | TContainerNode | TElementContainerNode | null,
+    private _lView: LView,
+  ) {}
+
+  get(token: any, notFoundValue?: any, flags?: InjectOptions): any {
+    return getOrCreateInjectable(this._tNode, this._lView, token, ...);
+  }
+}
+```
+
+Key differences from `R3Injector`:
+- **No `destroy()` or `runInContext()`** — only implements the base `Injector` interface
+- **Bloom filters** for fast token presence checks instead of a `Map`
+- **Walks `TNode`/`LView` arrays** up the component tree, not a parent injector chain
+- **View provider visibility** — respects `providers` vs `viewProviders` boundaries (`<#VIEW>` logical tree)
+
+### runInInjectionContext Scope
+
+The injector type passed to `runInInjectionContext` determines what the closure can resolve:
+
+```typescript
+// EnvironmentInjector — only environment-scoped providers
+@Injectable({ providedIn: 'root' })
+export class Utility {
+  #injector = inject(EnvironmentInjector);
+
+  executeWithDI<T>(fn: () => T): T {
+    return runInInjectionContext(this.#injector, fn);
+    // fn() can resolve root/environment providers only
+  }
+}
+
+// NodeInjector from a component — both element-level AND environment-level providers
+@Component({
+  providers: [EditorState],
+})
+export class Editor {
+  #injector = inject(Injector); // NodeInjector
+
+  runWithComponentScope<T>(fn: () => T): T {
+    return runInInjectionContext(this.#injector, fn);
+    // fn() can inject(EditorState) — visible via NodeInjector
+  }
+}
+```
+
+**Note**: `inject()` inside `runInInjectionContext` is only usable **synchronously** — not in async callbacks or after `await`.
+
+### When to Use Which
+
+| Scenario | Inject | Why |
+|---|---|---|
+| Service creating dynamic components | `EnvironmentInjector` | `createComponent()` requires it |
+| Service using `runInInjectionContext` | `EnvironmentInjector` | Explicit intent, correct type |
+| Component needs to pass its own scope | `Injector` | Gets `NodeInjector` with component providers |
+| Component needs `createComponent` | `EnvironmentInjector` | API requires `EnvironmentInjector` type |
+| Either works (root service) | `EnvironmentInjector` | More explicit, better communicates intent |
+
+## Service Patterns
+
+### Facade Service
+
+Combine multiple services into a single API:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class ShopFacade {
+  #productService = inject(Product);
+  #cartService = inject(Cart);
+  #orderService = inject(Order);
+
+  // Expose combined state
+  readonly products = this.#productService.products;
+  readonly cart = this.#cartService.items;
+  readonly cartTotal = this.#cartService.total;
+
+  // Unified actions
+  addToCart(productId: string, quantity: number) {
+    const product = this.#productService.getById(productId);
+    if (product) {
+      this.#cartService.add(product, quantity);
+    }
+  }
+
+  async checkout() {
+    const items = this.#cartService.items();
+    const order = await this.#orderService.create(items);
+    this.#cartService.clear();
+    return order;
+  }
+}
+```
+
+### State Service Pattern
+
+```typescript
+interface UserState {
+  user: User | null;
+  loading: boolean;
+  error: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserState {
+  #state = signal<UserState>({
+    user: null,
+    loading: false,
+    error: null,
+  });
+
+  // Selectors
+  readonly user = computed(() => this.#state().user);
+  readonly loading = computed(() => this.#state().loading);
+  readonly error = computed(() => this.#state().error);
+  readonly isAuthenticated = computed(() => this.#state().user !== null);
+  
+  // Actions
+  setUser(user: User) {
+    this.#state.update(s => ({ ...s, user, loading: false, error: null }));
+  }
+
+  setLoading() {
+    this.#state.update(s => ({ ...s, loading: true, error: null }));
+  }
+
+  setError(error: string) {
+    this.#state.update(s => ({ ...s, loading: false, error }));
+  }
+
+  clear() {
+    this.#state.set({ user: null, loading: false, error: null });
+  }
+}
+```
+
+### Repository Pattern
+
+```typescript
+// Generic repository interface
+export abstract class Repository<T extends { id: string }> {
+  abstract getAll(): Promise<T[]>;
+  abstract getById(id: string): Promise<T | null>;
+  abstract create(item: Omit<T, 'id'>): Promise<T>;
+  abstract update(id: string, item: Partial<T>): Promise<T>;
+  abstract delete(id: string): Promise<void>;
+}
+
+// HTTP implementation
+@Injectable()
+export class HttpUserRepo extends Repository<User> {
+  #http = inject(HttpClient);
+  #apiUrl = inject(API_URL);
+ // Using promises way of doing things
+  async getAll(): Promise<User[]> {
+    return firstValueFrom(this.#http.get<User[]>(`${this.#apiUrl}/users`));
+  }
+
+  async getById(id: string): Promise<User | null> {
+    return firstValueFrom(
+      this.#http.get<User>(`${this.#apiUrl}/users/${id}`).pipe(
+        catchError(() => of(null))
+      )
+    );
+  }
+
+  async create(user: Omit<User, 'id'>): Promise<User> {
+    return firstValueFrom(this.#http.post<User>(`${this.#apiUrl}/users`, user));
+  }
+
+  async update(id: string, user: Partial<User>): Promise<User> {
+    return firstValueFrom(this.#http.patch<User>(`${this.#apiUrl}/users/${id}`, user));
+  }
+
+  async delete(id: string): Promise<void> {
+    await firstValueFrom(this.#http.delete(`${this.#apiUrl}/users/${id}`));
+  }
+}
+
+// Provide implementation
+{ provide: Repository, useClass: HttpUserRepo }
+```
+
+## Abstract Classes as Tokens
+
+Use abstract classes for better type safety:
+
+```typescript
+// Abstract service definition
+export abstract class Logger {
+  abstract log(message: string): void;
+  abstract error(message: string, error?: Error): void;
+  abstract warn(message: string): void;
+}
+
+// Console implementation
+@Injectable()
+export class ConsoleLog extends Logger {
+  log(message: string) {
+    console.log(`[LOG] ${message}`);
+  }
+  
+  error(message: string, error?: Error) {
+    console.error(`[ERROR] ${message}`, error);
+  }
+  
+  warn(message: string) {
+    console.warn(`[WARN] ${message}`);
+  }
+}
+
+// Remote implementation
+@Injectable()
+export class RemoteLog extends Logger {
+  #http = inject(HttpClient);
+
+  log(message: string) {
+    this.#send('log', message);
+  }
+
+  error(message: string, error?: Error) {
+    this.#send('error', message, error);
+  }
+
+  warn(message: string) {
+    this.#send('warn', message);
+  }
+
+  #send(level: string, message: string, error?: Error) {
+    this.#http.post('/api/logs', { level, message, error: error?.message }).subscribe();
+  }
+}
+
+// Provide based on environment
+{
+  provide: Logger,
+  useClass: environment.production ? RemoteLog : ConsoleLog,
+}
+
+// Inject using abstract class
+@Injectable({ providedIn: 'root' })
+export class User {
+  #logger = inject(Logger);
+
+  createUser(user: UserData) {
+    this.#logger.log(`Creating user: ${user.email}`);
+    // ...
+  }
+}
+```
+
+## Hierarchical Injection
+
+### Component Tree Injection
+
+```typescript
+// Parent provides service
+@Component({
+  selector: 'app-form-container',
+  providers: [FormState],
+  template: `
+    <app-form-header />
+    <app-form-body />
+    <app-form-footer />
+  `,
+})
+export class FormContainer {
+  #formState = inject(FormState);
+}
+
+// Children share same instance
+@Component({
+  selector: 'app-form-body',
+  template: `...`,
+})
+export class FormBody {
+  // Gets same instance as parent
+  #formState = inject(FormState);
+}
+
+// Grandchildren also share
+@Component({
+  selector: 'app-form-field',
+  template: `...`,
+})
+export class FormField {
+  // Gets same instance from ancestor
+  #formState = inject(FormState);
+}
+```
+
+### viewProviders vs providers
+
+```typescript
+@Component({
+  selector: 'app-tabs',
+  // providers: Available to component AND content children
+  providers: [TabsSvc],
+
+  // viewProviders: Available to component AND view children only
+  // NOT available to content children (<ng-content>)
+  viewProviders: [InternalTabs],
+  
+  template: `
+    <div class="tabs">
+      <ng-content /> <!-- Content children can't access viewProviders -->
+    </div>
+  `,
+})
+export class Tabs {}
+```
+
+## Dynamic Providers
+
+### Feature Flags
+
+```typescript
+export const FEATURE_FLAGS = new InjectionToken<FeatureFlags>('FeatureFlags');
+
+interface FeatureFlags {
+  newDashboard: boolean;
+  betaFeatures: boolean;
+  experimentalApi: boolean;
+}
+
+// Load from API
+{
+  provide: FEATURE_FLAGS,
+  useFactory: async () => {
+    const response = await fetch('/api/features');
+    return response.json();
+  },
+}
+
+// Use in components
+@Component({...})
+export class Dashboard {
+  #features = inject(FEATURE_FLAGS);
+
+  showNewDashboard = this.#features.newDashboard;
+}
+```
+
+### Platform-Specific Services
+
+```typescript
+export abstract class Storage {
+  abstract get(key: string): string | null;
+  abstract set(key: string, value: string): void;
+  abstract remove(key: string): void;
+}
+
+@Injectable()
+export class BrowserStorage extends Storage {
+  get(key: string) { return localStorage.getItem(key); }
+  set(key: string, value: string) { localStorage.setItem(key, value); }
+  remove(key: string) { localStorage.removeItem(key); }
+}
+
+@Injectable()
+export class ServerStorage extends Storage {
+  #store = new Map<string, string>();
+
+  get(key: string) { return this.#store.get(key) ?? null; }
+  set(key: string, value: string) { this.#store.set(key, value); }
+  remove(key: string) { this.#store.delete(key); }
+}
+
+// Provide based on platform
+import { PLATFORM_ID, isPlatformBrowser } from '@angular/common';
+
+{
+  provide: Storage,
+  useFactory: (platformId: object) => {
+    return isPlatformBrowser(platformId)
+      ? new BrowserStorage()
+      : new ServerStorage();
+  },
+  deps: [PLATFORM_ID],
+}
+```
+
+## Testing with DI
+
+### Mocking Services
+
+```typescript
+describe('UserCmpt', () => {
+  let userServiceSpy: jasmine.SpyObj<User>;
+  
+  beforeEach(async () => {
+    userServiceSpy = jasmine.createSpyObj('User', ['getUser', 'updateUser']);
+    userServiceSpy.getUser.and.returnValue(of({ id: '1', name: 'Test' }));
+    
+    await TestBed.configureTestingModule({
+      imports: [UserCmpt],
+      providers: [
+        { provide: User, useValue: userServiceSpy },
+      ],
+    }).compileComponents();
+  });
+  
+  it('should load user', () => {
+    const fixture = TestBed.createComponent(UserCmpt);
+    fixture.detectChanges();
+    
+    expect(userServiceSpy.getUser).toHaveBeenCalled();
+  });
+});
+```
+
+### Overriding Providers
+
+```typescript
+describe('with different config', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [App],
+    })
+    .overrideProvider(APP_CONFIG, {
+      useValue: { apiUrl: 'http://test-api.com' },
+    })
+    .compileComponents();
+  });
+});
+```
+
+### Testing Injection Tokens
+
+```typescript
+describe('API_URL token', () => {
+  it('should provide correct URL', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: API_URL, useValue: 'https://api.test.com' },
+      ],
+    });
+    
+    const apiUrl = TestBed.inject(API_URL);
+    expect(apiUrl).toBe('https://api.test.com');
+  });
+});
+```
+
+## DestroyRef and Cleanup
+
+### Automatic Cleanup
+
+```typescript
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+@Component({...})
+export class Data {
+  #destroyRef = inject(DestroyRef);
+  #dataService = inject(DataSvc);
+
+  constructor() {
+    // Auto-unsubscribe when component destroys
+    this.#dataService.data$
+      .pipe(takeUntilDestroyed())
+      .subscribe(data => {
+        console.log(data);
+      });
+  }
+
+  // Or use DestroyRef directly
+  ngOnInit() {
+    const subscription = this.#dataService.updates$.subscribe();
+
+    this.#destroyRef.onDestroy(() => {
+      subscription.unsubscribe();
+      console.log('Cleaned up!');
+    });
+  }
+}
+```
+
+### In Services
+
+```typescript
+@Injectable()
+export class WebSocket {
+  #destroyRef = inject(DestroyRef);
+  #socket: WebSocket | null = null;
+
+  constructor() {
+    this.#destroyRef.onDestroy(() => {
+      this.#socket?.close();
+    });
+  }
+
+  connect(url: string) {
+    this.#socket = new WebSocket(url);
+  }
+}
+```
+
+### takeUntilDestroyed Outside Constructor
+
+```typescript
+@Component({...})
+export class My {
+  #destroyRef = inject(DestroyRef);
+  #http = inject(HttpClient);
+
+  loadData() {
+    // Pass destroyRef when using outside constructor
+    this.#http.get('/api/data')
+      .pipe(takeUntilDestroyed(this.#destroyRef))
+      .subscribe();
+  }
+}
+```
+
+## Injection Context Utilities
+
+### assertInInjectionContext
+
+```typescript
+import { assertInInjectionContext, inject } from '@angular/core';
+
+export function injectLogger(): Logger {
+  assertInInjectionContext(injectLogger);
+  return inject(Logger);
+}
+
+// Usage - must be called in injection context
+@Component({...})
+export class My2 {
+  #logger = injectLogger(); // OK
+
+  someMethod() {
+    // injectLogger(); // ERROR - not in injection context
+  }
+}
+```
+
+### Custom inject Functions
+
+```typescript
+// Create reusable injection utilities
+export function injectRouteParam(param: string): Signal<string | null> {
+  assertInInjectionContext(injectRouteParam);
+  
+  const route = inject(ActivatedRoute);
+  return toSignal(
+    route.paramMap.pipe(map(params => params.get(param))),
+    { initialValue: null }
+  );
+}
+
+export function injectQueryParam(param: string): Signal<string | null> {
+  assertInInjectionContext(injectQueryParam);
+  
+  const route = inject(ActivatedRoute);
+  return toSignal(
+    route.queryParamMap.pipe(map(params => params.get(param))),
+    { initialValue: null }
+  );
+}
+
+// Usage
+@Component({...})
+export class UserCmpt {
+  userId = injectRouteParam('id');
+  tab = injectQueryParam('tab');
+}
+```

--- a/skills/dev-skills/angular-directives/SKILL.md
+++ b/skills/dev-skills/angular-directives/SKILL.md
@@ -1,0 +1,460 @@
+---
+name: angular-directives
+description: Create custom directives in Angular for DOM manipulation and behavior extension. Use for attribute directives that modify element behavior/appearance, structural directives for portals/overlays, and host directives for composition. Triggers on creating reusable DOM behaviors, extending element functionality, or composing behaviors across components. Note - use native @if/@for/@switch for control flow, not custom structural directives. Do not use for component creation or control flow; use native @if/@for/@switch instead.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Directives
+
+Create custom directives for reusable DOM manipulation and behavior in Angular v20+.
+
+
+## Key Rules
+
+- **CRITICAL**: Do NOT use `@HostBinding` or `@HostListener` decorators
+- Use the `host` object in `@Directive` decorator instead
+- Use `inject()` for all dependencies
+- For control flow, use native `@if`, `@for`, `@switch` - NOT custom structural directives
+
+## Attribute Directives
+
+Modify the appearance or behavior of an element:
+
+```typescript
+import { Directive, input, effect, inject, ElementRef } from '@angular/core';
+
+@Directive({
+  selector: '[appHighlight]',
+})
+export class Highlight {
+  #el = inject(ElementRef<HTMLElement>);
+  
+  // Input with alias matching selector
+  color = input('yellow', { alias: 'appHighlight' });
+  
+  constructor() {
+    effect(() => {
+      this.#el.nativeElement.style.backgroundColor = this.color();
+    });
+  }
+}
+
+// Usage: <p appHighlight="lightblue">Highlighted text</p>
+// Usage: <p appHighlight>Default yellow highlight</p>
+```
+
+### Using host Property
+
+Prefer `host` over `@HostBinding`/`@HostListener`:
+
+```typescript
+@Directive({
+  selector: '[appTooltip]',
+  host: {
+    '(mouseenter)': 'show()',
+    '(mouseleave)': 'hide()',
+    '[attr.aria-describedby]': 'tooltipId',
+  },
+})
+export class Tooltip {
+  text = input.required<string>({ alias: 'appTooltip' });
+  position = input<'top' | 'bottom' | 'left' | 'right'>('top');
+  
+  tooltipId = `tooltip-${crypto.randomUUID()}`;
+  #tooltipEl: HTMLElement | null = null;
+  #el = inject(ElementRef<HTMLElement>);
+  
+  show() {
+    this.#tooltipEl = document.createElement('div');
+    this.#tooltipEl.id = this.tooltipId;
+    this.#tooltipEl.className = `tooltip tooltip-${this.position()}`;
+    this.#tooltipEl.textContent = this.text();
+    this.#tooltipEl.setAttribute('role', 'tooltip');
+    document.body.appendChild(this.#tooltipEl);
+    this.#positionTooltip();
+  }
+
+  hide() {
+    this.#tooltipEl?.remove();
+    this.#tooltipEl = null;
+  }
+
+  #positionTooltip() {
+    // Position logic based on this.position() and this.#el
+  }
+    ngOnDestroy() {
+        this.hide(); // Clean up on directive destroy
+    }
+}
+
+// Usage: <button appTooltip="Click to save" position="bottom">Save</button>
+```
+
+### Class and Style Manipulation
+
+```typescript
+@Directive({
+  selector: '[appButton]',
+  host: {
+    'class': 'btn',
+    '[class.btn-primary]': 'variant() === "primary"',
+    '[class.btn-secondary]': 'variant() === "secondary"',
+    '[class.btn-sm]': 'size() === "small"',
+    '[class.btn-lg]': 'size() === "large"',
+    '[class.disabled]': 'disabled()',
+    '[attr.disabled]': 'disabled() || null',
+  },
+})
+export class Button {
+  variant = input<'primary' | 'secondary'>('primary');
+  size = input<'small' | 'medium' | 'large'>('medium');
+  disabled = input(false, { transform: booleanAttribute });
+}
+
+// Usage: <button appButton variant="primary" size="large">Click</button>
+```
+
+### Event Handling
+
+```typescript
+@Directive({
+  selector: '[appClickOutside]',
+  host: {
+    '(document:click)': 'onDocumentClick($event)',
+  },
+})
+export class ClickOutside {
+  #el = inject(ElementRef<HTMLElement>);
+  
+  clickOutside = output<void>();
+  
+  onDocumentClick(event: MouseEvent) {
+    if (!this.#el.nativeElement.contains(event.target as Node)) {
+      this.clickOutside.emit();
+    }
+  }
+}
+
+// Usage: <div appClickOutside (clickOutside)="closeMenu()">...</div>
+```
+
+### Keyboard Shortcuts
+
+```typescript
+@Directive({
+  selector: '[appShortcut]',
+  host: {
+    '(document:keydown)': 'onKeydown($event)',
+  },
+})
+export class Shortcut {
+  key = input.required<string>({ alias: 'appShortcut' });
+  ctrl = input(false, { transform: booleanAttribute });
+  shift = input(false, { transform: booleanAttribute });
+  alt = input(false, { transform: booleanAttribute });
+  
+  triggered = output<KeyboardEvent>();
+  
+  onKeydown(event: KeyboardEvent) {
+    const keyMatch = event.key.toLowerCase() === this.key().toLowerCase();
+    const ctrlMatch = this.ctrl() ? event.ctrlKey || event.metaKey : !event.ctrlKey && !event.metaKey;
+    const shiftMatch = this.shift() ? event.shiftKey : !event.shiftKey;
+    const altMatch = this.alt() ? event.altKey : !event.altKey;
+    
+    if (keyMatch && ctrlMatch && shiftMatch && altMatch) {
+      event.preventDefault();
+      this.triggered.emit(event);
+    }
+  }
+}
+
+// Usage: <button appShortcut="s" ctrl (triggered)="save()">Save (Ctrl+S)</button>
+```
+
+## Structural Directives
+
+Use structural directives for DOM manipulation beyond control flow (portals, overlays, dynamic insertion points). For conditionals and loops, use native `@if`, `@for`, `@switch`.
+
+### Portal Directive
+
+Render content in a different DOM location:
+
+```typescript
+import {Directive, inject, TemplateRef, ViewContainerRef, OnInit, OnDestroy, input} from '@angular/core';
+
+@Directive({
+    selector: '[appPortal]',
+})
+export class Portal implements OnInit, OnDestroy {
+    #templateRef = inject(TemplateRef<any>);
+    #viewContainerRef = inject(ViewContainerRef);
+    #viewRef: EmbeddedViewRef<any> | null = null;
+
+    // Target container selector or element
+    target = input<string | HTMLElement>('body', {alias: 'appPortal'});
+
+    ngOnInit() {
+        const container = this.getContainer();
+        if (container) {
+            this.#viewRef = this.#viewContainerRef.createEmbeddedView(this.#templateRef);
+            this.#viewRef.rootNodes.forEach(node => container.appendChild(node));
+        }
+    }
+
+
+    ngOnDestroy() {
+        // Remove nodes from DOM before destroying view
+        this.#viewRef?.rootNodes.forEach(node => node.parentNode?.removeChild(node));
+        // Or with the modern Element.remove():
+        this.#viewRef?.rootNodes.forEach((node: ChildNode) => node.remove());
+
+        // then destroy the view
+        this.#viewRef?.destroy();
+    }
+
+
+    #getContainer(): HTMLElement | null {
+        const target = this.target();
+        if (typeof target === 'string') {
+            return document.querySelector(target);
+        }
+        return target;
+    }
+}
+
+// Usage: Render modal at body level
+// <div *appPortal="'body'">
+//   <div class="modal">Modal content</div>
+// </div>
+```
+
+### Lazy Render Directive
+
+Defer rendering until condition is met (one-time):
+
+```typescript
+@Directive({
+  selector: '[appLazyRender]',
+})
+export class LazyRender {
+  #templateRef = inject(TemplateRef<any>);
+  #viewContainer = inject(ViewContainerRef);
+  #rendered = signal(false);
+  
+  condition = input.required<boolean>({ alias: 'appLazyRender' });
+  
+  constructor() {
+    effect(() => {
+      // Only render once when condition becomes true
+      if (this.condition() && !this.#rendered()) {
+        this.#viewContainer.createEmbeddedView(this.#templateRef);
+        this.#rendered.set(true);
+      }
+    });
+  }
+}
+
+// Usage: Render heavy component only when tab is first activated
+// <div *appLazyRender="activeTab() === 'reports'">
+//   <app-heavy-reports />
+// </div>
+```
+
+### Template Outlet with Context
+
+```typescript
+interface TemplateContext<T> {
+  $implicit: T;
+  item: T;
+  index: number;
+}
+
+@Directive({
+  selector: '[appTemplateOutlet]',
+})
+export class TemplateOutlet<T> {
+  #viewContainer = inject(ViewContainerRef);
+  #currentView: EmbeddedViewRef<TemplateContext<T>> | null = null;
+  
+  template = input.required<TemplateRef<TemplateContext<T>>>({ alias: 'appTemplateOutlet' });
+  context = input.required<T>({ alias: 'appTemplateOutletContext' });
+  index = input(0, { alias: 'appTemplateOutletIndex' });
+  
+  constructor() {
+    effect(() => {
+      const template = this.template();
+      const context = this.context();
+      const index = this.index();
+      
+      if (this.#currentView) {
+        this.#currentView.context.$implicit = context;
+        this.#currentView.context.item = context;
+        this.#currentView.context.index = index;
+        this.#currentView.markForCheck();
+      } else {
+        this.#currentView = this.#viewContainer.createEmbeddedView(template, {
+          $implicit: context,
+          item: context,
+          index,
+        });
+      }
+    });
+  }
+}
+
+// Usage: Custom list with template
+// <ng-template #itemTemplate let-item let-i="index">
+//   <div>{{ i }}: {{ item.name }}</div>
+// </ng-template>
+// <ng-container 
+//   *appTemplateOutlet="itemTemplate; context: item; index: i"
+// />
+```
+
+## Host Directives
+
+Compose directives on components or other directives:
+
+```typescript
+// Reusable behavior directives
+@Directive({
+  selector: '[focusable]',
+  host: {
+    'tabindex': '0',
+    '(focus)': 'onFocus()',
+    '(blur)': 'onBlur()',
+    '[class.focused]': 'isFocused()',
+  },
+})
+export class Focusable {
+  isFocused = signal(false);
+  
+  onFocus() { this.isFocused.set(true); }
+  onBlur() { this.isFocused.set(false); }
+}
+
+@Directive({
+  selector: '[disableable]',
+  host: {
+    '[class.disabled]': 'disabled()',
+    '[attr.aria-disabled]': 'disabled()',
+  },
+})
+export class Disableable {
+  disabled = input(false, { transform: booleanAttribute });
+}
+
+// Component using host directives
+@Component({
+  selector: 'app-custom-button',
+  hostDirectives: [
+    Focusable,
+    {
+      directive: Disableable,
+      inputs: ['disabled'],
+    },
+  ],
+  host: {
+    'role': 'button',
+    '(click)': 'onClick($event)',
+    '(keydown.enter)': 'onClick($event)',
+    '(keydown.space)': 'onClick($event)',
+  },
+  template: `<ng-content />`,
+})
+export class CustomButton {
+  #disableable = inject(Disableable);
+  
+  clicked = output<void>();
+  
+  onClick(event: Event) {
+    if (!this.#disableable.disabled()) {
+      this.clicked.emit();
+    }
+  }
+}
+
+// Usage: <app-custom-button disabled>Click me</app-custom-button>
+```
+
+### Exposing Host Directive Outputs
+
+```typescript
+@Directive({
+  selector: '[hoverable]',
+  host: {
+    '(mouseenter)': 'onEnter()',
+    '(mouseleave)': 'onLeave()',
+    '[class.hovered]': 'isHovered()',
+  },
+})
+export class Hoverable {
+  isHovered = signal(false);
+  
+  hoverChange = output<boolean>();
+  
+  onEnter() {
+    this.isHovered.set(true);
+    this.hoverChange.emit(true);
+  }
+  
+  onLeave() {
+    this.isHovered.set(false);
+    this.hoverChange.emit(false);
+  }
+}
+
+@Component({
+  selector: 'app-card',
+  hostDirectives: [
+    {
+      directive: Hoverable,
+      outputs: ['hoverChange'],
+    },
+  ],
+  template: `<ng-content />`,
+})
+export class Card {}
+
+// Usage: <app-card (hoverChange)="onHover($event)">...</app-card>
+```
+
+## Directive Composition API
+
+Combine multiple behaviors:
+
+```typescript
+// Base directives
+@Directive({ selector: '[withRipple]' })
+export class Ripple {
+  // Ripple effect implementation
+}
+
+@Directive({ selector: '[withElevation]' })
+export class Elevation {
+  elevation = input(2);
+}
+
+// Composed component
+@Component({
+  selector: 'app-material-button',
+  hostDirectives: [
+    Ripple,
+    {
+      directive: Elevation,
+      inputs: ['elevation'],
+    },
+    {
+      directive: Disableable,
+      inputs: ['disabled'],
+    },
+  ],
+  template: `<ng-content />`,
+})
+export class MaterialButton {}
+```
+
+See `references/directive-patterns.md` for advanced directive patterns and composition examples.

--- a/skills/dev-skills/angular-directives/references/directive-patterns.md
+++ b/skills/dev-skills/angular-directives/references/directive-patterns.md
@@ -1,0 +1,570 @@
+# Angular Directive Patterns
+
+## Table of Contents
+- [DOM Manipulation](#dom-manipulation)
+- [Form Directives](#form-directives)
+- [Intersection Observer](#intersection-observer)
+- [Resize Observer](#resize-observer)
+- [Drag and Drop](#drag-and-drop)
+- [Permission Directive](#permission-directive)
+
+## DOM Manipulation
+
+### Auto-Focus Directive
+
+```typescript
+@Directive({
+  selector: '[appAutoFocus]',
+})
+export class AutoFocus {
+  #el = inject(ElementRef<HTMLElement>);
+  
+  enabled = input(true, { alias: 'appAutoFocus', transform: booleanAttribute });
+  delay = input(0);
+  
+  constructor() {
+    afterNextRender(() => {
+      if (this.enabled()) {
+        setTimeout(() => {
+          this.#el.nativeElement.focus();
+        }, this.delay());
+      }
+    });
+  }
+}
+
+// Usage: <input appAutoFocus />
+// Usage: <input [appAutoFocus]="shouldFocus()" [delay]="100" />
+```
+
+### Text Selection Directive
+
+```typescript
+@Directive({
+  selector: '[appSelectAll]',
+  host: {
+    '(focus)': 'onFocus()',
+    '(click)': 'onClick($event)',
+  },
+})
+export class SelectAll {
+  #el = inject(ElementRef<HTMLInputElement>);
+  
+  onFocus() {
+    // Delay to ensure value is set
+    setTimeout(() => this.#el.nativeElement.select(), 0);
+  }
+  
+  onClick(event: MouseEvent) {
+    // Select all on first click if not already focused
+    if (document.activeElement !== this.#el.nativeElement) {
+      this.#el.nativeElement.select();
+    }
+  }
+}
+
+// Usage: <input appSelectAll value="Select me on focus" />
+```
+
+### Copy to Clipboard
+
+```typescript
+@Directive({
+  selector: '[appCopyToClipboard]',
+  host: {
+    '(click)': 'copy()',
+    '[style.cursor]': '"pointer"',
+  },
+})
+export class CopyToClipboard {
+  text = input.required<string>({ alias: 'appCopyToClipboard' });
+  
+  copied = output<void>();
+  error = output<Error>();
+  
+  async copy() {
+    try {
+      await navigator.clipboard.writeText(this.text());
+      this.copied.emit();
+    } catch (err) {
+      this.error.emit(err as Error);
+    }
+  }
+}
+
+// Usage: 
+// <button [appCopyToClipboard]="textToCopy" (copied)="showToast('Copied!')">
+//   Copy
+// </button>
+```
+
+## Form Directives
+
+### Trim Input
+
+```typescript
+@Directive({
+  selector: 'input[appTrim], textarea[appTrim]',
+  host: {
+    '(blur)': 'onBlur()',
+  },
+})
+export class Trim {
+  #el = inject(ElementRef<HTMLInputElement | HTMLTextAreaElement>);
+  #ngControl = inject(NgControl, { optional: true, self: true });
+
+  onBlur() {
+    const value = this.#el.nativeElement.value;
+    const trimmed = value.trim();
+
+    if (value !== trimmed) {
+      this.#el.nativeElement.value = trimmed;
+      this.#ngControl?.control?.setValue(trimmed);
+    }
+  }
+}
+
+// Usage: <input appTrim formControlName="name" />
+```
+
+### Input Mask
+
+```typescript
+@Directive({
+  selector: '[appMask]',
+  host: {
+    '(input)': 'onInput($event)',
+    '(keydown)': 'onKeydown($event)',
+  },
+})
+export class Mask {
+  #el = inject(ElementRef<HTMLInputElement>);
+  
+  // Mask pattern: 9 = digit, A = letter, * = any
+  mask = input.required<string>({ alias: 'appMask' });
+  
+  onInput(event: InputEvent) {
+    const input = this.#el.nativeElement;
+    const value = input.value;
+    const masked = this.applyMask(value);
+    
+    if (value !== masked) {
+      input.value = masked;
+    }
+  }
+  
+  onKeydown(event: KeyboardEvent) {
+    // Allow navigation keys
+    if (['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(event.key)) {
+      return;
+    }
+    
+    const input = this.#el.nativeElement;
+    const position = input.selectionStart ?? 0;
+    const maskChar = this.mask()[position];
+    
+    if (!maskChar) {
+      event.preventDefault();
+      return;
+    }
+    
+    if (!this.isValidChar(event.key, maskChar)) {
+      event.preventDefault();
+    }
+  }
+  
+  #applyMask(value: string): string {
+    const mask = this.mask();
+    let result = '';
+    let valueIndex = 0;
+    
+    for (let i = 0; i < mask.length && valueIndex < value.length; i++) {
+      const maskChar = mask[i];
+      const inputChar = value[valueIndex];
+      
+      if (maskChar === '9' || maskChar === 'A' || maskChar === '*') {
+        if (this.isValidChar(inputChar, maskChar)) {
+          result += inputChar;
+          valueIndex++;
+        } else {
+          valueIndex++;
+          i--;
+        }
+      } else {
+        result += maskChar;
+        if (inputChar === maskChar) {
+          valueIndex++;
+        }
+      }
+    }
+    
+    return result;
+  }
+  
+  #isValidChar(char: string, maskChar: string): boolean {
+    switch (maskChar) {
+      case '9': return /\d/.test(char);
+      case 'A': return /[a-zA-Z]/.test(char);
+      case '*': return /[a-zA-Z0-9]/.test(char);
+      default: return char === maskChar;
+    }
+  }
+}
+
+// Usage: <input appMask="(999) 999-9999" placeholder="(555) 123-4567" />
+```
+
+### Character Counter
+
+```typescript
+@Directive({
+  selector: '[appCharCount]',
+})
+export class CharCount {
+  #el = inject(ElementRef<HTMLInputElement | HTMLTextAreaElement>);
+  
+  maxLength = input.required<number>({ alias: 'appCharCount' });
+  
+  currentLength = signal(0);
+  remaining = computed(() => this.maxLength() - this.currentLength());
+  isOverLimit = computed(() => this.remaining() < 0);
+  
+  constructor() {
+    effect(() => {
+      this.currentLength.set(this.#el.nativeElement.value.length);
+    });
+
+    // Listen for input changes
+    afterNextRender(() => {
+      this.#el.nativeElement.addEventListener('input', () => {
+        this.currentLength.set(this.#el.nativeElement.value.length);
+      });
+    });
+  }
+}
+
+// Usage with template:
+// <textarea appCharCount="500" #counter="appCharCount"></textarea>
+// <span>{{ counter.remaining() }} characters remaining</span>
+```
+
+## Intersection Observer
+
+### Lazy Load Directive
+
+```typescript
+@Directive({
+  selector: '[appLazyLoad]',
+})
+export class LazyLoad implements OnDestroy {
+  #el = inject(ElementRef<HTMLElement>);
+  #observer: IntersectionObserver | null = null;
+  
+  src = input.required<string>({ alias: 'appLazyLoad' });
+  placeholder = input('/assets/placeholder.png');
+  
+  loaded = output<void>();
+  
+  constructor() {
+    afterNextRender(() => {
+      this.setupObserver();
+    });
+  }
+  
+  #setupObserver() {
+    this.#observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            this.#loadImage();
+            this.#observer?.disconnect();
+          }
+        });
+      },
+      { rootMargin: '50px' }
+    );
+
+    this.#observer.observe(this.#el.nativeElement);
+
+    // Set placeholder
+    if (this.#el.nativeElement instanceof HTMLImageElement) {
+      this.#el.nativeElement.src = this.placeholder();
+    }
+  }
+
+  #loadImage() {
+    const element = this.#el.nativeElement;
+    
+    if (element instanceof HTMLImageElement) {
+      element.src = this.src();
+      element.onload = () => this.loaded.emit();
+    } else {
+      element.style.backgroundImage = `url(${this.src()})`;
+      this.loaded.emit();
+    }
+  }
+  
+  ngOnDestroy() {
+    this.#observer?.disconnect();
+  }
+}
+
+// Usage: <img [appLazyLoad]="imageUrl" alt="Lazy loaded image" />
+```
+
+### Infinite Scroll
+
+```typescript
+@Directive({
+  selector: '[appInfiniteScroll]',
+})
+export class InfiniteScroll implements OnDestroy {
+  #el = inject(ElementRef<HTMLElement>);
+  #observer: IntersectionObserver | null = null;
+
+  threshold = input(0.1);
+  disabled = input(false);
+
+  scrolled = output<void>();
+
+  constructor() {
+    afterNextRender(() => {
+      this.#setupObserver();
+    });
+
+    effect(() => {
+      if (this.disabled()) {
+        this.#observer?.disconnect();
+      } else {
+        this.#setupObserver();
+      }
+    });
+  }
+
+  #setupObserver() {
+    this.#observer?.disconnect();
+
+    this.#observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !this.disabled()) {
+          this.scrolled.emit();
+        }
+      },
+      { threshold: this.threshold() }
+    );
+
+    this.#observer.observe(this.#el.nativeElement);
+  }
+
+  ngOnDestroy() {
+    this.#observer?.disconnect();
+  }
+}
+
+// Usage:
+// <div class="list">
+//   @for (item of items(); track item.id) {
+//     <div>{{ item.name }}</div>
+//   }
+//   <div appInfiniteScroll (scrolled)="loadMore()" [disabled]="isLoading()">
+//     Loading...
+//   </div>
+// </div>
+```
+
+## Resize Observer
+
+```typescript
+@Directive({
+  selector: '[appResize]',
+})
+export class Resize implements OnDestroy {
+  #el = inject(ElementRef<HTMLElement>);
+  #observer: ResizeObserver | null = null;
+  
+  width = signal(0);
+  height = signal(0);
+  
+  resized = output<{ width: number; height: number }>();
+  
+  constructor() {
+    afterNextRender(() => {
+      this.#observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        const { width, height } = entry.contentRect;
+
+        this.width.set(width);
+        this.height.set(height);
+        this.resized.emit({ width, height });
+      });
+
+      this.#observer.observe(this.#el.nativeElement);
+    });
+  }
+
+  ngOnDestroy() {
+    this.#observer?.disconnect();
+  }
+}
+
+// Usage:
+// <div appResize #resize="appResize">
+//   Size: {{ resize.width() }}x{{ resize.height() }}
+// </div>
+```
+
+## Drag and Drop
+
+```typescript
+@Directive({
+  selector: '[appDraggable]',
+  host: {
+    'draggable': 'true',
+    '[class.dragging]': 'isDragging()',
+    '(dragstart)': 'onDragStart($event)',
+    '(dragend)': 'onDragEnd($event)',
+  },
+})
+export class Draggable {
+  data = input<any>(null, { alias: 'appDraggable' });
+  effectAllowed = input<DataTransfer['effectAllowed']>('move');
+  
+  isDragging = signal(false);
+  
+  dragStart = output<DragEvent>();
+  dragEnd = output<DragEvent>();
+  
+  onDragStart(event: DragEvent) {
+    this.isDragging.set(true);
+    
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = this.effectAllowed();
+      event.dataTransfer.setData('application/json', JSON.stringify(this.data()));
+    }
+    
+    this.dragStart.emit(event);
+  }
+  
+  onDragEnd(event: DragEvent) {
+    this.isDragging.set(false);
+    this.dragEnd.emit(event);
+  }
+}
+
+@Directive({
+  selector: '[appDropZone]',
+  host: {
+    '[class.drag-over]': 'isDragOver()',
+    '(dragover)': 'onDragOver($event)',
+    '(dragleave)': 'onDragLeave($event)',
+    '(drop)': 'onDrop($event)',
+  },
+})
+export class DropZone {
+  isDragOver = signal(false);
+  
+  dropped = output<DragEvent['dataTransfer']['items'][0]>();
+  
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+    this.isDragOver.set(true);
+  }
+  
+  onDragLeave(event: DragEvent) {
+    this.isDragOver.set(false);
+  }
+  
+  onDrop(event: DragEvent) {
+    event.preventDefault();
+    this.isDragOver.set(false);
+    
+    const data = event.dataTransfer?.getData('application/json');
+    if (data) {
+      this.dropped.emit(JSON.parse(data));
+    }
+  }
+}
+
+// Usage:
+// <div [appDraggable]="item">Drag me</div>
+// <div appDropZone (dropped)="onItemDropped($event)">Drop here</div>
+```
+
+## Permission Directive
+
+```typescript
+@Directive({
+  selector: '[appHasPermission]',
+})
+export class HasPermission {
+  #templateRef = inject(TemplateRef<any>);
+  #viewContainer = inject(ViewContainerRef);
+  #authService = inject(Auth);
+  #hasView = signal<boolean>(false);
+  
+  permission = input.required<string | string[]>({ alias: 'appHasPermission' });
+  mode = input<'any' | 'all'>('any');
+  
+  constructor() {
+    effect(() => {
+      const hasPermission = this.#checkPermission();
+
+      if (hasPermission && !this.#hasView()) {
+        this.#viewContainer.createEmbeddedView(this.#templateRef);
+        this.#hasView.set(true);
+      } else if (!hasPermission && this.#hasView()) {
+        this.#viewContainer.clear();
+        this.#hasView.set(false)
+      }
+    });
+  }
+  
+  #checkPermission(): boolean {
+    const required = this.permission();
+    const permissions = Array.isArray(required) ? required : [required];
+    const userPermissions = this.#authService.permissions();
+    
+    if (this.mode() === 'all') {
+      return permissions.every(p => userPermissions.includes(p));
+    }
+    
+    return permissions.some(p => userPermissions.includes(p));
+  }
+}
+
+// Usage:
+// <button *appHasPermission="'admin'">Admin Only</button>
+// <div *appHasPermission="['edit', 'delete']; mode: 'all'">Edit & Delete</div>
+```
+
+## Export Directive Reference
+
+```typescript
+@Directive({
+  selector: '[appToggle]',
+  exportAs: 'appToggle',
+})
+export class Toggle {
+  isOpen = signal(false);
+  
+  toggle() {
+    this.isOpen.update(v => !v);
+  }
+  
+  open() {
+    this.isOpen.set(true);
+  }
+  
+  close() {
+    this.isOpen.set(false);
+  }
+}
+
+// Usage:
+// <div appToggle #toggle="appToggle">
+//   <button (click)="toggle.toggle()">Toggle</button>
+//   @if (toggle.isOpen()) {
+//     <div>Content</div>
+//   }
+// </div>
+```

--- a/skills/dev-skills/angular-forms/SKILL.md
+++ b/skills/dev-skills/angular-forms/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: angular-forms
+description: Build forms in Angular using Reactive Forms (production-stable) with NonNullableFormBuilder, typed controls, validation, and dynamic FormArrays. Covers all form approaches including template-driven and experimental Signal Forms. Triggers on form implementation, adding validation, creating multi-step forms, or building forms with conditional fields. Do not use for simple display-only data or non-interactive UI.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Forms
+
+
+Build type-safe, reactive forms using Angular's Reactive Forms API with `NonNullableFormBuilder`, typed `FormControl`/`FormGroup`, and explicit control definitions.
+
+## Choosing Form Approach
+
+**Best Practice**: Prefer Reactive Forms over Template-driven forms.
+
+| Approach | Use Case | Status | Reference |
+|----------|----------|--------|-----------|
+| **Reactive Forms** | Production apps, complex validation | Stable, recommended | This file |
+| **Signal Forms** | New projects, modern patterns | Experimental (v21+) | See `references/signal-forms.md` |
+| Template-driven | Simple forms only | Not recommended | See `references/template-driven-forms.md` |
+
+## Basic Setup
+
+```typescript
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { ReactiveFormsModule, NonNullableFormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-login',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <label for="email">Email</label>
+      <input id="email" formControlName="email" />
+      @if (form.controls.email.errors?.['required'] && form.controls.email.touched) {
+        <span class="error">Email is required</span>
+      }
+
+      <label for="password">Password</label>
+      <input id="password" type="password" formControlName="password" />
+
+      <button type="submit" [disabled]="form.invalid">Login</button>
+    </form>
+  `,
+})
+export class Login {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    email: this.#fb.control<string>('', { validators: [Validators.required, Validators.email] }),
+    password: this.#fb.control<string>('', { validators: [Validators.required, Validators.minLength(8)] }),
+  });
+
+  onSubmit() {
+    if (this.form.valid) {
+      console.log(this.form.getRawValue());
+    }
+  }
+}
+```
+
+**Form definition convention (mandatory):** Always use `this.#fb.control<T>('', {validators: [...]})`. Never use shorthand arrays like `['', Validators.required]`.
+
+```typescript
+// CORRECT — explicit typed controls
+form = this.#fb.group({
+  name: this.#fb.control<string>('', { validators: [Validators.required] }),
+  address: this.#fb.group({
+    street: this.#fb.control<string>(''),
+    city: this.#fb.control<string>(''),
+    zip: this.#fb.control<string>(''),
+    state: this.#fb.group({
+      name: this.#fb.control<string>(''),
+      abbreviation: this.#fb.control<string>(''),
+    }),
+  }),
+});
+
+// WRONG — loses type inference, becomes AbstractControl
+form = this.#fb.group({
+  name: ['', Validators.required],
+  address: this.#fb.group({
+    street: [''],
+    city: [''],
+  }),
+});
+```
+
+## Typed Reactive Forms
+
+### Typed FormControl
+
+```typescript
+import { FormControl } from '@angular/forms';
+
+// Inferred type: FormControl<string | null>
+const name = new FormControl<string>('');
+
+// Non-nullable (no reset to null)
+const email = new FormControl<string>('', { nonNullable: true });
+// Type: FormControl<string>
+
+// With validators
+const username = new FormControl<string>('', {
+  nonNullable: true,
+  validators: [Validators.required, Validators.minLength(3)],
+});
+```
+
+### Typed FormGroup
+
+```typescript
+import { FormGroup, FormControl } from '@angular/forms';
+
+interface UserForm {
+  name: FormControl<string>;
+  email: FormControl<string>;
+  age: FormControl<number | null>;
+}
+
+const form = new FormGroup<UserForm>({
+  name: new FormControl<string>('', { nonNullable: true }),
+  email: new FormControl<string>('', { nonNullable: true }),
+  age: new FormControl<number | null>(null),
+});
+
+// Typed value access
+const name: string = form.controls.name.value;
+```
+
+### NonNullableFormBuilder
+
+`NonNullableFormBuilder` creates controls that reset to their initial value instead of `null`. Always prefer it over `FormBuilder`:
+
+```typescript
+import { inject } from '@angular/core';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
+
+type Theme = 'light' | 'dark';
+
+@Component({...})
+export class Profile {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    name: this.#fb.control<string>('', { validators: [Validators.required] }),
+    email: this.#fb.control<string>('', { validators: [Validators.required, Validators.email] }),
+    preferences: this.#fb.group({
+      newsletter: this.#fb.control<boolean>(false),
+      theme: this.#fb.control<Theme>('light'),
+    }),
+  });
+}
+```
+
+## `[formControl]` vs `formControlName`
+
+- `[formControl]` — binds a `FormControl` instance directly; type-safe but verbose for nested groups; best for standalone inputs and FormArray iteration
+- `formControlName` — binds by string name within `[formGroup]`/`formGroupName`; cleaner hierarchical templates; best for standard forms
+
+Refer to `references/form-patterns.md` for detailed examples of both directives with nested groups and comparison table.
+
+## Nested FormGroups
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <input formControlName="name" placeholder="Name" />
+
+      <div formGroupName="address">
+        <input formControlName="street" placeholder="Street" />
+        <input formControlName="city" placeholder="City" />
+        <input formControlName="zip" placeholder="ZIP" />
+      </div>
+
+      <button type="submit">Submit</button>
+    </form>
+  `,
+})
+export class Profile {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    name: this.#fb.control<string>('', { validators: [Validators.required] }),
+    address: this.#fb.group({
+      street: this.#fb.control<string>(''),
+      city: this.#fb.control<string>(''),
+      zip: this.#fb.control<string>(''),
+    }),
+  });
+
+  onSubmit() {
+    if (this.form.valid) {
+      console.log(this.form.getRawValue());
+    }
+  }
+}
+```
+
+## Dynamic Forms with FormArray
+
+```typescript
+import { FormArray } from '@angular/forms';
+
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <div formArrayName="items">
+        @for (item of form.controls.items.controls; track item; ) {
+          // in the for loop you have access to the following variables:
+          // $index , $odd, $even ,$first, $last out of the box
+          <div [formGroupName]="$index">
+            <input formControlName="product" placeholder="Product" />
+            <input formControlName="quantity" type="number" />
+            <button type="button" (click)="removeItem($index)">Remove</button>
+          </div>
+        }
+      </div>
+      <button type="button" (click)="addItem()">Add Item</button>
+    </form>
+  `,
+})
+export class OrderForm {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    items: this.#fb.array([this.#createItem()]),
+  });
+  
+  #createItem() {
+    return this.#fb.group({
+      product: this.#fb.control<string>('', { validators: [Validators.required] }),
+      quantity: this.#fb.control<number>(1, { validators: [Validators.required, Validators.min(1)] }),
+    });
+  }
+
+  addItem() {
+    this.form.controls.items.push(this.#createItem());
+  }
+
+  removeItem(index: number) {
+    this.form.controls.items.removeAt(index);
+  }
+}
+```
+
+## Custom Validators
+
+Create sync validators with `ValidatorFn`, cross-field validators on `FormGroup`, and async validators with `AsyncValidatorFn`. Apply via the `validators` / `asyncValidators` options in `this.#fb.control<T>()` for per-control validation, or in `this.#fb.group()` for cross-field (group-level) validation.
+
+Refer to `references/form-patterns.md` for custom validator examples including sync, cross-field, and async validators.
+
+## Form State Management
+
+Key state properties: `valid`, `invalid`, `pending`, `dirty`, `pristine`, `touched`, `untouched`. Update with `setValue()` (all fields) or `patchValue()` (partial). Reset with `form.reset()`. Mark all touched with `form.markAllAsTouched()`. Subscribe to `valueChanges` and `statusChanges` observables with `takeUntilDestroyed`. Use `form.events` (v21+) for unified ValueChangeEvent, StatusChangeEvent, FormSubmittedEvent, FormResetEvent.
+
+Refer to `references/form-patterns.md` for form state management patterns, valueChanges, and unified events API.
+
+## Error Display Pattern
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <input formControlName="email" />
+
+    @if (form.controls.email.invalid && form.controls.email.touched) {
+      <div class="errors">
+        @if (form.controls.email.errors?.['required']) {
+          <span>Email is required</span>
+        }
+        @if (form.controls.email.errors?.['email']) {
+          <span>Invalid email format</span>
+        }
+      </div>
+    }
+  `,
+})
+export class FormWithErrors {
+  // Helper for cleaner templates
+  hasError(controlName: string, errorKey: string): boolean {
+    const control = this.form.get(controlName) as FormControl;
+    return control?.hasError(errorKey) && control?.touched || false;
+  }
+}
+```
+
+## Form Submission Pattern
+
+Use `signal<boolean>(false)` for `isSubmitting` state. Call `form.markAllAsTouched()` on invalid submit. Wrap the async call in try/finally to reset `isSubmitting`.
+
+Refer to `references/form-patterns.md` for the complete form submission pattern with loading state and error handling.
+
+## Form Accessibility
+
+Forms MUST pass AXE checks and meet WCAG AA standards. Link labels to inputs via `for`/`id`. Announce error messages with `role="alert"`. Set `[attr.aria-invalid]` and `[attr.aria-describedby]` on inputs when invalid.
+
+Refer to `references/form-patterns.md` for the complete accessible form template with ARIA attributes.
+
+## Reference Guides
+
+- Refer to `references/form-patterns.md` for Form Patterns (Advanced) — typed forms, FormBuilder patterns, FormArray, custom validators, state management, and formControl vs formControlName
+- Refer to `references/signal-forms.md` for Signal Forms (Experimental) — Angular v21+ Signal Forms API with automatic two-way binding and schema-based validation
+- Refer to `references/template-driven-forms.md` for Template-Driven Forms — FormsModule/NgModel patterns for simple forms

--- a/skills/dev-skills/angular-forms/references/form-patterns.md
+++ b/skills/dev-skills/angular-forms/references/form-patterns.md
@@ -1,0 +1,555 @@
+# Angular Form Patterns
+
+## Table of Contents
+- [Reactive Forms (Production-Stable)](#reactive-forms-production-stable)
+- [Typed Reactive Forms](#typed-reactive-forms)
+- [FormBuilder Patterns](#formbuilder-patterns)
+- [Dynamic Forms with FormArray](#dynamic-forms-with-formarray)
+- [Custom Validators](#custom-validators)
+- [Form State Management](#form-state-management)
+- [Error Display Pattern](#error-display-pattern)
+- [Form Submission Pattern](#form-submission-pattern)
+- [`[formControl]` vs `formControlName`](#formcontrol-vs-formcontrolname)
+
+## Reactive Forms (Production-Stable)
+
+For production applications requiring stability guarantees, use Reactive Forms:
+
+```typescript
+import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { ReactiveFormsModule, NonNullableFormBuilder, Validators } from '@angular/forms';
+
+@Component({
+  selector: 'app-login',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <input formControlName="email" />
+      @if (form.controls.email.errors?.['required'] && form.controls.email.touched) {
+        <span class="error">Email is required</span>
+      }
+
+      <input type="password" formControlName="password" />
+
+      <button type="submit" [disabled]="form.invalid">Login</button>
+    </form>
+  `,
+})
+export class Login {
+  #fb = inject(NonNullableFormBuilder);
+
+  // Always use explicit typed controls — never shorthand arrays
+  form = this.#fb.group({
+    email: this.#fb.control<string>('', { validators: [Validators.required, Validators.email] }),
+    password: this.#fb.control<string>('', { validators: [Validators.required, Validators.minLength(8)] }),
+  });
+
+  onSubmit() {
+    if (this.form.valid) {
+      console.log(this.form.getRawValue());
+    }
+  }
+}
+```
+
+## Typed Reactive Forms
+
+### Typed FormControl
+
+```typescript
+import { FormControl } from '@angular/forms';
+
+// Inferred type: FormControl<string | null>
+const name = new FormControl<string>('');
+
+// Non-nullable (no reset to null)
+const email = new FormControl<string>('', { nonNullable: true });
+// Type: FormControl<string>
+
+// With validators
+const username = new FormControl<string>('', {
+  nonNullable: true,
+  validators: [Validators.required, Validators.minLength(3)],
+});
+```
+
+### Typed FormGroup
+
+```typescript
+import { FormGroup, FormControl } from '@angular/forms';
+
+interface UserForm {
+  name: FormControl<string>;
+  email: FormControl<string>;
+  age: FormControl<number | null>;
+}
+
+const form = new FormGroup<UserForm>({
+  name: new FormControl<string>('', { nonNullable: true }),
+  email: new FormControl<string>('', { nonNullable: true }),
+  age: new FormControl<number | null>(null),
+});
+
+// Typed value access
+const name: string = form.controls.name.value;
+```
+
+### NonNullableFormBuilder
+
+```typescript
+import { inject } from '@angular/core';
+import { NonNullableFormBuilder, Validators } from '@angular/forms';
+
+type Theme = 'light' | 'dark';
+
+@Component({...})
+export class Profile {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    name: this.#fb.control<string>('', { validators: [Validators.required] }),
+    email: this.#fb.control<string>('', { validators: [Validators.required, Validators.email] }),
+    preferences: this.#fb.group({
+      newsletter: this.#fb.control<boolean>(false),
+      theme: this.#fb.control<Theme>('light'),
+    }),
+  });
+}
+```
+
+## FormBuilder Patterns
+
+### Nested FormGroups
+
+```typescript
+@Component({
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <input formControlName="name" placeholder="Name" />
+      
+      <div formGroupName="address">
+        <input formControlName="street" placeholder="Street" />
+        <input formControlName="city" placeholder="City" />
+        <input formControlName="zip" placeholder="ZIP" />
+      </div>
+      
+      <button type="submit">Submit</button>
+    </form>
+  `,
+})
+export class Profile {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    name: this.#fb.control<string>('', { validators: [Validators.required] }),
+    address: this.#fb.group({
+      street: this.#fb.control<string>(''),
+      city: this.#fb.control<string>(''),
+      zip: this.#fb.control<string>(''),
+    }),
+  });
+}
+```
+
+## Dynamic Forms with FormArray
+
+```typescript
+import { FormArray } from '@angular/forms';
+
+@Component({
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      <div formArrayName="items">
+        @for (item of items.controls; track $index; let i = $index) {
+          <div [formGroupName]="i">
+            <input formControlName="product" placeholder="Product" />
+            <input formControlName="quantity" type="number" />
+            <button type="button" (click)="removeItem(i)">Remove</button>
+          </div>
+        }
+      </div>
+      <button type="button" (click)="addItem()">Add Item</button>
+    </form>
+  `,
+})
+export class Order {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    items: this.#fb.array([this.#createItem()]),
+  });
+
+  get items() {
+    return this.form.controls.items;
+  }
+
+  #createItem() {
+    return this.#fb.group({
+      product: this.#fb.control<string>('', { validators: [Validators.required] }),
+      quantity: this.#fb.control<number>(1, { validators: [Validators.required, Validators.min(1)] }),
+    });
+  }
+
+  addItem() {
+    this.items.push(this.#createItem());
+  }
+  
+  removeItem(index: number) {
+    this.items.removeAt(index);
+  }
+}
+```
+
+## Custom Validators
+
+### Sync Validator
+
+```typescript
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function forbiddenValue(forbidden: string): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    return control.value === forbidden 
+      ? { forbiddenValue: { value: control.value } } 
+      : null;
+  };
+}
+
+// Usage
+name: this.#fb.control<string>('', { validators: [Validators.required, forbiddenValue('admin')] }),
+```
+
+### Cross-Field Validator
+
+```typescript
+export function passwordMatch(): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const password = group.get('password')?.value;
+    const confirm = group.get('confirmPassword')?.value;
+    return password === confirm ? null : { passwordMismatch: true };
+  };
+}
+
+// Usage
+form = this.#fb.group({
+  password: this.#fb.control<string>('', { validators: [Validators.required, Validators.minLength(8)] }),
+  confirmPassword: this.#fb.control<string>('', { validators: [Validators.required] }),
+}, { validators: [passwordMatch()] });
+```
+
+### Async Validator
+
+```typescript
+import { AsyncValidatorFn } from '@angular/forms';
+import { map, catchError, of } from 'rxjs';
+
+export function uniqueEmail(userService: UserService): AsyncValidatorFn {
+  return (control: AbstractControl) => {
+    return userService.checkEmail(control.value).pipe(
+      map(exists => exists ? { emailTaken: true } : null),
+      catchError(() => of(null))
+    );
+  };
+}
+
+// Usage
+email: this.#fb.control<string>('', {
+  validators: [Validators.required, Validators.email],
+  asyncValidators: [uniqueEmail(this.#userService)],
+}),
+```
+
+## Form State Management
+
+### State Properties
+
+```typescript
+// Check states
+form.valid      // All validations pass
+form.invalid    // Has validation errors
+form.pending    // Async validation in progress
+form.dirty      // Value changed by user
+form.pristine   // Value not changed
+form.touched    // Control has been focused
+form.untouched  // Control never focused
+
+// Update values
+form.setValue({ name: 'John', email: 'john@example.com' }); // Must include all
+form.patchValue({ name: 'John' }); // Partial update
+
+// Reset
+form.reset();
+form.reset({ name: 'Default' });
+
+// Disable/Enable
+form.disable();
+form.enable();
+form.controls.email.disable();
+
+// Mark states
+form.markAllAsTouched(); // Show all errors
+form.markAsPristine();
+form.markAsDirty();
+```
+
+### Value Changes Observable
+
+```typescript
+// Subscribe to value changes
+form.valueChanges.subscribe(value => {
+  console.log('Form value:', value);
+});
+
+// Single control with debounce
+form.controls.email.valueChanges.pipe(
+  debounceTime(300),
+  distinctUntilChanged()
+).subscribe(email => {
+  this.validateEmail(email);
+});
+
+// Status changes
+form.statusChanges.subscribe(status => {
+  console.log('Form status:', status); // VALID, INVALID, PENDING
+});
+```
+
+### Unified Events (Angular v21+)
+
+```typescript
+import { 
+  ValueChangeEvent, StatusChangeEvent, 
+  FormSubmittedEvent, FormResetEvent 
+} from '@angular/forms';
+
+form.events.subscribe(event => {
+  if (event instanceof ValueChangeEvent) {
+    console.log('Value changed:', event.value);
+  }
+  if (event instanceof StatusChangeEvent) {
+    console.log('Status changed:', event.status);
+  }
+  if (event instanceof FormSubmittedEvent) {
+    console.log('Form submitted');
+  }
+  if (event instanceof FormResetEvent) {
+    console.log('Form reset');
+  }
+});
+```
+
+## Error Display Pattern
+
+```typescript
+@Component({
+  template: `
+    <input formControlName="email" />
+    
+    @if (form.controls.email.invalid && form.controls.email.touched) {
+      <div class="errors">
+        @if (form.controls.email.errors?.['required']) {
+          <span>Email is required</span>
+        }
+        @if (form.controls.email.errors?.['email']) {
+          <span>Invalid email format</span>
+        }
+      </div>
+    }
+  `,
+})
+export class Form {
+  // Helper for cleaner templates
+  hasError(controlName: string, errorKey: string): boolean {
+    const control = this.form.get(controlName);
+    return control?.hasError(errorKey) && control?.touched || false;
+  }
+}
+```
+
+## Form Submission Pattern
+
+```typescript
+@Component({
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <!-- fields -->
+      <button type="submit" [disabled]="form.invalid || isSubmitting">
+        {{ isSubmitting ? 'Submitting...' : 'Submit' }}
+      </button>
+    </form>
+  `,
+})
+export class Form {
+  isSubmitting = false;
+  
+  async onSubmit() {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    
+    this.isSubmitting = true;
+    try {
+      await this.api.submit(this.form.getRawValue());
+      this.form.reset();
+    } catch (error) {
+      // Handle error
+    } finally {
+      this.isSubmitting = false;
+    }
+  }
+}
+```
+
+## `[formControl]` vs `formControlName`
+
+Angular provides two directives for binding form controls in templates. Understanding when to use each is critical for correct form wiring.
+
+### `FormControlDirective` — `[formControl]`
+
+Binds a `FormControl` instance directly to a DOM element. Does **not** require a parent `[formGroup]` or `formGroupName`.
+
+```typescript
+@Component({
+  imports: [ReactiveFormsModule],
+  template: `
+    <input [formControl]="nameControl" />
+    <p>Value: {{ nameControl.value }}</p>
+  `,
+})
+export class StandaloneInput {
+  #fb = inject(NonNullableFormBuilder);
+  nameControl = this.#fb.control<string>('', { validators: [Validators.required] });
+}
+```
+
+### `FormControlName` — `formControlName`
+
+Binds a control **by name** within a parent `[formGroup]` or `formGroupName` context. Angular resolves the `FormControl` from the group hierarchy.
+
+```typescript
+@Component({
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+      <input formControlName="name" />
+      <input formControlName="email" />
+    </form>
+  `,
+})
+export class NameBasedForm {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    name: this.#fb.control<string>('', { validators: [Validators.required] }),
+    email: this.#fb.control<string>('', { validators: [Validators.required, Validators.email] }),
+  });
+
+  onSubmit() {
+    if (this.form.valid) {
+      console.log(this.form.getRawValue());
+    }
+  }
+}
+```
+
+### Nested Groups Comparison
+
+**`formGroupName` + `formControlName` (recommended for nested forms):**
+
+```html
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
+  <input formControlName="name" />
+  <fieldset formGroupName="address">
+    <legend>Address</legend>
+    <input formControlName="street" />
+    <input formControlName="city" />
+    <input formControlName="zip" />
+    <fieldset formGroupName="state">
+      <legend>State</legend>
+      <input formControlName="name" />
+      <input formControlName="abbreviation" />
+    </fieldset>
+  </fieldset>
+</form>
+```
+
+**`[formControl]` with explicit paths (alternative):**
+
+```html
+<form [formGroup]="form" (ngSubmit)="onSubmit()">
+  <input [formControl]="form.controls.name" />
+  <fieldset>
+    <legend>Address</legend>
+    <input [formControl]="form.controls.address.controls.street" />
+    <input [formControl]="form.controls.address.controls.city" />
+    <input [formControl]="form.controls.address.controls.zip" />
+    <fieldset>
+      <legend>State</legend>
+      <input [formControl]="form.controls.address.controls.state.controls.name" />
+      <input [formControl]="form.controls.address.controls.state.controls.abbreviation" />
+    </fieldset>
+  </fieldset>
+</form>
+```
+
+### When to Use Each
+
+| Scenario | Recommended | Why |
+|----------|-------------|-----|
+| Standard forms with `[formGroup]` | `formControlName` | Cleaner templates, automatic group hierarchy |
+| Standalone inputs (no parent group) | `[formControl]` | Only option without a `FormGroup` context |
+| `FormArray` iteration | `[formControl]` | Direct binding to each array element's control |
+| Reusable input components | `[formControl]` | Accept `FormControl` as input, no group dependency |
+| Dynamic/programmatic controls | `[formControl]` | Direct reference to the control instance |
+| Deeply nested groups | `formGroupName` + `formControlName` | Avoids long `.controls.x.controls.y` chains |
+
+### FormArray with `[formControl]`
+
+When iterating `FormArray` items, `[formControl]` provides direct access to each control:
+
+```typescript
+@Component({
+  imports: [ReactiveFormsModule],
+  template: `
+    <form [formGroup]="form">
+      @for (tag of tags.controls; track $index; let i = $index) {
+        <div>
+          <input [formControl]="tag" />
+          <button type="button" (click)="removeTag(i)">Remove</button>
+        </div>
+      }
+      <button type="button" (click)="addTag()">Add Tag</button>
+    </form>
+  `,
+})
+export class TagEditor {
+  #fb = inject(NonNullableFormBuilder);
+
+  form = this.#fb.group({
+    tags: this.#fb.array([
+      this.#fb.control<string>('', { validators: [Validators.required] }),
+    ]),
+  });
+
+  get tags() {
+    return this.form.controls.tags;
+  }
+
+  addTag() {
+    this.tags.push(this.#fb.control<string>('', { validators: [Validators.required] }));
+  }
+
+  removeTag(index: number) {
+    this.tags.removeAt(index);
+  }
+}
+```
+
+### Summary
+
+- **`formControlName`**: Use with `formGroupName`/`[formGroup]` for clean, hierarchical templates. Angular resolves control references by name.
+- **`[formControl]`**: Use for standalone controls, `FormArray` iteration, reusable components, or when you need a direct reference to the `FormControl` instance.

--- a/skills/dev-skills/angular-forms/references/signal-forms.md
+++ b/skills/dev-skills/angular-forms/references/signal-forms.md
@@ -1,0 +1,462 @@
+# Angular Signal Forms (Experimental)
+
+> **Status: Experimental in Angular v21+.** Signal Forms are not yet stable. For production applications, use Reactive Forms (see [SKILL.md](../SKILL.md)).
+
+
+Build type-safe, reactive forms using Angular's Signal Forms API. Signal Forms provide automatic two-way binding, schema-based validation, and reactive field state.
+
+## Basic Setup
+
+```typescript
+import { Component, signal } from '@angular/core';
+import { form, FormField, required, email } from '@angular/forms/signals';
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+@Component({
+  selector: 'app-login',
+  imports: [FormField],
+  template: `
+    <form (submit)="login($event)">
+      <label>
+        Email
+        <input type="email" [formField]="loginForm.email" />
+      </label>
+      @if (loginForm.email().touched() && loginForm.email().invalid()) {
+        <p class="error">{{ loginForm.email().errors()[0].message }}</p>
+      }
+
+      <label>
+        Password
+        <input type="password" [formField]="loginForm.password" />
+      </label>
+      @if (loginForm.password().touched() && loginForm.password().invalid()) {
+        <p class="error">{{ loginForm.password().errors()[0].message }}</p>
+      }
+
+      <button type="submit" [disabled]="loginForm().invalid()">Login</button>
+    </form>
+  `,
+})
+export class Login {
+  // Form model - a writable signal
+  loginModel = signal<LoginData>({
+    email: '',
+    password: '',
+  });
+
+  // Create form with validation schema
+  loginForm = form(this.loginModel, (schemaPath) => {
+    required(schemaPath.email, { message: 'Email is required' });
+    email(schemaPath.email, { message: 'Enter a valid email address' });
+    required(schemaPath.password, { message: 'Password is required' });
+  });
+
+  login(event: Event) {
+    event.preventDefault();
+    if (this.loginForm().valid()) {
+      const credentials = this.loginModel();
+      console.log('Submitting:', credentials);
+    }
+  }
+}
+```
+
+## Form Models
+
+Form models are writable signals that serve as the single source of truth:
+
+```typescript
+// Define interface for type safety
+interface UserProfile {
+  name: string;
+  email: string;
+  age: number | null;
+  preferences: {
+    newsletter: boolean;
+    theme: 'light' | 'dark';
+  };
+}
+
+// Create model signal with initial values
+const userModel = signal<UserProfile>({
+  name: '',
+  email: '',
+  age: null,
+  preferences: {
+    newsletter: false,
+    theme: 'light',
+  },
+});
+
+// Create form from model
+const userForm = form(userModel);
+
+// Access nested fields via dot notation
+userForm.name                    // FieldTree<string>
+userForm.preferences.theme       // FieldTree<'light' | 'dark'>
+```
+
+### Reading Values
+
+```typescript
+// Read entire model
+const data = this.userModel();
+
+// Read field value via field state
+const name = this.userForm.name().value();
+const theme = this.userForm.preferences.theme().value();
+```
+
+### Updating Values
+
+```typescript
+// Replace entire model
+this.userModel.set({
+  name: 'Alice',
+  email: 'alice@example.com',
+  age: 30,
+  preferences: { newsletter: true, theme: 'dark' },
+});
+
+// Update single field
+this.userForm.name().value.set('Bob');
+this.userForm.age().value.update(age => (age ?? 0) + 1);
+```
+
+## Field State
+
+Each field provides reactive signals for validation, interaction, and availability:
+
+```typescript
+const emailField = this.form.email();
+
+// Validation state
+emailField.valid()      // true if passes all validation
+emailField.invalid()    // true if has validation errors
+emailField.errors()     // array of error objects
+emailField.pending()    // true if async validation in progress
+
+// Interaction state
+emailField.touched()    // true after focus + blur
+emailField.dirty()      // true after user modification
+
+// Availability state
+emailField.disabled()   // true if field is disabled
+emailField.hidden()     // true if field should be hidden
+emailField.readonly()   // true if field is readonly
+
+// Value
+emailField.value()      // current field value (signal)
+```
+
+### Form-Level State
+
+The form itself is also a field with aggregated state:
+
+```typescript
+// Form is valid when all interactive fields are valid
+this.form().valid()
+
+// Form is touched when any field is touched
+this.form().touched()
+
+// Form is dirty when any field is modified
+this.form().dirty()
+```
+
+## Validation
+
+### Built-in Validators
+
+```typescript
+import {
+  form, required, email, min, max,
+  minLength, maxLength, pattern
+} from '@angular/forms/signals';
+
+const userForm = form(this.userModel, (schemaPath) => {
+  // Required field
+  required(schemaPath.name, { message: 'Name is required' });
+
+  // Email format
+  email(schemaPath.email, { message: 'Invalid email' });
+
+  // Numeric range
+  min(schemaPath.age, 18, { message: 'Must be 18+' });
+  max(schemaPath.age, 120, { message: 'Invalid age' });
+
+  // String/array length
+  minLength(schemaPath.password, 8, { message: 'Min 8 characters' });
+  maxLength(schemaPath.bio, 500, { message: 'Max 500 characters' });
+
+  // Regex pattern
+  pattern(schemaPath.phone, /^\d{3}-\d{3}-\d{4}$/, {
+    message: 'Format: 555-123-4567',
+  });
+});
+```
+
+### Conditional Validation
+
+```typescript
+const orderForm = form(this.orderModel, (schemaPath) => {
+  required(schemaPath.promoCode, {
+    message: 'Promo code required for discounts',
+    when: ({ valueOf }) => valueOf(schemaPath.applyDiscount),
+  });
+});
+```
+
+### Custom Validators
+
+```typescript
+import { validate } from '@angular/forms/signals';
+
+const signupForm = form(this.signupModel, (schemaPath) => {
+  // Custom validation logic
+  validate(schemaPath.username, ({ value }) => {
+    if (value().includes(' ')) {
+      return { kind: 'noSpaces', message: 'Username cannot contain spaces' };
+    }
+    return null;
+  });
+});
+```
+
+### Cross-Field Validation
+
+```typescript
+const passwordForm = form(this.passwordModel, (schemaPath) => {
+  required(schemaPath.password);
+  required(schemaPath.confirmPassword);
+
+  // Compare fields
+  validate(schemaPath.confirmPassword, ({ value, valueOf }) => {
+    if (value() !== valueOf(schemaPath.password)) {
+      return { kind: 'mismatch', message: 'Passwords do not match' };
+    }
+    return null;
+  });
+});
+```
+
+### Async Validation
+
+```typescript
+import { validateHttp } from '@angular/forms/signals';
+
+const signupForm = form(this.signupModel, (schemaPath) => {
+  validateHttp(schemaPath.username, {
+    request: ({ value }) => `/api/check-username?u=${value()}`,
+    onSuccess: (response: { taken: boolean }) => {
+      if (response.taken) {
+        return { kind: 'taken', message: 'Username already taken' };
+      }
+      return null;
+    },
+    onError: () => ({
+      kind: 'networkError',
+      message: 'Could not verify username',
+    }),
+  });
+});
+```
+
+## Conditional Fields
+
+### Hidden Fields
+
+```typescript
+import { hidden } from '@angular/forms/signals';
+
+const profileForm = form(this.profileModel, (schemaPath) => {
+  hidden(schemaPath.publicUrl, ({ valueOf }) => !valueOf(schemaPath.isPublic));
+});
+```
+
+```html
+@if (!profileForm.publicUrl().hidden()) {
+  <input [formField]="profileForm.publicUrl" />
+}
+```
+
+### Disabled Fields
+
+```typescript
+import { disabled } from '@angular/forms/signals';
+
+const orderForm = form(this.orderModel, (schemaPath) => {
+  disabled(schemaPath.couponCode, ({ valueOf }) => valueOf(schemaPath.total) < 50);
+});
+```
+
+### Readonly Fields
+
+```typescript
+import { readonly } from '@angular/forms/signals';
+
+const accountForm = form(this.accountModel, (schemaPath) => {
+  readonly(schemaPath.username); // Always readonly
+});
+```
+
+## Form Submission
+
+```typescript
+import { submit } from '@angular/forms/signals';
+
+@Component({
+  template: `
+    <form (submit)="onSubmit($event)">
+      <input [formField]="form.email" />
+      <input [formField]="form.password" />
+      <button type="submit" [disabled]="form().invalid()">Submit</button>
+    </form>
+  `,
+})
+export class Login {
+  model = signal({ email: '', password: '' });
+  form = form(this.model, (schemaPath) => {
+    required(schemaPath.email);
+    required(schemaPath.password);
+  });
+
+  onSubmit(event: Event) {
+    event.preventDefault();
+
+    // submit() marks all fields touched and runs callback if valid
+    submit(this.form, async () => {
+      await this.authService.login(this.model());
+    });
+  }
+}
+```
+
+## Arrays and Dynamic Fields
+
+```typescript
+interface Order {
+  items: Array<{ product: string; quantity: number }>;
+}
+
+@Component({
+  template: `
+    @for (item of orderForm.items; track $index; let i = $index) {
+      <div>
+        <input [formField]="item.product" placeholder="Product" />
+        <input [formField]="item.quantity" type="number" />
+        <button type="button" (click)="removeItem(i)">Remove</button>
+      </div>
+    }
+    <button type="button" (click)="addItem()">Add Item</button>
+  `,
+})
+export class OrderComponent {
+  orderModel = signal<Order>({
+    items: [{ product: '', quantity: 1 }],
+  });
+
+  orderForm = form(this.orderModel, (schemaPath) => {
+    applyEach(schemaPath.items, (item) => {
+      required(item.product, { message: 'Product required' });
+      min(item.quantity, 1, { message: 'Min quantity is 1' });
+    });
+  });
+
+  addItem() {
+    this.orderModel.update(m => ({
+      ...m,
+      items: [...m.items, { product: '', quantity: 1 }],
+    }));
+  }
+
+  removeItem(index: number) {
+    this.orderModel.update(m => ({
+      ...m,
+      items: m.items.filter((_, i) => i !== index),
+    }));
+  }
+}
+```
+
+## Displaying Errors
+
+```html
+<input [formField]="form.email" />
+
+@if (form.email().touched() && form.email().invalid()) {
+  <ul class="errors">
+    @for (error of form.email().errors(); track error) {
+      <li>{{ error.message }}</li>
+    }
+  </ul>
+}
+
+@if (form.email().pending()) {
+  <span>Validating...</span>
+}
+```
+
+## Styling Based on State
+
+```html
+<input
+  [formField]="form.email"
+  [class.is-invalid]="form.email().touched() && form.email().invalid()"
+  [class.is-valid]="form.email().touched() && form.email().valid()"
+/>
+```
+
+## Reset Form
+
+```typescript
+async onSubmit() {
+  if (!this.form().valid()) return;
+
+  await this.api.submit(this.model());
+
+  // Clear interaction state
+  this.form().reset();
+
+  // Clear values
+  this.model.set({ email: '', password: '' });
+}
+```
+
+## Form Accessibility
+
+Forms MUST meet accessibility requirements:
+
+```html
+<form (submit)="onSubmit($event)">
+  <div role="group" aria-labelledby="name-label">
+    <label id="name-label" for="name-input">Name</label>
+    <input
+      id="name-input"
+      [formField]="form.name"
+      [attr.aria-invalid]="form.name().invalid()"
+      [attr.aria-describedby]="form.name().invalid() ? 'name-error' : null"
+    />
+    @if (form.name().touched() && form.name().invalid()) {
+      <p id="name-error" role="alert" class="error">
+        {{ form.name().errors()[0].message }}
+      </p>
+    }
+  </div>
+
+  <button type="submit" [disabled]="form().invalid()">
+    Submit
+  </button>
+</form>
+```
+
+**Requirements**:
+- Labels linked to inputs via `for`/`id`
+- Error messages announced with `role="alert"`
+- Invalid state communicated with `aria-invalid`
+- Submit button disabled state is accessible
+- Must pass AXE accessibility checks

--- a/skills/dev-skills/angular-forms/references/template-driven-forms.md
+++ b/skills/dev-skills/angular-forms/references/template-driven-forms.md
@@ -1,0 +1,402 @@
+# Angular Template-Driven Forms
+
+> **Not recommended for complex forms.** Template-driven forms are suitable only for simple scenarios. For production applications with complex validation, use Reactive Forms (see [SKILL.md](../SKILL.md)). For experimental signal-based forms, see [signal-forms.md](signal-forms.md).
+
+
+## Overview
+
+Template-driven forms use directives from `FormsModule` to create forms directly in the template. They rely on two-way data binding with `[(ngModel)]` and use an **asynchronous** data flow (values and validation update on the next change detection cycle). This async nature means tests require `fixture.whenStable()` before assertions.
+
+## Setup
+
+```typescript
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-login',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule],
+  template: `
+    <form #loginForm="ngForm" (ngSubmit)="onSubmit(loginForm)">
+      <label for="email">Email</label>
+      <input
+        id="email"
+        name="email"
+        type="email"
+        [(ngModel)]="templateDrivenForm().email"
+        #emailRef="ngModel"
+        required
+        email
+      />
+      @if (emailRef.invalid && emailRef.touched) {
+        <div class="errors">
+          @if (emailRef.errors?.['required']) {
+            <span>Email is required</span>
+          }
+          @if (emailRef.errors?.['email']) {
+            <span>Invalid email format</span>
+          }
+        </div>
+      }
+
+      <label for="password">Password</label>
+      <input
+        id="password"
+        name="password"
+        type="password"
+        [(ngModel)]="templateDrivenForm().password"
+        #passwordRef="ngModel"
+        required
+        minlength="8"
+      />
+      @if (passwordRef.invalid && passwordRef.touched) {
+        <div class="errors">
+          @if (passwordRef.errors?.['required']) {
+            <span>Password is required</span>
+          }
+          @if (passwordRef.errors?.['minlength']) {
+            <span>Password must be at least 8 characters</span>
+          }
+        </div>
+      }
+
+      <button type="submit" [disabled]="loginForm.invalid">Login</button>
+    </form>
+  `,
+})
+export class Login {
+    templateDrivenForm = signal<LoginUser>({
+        email: '',
+        password: '',
+    })
+  onSubmit(form: any) {
+    if (form.valid) {
+      console.log('Submitting:', { email: this.email, password: this.password });
+    }
+  }
+}
+```
+
+## Core Directives
+
+| Directive | Export As | Description |
+|-----------|----------|-------------|
+| `NgModel` | `ngModel` | Two-way binding for form controls. Requires `name` attribute. |
+| `NgForm` | `ngForm` | Top-level form directive, auto-applied to `<form>` elements. |
+| `NgModelGroup` | `ngModelGroup` | Groups related controls under a sub-object. |
+
+## CSS State Classes
+
+Angular automatically adds CSS classes to form controls based on their state:
+
+| State | True Class | False Class |
+|-------|-----------|-------------|
+| Visited | `ng-touched` | `ng-untouched` |
+| Changed | `ng-dirty` | `ng-pristine` |
+| Valid | `ng-valid` | `ng-invalid` |
+
+```css
+input.ng-invalid.ng-touched {
+  border-color: red;
+}
+
+input.ng-valid.ng-touched {
+  border-color: green;
+}
+```
+
+## Template Reference Variables
+
+Access control state using template reference variables exported as `ngModel`:
+
+```html
+<input
+  name="username"
+  [(ngModel)]="username"
+  #usernameRef="ngModel"
+  required
+  minlength="3"
+/>
+
+<!-- Access state properties -->
+@if (usernameRef.invalid && usernameRef.touched) {
+  <span>Username is invalid</span>
+}
+
+<!-- Available properties -->
+<!-- usernameRef.valid, usernameRef.invalid -->
+<!-- usernameRef.touched, usernameRef.untouched -->
+<!-- usernameRef.dirty, usernameRef.pristine -->
+<!-- usernameRef.errors -->
+```
+
+## Grouping Controls with NgModelGroup
+
+```typescript
+
+@Component({
+    selector: 'app-profile',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [FormsModule],
+    template: `
+     <form #profileForm="ngForm" (ngSubmit)="onProfileSubmit(profileForm)" class="form-container"
+            style="margin-top: 40px;">
+        <label for="td-name" class="form-label">Name
+          <input id="td-name" name="name" class="form-input" [(ngModel)]="templateDrivenFormV2().name" required/>
+        </label>
+
+        <fieldset ngModelGroup="address" #addressGroup="ngModelGroup" class="form-fieldset">
+          <legend class="form-legend">Address</legend>
+          <div class="fieldset-content">
+            <label for="td-street" class="form-label">Street
+              <input id="td-street" name="street" class="form-input"
+                     [(ngModel)]="templateDrivenFormV2().address.street"/>
+            </label>
+
+            <label for="td-city" class="form-label">City
+              <input id="td-city" name="city" class="form-input" [(ngModel)]="templateDrivenFormV2().address.city"
+                     required/>
+            </label>
+
+            <label for="td-zip" class="form-label">Zip
+              <input id="td-zip" name="zip" class="form-input" [(ngModel)]="templateDrivenFormV2().address.zip"
+                     minlength="3"/>
+            </label>
+          </div>
+        </fieldset>
+
+        @if (addressGroup.invalid && addressGroup.touched) {
+          <div class="errors">
+            <span>Please complete the address</span>
+          </div>
+        }
+
+        <button type="submit" class="submit-button">Save</button>
+      </form>
+  `,
+})
+export class Profile {
+    templateDrivenFormV2 = signal({
+        name: '',
+        address: {
+            street: '',
+            city: '',
+            zip: '',
+        }
+    })
+
+
+    protected onProfileSubmit(form: NgForm) {
+        form.form.markAllAsTouched(); //  to force validation errors to show if the user tries to submit without interacting with the form
+        if (form.valid) {
+            console.log('Profile form submitted:', {
+                name: this.templateDrivenFormV2().name,
+                address: this.templateDrivenFormV2().address
+            });
+        }
+    }
+}
+```
+
+## Validation
+
+### Built-in HTML5 Validators
+
+Angular maps standard HTML5 validation attributes to built-in validator directives:
+
+```html
+<input name="email" [(ngModel)]="email" required email />
+<input name="age" [(ngModel)]="age" required min="18" max="120" />
+<input name="username" [(ngModel)]="username" required minlength="3" maxlength="20" />
+<input name="phone" [(ngModel)]="phone" pattern="^\d{3}-\d{3}-\d{4}$" />
+```
+
+### Custom Validator Directive
+
+Create reusable validators as directives that implement `Validator` and provide `NG_VALIDATORS`:
+
+```typescript
+import { Directive } from '@angular/core';
+import { NG_VALIDATORS, Validator, AbstractControl, ValidationErrors } from '@angular/forms';
+
+@Directive({
+  selector: '[appForbiddenValue]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: ForbiddenValueDirective,
+      multi: true,
+    },
+  ],
+})
+export class ForbiddenValueDirective implements Validator {
+  forbiddenValue = input.required<string>({ alias: 'appForbiddenValue' });
+
+  validate(control: AbstractControl): ValidationErrors | null {
+    return control.value === this.forbiddenValue()
+      ? { forbiddenValue: { value: control.value } }
+      : null;
+  }
+}
+```
+
+```html
+<input name="username" [(ngModel)]="username" appForbiddenValue="admin" />
+```
+
+### Cross-Field Validator Directive
+
+```typescript
+import { Directive } from '@angular/core';
+import { NG_VALIDATORS, Validator, AbstractControl, ValidationErrors } from '@angular/forms';
+
+@Directive({
+  selector: '[appPasswordMatch]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: PasswordMatchDirective,
+      multi: true,
+    },
+  ],
+})
+export class PasswordMatchDirective implements Validator {
+  validate(group: AbstractControl): ValidationErrors | null {
+    const password = group.get('password')?.value;
+    const confirm = group.get('confirmPassword')?.value;
+    return password === confirm ? null : { passwordMismatch: true };
+  }
+}
+```
+
+```html
+<div ngModelGroup="passwords" appPasswordMatch>
+  <input name="password" [(ngModel)]="password" required />
+  <input name="confirmPassword" [(ngModel)]="confirmPassword" required />
+  @if (passwordsGroup.errors?.['passwordMismatch']) {
+    <span>Passwords do not match</span>
+  }
+</div>
+```
+
+## Form Submission
+
+```typescript
+@Component({
+  selector: 'app-contact',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule],
+  template: `
+    <form #contactForm="ngForm" (ngSubmit)="onSubmit(contactForm)">
+      <label for="message">Message</label>
+      <textarea
+        id="message"
+        name="message"
+        [(ngModel)]="message"
+        required
+        minlength="10"
+      ></textarea>
+
+      <button type="submit" [disabled]="contactForm.invalid">Send</button>
+    </form>
+  `,
+})
+export class Contact {
+  message = signal<string>('');
+  
+
+  onSubmit(form: NgForm) {
+    if (form.invalid) return;
+
+    console.log('Sending:', this.message());
+
+    // Reset form state and values
+    form.resetForm();
+    this.message.set('');
+  }
+}
+```
+
+**Key points:**
+- Use `(ngSubmit)` on the form, not `(submit)` or `(click)` on the button
+- Use `resetForm()` (not `reset()`) to clear both values and validation state
+- Pass the template reference variable to the handler for access to form state
+
+## Testing
+
+Template-driven forms are **asynchronous** — values and validation update on the next change detection cycle. Tests must account for this:
+
+```typescript
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+
+describe('Login', () => {
+  let fixture: ComponentFixture<Login>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Login, FormsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Login);
+    fixture.detectChanges();
+    await fixture.whenStable(); // Wait for async form initialization
+  });
+
+  it('should validate required email', async () => {
+    const emailInput: HTMLInputElement = fixture.nativeElement.querySelector('#email');
+
+    emailInput.value = '';
+    emailInput.dispatchEvent(new Event('input'));
+    emailInput.dispatchEvent(new Event('blur'));
+
+    fixture.detectChanges();
+    await fixture.whenStable(); // Wait for async validation
+
+    const error = fixture.nativeElement.querySelector('.errors span');
+    expect(error?.textContent).toContain('Email is required');
+  });
+});
+```
+
+## Accessibility
+
+```html
+<form #form="ngForm" (ngSubmit)="onSubmit(form)">
+  <div role="group" aria-labelledby="name-label">
+    <label id="name-label" for="name-input">Name</label>
+    <input
+      id="name-input"
+      name="name"
+      [(ngModel)]="name"
+      #nameRef="ngModel"
+      required
+      [attr.aria-invalid]="nameRef.invalid && nameRef.touched"
+      [attr.aria-describedby]="nameRef.invalid && nameRef.touched ? 'name-error' : null"
+    />
+    @if (nameRef.invalid && nameRef.touched) {
+      <p id="name-error" role="alert" class="error">Name is required</p>
+    }
+  </div>
+
+  <button type="submit" [disabled]="form.invalid">Submit</button>
+</form>
+```
+
+**Requirements:**
+- Labels linked to inputs via `for`/`id`
+- Error messages announced with `role="alert"`
+- Invalid state communicated with `aria-invalid`
+- Every input must have a `name` attribute (required by NgModel)
+- Must pass AXE accessibility checks
+
+## When to Use
+
+| Suitable For | Not Suitable For |
+|-------------|-----------------|
+| Simple login/contact forms | Complex multi-step wizards |
+| Quick prototyping | Dynamic form generation |
+| Forms with few fields | Forms with complex cross-field validation |
+| Teams familiar with AngularJS | Forms requiring programmatic control |
+| Static form structures | Forms needing unit-testable validation logic |

--- a/skills/dev-skills/angular-http/SKILL.md
+++ b/skills/dev-skills/angular-http/SKILL.md
@@ -1,0 +1,467 @@
+---
+name: angular-http
+description: Implement HTTP data fetching in Angular v20+ using resource(), httpResource(), and HttpClient. Use for API calls, data loading with signals, request/response handling, and interceptors. Triggers on data fetching, API integration, loading states, error handling, or converting Observable-based HTTP to signal-based patterns. Do not use for WebSocket connections, GraphQL, or non-HTTP data sources.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular HTTP & Data Fetching
+
+Fetch data in Angular using signal-based `resource()`, `httpResource()`, and the traditional `HttpClient`.
+
+## httpResource() - Signal-Based HTTP
+
+`httpResource()` wraps HttpClient with signal-based state management:
+
+```typescript
+import { Component, signal } from '@angular/core';
+import { httpResource } from '@angular/common/http';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+@Component({
+  selector: 'app-user-profile',
+  template: `
+    @if (userResource.isLoading()) {
+      <p>Loading...</p>
+    } @else if (userResource.error()) {
+      <p>Error: {{ userResource.error()?.message }}</p>
+      <button (click)="userResource.reload()">Retry</button>
+    } @else if (userResource.hasValue()) {
+      <h1>{{ userResource.value().name }}</h1>
+      <p>{{ userResource.value().email }}</p>
+    }
+  `,
+})
+export class UserProfile {
+  userId = signal('123');
+  
+  // Reactive HTTP resource - refetches when userId changes
+  userResource = httpResource<User>(() => `/api/users/${this.userId()}`);
+}
+```
+
+### httpResource Options
+
+```typescript
+// Simple GET request
+userResource = httpResource<User>(() => `/api/users/${this.userId()}`);
+
+// With full request options
+userResource = httpResource<User>(() => ({
+  url: `/api/users/${this.userId()}`,
+  method: 'GET',
+  headers: { 'Authorization': `Bearer ${this.token()}` },
+  params: { include: 'profile' },
+}));
+
+// With default value
+usersResource = httpResource<User[]>(() => '/api/users', {
+  defaultValue: [],
+});
+
+// Skip request when params undefined
+userResource = httpResource<User>(() => {
+  const id = this.userId();
+  return id ? `/api/users/${id}` : undefined;
+});
+```
+
+### Resource State
+
+```typescript
+// Status signals
+userResource.value()      // Current value or undefined
+userResource.hasValue()   // Boolean - has resolved value
+userResource.error()      // Error or undefined
+userResource.isLoading()  // Boolean - currently loading
+userResource.status()     // 'idle' | 'loading' | 'reloading' | 'resolved' | 'error' | 'local'
+
+// Actions
+userResource.reload()     // Manually trigger reload
+userResource.set(value)   // Set local value
+userResource.update(fn)   // Update local value
+```
+
+## resource() - Generic Async Data
+
+For non-HTTP async operations or custom fetch logic:
+
+```typescript
+import { resource, signal } from '@angular/core';
+
+@Component({...})
+export class Search {
+  query = signal('');
+  
+  searchResource = resource({
+    // Reactive params - triggers reload when changed
+    params: () => ({ q: this.query() }),
+    
+    // Async loader function
+    loader: async ({ params, abortSignal }) => {
+      if (!params.q) return [];
+      
+      const response = await fetch(`/api/search?q=${params.q}`, {
+        signal: abortSignal,
+      });
+      return response.json() as Promise<SearchResult[]>;
+    },
+  });
+}
+```
+
+### Resource with Default Value
+
+```typescript
+todosResource = resource({
+  defaultValue: [] as Todo[],
+  params: () => ({ filter: this.filter() }),
+  loader: async ({ params }) => {
+    const res = await fetch(`/api/todos?filter=${params.filter}`);
+    return res.json();
+  },
+});
+
+// value() returns Todo[] (never undefined)
+```
+
+### Conditional Loading
+
+```typescript
+const userId = signal<string | null>(null);
+
+userResource = resource({
+  params: () => {
+    const id = userId();
+    // Return undefined to skip loading
+    return id ? { id } : undefined;
+  },
+  loader: async ({ params }) => {
+    return fetch(`/api/users/${params.id}`).then(r => r.json());
+  },
+});
+// Status is 'idle' when params returns undefined
+// you can use either the `loader` or `stream` option, but not both
+```
+
+## rxResource API
+
+```ts
+  userRxResource = rxResource({
+    // Reactive params — reruns stream when these change
+    params: () => ({id: this.userId()}),
+
+    // Returns an Observable (not a Promise)
+    stream: ({params, abortSignal}) =>
+        this.http.get<User>(`/api/users/${params.id}`),
+
+    // Fallback value while loading (makes value() never undefined)
+    defaultValue: {id: 0, name: ''} as User,
+
+    // Custom equality to avoid unnecessary re-renders
+    equal: (a, b) => a.id === b.id,
+});
+
+```
+
+### RXResource Status
+
+```typescript
+  userRxResource.value()      // T | undefined (or T if defaultValue set)
+  userRxResource.hasValue()   // boolean
+  userRxResource.isLoading()  // boolean
+  userRxResource.error()      // unknown | undefined
+  userRxResource.status()     // 'idle' | 'loading' | 'reloading' | 'resolved' | 'error' | 'local'
+  userRxResource.reload()     // manually retrigger
+  userRxResource.set(value)   // set local value
+
+```
+
+### Streaming Use Case
+
+```typescript
+  //Streaming Use Case (SSE/WebSocket)
+
+//Since stream returns an Observable, it can emit multiple values — making it useful for Server-Sent Events:
+
+sseResource = rxResource({
+    stream: () => this.eventSource.getStream(), // Observable that emits repeatedly
+});
+```
+### Key Differences Between rxResource and resource
+```markdown
+
+┌─────────────────────────────┬────────────────────────────────┐
+│         resource()          │          rxResource()          │
+├─────────────────────────────┼────────────────────────────────┤
+│ loader — returns Promise<T> │ stream — returns Observable<T> │
+├─────────────────────────────┼────────────────────────────────┤
+│ @angular/core               │ @angular/core/rxjs-interop     │
+└─────────────────────────────┴────────────────────────────────┘
+
+```
+## HttpClient - Traditional Approach
+
+For complex scenarios or when you need Observable operators:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+@Component({...})
+export class Users {
+  #http = inject(HttpClient);
+
+  // Convert Observable to Signal
+  users = toSignal(
+    this.#http.get<User[]>('/api/users'),
+    { initialValue: [] }
+  );
+
+  // Or use Observable directly
+  users$ = this.http.get<User[]>('/api/users');
+}
+```
+
+### Async Pipe Pattern
+
+Use the async pipe for observables in templates:
+
+```typescript
+@Component({
+  template: `
+    @if (users$ | async; as users) {
+      @for (user of users; track user.id) {
+        <p>{{ user.name }}</p>
+      }
+    } @else {
+      <p>Loading...</p>
+    }
+  `,
+})
+export class UserList {
+  #http = inject(HttpClient);
+  users$ = this.#http.get<User[]>('/api/users');
+}
+```
+
+### Type Safety
+
+**CRITICAL**: Avoid using `any` type in HTTP responses:
+
+```typescript
+// WRONG - using any
+this.http.get<any>('/api/users');
+
+// CORRECT - explicit type
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+this.#http.get<User[]>('/api/users');
+```
+
+### HTTP Methods
+
+```typescript
+#http = inject(HttpClient);
+
+// GET
+getUser(id: string) {
+  return this.#http.get<User>(`/api/users/${id}`);
+}
+
+// POST
+createUser(user: CreateUserDto) {
+  return this.#http.post<User>('/api/users', user);
+}
+
+// PUT
+updateUser(id: string, user: UpdateUserDto) {
+  return this.#http.put<User>(`/api/users/${id}`, user);
+}
+
+// PATCH
+patchUser(id: string, changes: Partial<User>) {
+  return this.#http.patch<User>(`/api/users/${id}`, changes);
+}
+
+// DELETE
+deleteUser(id: string) {
+  return this.#http.delete<void>(`/api/users/${id}`);
+}
+```
+
+### Request Options
+
+```typescript
+this.#http.get<User[]>('/api/users', {
+    headers: {
+        'Authorization': 'Bearer token',
+        'Content-Type': 'application/json',
+    },
+    params: {
+        page: '1',
+        limit: '10',
+        sort: 'name',
+    },
+    observe: 'response', // Get full HttpResponse
+    responseType: 'json', // there are other options too like 'blob' , 'text' , 'arraybuffer' 
+});
+```
+
+## Interceptors
+
+### Functional Interceptor (Recommended)
+
+```typescript
+// auth.interceptor.ts
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(Auth);
+  const token = authService.token();
+  
+  if (token) {
+    req = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` },
+    });
+  }
+  
+  return next(req);
+};
+
+// error.interceptor.ts
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status === 401) {
+        inject(Router).navigate(['/login']);
+      }
+      return throwError(() => error);
+    })
+  );
+};
+
+// logging.interceptor.ts
+export const loggingInterceptor: HttpInterceptorFn = (req, next) => {
+  const started = Date.now();
+  return next(req).pipe(
+    tap({
+      next: () => console.log(`${req.method} ${req.url} - ${Date.now() - started}ms`),
+      error: (err) => console.error(`${req.method} ${req.url} failed`, err),
+    })
+  );
+};
+```
+
+### Register Interceptors
+
+```typescript
+// app.config.ts
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideHttpClient(
+      withInterceptors([
+        authInterceptor,
+        errorInterceptor,
+        loggingInterceptor,
+      ])
+    ),
+  ],
+};
+```
+
+## Error Handling
+
+### With httpResource
+
+```typescript
+@Component({
+  template: `
+    @if (userResource.error(); as error) {
+      <div class="error">
+        <p>{{ getErrorMessage(error) }}</p>
+        <button (click)="userResource.reload()">Retry</button>
+      </div>
+    }
+  `,
+})
+export class UserCmpt {
+  userResource = httpResource<User>(() => `/api/users/${this.userId()}`);
+  
+  getErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      return error.error?.message || `Error ${error.status}: ${error.statusText}`;
+    }
+    return 'An unexpected error occurred';
+  }
+}
+```
+
+### With HttpClient
+
+```typescript
+import { catchError, retry } from 'rxjs';
+
+getUser(id: string) {
+  return this.http.get<User>(`/api/users/${id}`).pipe(
+    retry(2), // Retry up to 2 times
+    catchError((error: HttpErrorResponse) => {
+      console.error('Error fetching user:', error);
+      return throwError(() => new Error('Failed to load user'));
+    })
+  );
+}
+```
+
+## Loading States Pattern With httpResource
+
+```typescript
+@Component({
+  template: `
+    @switch (dataResource.status()) {
+      @case ('idle') {
+        <p>Enter a search term</p>
+      }
+      @case ('loading') {
+        <app-spinner />
+      }
+      @case ('reloading') {
+        <app-data [data]="dataResource.value()" />
+        <app-spinner size="small" />
+      }
+      @case ('resolved') {
+        <app-data [data]="dataResource.value()" />
+      }
+      @case ('error') {
+        <app-error 
+          [error]="dataResource.error()" 
+          (retry)="dataResource.reload()" 
+        />
+      }
+    }
+  `,
+})
+export class Data {
+  query = signal('');
+  dataResource = httpResource<Data[]>(() => 
+    this.query() ? `/api/search?q=${this.query()}` : undefined
+  );
+}
+```
+
+See `references/http-patterns.md` for advanced HTTP patterns, caching, and retry strategies.

--- a/skills/dev-skills/angular-http/references/http-patterns.md
+++ b/skills/dev-skills/angular-http/references/http-patterns.md
@@ -1,0 +1,389 @@
+# Angular HTTP Patterns
+
+## Table of Contents
+- [Service Layer Pattern](#service-layer-pattern)
+- [Caching Strategies](#caching-strategies)
+- [Pagination](#pagination)
+- [File Upload](#file-upload)
+- [Request Cancellation](#request-cancellation)
+- [Testing HTTP](#testing-http)
+
+## Service Layer Pattern
+
+Encapsulate HTTP logic in services:
+
+```typescript
+import { Injectable, inject, signal, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { httpResource } from '@angular/common/http';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class User {
+  #http = inject(HttpClient);
+  #baseUrl = '/api/users';
+
+  // Current user ID for reactive fetching
+  #currentUserId = signal<string | null>(null);
+
+  // Reactive resource that updates when currentUserId changes
+  currentUser = httpResource<User>(() => {
+    const id = this.#currentUserId();
+    return id ? `${this.#baseUrl}/${id}` : undefined;
+  });
+
+  // Set current user to fetch
+  selectUser(id: string) {
+    this.#currentUserId.set(id);
+  }
+
+  // CRUD operations
+  getAll() {
+    return this.#http.get<User[]>(this.#baseUrl);
+  }
+
+  getById(id: string) {
+    return this.#http.get<User>(`${this.#baseUrl}/${id}`);
+  }
+
+  create(user: Omit<User, 'id'>) {
+    return this.#http.post<User>(this.#baseUrl, user);
+  }
+
+  update(id: string, user: Partial<User>) {
+    return this.#http.patch<User>(`${this.#baseUrl}/${id}`, user);
+  }
+
+  delete(id: string) {
+    return this.#http.delete<void>(`${this.#baseUrl}/${id}`);
+  }
+}
+```
+
+## Caching Strategies
+
+### Simple In-Memory Cache
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class CachedUser {
+  #http = inject(HttpClient);
+  #cache = new Map<string, { data: User; timestamp: number }>();
+  #cacheDuration = 5 * 60 * 1000; // 5 minutes
+
+  getUser(id: string): Observable<User> {
+    const cached = this.#cache.get(id);
+
+    if (cached && Date.now() - cached.timestamp < this.#cacheDuration) {
+      return of(cached.data);
+    }
+
+    return this.#http.get<User>(`/api/users/${id}`).pipe(
+      tap(user => {
+        this.#cache.set(id, { data: user, timestamp: Date.now() });
+      })
+    );
+  }
+
+  invalidateCache(id?: string) {
+    if (id) {
+      this.#cache.delete(id);
+    } else {
+      this.#cache.clear();
+    }
+  }
+}
+```
+
+### Signal-Based Cache
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class UserCache {
+  #http = inject(HttpClient);
+
+  // Cache as signal
+  #usersCache = signal<Map<string, User>>(new Map());
+
+  // Computed for easy access
+  users = computed(() => Array.from(this.#usersCache().values()));
+
+  getUser(id: string): User | undefined {
+    return this.#usersCache().get(id);
+  }
+
+  async fetchUser(id: string): Promise<User> {
+    const cached = this.getUser(id);
+    if (cached) return cached;
+
+    const user = await firstValueFrom(
+      this.#http.get<User>(`/api/users/${id}`)
+    );
+
+    this.#usersCache.update(cache => {
+      const newCache = new Map(cache);
+      newCache.set(id, user);
+      return newCache;
+    });
+
+    return user;
+  }
+}
+```
+
+## Pagination
+
+### Paginated Resource
+
+```typescript
+interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+@Component({
+  template: `
+    @if (usersResource.isLoading()) {
+      <app-spinner />
+    } @else if (usersResource.hasValue()) {
+      <ul>
+        @for (user of usersResource.value().data; track user.id) {
+          <li>{{ user.name }}</li>
+        }
+      </ul>
+      
+      <div class="pagination">
+        <button 
+          (click)="prevPage()" 
+          [disabled]="page() === 1"
+        >Previous</button>
+        
+        <span>Page {{ page() }} of {{ usersResource.value().totalPages }}</span>
+        
+        <button 
+          (click)="nextPage()" 
+          [disabled]="page() >= usersResource.value().totalPages"
+        >Next</button>
+      </div>
+    }
+  `,
+})
+export class UsersList {
+  page = signal(1);
+  pageSize = signal(10);
+  
+  usersResource = httpResource<PaginatedResponse<User>>(() => ({
+    url: '/api/users',
+    params: {
+      page: this.page().toString(),
+      pageSize: this.pageSize().toString(),
+    },
+  }));
+  
+  nextPage() {
+    this.page.update(p => p + 1);
+  }
+  
+  prevPage() {
+    this.page.update(p => Math.max(1, p - 1));
+  }
+}
+```
+
+## File Upload
+
+### Single File Upload
+
+```typescript
+@Component({
+  template: `
+    <input type="file" (change)="onFileSelected($event)" />
+    
+    @if (uploadProgress() !== null) {
+      <progress [value]="uploadProgress()" max="100"></progress>
+    }
+  `,
+})
+export class FileUpload {
+  #http = inject(HttpClient);
+
+  uploadProgress = signal<number | null>(null);
+
+  onFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    this.#http.post('/api/upload', formData, {
+      reportProgress: true, // Enables progress events
+      observe: 'events', // Returns progress events instead of response
+    }).subscribe(event => {
+      if (event.type === HttpEventType.UploadProgress && event.total) {
+        this.uploadProgress.set(Math.round(100 * event.loaded / event.total));
+      } else if (event.type === HttpEventType.Response) {
+        this.uploadProgress.set(null);
+        console.log('Upload complete:', event.body);
+      }
+    });
+  }
+}
+```
+
+### Multiple Files
+
+```typescript
+uploadFiles(files: FileList) {
+  const formData = new FormData();
+  
+  for (let i = 0; i < files.length; i++) {
+    formData.append('files', files[i]);
+  }
+  
+  return this.http.post<{ urls: string[] }>('/api/upload-multiple', formData);
+}
+```
+
+## Request Cancellation
+
+### With resource()
+
+```typescript
+// resource() automatically handles cancellation via abortSignal
+searchResource = resource({
+  params: () => ({ q: this.query() }),
+  loader: async ({ params, abortSignal }) => {
+    const response = await fetch(`/api/search?q=${params.q}`, {
+      signal: abortSignal, // Cancels if params change
+    });
+    return response.json();
+  },
+});
+```
+
+### With HttpClient
+
+```typescript
+@Component({...})
+export class Search implements OnDestroy {
+  #http = inject(HttpClient);
+  #destroyRef = inject(DestroyRef);
+
+  query = signal('');
+  results = signal<Result[]>([]);
+
+  #searchSubscription?: Subscription;
+
+  search() {
+    // Cancel previous request
+    this.#searchSubscription?.unsubscribe();
+
+    this.#searchSubscription = this.#http
+      .get<Result[]>(`/api/search?q=${this.query()}`)
+      .pipe(takeUntilDestroyed(this.#destroyRef))
+      .subscribe(results => this.results.set(results));
+  }
+}
+```
+
+### Debounced Search
+
+```typescript
+@Component({...})
+export class SearchDebounced {
+  query = signal('');
+
+  #http = inject(HttpClient);
+
+  results = toSignal(
+    toObservable(this.query).pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      filter(q => q.length >= 2),
+      switchMap(q => this.#http.get<Result[]>(`/api/search?q=${q}`)),
+      catchError(() => of([]))
+    ),
+    { initialValue: [] }
+  );
+}
+```
+
+## Testing HTTP
+
+### Testing httpResource
+
+```typescript
+describe('UserCmpt', () => {
+  let component: UserCmpt;
+  let httpMock: HttpTestingController;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UserCmpt],
+      providers: [provideHttpClientTesting()],
+    });
+    
+    component = TestBed.createComponent(UserCmpt).componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+  
+  it('should load user', () => {
+    component.userId.set('123');
+    
+    const req = httpMock.expectOne('/api/users/123');
+    req.flush({ id: '123', name: 'Test User' });
+    
+    expect(component.userResource.value()?.name).toBe('Test User');
+  });
+  
+  afterEach(() => {
+    httpMock.verify();
+  });
+});
+```
+
+### Testing Services
+
+```typescript
+describe('User', () => {
+  let service: User;
+  let httpMock: HttpTestingController;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        User,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    
+    service = TestBed.inject(User);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+  
+  it('should create user', () => {
+    const newUser = { name: 'Test', email: 'test@example.com' };
+    
+    service.create(newUser).subscribe(user => {
+      expect(user.id).toBeDefined();
+      expect(user.name).toBe('Test');
+    });
+    
+    const req = httpMock.expectOne('/api/users');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(newUser);
+    
+    req.flush({ id: '1', ...newUser });
+  });
+});
+```

--- a/skills/dev-skills/angular-performance/SKILL.md
+++ b/skills/dev-skills/angular-performance/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: angular-performance
+description: Optimize Angular application performance with OnPush change detection, signals, lazy loading, bundle optimization, and runtime techniques. Use when asked to improve performance, reduce bundle size, optimize change detection, implement lazy loading, add virtual scrolling, or troubleshoot slow Angular apps. Do not use for initial project setup or feature implementation.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Performance
+
+
+## Quick Diagnosis
+
+When optimizing an Angular app, check these areas in order:
+
+1. **Change Detection** - Is OnPush used everywhere? Are there function calls in templates?
+2. **Bundle Size** - Run `ng build --stats-json` and analyze with webpack-bundle-analyzer
+3. **Lazy Loading** - Are routes and heavy components deferred?
+4. **Runtime** - Are large lists virtualized? Is trackBy used with @for?
+
+## Core Patterns
+
+### Always Use OnPush + Signals
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <h1>{{ title() }}</h1>
+    <p>Items: {{ itemCount() }}</p>
+  `
+})
+export class MyComponent {
+  items = input.required<Item[]>();
+  title = input('Default');
+
+  // Derived state - automatically cached
+  itemCount = computed(() => this.items().length);
+}
+```
+
+### Lazy Load Routes
+
+```typescript
+export const routes: Routes = [
+  {
+    path: 'dashboard',
+    loadComponent: () => import('./dashboard/dashboard').then(m => m.DashboardComponent)
+  }
+];
+```
+
+### Defer Heavy Content
+
+```html
+@defer (on viewport) {
+  <app-heavy-chart [data]="data()" />
+} @placeholder {
+  <div class="skeleton"></div>
+}
+```
+
+### Virtualize Large Lists
+
+```html
+<cdk-virtual-scroll-viewport itemSize="50">
+  <div *cdkVirtualFor="let item of items(); trackBy: trackById">
+    {{ item.name }}
+  </div>
+</cdk-virtual-scroll-viewport>
+```
+
+## Reference Guides
+
+Detailed patterns and examples for each optimization area:
+
+- Refer to `references/change-detection.md` for OnPush, signals, zone-less Angular, and common pitfalls
+- Refer to `references/lazy-loading.md` for route splitting, @defer triggers, and dynamic components
+- Refer to `references/bundle-optimization.md` for tree shaking, code splitting, and image optimization
+- Refer to `references/runtime-performance.md` for virtual scrolling, memoization, debouncing, and web workers

--- a/skills/dev-skills/angular-performance/references/bundle-optimization.md
+++ b/skills/dev-skills/angular-performance/references/bundle-optimization.md
@@ -1,0 +1,149 @@
+# Bundle Optimization
+
+## Analyzing Bundle Size
+
+Use Angular's built-in bundle analyzer:
+
+```bash
+ng build --stats-json
+npx webpack-bundle-analyzer dist/app/stats.json
+```
+
+Or use source-map-explorer:
+
+```bash
+ng build --source-map
+npx source-map-explorer dist/app/browser/*.js
+```
+
+## Tree Shaking Best Practices
+
+### Use providedIn for services
+
+```typescript
+// ✅ Tree-shakeable - removed if never injected
+@Injectable({ providedIn: 'root' })
+export class AnalyticsService {}
+
+// ❌ Not tree-shakeable - always included
+// providers: [AnalyticsService] in module/component
+```
+
+### Import only what you need
+
+```typescript
+// ❌ Bad - imports entire library
+import * as _ from 'lodash';
+
+// ✅ Good - imports only used function
+import debounce from 'lodash-es/debounce';
+
+// ✅ Better - use native or smaller alternatives
+const debounce = (fn: Function, ms: number) => {
+  let timeout: ReturnType<typeof setTimeout>;
+  return (...args: any[]) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), ms);
+  };
+};
+```
+
+### Use ES modules
+
+```typescript
+// ❌ CommonJS - not tree-shakeable
+const moment = require('moment');
+
+// ✅ ES modules - tree-shakeable
+import { format } from 'date-fns';
+```
+
+## Code Splitting
+
+### Route-based splitting (automatic)
+
+```typescript
+// Each lazy route creates a separate chunk
+{
+  path: 'reports',
+  loadComponent: () => import('./reports/reports')
+}
+```
+
+### Manual chunk optimization
+
+```typescript
+// angular.json
+{
+  "optimization": {
+    "scripts": true,
+    "styles": {
+      "minify": true,
+      "inlineCritical": true
+    }
+  },
+  "budgets": [
+    {
+      "type": "initial",
+      "maximumWarning": "500kb",
+      "maximumError": "1mb"
+    },
+    {
+      "type": "anyComponentStyle",
+      "maximumWarning": "4kb",
+      "maximumError": "8kb"
+    }
+  ]
+}
+```
+
+## Image Optimization
+
+Use NgOptimizedImage:
+
+```typescript
+import { NgOptimizedImage } from '@angular/common';
+
+@Component({
+  imports: [NgOptimizedImage],
+  template: `
+    <!-- LCP image - priority loading -->
+    <img ngSrc="/hero.jpg" width="1200" height="600" priority />
+
+    <!-- Below fold - lazy loaded -->
+    <img ngSrc="/product.jpg" width="400" height="300" />
+
+    <!-- Responsive image -->
+    <img
+      ngSrc="/banner.jpg"
+      width="800"
+      height="400"
+      sizes="(max-width: 768px) 100vw, 50vw"
+    />
+  `
+})
+export class PageComponent {}
+```
+
+Configure image loader for CDN:
+
+```typescript
+// app.config.ts
+import { provideImgixLoader } from '@angular/common';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideImgixLoader('https://my-cdn.imgix.net/')
+  ]
+};
+```
+
+## Build Optimization Flags
+
+```bash
+# Production build with all optimizations
+ng build --configuration=production
+
+# Additional flags for analysis
+ng build --named-chunks --stats-json
+```

--- a/skills/dev-skills/angular-performance/references/change-detection.md
+++ b/skills/dev-skills/angular-performance/references/change-detection.md
@@ -1,0 +1,100 @@
+# Change Detection Optimization
+
+## OnPush Strategy
+
+Always use `ChangeDetectionStrategy.OnPush` for components:
+
+```typescript
+@Component({
+  selector: 'app-user-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="card">
+      <h3>{{ user().name }}</h3>
+      <p>{{ user().email }}</p>
+    </div>
+  `
+})
+export class UserCardComponent {
+  user = input.required<User>();
+}
+```
+
+OnPush triggers change detection only when:
+- Input reference changes
+- Event originates from component or children
+- Async pipe emits
+- Signal value changes
+- `markForCheck()` is called manually
+
+## Signal-Based Reactivity
+
+Prefer signals over BehaviorSubject for local state:
+
+```typescript
+@Component({
+  selector: 'app-counter',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <p>Count: {{ count() }}</p>
+    <p>Double: {{ doubleCount() }}</p>
+    <button (click)="increment()">+1</button>
+  `
+})
+export class CounterComponent {
+  count = signal(0);
+  doubleCount = computed(() => this.count() * 2);
+
+  increment() {
+    this.count.update(c => c + 1);
+  }
+}
+```
+
+## Zone-less Angular
+
+Zone-less is now **default in Angular v21+** - no configuration needed.
+
+For Angular v20, enable it explicitly:
+
+```typescript
+// app.config.ts
+import { provideZonelessChangeDetection } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZonelessChangeDetection(),
+    // other providers...
+  ]
+};
+```
+
+Requirements for zone-less:
+- All components must use OnPush
+- Use signals for all reactive state
+- Replace setTimeout/setInterval with Angular's alternatives
+- Use `afterNextRender` instead of `ngAfterViewInit` for DOM timing
+- Ensure `provideZoneChangeDetection` is not used anywhere (would override zoneless)
+
+## Avoiding Common Pitfalls
+
+### Don't call functions in templates
+
+```typescript
+// ❌ Bad - function called every change detection
+template: `<p>{{ getFullName() }}</p>`
+
+// ✅ Good - computed signal, cached
+fullName = computed(() => `${this.firstName()} ${this.lastName()}`);
+template: `<p>{{ fullName() }}</p>`
+```
+
+### Don't mutate objects directly
+
+```typescript
+// ❌ Bad - OnPush won't detect this
+this.user.name = 'New Name';
+
+// ✅ Good - new reference triggers detection
+this.user.set({ ...this.user(), name: 'New Name' });
+```

--- a/skills/dev-skills/angular-performance/references/lazy-loading.md
+++ b/skills/dev-skills/angular-performance/references/lazy-loading.md
@@ -1,0 +1,111 @@
+# Lazy Loading
+
+## Route-Based Lazy Loading
+
+Lazy load feature modules by route:
+
+```typescript
+// app.routes.ts
+export const routes: Routes = [
+  { path: '', component: HomeComponent },
+  {
+    path: 'dashboard',
+    loadComponent: () => import('./pages/dashboard/dashboard').then(m => m.DashboardComponent)
+  },
+  {
+    path: 'admin',
+    loadChildren: () => import('./pages/admin/admin.routes').then(m => m.ADMIN_ROUTES),
+    canActivate: [authGuard]
+  }
+];
+```
+
+## Deferrable Views (@defer)
+
+Lazy load parts of a template:
+
+```typescript
+@Component({
+  template: `
+    <h1>Dashboard</h1>
+
+    <!-- Load when visible in viewport -->
+    @defer (on viewport) {
+      <app-heavy-chart [data]="chartData()" />
+    } @placeholder {
+      <div class="skeleton-chart"></div>
+    } @loading (minimum 200ms) {
+      <app-spinner />
+    }
+
+    <!-- Load on interaction -->
+    @defer (on interaction) {
+      <app-comments [postId]="postId()" />
+    } @placeholder {
+      <button>Load Comments</button>
+    }
+
+    <!-- Load when condition is true -->
+    @defer (when showAdvanced()) {
+      <app-advanced-settings />
+    }
+
+    <!-- Load after idle + timer -->
+    @defer (on idle; prefetch on timer(2s)) {
+      <app-recommendations />
+    }
+  `
+})
+export class DashboardComponent {
+  chartData = input.required<ChartData>();
+  postId = input.required<string>();
+  showAdvanced = signal(false);
+}
+```
+
+### @defer Triggers
+
+| Trigger | When it loads |
+|---------|---------------|
+| `on idle` | Browser is idle |
+| `on viewport` | Element enters viewport |
+| `on interaction` | User clicks/focuses placeholder |
+| `on hover` | User hovers over placeholder |
+| `on immediate` | After other content renders |
+| `on timer(Xms)` | After X milliseconds |
+| `when condition` | When expression is truthy |
+
+### Prefetch Strategies
+
+```html
+<!-- Prefetch while idle, load on viewport -->
+@defer (on viewport; prefetch on idle) {
+  <app-widget />
+}
+
+<!-- Prefetch on hover, load on click -->
+@defer (on interaction; prefetch on hover) {
+  <app-modal />
+}
+```
+
+## Component-Level Lazy Loading
+
+Dynamically load components:
+
+```typescript
+@Component({
+  template: `
+    <ng-container #outlet />
+    <button (click)="loadEditor()">Open Editor</button>
+  `
+})
+export class PageComponent {
+  #vcr = inject(ViewContainerRef);
+
+  async loadEditor() {
+    const { EditorComponent } = await import('./editor/editor');
+    this.#vcr.createComponent(EditorComponent);
+  }
+}
+```

--- a/skills/dev-skills/angular-performance/references/runtime-performance.md
+++ b/skills/dev-skills/angular-performance/references/runtime-performance.md
@@ -1,0 +1,210 @@
+# Runtime Performance
+
+## Virtual Scrolling
+
+Use CDK virtual scrolling for large lists:
+
+```typescript
+import { ScrollingModule } from '@angular/cdk/scrolling';
+
+@Component({
+  imports: [ScrollingModule],
+  template: `
+    <cdk-virtual-scroll-viewport itemSize="50" class="viewport">
+      <div *cdkVirtualFor="let item of items(); trackBy: trackById" class="item">
+        {{ item.name }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `,
+  styles: `
+    .viewport {
+      height: 400px;
+      width: 100%;
+    }
+    .item {
+      height: 50px;
+    }
+  `
+})
+export class ListComponent {
+  items = input.required<Item[]>();
+
+  trackById(index: number, item: Item): string {
+    return item.id;
+  }
+}
+```
+
+### Dynamic item sizes
+
+```typescript
+@Component({
+  template: `
+    <cdk-virtual-scroll-viewport
+      [itemSize]="50"
+      [minBufferPx]="200"
+      [maxBufferPx]="400">
+      <div *cdkVirtualFor="let item of items()">
+        {{ item.content }}
+      </div>
+    </cdk-virtual-scroll-viewport>
+  `
+})
+```
+
+## Track By Functions
+
+Always use trackBy with @for:
+
+```typescript
+@Component({
+  template: `
+    @for (user of users(); track user.id) {
+      <app-user-card [user]="user" />
+    }
+  `
+})
+export class UsersComponent {
+  users = input.required<User[]>();
+}
+```
+
+For complex keys:
+
+```typescript
+@Component({
+  template: `
+    @for (item of items(); track trackItem($index, item)) {
+      <app-item [data]="item" />
+    }
+  `
+})
+export class ItemsComponent {
+  items = input.required<Item[]>();
+
+  trackItem(index: number, item: Item): string {
+    return `${item.type}-${item.id}`;
+  }
+}
+```
+
+## Memoization with Computed Signals
+
+Cache expensive calculations:
+
+```typescript
+@Component({
+  template: `
+    <div>Filtered: {{ filteredItems().length }}</div>
+    @for (item of filteredItems(); track item.id) {
+      <app-item [data]="item" />
+    }
+  `
+})
+export class FilteredListComponent {
+  items = input.required<Item[]>();
+  filter = input<string>('');
+
+  // Computed - only recalculates when items or filter changes
+  filteredItems = computed(() => {
+    const filterValue = this.filter().toLowerCase();
+    return this.items().filter(item =>
+      item.name.toLowerCase().includes(filterValue)
+    );
+  });
+}
+```
+
+## Avoiding Layout Thrashing
+
+Batch DOM reads and writes:
+
+```typescript
+@Component({...})
+export class AnimatedComponent {
+  #elementRef = inject(ElementRef);
+
+  animate() {
+    // ❌ Bad - read/write interleaved causes reflow
+    const height = this.#elementRef.nativeElement.offsetHeight;
+    this.#elementRef.nativeElement.style.height = height + 10 + 'px';
+    const width = this.#elementRef.nativeElement.offsetWidth;
+    this.#elementRef.nativeElement.style.width = width + 10 + 'px';
+
+    // ✅ Good - batch reads, then batch writes
+    const el = this.#elementRef.nativeElement;
+    const height = el.offsetHeight;
+    const width = el.offsetWidth;
+
+    requestAnimationFrame(() => {
+      el.style.height = height + 10 + 'px';
+      el.style.width = width + 10 + 'px';
+    });
+  }
+}
+```
+
+## Debouncing User Input
+
+```typescript
+@Component({
+  template: `
+    <input
+      [value]="searchTerm()"
+      (input)="onSearch($event)"
+      placeholder="Search..."
+    />
+  `
+})
+export class SearchComponent {
+  searchTerm = signal('');
+  #searchSubject = new Subject<string>();
+
+  constructor() {
+    this.#searchSubject.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      takeUntilDestroyed()
+    ).subscribe(term => {
+      this.searchTerm.set(term);
+      this.#performSearch(term);
+    });
+  }
+
+  onSearch(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.#searchSubject.next(value);
+  }
+
+  #performSearch(term: string) {
+    // API call or filtering logic
+  }
+}
+```
+
+## Web Workers for Heavy Computation
+
+Offload CPU-intensive work:
+
+```typescript
+// heavy-calc.worker.ts
+addEventListener('message', ({ data }) => {
+  const result = performHeavyCalculation(data);
+  postMessage(result);
+});
+
+// component.ts
+@Component({...})
+export class DataProcessorComponent {
+  private worker = new Worker(
+    new URL('./heavy-calc.worker', import.meta.url)
+  );
+
+  processData(data: any[]) {
+    this.worker.postMessage(data);
+    this.worker.onmessage = ({ data: result }) => {
+      this.result.set(result);
+    };
+  }
+}
+```

--- a/skills/dev-skills/angular-routing/SKILL.md
+++ b/skills/dev-skills/angular-routing/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: angular-routing
+description: Implement routing in Angular v20+ applications with lazy loading, functional guards, resolvers, and route parameters. Use for navigation setup, protected routes, route-based data loading, and nested routing. Triggers on route configuration, adding authentication guards, implementing lazy loading, or reading route parameters with signals. Do not use for in-component navigation logic or state management.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Routing
+
+
+Configure routing in Angular v20+ with lazy loading, functional guards, and signal-based route parameters.
+
+## Basic Setup
+
+```typescript
+// app.routes.ts
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: Home },
+  { path: 'about', component: About },
+  { path: '**', component: NotFound },
+];
+
+// app.config.ts
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+  ],
+};
+
+// app.component.ts
+import { Component } from '@angular/core';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  template: `
+    <nav>
+      <a routerLink="/home" routerLinkActive="active">Home</a>
+      <a routerLink="/about" routerLinkActive="active">About</a>
+    </nav>
+    <router-outlet />
+  `,
+})
+export class App {}
+```
+
+## Lazy Loading
+
+Load feature modules on demand:
+
+```typescript
+// app.routes.ts
+export const routes: Routes = [
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: 'home', component: Home },
+  
+  // Lazy load entire feature
+  {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.routes').then(m => m.adminRoutes),
+  },
+  
+  // Lazy load single component
+  {
+    path: 'settings',
+    loadComponent: () => import('./settings/settings.component').then(m => m.Settings),
+  },
+];
+
+// admin/admin.routes.ts
+export const adminRoutes: Routes = [
+  { path: '', component: AdminDashboard },
+  { path: 'users', component: AdminUsers },
+  { path: 'settings', component: AdminSettings },
+];
+```
+
+## Route Parameters
+
+### With Signal Inputs (Recommended)
+
+```typescript
+// Route config
+{ path: 'users/:id', component: UserDetail }
+
+// Component - use input() for route params
+import { Component, input, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-user-detail',
+  template: `
+    <h1>User {{ id() }}</h1>
+  `,
+})
+export class UserDetail {
+  // Route param as signal input
+  id = input.required<string>();
+  
+  // Computed based on route param
+  userId = computed(() => parseInt(this.id(), 10));
+}
+```
+
+Enable with `withComponentInputBinding()`:
+
+```typescript
+// app.config.ts
+import { provideRouter, withComponentInputBinding } from '@angular/router';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withComponentInputBinding()),
+  ],
+};
+```
+
+### Query Parameters
+
+```typescript
+// Route: /search?q=angular&page=1
+
+@Component({...})
+export class Search {
+  // Query params as inputs
+  q = input<string>('');
+  page = input<string>('1');
+  
+  currentPage = computed(() => parseInt(this.page(), 10));
+}
+```
+
+### With ActivatedRoute (Alternative)
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { map } from 'rxjs';
+
+@Component({...})
+export class UserDetail {
+  #route = inject(ActivatedRoute);
+
+  // Convert route params to signal
+  id = toSignal(
+    this.#route.paramMap.pipe(map(params => params.get('id'))),
+    { initialValue: null }
+  );
+
+  // Query params
+  query = toSignal(
+    this.#route.queryParamMap.pipe(map(params => params.get('q'))),
+    { initialValue: '' }
+  );
+}
+```
+
+## Functional Guards
+
+### Auth Guard
+
+```typescript
+// guards/auth.guard.ts
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(Auth);
+  const router = inject(Router);
+  
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+  
+  // Redirect to login with return URL
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url },
+  });
+};
+
+// Usage in routes
+{
+  path: 'dashboard',
+  component: Dashboard,
+  canActivate: [authGuard],
+}
+```
+
+### Role Guard
+
+```typescript
+export const roleGuard = (allowedRoles: string[]): CanActivateFn => {
+  return (route, state) => {
+    const authService = inject(Auth);
+    const router = inject(Router);
+    
+    const userRole = authService.currentUser()?.role;
+    
+    if (userRole && allowedRoles.includes(userRole)) {
+      return true;
+    }
+    
+    return router.createUrlTree(['/unauthorized']);
+  };
+};
+
+// Usage
+{
+  path: 'admin',
+  component: Admin,
+  canActivate: [authGuard, roleGuard(['admin', 'superadmin'])],
+}
+```
+
+### Can Deactivate Guard
+
+```typescript
+export interface CanDeactivate {
+  canDeactivate: () => boolean | Promise<boolean>;
+}
+
+export const unsavedChangesGuard: CanDeactivateFn<CanDeactivate> = (component) => {
+  if (component.canDeactivate()) {
+    return true;
+  }
+  
+  return confirm('You have unsaved changes. Leave anyway?');
+};
+
+// Component implementation
+@Component({...})
+export class Edit implements CanDeactivate {
+  form = inject(FormBuilder).group({...});
+  
+  canDeactivate(): boolean {
+    return !this.form.dirty;
+  }
+}
+
+// Route
+{
+  path: 'edit/:id',
+  component: Edit,
+  canDeactivate: [unsavedChangesGuard],
+}
+```
+
+## Resolvers
+
+Pre-fetch data before route activation:
+
+```typescript
+// resolvers/user.resolver.ts
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+
+export const userResolver: ResolveFn<User> = (route) => {
+  const userService = inject(User);
+  const id = route.paramMap.get('id')!;
+  return userService.getById(id);
+};
+
+// Route config
+{
+  path: 'users/:id',
+  component: UserDetail,
+  resolve: { user: userResolver },
+}
+
+// Component - access resolved data via input
+@Component({...})
+export class UserDetail {
+  user = input.required<User>();
+}
+```
+
+## Nested Routes
+
+```typescript
+// Parent route with children
+export const routes: Routes = [
+  {
+    path: 'products',
+    component: ProductsLayout,
+    children: [
+      { path: '', component: ProductList },
+      { path: ':id', component: ProductDetail },
+      { path: ':id/edit', component: ProductEdit },
+    ],
+  },
+];
+
+// ProductsLayout
+@Component({
+  imports: [RouterOutlet],
+  template: `
+    <h1>Products</h1>
+    <router-outlet /> <!-- Child routes render here -->
+  `,
+})
+export class ProductsLayout {}
+```
+
+## Programmatic Navigation
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { Router, ActivatedRoute } from '@angular/router';
+
+@Component({...})
+export class Product {
+  // Use inject() for all dependencies
+  #router = inject(Router);
+  #route = inject(ActivatedRoute);
+
+  // Navigate to route
+  goToProducts() {
+    this.#router.navigate(['/products']);
+  }
+
+  // Navigate with params
+  goToProduct(id: string) {
+    this.#router.navigate(['/products', id]);
+  }
+
+  // Navigate with query params
+  search(query: string) {
+    this.#router.navigate(['/search'], {
+      queryParams: { q: query, page: 1 },
+    });
+  }
+
+  // Navigate relative to current route
+  goToEdit() {
+    this.#router.navigate(['edit'], { relativeTo: this.#route });
+  }
+
+  // Replace current history entry
+  replaceUrl() {
+    this.#router.navigate(['/new-page'], { replaceUrl: true });
+  }
+}
+```
+
+## Route Data
+
+```typescript
+// Static route data
+{
+  path: 'admin',
+  component: Admin,
+  data: {
+    title: 'Admin Dashboard',
+    roles: ['admin'],
+  },
+}
+
+// Access in component
+@Component({...})
+export class AdminCmpt {
+  title = input<string>(); // From route data
+  roles = input<string[]>(); // From route data
+}
+
+// Or via ActivatedRoute
+#route = inject(ActivatedRoute);
+data = toSignal(this.#route.data);
+```
+
+## Router Events
+
+```typescript
+import { Router, NavigationStart, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs';
+
+@Component({...})
+export class AppMain {
+  #router = inject(Router);
+
+  isNavigating = signal(false);
+
+  constructor() {
+    this.#router.events.pipe(
+      filter(e => e instanceof NavigationStart || e instanceof NavigationEnd)
+    ).subscribe(event => {
+      this.isNavigating.set(event instanceof NavigationStart);
+    });
+  }
+}
+```
+
+## Navigation Accessibility
+
+Manage focus after route changes for accessibility:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs';
+
+@Component({...})
+export class App {
+  #router = inject(Router);
+
+  constructor() {
+    this.#router.events.pipe(
+      filter(e => e instanceof NavigationEnd)
+    ).subscribe(() => {
+      // Focus main content after navigation
+      const main = document.querySelector('main');
+      main?.setAttribute('tabindex', '-1');
+      main?.focus();
+    });
+  }
+}
+```
+
+## Router Lifecycle Events
+
+The Angular Router emits events through `Router.events` for tracking navigation (loading indicators, analytics, scroll management). Use `withDebugTracing()` for debugging.
+
+See `references/router-lifecycle.md` for the full event chronology and common use case patterns.
+
+## Route Transition Animations
+
+Use the View Transitions API with `withViewTransitions()` for smooth visual transitions between routes. This is a progressive enhancement — browsers without support still work normally.
+
+See `references/route-animations.md` for CSS customization, advanced control, and best practices.
+
+See `references/routing-patterns.md` for advanced routing patterns, route reuse strategies, and preloading.

--- a/skills/dev-skills/angular-routing/references/route-animations.md
+++ b/skills/dev-skills/angular-routing/references/route-animations.md
@@ -1,0 +1,56 @@
+# Route Transition Animations
+
+Angular Router supports the browser's **View Transitions API** for smooth visual transitions between routes.
+
+## Enabling View Transitions
+
+Add `withViewTransitions()` to your router configuration.
+
+```ts
+provideRouter(routes, withViewTransitions());
+```
+
+This is a **progressive enhancement**. In browsers that don't support the API, the router will still work but without the transition animation.
+
+## How it Works
+
+1. Browser takes a screenshot of the old state.
+2. Router updates the DOM (activates new component).
+3. Browser takes a screenshot of the new state.
+4. Browser animates between the two states.
+
+## Customizing with CSS
+
+Transitions are customized in **global CSS files** (not component-scoped CSS).
+
+Use the `::view-transition-old()` and `::view-transition-new()` pseudo-elements.
+
+```css
+/* Example: Cross-fade + Slide */
+::view-transition-old(root) {
+  animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out;
+}
+::view-transition-new(root) {
+  animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in;
+}
+```
+
+## Advanced Control
+
+Use `onViewTransitionCreated` to skip transitions or customize behavior based on the navigation context.
+
+```ts
+withViewTransitions({
+  onViewTransitionCreated: ({transition, from, to}) => {
+    // Skip animation for specific routes
+    if (to.url === '/no-animation') {
+      transition.skipTransition();
+    }
+  },
+});
+```
+
+## Best Practices
+
+- **Global Styles**: Always define transition animations in `styles.css` to avoid view encapsulation issues.
+- **View Transition Names**: Assign unique `view-transition-name` to elements that should transition smoothly across routes (e.g., a header image).

--- a/skills/dev-skills/angular-routing/references/router-lifecycle.md
+++ b/skills/dev-skills/angular-routing/references/router-lifecycle.md
@@ -1,0 +1,45 @@
+# Router Lifecycle and Events
+
+Angular Router emits events through the `Router.events` observable, allowing you to track the navigation lifecycle from start to finish.
+
+## Common Router Events (Chronological)
+
+1. **`NavigationStart`**: Navigation begins.
+2. **`RoutesRecognized`**: Router matches the URL to a route.
+3. **`GuardsCheckStart` / `End`**: Evaluation of `canActivate`, `canMatch`, etc.
+4. **`ResolveStart` / `End`**: Data resolution phase (fetching data via resolvers).
+5. **`NavigationEnd`**: Navigation completed successfully.
+6. **`NavigationCancel`**: Navigation canceled (e.g., guard returned `false`).
+7. **`NavigationError`**: Navigation failed (e.g., error in resolver).
+
+## Subscribing to Events
+
+Inject the `Router` and filter the `events` observable.
+
+```ts
+import {Router, NavigationStart, NavigationEnd} from '@angular/router';
+
+export class MyService {
+  #router = inject(Router);
+
+  constructor() {
+    this.#router.events.pipe(filter((e) => e instanceof NavigationEnd)).subscribe((event) => {
+      console.log('Navigated to:', event.url);
+    });
+  }
+}
+```
+
+## Debugging
+
+Enable detailed console logging of all routing events during application bootstrap.
+
+```ts
+provideRouter(routes, withDebugTracing());
+```
+
+## Common Use Cases
+
+- **Loading Indicators**: Show a spinner when `NavigationStart` fires and hide it on `NavigationEnd`/`Cancel`/`Error`.
+- **Analytics**: Track page views by listening for `NavigationEnd`.
+- **Scroll Management**: Respond to `Scroll` events for custom scroll behavior.

--- a/skills/dev-skills/angular-routing/references/routing-patterns.md
+++ b/skills/dev-skills/angular-routing/references/routing-patterns.md
@@ -1,0 +1,472 @@
+# Angular Routing Patterns
+
+## Table of Contents
+- [Route Configuration Options](#route-configuration-options)
+- [Authentication Flow](#authentication-flow)
+- [Breadcrumbs](#breadcrumbs)
+- [Tab Navigation](#tab-navigation)
+- [Modal Routes](#modal-routes)
+- [Preloading Strategies](#preloading-strategies)
+
+## Route Configuration Options
+
+### Full Route Options
+
+```typescript
+{
+  path: 'users/:id',
+  component: UserCmpt,
+  
+  // Lazy loading alternatives
+  loadComponent: () => import('./user.component').then(m => m.UserCmpt),
+  loadChildren: () => import('./user.routes').then(m => m.userRoutes),
+  
+  // Guards
+  canActivate: [authGuard],
+  canActivateChild: [authGuard],
+  canDeactivate: [unsavedChangesGuard],
+  canMatch: [featureFlagGuard],
+  
+  // Data
+  resolve: { user: userResolver },
+  data: { title: 'User Profile', animation: 'userPage' },
+  
+  // Children
+  children: [...],
+  
+  // Outlet
+  outlet: 'sidebar',
+  
+  // Path matching
+  pathMatch: 'full', // or 'prefix'
+  
+  // Title
+  title: 'User Profile',
+  // Or dynamic title
+  title: userTitleResolver,
+}
+```
+
+### Dynamic Title Resolver
+
+```typescript
+export const userTitleResolver: ResolveFn<string> = (route) => {
+  const userService = inject(User);
+  const id = route.paramMap.get('id')!;
+  return userService.getById(id).pipe(
+    map(user => `${user.name} - Profile`)
+  );
+};
+```
+
+## Authentication Flow
+
+### Complete Auth Setup
+
+```typescript
+// auth.service.ts
+@Injectable({ providedIn: 'root' })
+export class Auth {
+  #user = signal<User | null>(null);
+  #token = signal<string | null>(null);
+
+  readonly user = this.#user.asReadonly();
+  readonly isAuthenticated = computed(() => this.#user() !== null);
+
+  #router = inject(Router);
+  #http = inject(HttpClient);
+
+  async login(credentials: Credentials): Promise<boolean> {
+    try {
+      const response = await firstValueFrom(
+        this.#http.post<AuthResponse>('/api/login', credentials)
+      );
+
+      this.#token.set(response.token);
+      this.#user.set(response.user);
+      localStorage.setItem('token', response.token);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  logout(): void {
+    this.#user.set(null);
+    this.#token.set(null);
+    localStorage.removeItem('token');
+    this.#router.navigate(['/login']);
+  }
+
+  async checkAuth(): Promise<boolean> {
+    const token = localStorage.getItem('token');
+    if (!token) return false;
+
+    try {
+      const user = await firstValueFrom(
+        this.#http.get<User>('/api/me')
+      );
+      this.#user.set(user);
+      this.#token.set(token);
+      return true;
+    } catch {
+      localStorage.removeItem('token');
+      return false;
+    }
+  }
+}
+
+// auth.guard.ts
+export const authGuard: CanActivateFn = async (route, state) => {
+  const authService = inject(Auth);
+  const router = inject(Router);
+  
+  // Check if already authenticated
+  if (authService.isAuthenticated()) {
+    return true;
+  }
+  
+  // Try to restore session
+  const isValid = await authService.checkAuth();
+  if (isValid) {
+    return true;
+  }
+  
+  // Redirect to login
+  return router.createUrlTree(['/login'], {
+    queryParams: { returnUrl: state.url },
+  });
+};
+
+// login.component.ts
+@Component({
+  template: `
+    <form (ngSubmit)="login()">
+      <input [(ngModel)]="email" name="email" />
+      <input [(ngModel)]="password" name="password" type="password" />
+      <button type="submit">Login</button>
+    </form>
+  `,
+})
+export class Login {
+  #authService = inject(Auth);
+  #router = inject(Router);
+  #route = inject(ActivatedRoute);
+
+  email = '';
+  password = '';
+
+  async login() {
+    const success = await this.#authService.login({
+      email: this.email,
+      password: this.password,
+    });
+
+    if (success) {
+      const returnUrl = this.#route.snapshot.queryParams['returnUrl'] || '/';
+      this.#router.navigateByUrl(returnUrl);
+    }
+  }
+}
+```
+
+## Breadcrumbs
+
+```typescript
+// breadcrumb.service.ts
+@Injectable({ providedIn: 'root' })
+export class Breadcrumb {
+  #router = inject(Router);
+  #route = inject(ActivatedRoute);
+
+  breadcrumbs = toSignal(
+    this.#router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      map(() => this.#buildBreadcrumbs(this.#route.root))
+    ),
+    { initialValue: [] }
+  );
+
+  #buildBreadcrumbs(
+    route: ActivatedRoute,
+    url: string = '',
+    breadcrumbs: Breadcrumb[] = []
+  ): Breadcrumb[] {
+    const children = route.children;
+    
+    if (children.length === 0) {
+      return breadcrumbs;
+    }
+    
+    for (const child of children) {
+      const routeUrl = child.snapshot.url
+        .map(segment => segment.path)
+        .join('/');
+      
+      if (routeUrl) {
+        url += `/${routeUrl}`;
+      }
+      
+      const label = child.snapshot.data['breadcrumb'];
+      if (label) {
+        breadcrumbs.push({ label, url });
+      }
+      
+      return this.#buildBreadcrumbs(child, url, breadcrumbs);
+    }
+    
+    return breadcrumbs;
+  }
+}
+
+// Route config with breadcrumb data
+export const routes: Routes = [
+  {
+    path: 'products',
+    data: { breadcrumb: 'Products' },
+    children: [
+      { path: '', component: ProductList },
+      {
+        path: ':id',
+        data: { breadcrumb: 'Product Details' },
+        component: ProductDetail,
+      },
+    ],
+  },
+];
+
+// breadcrumb.component.ts
+@Component({
+  selector: 'app-breadcrumb',
+  template: `
+    <nav aria-label="Breadcrumb">
+      <ol>
+        <li><a routerLink="/">Home</a></li>
+        @for (crumb of breadcrumbService.breadcrumbs(); track crumb.url) {
+          <li>
+            <a [routerLink]="crumb.url">{{ crumb.label }}</a>
+          </li>
+        }
+      </ol>
+    </nav>
+  `,
+})
+export class BreadcrumbCmpt {
+  breadcrumbService = inject(Breadcrumb);
+}
+```
+
+## Tab Navigation
+
+```typescript
+// tabs-layout.component.ts
+@Component({
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  template: `
+    <div class="tabs">
+      @for (tab of tabs; track tab.path) {
+        <a 
+          [routerLink]="tab.path" 
+          routerLinkActive="active"
+          [routerLinkActiveOptions]="{ exact: tab.exact }"
+        >
+          {{ tab.label }}
+        </a>
+      }
+    </div>
+    <div class="tab-content">
+      <router-outlet />
+    </div>
+  `,
+})
+export class TabsLayout {
+  tabs = [
+    { path: './', label: 'Overview', exact: true },
+    { path: 'details', label: 'Details', exact: false },
+    { path: 'settings', label: 'Settings', exact: false },
+  ];
+}
+
+// Routes
+{
+  path: 'account',
+  component: TabsLayout,
+  children: [
+    { path: '', component: AccountOverview },
+    { path: 'details', component: AccountDetails },
+    { path: 'settings', component: AccountSettings },
+  ],
+}
+```
+
+## Modal Routes
+
+Using auxiliary outlets for modals:
+
+```typescript
+// Routes
+export const routes: Routes = [
+  { path: 'products', component: ProductList },
+  { path: 'product-modal/:id', component: ProductModal, outlet: 'modal' },
+];
+
+// App template
+@Component({
+  template: `
+    <router-outlet />
+    <router-outlet name="modal" />
+  `,
+})
+export class App {}
+
+// Open modal
+this.router.navigate([{ outlets: { modal: ['product-modal', productId] } }]);
+
+// Close modal
+this.router.navigate([{ outlets: { modal: null } }]);
+
+// Link to open modal
+<a [routerLink]="[{ outlets: { modal: ['product-modal', product.id] } }]">
+  View Details
+</a>
+```
+
+## Preloading Strategies
+
+### Built-in Strategies
+
+```typescript
+import { 
+  provideRouter, 
+  withPreloading,
+  PreloadAllModules,
+  NoPreloading 
+} from '@angular/router';
+
+// Preload all lazy modules
+provideRouter(routes, withPreloading(PreloadAllModules))
+
+// No preloading (default)
+provideRouter(routes, withPreloading(NoPreloading))
+```
+
+### Custom Preloading Strategy
+
+```typescript
+// selective-preload.strategy.ts
+@Injectable({ providedIn: 'root' })
+export class SelectivePreloadStrategy implements PreloadingStrategy {
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+    // Only preload routes marked with data.preload = true
+    if (route.data?.['preload']) {
+      return load();
+    }
+    return of(null);
+  }
+}
+
+// Routes
+{
+  path: 'dashboard',
+  loadComponent: () => import('./dashboard.component'),
+  data: { preload: true }, // Will be preloaded
+}
+
+// Config
+provideRouter(routes, withPreloading(SelectivePreloadStrategy))
+```
+
+### Network-Aware Preloading
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class NetworkAwarePreloadStrategy implements PreloadingStrategy {
+  preload(route: Route, load: () => Observable<any>): Observable<any> {
+    // Check network conditions
+    const connection = (navigator as any).connection;
+    
+    if (connection) {
+      // Don't preload on slow connections
+      if (connection.saveData || connection.effectiveType === '2g') {
+        return of(null);
+      }
+    }
+    
+    // Preload if marked
+    if (route.data?.['preload']) {
+      return load();
+    }
+    
+    return of(null);
+  }
+}
+```
+
+## Route Animations
+
+```typescript
+// app.routes.ts
+export const routes: Routes = [
+  { path: 'home', component: Home, data: { animation: 'HomePage' } },
+  { path: 'about', component: About, data: { animation: 'AboutPage' } },
+];
+
+// app.component.ts
+@Component({
+  imports: [RouterOutlet],
+  template: `
+    <div [@routeAnimations]="getRouteAnimationData()">
+      <router-outlet />
+    </div>
+  `,
+  animations: [
+    trigger('routeAnimations', [
+      transition('HomePage <=> AboutPage', [
+        style({ position: 'relative' }),
+        query(':enter, :leave', [
+          style({
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+          }),
+        ]),
+        query(':enter', [style({ left: '-100%' })]),
+        query(':leave', animateChild()),
+        group([
+          query(':leave', [animate('300ms ease-out', style({ left: '100%' }))]),
+          query(':enter', [animate('300ms ease-out', style({ left: '0%' }))]),
+        ]),
+      ]),
+    ]),
+  ],
+})
+export class AppMain {
+  getRouteAnimationData() {
+    return this.route.firstChild?.snapshot.data['animation'];
+  }
+}
+```
+
+## Scroll Position Restoration
+
+```typescript
+// app.config.ts
+import { 
+  provideRouter, 
+  withInMemoryScrolling,
+  withRouterConfig 
+} from '@angular/router';
+
+provideRouter(
+  routes,
+  withInMemoryScrolling({
+    scrollPositionRestoration: 'enabled', // or 'top'
+    anchorScrolling: 'enabled',
+  }),
+  withRouterConfig({
+    onSameUrlNavigation: 'reload',
+  })
+)
+```

--- a/skills/dev-skills/angular-signals/SKILL.md
+++ b/skills/dev-skills/angular-signals/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: angular-signals
+description: Implement signal-based reactive state management in Angular v20+. Use for creating reactive state with signal(), derived state with computed(), dependent state with linkedSignal(), and side effects with effect(). Triggers on state management questions, converting from BehaviorSubject/Observable patterns to signals, or implementing reactive data flows. Do not use for HTTP data fetching (use angular-http) or complex form state (use angular-forms).
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Signals
+
+Signals are Angular's reactive primitive for state management. They provide synchronous, fine-grained reactivity.
+
+## Core Signal APIs
+
+### Signal Best Practices
+
+**CRITICAL**: Do NOT use `mutate` on signals - use `update` or `set` instead:
+
+```typescript
+const items = signal<Item[]>([]);
+
+// WRONG - mutate is deprecated/removed
+// items.mutate(arr => arr.push(newItem));
+
+// CORRECT - use update with spread
+items.update(arr => [...arr, newItem]);
+
+// CORRECT - use set for replacement
+items.set([...items(), newItem]);
+```
+
+**Keep state transformations pure and predictable**:
+
+```typescript
+// WRONG - impure transformation
+const items = signal<Item[]>([]);
+items.update(arr => {
+  arr.push(newItem); // Mutates original array
+  return arr;
+});
+
+// CORRECT - pure transformation
+items.update(arr => [...arr, newItem]); // Returns new array
+```
+
+### signal() - Writable State
+
+```typescript
+import {signal} from '@angular/core';
+
+// Create writable signal
+const count = signal(0);
+
+// Read value
+console.log(count()); // 0
+
+// Set new value
+count.set(5);
+
+// Update based on current value
+count.update(c => c + 1);
+
+// With explicit type
+const user = signal<User | null>(null);
+user.set({id: 1, name: 'Alice'});
+
+
+```
+
+### computed() - Derived State
+
+```typescript
+import { signal, computed } from '@angular/core';
+
+const firstName = signal('John');
+const lastName = signal('Doe');
+
+// Derived signal - automatically updates when dependencies change
+const fullName = computed(() => `${firstName()} ${lastName()}`);
+
+console.log(fullName()); // "John Doe"
+firstName.set('Jane');
+console.log(fullName()); // "Jane Doe"
+
+// Computed with complex logic
+const items = signal<Item[]>([]);
+const filter = signal('');
+
+const filteredItems = computed(() => {
+  const query = filter().toLowerCase();
+  return items().filter(item => 
+    item.name.toLowerCase().includes(query)
+  );
+});
+
+const totalPrice = computed(() => 
+  filteredItems().reduce((sum, item) => sum + item.price, 0)
+);
+```
+
+### linkedSignal() - Dependent State with Reset
+
+```typescript
+import { signal, linkedSignal } from '@angular/core';
+
+const options = signal(['A', 'B', 'C']);
+
+// Resets to first option when options change
+const selected = linkedSignal(() => options()[0]);
+
+console.log(selected()); // "A"
+selected.set('B');       // User selects B
+console.log(selected()); // "B"
+options.set(['X', 'Y']); // Options change
+console.log(selected()); // "X" - auto-reset to first
+
+// With previous value access
+const items = signal<Item[]>([]);
+
+const selectedItem = linkedSignal<Item[], Item | null>({
+  source: () => items(),
+  computation: (newItems, previous) => {
+    // Try to preserve selection if item still exists
+    const prevItem = previous?.value;
+    if (prevItem && newItems.some(i => i.id === prevItem.id)) {
+      return prevItem;
+    }
+    return newItems[0] ?? null;
+  },
+});
+```
+
+### effect() - Side Effects
+
+```typescript
+import {signal, effect, inject, DestroyRef} from '@angular/core';
+
+@Component({...})
+export class Search {
+    query = signal('');
+
+    constructor() {
+        // Effect runs when query changes
+        effect(() => {
+            console.log('Search query:', this.query());
+        });
+
+        // Effect with cleanup
+        effect((onCleanup) => {
+            const timer = setInterval(() => {
+                console.log('Current query:', this.query());
+            }, 1000);
+
+            onCleanup(() => clearInterval(timer));
+        });
+    }
+
+    // Effect in other injection context
+    effectInOtherContext = effect(() => {
+        console.log('Effect in other injection context');
+    });
+}
+```
+
+**Effect rules:**
+- Run in injection context (constructor or with `runInInjectionContext` , or in other injection context)
+- Automatically cleaned up when component destroys
+
+## Component State Pattern
+
+```typescript
+@Component({
+  selector: 'app-todo-list',
+  template: `
+    <input [value]="newTodo()" (input)="newTodo.set($any($event.target).value)" />
+    <button (click)="addTodo()" [disabled]="!canAdd()">Add</button>
+    
+    <ul>
+      @for (todo of filteredTodos(); track todo.id) {
+        <li [class.done]="todo.done">
+          {{ todo.text }}
+          <button (click)="toggleTodo(todo.id)">Toggle</button>
+        </li>
+      }
+    </ul>
+    
+    <p>{{ remaining() }} remaining</p>
+  `,
+})
+export class TodoList {
+  // State
+  todos = signal<Todo[]>([]);
+  newTodo = signal('');
+  filter = signal<'all' | 'active' | 'done'>('all');
+  
+  // Derived state
+  canAdd = computed(() => this.newTodo().trim().length > 0);
+  
+  filteredTodos = computed(() => {
+    const todos = this.todos();
+    switch (this.filter()) {
+      case 'active': return todos.filter(t => !t.done);
+      case 'done': return todos.filter(t => t.done);
+      default: return todos;
+    }
+  });
+  
+  remaining = computed(() => 
+    this.todos().filter(t => !t.done).length
+  );
+  
+  // Actions
+  addTodo() {
+    const text = this.newTodo().trim();
+    if (text) {
+      this.todos.update(todos => [
+        ...todos,
+        { id: crypto.randomUUID(), text, done: false }
+      ]);
+      this.newTodo.set('');
+    }
+  }
+  
+  toggleTodo(id: string) {
+    this.todos.update(todos =>
+      todos.map(t => t.id === id ? { ...t, done: !t.done } : t)
+    );
+  }
+}
+```
+
+## RxJS Interop
+
+### toSignal() - Observable to Signal
+
+```typescript
+import {toSignal} from '@angular/core/rxjs-interop';
+import {interval} from 'rxjs';
+
+@Component({...})
+export class Timer {
+    #http = inject(HttpClient);
+
+    // From observable - requires initial value or allowUndefined
+    counter = toSignal(interval(1000), {initialValue: 0});
+
+    // From HTTP - undefined until loaded
+    users = toSignal(this.#http.get<User[]>('/api/users'));
+
+    // With requireSync for synchronous observables (BehaviorSubject)
+    #user$ = new BehaviorSubject<User | null>(null);
+    currentUser = toSignal(this.#user$, {requireSync: true});
+
+    // FormControl State handling with chaining and adding side effects
+    isControlVisible = toSignal(this.formControl.valueChanges.pipe(tap(() => {
+        // Side effect: log value changes
+        
+        console.log('Form control value changed');
+    })), {initialValue: this.formControl.value});
+}
+```
+
+### toObservable() - Signal to Observable
+
+```typescript
+import { toObservable } from '@angular/core/rxjs-interop';
+import { switchMap, debounceTime } from 'rxjs';
+
+@Component({...})
+export class Search {
+  query = signal('');
+
+  #http = inject(HttpClient);
+
+  // Convert signal to observable for RxJS operators
+  results = toSignal(
+    toObservable(this.query).pipe(
+      debounceTime(300),
+      switchMap(q => this.#http.get<Result[]>(`/api/search?q=${q}`))
+    ),
+    { initialValue: [] }
+  );
+}
+```
+
+## Signal Equality
+
+```typescript
+// Custom equality function
+const user = signal<User>(
+  { id: 1, name: 'Alice' },
+  { equal: (a, b) => a.id === b.id }
+);
+
+// Only triggers updates when ID changes
+user.set({ id: 1, name: 'Alice Updated' }); // No update
+user.set({ id: 2, name: 'Bob' }); // Triggers update
+
+
+const equalitySignal = signal(0, {equal: (a, b) => a === b});
+this.equalitySignal.set(0); // No update triggered due to the equality function it will not inform its consumers since the value is considered unchanged
+this.equalitySignal.set(1); // Update triggered, value changes from 0 to 1
+```
+
+## Untracked Reads
+
+```typescript
+import { untracked } from '@angular/core';
+
+const a = signal(1);
+const b = signal(2);
+
+// Only depends on 'a', not 'b'
+const result = computed(() => {
+  const aVal = a();
+  const bVal = untracked(() => b());
+  return aVal + bVal;
+});
+```
+
+## Service State Pattern
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class Auth {
+  // Private writable state
+  #user = signal<User | null>(null);
+  #loading = signal(false);
+
+  // Public read-only signals
+  readonly _user = this.#user.asReadonly();
+  readonly _loading = this.#loading.asReadonly();
+  readonly isAuthenticated = computed(() => this.#user() !== null);
+
+  #http = inject(HttpClient);
+
+  async login(credentials: Credentials): Promise<void> {
+    this.#loading.set(true);
+    try {
+      const user = await firstValueFrom(
+        this.#http.post<User>('/api/login', credentials)
+      );
+      this.#user.set(user);
+    } finally {
+      this.#loading.set(false);
+    }
+  }
+
+  logout(): void {
+    this.#user.set(null);
+  }
+}
+```
+
+See `references/signal-patterns.md` for advanced patterns including resource() and complex state management.

--- a/skills/dev-skills/angular-signals/references/signal-patterns.md
+++ b/skills/dev-skills/angular-signals/references/signal-patterns.md
@@ -1,0 +1,394 @@
+# Angular Signal Patterns
+
+## Table of Contents
+
+- [Resource API](#resource-api)
+- [rxResource API](#rxresource-api)
+- [Signal Store Pattern](#signal-store-pattern)
+- [Form State with Signals](#form-state-with-signals)
+- [Async Operations](#async-operations)
+- [Testing Signals](#testing-signals)
+
+## Resource API
+
+The `resource()` API handles async data fetching with signals:
+
+```typescript
+import {resource, signal, computed} from '@angular/core';
+
+@Component({...})
+export class UserProfile {
+    userId = signal<string>('');
+
+    // Resource fetches data when params change
+    userResource = resource({
+        params: () => ({id: this.userId()}),
+        loader: async ({params, abortSignal}) => {
+            const response = await fetch(`/api/users/${params.id}`, {
+                signal: abortSignal,
+            });
+            return response.json() as Promise<User>;
+        },
+    });
+
+    // Access resource state
+    readonly user = computed(() => this.userResource.value());
+    readonly isLoading = computed(() => this.userResource.isLoading());
+    readonly error = computed(() => this.userResource.error());
+}
+```
+
+### Resource Status
+
+```typescript
+const userResource = resource({...});
+
+// Status signals
+userResource.value();      // Current value or undefined
+userResource.hasValue();   // Boolean - has resolved value
+userResource.error();      // Error or undefined
+userResource.isLoading();  // Boolean - currently loading
+userResource.status();     // 'idle' | 'loading' | 'reloading' | 'resolved' | 'error' | 'local'
+
+// Manual reload
+userResource.reload();
+
+// Local updates
+userResource.set(newValue);
+userResource.update(current => ({...current, name: 'Updated'}));
+```
+
+### Resource with Default Value
+
+```typescript
+const todosResource = resource({
+    defaultValue: [] as Todo[],
+    params: () => ({filter: this.filter()}),
+    loader: async ({params}) => {
+        const response = await fetch(`/api/todos?filter=${params.filter}`);
+        return response.json();
+    },
+});
+
+// value() returns Todo[] (never undefined due to defaultValue)
+```
+
+### Conditional Loading
+
+```typescript
+const userId = signal<string | null>(null);
+
+const userResource = resource({
+    params: () => {
+        const id = userId();
+        // Return undefined to skip loading
+        return id ? {id} : undefined;
+    },
+    loader: async ({params}) => {
+        return fetch(`/api/users/${params.id}`).then(r => r.json());
+    },
+});
+// Status is 'idle' when params returns undefined
+```
+
+## rxResource API
+
+```ts
+  userRxResource = rxResource({
+    // Reactive params — reruns stream when these change
+    params: () => ({id: this.userId()}),
+
+    // Returns an Observable (not a Promise)
+    stream: ({params, abortSignal}) =>
+        this.http.get<User>(`/api/users/${params.id}`),
+
+    // Fallback value while loading (makes value() never undefined)
+    defaultValue: {id: 0, name: ''} as User,
+
+    // Custom equality to avoid unnecessary re-renders
+    equal: (a, b) => a.id === b.id,
+});
+
+```
+
+### RXResource Status
+
+```typescript
+  userRxResource.value()      // T | undefined (or T if defaultValue set)
+  userRxResource.hasValue()   // boolean
+  userRxResource.isLoading()  // boolean
+  userRxResource.error()      // unknown | undefined
+  userRxResource.status()     // 'idle' | 'loading' | 'reloading' | 'resolved' | 'error' | 'local'
+  userRxResource.reload()     // manually retrigger
+  userRxResource.set(value)   // set local value
+
+```
+
+### Streaming Use Case
+
+```typescript
+  //Streaming Use Case (SSE/WebSocket)
+
+//Since stream returns an Observable, it can emit multiple values — making it useful for Server-Sent Events:
+
+sseResource = rxResource({
+    stream: () => this.eventSource.getStream(), // Observable that emits repeatedly
+});
+```
+### Key Differences Between rxResource and resource
+```markdown
+
+┌─────────────────────────────┬────────────────────────────────┐
+│         resource()          │          rxResource()          │
+├─────────────────────────────┼────────────────────────────────┤
+│ loader — returns Promise<T> │ stream — returns Observable<T> │
+├─────────────────────────────┼────────────────────────────────┤
+│ @angular/core               │ @angular/core/rxjs-interop     │
+└─────────────────────────────┴────────────────────────────────┘
+
+```
+## Signal Store Pattern
+
+For a complex state, create a dedicated store (State Machine):
+
+```typescript
+interface ProductState {
+    products: Product[];
+    selectedId: string | null;
+    filter: string;
+    loading: boolean;
+    error: string | null;
+}
+
+@Injectable({providedIn: 'root'})
+export class ProductSt {
+    // Private state
+     #state = signal<ProductState>({
+        products: [],
+        selectedId: null,
+        filter: '',
+        loading: false,
+        error: null,
+    });
+
+    // Selectors (computed signals)
+    readonly products = computed(() => this.#state().products);
+    readonly selectedId = computed(() => this.#state().selectedId);
+    readonly filter = computed(() => this.#state().filter);
+    readonly loading = computed(() => this.#state().loading);
+    readonly error = computed(() => this.#state().error);
+
+    readonly filteredProducts = computed(() => {
+        const {products, filter} = this.#state();
+        if (!filter) return products;
+        return products.filter(p =>
+            p.name.toLowerCase().includes(filter.toLowerCase())
+        );
+    });
+
+    readonly selectedProduct = computed(() => {
+        const {products, selectedId} = this.#state();
+        return products.find(p => p.id === selectedId) ?? null;
+    });
+
+     #http = inject(HttpClient);
+
+    // Actions
+    setFilter(filter: string): void {
+        this.#state.update(s => ({...s, filter}));
+    }
+
+    selectProduct(id: string | null): void {
+        this.#state.update(s => ({...s, selectedId: id}));
+    }
+
+    async loadProducts(): Promise<void> {
+        this.#state.update(s => ({...s, loading: true, error: null}));
+
+        try {
+            const products = await firstValueFrom(
+                this.#http.get<Product[]>('/api/products')
+            );
+            this.#state.update(s => ({...s, products, loading: false}));
+        } catch (err) {
+            this.#state.update(s => ({
+                ...s,
+                loading: false,
+                error: 'Failed to load products'
+            }));
+        }
+    }
+
+    async addProduct(product: Omit<Product, 'id'>): Promise<void> {
+        const newProduct = await firstValueFrom(
+            this.#http.post<Product>('/api/products', product)
+        );
+        this.#state.update(s => ({
+            ...s,
+            products: [...s.products, newProduct],
+        }));
+    }
+}
+```
+
+## Async Operations
+
+### Debounced Search
+
+```typescript
+
+@Component({...})
+export class Search {
+    query = signal('');
+
+     #http = inject(HttpClient);
+
+    // Debounced search using toObservable
+    results = toSignal(
+        toObservable(this.query).pipe(
+            debounceTime(300),
+            distinctUntilChanged(),
+            filter(q => q.length >= 2),
+            switchMap(q => this.#http.get<Result[]>(`/api/search?q=${q}`)),
+            catchError(() => of([]))
+        ),
+        {initialValue: []}
+    );
+
+    // Loading state
+     #searching = signal<boolean>(false);
+    readonly isSearching = this.#searching.asReadonly();
+
+    constructor() {
+        // Track loading state
+        effect(() => {
+            const query = this.query();
+            if (qusery.length >= 2) {
+                this.#searching.set(true);
+            }
+        });
+
+        effect(() => {
+            this.results(); // Subscribe to results
+            this.#searching.set(false);
+        });
+    }
+}
+```
+
+### Optimistic Updates
+
+```typescript
+
+@Injectable({providedIn: 'root'})
+export class Todo {
+    private todos = signal<Todo[]>([]);
+    readonly items = this.todos.asReadonly();
+
+    private http = inject(HttpClient);
+
+    async toggleTodo(id: string): Promise<void> {
+        // Optimistic update
+        const previousTodos = this.todos();
+        this.todos.update(todos =>
+            todos.map(t => t.id === id ? {...t, done: !t.done} : t)
+        );
+
+        try {
+            await firstValueFrom(
+                this.http.patch(`/api/todos/${id}/toggle`, {})
+            );
+        } catch {
+            // Rollback on error
+            this.todos.set(previousTodos);
+        }
+    }
+}
+```
+
+## Testing Signals
+
+```typescript
+describe('Counter', () => {
+    it('should increment count', () => {
+        const component = new Counter();
+
+        expect(component.count()).toBe(0);
+
+        component.increment();
+        expect(component.count()).toBe(1);
+
+        component.increment();
+        expect(component.count()).toBe(2);
+    });
+
+    it('should compute doubled value', () => {
+        const component = new Counter();
+
+        expect(component.doubled()).toBe(0);
+
+        component.count.set(5);
+        expect(component.doubled()).toBe(10);
+    });
+});
+
+describe('ProductSt', () => {
+    let store: ProductSt;
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                ProductSt,
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
+        });
+
+        store = TestBed.inject(ProductSt);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    it('should filter products', () => {
+        // Set initial state
+        store['state'].set({
+            products: [
+                {id: '1', name: 'Apple'},
+                {id: '2', name: 'Banana'},
+            ],
+            selectedId: null,
+            filter: '',
+            loading: false,
+            error: null,
+        });
+
+        expect(store.filteredProducts().length).toBe(2);
+
+        store.setFilter('app');
+        expect(store.filteredProducts().length).toBe(1);
+        expect(store.filteredProducts()[0].name).toBe('Apple');
+    });
+});
+```
+
+## Signal Debugging
+
+```typescript
+// Debug effect to log signal changes
+effect(() => {
+    console.log('State changed:', {
+        count: this.count(),
+        items: this.items(),
+        filter: this.filter(),
+    });
+});
+
+// Conditional debugging
+const DEBUG = signal(false);
+
+effect(() => {
+    if (untracked(() => DEBUG())) {
+        console.log('Debug:', this.state());
+    }
+});
+```

--- a/skills/dev-skills/angular-ssr/SKILL.md
+++ b/skills/dev-skills/angular-ssr/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: angular-ssr
+description: Implement server-side rendering and hydration in Angular v20+ using @angular/ssr. Use for SSR setup, hydration strategies, prerendering static pages, and handling browser-only APIs. Triggers on SSR configuration, fixing hydration mismatches, prerendering routes, or making code SSR-compatible. Do not use for client-only SPAs that do not require server rendering or SEO.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular SSR
+
+
+Implement server-side rendering, hydration, and prerendering in Angular v20+.
+
+## Choosing a Rendering Strategy
+
+Before adding SSR, consider whether your app needs it. Angular supports CSR (default), SSG (prerendering at build time), and SSR (per-request rendering). See `references/rendering-strategies.md` for the decision matrix comparing use cases, pros/cons, and hydration options.
+
+## Setup
+
+### Add SSR to Existing Project
+
+```bash
+ng add @angular/ssr
+```
+
+This adds:
+- `@angular/ssr` package
+- `server.ts` - Express server
+- `src/main.server.ts` - Server bootstrap
+- `src/app/app.config.server.ts` - Server providers
+- Updates `angular.json` with SSR configuration
+
+### Project Structure
+
+```
+src/
+├── app/
+│   ├── app.config.ts          # Browser config
+│   ├── app.config.server.ts   # Server config
+│   └── app.routes.ts
+├── main.ts                     # Browser bootstrap
+├── main.server.ts              # Server bootstrap
+server.ts                       # Express server
+```
+
+## Configuration
+
+### app.config.server.ts
+
+```typescript
+import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
+import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRoutesConfig } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    provideServerRoutesConfig(serverRoutes),
+  ],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+```
+
+### Server Routes Configuration
+
+```typescript
+// app.routes.server.ts
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '',
+    renderMode: RenderMode.Prerender, // Static at build time
+  },
+  {
+    path: 'products',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: 'products/:id',
+    renderMode: RenderMode.Server, // Dynamic SSR
+  },
+  {
+    path: 'dashboard',
+    renderMode: RenderMode.Client, // Client-only (SPA)
+  },
+  {
+    path: '**',
+    renderMode: RenderMode.Server,
+  },
+];
+```
+
+### Render Modes
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| `RenderMode.Prerender` | Static HTML at build time | Marketing pages, blogs |
+| `RenderMode.Server` | Dynamic SSR per request | User-specific content |
+| `RenderMode.Client` | Client-side only (SPA) | Authenticated dashboards |
+
+## Server Routing
+
+Configure server routing in `app.routes.server.ts`. Map each path to a `RenderMode`:
+- `RenderMode.Server` — dynamic SSR per request (user-specific data, parameterized routes)
+- `RenderMode.Prerender` — static HTML at build time (use `getPrerenderParams` for parameterized routes)
+- `RenderMode.Client` — client-side only, no SSR (dashboards, authenticated pages)
+
+Register with `provideServerRendering(withRoutes(serverRoutes))` in `app.config.server.ts`. Place specific routes before the catch-all `**`. SSR accessibility: ensure ARIA attributes in initial render; use `hydrate on interaction` for complex interactive components.
+
+Refer to `references/server-routing.md` for parameterized routes, catch-all patterns, headers/status codes, redirect behavior, and request/response access.
+
+## Hydration
+
+### Default Hydration
+
+Hydration is enabled by default with `provideClientHydration()`:
+
+```typescript
+// app.config.ts
+import { provideClientHydration } from '@angular/platform-browser';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideClientHydration(),
+    // ...
+  ],
+};
+```
+
+### Incremental Hydration
+
+Defer hydration of specific components:
+
+```typescript
+@Component({
+  template: `
+    <!-- Hydrate when visible -->
+    @defer (hydrate on viewport) {
+      <app-comments [postId]="postId" />
+    } @placeholder {
+      <div class="comments-placeholder">Loading comments...</div>
+    }
+    
+    <!-- Hydrate on interaction -->
+    @defer (hydrate on interaction) {
+      <app-interactive-chart [data]="chartData" />
+    }
+    
+    <!-- Hydrate on idle -->
+    @defer (hydrate on idle) {
+      <app-recommendations />
+    }
+    
+    <!-- Never hydrate (static only) -->
+    @defer (hydrate never) {
+      <app-static-footer />
+    }
+  `,
+})
+export class Post {
+  postId = input.required<string>();
+  chartData = input.required<ChartData>();
+}
+```
+
+### Hydration Triggers
+
+| Trigger | Description |
+|---------|-------------|
+| `hydrate on viewport` | When element enters viewport |
+| `hydrate on interaction` | On click, focus, or input |
+| `hydrate on idle` | When browser is idle |
+| `hydrate on immediate` | Immediately after load |
+| `hydrate on timer(ms)` | After specified delay |
+| `hydrate when condition` | When expression is true |
+| `hydrate never` | Never hydrate (static) |
+
+### Event Replay
+
+Capture user events before hydration completes:
+
+```typescript
+import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideClientHydration(withEventReplay()),
+  ],
+};
+```
+
+## Browser-Only Code
+
+### Platform Detection
+
+```typescript
+import { Component, PLATFORM_ID, inject, signal } from '@angular/core';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+
+@Component({...})
+export class MyComponent {
+  // Use inject() for platform detection
+  #platformId = inject(PLATFORM_ID);
+  #isBrowser = isPlatformBrowser(this.#platformId);
+
+  constructor() {
+    if (this.#isBrowser) {
+      // Browser-only initialization
+      window.addEventListener('scroll', this.#onScroll);
+    }
+  }
+
+  #onScroll = () => {
+    // Handle scroll
+  };
+}
+```
+
+### afterNextRender / afterRender
+
+Run code only in browser after rendering:
+
+```typescript
+import { afterNextRender, afterRender } from '@angular/core';
+
+@Component({...})
+export class Chart {
+  constructor() {
+    // Runs once after first render (browser only)
+    afterNextRender(() => {
+      this.initChart();
+    });
+    
+    // Runs after every render (browser only)
+    afterRender(() => {
+      this.updateChart();
+    });
+  }
+  
+  #initChart() {
+    // Safe to use DOM APIs here
+    const canvas = document.getElementById('chart');
+    new Chart(canvas, this.config);
+  }
+}
+```
+
+### Inject Browser APIs Safely
+
+```typescript
+// tokens.ts
+import { InjectionToken, PLATFORM_ID, inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+export const WINDOW = new InjectionToken<Window | null>('Window', {
+  providedIn: 'root',
+  factory: () => {
+    const platformId = inject(PLATFORM_ID);
+    return isPlatformBrowser(platformId) ? window : null;
+  },
+});
+
+export const LOCAL_STORAGE = new InjectionToken<Storage | null>('LocalStorage', {
+  providedIn: 'root',
+  factory: () => {
+    const platformId = inject(PLATFORM_ID);
+    return isPlatformBrowser(platformId) ? localStorage : null;
+  },
+});
+
+// Usage
+@Injectable({ providedIn: 'root' })
+export class Storage {
+  #storage = inject(LOCAL_STORAGE);
+
+  get(key: string): string | null {
+    return this.#storage?.getItem(key) ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.#storage?.setItem(key, value);
+  }
+}
+```
+
+## Prerendering
+
+Use `RenderMode.Prerender` for static pages. For dynamic routes, implement `getPrerenderParams()` to return all parameter combinations at build time. Configure `fallback` (`PrerenderFallback.Server`, `.Client`, or `.None`) for routes not prerendered.
+
+Refer to `references/prerendering.md` for static route config, dynamic getPrerenderParams examples, and fallback options.
+
+## HTTP Caching
+
+Use `withHttpTransferCacheOptions()` in `provideClientHydration()` to automatically transfer HTTP responses from server to client. For manual control, use `TransferState` with `makeStateKey<T>()` — store on server with `isPlatformServer()`, retrieve and remove on client.
+
+Refer to `references/caching-strategies.md` for HTTP cache headers, CDN Vary, and stale-while-revalidate strategies.
+
+## Build and Deploy
+
+Build with `ng build` (outputs `dist/my-app/browser/` and `dist/my-app/server/`). Run dev server with `npm run serve:ssr:my-app`. Run production with `node dist/my-app/server/server.mjs`.
+
+Refer to `references/build-deploy.md` for the complete Express server setup and deployment configuration.
+
+## Advanced Patterns
+
+- Refer to `references/hydration-debugging.md` for common mismatches, `ngSkipHydration`, and debug mode
+- Refer to `references/seo-optimization.md` for meta tags, Open Graph, JSON-LD, and route resolvers
+- Refer to `references/authentication-ssr.md` for cookie-based auth and skipping SSR for auth routes
+- Refer to `references/caching-strategies.md` for HTTP cache headers, CDN Vary, and stale-while-revalidate
+- Refer to `references/error-handling.md` for SSR error boundaries and graceful degradation
+- Refer to `references/performance-optimization.md` for lazy hydration, preloading, and streaming SSR
+- Refer to `references/testing-ssr.md` for server rendering tests and hydration tests

--- a/skills/dev-skills/angular-ssr/references/authentication-ssr.md
+++ b/skills/dev-skills/angular-ssr/references/authentication-ssr.md
@@ -1,0 +1,50 @@
+# Authentication with SSR
+
+## Cookie-Based Auth
+
+```typescript
+// Server-side cookie reading
+import { REQUEST } from '@angular/ssr/tokens';
+
+@Injectable({ providedIn: 'root' })
+export class Auth {
+  #request = inject(REQUEST, { optional: true });
+  #platformId = inject(PLATFORM_ID);
+
+  getToken(): string | null {
+    if (isPlatformServer(this.#platformId) && this.#request) {
+      // Read from request cookies on server
+      const cookies = this.#request.headers.cookie || '';
+      const match = cookies.match(/auth_token=([^;]+)/);
+      return match ? match[1] : null;
+    }
+    
+    if (isPlatformBrowser(this.#platformId)) {
+      // Read from document cookies on client
+      const match = document.cookie.match(/auth_token=([^;]+)/);
+      return match ? match[1] : null;
+    }
+
+    return null;
+  }
+}
+```
+
+## Skip SSR for Authenticated Routes
+
+```typescript
+// app.routes.server.ts
+export const serverRoutes: ServerRoute[] = [
+    // Public routes - prerender
+    {path: '', renderMode: RenderMode.Prerender},
+    {path: 'products', renderMode: RenderMode.Prerender},
+
+    // Authenticated routes - client only
+    {path: 'dashboard', renderMode: RenderMode.Client},
+    {path: 'profile', renderMode: RenderMode.Client},
+    {path: 'settings', renderMode: RenderMode.Client},
+
+    // Server-side routes - // Dynamic product page → server-side rendered
+    {path: 'product/:id', renderMode: RenderMode.Server }
+];
+```

--- a/skills/dev-skills/angular-ssr/references/build-deploy.md
+++ b/skills/dev-skills/angular-ssr/references/build-deploy.md
@@ -1,0 +1,62 @@
+# SSR Build and Deploy
+
+## Build Commands
+
+```bash
+# Build with SSR
+ng build
+
+# Output structure
+dist/
+├── my-app/
+│   ├── browser/      # Client assets
+│   └── server/       # Server bundle
+```
+
+## Run SSR Server
+
+```bash
+# Development
+npm run serve:ssr:my-app
+
+# Production
+node dist/my-app/server/server.mjs
+```
+
+## Deploy to Node.js Host
+
+```javascript
+// server.ts (generated)
+import { APP_BASE_HREF } from '@angular/common';
+import { CommonEngine } from '@angular/ssr/node';
+import express from 'express';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import bootstrap from './src/main.server';
+
+const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+const browserDistFolder = resolve(serverDistFolder, '../browser');
+const indexHtml = join(serverDistFolder, 'index.server.html');
+
+const app = express();
+const commonEngine = new CommonEngine();
+
+app.get('*', express.static(browserDistFolder, { maxAge: '1y', index: false }));
+
+app.get('*', (req, res, next) => {
+  commonEngine
+    .render({
+      bootstrap,
+      documentFilePath: indexHtml,
+      url: req.originalUrl,
+      publicPath: browserDistFolder,
+      providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+    })
+    .then((html) => res.send(html))
+    .catch((err) => next(err));
+});
+
+app.listen(4000, () => {
+  console.log('Server listening on http://localhost:4000');
+});
+```

--- a/skills/dev-skills/angular-ssr/references/caching-strategies.md
+++ b/skills/dev-skills/angular-ssr/references/caching-strategies.md
@@ -1,0 +1,44 @@
+# Caching Strategies
+
+## HTTP Cache Headers
+
+```typescript
+// server.ts
+import { REQUEST, RESPONSE_INIT } from '@angular/ssr/tokens';
+
+// In route configuration or component
+@Component({...})
+export class ProductList {
+  #responseInit = inject(RESPONSE_INIT, { optional: true });
+
+  constructor() {
+    // Set cache headers for SSR response
+    if (this.#responseInit) {
+      this.#responseInit.headers = {
+        ...this.#responseInit.headers,
+        'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      };
+    }
+  }
+}
+```
+
+## CDN Caching with Vary Headers
+
+```typescript
+// server.ts - Express middleware
+app.use((req, res, next) => {
+  // Vary by cookie for authenticated content
+  res.setHeader('Vary', 'Cookie');
+  next();
+});
+```
+
+## Stale-While-Revalidate
+
+```typescript
+// Set SWR headers for dynamic content
+this.responseInit.headers = {
+  'Cache-Control': 'public, max-age=60, stale-while-revalidate=3600',
+};
+```

--- a/skills/dev-skills/angular-ssr/references/error-handling.md
+++ b/skills/dev-skills/angular-ssr/references/error-handling.md
@@ -1,0 +1,63 @@
+# Error Handling
+
+## SSR Error Boundaries
+
+```typescript
+// error-handler.ts
+import { ErrorHandler, Injectable, inject } from '@angular/core';
+import { PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+
+@Injectable()
+export class SsrError implements ErrorHandler {
+  #platformId = inject(PLATFORM_ID);
+
+  handleError(error: Error) {
+    if (isPlatformServer(this.#platformId)) {
+      // Log server errors
+      console.error('SSR Error:', error);
+      // Could send to monitoring service
+    } else {
+      // Client-side error handling
+      console.error('Client Error:', error);
+    }
+  }
+}
+
+// Provide in app.config.ts
+{ provide: ErrorHandler, useClass: SsrError }
+```
+
+## Graceful Degradation
+
+```typescript
+@Component({
+  template: `
+    @if (dataError()) {
+      <!-- Fallback content that works without data -->
+      <app-fallback-content />
+    } @else {
+      <app-data-content [data]="data()" />
+    }
+  `,
+})
+export class PageCmpt {
+  #dataService = inject(Data);
+
+  data = signal<Data | null>(null);
+  dataError = signal(false);
+
+  constructor() {
+    this.#loadData();
+  }
+
+  async #loadData() {
+    try {
+      const data = await this.#dataService.getData();
+      this.data.set(data);
+    } catch {
+      this.dataError.set(true);
+    }
+  }
+}
+```

--- a/skills/dev-skills/angular-ssr/references/hydration-debugging.md
+++ b/skills/dev-skills/angular-ssr/references/hydration-debugging.md
@@ -1,0 +1,58 @@
+# Hydration Debugging
+
+## Common Hydration Mismatches
+
+```typescript
+// Problem: Different content on server vs client
+@Component({
+  template: `<p>Current time: {{ currentTime }}</p>`,
+})
+export class Time {
+  // BAD: Different value on server and client
+  currentTime = new Date().toLocaleTimeString();
+}
+
+// Solution: Use afterNextRender or skip SSR
+@Component({
+  template: `<p>Current time: {{ currentTime() }}</p>`,
+})
+export class Time {
+  currentTime = signal('');
+
+  constructor() {
+    afterNextRender(() => {
+      this.currentTime.set(new Date().toLocaleTimeString());
+    });
+  }
+}
+```
+
+## Skip Hydration for Dynamic Content
+
+```typescript
+@Component({
+  template: `
+    <!-- Skip hydration for this subtree -->
+    <div ngSkipHydration>
+      <app-dynamic-widget />
+    </div>
+  `,
+})
+export class Page {}
+```
+
+## Debug Hydration Issues
+
+```typescript
+// Enable hydration debugging in development
+import { provideClientHydration, withNoDomReuse } from '@angular/platform-browser';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideClientHydration(
+      // Disable DOM reuse to see hydration errors clearly
+      ...(isDevMode() ? [withNoDomReuse()] : [])
+    ),
+  ],
+};
+```

--- a/skills/dev-skills/angular-ssr/references/performance-optimization.md
+++ b/skills/dev-skills/angular-ssr/references/performance-optimization.md
@@ -1,0 +1,68 @@
+# Performance Optimization
+
+## Lazy Hydration Strategy
+
+```typescript
+@Component({
+  template: `
+    <!-- Critical content - hydrate immediately -->
+    <header>
+      <app-navigation />
+    </header>
+
+    <!-- Main content - hydrate on viewport -->
+    <main>
+      @defer (hydrate on viewport) {
+        <app-product-grid [products]="products()" />
+      }
+    </main>
+
+    <!-- Below fold - hydrate on idle -->
+    @defer (hydrate on idle) {
+      <app-reviews [productId]="productId()" />
+    }
+
+    <!-- Interactive only - hydrate on interaction -->
+    @defer (hydrate on interaction) {
+      <app-chat-widget />
+    }
+
+    <!-- Static footer - never hydrate -->
+    @defer (hydrate never) {
+      <app-footer />
+    }
+  `,
+})
+export class ProductPage {}
+```
+
+## Preload Critical Data
+
+```typescript
+// app.routes.server.ts
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'products/:id',
+    renderMode: RenderMode.Server,
+    async getPrerenderParams() {
+      // Prerender top 100 products
+      const topProducts = await fetchTopProducts(100);
+      return topProducts.map(p => ({ id: p.id }));
+    },
+  },
+];
+```
+
+## Streaming SSR (Experimental)
+
+```typescript
+// Enable streaming for faster TTFB
+import { provideServerRendering } from '@angular/platform-server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(),
+    // Streaming is automatic with @defer blocks
+  ],
+};
+```

--- a/skills/dev-skills/angular-ssr/references/prerendering.md
+++ b/skills/dev-skills/angular-ssr/references/prerendering.md
@@ -1,0 +1,53 @@
+# SSR Prerendering
+
+Prerendering generates static HTML at build time for known routes.
+
+## Static Routes
+
+```typescript
+// app.routes.server.ts
+export const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Prerender },
+  { path: 'about', renderMode: RenderMode.Prerender },
+  { path: 'contact', renderMode: RenderMode.Prerender },
+  { path: 'blog', renderMode: RenderMode.Prerender },
+];
+```
+
+## Dynamic Routes with getPrerenderParams
+
+```typescript
+// app.routes.server.ts
+import { RenderMode, ServerRoute, PrerenderFallback } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'products/:id',
+    renderMode: RenderMode.Prerender,
+    async getPrerenderParams() {
+      // Fetch product IDs to prerender
+      const response = await fetch('https://api.example.com/products');
+      const products = await response.json();
+      return products.map((p: Product) => ({ id: p.id }));
+    },
+    fallback: PrerenderFallback.Server, // SSR for non-prerendered
+  },
+  {
+    path: 'blog/:slug',
+    renderMode: RenderMode.Prerender,
+    async getPrerenderParams() {
+      const posts = await fetchBlogPosts();
+      return posts.map(post => ({ slug: post.slug }));
+    },
+    fallback: PrerenderFallback.Client, // SPA for non-prerendered
+  },
+];
+```
+
+## Prerender Fallback Options
+
+| Fallback | Description |
+|----------|-------------|
+| `PrerenderFallback.Server` | SSR for non-prerendered routes |
+| `PrerenderFallback.Client` | Client-side rendering |
+| `PrerenderFallback.None` | 404 for non-prerendered routes |

--- a/skills/dev-skills/angular-ssr/references/rendering-strategies.md
+++ b/skills/dev-skills/angular-ssr/references/rendering-strategies.md
@@ -1,0 +1,44 @@
+# Rendering Strategies
+
+Angular supports multiple rendering strategies to optimize for SEO, performance, and interactivity.
+
+## 1. Client-Side Rendering (CSR)
+
+**Default Strategy.** Content is rendered entirely in the browser.
+
+- **Use case**: Interactive dashboards, internal tools.
+- **Pros**: Simplest to configure, low server cost.
+- **Cons**: Poor SEO, slower initial content visibility (must wait for JS).
+
+## 2. Static Site Generation (SSG / Prerendering)
+
+Content is pre-rendered into static HTML files at **build time**.
+
+- **Use case**: Marketing pages, blogs, documentation.
+- **Pros**: Fastest initial load, excellent SEO, CDN-friendly.
+- **Cons**: Requires rebuild for content updates, not for user-specific data.
+
+## 3. Server-Side Rendering (SSR)
+
+Content is rendered on the server for the **initial request**. Subsequent navigations happen client-side (SPA style).
+
+- **Use case**: E-commerce product pages, news sites, personalized dynamic content.
+- **Pros**: Excellent SEO, fast initial content visibility.
+- **Cons**: Requires a server (Node.js), higher server cost/latency.
+
+## Hydration
+
+Hydration is the process of making server-rendered HTML interactive in the browser.
+
+- **Full Hydration**: The entire app becomes interactive at once.
+- **Incremental Hydration**: (Advanced) Parts become interactive as needed using `@defer` blocks.
+- **Event Replay**: Captures and replays user events that happened before hydration finished.
+
+## Decision Matrix
+
+| Requirement                     | Strategy             |
+| :------------------------------ | :------------------- |
+| **SEO + Static Content**        | SSG                  |
+| **SEO + Dynamic Content**       | SSR                  |
+| **No SEO + High Interactivity** | CSR                  |
+| **Mixed**                       | Hybrid (Route-based) |

--- a/skills/dev-skills/angular-ssr/references/seo-optimization.md
+++ b/skills/dev-skills/angular-ssr/references/seo-optimization.md
@@ -1,0 +1,145 @@
+# SEO Optimization
+
+## Meta Tags Service
+
+```typescript
+import { Injectable, inject } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({ providedIn: 'root' })
+export class Seo {
+  #meta = inject(Meta);
+  #title = inject(Title);
+  #document = inject(DOCUMENT);
+
+  updateMetaTags(config: {
+    title: string;
+    description: string;
+    image?: string;
+    url?: string;
+    type?: string;
+  }) {
+    // Basic meta
+    this.#title.setTitle(config.title);
+    this.#meta.updateTag({ name: 'description', content: config.description });
+
+    // Open Graph
+    this.#meta.updateTag({ property: 'og:title', content: config.title });
+    this.#meta.updateTag({ property: 'og:description', content: config.description });
+    this.#meta.updateTag({ property: 'og:type', content: config.type || 'website' });
+
+    if (config.image) {
+      this.#meta.updateTag({ property: 'og:image', content: config.image });
+    }
+
+    if (config.url) {
+      this.#meta.updateTag({ property: 'og:url', content: config.url });
+      this.#updateCanonicalUrl(config.url);
+    }
+
+    // Twitter Card
+    this.#meta.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
+    this.#meta.updateTag({ name: 'twitter:title', content: config.title });
+    this.#meta.updateTag({ name: 'twitter:description', content: config.description });
+
+    if (config.image) {
+      this.#meta.updateTag({ name: 'twitter:image', content: config.image });
+    }
+  }
+
+  #updateCanonicalUrl(url: string) {
+    let link: HTMLLinkElement | null = this.#document.querySelector('link[rel="canonical"]');
+
+    if (!link) {
+      link = this.#document.createElement('link');
+      link.setAttribute('rel', 'canonical');
+      this.#document.head.appendChild(link);
+    }
+
+    link.setAttribute('href', url);
+  }
+
+  setJsonLd(data: object) {
+    let script: HTMLScriptElement | null = this.#document.querySelector('script[type="application/ld+json"]');
+
+    if (!script) {
+      script = this.#document.createElement('script');
+      script.type = 'application/ld+json';
+      this.#document.head.appendChild(script);
+    }
+
+    script.textContent = JSON.stringify(data);
+  }
+}
+
+// Usage in component
+@Component({...})
+export class Product {
+  #seo = inject(Seo);
+  product = input.required<Product>();
+
+  constructor() {
+    effect(() => {
+      const product = this.product();
+      this.#seo.updateMetaTags({
+        title: `${product.name} | My Store`,
+        description: product.description,
+        image: product.imageUrl,
+        url: `https://mystore.com/products/${product.id}`,
+        type: 'product',
+      });
+
+      this.#seo.setJsonLd({
+        '@context': 'https://schema.org',
+        '@type': 'Product',
+        name: product.name,
+        description: product.description,
+        image: product.imageUrl,
+        offers: {
+          '@type': 'Offer',
+          price: product.price,
+          priceCurrency: 'USD',
+        },
+      });
+    });
+  }
+}
+```
+
+## Route-Based SEO with Resolvers
+
+```typescript
+// seo.resolver.ts
+export const seoResolver: ResolveFn<SeoData> = async (route) => {
+  const productId = route.paramMap.get('id')!;
+  const productService = inject(Product);
+  const product = await productService.getById(productId);
+
+  return {
+    title: `${product.name} | My Store`,
+    description: product.description,
+    image: product.imageUrl,
+  };
+};
+
+// Routes
+{
+  path: 'products/:id',
+  component: Product,
+  resolve: { seo: seoResolver },
+}
+
+// Component
+@Component({...})
+export class Product {
+  #seo = inject(Seo);
+  seoData = input.required<SeoData>(); // From resolver
+
+  constructor() {
+    effect(() => {
+      this.#seo.updateMetaTags(this.seoData());
+    });
+  }
+}
+```

--- a/skills/dev-skills/angular-ssr/references/server-routing.md
+++ b/skills/dev-skills/angular-ssr/references/server-routing.md
@@ -1,0 +1,169 @@
+# SSR Server Routing
+
+Server routing controls how each route is rendered. Configure in `app.routes.server.ts`.
+
+## Choosing the Right Render Mode
+
+| Mode | When to use | Example routes |
+|------|-------------|----------------|
+| `RenderMode.Server` | Dynamic, user/request-specific data | `product/:id`, `profile`, `search` |
+| `RenderMode.Prerender` | Content known at build time | `about`, `blog/:slug` (with `getPrerenderParams`) |
+| `RenderMode.Client` | Fully client-side, no SEO needed | `dashboard`, `settings` |
+
+## Parameterized Routes with SSR
+
+Use `RenderMode.Server` for routes with dynamic parameters that depend on request-time data:
+
+```typescript
+// app.routes.server.ts
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'product/:id',        // Each product rendered on the server per request
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'category/:slug',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'user/:userId/orders',
+    renderMode: RenderMode.Server,
+  },
+];
+```
+
+## Parameterized Routes with Pre-rendering
+
+Use `RenderMode.Prerender` with `getPrerenderParams` when all parameter values are known at build time:
+
+```typescript
+// app.routes.server.ts
+import { RenderMode, ServerRoute, PrerenderFallback } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'product/:id',
+    renderMode: RenderMode.Prerender,
+    async getPrerenderParams() {
+      const productService = inject(ProductService);
+      const ids = await productService.getAllIds(); // e.g. ['1', '2', '3']
+      return ids.map((id) => ({ id }));
+      // Generates: /product/1, /product/2, /product/3
+    },
+    fallback: PrerenderFallback.Server, // SSR fallback for unknown IDs
+  },
+];
+```
+
+> **IMPORTANT:** `inject()` inside `getPrerenderParams` must be called synchronously — it cannot be used after any `await` statement.
+
+## Catch-All Routes with Parameters
+
+Use `**` for catch-all segments. The parameter name is `'**'` and the value is the full remaining path:
+
+```typescript
+{
+  path: 'docs/:version/**',
+  renderMode: RenderMode.Prerender,
+  async getPrerenderParams() {
+    return [
+      { version: 'v20', '**': 'getting-started/setup' },
+      { version: 'v20', '**': 'api/core' },
+      { version: 'v19', '**': 'migration-guide' },
+    ];
+    // Generates: /docs/v20/getting-started/setup, /docs/v20/api/core, /docs/v19/migration-guide
+  },
+},
+```
+
+## Setting Headers and Status Codes
+
+Set custom HTTP headers and status codes per route:
+
+```typescript
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'product/:id',
+    renderMode: RenderMode.Server,
+    headers: {
+      'Cache-Control': 'public, max-age=3600',
+      'X-Robots-Tag': 'index, follow',
+    },
+    status: 200,
+  },
+  {
+    path: 'legacy-page',
+    renderMode: RenderMode.Server,
+    status: 301,
+    headers: {
+      'Location': '/new-page',
+    },
+  },
+];
+```
+
+## Redirect Behavior
+
+Angular handles `redirectTo` differently depending on render mode:
+
+- **SSR (`RenderMode.Server`)** — redirects use standard HTTP redirects (301/302)
+- **Prerender (`RenderMode.Prerender`)** — redirects use `<meta http-equiv="refresh">` tags in prerendered HTML
+
+## Accessing Request and Response in SSR Routes
+
+Use DI tokens from `@angular/core` to access the incoming request during server rendering:
+
+```typescript
+import { inject, REQUEST, RESPONSE_INIT } from '@angular/core';
+
+@Component({...})
+export class ProductDetail {
+  #request = inject(REQUEST, { optional: true });
+
+  constructor() {
+    // Access request URL, headers, cookies during SSR
+    if (this.#request) {
+      const userAgent = this.#request.headers.get('user-agent');
+      console.log('Request URL:', this.#request.url);
+    }
+  }
+}
+```
+
+> **Note:** `REQUEST`, `RESPONSE_INIT`, and `REQUEST_CONTEXT` are `null` during CSR, SSG, and build processes.
+
+## Route Order
+
+Routes are matched top-to-bottom. Always place specific routes before the catch-all `**`:
+
+```typescript
+export const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Prerender },           // Homepage
+  { path: 'about', renderMode: RenderMode.Prerender },      // Static pages
+  { path: 'product/:id', renderMode: RenderMode.Server },   // Dynamic SSR
+  { path: 'dashboard', renderMode: RenderMode.Client },     // Client-only
+  { path: '**', renderMode: RenderMode.Server },            // Catch-all (last)
+];
+```
+
+## Wiring Up in app.config.server.ts
+
+Register server routes using `provideServerRendering` with `withRoutes`:
+
+```typescript
+// app.config.server.ts
+import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
+import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerRendering(withRoutes(serverRoutes)),
+  ],
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);
+```

--- a/skills/dev-skills/angular-ssr/references/testing-ssr.md
+++ b/skills/dev-skills/angular-ssr/references/testing-ssr.md
@@ -1,0 +1,56 @@
+# Testing SSR
+
+## Test Server Rendering
+
+```typescript
+import { renderApplication } from '@angular/platform-server';
+import { App } from './app.component';
+import { config } from './app.config.server';
+
+describe('SSR', () => {
+  it('should render home page', async () => {
+    const html = await renderApplication(App, {
+      appId: 'my-app',
+      providers: config.providers,
+      url: '/',
+    });
+
+    expect(html).toContain('<h1>Welcome</h1>');
+    expect(html).toContain('</app-root>');
+  });
+
+  it('should render product page with data', async () => {
+    const html = await renderApplication(App, {
+      appId: 'my-app',
+      providers: config.providers,
+      url: '/products/123',
+    });
+
+    expect(html).toContain('Product Name');
+    expect(html).not.toContain('Loading...');
+  });
+});
+```
+
+## Test Hydration
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { provideClientHydration } from '@angular/platform-browser';
+
+describe('Hydration', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideClientHydration()],
+    });
+  });
+
+  it('should hydrate without errors', () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    // No hydration mismatch errors should be thrown
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
+```

--- a/skills/dev-skills/angular-testing/SKILL.md
+++ b/skills/dev-skills/angular-testing/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: angular-testing
+description: Write unit and integration tests for Angular v21+ applications using Vitest or Jasmine with TestBed, component harnesses, and modern testing patterns. Use for testing components with signals, OnPush change detection, services with inject(), and HTTP interactions. Triggers on test creation, testing signal-based components, mocking dependencies, or setting up test infrastructure. Do not use for E2E testing with Playwright or Cypress; use a dedicated QA skill.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Testing
+
+
+Test Angular v21+ applications with Vitest (recommended) or Jasmine, focusing on signal-based components and modern patterns.
+
+## Vitest Setup (Angular v20+)
+
+Angular v20+ has native Vitest support via `@angular/build`. First, install `vitest jsdom`. Then configure `angular.json` with builder `@angular/build:unit-test`. Finally, add `"types": ["vitest/globals"]` to `tsconfig.spec.json`. Run tests with `ng test`.
+
+See `references/vitest-setup.md` for full configuration, test examples, mocking with `vi.fn()`, HTTP testing, and Jasmine-to-Vitest migration guide.
+
+---
+
+## Basic Component Test
+
+```typescript
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Counter } from './counter.component';
+
+describe('Counter', () => {
+  let component: Counter;
+  let fixture: ComponentFixture<Counter>;
+  
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Counter], // Standalone component
+    }).compileComponents();
+    
+    fixture = TestBed.createComponent(Counter);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+  
+  it('should increment count', () => {
+    expect(component.count()).toBe(0);
+    
+    component.increment();
+    
+    expect(component.count()).toBe(1);
+  });
+  
+  it('should display count in template', () => {
+    component.count.set(5);
+    fixture.detectChanges();
+    
+    const element = fixture.nativeElement.querySelector('.count');
+    expect(element.textContent).toContain('5');
+  });
+});
+```
+
+## Testing Signals
+
+### Direct Signal Testing
+
+```typescript
+import { signal, computed } from '@angular/core';
+
+describe('Signal logic', () => {
+  it('should update computed when signal changes', () => {
+    const count = signal(0);
+    const doubled = computed(() => count() * 2);
+    
+    expect(doubled()).toBe(0);
+    
+    count.set(5);
+    expect(doubled()).toBe(10);
+    
+    count.update(c => c + 1);
+    expect(doubled()).toBe(12);
+  });
+});
+```
+
+### Testing Component Signals
+
+```typescript
+@Component({
+  selector: 'app-todo-list',
+  template: `
+    <ul>
+      @for (todo of filteredTodos(); track todo.id) {
+        <li>{{ todo.text }}</li>
+      }
+    </ul>
+    <p>{{ remaining() }} remaining</p>
+  `,
+})
+export class TodoList {
+  todos = signal<Todo[]>([]);
+  filter = signal<'all' | 'active' | 'done'>('all');
+  
+  filteredTodos = computed(() => {
+    const todos = this.todos();
+    switch (this.filter()) {
+      case 'active': return todos.filter(t => !t.done);
+      case 'done': return todos.filter(t => t.done);
+      default: return todos;
+    }
+  });
+  
+  remaining = computed(() => this.todos().filter(t => !t.done).length);
+}
+
+describe('TodoList', () => {
+  let component: TodoList;
+  let fixture: ComponentFixture<TodoList>;
+  
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TodoList],
+    }).compileComponents();
+    
+    fixture = TestBed.createComponent(TodoList);
+    component = fixture.componentInstance;
+  });
+  
+  it('should filter active todos', () => {
+    component.todos.set([
+      { id: '1', text: 'Task 1', done: false },
+      { id: '2', text: 'Task 2', done: true },
+      { id: '3', text: 'Task 3', done: false },
+    ]);
+    
+    component.filter.set('active');
+    
+    expect(component.filteredTodos().length).toBe(2);
+    expect(component.remaining()).toBe(2);
+  });
+  
+  it('should render filtered todos', () => {
+    component.todos.set([
+      { id: '1', text: 'Active Task', done: false },
+      { id: '2', text: 'Done Task', done: true },
+    ]);
+    component.filter.set('active');
+    fixture.detectChanges();
+    
+    const items = fixture.nativeElement.querySelectorAll('li');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('Active Task');
+  });
+});
+```
+
+## Testing OnPush Components
+
+OnPush components require explicit change detection:
+
+```typescript
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<span>{{ data().name }}</span>`,
+})
+export class OnPush {
+  data = input.required<{ name: string }>();
+}
+
+describe('OnPush', () => {
+  it('should update when input signal changes', () => {
+    const fixture = TestBed.createComponent(OnPush);
+    
+    // Set input using setInput (for signal inputs)
+    fixture.componentRef.setInput('data', { name: 'Initial' });
+    fixture.detectChanges();
+    
+    expect(fixture.nativeElement.textContent).toContain('Initial');
+    
+    // Update input
+    fixture.componentRef.setInput('data', { name: 'Updated' });
+    fixture.detectChanges();
+    
+    expect(fixture.nativeElement.textContent).toContain('Updated');
+  });
+});
+```
+
+## Testing Services
+
+### Basic Service Test
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+
+@Injectable({ providedIn: 'root' })
+export class CounterSvc {
+  #count = signal(0);
+  readonly count = this.#count.asReadonly();
+
+  increment() {
+    this.#count.update(c => c + 1);
+  }
+
+  reset() {
+    this.#count.set(0);
+  }
+}
+
+describe('CounterSvc', () => {
+  let service: CounterSvc;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CounterSvc);
+  });
+  
+  it('should increment count', () => {
+    expect(service.count()).toBe(0);
+    
+    service.increment();
+    expect(service.count()).toBe(1);
+    
+    service.increment();
+    expect(service.count()).toBe(2);
+  });
+  
+  it('should reset count', () => {
+    service.increment();
+    service.increment();
+    
+    service.reset();
+    
+    expect(service.count()).toBe(0);
+  });
+});
+```
+
+### Service with Dependencies
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class User {
+  #http = inject(HttpClient);
+
+  getUser(id: string) {
+    return this.#http.get<User>(`/api/users/${id}`);
+  }
+}
+
+describe('User', () => {
+  let service: User;
+  let httpMock: HttpTestingController;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    
+    service = TestBed.inject(User);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+  
+  afterEach(() => {
+    httpMock.verify(); // Verify no outstanding requests
+  });
+  
+  it('should fetch user by id', () => {
+    const mockUser: User = { id: '1', name: 'Test User' };
+    
+    service.getUser('1').subscribe(user => {
+      expect(user).toEqual(mockUser);
+    });
+    
+    const req = httpMock.expectOne('/api/users/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockUser);
+  });
+});
+```
+
+## Mocking Dependencies
+
+### Using Jasmine Spies
+
+```typescript
+describe('ComponentWithDependency', () => {
+  let userServiceSpy: jasmine.SpyObj<User>;
+  
+  beforeEach(async () => {
+    userServiceSpy = jasmine.createSpyObj('User', ['getUser', 'updateUser']);
+    userServiceSpy.getUser.and.returnValue(of({ id: '1', name: 'Test' }));
+    
+    await TestBed.configureTestingModule({
+      imports: [UserProfile],
+      providers: [
+        { provide: User, useValue: userServiceSpy },
+      ],
+    }).compileComponents();
+  });
+  
+  it('should call getUser on init', () => {
+    const fixture = TestBed.createComponent(UserProfile);
+    fixture.detectChanges();
+    
+    expect(userServiceSpy.getUser).toHaveBeenCalledWith('1');
+  });
+});
+```
+
+### Mock Signal-Based Service
+
+```typescript
+// Create mock with signal
+const mockAuth = {
+  user: signal<User | null>(null),
+  isAuthenticated: computed(() => mockAuth.user() !== null),
+  login: jasmine.createSpy('login'),
+  logout: jasmine.createSpy('logout'),
+};
+
+beforeEach(async () => {
+  await TestBed.configureTestingModule({
+    imports: [Protected],
+    providers: [
+      { provide: Auth, useValue: mockAuth },
+    ],
+  }).compileComponents();
+});
+
+it('should show content when authenticated', () => {
+  mockAuth.user.set({ id: '1', name: 'Test User' });
+  
+  const fixture = TestBed.createComponent(Protected);
+  fixture.detectChanges();
+  
+  expect(fixture.nativeElement.querySelector('.protected-content')).toBeTruthy();
+});
+```
+
+## Testing Inputs and Outputs
+
+```typescript
+@Component({
+  selector: 'app-item',
+  template: `
+    <div (click)="select()">{{ item().name }}</div>
+  `,
+})
+export class Item {
+  item = input.required<Item>();
+  selected = output<Item>();
+  
+  select() {
+    this.selected.emit(this.item());
+  }
+}
+
+describe('Item', () => {
+  it('should emit selected event on click', () => {
+    const fixture = TestBed.createComponent(Item);
+    const item: Item = { id: '1', name: 'Test Item' };
+    
+    fixture.componentRef.setInput('item', item);
+    fixture.detectChanges();
+    
+    // Subscribe to output
+    let emittedItem: Item | undefined;
+    fixture.componentInstance.selected.subscribe(i => emittedItem = i);
+    
+    // Trigger click
+    fixture.nativeElement.querySelector('div').click();
+    
+    expect(emittedItem).toEqual(item);
+  });
+});
+```
+
+## Testing Async Operations
+
+Use `fakeAsync`/`tick(ms)`/`flush()` for timer-based async. Use `waitForAsync`/`fixture.whenStable()` for promise-based async. For `httpResource`, use `provideHttpClientTesting()` and `HttpTestingController` to flush responses.
+
+See `references/async-testing.md` for fakeAsync, waitForAsync, and httpResource testing examples.
+
+## Accessibility Testing
+
+Install `axe-core` and call `axe.run(fixture.nativeElement)`. All components MUST pass AXE checks and meet WCAG AA standards.
+
+See `references/a11y-testing.md` for Vitest and Jasmine accessibility testing examples.
+
+See `references/testing-patterns.md` for advanced testing patterns, harnesses, and component interaction tests.

--- a/skills/dev-skills/angular-testing/references/a11y-testing.md
+++ b/skills/dev-skills/angular-testing/references/a11y-testing.md
@@ -1,0 +1,47 @@
+# Accessibility Testing in Angular
+
+Test accessibility compliance with AXE.
+
+## Install axe-core
+
+```bash
+npm install -D axe-core
+```
+
+## Vitest Example
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import axe from 'axe-core';
+
+describe('Button accessibility', () => {
+  it('should pass axe accessibility checks', async () => {
+    const fixture = TestBed.createComponent(Button);
+    fixture.componentRef.setInput('label', 'Submit');
+    fixture.detectChanges();
+
+    const results = await axe.run(fixture.nativeElement);
+
+    expect(results.violations).toEqual([]);
+  });
+});
+```
+
+## Jasmine Example
+
+```typescript
+import axe from 'axe-core';
+
+describe('Form accessibility', () => {
+  it('should have no accessibility violations', async () => {
+    const fixture = TestBed.createComponent(LoginForm);
+    fixture.detectChanges();
+
+    const results = await axe.run(fixture.nativeElement);
+
+    expect(results.violations.length).toBe(0);
+  });
+});
+```
+
+**Requirements**: All components MUST pass AXE checks and meet WCAG AA standards.

--- a/skills/dev-skills/angular-testing/references/async-testing.md
+++ b/skills/dev-skills/angular-testing/references/async-testing.md
@@ -1,0 +1,89 @@
+# Async Testing in Angular
+
+## Testing Async Operations with fakeAsync
+
+```typescript
+import { fakeAsync, tick, flush } from '@angular/core/testing';
+
+it('should debounce search', fakeAsync(() => {
+  const fixture = TestBed.createComponent(Search);
+  fixture.detectChanges();
+
+  // Type in search
+  fixture.componentInstance.query.set('test');
+
+  // Advance time for debounce
+  tick(300);
+  fixture.detectChanges();
+
+  expect(fixture.componentInstance.results().length).toBeGreaterThan(0);
+
+  // Flush any remaining timers
+  flush();
+}));
+```
+
+## Testing with waitForAsync
+
+```typescript
+import { waitForAsync } from '@angular/core/testing';
+
+it('should load data', waitForAsync(() => {
+  const fixture = TestBed.createComponent(Data);
+  fixture.detectChanges();
+
+  fixture.whenStable().then(() => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance.data()).toBeDefined();
+  });
+}));
+```
+
+## Testing HTTP Resources
+
+```typescript
+@Component({
+  template: `
+    @if (userResource.isLoading()) {
+      <p>Loading...</p>
+    } @else if (userResource.hasValue()) {
+      <p>{{ userResource.value().name }}</p>
+    }
+  `,
+})
+export class UserCmpt {
+  userId = signal('1');
+  userResource = httpResource<UserData>(() => `/api/users/${this.userId()}`);
+}
+
+describe('UserCmpt', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserCmpt],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  it('should display user name after loading', () => {
+    const fixture = TestBed.createComponent(UserCmpt);
+    fixture.detectChanges();
+
+    // Initially loading
+    expect(fixture.nativeElement.textContent).toContain('Loading');
+
+    // Respond to request
+    const req = httpMock.expectOne('/api/users/1');
+    req.flush({ id: '1', name: 'John Doe' });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('John Doe');
+  });
+});
+```

--- a/skills/dev-skills/angular-testing/references/testing-patterns.md
+++ b/skills/dev-skills/angular-testing/references/testing-patterns.md
@@ -1,0 +1,707 @@
+# Angular Testing Patterns
+
+## Table of Contents
+- [Vitest Advanced Patterns](#vitest-advanced-patterns)
+- [Component Harnesses](#component-harnesses)
+- [Testing Router](#testing-router)
+- [Testing Forms](#testing-forms)
+- [Testing Directives](#testing-directives)
+- [Testing Pipes](#testing-pipes)
+- [E2E Testing Setup](#e2e-testing-setup)
+
+## Vitest Advanced Patterns
+
+### Snapshot Testing
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('UserCard', () => {
+  it('should match snapshot', () => {
+    const fixture = TestBed.createComponent(UserCard);
+    fixture.componentRef.setInput('user', { id: '1', name: 'John', email: 'john@example.com' });
+    fixture.detectChanges();
+    
+    expect(fixture.nativeElement.innerHTML).toMatchSnapshot();
+  });
+});
+```
+
+### Parameterized Tests
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+describe('Validator', () => {
+  it.each([
+    { input: '', expected: false },
+    { input: 'test', expected: false },
+    { input: 'test@example.com', expected: true },
+    { input: 'invalid@', expected: false },
+  ])('should validate email "$input" as $expected', ({ input, expected }) => {
+    expect(isValidEmail(input)).toBe(expected);
+  });
+});
+```
+
+### Testing with Fake Timers
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('Debounced Search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+  
+  it('should debounce search input', async () => {
+    const fixture = TestBed.createComponent(Search);
+    fixture.detectChanges();
+    
+    fixture.componentInstance.query.set('test');
+    
+    // Search not called yet
+    expect(fixture.componentInstance.results()).toEqual([]);
+    
+    // Advance timers
+    vi.advanceTimersByTime(300);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    
+    expect(fixture.componentInstance.results().length).toBeGreaterThan(0);
+  });
+});
+```
+
+### Module Mocking
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock entire module
+vi.mock('./analytics.service', () => ({
+  Analytics: class {
+    track = vi.fn();
+    identify = vi.fn();
+  },
+}));
+
+describe('with mocked analytics', () => {
+  it('should track events', () => {
+    const fixture = TestBed.createComponent(Dashboard);
+    const analytics = TestBed.inject(Analytics);
+    
+    fixture.detectChanges();
+    
+    expect(analytics.track).toHaveBeenCalledWith('dashboard_viewed');
+  });
+});
+```
+
+### Testing Async/Await
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+
+describe('User', () => {
+  it('should load user data', async () => {
+    const mockUser = { id: '1', name: 'Test' };
+    const httpMock = TestBed.inject(HttpTestingController);
+    const service = TestBed.inject(User);
+    
+    const userPromise = service.loadUser('1');
+    
+    httpMock.expectOne('/api/users/1').flush(mockUser);
+    
+    const user = await userPromise;
+    expect(user).toEqual(mockUser);
+  });
+});
+```
+
+### Coverage Configuration
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      exclude: [
+        'node_modules/',
+        'src/test-setup.ts',
+        '**/*.spec.ts',
+        '**/*.d.ts',
+      ],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+});
+```
+
+### Vitest UI Mode
+
+```bash
+# Run with UI
+npx vitest --ui
+
+# Open UI at specific port
+npx vitest --ui --port 51204
+```
+
+### Concurrent Tests
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// Run tests in this describe block concurrently
+describe.concurrent('API calls', () => {
+  it('should fetch users', async () => {
+    // ...
+  });
+  
+  it('should fetch products', async () => {
+    // ...
+  });
+  
+  it('should fetch orders', async () => {
+    // ...
+  });
+});
+```
+
+### Test Fixtures
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Shared test fixtures
+const createTestUser = (overrides = {}) => ({
+  id: '1',
+  name: 'Test User',
+  email: 'test@example.com',
+  ...overrides,
+});
+
+const createTestProduct = (overrides = {}) => ({
+  id: '1',
+  name: 'Test Product',
+  price: 99.99,
+  ...overrides,
+});
+
+describe('Order', () => {
+  it('should calculate total', () => {
+    const fixture = TestBed.createComponent(Order);
+    fixture.componentRef.setInput('user', createTestUser());
+    fixture.componentRef.setInput('products', [
+      createTestProduct({ price: 10 }),
+      createTestProduct({ id: '2', price: 20 }),
+    ]);
+    fixture.detectChanges();
+    
+    expect(fixture.componentInstance.total()).toBe(30);
+  });
+});
+```
+
+## Component Harnesses
+
+Use Angular CDK component harnesses for more maintainable tests:
+
+### Creating a Harness
+
+```typescript
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+export class CounterHarn extends ComponentHarness {
+  static hostSelector = 'app-counter';
+  
+  // Locators
+  private getIncrementButton = this.locatorFor('button.increment');
+  private getDecrementButton = this.locatorFor('button.decrement');
+  private getCountDisplay = this.locatorFor('.count');
+  
+  // Actions
+  async increment(): Promise<void> {
+    const button = await this.getIncrementButton();
+    await button.click();
+  }
+  
+  async decrement(): Promise<void> {
+    const button = await this.getDecrementButton();
+    await button.click();
+  }
+  
+  // Queries
+  async getCount(): Promise<number> {
+    const display = await this.getCountDisplay();
+    const text = await display.text();
+    return parseInt(text, 10);
+  }
+  
+  // Filter factory
+  static with(options: { count?: number } = {}): HarnessPredicate<CounterHarn> {
+    return new HarnessPredicate(CounterHarn, options)
+      .addOption('count', options.count, async (harness, count) => {
+        return (await harness.getCount()) === count;
+      });
+  }
+}
+```
+
+### Using Harnesses in Tests
+
+```typescript
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+describe('Counter with Harness', () => {
+  let loader: HarnessLoader;
+  
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Counter],
+    }).compileComponents();
+    
+    const fixture = TestBed.createComponent(Counter);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+  
+  it('should increment count', async () => {
+    const counter = await loader.getHarness(CounterHarn);
+    
+    expect(await counter.getCount()).toBe(0);
+    
+    await counter.increment();
+    expect(await counter.getCount()).toBe(1);
+    
+    await counter.increment();
+    expect(await counter.getCount()).toBe(2);
+  });
+  
+  it('should find counter with specific count', async () => {
+    const counter = await loader.getHarness(CounterHarn);
+    await counter.increment();
+    await counter.increment();
+    
+    // Find counter with count of 2
+    const counterWith2 = await loader.getHarness(CounterHarn.with({ count: 2 }));
+    expect(counterWith2).toBeTruthy();
+  });
+});
+```
+
+## Testing Router
+
+### RouterTestingHarness
+
+```typescript
+import { RouterTestingHarness } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
+
+describe('Router Navigation', () => {
+  let harness: RouterTestingHarness;
+  
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: '', component: Home },
+          { path: 'users/:id', component: UserCmpt },
+        ]),
+      ],
+    }).compileComponents();
+    
+    harness = await RouterTestingHarness.create();
+  });
+  
+  it('should navigate to user page', async () => {
+    const component = await harness.navigateByUrl('/users/123', UserCmpt);
+    
+    expect(component.id()).toBe('123');
+  });
+  
+  it('should display user name', async () => {
+    await harness.navigateByUrl('/users/123');
+    
+    expect(harness.routeNativeElement?.textContent).toContain('User 123');
+  });
+});
+```
+
+### Testing Guards
+
+```typescript
+describe('AuthGuard', () => {
+  let authService: jasmine.SpyObj<Auth>;
+  
+  beforeEach(() => {
+    authService = jasmine.createSpyObj('Auth', ['isAuthenticated']);
+    
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Auth, useValue: authService },
+        provideRouter([
+          { path: 'login', component: Login },
+          { 
+            path: 'dashboard', 
+            component: Dashboard,
+            canActivate: [authGuard],
+          },
+        ]),
+      ],
+    });
+  });
+  
+  it('should allow access when authenticated', async () => {
+    authService.isAuthenticated.and.returnValue(true);
+    
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/dashboard');
+    
+    expect(harness.routeNativeElement?.textContent).toContain('Dashboard');
+  });
+  
+  it('should redirect to login when not authenticated', async () => {
+    authService.isAuthenticated.and.returnValue(false);
+    
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/dashboard');
+    
+    expect(TestBed.inject(Router).url).toBe('/login');
+  });
+});
+```
+
+## Testing Forms
+
+### Testing Signal Forms
+
+```typescript
+import { form, FormField, required, email } from '@angular/forms/signals';
+
+@Component({
+  imports: [FormField],
+  template: `
+    <form (submit)="onSubmit($event)">
+      <input [formField]="loginForm.email" />
+      <input [formField]="loginForm.password" type="password" />
+      <button type="submit" [disabled]="loginForm().invalid()">Submit</button>
+    </form>
+  `,
+})
+export class Login {
+  model = signal({ email: '', password: '' });
+  loginForm = form(this.model, (schemaPath) => {
+    required(schemaPath.email);
+    email(schemaPath.email);
+    required(schemaPath.password);
+  });
+  
+  submitted = signal(false);
+  
+  onSubmit(event: Event) {
+    event.preventDefault();
+    if (this.loginForm().valid()) {
+      this.submitted.set(true);
+    }
+  }
+}
+
+describe('Login', () => {
+  let fixture: ComponentFixture<Login>;
+  let component: Login;
+  
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Login],
+    }).compileComponents();
+    
+    fixture = TestBed.createComponent(Login);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+  
+  it('should be invalid when empty', () => {
+    expect(component.loginForm().invalid()).toBeTrue();
+  });
+  
+  it('should be valid with correct data', () => {
+    component.model.set({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    
+    expect(component.loginForm().valid()).toBeTrue();
+  });
+  
+  it('should show email error for invalid email', () => {
+    component.loginForm.email().value.set('invalid');
+    fixture.detectChanges();
+    
+    expect(component.loginForm.email().invalid()).toBeTrue();
+    expect(component.loginForm.email().errors().some(e => e.kind === 'email')).toBeTrue();
+  });
+  
+  it('should disable submit button when invalid', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.disabled).toBeTrue();
+  });
+});
+```
+
+### Testing Reactive Forms
+
+```typescript
+describe('ReactiveForm', () => {
+  it('should validate form', () => {
+    const fixture = TestBed.createComponent(ProfileForm);
+    const component = fixture.componentInstance;
+    
+    expect(component.form.valid).toBeFalse();
+    
+    component.form.patchValue({
+      name: 'John',
+      email: 'john@example.com',
+    });
+    
+    expect(component.form.valid).toBeTrue();
+  });
+  
+  it('should show validation errors', () => {
+    const fixture = TestBed.createComponent(ProfileForm);
+    fixture.detectChanges();
+    
+    const emailControl = fixture.componentInstance.form.controls.email;
+    emailControl.setValue('invalid');
+    emailControl.markAsTouched();
+    fixture.detectChanges();
+    
+    const errorElement = fixture.nativeElement.querySelector('.error');
+    expect(errorElement.textContent).toContain('Invalid email');
+  });
+});
+```
+
+## Testing Directives
+
+### Attribute Directive
+
+```typescript
+@Directive({
+  selector: '[appHighlight]',
+  host: {
+    '[style.backgroundColor]': 'color()',
+  },
+})
+export class Highlight {
+  color = input('yellow', { alias: 'appHighlight' });
+}
+
+describe('Highlight', () => {
+  @Component({
+    imports: [Highlight],
+    template: `<p appHighlight="lightblue">Test</p>`,
+  })
+  class Test {}
+  
+  it('should apply background color', () => {
+    const fixture = TestBed.createComponent(Test);
+    fixture.detectChanges();
+    
+    const p = fixture.nativeElement.querySelector('p');
+    expect(p.style.backgroundColor).toBe('lightblue');
+  });
+});
+```
+
+### Structural Directive
+
+```typescript
+@Directive({
+  selector: '[appIf]',
+})
+export class If {
+  #templateRef = inject(TemplateRef);
+  #viewContainer = inject(ViewContainerRef);
+
+  condition = input.required<boolean>({ alias: 'appIf' });
+
+  constructor() {
+    effect(() => {
+      if (this.condition()) {
+        this.#viewContainer.createEmbeddedView(this.#templateRef);
+      } else {
+        this.#viewContainer.clear();
+      }
+    });
+  }
+}
+
+describe('If', () => {
+  @Component({
+    imports: [If],
+    template: `<p *appIf="show()">Visible</p>`,
+  })
+  class TestCmpt {
+    show = signal(false);
+  }
+  
+  it('should show content when condition is true', () => {
+    const fixture = TestBed.createComponent(Test);
+    fixture.detectChanges();
+    
+    expect(fixture.nativeElement.querySelector('p')).toBeNull();
+    
+    fixture.componentInstance.show.set(true);
+    fixture.detectChanges();
+    
+    expect(fixture.nativeElement.querySelector('p')).toBeTruthy();
+  });
+});
+```
+
+## Testing Pipes
+
+```typescript
+@Pipe({ name: 'truncate' })
+export class Truncate implements PipeTransform {
+  transform(value: string, length: number = 50): string {
+    if (value.length <= length) return value;
+    return value.substring(0, length) + '...';
+  }
+}
+
+describe('Truncate', () => {
+  let pipe: Truncate;
+  
+  beforeEach(() => {
+    pipe = new Truncate();
+  });
+  
+  it('should not truncate short strings', () => {
+    expect(pipe.transform('Hello', 10)).toBe('Hello');
+  });
+  
+  it('should truncate long strings', () => {
+    expect(pipe.transform('Hello World', 5)).toBe('Hello...');
+  });
+  
+  it('should use default length', () => {
+    const longString = 'a'.repeat(60);
+    const result = pipe.transform(longString);
+    expect(result.length).toBe(53); // 50 + '...'
+  });
+});
+```
+
+## E2E Testing Setup
+
+### Playwright Configuration
+
+```typescript
+// playwright.config.ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:4200',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:4200',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+### E2E Test Example
+
+```typescript
+// e2e/login.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Login', () => {
+  test('should login successfully', async ({ page }) => {
+    await page.goto('/login');
+    
+    await page.fill('input[name="email"]', 'test@example.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('button[type="submit"]');
+    
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.locator('h1')).toContainText('Welcome');
+  });
+  
+  test('should show error for invalid credentials', async ({ page }) => {
+    await page.goto('/login');
+    
+    await page.fill('input[name="email"]', 'wrong@example.com');
+    await page.fill('input[name="password"]', 'wrongpassword');
+    await page.click('button[type="submit"]');
+    
+    await expect(page.locator('.error')).toBeVisible();
+    await expect(page.locator('.error')).toContainText('Invalid credentials');
+  });
+});
+```
+
+## Test Utilities
+
+### Custom Test Helpers
+
+```typescript
+// test-utils.ts
+export function setSignalInput<T>(
+  fixture: ComponentFixture<any>,
+  inputName: string,
+  value: T
+): void {
+  fixture.componentRef.setInput(inputName, value);
+  fixture.detectChanges();
+}
+
+export async function waitForSignal<T>(
+  signal: () => T,
+  predicate: (value: T) => boolean,
+  timeout = 5000
+): Promise<T> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const value = signal();
+    if (predicate(value)) return value;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('Timeout waiting for signal');
+}
+
+// Usage
+it('should load data', async () => {
+  const fixture = TestBed.createComponent(Data);
+  fixture.detectChanges();
+  
+  await waitForSignal(
+    () => fixture.componentInstance.data(),
+    data => data !== undefined
+  );
+  
+  expect(fixture.componentInstance.data()).toBeDefined();
+});
+```

--- a/skills/dev-skills/angular-testing/references/vitest-setup.md
+++ b/skills/dev-skills/angular-testing/references/vitest-setup.md
@@ -1,0 +1,193 @@
+# Vitest Setup for Angular
+
+Angular v20+ has native Vitest support through the `@angular/build` package.
+
+## Installation
+
+```bash
+npm install -D vitest jsdom
+```
+
+## Configuration
+
+```json
+// angular.json - update test architect
+{
+  "projects": {
+    "your-app": {
+      "architect": {
+        "test": {
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "tsConfig": "tsconfig.spec.json",
+            "buildTarget": "your-app:build"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+// tsconfig.spec.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.spec.ts"]
+}
+```
+
+## Running Tests
+
+```bash
+# Run tests
+ng test
+
+# Watch mode
+ng test --watch
+
+# Coverage
+ng test --code-coverage
+```
+
+## Vitest Test Example
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Counter } from './counter.component';
+
+describe('Counter', () => {
+  let component: Counter;
+  let fixture: ComponentFixture<Counter>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Counter],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Counter);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should increment count', () => {
+    expect(component.count()).toBe(0);
+    component.increment();
+    expect(component.count()).toBe(1);
+  });
+});
+```
+
+## Vitest Mocking
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('UserCmpt', () => {
+  const mockUserService = {
+    getUser: vi.fn(),
+    updateUser: vi.fn(),
+    user: signal<User | null>(null),
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockUserService.getUser.mockReturnValue(of({ id: '1', name: 'Test' }));
+
+    await TestBed.configureTestingModule({
+      imports: [UserCmpt],
+      providers: [
+        { provide: User, useValue: mockUserService },
+      ],
+    }).compileComponents();
+  });
+
+  it('should call getUser on init', () => {
+    const fixture = TestBed.createComponent(UserCmpt);
+    fixture.detectChanges();
+    expect(mockUserService.getUser).toHaveBeenCalledWith('1');
+  });
+});
+```
+
+## Vitest with HTTP Testing
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+
+describe('User', () => {
+  let service: User;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(User);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch user', () => {
+    const mockUser = { id: '1', name: 'Test User' };
+
+    service.getUser('1').subscribe(user => {
+      expect(user).toEqual(mockUser);
+    });
+
+    const req = httpMock.expectOne('/api/users/1');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockUser);
+  });
+});
+```
+
+## Vitest vs Jasmine Comparison
+
+| Feature | Vitest | Jasmine/Karma |
+|---------|--------|---------------|
+| Speed | Faster (native ESM) | Slower |
+| Watch mode | Instant feedback | Slower rebuilds |
+| Mocking | `vi.fn()`, `vi.mock()` | `jasmine.createSpy()` |
+| Assertions | `expect()` (Chai-style) | `expect()` (Jasmine) |
+| UI | Built-in UI mode | Karma browser |
+| Config | `angular.json` | `karma.conf.js` |
+
+## Migration from Jasmine to Vitest
+
+```typescript
+// Jasmine
+const spy = jasmine.createSpy('callback');
+spy.and.returnValue('value');
+expect(spy).toHaveBeenCalledWith('arg');
+
+// Vitest
+const spy = vi.fn();
+spy.mockReturnValue('value');
+expect(spy).toHaveBeenCalledWith('arg');
+```
+
+```typescript
+// Jasmine
+spyOn(service, 'method').and.returnValue(of(data));
+
+// Vitest
+vi.spyOn(service, 'method').mockReturnValue(of(data));
+```

--- a/skills/dev-skills/angular-tooling/SKILL.md
+++ b/skills/dev-skills/angular-tooling/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: angular-tooling
+description: Use Angular CLI and development tools effectively in Angular v20+ projects. Use for project setup, code generation, building, testing, and configuration. Triggers on creating new projects, generating components/services/modules, configuring builds, running tests, or optimizing production builds. Do not use for framework-level API guidance; use specific Angular skills instead.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Tooling
+
+
+Use Angular CLI and development tools for efficient Angular v20+ development.
+
+## Project Setup
+
+### Create New Project
+
+First, create the project using the Angular CLI. Then, configure defaults in `angular.json`. Finally, generate features with `ng generate`.
+
+```bash
+# Create new standalone project (default in v20+)
+ng new my-app
+
+# With specific options
+ng new my-app --style=scss --routing --ssr=false
+
+# Skip tests
+ng new my-app --skip-tests
+
+# Minimal setup
+ng new my-app --minimal --inline-style --inline-template
+```
+
+### Project Structure
+
+```
+my-app/
+├── src/
+│   ├── app/
+│   │   ├── app.component.ts
+│   │   ├── app.config.ts
+│   │   └── app.routes.ts
+│   ├── index.html
+│   ├── main.ts
+│   └── styles.scss
+├── public/                  # Static assets
+├── angular.json             # CLI configuration
+├── package.json
+├── tsconfig.json
+└── tsconfig.app.json
+```
+
+## Recommended Defaults
+
+### Strict Mode
+
+Enable strict TypeScript checking (default in new projects):
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  }
+}
+```
+
+### Default Schematics
+
+Configure defaults in `angular.json`:
+
+```json
+{
+  "schematics": {
+    "@schematics/angular:component": {
+      "changeDetection": "OnPush",
+      "style": "scss",
+      "skipTests": false
+    },
+    "@schematics/angular:service": {
+      "skipTests": false
+    }
+  }
+}
+```
+
+## Code Generation
+
+### Components
+
+```bash
+# Generate component
+ng generate component features/user-profile
+ng g c features/user-profile  # Short form
+
+# With options
+ng g c shared/button --inline-template --inline-style
+ng g c features/dashboard --skip-tests
+ng g c features/settings --change-detection=OnPush
+
+# Flat (no folder)
+ng g c shared/icon --flat
+
+# Dry run (preview)
+ng g c features/checkout --dry-run
+```
+
+### Services
+
+```bash
+# Generate service (providedIn: 'root' by default)
+ng g service services/auth
+ng g s services/user
+
+# Skip tests
+ng g s services/api --skip-tests
+```
+
+### Other Schematics
+
+```bash
+# Directive
+ng g directive directives/highlight
+ng g d directives/tooltip
+
+# Pipe
+ng g pipe pipes/truncate
+ng g p pipes/date-format
+
+# Guard (functional by default)
+ng g guard guards/auth
+
+# Interceptor (functional by default)
+ng g interceptor interceptors/auth
+
+# Interface
+ng g interface models/user
+
+# Enum
+ng g enum models/status
+
+# Class
+ng g class models/product
+```
+
+### Generate with Path Alias
+
+```bash
+# Components in feature folders
+ng g c @features/products/product-list
+ng g c @shared/ui/button
+```
+
+## Development Server
+
+```bash
+# Start dev server
+ng serve
+ng s  # Short form
+
+# With options
+ng serve --port 4201
+ng serve --open  # Open browser
+ng serve --host 0.0.0.0  # Expose to network
+
+# Production mode locally
+ng serve --configuration=production
+
+# With SSL
+ng serve --ssl --ssl-key ./ssl/key.pem --ssl-cert ./ssl/cert.pem
+```
+
+## Building
+
+### Development Build
+
+```bash
+ng build
+```
+
+### Production Build
+
+```bash
+ng build --configuration=production
+ng build -c production  # Short form
+
+# With specific options
+ng build -c production --source-map=false
+ng build -c production --named-chunks
+```
+
+### Build Output
+
+```
+dist/my-app/
+├── browser/
+│   ├── index.html
+│   ├── main-[hash].js
+│   ├── polyfills-[hash].js
+│   └── styles-[hash].css
+└── server/              # If SSR enabled
+    └── main.js
+```
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Run tests
+ng test
+ng t  # Short form
+
+# Single run (CI)
+ng test --watch=false --browsers=ChromeHeadless
+
+# With coverage
+ng test --code-coverage
+
+# Specific file
+ng test --include=**/user.service.spec.ts
+```
+
+### E2E Tests
+
+```bash
+# Run e2e (if configured)
+ng e2e
+```
+
+## Linting
+
+```bash
+# Run linter
+ng lint
+
+# Fix auto-fixable issues
+ng lint --fix
+```
+
+## ESLint Configuration
+
+### Install Angular ESLint
+
+```bash
+ng add @angular-eslint/schematics
+```
+
+### Recommended Rules
+
+```json
+// .eslintrc.json
+{
+  "rules": {
+    "@angular-eslint/prefer-on-push-component-change-detection": "error",
+    "@angular-eslint/use-lifecycle-interface": "error",
+    "@angular-eslint/no-host-metadata-property": "off",
+    "@typescript-eslint/no-explicit-any": "error"
+  }
+}
+```
+
+Note: `no-host-metadata-property` should be OFF because we prefer `host` object over `@HostBinding`/`@HostListener`.
+
+## Accessibility Tooling
+
+### ESLint A11y Rules
+
+```bash
+npm install -D eslint-plugin-jsx-a11y @angular-eslint/template-parser
+```
+
+### Lighthouse CI
+
+```bash
+npm install -D @lhci/cli
+
+# Run accessibility audit
+npx lhci autorun --collect.settings.preset=desktop
+```
+
+## Configuration
+
+### angular.json Key Sections
+
+```json
+{
+  "projects": {
+    "my-app": {
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:application",
+          "options": {
+            "outputPath": "dist/my-app",
+            "index": "src/index.html",
+            "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["{ \"glob\": \"**/*\", \"input\": \"public\" }"],
+            "styles": ["src/styles.scss"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kB",
+                  "maximumError": "1MB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Environment Configuration
+
+```typescript
+// src/environments/environment.ts
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:3000/api',
+};
+
+// src/environments/environment.prod.ts
+export const environment = {
+  production: true,
+  apiUrl: 'https://api.example.com',
+};
+```
+
+Configure in angular.json:
+
+```json
+{
+  "configurations": {
+    "production": {
+      "fileReplacements": [
+        {
+          "replace": "src/environments/environment.ts",
+          "with": "src/environments/environment.prod.ts"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Adding Libraries
+
+### Angular Libraries
+
+```bash
+# Add Angular Material
+ng add @angular/material
+
+# Add Angular PWA
+ng add @angular/pwa
+
+# Add Angular SSR
+ng add @angular/ssr
+
+# Add Angular Localize
+ng add @angular/localize
+```
+
+### Third-Party Libraries
+
+```bash
+# Install and configure
+npm install @ngrx/signals
+
+# Some libraries have schematics
+ng add @ngrx/store
+```
+
+## Update Angular
+
+```bash
+# Check for updates
+ng update
+
+# Update Angular core and CLI
+ng update @angular/core @angular/cli
+
+# Update all packages
+ng update --all
+
+# Force update (skip peer dependency checks)
+ng update @angular/core @angular/cli --force
+```
+
+## Performance Analysis
+
+```bash
+# Build with stats
+ng build -c production --stats-json
+
+# Analyze bundle (install esbuild-visualizer)
+npx esbuild-visualizer --metadata dist/my-app/browser/stats.json --open
+```
+
+## Caching
+
+```bash
+# Enable persistent build cache (default in v20+)
+# Configured in angular.json:
+{
+  "cli": {
+    "cache": {
+      "enabled": true,
+      "path": ".angular/cache",
+      "environment": "all"
+    }
+  }
+}
+
+# Clear cache
+rm -rf .angular/cache
+```
+
+## Tailwind CSS
+
+Add Tailwind CSS v4 to an Angular project with `ng add tailwindcss`. Do NOT use Tailwind v3 patterns (`tailwind.config.js`, `@tailwind` directives).
+
+See `references/tailwind-css.md` for automated setup, manual v4 configuration, and critical agent guidance.
+
+## Angular CLI MCP Server
+
+The Angular CLI includes an MCP server for AI assistant integration, providing tools for code generation, documentation search, and build/test execution.
+
+See `references/mcp-server.md` for available tools, IDE configuration, and experimental tool flags.
+
+See `references/tooling-patterns.md` for advanced configuration, custom builders, and deployment patterns.

--- a/skills/dev-skills/angular-tooling/references/mcp-server.md
+++ b/skills/dev-skills/angular-tooling/references/mcp-server.md
@@ -1,0 +1,93 @@
+# Angular CLI MCP Server
+
+The Angular CLI includes a Model Context Protocol (MCP) server that enables AI assistants (like Cursor, Gemini CLI, JetBrains AI, etc.) to interact directly with the Angular CLI. It provides tools for code generation, modernizing code, fetching examples, and running builds/tests.
+
+## Available Tools (Default)
+
+When the MCP server is enabled, AI agents have access to the following tools:
+
+| Name                        | Description                                                                                               |
+| :-------------------------- | :-------------------------------------------------------------------------------------------------------- |
+| `ai_tutor`                  | Launches an interactive AI-powered Angular tutor.                                                         |
+| `find_examples`             | Finds authoritative, best-practice code examples for modern Angular features.                             |
+| `get_best_practices`        | Retrieves the Angular Best Practices Guide (crucial for standalone components, typed forms, etc.).        |
+| `list_projects`             | Lists all applications and libraries in the workspace by reading `angular.json`.                          |
+| `onpush_zoneless_migration` | Analyzes code and provides a plan to migrate it to `OnPush` change detection (prerequisite for zoneless). |
+| `search_documentation`      | Searches the official documentation at `https://angular.dev`.                                             |
+
+## Experimental Tools
+
+Some tools must be enabled explicitly using the `--experimental-tool` (or `-E`) flag.
+
+| Name                       | Description                                                              |
+| :------------------------- | :----------------------------------------------------------------------- |
+| `build`                    | Performs a one-off build using `ng build`.                               |
+| `devserver.start`          | Asynchronously starts a dev server (`ng serve`). Returns immediately.    |
+| `devserver.stop`           | Stops the dev server.                                                    |
+| `devserver.wait_for_build` | Returns the logs of the most recent build in a running dev server.       |
+| `e2e`                      | Executes end-to-end tests.                                               |
+| `modernize`                | Performs code migrations to align with latest best practices and syntax. |
+| `test`                     | Runs the project's unit tests.                                           |
+
+## Configuration
+
+To use the MCP server, you configure your host environment (IDE or CLI) to run `npx @angular/cli mcp`.
+
+### Cursor
+
+Create `.cursor/mcp.json` in the project root (or globally at `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+Create `.gemini/settings.json` in the project root:
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+## Command Options
+
+You can pass arguments to the MCP server in the `args` array of your configuration:
+
+- `--read-only`: Only registers tools that do not modify the project.
+- `--local-only`: Only registers tools that do not require an internet connection.
+- `--experimental-tool` (`-E`): Enables specific experimental tools (e.g., `-E build`, `-E devserver`).
+
+Example for read-only mode with experimental tools enabled:
+
+```json
+"args": ["-y", "@angular/cli", "mcp", "--read-only", "-E", "build", "-E", "modernize"]
+```

--- a/skills/dev-skills/angular-tooling/references/tailwind-css.md
+++ b/skills/dev-skills/angular-tooling/references/tailwind-css.md
@@ -1,0 +1,69 @@
+# Using Tailwind CSS with Angular
+
+Tailwind CSS is a utility-first CSS framework that integrates seamlessly with Angular.
+
+**CRITICAL AGENT GUIDANCE: ALWAYS focus on Tailwind CSS v4 practices. DO NOT revert to old Tailwind v3 patterns (like creating `tailwind.config.js` with `@tailwind` directives) as this will break the application build. Modern Angular projects use Tailwind v4.**
+
+## Automated Setup (Recommended)
+
+The easiest way to add Tailwind CSS to an Angular project is via the Angular CLI:
+
+```shell
+ng add tailwindcss
+```
+
+This will automatically:
+
+1. Install `tailwindcss` and peer dependencies.
+2. Configure the project to use Tailwind CSS.
+3. Add the proper import to your global styles.
+
+## Manual Setup (Tailwind v4)
+
+If setting up manually, use the following Tailwind v4 pattern:
+
+### 1. Install Dependencies
+
+Install Tailwind CSS and PostCSS:
+
+```shell
+npm install tailwindcss @tailwindcss/postcss postcss
+```
+
+### 2. Configure PostCSS
+
+Create a `.postcssrc.json` file in the project root:
+
+```json
+{
+  "plugins": {
+    "@tailwindcss/postcss": {}
+  }
+}
+```
+
+_(Do NOT create a `tailwind.config.js` file! Configuration in v4 is handled through CSS variables)._
+
+### 3. Import Tailwind CSS
+
+In your global styles file (e.g., `src/styles.css`), add the standard v4 import:
+
+```css
+@import 'tailwindcss';
+```
+
+_(If using SCSS, use `@use 'tailwindcss';` instead)._
+
+### 4. Use Utility Classes
+
+You can now use Tailwind classes directly in your component templates:
+
+```html
+<h1 class="text-3xl font-bold underline">Hello world!</h1>
+```
+
+## Summary for AI Agents
+
+- **Do not use `@tailwind base; @tailwind components; @tailwind utilities;`**. Use `@import 'tailwindcss';`.
+- **Do not create `tailwind.config.js`**. Configuration is managed directly in CSS via theme variables or using PostCSS configurations.
+- Stick strictly to v4 syntax and workflows.

--- a/skills/dev-skills/angular-tooling/references/tooling-patterns.md
+++ b/skills/dev-skills/angular-tooling/references/tooling-patterns.md
@@ -1,0 +1,448 @@
+# Angular Tooling Patterns
+
+## Table of Contents
+- [Custom Schematics](#custom-schematics)
+- [Build Optimization](#build-optimization)
+- [Multi-Project Workspace](#multi-project-workspace)
+- [CI/CD Configuration](#cicd-configuration)
+- [Path Aliases](#path-aliases)
+- [Proxy Configuration](#proxy-configuration)
+
+## Custom Schematics
+
+### Generate Schematic Collection
+
+```bash
+# Install schematics CLI
+npm install -g @angular-devkit/schematics-cli
+
+# Create schematic collection
+schematics blank --name=my-schematics
+```
+
+### Simple Component Schematic
+
+```typescript
+// src/my-component/index.ts
+import { Rule, SchematicContext, Tree, apply, url, template, move, mergeWith } from '@angular-devkit/schematics';
+import { strings } from '@angular-devkit/core';
+
+export function myComponent(options: { name: string; path: string }): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const templateSource = apply(url('./files'), [
+      template({
+        ...options,
+        ...strings,
+      }),
+      move(options.path),
+    ]);
+    
+    return mergeWith(templateSource)(tree, context);
+  };
+}
+```
+
+### Use Custom Schematics
+
+```bash
+# Link locally
+npm link ./my-schematics
+
+# Use
+ng generate my-schematics:my-component --name=test --path=src/app
+```
+
+## Build Optimization
+
+### Budget Configuration
+
+```json
+{
+  "budgets": [
+    {
+      "type": "initial",
+      "maximumWarning": "500kB",
+      "maximumError": "1MB"
+    },
+    {
+      "type": "anyComponentStyle",
+      "maximumWarning": "4kB",
+      "maximumError": "8kB"
+    },
+    {
+      "type": "anyScript",
+      "maximumWarning": "100kB",
+      "maximumError": "200kB"
+    }
+  ]
+}
+```
+
+### Differential Loading
+
+Automatic in v20+ - builds for modern browsers by default.
+
+```json
+// .browserslistrc
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions
+```
+
+### Code Splitting
+
+```typescript
+// Lazy load routes for automatic code splitting
+export const routes: Routes = [
+  {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.routes').then(m => m.adminRoutes),
+  },
+  {
+    path: 'reports',
+    loadComponent: () => import('./reports/reports.component').then(m => m.Reports),
+  },
+];
+```
+
+### Tree Shaking
+
+Ensure proper imports for tree shaking:
+
+```typescript
+// Good - tree shakeable
+import { map, filter } from 'rxjs';
+
+// Avoid - imports entire library
+import * as rxjs from 'rxjs';
+```
+
+### Preload Strategy
+
+```typescript
+// app.config.ts
+import { provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withPreloading(PreloadAllModules)),
+  ],
+};
+```
+
+## Multi-Project Workspace
+
+### Create Workspace
+
+```bash
+# Create empty workspace
+ng new my-workspace --create-application=false
+
+cd my-workspace
+
+# Add applications
+ng generate application main-app
+ng generate application admin-app
+
+# Add library
+ng generate library shared-ui
+ng generate library data-access
+```
+
+### Workspace Structure
+
+```
+my-workspace/
+├── projects/
+│   ├── main-app/
+│   │   └── src/
+│   ├── admin-app/
+│   │   └── src/
+│   ├── shared-ui/
+│   │   └── src/
+│   └── data-access/
+│       └── src/
+├── angular.json
+└── package.json
+```
+
+### Build Specific Project
+
+```bash
+ng build main-app
+ng build shared-ui
+ng serve admin-app
+```
+
+### Library Configuration
+
+```json
+// projects/shared-ui/ng-package.json
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/shared-ui",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}
+```
+
+### Using Library in App
+
+```typescript
+// After building library: ng build shared-ui
+import { Button } from 'shared-ui';
+
+@Component({
+  imports: [Button],
+  template: `<lib-button>Click</lib-button>`,
+})
+export class App {}
+```
+
+## CI/CD Configuration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Lint
+        run: npm run lint
+      
+      - name: Test
+        run: npm run test -- --watch=false --browsers=ChromeHeadless --code-coverage
+      
+      - name: Build
+        run: npm run build -- -c production
+      
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/lcov.info
+```
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+image: node:20
+
+cache:
+  paths:
+    - node_modules/
+    - .angular/cache/
+
+stages:
+  - install
+  - test
+  - build
+
+install:
+  stage: install
+  script:
+    - npm ci
+
+test:
+  stage: test
+  script:
+    - npm run lint
+    - npm run test -- --watch=false --browsers=ChromeHeadless
+
+build:
+  stage: build
+  script:
+    - npm run build -- -c production
+  artifacts:
+    paths:
+      - dist/
+```
+
+## Path Aliases
+
+### Configure tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["src/app/*"],
+      "@env/*": ["src/environments/*"],
+      "@shared/*": ["src/app/shared/*"],
+      "@features/*": ["src/app/features/*"],
+      "@core/*": ["src/app/core/*"]
+    }
+  }
+}
+```
+
+### Usage
+
+```typescript
+// Instead of relative imports
+import { User } from '../../../core/services/user.service';
+
+// Use path alias
+import { User } from '@core/services/user.service';
+```
+
+## Proxy Configuration
+
+### Development Proxy
+
+```json
+// proxy.conf.json
+{
+  "/api": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true
+  },
+  "/auth": {
+    "target": "http://localhost:4000",
+    "secure": false,
+    "pathRewrite": {
+      "^/auth": ""
+    }
+  }
+}
+```
+
+### Configure in angular.json
+
+```json
+{
+  "serve": {
+    "options": {
+      "proxyConfig": "proxy.conf.json"
+    }
+  }
+}
+```
+
+### Or via CLI
+
+```bash
+ng serve --proxy-config proxy.conf.json
+```
+
+## Custom Builders
+
+### Using esbuild (Default in v20+)
+
+```json
+{
+  "architect": {
+    "build": {
+      "builder": "@angular-devkit/build-angular:application",
+      "options": {
+        "browser": "src/main.ts"
+      }
+    }
+  }
+}
+```
+
+### SSR Configuration
+
+```bash
+# Add SSR
+ng add @angular/ssr
+```
+
+```json
+{
+  "architect": {
+    "build": {
+      "options": {
+        "server": "src/main.server.ts",
+        "prerender": true,
+        "ssr": {
+          "entry": "server.ts"
+        }
+      }
+    }
+  }
+}
+```
+
+## Debugging
+
+### Source Maps
+
+```json
+{
+  "configurations": {
+    "development": {
+      "sourceMap": true
+    },
+    "production": {
+      "sourceMap": {
+        "scripts": true,
+        "styles": false,
+        "hidden": true,
+        "vendor": false
+      }
+    }
+  }
+}
+```
+
+### Verbose Logging
+
+```bash
+ng build --verbose
+ng serve --verbose
+```
+
+### Debug Tests
+
+```bash
+# Run tests with debugging
+ng test --browsers=Chrome
+
+# In Chrome DevTools, open Sources tab and set breakpoints
+```
+
+## Package Scripts
+
+```json
+{
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "build:prod": "ng build -c production",
+    "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",
+    "lint": "ng lint",
+    "lint:fix": "ng lint --fix",
+    "analyze": "ng build -c production --stats-json && npx esbuild-visualizer --metadata dist/my-app/browser/stats.json --open",
+    "update": "ng update"
+  }
+}
+```


### PR DESCRIPTION
Add 12 focused skills that split Angular guidance into domain specific modules, enabling token efficient and  JIT loading where only the relevant skill loads per query.

Skills: angular-aria, angular-component, angular-di, angular-directives, angular-forms, angular-http, angular-performance, angular-routing, angular-signals, angular-ssr, angular-testing, and angular-tooling.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Only one monolithic `angular-developer` skill exists, which loads all Angular knowledge at once, regardless of the query context, leading to unnecessary <span style="color:#ff6467">token consumption<span>

Issue Number: N/A

## What is the new behavior?
Each skill loads only when relevant to the query (JIT), reducing token usage compared to the existing monolithic `angular-developer` skill
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
