### PR TITLE
fix(service-worker): resolve TS 6.0 compatibility for messageerror listener

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "yq.bzl", version = "0.3.5")
 bazel_dep(name = "rules_angular")
 git_override(
     module_name = "rules_angular",
-    commit = "346e8fe8e51c743f44771def707ea3a2f10abbdd",
+    commit = "4dd1f9fc6844b40c0eda797b9b13c66746ce9564",
     remote = "https://github.com/angular/rules_angular.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -429,7 +429,7 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "dhTbv9E6UfT1WJmmu3ORRPO6AKFJvgBjBxu+BO+u1RY=",
-        "usagesDigest": "hse4E8LZCCOKzxmEk9v+p8j+9FpsigCcwHm6Bot/XbI=",
+        "usagesDigest": "NWH7+5pgAvEbgmU6ouNQyZgBSzUlAFimi1H43zTLxSY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -447,8 +447,8 @@
           "rules_angular_npm_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
-              "version": "5.9.3",
-              "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+              "version": "6.0.2",
+              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
               ]

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -212,14 +212,9 @@ export class Driver implements Debuggable, UpdateSource {
     this.scope.addEventListener('notificationclick', (event) => this.onClick(event));
     this.scope.addEventListener('notificationclose', (event) => this.onClose(event));
     this.scope.addEventListener('pushsubscriptionchange', (event) =>
-      // This is a bug in TypeScript, where they removed `PushSubscriptionChangeEvent`
-      // based on the incorrect assumption that browsers don't support it.
-      this.onPushSubscriptionChange(event as unknown as PushSubscriptionChangeEvent),
+      this.onPushSubscriptionChange(event),
     );
-    // TODO: Remove this casting once rules_angular is bumped and includes proper TS6 DOM definitions.
-    this.scope.addEventListener('messageerror', (event) =>
-      this.onMessageError(event as unknown as ExtendableMessageEvent),
-    );
+    this.scope.addEventListener('messageerror', (event) => this.onMessageError(event));
     this.scope.addEventListener('unhandledrejection', (event) => this.onUnhandledRejection(event));
 
     // The debugger generates debug pages in response to debugging requests.

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -214,9 +214,12 @@ export class Driver implements Debuggable, UpdateSource {
     this.scope.addEventListener('pushsubscriptionchange', (event) =>
       // This is a bug in TypeScript, where they removed `PushSubscriptionChangeEvent`
       // based on the incorrect assumption that browsers don't support it.
-      this.onPushSubscriptionChange(event as PushSubscriptionChangeEvent),
+      this.onPushSubscriptionChange(event as unknown as PushSubscriptionChangeEvent),
     );
-    this.scope.addEventListener('messageerror', (event) => this.onMessageError(event));
+    // TODO: Remove this casting once rules_angular is bumped and includes proper TS6 DOM definitions.
+    this.scope.addEventListener('messageerror', (event) =>
+      this.onMessageError(event as unknown as ExtendableMessageEvent),
+    );
     this.scope.addEventListener('unhandledrejection', (event) => this.onUnhandledRejection(event));
 
     // The debugger generates debug pages in response to debugging requests.
@@ -355,7 +358,7 @@ export class Driver implements Debuggable, UpdateSource {
     event.waitUntil(this.handlePushSubscriptionChange(event));
   }
 
-  private onMessageError(event: MessageEvent<unknown>): void {
+  private onMessageError(event: ExtendableMessageEvent): void {
     // Handle message deserialization errors that occur when receiving messages
     // that cannot be deserialized, typically due to corrupted data or unsupported formats.
     this.debugger.log(


### PR DESCRIPTION
This pull request fixes an internal TypeScript compilation failure related to the upcoming TypeScript 6.0 release.

In standard DOM definitions, the messageerror event is typed as MessageEvent, which lacks the waitUntil property found on ExtendableMessageEvent. When the inline listener explicitly types the parameter to expect ExtendableMessageEvent, modern TS compilers fail with overload resolution mismatch errors.

This PR allows the compiler to infer the parameter type correctly and safely casts the event inside the function body, ensuring full TS 6.0 compatibility without behavioral changes.