### PR TITLE
docs(docs-infra): add external links to W3C specs in Angular Aria overview

### DIFF
--- a/adev/src/content/guide/aria/overview.md
+++ b/adev/src/content/guide/aria/overview.md
@@ -3,9 +3,9 @@
 
 ## What is Angular Aria?
 
-Building accessible components seems straightforward, but implementing them according to the W3C Accessibility Guidelines requires significant effort and accessibility expertise.
+Building accessible components seems straightforward, but implementing them according to the [W3C Accessibility Guidelines](https://www.w3.org/TR/wcag/) requires significant effort and accessibility expertise.
 
-Angular Aria is a collection of headless, accessible directives that implement common WAI-ARIA patterns. The directives handle keyboard interactions, ARIA attributes, focus management, and screen reader support. All you have to do is provide the HTML structure, CSS styling, and business logic!
+Angular Aria is a collection of headless, accessible directives that implement common [WAI-ARIA patterns](https://www.w3.org/WAI/ARIA/apg/patterns/). The directives handle keyboard interactions, ARIA attributes, focus management, and screen reader support. All you have to do is provide the HTML structure, CSS styling, and business logic!
 
 ## Installation
 


### PR DESCRIPTION
docs(docs-infra): add external links to W3C specs in Angular Aria overview

Link "W3C Accessibility Guidelines" to WCAG 2.2 and "WAI-ARIA patterns" to the W3C APG patterns page, giving readers direct access to the referenced specifications.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

"W3C Accessibility Guidelines" and "WAI-ARIA patterns" in the Angular Aria overview page are plain text with no links to the actual specs.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #68143 

## What is the new behavior?

Both terms now link to their respective W3C pages (WCAG 2.2 and APG patterns).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
