### PR TITLE
fix(router): prevent memory leak in RouterScroller scroll position store

### DIFF
--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -69,6 +69,16 @@ export class RouterScroller implements OnDestroy {
       if (e instanceof NavigationStart) {
         // store the scroll position of the current stable navigations.
         this.store[this.lastId] = this.viewportScroller.getScrollPosition();
+        // Evict the oldest entry once the store exceeds the browser's session history
+        // limit. Chromium/Blink enforces a hard cap of 50 entries via
+        // kMaxSessionHistoryEntries (third_party/blink/public/common/history/
+        // session_history_constants.h), pruning in NavigationControllerImpl::
+        // PruneOldestSkippableEntryIfFull(). Entries beyond that can never be
+        // restored via popstate, so keeping them would be a memory leak.
+        const keys = Object.keys(this.store);
+        if (keys.length > 50) {
+          delete this.store[Math.min(...keys.map(Number))];
+        }
         this.lastSource = e.navigationTrigger;
         this.restoredId = e.restoredState ? e.restoredState.navigationId : 0;
       } else if (e instanceof NavigationEnd) {


### PR DESCRIPTION
The `store` map in `RouterScroller` accumulates scroll positions keyed by navigation ID, which increments indefinitely. Entries were never evicted, causing unbounded memory growth over the lifetime of the application.

Scroll positions are only ever read on popstate events, meaning only entries corresponding to current browser history stack entries are useful. Chromium/Blink enforces a hard cap of 50 history entries via `kMaxSessionHistoryEntries`, pruning via
`NavigationControllerImpl::PruneOldestSkippableEntryIfFull()`. Entries beyond that limit can never be restored via popstate.

The fix evicts the oldest entry (smallest navigation ID) whenever the store exceeds 50 entries, bounding memory usage to a constant size.

Closes #51120