### PR TITLE
fix(router): skip scroll-to-top on initial navigation when hydrating

### DIFF
--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -7,7 +7,15 @@
  */
 
 import {ViewportScroller} from '@angular/common';
-import {inject, Injectable, InjectionToken, NgZone, OnDestroy, untracked} from '@angular/core';
+import {
+  inject,
+  Injectable,
+  InjectionToken,
+  NgZone,
+  OnDestroy,
+  untracked,
+  ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED,
+} from '@angular/core';
 import {Unsubscribable} from 'rxjs';
 
 import {
@@ -35,6 +43,9 @@ export class RouterScroller implements OnDestroy {
   private lastSource: NavigationTrigger | undefined = IMPERATIVE_NAVIGATION;
   private restoredId = 0;
   private store: {[key: string]: [number, number]} = {};
+  private initialNavigationConsumed = false;
+
+  private readonly isHydrating = inject(IS_HYDRATION_DOM_REUSE_ENABLED, {optional: true}) ?? false;
 
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly zone = inject(NgZone);
@@ -101,8 +112,13 @@ export class RouterScroller implements OnDestroy {
         if (e.anchor && this.options.anchorScrolling === 'enabled') {
           this.viewportScroller.scrollToAnchor(e.anchor);
         } else if (this.options.scrollPositionRestoration !== 'disabled') {
-          this.viewportScroller.scrollToPosition([0, 0]);
+          // skip scrolling to top on the initial navigation when hydrating—the
+          // user may have already scrolled on the SSR-rendered page.
+          if (!this.isHydrating || this.initialNavigationConsumed) {
+            this.viewportScroller.scrollToPosition([0, 0]);
+          }
         }
+        this.initialNavigationConsumed = true;
       }
     });
   }

--- a/packages/router/test/router_scroller.spec.ts
+++ b/packages/router/test/router_scroller.spec.ts
@@ -21,7 +21,10 @@ import {filter, switchMap, take} from 'rxjs/operators';
 
 import {PrivateRouterEvents, Scroll} from '../src/events';
 import {ROUTER_SCROLLER, RouterScroller} from '../src/router_scroller';
-import {ɵWritable as Writable} from '@angular/core';
+import {
+  ɵWritable as Writable,
+  ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED,
+} from '@angular/core';
 import {ViewportScroller} from '@angular/common';
 import {NavigationTransitions} from '../src/navigation_transition';
 import {timeout} from '@angular/private/testing';
@@ -151,6 +154,56 @@ describe('RouterScroller', () => {
     });
   });
 
+  describe('SSR hydration', () => {
+    it('should not scroll to top on initial navigation when hydrating', async () => {
+      const {events, viewportScroller} = createRouterScroller(
+        {scrollPositionRestoration: 'enabled', anchorScrolling: 'disabled'},
+        [{provide: IS_HYDRATION_DOM_REUSE_ENABLED, useValue: true}],
+      );
+
+      // Simulate the initial navigation that happens during SSR hydration.
+      // The user may have already scrolled down on the server-rendered page,
+      // so the scroller must not reset the position to [0, 0].
+      events.next(new NavigationStart(1, '/a'));
+      events.next(new NavigationEnd(1, '/a', '/a'));
+      await nextScrollEvent(events);
+
+      expect(viewportScroller.scrollToPosition).not.toHaveBeenCalledWith([0, 0]);
+    });
+
+    it('should not scroll to top on initial navigation when hydrating (top mode)', async () => {
+      const {events, viewportScroller} = createRouterScroller(
+        {scrollPositionRestoration: 'top', anchorScrolling: 'disabled'},
+        [{provide: IS_HYDRATION_DOM_REUSE_ENABLED, useValue: true}],
+      );
+
+      events.next(new NavigationStart(1, '/a'));
+      events.next(new NavigationEnd(1, '/a', '/a'));
+      await nextScrollEvent(events);
+
+      expect(viewportScroller.scrollToPosition).not.toHaveBeenCalledWith([0, 0]);
+    });
+
+    it('should scroll to top on subsequent navigations after hydration', async () => {
+      const {events, viewportScroller} = createRouterScroller(
+        {scrollPositionRestoration: 'top', anchorScrolling: 'disabled'},
+        [{provide: IS_HYDRATION_DOM_REUSE_ENABLED, useValue: true}],
+      );
+
+      // Skip the initial navigation
+      events.next(new NavigationStart(1, '/a'));
+      events.next(new NavigationEnd(1, '/a', '/a'));
+      await nextScrollEvent(events);
+
+      // A subsequent navigation should still scroll to top as normal
+      events.next(new NavigationStart(2, '/b'));
+      events.next(new NavigationEnd(2, '/b', '/b'));
+      await nextScrollEvent(events);
+
+      expect(viewportScroller.scrollToPosition).toHaveBeenCalledWith([0, 0]);
+    });
+  });
+
   describe('extending a scroll service', () => {
     it('work', async () => {
       const {events, viewportScroller} = createRouterScroller({
@@ -262,13 +315,20 @@ describe('RouterScroller', () => {
   });
 });
 
-function createRouterScroller({
-  scrollPositionRestoration,
-  anchorScrolling,
-}: {
-  scrollPositionRestoration: 'disabled' | 'enabled' | 'top';
-  anchorScrolling: 'disabled' | 'enabled';
-}) {
+function createRouterScroller(
+  {
+    scrollPositionRestoration,
+    anchorScrolling,
+  }: {
+    scrollPositionRestoration: 'disabled' | 'enabled' | 'top';
+    anchorScrolling: 'disabled' | 'enabled';
+  },
+  extraProviders: any[] = [],
+) {
+  if (extraProviders.length > 0) {
+    TestBed.configureTestingModule({providers: extraProviders});
+  }
+
   const events = new Subject<Event | PrivateRouterEvents>();
   (TestBed.inject(NavigationTransitions) as Writable<NavigationTransitions>).events = events;
 


### PR DESCRIPTION
When scrollPositionRestoration is enabled and the app hydrates an SSR-rendered page, RouterScroller was unconditionally scrolling the viewport to [0, 0] on the first imperative navigation. This discards any scroll position the user established while the server-rendered page was loading.

Fix by injecting IS_HYDRATION_DOM_REUSE_ENABLED into RouterScroller and suppressing the scroll-to-top for the initial navigation only. Subsequent navigations are unaffected.

Closes #64578