### PR TITLE
docs(docs-infra): consolidate tab menu margins for phone breakpoint

### DIFF
--- a/adev/src/app/features/home/home.component.scss
+++ b/adev/src/app/features/home/home.component.scss
@@ -278,6 +278,11 @@ section {
     width: fit-content;
     margin: 0 auto 2rem;
 
+    @include mq.for-phone-only {
+      width: auto;
+      margin: 0 0.5rem 1rem;
+    }
+
     .tab-background {
       position: absolute;
       top: 4px;


### PR DESCRIPTION
Replace separate margin-left/margin-right overrides with a single margin shorthand in the phone-only media query, aligning spacing with the base rule and preventing edge collision on small screens.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

https://github.com/angular/angular/pull/68098#issuecomment-4209594523 as we shortly discussed here @JeanMeche @aparzi 

On phone-sized screens, the homepage tab menu (Signals / Control Flow / Deferrable Views / Hydration) uses separate margin-left and margin-right properties that don't align with the base margin shorthand. This causes the menu to collide with the page edges and appear inconsistent with surrounding element spacing.

Issue Number: N/A

## What is the new behavior?

The phone-only media query now uses a single margin shorthand (0 0.5rem 1rem), keeping spacing consistent with the base rule and preventing edge collision on small screens.

Before:
<img width="719" height="663" alt="before" src="https://github.com/user-attachments/assets/803bb33a-948b-48b4-a1e9-b66d69a58812" />

After:
<img width="720" height="632" alt="after" src="https://github.com/user-attachments/assets/1f9c48eb-6b82-4274-bf27-1a451db4278f" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information


