### PR TITLE
refactor(benchmark): use shell: false and quote args in benchmark-compare workflow

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -49,7 +49,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: pnpm benchmarks prepare-for-github-action "$COMMENT_BODY"
 
-      - run: pnpm benchmarks run-compare ${{steps.info.outputs.compareSha}} ${{steps.info.outputs.benchmarkTarget}}
+      - run: pnpm benchmarks run-compare ${{steps.info.outputs.compareSha}} "${{steps.info.outputs.benchmarkTarget}}"
+
         id: benchmark
         name: Running benchmark
 

--- a/scripts/benchmarks/utils.mts
+++ b/scripts/benchmarks/utils.mts
@@ -17,15 +17,20 @@ const scriptDir = path.dirname(url.fileURLToPath(import.meta.url));
 export const projectDir: string = path.join(scriptDir, '../..');
 
 /**
- * Executes the given command, forwarding stdin, stdout and stderr while
- * still capturing stdout in order to return it.
+ * Executes the given command with the provided arguments. Arguments are passed
+ * as a discrete array to the child process, bypassing shell interpretation.
+ * This ensures that special shell characters within arguments are treated as
+ * literal values and cannot be used to inject additional commands.
  */
 export function exec(cmd: string, args: string[] = []): Promise<string> {
   return new Promise((resolve, reject) => {
     Log.info('Running command:', cmd, args.join(' '));
 
     const proc = childProcess.spawn(cmd, args, {
-      shell: true,
+      // Do not use a shell to spawn the process. This ensures that arguments
+      // are passed directly to the executable without shell interpretation,
+      // preventing injection via shell metacharacters.
+      shell: false,
       cwd: projectDir,
       // Only capture `stdout`. Forward the rest to the parent TTY.
       stdio: ['inherit', 'pipe', 'inherit'],


### PR DESCRIPTION
Currently, the exec() utility in scripts/benchmarks/utils.mts uses childProcess.spawn() with shell: true. This causes the OS shell to interpret the entire command string, including any arguments, so that special characters within an argument value could alter the intended behavior of the command.

This commit changes the spawn option to shell: false (the Node.js default). With this setting, cmd and args are passed directly to the OS, so each argument is treated as a literal string. Special characters within argument values are not interpreted by any shell.

Additionally, the benchmarkTarget step output in .github/workflows/benchmark-compare.yml is now quoted to prevent unintended word-splitting in the shell run step.

Files changed:
- scripts/benchmarks/utils.mts: Changed shell: true to shell: false, updated JSDoc.
- - .github/workflows/benchmark-compare.yml: Quoted the benchmarkTarget output variable.