### PR TITLE
refactor(core): deprecate `withIncrementalHydration`

### DIFF
--- a/adev/src/content/guide/incremental-hydration.md
+++ b/adev/src/content/guide/incremental-hydration.md
@@ -12,22 +12,31 @@ Incremental hydration also lets you use deferrable views (`@defer`) for content 
 
 You can enable incremental hydration for applications that already use server-side rendering (SSR) with hydration. Follow the [Angular SSR Guide](guide/ssr) to enable server-side rendering and the [Angular Hydration Guide](guide/hydration) to enable hydration first.
 
-Enable incremental hydration by adding the `withIncrementalHydration()` function to the `provideClientHydration` provider.
+Incremental hydration is enabled by default when you use `provideClientHydration()`.
 
-```typescript
-import {
-  bootstrapApplication,
-  provideClientHydration,
-  withIncrementalHydration,
-} from '@angular/platform-browser';
-...
+```ts
+import {bootstrapApplication, provideClientHydration} from '@angular/platform-browser';
 
 bootstrapApplication(App, {
-  providers: [provideClientHydration(withIncrementalHydration())]
+  providers: [provideClientHydration()],
 });
 ```
 
-Incremental Hydration depends on and enables [event replay](guide/hydration#capturing-and-replaying-events) automatically. If you already have `withEventReplay()` in your list, you can safely remove it after enabling incremental hydration.
+NOTE: Incremental Hydration depends on and enables [event replay](guide/hydration#capturing-and-replaying-events) automatically. If you already have `withEventReplay()` in your list, you can safely remove it.
+
+To opt out of incremental hydration, use `withNoIncrementalHydration()`:
+
+```ts
+import {
+  bootstrapApplication,
+  provideClientHydration,
+  withNoIncrementalHydration,
+} from '@angular/platform-browser';
+
+bootstrapApplication(App, {
+  providers: [provideClientHydration(withNoIncrementalHydration())],
+});
+```
 
 ## How does incremental hydration work?
 

--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -211,7 +211,7 @@ export function withHttpTransferCacheOptions(options: HttpTransferCacheOptions):
 // @public
 export function withI18nSupport(): HydrationFeature<HydrationFeatureKind.I18nSupport>;
 
-// @public
+// @public @deprecated
 export function withIncrementalHydration(): HydrationFeature<HydrationFeatureKind.IncrementalHydration>;
 
 // @public

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -354,6 +354,9 @@ export function withI18nSupport(): Provider[] {
  * Requires hydration to be enabled separately.
  * Enabling incremental hydration also enables event replay for the entire app.
  * @see [Incremental Hydration](guide/incremental-hydration#how-do-you-enable-incremental-hydration-in-angular)
+ *
+ * @deprecated Since v22.0.0, incremental hydration is enabled by default with `provideClientHydration`.
+ * Intent to remove in v24.
  */
 export function withIncrementalHydration(): Provider[] {
   const providers: Provider[] = [

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -424,9 +424,9 @@ export function warnIncrementalHydrationNotConfigured(): void {
       formatRuntimeError(
         RuntimeErrorCode.MISCONFIGURED_INCREMENTAL_HYDRATION,
         'Angular has detected that some `@defer` blocks use `hydrate` triggers, ' +
-          'but incremental hydration was not enabled. Please ensure that the `withIncrementalHydration()` ' +
-          'call is added as an argument for the `provideClientHydration()` function call ' +
-          'in your application config.',
+          'but incremental hydration was not enabled. Incremental hydration is enabled by default ' +
+          'with `provideClientHydration()`. Make sure `provideClientHydration()` is included in ' +
+          'your application config and that you have not opted out using `withNoIncrementalHydration()`.',
       ),
     );
   }

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -19,7 +19,6 @@ import {
   ɵwithDomHydration as withDomHydration,
   ɵwithEventReplay,
   ɵwithI18nSupport,
-  ɵZONELESS_ENABLED as ZONELESS_ENABLED,
   ɵwithIncrementalHydration,
   ɵIS_ENABLED_BLOCKING_INITIAL_NAVIGATION as IS_ENABLED_BLOCKING_INITIAL_NAVIGATION,
   provideStabilityDebugging,
@@ -115,7 +114,7 @@ export function withI18nSupport(): HydrationFeature<HydrationFeatureKind.I18nSup
  * Basic example of how you can enable event replay in your application when
  * `bootstrapApplication` function is used:
  * ```ts
- * bootstrapApplication(AppComponent, {
+ * bootstrapApplication(App, {
  *   providers: [provideClientHydration(withEventReplay())]
  * });
  * ```
@@ -134,12 +133,15 @@ export function withEventReplay(): HydrationFeature<HydrationFeatureKind.EventRe
  * Basic example of how you can enable incremental hydration in your application when
  * the `bootstrapApplication` function is used:
  * ```ts
- * bootstrapApplication(AppComponent, {
+ * bootstrapApplication(App, {
  *   providers: [provideClientHydration(withIncrementalHydration())]
  * });
  * ```
  * @publicApi 20.0
  * @see {@link provideClientHydration}
+ *
+ * @deprecated Since v22.0.0, incremental hydration is enabled by default with `provideClientHydration`.
+ * Intent to remove in v24.
  */
 export function withIncrementalHydration(): HydrationFeature<HydrationFeatureKind.IncrementalHydration> {
   return hydrationFeature(HydrationFeatureKind.IncrementalHydration, ɵwithIncrementalHydration());
@@ -194,6 +196,7 @@ function provideEnabledBlockingInitialNavigationDetector(): Provider[] {
  * * [`HttpClient`](api/common/http/HttpClient) response caching while running on the server and
  * transferring this cache to the client to avoid extra HTTP requests. Learn more about data caching
  * [here](guide/ssr#caching-data-when-using-httpclient).
+ * Incremental hydration. [Learn more](guide/incremental-hydration).
  *
  * These functions allow you to disable some of the default features or enable new ones:
  *
@@ -201,13 +204,14 @@ function provideEnabledBlockingInitialNavigationDetector(): Provider[] {
  * * {@link withHttpTransferCacheOptions} to configure some HTTP transfer cache options
  * * {@link withI18nSupport} to enable hydration support for i18n blocks
  * * {@link withEventReplay} to enable support for replaying user events
+ * * {@link withNoIncrementalHydration} to disable incremental hydration
  *
  * @usageNotes
  *
  * Basic example of how you can enable hydration in your application when
  * `bootstrapApplication` function is used:
  * ```ts
- * bootstrapApplication(AppComponent, {
+ * bootstrapApplication(App, {
  *   providers: [provideClientHydration()]
  * });
  * ```
@@ -227,6 +231,7 @@ function provideEnabledBlockingInitialNavigationDetector(): Provider[] {
  * @see {@link withHttpTransferCacheOptions}
  * @see {@link withI18nSupport}
  * @see {@link withEventReplay}
+ * @see {@link withNoIncrementalHydration}
  *
  * @param features Optional features to configure additional hydration behaviors.
  * @returns A set of providers to enable hydration.


### PR DESCRIPTION
Deprecates `withIncrementalHydration()` as it is no longer required. ( Considering that this is now the default behavior https://github.com/angular/angular/pull/68092 )

Updates API docs and runtime errors to reflect the new default and guide opt-out.

