### PR TITLE
fix(platform-server): prevent SSRF bypasses via protocol-relative and backslash URLs

### DIFF
--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -30,16 +30,66 @@ function parseUrl(
   hash: string;
   href: string;
 } {
-  const {hostname, protocol, port, pathname, search, hash, href} = new URL(urlStr, origin);
+  let isAbsolute = false;
+  try {
+    new URL(urlStr);
+    isAbsolute = true;
+  } catch {}
+
+  const parsedUrl = new URL(urlStr, origin);
+
+  // Security: if the input is not an absolute URL (i.e. it is relative),
+  // ensure it cannot override the origin's hostname, protocol, or port.
+  // This prevents SSRF via protocol-relative URLs (//evil.com) and
+  // backslash bypass URLs (/\evil.com) which the WHATWG URL parser
+  // normalizes into authority-changing URLs.
+  if (!isAbsolute) {
+    let originUrl: URL;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      // If origin itself is not a valid URL (e.g. 'undefined://'),
+      // fall through and return parsed values as-is since the
+      // interceptor's protocol check will reject non-http protocols.
+      return {
+        hostname: parsedUrl.hostname,
+        href: parsedUrl.href,
+        protocol: parsedUrl.protocol,
+        port: parsedUrl.port,
+        pathname: parsedUrl.pathname,
+        search: parsedUrl.search,
+        hash: parsedUrl.hash,
+      };
+    }
+
+    if (
+      parsedUrl.hostname !== originUrl.hostname ||
+      parsedUrl.protocol !== originUrl.protocol ||
+      parsedUrl.port !== originUrl.port
+    ) {
+      // Neutralize the hostname override: keep only the path components
+      // from the user input but use the origin's host identity.
+      const safeUrl = new URL(parsedUrl.pathname + parsedUrl.search + parsedUrl.hash, origin);
+      return {
+        hostname: safeUrl.hostname,
+        href: safeUrl.href,
+        protocol: safeUrl.protocol,
+        port: safeUrl.port,
+        pathname: safeUrl.pathname,
+        search: safeUrl.search,
+        hash: safeUrl.hash,
+      };
+    }
+  }
 
   return {
-    hostname,
-    href,
-    protocol,
-    port,
-    pathname,
-    search,
-    hash,
+    hostname: parsedUrl.hostname,
+    href: parsedUrl.href,
+    protocol: parsedUrl.protocol,
+    port: parsedUrl.port,
+    pathname: parsedUrl.pathname,
+    search: parsedUrl.search,
+    hash: parsedUrl.hash,
   };
 }
 

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -225,5 +225,73 @@ import {bootstrapApplication} from '@angular/platform-browser';
         location.pushState(null, 'Test', '/foo#bar');
       });
     });
+
+    it('neutralizes protocol-relative URL hostname hijack attempts', async () => {
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '<app></app>',
+            url: '//attacker.com/deep/path',
+          },
+        },
+      ]);
+
+      const appRef = await bootstrapApplication(
+        LocationApp,
+        {
+          providers: [
+            {
+              provide: INITIAL_CONFIG,
+              useValue: {
+                document: '<app></app>',
+                url: '//attacker.com/deep/path',
+              },
+            },
+          ],
+        },
+        {platformRef: platform},
+      );
+
+      const location = appRef.injector.get(PlatformLocation);
+      // The hostname must NOT be 'attacker.com' — the SSRF must be neutralized.
+      expect(location.hostname).not.toBe('attacker.com');
+      // The pathname should still reflect the requested path.
+      expect(location.pathname).toBe('/deep/path');
+      platform.destroy();
+    });
+
+    it('neutralizes backslash-based URL hostname hijack attempts', async () => {
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '<app></app>',
+            url: '/\\attacker.com/deep/path',
+          },
+        },
+      ]);
+
+      const appRef = await bootstrapApplication(
+        LocationApp,
+        {
+          providers: [
+            {
+              provide: INITIAL_CONFIG,
+              useValue: {
+                document: '<app></app>',
+                url: '/\\attacker.com/deep/path',
+              },
+            },
+          ],
+        },
+        {platformRef: platform},
+      );
+
+      const location = appRef.injector.get(PlatformLocation);
+      // The hostname must NOT be 'attacker.com' — the SSRF must be neutralized.
+      expect(location.hostname).not.toBe('attacker.com');
+      platform.destroy();
+    });
   });
 })();


### PR DESCRIPTION
## Description

The `parseUrl` function in `ServerPlatformLocation` uses `new URL(urlStr, origin)` to parse incoming request URLs during SSR. Per the WHATWG URL specification, protocol-relative URLs (`//evil.com`) and backslash-prefixed URLs (`/\evil.com`) can override the hostname component of the base URL, causing the `relativeUrlsTransformerInterceptorFn` interceptor to redirect all subsequent `HttpClient` requests to attacker-controlled domains (Server-Side Request Forgery).

### Root Cause

When a user sends `GET //evil.com/ HTTP/1.1` or `GET /\evil.com/ HTTP/1.1`, Express passes `req.url` as `//evil.com/` or `/\evil.com/`. This value flows into `renderApplication({url: req.url})` → `INITIAL_CONFIG` → `ServerPlatformLocation` constructor → `parseUrl()`. The WHATWG `URL` constructor resolves these as `hostname: 'evil.com'`, which the HTTP interceptor then uses to construct outbound request URLs.

The backslash variant (`/\evil.com`) is particularly dangerous because it bypasses any WAF or filter rule that checks for `//` patterns — the input contains no double-slash, yet the URL parser normalizes backslash to forward slash for special schemes (http/https).

### Fix

This PR adds validation in `parseUrl()` to detect when a relative URL input attempts to alter the origin's hostname, protocol, or port. When such a hijack attempt is detected, the parsed result is **neutralized** by reconstructing the URL using only the path components against the original origin, preventing hostname takeover while preserving the intended routing path.

### Security Impact

- **SSRF to external domains**: Attacker forces the SSR server to send HTTP requests to arbitrary hosts
- **Filter bypass**: The backslash variant defeats WAF rules and reverse proxy filters that only look for `//` patterns
- **Affects standard Angular Universal deployments** that pass `req.url` to `renderApplication()`

### Testing

- Added unit tests verifying that protocol-relative URL (`//attacker.com/...`) hostname hijack is neutralized
- Added unit tests verifying that backslash URL (`/\attacker.com/...`) hostname hijack is neutralized
- All 344 existing specs continue to pass

### Related

- CVE-2025-62427 (SSRF in `@angular/ssr`)
- Variant: Backslash URL bypass of double-slash filters