### PR TITLE
feat(forms): Make FieldPathNode public to allow defining metadata behavior

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -126,7 +126,26 @@ export class EmailValidationError extends BaseNgValidationError {
 export type Field<TValue, TKey extends string | number = string | number> = () => FieldState<TValue, TKey>;
 
 // @public
+export const FIELD_PATH_PROXY_HANDLER: ProxyHandler<FieldPathNode>;
+
+// @public
 export type FieldContext<TValue, TPathKind extends PathKind = PathKind.Root> = TPathKind extends PathKind.Item ? ItemFieldContext<TValue> : TPathKind extends PathKind.Child ? ChildFieldContext<TValue> : RootFieldContext<TValue>;
+
+// @public
+export class FieldPathNode {
+    protected constructor(
+    keys: PropertyKey[], root: FieldPathNode | undefined,
+    parent: FieldPathNode | undefined,
+    keyInParent: PropertyKey | undefined);
+    get builder(): LogicNodeBuilder;
+    readonly fieldPathProxy: SchemaPath<any>;
+    getChild(key: PropertyKey): FieldPathNode;
+    readonly keys: PropertyKey[];
+    mergeIn(other: SchemaImpl, predicate?: Predicate): void;
+    static newRoot(): FieldPathNode;
+    readonly root: FieldPathNode;
+    static unwrapFieldPath(formPath: SchemaPath<unknown, SchemaPathRules>): FieldPathNode;
+}
 
 // @public
 export interface FieldState<TValue, TKey extends string | number = string | number> extends ReadonlyFieldState<TValue, TKey> {

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -22,3 +22,4 @@ export * from './src/api/transformed_value';
 export * from './src/api/types';
 export * from './src/directive/form_field';
 export * from './src/directive/form_root';
+export * from './src/schema/path_node';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently it is not possible to define custom behavior for a schema metadata as `FieldPathNode` is not listed in the public api.
It is needed to do so.
e.g.
https://github.com/angular/angular/blob/5516769e170f282bed9f54e84b9a10a8ab66f899/packages/forms/signals/src/api/rules/debounce.ts#L32-L34

Issue Number: [67769](https://github.com/angular/angular/issues/67769)

## What is the new behavior?

 `FieldPathNode` is accessable and therefor a behaviour for a metadata can be defined directly

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


