### PR TITLE
fix(platform-server): escape appId in event replay script to prevent XSS

### DIFF
--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -158,12 +158,15 @@ function insertEventRecordScript(
   // Note: this is only true when build with the CLI tooling, which inserts the script in the HTML
   if (eventDispatchScript) {
     // This is defined in packages/core/primitives/event-dispatch/contract_binary.ts
+    // Escape appId to prevent script injection (e.g. via </script> breakout).
+    // This matches the escaping used in TransferState.toJson().
+    const escapedAppId = JSON.stringify(appId).replace(/</g, '\\u003C');
     const replayScriptContents =
       `window.__jsaction_bootstrap(` +
       `document.body,` +
-      `"${appId}",` +
-      `${JSON.stringify(Array.from(regular))},` +
-      `${JSON.stringify(Array.from(capture))}` +
+      `${escapedAppId},` +
+      `${JSON.stringify(Array.from(regular)).replace(/</g, '\\u003C')},` +
+      `${JSON.stringify(Array.from(capture)).replace(/</g, '\\u003C')}` +
       `);`;
 
     const replayScript = createScript(doc, replayScriptContents, nonce);


### PR DESCRIPTION
## Description

`insertEventRecordScript` in `packages/platform-server/src/utils.ts` interpolates `appId` directly into a `<script>` tag without any escaping:

```typescript
`"${appId}",`
```

If `appId` contains characters like `</script>`, this allows script tag breakout and cross-site scripting in SSR-rendered pages. The `validAppIdInitializer` regex check only runs in dev mode (`ngDevMode`) and is tree-shaken out of production builds, so there is no runtime protection.

## Fix

Apply the same `JSON.stringify()` + `\u003C` escaping pattern already used by `TransferState.toJson()` (in `packages/core/src/transfer_state.ts:145`):

```typescript
const escapedAppId = JSON.stringify(appId).replace(/</g, '\\u003C');
```

This ensures:
- Quotes and special characters inside `appId` are properly escaped by `JSON.stringify`
- `<` characters are encoded as `\u003C` to prevent `</script>` breakout (matching the existing G3 script_builders convention)

Also applied the same `<` escaping to the serialized event type arrays for consistency.

## Inconsistency addressed

| Location | Data | Escaping |
|----------|------|----------|
| `transfer_state.ts:145` | TransferState store | `JSON.stringify().replace(/</g, '\\u003C')` |
| `utils.ts:254` | SERVER_CONTEXT | `replace(/[^a-zA-Z0-9\-]/g, '')` whitelist |
| `utils.ts:164` | **appId** | **None** (this PR fixes it) |