### PR TITLE
docs: document hydration completion check for e2e tests

### DIFF
--- a/adev/src/content/guide/hydration.md
+++ b/adev/src/content/guide/hydration.md
@@ -61,6 +61,17 @@ While running an application in dev mode, you can confirm hydration is enabled b
 
 You can also use [Angular DevTools browser extension](tools/devtools) to see hydration status of components on a page. Angular DevTools also allows to enable an overlay to indicate which parts of the page were hydrated. If there is a hydration mismatch error - DevTools would also highlight a component that caused the error.
 
+### Verify hydration in E2E tests
+
+During hydration, Angular annotates component host elements with an `ngh` attribute that contains hydration metadata. After hydration finishes, Angular removes these attributes.
+
+In end-to-end tests, you can wait for hydration to complete by asserting that there are no `[ngh]` attributes left in the DOM. For example, in Playwright:
+
+```typescript
+// Ensure hydration is finished
+await expect(app.locator('[ngh]')).toHaveCount(0);
+```
+
 ## Capturing and replaying events
 
 When an application is rendered on the server, it is visible in a browser as soon as produced HTML loads. Users may assume that they can interact with the page, but event listeners are not attached until hydration completes. Starting from v18, you can enable the Event Replay feature that allows to capture all events that happen before hydration and replay those events once hydration has completed. You can enable it using the `withEventReplay()` function, for example:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Add guidance to the hydration guide so E2E tests can reliably wait for client-side hydration to complete by observing the removal of Angular's temporary ngh attributes on component hosts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
