### PR TITLE
docs(docs-infra): fix homepage nav overlay and banner visibility between 701–900px

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -94,6 +94,7 @@
     width: 100%;
     padding-inline: calc(var(--layout-padding) - 1.25rem);
     height: auto;
+    scrollbar-width: none;
     padding-block: 0;
   }
 
@@ -169,6 +170,7 @@
 
     @include mq.for-tablet {
       flex-direction: row;
+      padding-block-start: 0;
     }
 
     // version dropdown button
@@ -233,7 +235,9 @@
 
     @include mq.for-tablet {
       flex-direction: row !important;
+      align-items: center;
       margin-inline-end: 1.25rem;
+      margin-top: 0.25rem;
       gap: 0.75rem;
     }
 

--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -28,8 +28,12 @@
   left: calc(var(--layout-padding) + var(--primary-nav-width));
   z-index: 1;
 
-  @include mq.for-tablet-down {
-    justify-content: flex-start;
+  @include mq.for-tablet-landscape-down {
+    justify-content: center;
+    margin-top: 4rem;
+  }
+
+  @include mq.for-phone-only {
     margin-top: 1rem;
   }
 }
@@ -187,7 +191,7 @@ section {
   }
 
   .search-field {
-    @include mq.for-tablet-down() {
+    @include mq.for-tablet-landscape-down() {
       display: none;
     }
   }


### PR DESCRIPTION
docs(docs-infra): fix homepage nav overlay and banner visibility between 701–900px

The homepage navigation bar rendered with `height: 0` on viewports between 701–900px, causing its content to overflow on top of the announcement banner and block scrolling. Reset nav height to `auto` at tablet sizes, center the v21 banner, adjust its top margin, and hide the redundant search field since the nav bar already provides one.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Between 701–900px viewport width, the homepage navigation renders with `height: 0` while its content overflows, covering the "Angular v21 is here!" banner and blocking page scrolling. The search field is also redundantly shown alongside the nav bar's own search.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #68087 

## What is the new behavior?

- The v21 banner is centered on tablet viewports
- The homepage search field is hidden at ≤900px since the nav bar already provides search make sure

https://github.com/user-attachments/assets/2be3a662-9a7d-417a-bc2a-f62dff97ce4e

search field
before
<img width="914" height="770" alt="Screenshot 2026-04-08 at 22 59 18" src="https://github.com/user-attachments/assets/df888d41-7fd3-437f-9ebf-06daa6cbf58b" />

after
<img width="960" height="760" alt="image" src="https://github.com/user-attachments/assets/ac5ced79-ebe3-48f2-b471-7c64f1fafcce" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
