### PR TITLE
fix(core): escape forward slashes in transfer state to prevent crawler indexing

### DIFF
--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -142,7 +142,8 @@ export class TransferState {
 
     // Escape script tag to avoid break out of <script> tag in serialized output.
     // Encoding of `<` is the same behaviour as G3 script_builders.
-    return JSON.stringify(this.store).replace(/</g, '\\u003C');
+    // Encoding of `/` prevents crawlers from incorrectly indexing relative URLs in inline JSON.
+    return JSON.stringify(this.store).replace(/</g, '\\u003C').replace(/\//g, '\\u002F');
   }
 }
 

--- a/packages/core/test/transfer_state_spec.ts
+++ b/packages/core/test/transfer_state_spec.ts
@@ -136,12 +136,18 @@ describe('TransferState', () => {
 
     transferState.set(DELAYED_KEY, '</script><script>alert(\'Hello&\' + "World");');
     expect(transferState.toJson()).toBe(
-      `{"delayed":"\\u003C/script>\\u003Cscript>alert('Hello&' + \\"World\\");"}`,
+      `{"delayed":"\\u003C\\u002Fscript>\\u003Cscript>alert('Hello&' + \\"World\\");"}`,
     );
   });
 
-  it('should decode `\\u003C` (<) when restoring stating', () => {
-    const encodedState = `{"delayed":"\\u003C/script>\\u003Cscript>alert('Hello&' + \\"World\\");"}`;
+  it('should encode `/` to avoid crawler indexing of inline JSON', () => {
+    const transferState = TestBed.inject(TransferState);
+    transferState.set(DELAYED_KEY, '/foo/bar');
+    expect(transferState.toJson()).toBe(`{"delayed":"\\u002Ffoo\\u002Fbar"}`);
+  });
+
+  it('should decode `\\u003C` (<) and `\\u002F` (/) when restoring stating', () => {
+    const encodedState = `{"delayed":"\\u003C\\u002Fscript>\\u003Cscript>alert('Hello&' + \\"World\\");"}`;
     addScriptTag(doc, APP_ID, encodedState);
     const transferState = TestBed.inject(TransferState);
 
@@ -149,5 +155,17 @@ describe('TransferState', () => {
     expect(transferState.get(DELAYED_KEY, null)).toBe(
       '</script><script>alert(\'Hello&\' + "World");',
     );
+  });
+
+  it('should properly encode and decode relative links in JSON', () => {
+    const relativeLink = '/about/us?query=1';
+    const encodedState = `{"delayed":"\\u002Fabout\\u002Fus?query=1"}`;
+
+    // Ensure restoring from the encoded state correctly decodes the relative link
+    addScriptTag(doc, APP_ID, encodedState);
+    const transferState = TestBed.inject(TransferState);
+
+    expect(transferState.get(DELAYED_KEY, null)).toBe(relativeLink);
+    expect(transferState.toJson()).toBe(encodedState);
   });
 });

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -77,7 +77,7 @@ describe('transfer_state', () => {
     expect(output).toBe(
       '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</esc-app>' +
         '<script id="ng-state" type="application/json">' +
-        `{"testString":"\\u003C/script>\\u003Cscript>alert('Hello&' + \\"World\\");"}` +
+        `{"testString":"\\u003C\\u002Fscript>\\u003Cscript>alert('Hello&' + \\"World\\");"}` +
         '</script></body></html>',
     );
   });


### PR DESCRIPTION
Escapes forward slashes as \u002F in TransferState to prevent aggressive Googlebot indexing of relative paths inside inline JSON blocks.

Fixes https://github.com/angular/angular/issues/65310