### PR TITLE
fix(migrations): use inline block syntax to prevent whitespace in control flow migration

### DIFF
--- a/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/cases.ts
@@ -11,6 +11,7 @@ import {visitAll} from '@angular/compiler';
 import {ElementCollector, ElementToMigrate, endMarker, Result, startMarker} from './types';
 import {
   calculateNesting,
+  getBlockLineBreak,
   getMainBlock,
   getOriginals,
   hasLineBreaks,
@@ -93,9 +94,11 @@ function migrateNgSwitchCase(etm: ElementToMigrate, tmpl: string, offset: number
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${startMarker}${leadingSpace}@case (${condition}) {${leadingSpace}${lbString}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}${endMarker}`;
+  const mainBlock = getMainBlock(etm, tmpl, offset);
+  const {start, middle, end} = mainBlock;
+  const blockLb = getBlockLineBreak(mainBlock, lbString);
+  const startBlock = `${startMarker}${leadingSpace}@case (${condition}) {${leadingSpace}${blockLb}${start}`;
+  const endBlock = `${end}${blockLb}${leadingSpace}}${endMarker}`;
 
   const defaultBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));
@@ -115,9 +118,11 @@ function migrateNgSwitchDefault(etm: ElementToMigrate, tmpl: string, offset: num
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${startMarker}${leadingSpace}@default {${leadingSpace}${lbString}${start}`;
-  const endBlock = `${end}${lbString}${leadingSpace}}${endMarker}`;
+  const mainBlock = getMainBlock(etm, tmpl, offset);
+  const {start, middle, end} = mainBlock;
+  const blockLb = getBlockLineBreak(mainBlock, lbString);
+  const startBlock = `${startMarker}${leadingSpace}@default {${leadingSpace}${blockLb}${start}`;
+  const endBlock = `${end}${blockLb}${leadingSpace}}${endMarker}`;
 
   const defaultBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + defaultBlock + tmpl.slice(etm.end(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/fors.ts
@@ -11,6 +11,7 @@ import {visitAll} from '@angular/compiler';
 import {ElementCollector, ElementToMigrate, endMarker, Result, startMarker} from './types';
 import {
   calculateNesting,
+  getBlockLineBreak,
   getMainBlock,
   getOriginals,
   getPlaceholder,
@@ -166,17 +167,20 @@ function migrateStandardNgFor(etm: ElementToMigrate, tmpl: string, offset: numbe
 
   const aliasStr = aliases.length > 0 ? `;${aliases.join(';')}` : '';
 
-  let startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {${lbString}`;
-  let endBlock = `${lbString}}${endMarker}`;
+  let startBlock: string;
+  let endBlock: string;
   let forBlock = '';
 
   if (tmplPlaceholder !== '') {
-    startBlock = startBlock + tmplPlaceholder;
+    startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {${lbString}${tmplPlaceholder}`;
+    endBlock = `${lbString}}${endMarker}`;
     forBlock = startBlock + endBlock;
   } else {
-    const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-    startBlock += start;
-    endBlock = end + endBlock;
+    const mainBlock = getMainBlock(etm, tmpl, offset);
+    const {start, middle, end} = mainBlock;
+    const blockLb = getBlockLineBreak(mainBlock, lbString);
+    startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {${blockLb}${start}`;
+    endBlock = `${end}${blockLb}}${endMarker}`;
     forBlock = startBlock + middle + endBlock;
   }
 
@@ -212,10 +216,12 @@ function migrateBoundNgFor(etm: ElementToMigrate, tmpl: string, offset: number):
     trackBy = `${forAttrs.trackBy.trim()}(${aliasedIndex}, ${aliasAttrs.item})`;
   }
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {\n${start}`;
+  const mainBlock = getMainBlock(etm, tmpl, offset);
+  const {start, middle, end} = mainBlock;
+  const blockLb = getBlockLineBreak(mainBlock, '\n');
+  const startBlock = `${startMarker}@for (${condition}; track ${trackBy}${aliasStr}) {${blockLb}${start}`;
 
-  const endBlock = `${end}\n}${endMarker}`;
+  const endBlock = `${end}${blockLb}}${endMarker}`;
   const forBlock = startBlock + middle + endBlock;
 
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + forBlock + tmpl.slice(etm.end(offset));

--- a/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/ifs.ts
@@ -11,6 +11,7 @@ import {visitAll} from '@angular/compiler';
 import {ElementCollector, ElementToMigrate, endMarker, Result, startMarker} from './types';
 import {
   calculateNesting,
+  getBlockLineBreak,
   getMainBlock,
   getOriginals,
   getPlaceholder,
@@ -119,9 +120,11 @@ function buildIfBlock(etm: ElementToMigrate, tmpl: string, offset: number): Resu
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${startMarker}@if (${condition}) {${lbString}${start}`;
-  const endBlock = `${end}${lbString}}${endMarker}`;
+  const mainBlock = getMainBlock(etm, tmpl, offset);
+  const {start, middle, end} = mainBlock;
+  const blockLb = getBlockLineBreak(mainBlock, lbString);
+  const startBlock = `${startMarker}@if (${condition}) {${blockLb}${start}`;
+  const endBlock = `${end}${blockLb}}${endMarker}`;
 
   const ifBlock = startBlock + middle + endBlock;
   const updatedTmpl = tmpl.slice(0, etm.start(offset)) + ifBlock + tmpl.slice(etm.end(offset));
@@ -186,10 +189,12 @@ function buildIfElseBlock(
 
   const originals = getOriginals(etm, tmpl, offset);
 
-  const {start, middle, end} = getMainBlock(etm, tmpl, offset);
-  const startBlock = `${startMarker}@if (${condition}) {${lbString}${start}`;
+  const mainBlock = getMainBlock(etm, tmpl, offset);
+  const {start, middle, end} = mainBlock;
+  const blockLb = getBlockLineBreak(mainBlock, lbString);
+  const startBlock = `${startMarker}@if (${condition}) {${blockLb}${start}`;
 
-  const elseBlock = `${end}${lbString}} @else {${lbString}`;
+  const elseBlock = `${end}${blockLb}} @else {${lbString}`;
 
   const postBlock = elseBlock + elsePlaceholder + `${lbString}}${endMarker}`;
   const ifElseBlock = startBlock + middle + postBlock;

--- a/packages/core/schematics/ng-generate/control-flow-migration/util.ts
+++ b/packages/core/schematics/ng-generate/control-flow-migration/util.ts
@@ -368,6 +368,29 @@ export function hasLineBreaks(template: string): boolean {
 }
 
 /**
+ * Returns an empty string instead of the given line break when the block content is
+ * plain text from a removed container, to prevent Angular from introducing extra
+ * whitespace. Angular does not strip whitespace around plain text inside control flow blocks.
+ */
+export function getBlockLineBreak(
+  {start, middle, end}: {start: string; middle: string; end: string},
+  lbString: string,
+): string {
+  if (start !== '' || end !== '') return lbString;
+  const stripped = middle
+    .replace(new RegExp(startMarker, 'g'), '')
+    .replace(new RegExp(endMarker, 'g'), '')
+    .replace(new RegExp(startI18nMarker, 'g'), '')
+    .replace(new RegExp(endI18nMarker, 'g'), '')
+    .trim();
+  if (stripped.length === 0) return lbString;
+  const startsWithStructure = stripped.startsWith('<') || stripped.startsWith('@');
+  const endsWithStructure = stripped.endsWith('>') || stripped.endsWith('}');
+  if (startsWithStructure && endsWithStructure) return lbString;
+  return '';
+}
+
+/**
  * properly adjusts template offsets based on current nesting levels
  */
 export function reduceNestingOffset(
@@ -845,6 +868,9 @@ export function formatTemplate(tmpl: string, templateType: string): string {
     // @if | @switch | @case | @default | @for | } @else
     const openBlockRegex = /^\s*\@(if|switch|case|default|for)|^\s*\}\s\@else/;
 
+    // match a control flow block that opens and closes on the same line
+    const singleLineBlockRegex = /\}\s*$/;
+
     // regex for matching an html element opening
     // <div thing="stuff" [binding]="true"> || <div thing="stuff" [binding]="true"
     const openElRegex = /^\s*<([a-z0-9]+)(?![^>]*\/>)[^>]*>?/;
@@ -989,12 +1015,13 @@ export function formatTemplate(tmpl: string, templateType: string): string {
       }
 
       // this matches an open control flow block, an open HTML element, but excludes single line
-      // self closing tags
+      // self closing tags and single line control flow blocks
       if (
         (openBlockRegex.test(line) || openElRegex.test(line)) &&
         !singleLineElRegex.test(line) &&
         !selfClosingRegex.test(line) &&
-        !openSelfClosingRegex.test(line)
+        !openSelfClosingRegex.test(line) &&
+        !(openBlockRegex.test(line) && singleLineBlockRegex.test(line))
       ) {
         // open block, increase indent
         indent += '  ';

--- a/packages/core/schematics/test/control_flow_migration_spec.ts
+++ b/packages/core/schematics/test/control_flow_migration_spec.ts
@@ -498,6 +498,133 @@ describe('control flow migration (ng update)', () => {
       );
     });
 
+    it('should use inline block syntax when ng-container content is text not wrapped in elements', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [`<div>`, `5<ng-container *ngIf="showUnit">pts</ng-container>`, `</div>`].join('\n'),
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([`<div>`, `  5@if (showUnit) {pts}`, `</div>`].join('\n'));
+    });
+
+    it('should preserve newlines when ng-container text content is already multi-line', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [`<div>`, `<ng-container *ngIf="showUnit">`, `  pts`, `</ng-container>`, `</div>`].join(
+          '\n',
+        ),
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe([`<div>`, `  @if (showUnit) {`, `    pts`, `  }`, `</div>`].join('\n'));
+    });
+
+    it('should not use inline block syntax when ng-container content is wrapped in elements', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [`<div>`, `<ng-container *ngIf="showUnit"><span>pts</span></ng-container>`, `</div>`].join(
+          '\n',
+        ),
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe(
+        [`<div>`, `  @if (showUnit) {`, `    <span>pts</span>`, `  }`, `</div>`].join('\n'),
+      );
+    });
+
+    it('should use inline block syntax for if-branch text in an if/else', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgIf} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          show = false;
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [
+          `<div>`,
+          `<ng-container *ngIf="showUnit; else noUnit">pts</ng-container>`,
+          `<ng-template #noUnit><span>no unit</span></ng-template>`,
+          `</div>`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe(
+        [
+          `<div>`,
+          `  @if (showUnit) {pts} @else {`,
+          `    <span>no unit</span>`,
+          `  }`,
+          `</div>`,
+        ].join('\n'),
+      );
+    });
+
     it('should migrate an if case on an empty container', async () => {
       writeFile(
         '/comp.ts',
@@ -1818,6 +1945,39 @@ describe('control flow migration (ng update)', () => {
       );
     });
 
+    it('should use inline block syntax when ng-container ngFor content is text', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgFor} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          items = ['a', 'b'];
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [
+          `<ul>`,
+          `<ng-container *ngFor="let item of items">{{ item }}, </ng-container>`,
+          `</ul>`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const content = tree.readContent('/comp.html');
+
+      expect(content).toBe(
+        [`<ul>`, `  @for (item of items; track item) {{{ item }}, }`, `</ul>`].join('\n'),
+      );
+    });
+
     it('should migrate multiple inline templates in the same file', async () => {
       writeFile(
         '/comp.ts',
@@ -2848,6 +3008,51 @@ describe('control flow migration (ng update)', () => {
       );
     });
 
+    it('should use inline block syntax when switch case content is text', async () => {
+      writeFile(
+        '/comp.ts',
+        `
+        import {Component} from '@angular/core';
+        import {ngSwitch, ngSwitchCase, ngSwitchDefault} from '@angular/common';
+
+        @Component({
+          templateUrl: './comp.html'
+        })
+        class Comp {
+          status = 'active';
+        }
+      `,
+      );
+
+      writeFile(
+        '/comp.html',
+        [
+          `<div [ngSwitch]="status">`,
+          `<ng-container *ngSwitchCase="'active'">Active</ng-container>`,
+          `<ng-container *ngSwitchCase="'inactive'">Inactive</ng-container>`,
+          `<ng-container *ngSwitchDefault><span class="badge">Unknown</span></ng-container>`,
+          `</div>`,
+        ].join('\n'),
+      );
+
+      await runMigration();
+      const actual = tree.readContent('/comp.html');
+
+      const expected = [
+        `<div>`,
+        `  @switch (status) {`,
+        `    @case ('active') {Active}`,
+        `    @case ('inactive') {Inactive}`,
+        `    @default {`,
+        `      <span class="badge">Unknown</span>`,
+        `    }`,
+        `  }`,
+        `</div>`,
+      ].join('\n');
+
+      expect(actual).toBe(expected);
+    });
+
     it('should migrate multiple inline templates in the same file', async () => {
       writeFile(
         '/comp.ts',
@@ -3143,12 +3348,8 @@ describe('control flow migration (ng update)', () => {
       const actual = tree.readContent('/comp.html');
       const expected = [
         `\n@switch (type) {`,
-        `  @case ('foo') {`,
-        `    Foo`,
-        `  }`,
-        `  @case ('bar') {`,
-        `    Bar`,
-        `  }`,
+        `  @case ('foo') { Foo }`,
+        `  @case ('bar') { Bar }`,
         `  @default {`,
         `  }`,
         `}\n`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When migrating `5<ng-container *ngIf="showUnit">pts</ng-container>` to control flow syntax, the schematic produced `5@if (showUnit) {\npts\n}`, introducing extra whitespace that Angular does not strip around plain text inside control flow blocks, rendering as `5 pts` instead of `5pts`.

Issue Number: N/A

## What is the new behavior?

Now, when a removed ng-container/ng-template has content that is not wrapped in HTML elements or control flow blocks (i.e. plain text or interpolation), the block is emitted without surrounding newlines: `5@if (showUnit) {pts}`. This applies to `@if`, `@for`, `@switch`/`@case`, and `@default` blocks. Content that already has newlines in the source is preserved as-is.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Related is the prettier PR to prevent prettier introducing additional whitespace when formatting control flow: https://github.com/prettier/prettier/pull/19020

That PR will only preserve newlines as they are in the source code, so in this specific case it relies on the schematic to output the correct newlines, that the fix in the prettier PR will then preserve