### PR TITLE
fix(compiler-cli): animation events not type checked properly when bound through HostListener decorator

### DIFF
--- a/packages/compiler-cli/private/hybrid_analysis.ts
+++ b/packages/compiler-cli/private/hybrid_analysis.ts
@@ -21,7 +21,7 @@ export {
   type OutOfBandDiagnosticRecorder,
   type DomSchemaChecker,
   type SymbolReference,
-  OutOfBadDiagnosticCategory,
+  OutOfBandDiagnosticCategory,
   SymbolKind,
 } from '../src/ngtsc/typecheck/api';
 export {RegistryDomSchemaChecker} from '../src/ngtsc/typecheck/src/dom';

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/oob.ts
@@ -32,7 +32,7 @@ import {
 import {TcbDirectiveMetadata, TypeCheckId} from './api';
 
 /** Categories of diagnostics that can be reported by a `OutOfBandDiagnosticRecorder`. */
-export enum OutOfBadDiagnosticCategory {
+export enum OutOfBandDiagnosticCategory {
   Error,
   Warning,
 }
@@ -151,7 +151,7 @@ export interface OutOfBandDiagnosticRecorder<T> {
    */
   controlFlowPreventingContentProjection(
     id: TypeCheckId,
-    category: OutOfBadDiagnosticCategory,
+    category: OutOfBandDiagnosticCategory,
     projectionNode: TmplAstElement | TmplAstTemplate,
     componentName: string,
     slotSelector: string,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/host_bindings.ts
@@ -416,7 +416,9 @@ function createNodeFromListenerDecorator(
     target = null;
   } else {
     const parsedName = parser.parseEventListenerName(eventNameNode.text);
-    type = ParsedEventType.Regular;
+    type = parsedName.eventName.startsWith('animate.')
+      ? ParsedEventType.Animation
+      : ParsedEventType.Regular;
     eventName = parsedName.eventName;
     target = parsedName.target;
     phase = null;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -35,7 +35,7 @@ import ts from 'typescript';
 
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
 import {
-  OutOfBadDiagnosticCategory,
+  OutOfBandDiagnosticCategory,
   OutOfBandDiagnosticRecorder,
   TcbDirectiveMetadata,
   TemplateDiagnostic,
@@ -422,7 +422,7 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
 
   controlFlowPreventingContentProjection(
     id: TypeCheckId,
-    category: OutOfBadDiagnosticCategory,
+    category: OutOfBandDiagnosticCategory,
     projectionNode: TmplAstElement | TmplAstTemplate,
     componentName: string,
     slotSelector: string,
@@ -727,11 +727,11 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
   }
 }
 
-function translateCategory(category: OutOfBadDiagnosticCategory): ts.DiagnosticCategory {
+function translateCategory(category: OutOfBandDiagnosticCategory): ts.DiagnosticCategory {
   switch (category) {
-    case OutOfBadDiagnosticCategory.Error:
+    case OutOfBandDiagnosticCategory.Error:
       return ts.DiagnosticCategory.Error;
-    case OutOfBadDiagnosticCategory.Warning:
+    case OutOfBandDiagnosticCategory.Warning:
       return ts.DiagnosticCategory.Warning;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ops/content_projection.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ops/content_projection.ts
@@ -24,7 +24,7 @@ import {
 } from '@angular/compiler';
 import {TcbOp} from './base';
 import {Context} from './context';
-import {OutOfBadDiagnosticCategory} from '../../api';
+import {OutOfBandDiagnosticCategory} from '../../api';
 
 /**
  * A `TcbOp` that finds and flags control flow nodes that interfere with content projection.
@@ -39,7 +39,7 @@ import {OutOfBadDiagnosticCategory} from '../../api';
  * flow node didn't exist.
  */
 export class TcbControlFlowContentProjectionOp extends TcbOp {
-  private readonly category: OutOfBadDiagnosticCategory;
+  private readonly category: OutOfBandDiagnosticCategory;
 
   constructor(
     private tcb: Context,
@@ -53,8 +53,8 @@ export class TcbControlFlowContentProjectionOp extends TcbOp {
     // this check won't be enabled for `suppress`.
     this.category =
       tcb.env.config.controlFlowPreventingContentProjection === 'error'
-        ? OutOfBadDiagnosticCategory.Error
-        : OutOfBadDiagnosticCategory.Warning;
+        ? OutOfBandDiagnosticCategory.Error
+        : OutOfBandDiagnosticCategory.Warning;
   }
 
   override readonly optional = false;

--- a/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_bindings_type_check_spec.ts
@@ -278,7 +278,7 @@ runInEachFileSystem(() => {
       expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
     });
 
-    it('should check host animation event listeners', () => {
+    it('should check legacy host animation event listeners', () => {
       env.write(
         'test.ts',
         `
@@ -299,6 +299,56 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(1);
       expect(diags[0].messageText).toBe(`Expected 1 arguments, but got 0.`);
       expect(getDiagnosticSourceCode(diags[0])).toBe('handleEvent');
+    });
+
+    it('should check animation event listeners in `host` object', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'button[foo]',
+          host: {'(animate.leave)': 'handleEvent($event)'},
+        })
+        export class Comp {
+          handleEvent(event: Event) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toContain(
+        `Argument of type 'AnimationCallbackEvent' is not assignable to parameter of type 'Event'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
+    });
+
+    it('should check animation event listeners in `@HostListener`', () => {
+      env.write(
+        'test.ts',
+        `
+        import {Component, HostListener} from '@angular/core';
+
+        @Component({
+          template: '',
+          selector: 'button[foo]',
+        })
+        export class Comp {
+          @HostListener('animate.leave', ['$event'])
+          handleEvent(event: Event) {}
+        }
+      `,
+      );
+
+      const diags = env.driveDiagnostics();
+      expect(diags.length).toBe(1);
+      expect((diags[0].messageText as ts.DiagnosticMessageChain).messageText).toContain(
+        `Argument of type 'AnimationCallbackEvent' is not assignable to parameter of type 'Event'.`,
+      );
+      expect(getDiagnosticSourceCode(diags[0])).toBe('$event');
     });
 
     it('should not leak @let from the template into the host bindings', () => {


### PR DESCRIPTION
Fixes that we weren't inferring the type of `animate.` event correctly, if they're bound through a `@HostListener` decorator.