### PR TITLE
fix(core): prevent dangling prevConsumer reference from leaking destroyed views

### DIFF
--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -266,7 +266,11 @@ export function producerAccessed(node: ReactiveNode): void {
     // instead of eagerly destroying the previous link, we delay until we've finished recomputing
     // the producers list, so that we can destroy all of the old links at once.
     nextProducer: nextProducerLink,
-    prevConsumer: prevConsumerLink,
+    // Don't set prevConsumer here — it's only meaningful when the link is part of
+    // the producer's consumer list. producerAddLiveConsumer sets it correctly when
+    // the link is actually inserted. Setting it eagerly would create a dangling
+    // reference into the consumer list that prevents GC of removed entries.
+    prevConsumer: undefined,
     lastReadVersion: node.version,
     nextConsumer: undefined,
   };

--- a/packages/core/test/signals/BUILD.bazel
+++ b/packages/core/test/signals/BUILD.bazel
@@ -12,6 +12,7 @@ ts_project(
         "//packages/core",
         "//packages/core/primitives/signals",
         "//packages/core/src/util",
+        "//packages/private/testing",
     ],
 )
 
@@ -20,6 +21,7 @@ jasmine_test(
     data = [
         ":signals_lib",
     ],
+    node_options = ["--expose-gc"],
 )
 
 ng_web_test_suite(

--- a/packages/core/test/signals/signal_graph_leak_spec.ts
+++ b/packages/core/test/signals/signal_graph_leak_spec.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {computed, signal, WritableSignal} from '../../src/core';
+import {ReactiveNode, SIGNAL} from '../../primitives/signals';
+import {isBrowser, timeout} from '@angular/private/testing';
+
+import {flushEffects, resetEffects, testingEffect} from './effect_util';
+
+describe('signal graph: destroyed consumers should be GC-eligible', () => {
+  if (isBrowser) {
+    it('should pass', () => {});
+    return;
+  }
+
+  afterEach(() => {
+    resetEffects();
+  });
+
+  function setupAndReturnRef(source: WritableSignal<number>): WeakRef<object> {
+    const destroyEffect = testingEffect(() => source());
+    flushEffects();
+
+    const sourceNode = source[SIGNAL] as ReactiveNode;
+    let watchNode;
+    let link = (sourceNode as any).consumers;
+    while (link !== undefined) {
+      watchNode = link.consumer;
+      link = link.nextConsumer;
+    }
+    const ref = new WeakRef(watchNode!);
+
+    // Non-live computed that also reads source.
+    const derived = computed(() => source() + 1);
+    derived();
+
+    // Clearing the graph edges.
+    destroyEffect();
+
+    return ref;
+  }
+
+  it('should GC a destroyed effect when a non-live computed reads the same producer', async () => {
+    const source = signal(0);
+    const ref = setupAndReturnRef(source);
+
+    (globalThis as any).gc();
+    await timeout();
+    (globalThis as any).gc();
+
+    expect(ref.deref()).toBeUndefined();
+  });
+
+  it('should GC destroyed effects across repeated create/destroy cycles', async () => {
+    const source = signal(0);
+    const derived = computed(() => source() + 1);
+    derived();
+
+    const refs: WeakRef<object>[] = [];
+    for (let i = 0; i < 5; i++) {
+      refs.push(setupAndReturnRef(source));
+    }
+
+    (globalThis as any).gc();
+    await timeout();
+    (globalThis as any).gc();
+
+    for (let i = 0; i < refs.length; i++) {
+      expect(refs[i].deref()).withContext(`cycle ${i}`).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## What is the current behavior?

When `producerAccessed` creates a new `ReactiveLink` for a non-live consumer (e.g. a `computed` signal that has no readers yet), it eagerly sets `prevConsumer` to the producer's current `consumersTail`:

```ts
const prevConsumerLink = node.consumersTail;
// ...
const newLink = {
  // ...
  prevConsumer: prevConsumerLink,  // captures a pointer INTO the consumer list
};
// ...
if (isLive) {
  producerAddLiveConsumer(node, newLink);  // only called when live
}
```

Because the consumer is not live, `producerAddLiveConsumer` is skipped and the link is never inserted into the producer's consumer doubly-linked list. But `prevConsumer` already holds a reference to a node *inside* that list.

When that referenced node is later removed from the consumer list via `producerRemoveLiveConsumerLink`, the doubly-linked list is correctly patched — but the dangling `prevConsumer` on the non-live link is *not* patched, because the non-live link isn't part of the list and isn't traversable from it.

The removed link, and everything it retains, is kept alive indefinitely by this dangling reference.

## How I found it

I was investigating a memory leak in a large Angular app (~1.5GB heap, other leaks going on too from our side!). After navigating away from a page, 3.3 MB of detached DOM (53+ `cu-data-view-item` elements, their parent `DataViewListComponent`, `ViewsBarComponent`, `ViewBlockComponent`, etc.) remained alive.

Using heap snapshot retainer analysis, I traced the single retention path:

```
GC Root
  → Window.logNgrxState (closure)
    → NgZoneStoreService2.store
      → R3Injector.records (Map)
        → AttachmentApiV1Service [providedIn: 'root']
          → urls (computed signal)
            → SIGNAL node [producers linked list]
              → producer link @9563675 (edge: computed reads environmentSignal)
                → prevConsumer → @11501677 (STALE — destroyed view's consumer link)
                  → consumer → ReactiveLViewConsumer @20250859 (destroyed)
                    → view → LView (3.3 MB retained)
                      → ViewsBarComponent → ViewBlockComponent
                        → DataViewListComponent → 53+ detached DOM elements
```

<img width="2936" height="1958" alt="image" src="https://github.com/user-attachments/assets/6702100d-4295-406d-9188-85df49cb04b6" />

<img width="3340" height="1956" alt="image" src="https://github.com/user-attachments/assets/19e976c0-4d1b-4b68-9701-475bce156e4c" />


The key evidence from the heap:

- The `ReactiveLViewConsumer`'s own `producers` and `producersTail` are both `undefined` — confirming `consumerDestroy` ran and cleaned up the consumer side.
- But the producer link for the `urls` computed (`@9563675`) still has `prevConsumer` pointing to the stale consumer link (`@11501677`), because the link was never part of the consumer list and was never patched during removal.
- Cutting `AttachmentApiV1Service` alone eliminated **all** paths to GC roots (both JS and C++ InternalNode paths), confirming this is the sole retention mechanism.
- The `environmentSignal`'s own active consumer list (`consumers`/`consumersTail`) was correctly updated — the stale entry was removed from the active list. Only the dangling `prevConsumer` on the adjacent non-live link kept it alive.

## What is the fix?

Initialize `prevConsumer` to `undefined` at link creation time instead of eagerly capturing `node.consumersTail`.

This is safe because `producerAddLiveConsumer` unconditionally sets `link.prevConsumer = consumersTail` when the link is actually inserted into the consumer list. The value set in `producerAccessed` was always overwritten for live consumers, so it only ever mattered for non-live consumers — where it was always wrong (a dangling pointer into a list the link doesn't belong to).

## Does this PR introduce a breaking change?

No. The `prevConsumer` field set in `producerAccessed` was dead-on-arrival for live consumers (overwritten by `producerAddLiveConsumer`) and incorrect for non-live consumers (dangling reference). No code path reads `prevConsumer` on a link that hasn't been inserted via `producerAddLiveConsumer`.

I checked the PR where this was added, and it doesn't seem to be commented on that this reference could retain. https://github.com/angular/angular/pull/62284/changes#diff-f1832f2d695da63c1470248ac2005fb2b57549086f0bedf6bc6db00b54bc17f0R260

Noting that I have applied this patch to our internal repo and tested it - the leak is resolved and signals from the root service appear to be functioning correctly.