### PR TITLE
refactor(vscode-extension): allow toggle attributes via LS.

### DIFF
--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -363,7 +363,8 @@
           "source.ts"
         ],
         "embeddedLanguages": {
-          "template.tag.ng": "angular-tag-comment"
+          "template.tag.ng": "angular-tag-comment",
+          "template.tag.leading-space": "angular-tag-comment"
         }
       },
       {

--- a/vscode-ng-language-service/syntaxes/src/template-tag.ts
+++ b/vscode-ng-language-service/syntaxes/src/template-tag.ts
@@ -10,30 +10,19 @@ import {GrammarDefinition} from './types';
 
 export const TemplateTag: GrammarDefinition = {
   scopeName: 'template.tag.ng',
-  injectionSelector: 'L:text.html#meta.tag -comment',
+  injectionSelector: 'L:text.html#meta.tag -comment -string',
   patterns: [
     {include: '#inlineComments'},
+    {include: '#leadingSpace'},
     {include: '#twoWayBinding'},
     {include: '#propertyBinding'},
     {include: '#eventBinding'},
     {include: '#templateBinding'},
-    {include: '#standardAttribute'},
   ],
   repository: {
-    standardAttribute: {
-      begin: /([-_a-zA-Z0-9.$:]+)(=)(["'])/,
-      beginCaptures: {
-        1: {name: 'entity.other.attribute-name.html'},
-        2: {name: 'punctuation.separator.key-value.html'},
-        3: {name: 'string.quoted.html punctuation.definition.string.begin.html'},
-      },
-      // @ts-ignore
-      end: /\3/,
-      endCaptures: {
-        0: {name: 'string.quoted.html punctuation.definition.string.end.html'},
-      },
-      name: 'meta.attribute.standard.html',
-      patterns: [{include: 'expression.ng'}],
+    leadingSpace: {
+      match: /^\s+/,
+      name: 'template.tag.leading-space',
     },
     propertyBinding: {
       begin: /(\[\s*@?(?:[-_a-zA-Z0-9.$]+|\[[^\[\]]*]|\([^()]*\))*%?\s*])(=)(["'])/,

--- a/vscode-ng-language-service/syntaxes/template-tag.json
+++ b/vscode-ng-language-service/syntaxes/template-tag.json
@@ -1,9 +1,12 @@
 {
   "scopeName": "template.tag.ng",
-  "injectionSelector": "L:text.html#meta.tag -comment",
+  "injectionSelector": "L:text.html#meta.tag -comment -string",
   "patterns": [
     {
       "include": "#inlineComments"
+    },
+    {
+      "include": "#leadingSpace"
     },
     {
       "include": "#twoWayBinding"
@@ -16,37 +19,12 @@
     },
     {
       "include": "#templateBinding"
-    },
-    {
-      "include": "#standardAttribute"
     }
   ],
   "repository": {
-    "standardAttribute": {
-      "begin": "([-_a-zA-Z0-9.$:]+)(=)([\"'])",
-      "beginCaptures": {
-        "1": {
-          "name": "entity.other.attribute-name.html"
-        },
-        "2": {
-          "name": "punctuation.separator.key-value.html"
-        },
-        "3": {
-          "name": "string.quoted.html punctuation.definition.string.begin.html"
-        }
-      },
-      "end": "\\3",
-      "endCaptures": {
-        "0": {
-          "name": "string.quoted.html punctuation.definition.string.end.html"
-        }
-      },
-      "name": "meta.attribute.standard.html",
-      "patterns": [
-        {
-          "include": "expression.ng"
-        }
-      ]
+    "leadingSpace": {
+      "match": "^\\s+",
+      "name": "template.tag.leading-space"
     },
     "propertyBinding": {
       "begin": "(\\[\\s*@?(?:[-_a-zA-Z0-9.$]+|\\[[^\\[\\]]*]|\\([^()]*\\))*%?\\s*])(=)([\"'])",

--- a/vscode-ng-language-service/syntaxes/test/data/template-tag.html
+++ b/vscode-ng-language-service/syntaxes/test/data/template-tag.html
@@ -89,3 +89,6 @@
   */
   attr2="value2"
 ></div>
+
+<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Click me</a>
+<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">Click me too</a><a href="https://example.com" //inline-comment>

--- a/vscode-ng-language-service/syntaxes/test/data/template-tag.html.snap
+++ b/vscode-ng-language-service/syntaxes/test/data/template-tag.html.snap
@@ -438,13 +438,7 @@
 #                                        ^ template.tag.ng meta.ng-binding.template.html string.quoted.html punctuation.definition.string.end.html
 #                                         ^^^^^^^^^^^^^^^^^ template.tag.ng
 ><my-component *%invalid="expr"></my-component>
-#^^^^^^^^^^^^^^^^ template.tag.ng
-#                ^^^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
-#                       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
-#                        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
-#                         ^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
-#                             ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
-#                              ^^^^^^^^^^^^^^^^^ template.tag.ng
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
 >
 ><!-- Microsyntax -->
 #^^^^^^^^^^^^^^^^^^^^^ template.tag.ng
@@ -801,23 +795,19 @@
 ><div
 #^^^^^ template.tag.ng
 >  // comment 0
-#^^ template.tag.ng
+#^^ template.tag.ng template.tag.leading-space
 #  ^^ template.tag.ng comment.line.double-slash.ts punctuation.definition.comment.ts
 #    ^^^^^^^^^^ template.tag.ng comment.line.double-slash.ts
 >  /* comment 1 */
-#^^ template.tag.ng
+#^^ template.tag.ng template.tag.leading-space
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 #    ^^^^^^^^^^^ template.tag.ng comment.block.ts
 #               ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >  attr1="value1"
-#^^ template.tag.ng
-#  ^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
-#       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
-#        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
-#         ^^^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
-#               ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
+#^^ template.tag.ng template.tag.leading-space
+#  ^^^^^^^^^^^^^^^ template.tag.ng
 >  /*
-#^^ template.tag.ng
+#^^ template.tag.ng template.tag.leading-space
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >     comment 2
 #^^^^^^^^^^^^^^^ template.tag.ng comment.block.ts
@@ -827,11 +817,17 @@
 #^^ template.tag.ng comment.block.ts
 #  ^^ template.tag.ng comment.block.ts punctuation.definition.comment.ts
 >  attr2="value2"
-#^^ template.tag.ng
-#  ^^^^^ template.tag.ng meta.attribute.standard.html entity.other.attribute-name.html
-#       ^ template.tag.ng meta.attribute.standard.html punctuation.separator.key-value.html
-#        ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.begin.html
-#         ^^^^^^ template.tag.ng meta.attribute.standard.html variable.other.readwrite.ts
-#               ^ template.tag.ng meta.attribute.standard.html string.quoted.html punctuation.definition.string.end.html
+#^^ template.tag.ng template.tag.leading-space
+#  ^^^^^^^^^^^^^^^ template.tag.ng
 >></div>
 #^^^^^^^^ template.tag.ng
+>
+><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">Click me</a>
+#^^^^^^^^^^^^^^^ template.tag.ng
+#               ^^ template.tag.ng comment.line.double-slash.ts punctuation.definition.comment.ts
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng comment.line.double-slash.ts
+><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">Click me too</a><a href="https://example.com" //inline-comment>
+#^^^^^^^^^^^^^^^ template.tag.ng
+#               ^^ template.tag.ng comment.line.double-slash.ts punctuation.definition.comment.ts
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ template.tag.ng comment.line.double-slash.ts
+>


### PR DESCRIPTION
This change allows to toggle attributes that are on their own line and have a 1+ leading space.

This change doesn't suffer from the issue that was reverted in https://github.com/angular/angular/pull/68067.

Also this change fixes another regression that messed up highlighting if an attribute value included a '//', like in an href.