### PR TITLE
fix(vscode-extension): restore correct highlighting

### DIFF
--- a/vscode-ng-language-service/syntaxes/src/template-tag.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-tag.ts
@@ -18,13 +18,8 @@ export const TemplateTag: GrammarDefinition = {
     {include: '#eventBinding'},
     {include: '#templateBinding'},
     {include: '#standardAttribute'},
-    {include: '#other'},
   ],
   repository: {
-    other: {
-      match: /\s+/,
-      name: 'template.tag.ng',
-    },
     standardAttribute: {
       begin: /([-_a-zA-Z0-9.$:]+)(=)(["'])/,
       beginCaptures: {

--- a/vscode-ng-language-service/syntaxes/template-tag.json
+++ b/vscode-ng-language-service/syntaxes/template-tag.json
@@ -19,16 +19,9 @@
     },
     {
       "include": "#standardAttribute"
-    },
-    {
-      "include": "#other"
     }
   ],
   "repository": {
-    "other": {
-      "match": "\\s+",
-      "name": "template.tag.ng"
-    },
     "standardAttribute": {
       "begin": "([-_a-zA-Z0-9.$:]+)(=)([\"'])",
       "beginCaptures": {

--- a/vscode-ng-language-service/syntaxes/test/data/template-tag.html.snap
+++ b/vscode-ng-language-service/syntaxes/test/data/template-tag.html.snap
@@ -1,16 +1,7 @@
 ><!-- Property binding test -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
-#              ^^^^^^^ template.tag.ng
-#                     ^ template.tag.ng template.tag.ng
-#                      ^^^^ template.tag.ng
-#                          ^ template.tag.ng template.tag.ng
-#                           ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div [ ngStyle ]="{'max-width.px': i * 2 + 5}"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
 #       ^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.ngStyle.html
@@ -34,10 +25,9 @@
 #                                           ^ template.tag.ng meta.ng-binding.property.html expression.ng constant.numeric.decimal.ts
 #                                            ^ template.tag.ng meta.ng-binding.property.html expression.ng
 #                                             ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                                              ^^^^^^^ template.tag.ng
+#                                              ^^^^^^^^ template.tag.ng
 ><div [ngClass]="[
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.ngClass.html
 #             ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
@@ -64,10 +54,9 @@
 >]"></div>
 #^ template.tag.ng meta.ng-binding.property.html expression.ng meta.array.literal.ts meta.brace.square.ts
 # ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#  ^^^^^^^ template.tag.ng
+#  ^^^^^^^^ template.tag.ng
 ><div [style.right.%]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.style.right.%.html
 #           ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.style.right.%.html punctuation.accessor.html
@@ -79,10 +68,9 @@
 #                     ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                      ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                         ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                          ^^^^^^^ template.tag.ng
+#                          ^^^^^^^^ template.tag.ng
 ><div [@animation.trigger]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.@animation.trigger.html
 #                ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.@animation.trigger.html punctuation.accessor.html
@@ -92,10 +80,9 @@
 #                          ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                           ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                              ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                               ^^^^^^^ template.tag.ng
+#                               ^^^^^^^^ template.tag.ng
 ><img [attr.aria-label]="val" />
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.attr.aria-label.html
 #          ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.attr.aria-label.html punctuation.accessor.html
@@ -105,11 +92,9 @@
 #                       ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                        ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                           ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                            ^ template.tag.ng template.tag.ng
-#                             ^^ template.tag.ng
+#                            ^^^^ template.tag.ng
 ><div [my-property]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.my-property.html
 #                 ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
@@ -117,10 +102,9 @@
 #                   ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                    ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                       ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                        ^^^^^^^ template.tag.ng
+#                        ^^^^^^^^ template.tag.ng
 ><div [my_property]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.my_property.html
 #                 ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
@@ -128,10 +112,9 @@
 #                   ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                    ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                       ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                        ^^^^^^^ template.tag.ng
+#                        ^^^^^^^^ template.tag.ng
 ><div [myProperty$]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.myProperty$.html
 #                 ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.end.html
@@ -139,18 +122,13 @@
 #                   ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                    ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                       ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                        ^^^^^^^ template.tag.ng
+#                        ^^^^^^^^ template.tag.ng
 ><div [%invalidProperty]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div [invalidProperty)="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div [class.min-h-[calc(100vh-var(--header-height))]]="val"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.class.min-h-[calc(100vh-var(--header-height))].html
 #           ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.class.min-h-[calc(100vh-var(--header-height))].html punctuation.accessor.html
@@ -160,21 +138,12 @@
 #                                                      ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                                                       ^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                                                          ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                                                           ^^^^^^^ template.tag.ng
+#                                                           ^^^^^^^^ template.tag.ng
 >
 ><!-- Event binding test -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^ template.tag.ng
-#          ^ template.tag.ng template.tag.ng
-#           ^^^^^^^ template.tag.ng
-#                  ^ template.tag.ng template.tag.ng
-#                   ^^^^ template.tag.ng
-#                       ^ template.tag.ng template.tag.ng
-#                        ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><button (click)="onClick($event)"></button>
-#^^^^^^^ template.tag.ng
-#       ^ template.tag.ng template.tag.ng
+#^^^^^^^^ template.tag.ng
 #        ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #         ^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.click.html
 #              ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -185,10 +154,9 @@
 #                         ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                               ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                 ^^^^^^^^^^ template.tag.ng
+#                                 ^^^^^^^^^^^ template.tag.ng
 ><input (ngModelChange)="onModelChange($event)" />
-#^^^^^^ template.tag.ng
-#      ^ template.tag.ng template.tag.ng
+#^^^^^^^ template.tag.ng
 #       ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #        ^^^^^^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.ngModelChange.html
 #                     ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -199,11 +167,9 @@
 #                                      ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                            ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                             ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                              ^ template.tag.ng template.tag.ng
-#                                               ^^ template.tag.ng
+#                                              ^^^^ template.tag.ng
 ><div (@animation.done)="onAnimationDone($event)"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.@animation.done.html
 #                ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.@animation.done.html punctuation.accessor.html
@@ -216,10 +182,9 @@
 #                                        ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                              ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                               ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                                ^^^^^^^ template.tag.ng
+#                                                ^^^^^^^^ template.tag.ng
 ><div (someEvent)="
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.someEvent.html
 #               ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -255,10 +220,9 @@
 #^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng
 >"></div>
 #^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-# ^^^^^^^ template.tag.ng
+# ^^^^^^^^ template.tag.ng
 ><div ( extraSpacing )="onExtraSpacing($event)"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #      ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html
 #       ^^^^^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.extraSpacing.html
@@ -271,10 +235,9 @@
 #                                      ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                            ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                             ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                              ^^^^^^^ template.tag.ng
+#                                              ^^^^^^^^ template.tag.ng
 ><my-component (myEvent)="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.myEvent.html
 #                      ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -285,10 +248,9 @@
 #                                   ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                         ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                          ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                           ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                           ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component (my-event)="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.my-event.html
 #                       ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -299,10 +261,9 @@
 #                                    ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                          ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                           ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                            ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                            ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component (my_event)="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.my_event.html
 #                       ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -313,10 +274,9 @@
 #                                    ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                          ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                           ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                            ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                            ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component (myEvent$)="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html entity.other.ng-binding-name.myEvent$.html
 #                       ^ template.tag.ng meta.ng-binding.event.html entity.other.attribute-name.html entity.other.ng-binding-name.event.html punctuation.definition.ng-binding-name.end.html
@@ -327,29 +287,16 @@
 #                                    ^^^^^^ template.tag.ng meta.ng-binding.event.html expression.ng variable.other.readwrite.ts
 #                                          ^ template.tag.ng meta.ng-binding.event.html expression.ng meta.brace.round.ts
 #                                           ^ template.tag.ng meta.ng-binding.event.html string.quoted.html punctuation.definition.string.end.html
-#                                            ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                            ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component (%invalidEvent)="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
-#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component (invalidEvent]="onMyEvent($event)"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
-#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 >
 ><!-- Two-way binding test -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^ template.tag.ng
-#            ^ template.tag.ng template.tag.ng
-#             ^^^^^^^ template.tag.ng
-#                    ^ template.tag.ng template.tag.ng
-#                     ^^^^ template.tag.ng
-#                         ^ template.tag.ng template.tag.ng
-#                          ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><button [(click)]="clickProp"></button>
-#^^^^^^^ template.tag.ng
-#       ^ template.tag.ng template.tag.ng
+#^^^^^^^^ template.tag.ng
 #        ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #          ^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.click.html
 #               ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
@@ -357,10 +304,9 @@
 #                  ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                   ^^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                            ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                             ^^^^^^^^^^ template.tag.ng
+#                             ^^^^^^^^^^^ template.tag.ng
 ><div [( extraSpacing )]="extraSpacing"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #       ^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html
 #        ^^^^^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.extraSpacing.html
@@ -370,10 +316,9 @@
 #                        ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                         ^^^^^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                                     ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                                      ^^^^^^^ template.tag.ng
+#                                      ^^^^^^^^ template.tag.ng
 ><div [(@animation.done)]="animation"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #       ^^^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.@animation.done.html
 #                 ^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.@animation.done.html punctuation.accessor.html
@@ -383,10 +328,9 @@
 #                         ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                          ^^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                                   ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                                    ^^^^^^^ template.tag.ng
+#                                    ^^^^^^^^ template.tag.ng
 ><my-component [(my-prop)]="myProp"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #                ^^^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.my-prop.html
 #                       ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
@@ -394,10 +338,9 @@
 #                          ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                           ^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                                 ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                                  ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                  ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component [(my_prop)]="myProp"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #                ^^^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.my_prop.html
 #                       ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
@@ -405,10 +348,9 @@
 #                          ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                           ^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                                 ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                                  ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                  ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component [($my_prop)]="myProp"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.begin.html
 #                ^^^^^^^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html entity.other.ng-binding-name.$my_prop.html
 #                        ^^ template.tag.ng meta.ng-binding.two-way.html entity.other.attribute-name.html entity.other.ng-binding-name.two-way.html punctuation.definition.ng-binding-name.end.html
@@ -416,10 +358,9 @@
 #                           ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.begin.html
 #                            ^^^^^^ template.tag.ng meta.ng-binding.two-way.html expression.ng variable.other.readwrite.ts
 #                                  ^ template.tag.ng meta.ng-binding.two-way.html string.quoted.html punctuation.definition.string.end.html
-#                                   ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                   ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component [(%invalid)]="invalid"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html punctuation.definition.ng-binding-name.begin.html
 #                ^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html entity.other.ng-binding-name.%.html
 #                 ^^^^^^^^^ template.tag.ng meta.ng-binding.property.html entity.other.attribute-name.html entity.other.ng-binding-name.property.html
@@ -427,35 +368,23 @@
 #                           ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.begin.html
 #                            ^^^^^^^ template.tag.ng meta.ng-binding.property.html expression.ng variable.other.readwrite.ts
 #                                   ^ template.tag.ng meta.ng-binding.property.html string.quoted.html punctuation.definition.string.end.html
-#                                    ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                    ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component ([invalid)]="invalid"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
-#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 >
 ><!-- Event binding test -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^ template.tag.ng
-#          ^ template.tag.ng template.tag.ng
-#           ^^^^^^^ template.tag.ng
-#                  ^ template.tag.ng template.tag.ng
-#                   ^^^^ template.tag.ng
-#                       ^ template.tag.ng template.tag.ng
-#                        ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><button *ngModel="title"></button>
-#^^^^^^^ template.tag.ng
-#       ^ template.tag.ng template.tag.ng
+#^^^^^^^^ template.tag.ng
 #        ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #         ^^^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngModel.html
 #                ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
 #                 ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.begin.html
 #                  ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                       ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                        ^^^^^^^^^^ template.tag.ng
+#                        ^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let book of books"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -468,10 +397,9 @@
 #                        ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                         ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                              ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                               ^^^^^^^ template.tag.ng
+#                               ^^^^^^^^ template.tag.ng
 ><my-component *custom-if="true != false"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.custom-if.html
 #                        ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -482,10 +410,9 @@
 #                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng constant.language.boolean.false.ts
 #                                       ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                        ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                        ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component *custom_if="true != false"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.custom_if.html
 #                        ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -496,10 +423,9 @@
 #                                 ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                  ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng constant.language.boolean.false.ts
 #                                       ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                        ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                        ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component *custom_$if="true != false"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 #              ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #               ^^^^^^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.custom_$if.html
 #                         ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -510,35 +436,22 @@
 #                                  ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                   ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng constant.language.boolean.false.ts
 #                                        ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                         ^^^^^^^^^^^^^^^^ template.tag.ng
+#                                         ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component *%invalid="expr"></my-component>
-#^^^^^^^^^^^^^ template.tag.ng
-#             ^ template.tag.ng template.tag.ng
-#              ^^ template.tag.ng
+#^^^^^^^^^^^^^^^^ template.tag.ng
 #                ^^^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
 #                       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
 #                        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
 #                         ^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
 #                             ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
-#                              ^^^^^^^^^^^^^^^^ template.tag.ng
+#                              ^^^^^^^^^^^^^^^^^ template.tag.ng
 >
 ><!-- Microsyntax -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^^^^ template.tag.ng
-#                ^ template.tag.ng template.tag.ng
-#                 ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><!-- Let Expression -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^ template.tag.ng
-#        ^ template.tag.ng template.tag.ng
-#         ^^^^^^^^^^ template.tag.ng
-#                   ^ template.tag.ng template.tag.ng
-#                    ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -552,10 +465,9 @@
 #                     ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                          ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                           ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                            ^^^^^^^ template.tag.ng
+#                            ^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -568,18 +480,11 @@
 #                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                     ^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                          ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                           ^^^^^^^ template.tag.ng
+#                           ^^^^^^^^ template.tag.ng
 ><!-- Key Expression -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^ template.tag.ng
-#        ^ template.tag.ng template.tag.ng
-#         ^^^^^^^^^^ template.tag.ng
-#                   ^ template.tag.ng template.tag.ng
-#                    ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index; trackBy: hash;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -598,10 +503,9 @@
 #                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                          ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                           ^^^^^^^ template.tag.ng
+#                                           ^^^^^^^^ template.tag.ng
 ><div *ngFor="let i = index; trackBy: hash"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -619,10 +523,9 @@
 #                                   ^^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                     ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                         ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                          ^^^^^^^ template.tag.ng
+#                                          ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -636,10 +539,9 @@
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                 ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                  ^^^^^^^ template.tag.ng
+#                                  ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -652,18 +554,11 @@
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^^^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                 ^^^^^^^ template.tag.ng
+#                                 ^^^^^^^^ template.tag.ng
 ><!-- As Expression -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^ template.tag.ng
-#       ^ template.tag.ng template.tag.ng
-#        ^^^^^^^^^^ template.tag.ng
-#                  ^ template.tag.ng template.tag.ng
-#                   ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; index as i;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -684,10 +579,9 @@
 #                                           ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                            ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                             ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                              ^^^^^^^ template.tag.ng
+#                                              ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; index as i"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -707,10 +601,9 @@
 #                                          ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                           ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                            ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                             ^^^^^^^ template.tag.ng
+#                                             ^^^^^^^^ template.tag.ng
 ><div *ngIf='x as y'></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngIf.html
 #          ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -721,16 +614,11 @@
 #                ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                 ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                  ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                   ^^^^^^^ template.tag.ng
+#                   ^^^^^^^^ template.tag.ng
 ><!-- Mixed -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^ template.tag.ng
-#          ^ template.tag.ng template.tag.ng
-#           ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; let i = index; let last = last"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -761,10 +649,9 @@
 #                                                           ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                            ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                                                ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                                                 ^^^^^^^ template.tag.ng
+#                                                                 ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; let i = index; let last = last;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -796,10 +683,9 @@
 #                                                            ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng variable.other.readwrite.ts
 #                                                                ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                                                 ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                                                  ^^^^^^^ template.tag.ng
+#                                                                  ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; let i = index; last as last"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -828,10 +714,9 @@
 #                                                        ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                                         ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                                             ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                                              ^^^^^^^ template.tag.ng
+#                                                              ^^^^^^^^ template.tag.ng
 ><div *ngFor="let param of params; let i = index; last as last;"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -861,23 +746,14 @@
 #                                                         ^^^^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                                             ^ template.tag.ng meta.ng-binding.template.html expression.ng punctuation.terminator.statement.ts
 #                                                              ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                                               ^^^^^^^ template.tag.ng
+#                                                               ^^^^^^^^ template.tag.ng
 >
 ><!-- Regression -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^^^ template.tag.ng
-#               ^ template.tag.ng template.tag.ng
-#                ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><!-- #575 -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^ template.tag.ng
-#         ^ template.tag.ng template.tag.ng
-#          ^^^ template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngFor="let n of nums; index as i"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngFor.html
 #           ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -897,20 +773,13 @@
 #                                    ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                                     ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                                      ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                                       ^^^^^^^ template.tag.ng
+#                                       ^^^^^^^^ template.tag.ng
 ><div *matHeaderCellDef></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><!-- #613 -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^ template.tag.ng
-#         ^ template.tag.ng template.tag.ng
-#          ^^^ template.tag.ng
+#^^^^^^^^^^^^^^ template.tag.ng
 ><div *ngIf="x$ | async as a"></div>
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
+#^^^^^ template.tag.ng
 #     ^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html punctuation.definition.ng-binding-name.begin.html
 #      ^^^^ template.tag.ng meta.ng-binding.template.html entity.other.attribute-name.html entity.other.ng-binding-name.template.html entity.other.ng-binding-name.ngIf.html
 #          ^ template.tag.ng meta.ng-binding.template.html punctuation.separator.key-value.html
@@ -925,44 +794,30 @@
 #                         ^ template.tag.ng meta.ng-binding.template.html expression.ng
 #                          ^ template.tag.ng meta.ng-binding.template.html expression.ng entity.name.type.ts
 #                           ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
-#                            ^^^^^^^ template.tag.ng
+#                            ^^^^^^^^ template.tag.ng
 >
 ><!-- inline comments in the HTML element -->
-#^^^^ template.tag.ng
-#    ^ template.tag.ng template.tag.ng
-#     ^^^^^^ template.tag.ng
-#           ^ template.tag.ng template.tag.ng
-#            ^^^^^^^^ template.tag.ng
-#                    ^ template.tag.ng template.tag.ng
-#                     ^^ template.tag.ng
-#                       ^ template.tag.ng template.tag.ng
-#                        ^^^ template.tag.ng
-#                           ^ template.tag.ng template.tag.ng
-#                            ^^^^ template.tag.ng
-#                                ^ template.tag.ng template.tag.ng
-#                                 ^^^^^^^ template.tag.ng
-#                                        ^ template.tag.ng template.tag.ng
-#                                         ^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 ><div
-#^^^^ template.tag.ng
+#^^^^^ template.tag.ng
 >  // comment 0
-#^^ template.tag.ng template.tag.ng
+#^^ template.tag.ng
 #  ^^ template.tag.ng comment.line.double-slash.ts punctuation.definition.comment.ts
 #    ^^^^^^^^^^ template.tag.ng comment.line.double-slash.ts
 >  /* comment 1 */
-#^^ template.tag.ng template.tag.ng
+#^^ template.tag.ng
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 #    ^^^^^^^^^^^ template.tag.ng comment.block.ts
 #               ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >  attr1="value1"
-#^^ template.tag.ng template.tag.ng
+#^^ template.tag.ng
 #  ^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
 #       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
 #        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
 #         ^^^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
 #               ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
 >  /*
-#^^ template.tag.ng template.tag.ng
+#^^ template.tag.ng
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >     comment 2
 #^^^^^^^^^^^^^^^ template.tag.ng comment.block.ts
@@ -972,11 +827,11 @@
 #^^ template.tag.ng comment.block.ts
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >  attr2="value2"
-#^^ template.tag.ng template.tag.ng
+#^^ template.tag.ng
 #  ^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
 #       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
 #        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
 #         ^^^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
 #               ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
 >></div>
-#^^^^^^^ template.tag.ng
+#^^^^^^^^ template.tag.ng


### PR DESCRIPTION
This is a regression introduced by #66891 when trying to support commenting attribute via the language service extension