### PR TITLE
build: update rules_angular setup in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -125,14 +125,12 @@ use_repo(rules_ts_ext, **{"npm_typescript": "angular_npm_typescript"})
 
 # TODO: Figure out how to make ng_project update whenever the packages/core::pkg target changes.
 rules_angular = use_extension("@rules_angular//setup:extensions.bzl", "rules_angular")
-
-use_repo_rule("@rules_angular//setup:repositories.bzl", "configurable_deps_repo")(
-    name = "rules_angular_configurable_deps",
-    angular_compiler_cli = "@angular//:node_modules/@angular/compiler-cli",
-    typescript = "@angular//:node_modules/typescript",
+rules_angular.setup(
+    name = "angular_rules_angular_configurable_deps",
+    angular_compiler_cli = "//:node_modules/@angular/compiler-cli",
+    typescript = "//:node_modules/typescript",
 )
-
-override_repo(rules_angular, "rules_angular_configurable_deps")
+use_repo(rules_angular, rules_angular_configurable_deps = "angular_rules_angular_configurable_deps")
 
 register_toolchains(
     "@devinfra//bazel/git-toolchain:git_linux_toolchain",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -561,11 +561,18 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "CNAb5ACgssxjX+VPOt3bTKcvva13LTpWOPE9i6HFzRI=",
+        "usagesDigest": "uIgW7qG/kA4j8SzIbCzYi7B/51sAaC6JJxni7+JQIoI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
+          "angular_rules_angular_configurable_deps": {
+            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
+            "attributes": {
+              "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
+              "typescript": "@@//:node_modules/typescript"
+            }
+          },
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
@@ -576,8 +583,8 @@
           "rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
+              "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
+              "typescript": "@@//:node_modules/typescript"
             }
           }
         },


### PR DESCRIPTION
Migrate from using use_repo_rule and override_repo directly to using the rules_angular.setup module extension for configuring configurable dependencies.