### PR TITLE
refactor(core): extend signature of `createComponent`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -431,7 +431,7 @@ export interface ContentChildrenDecorator {
 // @public
 export function createComponent<C>(component: Type<C>, options: {
     environmentInjector: EnvironmentInjector;
-    hostElement?: Element;
+    hostElement?: Element | string;
     elementInjector?: Injector;
     projectableNodes?: Node[][];
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -62,7 +62,7 @@ import {assertComponentDef} from './errors';
  * @param component Component class reference.
  * @param options Set of options to use:
  *  * `environmentInjector`: An `EnvironmentInjector` instance to be used for the component.
- *  * `hostElement` (optional): A DOM node that should act as a host node for the component. If not
+ *  * `hostElement` (optional): A DOM node (or its selector) that should act as a host node for the component. If not
  * provided, Angular creates one based on the tag name used in the component selector (and falls
  * back to using `div` if selector doesn't have tag name info).
  *  * `elementInjector` (optional): An `ElementInjector` instance, see additional info about it
@@ -85,7 +85,7 @@ export function createComponent<C>(
   component: Type<C>,
   options: {
     environmentInjector: EnvironmentInjector;
-    hostElement?: Element;
+    hostElement?: Element | string;
     elementInjector?: Injector;
     projectableNodes?: Node[][];
     directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];

--- a/packages/core/test/acceptance/create_component_spec.ts
+++ b/packages/core/test/acceptance/create_component_spec.ts
@@ -12,6 +12,7 @@ import {
   createComponent,
   createEnvironmentInjector,
   Directive,
+  DOCUMENT,
   ElementRef,
   EmbeddedViewRef,
   EnvironmentInjector,
@@ -93,6 +94,36 @@ describe('createComponent', () => {
     componentRef.instance.name = 'ZoneJS';
     componentRef.changeDetectorRef.detectChanges();
     expect(hostElement.textContent).toBe('Hello ZoneJS!');
+  });
+
+  it('should create an instance of a component with a string selector', () => {
+    const selector = '#container';
+    @Component({
+      template: 'Hello {{name()}}!',
+    })
+    class StandaloneComponent {
+      name = signal('Angular');
+    }
+
+    const document = TestBed.inject(DOCUMENT);
+    const hostElement = document.createElement('div');
+    hostElement.setAttribute('id', 'container');
+    document.body.appendChild(hostElement);
+
+    const environmentInjector = TestBed.inject(EnvironmentInjector);
+    const componentRef = createComponent(StandaloneComponent, {
+      hostElement: selector,
+      environmentInjector,
+    });
+
+    componentRef.changeDetectorRef.detectChanges();
+    expect(hostElement.textContent).toBe('Hello Angular!');
+
+    // Verify basic change detection works.
+    componentRef.instance.name.set('ZoneJS');
+    componentRef.changeDetectorRef.detectChanges();
+    expect(hostElement.textContent).toBe('Hello ZoneJS!');
+    componentRef.destroy();
   });
 
   it('should render projected content', () => {


### PR DESCRIPTION
This is only a signature change, the function already supported a string selector.
