### PR TITLE
fix(compiler): don't escape dollar sign in literal expression

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -1029,3 +1029,32 @@ export declare class TestComp {
     static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: dollar_escape.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    price = '3.50';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, isStandalone: false, selector: "my-comp", ngImport: i0, template: `\${{price}}`, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-comp',
+                    template: `\${{price}}`,
+                    standalone: false,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: dollar_escape.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    price: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-comp", never, {}, {}, never, never, false, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -326,6 +326,16 @@
           "files": ["call_rest.js"]
         }
       ]
+    },
+    {
+      "description": "should support dollar escape in template",
+      "inputFiles": ["dollar_escape.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid dollar escape",
+          "files": ["dollar_escape.js"]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/dollar_escape.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/dollar_escape.js
@@ -1,0 +1,20 @@
+export class MyComponent {
+  // ...
+  static ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
+    type: MyComponent,
+    selectors: [["my-comp"]],
+    standalone: false,
+    decls: 1,
+    vars: 1,
+    template:  function MyComponent_Template(rf, ctx) {
+      if (rf & 1) {
+        $r3$.ɵɵtext(0);
+      }
+      if (rf & 2) {
+        $r3$.ɵɵtextInterpolate1("$", ctx.price);
+      }
+    },
+    encapsulation: 2
+  });
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/dollar_escape.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/dollar_escape.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'my-comp',
+  template: `\${{price}}`,
+  standalone: false,
+})
+export class MyComponent {
+  price = '3.50';
+}
+

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -11,7 +11,7 @@ import {ParseSourceSpan} from '../parse_util';
 import * as o from './output_ast';
 import {SourceMapGenerator} from './source_map';
 
-const SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\r|\$/g;
+const SINGLE_QUOTE_ESCAPE_STRING_RE = /'|\\|\n|\r/g;
 const LEGAL_IDENTIFIER_RE = /^[$A-Z_][0-9A-Z_$]*$/i;
 const INDENT_WITH = '  ';
 


### PR DESCRIPTION
Removes the escape for `$` in literal expressions. I don't think this is required with our output.