### PR TITLE
docs: fix typos and formatting in spam policy and saved replies

### DIFF
--- a/contributing-docs/saved-issue-replies.md
+++ b/contributing-docs/saved-issue-replies.md
@@ -99,8 +99,10 @@ Please rebase and squash your commits. To do this, make sure to `git fetch upstr
 
 ## Angular: Spam
 
-Woah, looks like you've opened a lot issues/PRs recently. While we appreciate contributions from the community, triaging and reviewing a large influx of content in a short time period takes time away from other ongoing projects. As a result, we're closing these issues/PRs to maintain the team's focus.
+```
+Woah, looks like you've opened a lot of issues/PRs recently. While we appreciate contributions from the community, triaging and reviewing a large influx of content in a short time period takes time away from other ongoing projects. As a result, we're closing these issues/PRs to maintain the team's focus.
 
 Note that this is not necessarily a rejection of the goals or direction of any of these contributions in particular, so much as a reflection of the team's current capacity and priorities.
 
 You are welcome to open a smaller subset of issues/PRs in accordance with [our policy](/contributing-docs/spam.md) focused on the most important and impactful contributions and we will do our best to prioritize a response as soon as possible.
+```

--- a/contributing-docs/spam.md
+++ b/contributing-docs/spam.md
@@ -1,7 +1,7 @@
 # Spam Policy
 
 Users who create excessive amounts of issues or PRs in a short time frame,
-particularly low-quality or low-value contributions may see those contributions
+particularly low-quality or low-value contributions, may see those contributions
 automatically closed without consideration.
 
 Community contributors should limit themselves to no more than 3 open PRs at a
@@ -9,7 +9,7 @@ single time.
 
 ## Why?
 
-Reviewing and sheparding PRs as well as managing large issue counts takes time
+Reviewing and shepherding PRs as well as managing large issue counts takes time
 and energy from the core team. Triaging a PR well enough to understand its goals
 and implementation takes a significant amount of time, regardless of whether the
 PR is ultimately accepted. This policy ensures the team is able to balance its


### PR DESCRIPTION
- Enclose the spam saved reply in a code block in `saved-issue-replies.md`
- Correct spelling and punctuation in `saved-issue-replies.md` and `spam.md`
