### PR TITLE
feat(router): handle null and undefined inputs in RouterLinkActive

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -871,10 +871,10 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
     ngOnChanges(changes: SimpleChanges): void;
     ngOnDestroy(): void;
     // (undocumented)
-    set routerLinkActive(data: string[] | string);
+    set routerLinkActive(data: string[] | string | null | undefined);
     routerLinkActiveOptions: {
         exact: boolean;
-    } | Partial<IsActiveMatchOptions>;
+    } | Partial<IsActiveMatchOptions> | null | undefined;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLinkActive, "[routerLinkActive]", ["routerLinkActive"], { "routerLinkActiveOptions": { "alias": "routerLinkActiveOptions"; "required": false; }; "ariaCurrentWhenActive": { "alias": "ariaCurrentWhenActive"; "required": false; }; "routerLinkActive": { "alias": "routerLinkActive"; "required": false; }; }, { "isActiveChange": "isActiveChange"; }, ["links"], never, true, never>;
     // (undocumented)

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -127,11 +127,16 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
    *
    * These options are passed to the `isActive()` function.
    *
+   * When `undefined`, the default subset match behavior is used.
+   * When `null`, the link is never considered active regardless of the current URL.
+   *
    * @see {@link isActive}
    */
-  @Input() routerLinkActiveOptions: {exact: boolean} | Partial<IsActiveMatchOptions> = {
-    exact: false,
-  };
+  @Input() routerLinkActiveOptions:
+    | {exact: boolean}
+    | Partial<IsActiveMatchOptions>
+    | null
+    | undefined = {exact: false};
 
   /**
    * Aria-current attribute to apply when the router link is active.
@@ -201,7 +206,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
 
   @Input()
-  set routerLinkActive(data: string[] | string) {
+  set routerLinkActive(data: string[] | string | null | undefined) {
+    if (data == null) {
+      this.classes = [];
+      return;
+    }
     const classes = Array.isArray(data) ? data : data.split(' ');
     this.classes = classes.filter((c) => !!c);
   }
@@ -218,6 +227,10 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
 
   private update(): void {
     if (!this.links || !this.router.navigated) return;
+    // Short-circuit: null options means "never active". Once _isActive has
+    // settled to false there is nothing for subsequent navigations to do, so
+    // skip even queuing the microtask.
+    if (this.routerLinkActiveOptions === null && !this._isActive) return;
 
     queueMicrotask(() => {
       const hasActiveLinks = this.hasActiveLinks();
@@ -249,14 +262,29 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
 
   private isLinkActive(router: Router): (link: RouterLink) => boolean {
-    const options: Partial<IsActiveMatchOptions> = isActiveMatchOptions(
-      this.routerLinkActiveOptions,
-    )
-      ? this.routerLinkActiveOptions
-      : // While the types should disallow `undefined` here, it's possible without strict inputs
-        (this.routerLinkActiveOptions.exact ?? false)
-        ? {...exactMatchOptions}
-        : {...subsetMatchOptions};
+    const opts = this.routerLinkActiveOptions;
+
+    // null vs undefined are intentionally treated differently:
+    //   undefined — semantically "not set", same as omitting the input entirely,
+    //               so the default subset match applies.
+    //   null      — an explicit opt-out: the caller wants the link to never be
+    //               considered active (e.g. dynamic UI where matching is not desired).
+    if (opts === null) {
+      return () => false;
+    }
+
+    let options: Partial<IsActiveMatchOptions>;
+    if (opts === undefined) {
+      options = {...subsetMatchOptions};
+    } else if (isActiveMatchOptions(opts)) {
+      options = opts;
+    } else if (opts.exact ?? false) {
+      // Note: `exact` can still be undefined with non-strict template type-checking,
+      // hence the nullish coalesce rather than a plain truthiness check.
+      options = {...exactMatchOptions};
+    } else {
+      options = {...subsetMatchOptions};
+    }
 
     return (link: RouterLink) => {
       const urlTree = link.urlTree;

--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -127,11 +127,16 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
    *
    * These options are passed to the `isActive()` function.
    *
+   * When `undefined`, the default subset match behavior is used.
+   * When `null`, the link is never considered active regardless of the current URL.
+   *
    * @see {@link isActive}
    */
-  @Input() routerLinkActiveOptions: {exact: boolean} | Partial<IsActiveMatchOptions> = {
-    exact: false,
-  };
+  @Input() routerLinkActiveOptions:
+    | {exact: boolean}
+    | Partial<IsActiveMatchOptions>
+    | null
+    | undefined = {exact: false};
 
   /**
    * Aria-current attribute to apply when the router link is active.
@@ -201,7 +206,11 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
 
   @Input()
-  set routerLinkActive(data: string[] | string) {
+  set routerLinkActive(data: string[] | string | null | undefined) {
+    if (data == null) {
+      this.classes = [];
+      return;
+    }
     const classes = Array.isArray(data) ? data : data.split(' ');
     this.classes = classes.filter((c) => !!c);
   }
@@ -218,6 +227,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
 
   private update(): void {
     if (!this.links || !this.router.navigated) return;
+    if (this.routerLinkActiveOptions === null && !this._isActive) return;
 
     queueMicrotask(() => {
       const hasActiveLinks = this.hasActiveLinks();
@@ -249,14 +259,29 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
   }
 
   private isLinkActive(router: Router): (link: RouterLink) => boolean {
-    const options: Partial<IsActiveMatchOptions> = isActiveMatchOptions(
-      this.routerLinkActiveOptions,
-    )
-      ? this.routerLinkActiveOptions
-      : // While the types should disallow `undefined` here, it's possible without strict inputs
-        (this.routerLinkActiveOptions.exact ?? false)
-        ? {...exactMatchOptions}
-        : {...subsetMatchOptions};
+    const opts = this.routerLinkActiveOptions;
+
+    // null vs undefined are intentionally treated differently:
+    //   undefined — semantically "not set", same as omitting the input entirely,
+    //               so the default subset match applies.
+    //   null      — an explicit opt-out: the caller wants the link to never be
+    //               considered active (e.g. dynamic UI where matching is not desired).
+    if (opts === null) {
+      return () => false;
+    }
+
+    let options: Partial<IsActiveMatchOptions>;
+    if (opts === undefined) {
+      options = {...subsetMatchOptions};
+    } else if (isActiveMatchOptions(opts)) {
+      options = opts;
+    } else if (opts.exact ?? false) {
+      // Note: `exact` can still be undefined with non-strict template type-checking,
+      // hence the nullish coalesce rather than a plain truthiness check.
+      options = {...exactMatchOptions};
+    } else {
+      options = {...subsetMatchOptions};
+    }
 
     return (link: RouterLink) => {
       const urlTree = link.urlTree;

--- a/packages/router/test/router_link_active.spec.ts
+++ b/packages/router/test/router_link_active.spec.ts
@@ -25,6 +25,72 @@ describe('RouterLinkActive', () => {
     expect(Array.from(fixture.nativeElement.querySelector('a').classList)).toEqual([]);
   });
 
+  it('accepts null for routerLinkActive and applies no classes', async () => {
+    @Component({
+      imports: [RouterLinkActive, RouterLink],
+      template: '<a [routerLinkActive]="null" routerLink="/abc"></a>',
+    })
+    class MyCmp {}
+
+    TestBed.configureTestingModule({providers: [provideRouter([{path: '**', children: []}])]});
+    const fixture = TestBed.createComponent(MyCmp);
+    fixture.autoDetectChanges();
+    await TestBed.inject(Router).navigateByUrl('/abc');
+    await fixture.whenStable();
+    expect(Array.from(fixture.nativeElement.querySelector('a').classList)).toEqual([]);
+  });
+
+  it('accepts undefined for routerLinkActive and applies no classes', async () => {
+    @Component({
+      imports: [RouterLinkActive, RouterLink],
+      template: '<a [routerLinkActive]="undefined" routerLink="/abc"></a>',
+    })
+    class MyCmp {}
+
+    TestBed.configureTestingModule({providers: [provideRouter([{path: '**', children: []}])]});
+    const fixture = TestBed.createComponent(MyCmp);
+    fixture.autoDetectChanges();
+    await TestBed.inject(Router).navigateByUrl('/abc');
+    await fixture.whenStable();
+    expect(Array.from(fixture.nativeElement.querySelector('a').classList)).toEqual([]);
+  });
+
+  it('accepts null for routerLinkActiveOptions and disables active matching', async () => {
+    // null is an explicit opt-out: the link should never be marked active regardless
+    // of the current URL, distinguishing it from undefined which means "use the default".
+    @Component({
+      imports: [RouterLinkActive, RouterLink],
+      template:
+        '<a routerLinkActive="active" [routerLinkActiveOptions]="null" routerLink="/abc"></a>',
+    })
+    class MyCmp {}
+
+    TestBed.configureTestingModule({providers: [provideRouter([{path: '**', children: []}])]});
+    const fixture = TestBed.createComponent(MyCmp);
+    fixture.autoDetectChanges();
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/abc');
+    await fixture.whenStable();
+    expect(Array.from(fixture.nativeElement.querySelector('a').classList)).not.toContain('active');
+  });
+
+  it('accepts undefined for routerLinkActiveOptions and uses default subset match', async () => {
+    @Component({
+      imports: [RouterLinkActive, RouterLink],
+      template:
+        '<a routerLinkActive="active" [routerLinkActiveOptions]="undefined" routerLink="/abc"></a>',
+    })
+    class MyCmp {}
+
+    TestBed.configureTestingModule({providers: [provideRouter([{path: '**', children: []}])]});
+    const fixture = TestBed.createComponent(MyCmp);
+    fixture.autoDetectChanges();
+    const router = TestBed.inject(Router);
+    await router.navigateByUrl('/abc');
+    await fixture.whenStable();
+    expect(Array.from(fixture.nativeElement.querySelector('a').classList)).toContain('active');
+  });
+
   it('supports partial match options', async () => {
     @Component({
       imports: [RouterLinkActive, RouterLink],


### PR DESCRIPTION
Without this change, components that use RouterLinkActive in multiple
contexts (e.g. both a navigation menu and body content) are forced to
branch the template for every conditional input:

```html
  @if (activeClass) {
    <a [routerLink]="href" [routerLinkActive]="activeClass"
       [routerLinkActiveOptions]="activeOptions"
       [ariaCurrentWhenActive]="ariaCurrent">
      <ng-content />
    </a>
  } @else {
    <a [routerLink]="href"><ng-content /></a>
  }
```

Every additional input multiplies the branching, and each @if/@else
injects unwanted comment nodes into the DOM. There is no way to
conditionally attach a directive in Angular templates, making imperative
TypeScript instantiation the only alternative.

Accepting null/undefined collapses this to a single template branch:

```html
  <a [routerLink]="href"
     [routerLinkActive]="activeClass"
     [routerLinkActiveOptions]="activeOptions"
     [ariaCurrentWhenActive]="ariaCurrent">
    <ng-content />
  </a>
```

When activeClass is undefined (e.g. in content areas), the directive
stays mounted but applies no CSS classes. When it is a string (e.g. in
the navigation), normal active-class behavior applies — no branching, no
extra DOM nodes, no TypeScript workarounds.

- `routerLinkActive`: null/undefined now sets an empty class list.

- `routerLinkActiveOptions`: null and undefined are treated differently:
  - undefined → falls back to the default subset match ("not set")
  - null → explicit opt-out, link is never considered active

Closes https://github.com/angular/angular/issues/66233