### PR TITLE
docs(docs-infra): adjust close button spacing in mobile navigation

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -293,6 +293,8 @@
 
   @include mq.for-phone-only {
     display: block;
+    position: relative;
+    top: 1rem;
   }
 }
 


### PR DESCRIPTION
Use relative positioning to offset the close button from the top edge without affecting the layout of surrounding elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On mobile, the close button in the navigation panel sits too close to the top edge, making it look visually off.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The close button is offset from the top edge using relative positioning, improving visual spacing without affecting the layout of surrounding elements.

Before vs After
<img width="348" height="834" alt="Before-After" src="https://github.com/user-attachments/assets/9b7cdd25-281f-4a36-ba7c-9166c0bd5aa4" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
