### PR TITLE
perf(forms): optimize reactivity by using shallow array equality

### DIFF
--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -39,6 +39,7 @@ import {InteropNgControl} from '../controls/interop_ng_control';
 import {RuntimeErrorCode} from '../errors';
 import {SIGNAL_FORMS_CONFIG} from '../field/di';
 import type {FieldNode} from '../field/node';
+import {shallowArrayEquals} from '../util/array';
 import {bindingUpdated, type ControlBindingKey, createBindings} from './bindings';
 import {customControlCreate} from './control_custom';
 import {cvaControlCreate} from './control_cva';
@@ -182,10 +183,12 @@ export class FormField<T> {
   );
 
   /** Errors associated with this form field. */
-  readonly errors = computed(() =>
-    this.state()
-      .errors()
-      .filter((err) => !err.formField || err.formField === this),
+  readonly errors = computed(
+    () =>
+      this.state()
+        .errors()
+        .filter((err) => !err.formField || err.formField === this),
+    {equal: shallowArrayEquals},
   );
 
   /** Whether this `FormField` has been registered as a binding on its associated `FieldState`. */

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -11,6 +11,7 @@ import type {FormField} from '../directive/form_field';
 import type {Debouncer, DisabledReason} from '../api/types';
 import {DEBOUNCER} from './debounce';
 import type {FieldNode} from './node';
+import {shallowArrayEquals} from '../util/array';
 import {shortCircuitTrue} from './util';
 
 /**
@@ -105,10 +106,13 @@ export class FieldNodeState {
    * The `field` property of the `DisabledReason` can be used to determine which field ultimately
    * caused the disablement.
    */
-  readonly disabledReasons: Signal<readonly DisabledReason[]> = computed(() => [
-    ...(this.node.structure.parent?.nodeState.disabledReasons() ?? []),
-    ...this.node.logicNode.logic.disabledReasons.compute(this.node.context),
-  ]);
+  readonly disabledReasons: Signal<readonly DisabledReason[]> = computed(
+    () => [
+      ...(this.node.structure.parent?.nodeState.disabledReasons() ?? []),
+      ...this.node.logicNode.logic.disabledReasons.compute(this.node.context),
+    ],
+    {equal: shallowArrayEquals},
+  );
 
   /**
    * Whether this field is considered disabled.

--- a/packages/forms/signals/src/field/validation.ts
+++ b/packages/forms/signals/src/field/validation.ts
@@ -12,6 +12,7 @@ import type {ReadonlyFieldTree, TreeValidationResult, ValidationResult} from '..
 import {isArray} from '../util/type_guards';
 import type {FieldNode} from './node';
 import {shortCircuitFalse} from './util';
+import {shallowArrayEquals} from '../util/array';
 
 /**
  * Helper function taking validation state, and returning own state of the node.
@@ -153,16 +154,19 @@ export class FieldValidationState implements ValidationState {
    * The full set of synchronous tree errors visible to this field. This includes ones that are
    * targeted at a descendant field rather than at this field.
    */
-  readonly rawSyncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(() => {
-    if (this.shouldSkipValidation()) {
-      return [];
-    }
+  readonly rawSyncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(
+    () => {
+      if (this.shouldSkipValidation()) {
+        return [];
+      }
 
-    return [
-      ...this.node.logicNode.logic.syncTreeErrors.compute(this.node.context),
-      ...(this.node.structure.parent?.validationState.rawSyncTreeErrors() ?? []),
-    ];
-  });
+      return [
+        ...this.node.logicNode.logic.syncTreeErrors.compute(this.node.context),
+        ...(this.node.structure.parent?.validationState.rawSyncTreeErrors() ?? []),
+      ];
+    },
+    {equal: shallowArrayEquals},
+  );
 
   /**
    * The full set of synchronous errors for this field, including synchronous tree errors and
@@ -170,18 +174,21 @@ export class FieldValidationState implements ValidationState {
    * added. From the perspective of the field state they are either there or not, they are never in a
    * pending state.
    */
-  readonly syncErrors: Signal<ValidationError.WithFieldTree[]> = computed(() => {
-    // Short-circuit running validators if validation doesn't apply to this field.
-    if (this.shouldSkipValidation()) {
-      return [];
-    }
+  readonly syncErrors: Signal<ValidationError.WithFieldTree[]> = computed(
+    () => {
+      // Short-circuit running validators if validation doesn't apply to this field.
+      if (this.shouldSkipValidation()) {
+        return [];
+      }
 
-    return [
-      ...this.node.logicNode.logic.syncErrors.compute(this.node.context),
-      ...this.syncTreeErrors(),
-      ...normalizeErrors(this.node.submitState.submissionErrors()),
-    ];
-  });
+      return [
+        ...this.node.logicNode.logic.syncErrors.compute(this.node.context),
+        ...this.syncTreeErrors(),
+        ...normalizeErrors(this.node.submitState.submissionErrors()),
+      ];
+    },
+    {equal: shallowArrayEquals},
+  );
 
   /**
    * Whether the field is considered valid according solely to its synchronous validators.
@@ -204,8 +211,9 @@ export class FieldValidationState implements ValidationState {
    * The synchronous tree errors visible to this field that are specifically targeted at this field
    * rather than a descendant.
    */
-  readonly syncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(() =>
-    this.rawSyncTreeErrors().filter((err) => err.fieldTree === this.node.fieldTree),
+  readonly syncTreeErrors: Signal<ValidationError.WithFieldTree[]> = computed(
+    () => this.rawSyncTreeErrors().filter((err) => err.fieldTree === this.node.fieldTree),
+    {equal: shallowArrayEquals},
   );
 
   /**
@@ -213,58 +221,71 @@ export class FieldValidationState implements ValidationState {
    * targeted at a descendant field rather than at this field, as well as sentinel 'pending' values
    * indicating that the validator is still running and an error could still occur.
    */
-  readonly rawAsyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(() => {
-    // Short-circuit running validators if validation doesn't apply to this field.
-    if (this.shouldSkipValidation()) {
-      return [];
-    }
+  readonly rawAsyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(
+    () => {
+      // Short-circuit running validators if validation doesn't apply to this field.
+      if (this.shouldSkipValidation()) {
+        return [];
+      }
 
-    return [
-      // TODO: add field in `validateAsync` and remove this map
-      ...this.node.logicNode.logic.asyncErrors.compute(this.node.context),
-      // TODO: does it make sense to filter this to errors in this subtree?
-      ...(this.node.structure.parent?.validationState.rawAsyncErrors() ?? []),
-    ];
-  });
+      return [
+        // TODO: add field in `validateAsync` and remove this map
+        ...this.node.logicNode.logic.asyncErrors.compute(this.node.context),
+        // TODO: does it make sense to filter this to errors in this subtree?
+        ...(this.node.structure.parent?.validationState.rawAsyncErrors() ?? []),
+      ];
+    },
+    {equal: shallowArrayEquals},
+  );
 
   /**
    * The asynchronous tree errors visible to this field that are specifically targeted at this field
    * rather than a descendant. This also includes all 'pending' sentinel values, since those could
    * theoretically result in errors for this field.
    */
-  readonly asyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(() => {
-    if (this.shouldSkipValidation()) {
-      return [];
-    }
-    return this.rawAsyncErrors().filter(
-      (err) => err === 'pending' || err.fieldTree === this.node.fieldTree,
-    );
-  });
+  readonly asyncErrors: Signal<(ValidationError.WithFieldTree | 'pending')[]> = computed(
+    () => {
+      if (this.shouldSkipValidation()) {
+        return [];
+      }
+      return this.rawAsyncErrors().filter(
+        (err) => err === 'pending' || err.fieldTree === this.node.fieldTree,
+      );
+    },
+    {equal: shallowArrayEquals},
+  );
 
-  readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(() =>
-    this.node.formFieldBindings().flatMap((field) => field.parseErrors()),
+  readonly parseErrors: Signal<ValidationError.WithFormField[]> = computed(
+    () => this.node.formFieldBindings().flatMap((field) => field.parseErrors()),
+    {equal: shallowArrayEquals},
   );
 
   /**
    * The combined set of all errors that currently apply to this field.
    */
-  readonly errors = computed(() => [
-    ...this.parseErrors(),
-    ...this.syncErrors(),
-    ...this.asyncErrors().filter((err) => err !== 'pending'),
-  ]);
+  readonly errors = computed(
+    () => [
+      ...this.parseErrors(),
+      ...this.syncErrors(),
+      ...this.asyncErrors().filter((err) => err !== 'pending'),
+    ],
+    {equal: shallowArrayEquals},
+  );
 
-  readonly errorSummary = computed(() => {
-    const errors = this.node.structure.reduceChildren(this.errors(), (child, result) => [
-      ...result,
-      ...child.errorSummary(),
-    ]);
-    // Sort by DOM order on client-side only.
-    if (typeof ngServerMode === 'undefined' || !ngServerMode) {
-      untracked(() => errors.sort(compareErrorPosition));
-    }
-    return errors;
-  });
+  readonly errorSummary = computed(
+    () => {
+      const errors = this.node.structure.reduceChildren(this.errors(), (child, result) => [
+        ...result,
+        ...child.errorSummary(),
+      ]);
+      // Sort by DOM order on client-side only.
+      if (typeof ngServerMode === 'undefined' || !ngServerMode) {
+        untracked(() => errors.sort(compareErrorPosition));
+      }
+      return errors;
+    },
+    {equal: shallowArrayEquals},
+  );
 
   /**
    * Whether this field has any asynchronous validators still pending.

--- a/packages/forms/signals/src/util/array.ts
+++ b/packages/forms/signals/src/util/array.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Checks shallow equality of two arrays.
+ * Returns true if both are arrays and have the same elements in the same order.
+ */
+export function shallowArrayEquals<T>(
+  a: readonly T[] | undefined,
+  b: readonly T[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/packages/forms/signals/src/util/array.ts
+++ b/packages/forms/signals/src/util/array.ts
@@ -18,7 +18,7 @@ export function shallowArrayEquals<T>(
   if (!a || !b) return false;
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
+    if (!Object.is(a[i], b[i])) return false;
   }
   return true;
 }

--- a/packages/forms/signals/test/node/validation_status.spec.ts
+++ b/packages/forms/signals/test/node/validation_status.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ApplicationRef, Injector, Resource, resource, signal} from '@angular/core';
+import {ApplicationRef, computed, Injector, Resource, resource, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
   form,
@@ -90,6 +90,31 @@ describe('validation status', () => {
       f.child().value.set('INVALID');
       expect(f.child().valid()).toBe(true);
       expect(f.child().invalid()).toBe(false);
+    });
+
+    it('should not notify dependents if errors are shallowly equal', () => {
+      let computeCount = 0;
+      const val = signal('VALID');
+      const f = form(
+        val,
+        (p) => {
+          validate(p, ({value}) => (value() === 'INVALID' ? [{kind: 'custom'}] : []));
+        },
+        {injector},
+      );
+
+      const errorWatcher = computed(() => {
+        computeCount++;
+        return f().errors();
+      });
+
+      errorWatcher();
+      expect(computeCount).toBe(1);
+
+      val.set('STILL_VALID');
+
+      errorWatcher();
+      expect(computeCount).toBe(1);
     });
   });
 


### PR DESCRIPTION
Add `shallowArrayEquals` to computed signals returning arrays of errors or reasons in Signal Forms. This prevents unnecessary downstream invalidations when the content of the arrays remains unchanged.
