### PR TITLE
refactor(language-service): Avoid deep import of comments helper

### DIFF
--- a/packages/language-service/src/inlay_hints.ts
+++ b/packages/language-service/src/inlay_hints.ts
@@ -54,7 +54,7 @@ import {
   ExpressionSymbol,
 } from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import {TemplateTypeChecker} from '@angular/compiler-cli/src/ngtsc/typecheck/api/checker';
-import {findFirstMatchingNode} from '@angular/compiler-cli/src/ngtsc/typecheck/src/comments';
+import {findFirstMatchingNode} from '@angular/compiler-cli/private/hybrid_analysis';
 import ts from 'typescript';
 
 import {TypeCheckInfo} from './utils';

--- a/packages/language-service/src/references_and_rename_utils.ts
+++ b/packages/language-service/src/references_and_rename_utils.ts
@@ -40,7 +40,7 @@ import {
 import {
   ExpressionIdentifier,
   hasExpressionIdentifier,
-} from '@angular/compiler-cli/src/ngtsc/typecheck/src/comments';
+} from '@angular/compiler-cli/private/hybrid_analysis';
 import ts from 'typescript';
 
 import {getTargetAtPosition, TargetNodeKind} from './template_target';

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -54,7 +54,7 @@ import {
   TmplAstVisitor,
 } from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import {findFirstMatchingNode} from '@angular/compiler-cli/src/ngtsc/typecheck/src/comments';
+import {findFirstMatchingNode} from '@angular/compiler-cli/private/hybrid_analysis';
 import tss from 'typescript';
 
 import {


### PR DESCRIPTION
avoids deep import from compiler-cli that causes issues in some environments
