### PR TITLE
fix(core): derive possible null value in rxResource stream params

### DIFF
--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -29,10 +29,10 @@ describe('rxResource()', () => {
     const appRef = TestBed.inject(ApplicationRef);
     const request = signal(1);
     let unsub = false;
-    let lastSeenRequest: number = 0;
+    let lastSeenRequest: number | null = 0;
     rxResource({
       params: request,
-      stream: ({params: request}) => {
+      stream: ({ params: request }) => {
         lastSeenRequest = request;
         return new Observable((sub) => {
           if (request === 2) {
@@ -75,7 +75,7 @@ describe('rxResource()', () => {
     expect(res.value()).toBe(3);
 
     response.error('fail');
-    expect(res.error()).toEqual(jasmine.objectContaining({cause: 'fail'}));
+    expect(res.error()).toEqual(jasmine.objectContaining({ cause: 'fail' }));
     expect(res.error()!.message).toContain('Resource');
   });
 
@@ -113,6 +113,47 @@ describe('rxResource()', () => {
     expect(rxRes.error()).toBeInstanceOf(FooError);
 
     expect(() => rxRes.value()).toThrowError(/This is a FooError/);
+  });
+
+  it('should receive null params at runtime when params option is not provided', async () => {
+    const injector = TestBed.inject(Injector);
+    const appRef = TestBed.inject(ApplicationRef);
+    let receivedParams: unknown = 'NOT_SET';
+
+    const res = rxResource({
+      // No `params` option — defaults to () => null! internally
+      stream: ({ params }) => {
+        receivedParams = params;
+        return of('result');
+      },
+      injector,
+    });
+
+    await appRef.whenStable();
+    // When no params function is provided, the resource defaults to `() => null!` internally,
+    // so params inside the stream callback should be null at runtime.
+    expect(receivedParams).toBeNull();
+    expect(res.value()).toBe('result');
+  });
+
+  it('should type params as including null when params option can be undefined (issue #62724)', async () => {
+    const injector = TestBed.inject(Injector);
+
+    // This should compile without TypeScript errors.
+    // Before the fix, `params` was typed as `string` — missing `null`.
+    // After the fix, `params` is typed as `string | null`.
+    const getParamsFn = (): (() => string) | undefined => undefined;
+
+    // The key assertion: assigning `params` to `string | null` must compile.
+    rxResource({
+      params: getParamsFn(),
+      stream: ({ params }) => {
+        // TypeScript must allow: params is `string | null`, not just `string`
+        const _typeCheck: string | null = params;
+        return of(_typeCheck ?? 'fallback');
+      },
+      injector,
+    });
   });
 });
 

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -179,7 +179,7 @@ export interface ResourceRef<T> extends WritableResource<T> {
  * @experimental
  */
 export interface ResourceLoaderParams<R> {
-  params: NoInfer<Exclude<R, undefined>>;
+  params: NoInfer<Exclude<R, undefined | null> | null>;
   abortSignal: AbortSignal;
   previous: {
     status: ResourceStatus;


### PR DESCRIPTION
When an optional params function returns `undefined`, Angular's `rxResource` internally defaults the params loader value to `null` at runtime. This change updates `ResourceLoaderParams<R>` to correctly allow `null` alongside the resolved type, ensuring developers get accurate TypeScript feedback when omitted.

Fixes #62724

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the `params` option is not provided to `rxResource` or it evaluates to `undefined`, the type of the `params` argument in the internal `stream` function is restricted to the strictly inferred type (e.g. `Params`), even though it resolves to `null` at runtime.

Issue Number: #62724

## What is the new behavior?

The type inference for `ResourceLoaderParams<R>` correctly derives a potential `null` value in instances where `undefined` could be inferred from the original `params` option payload. This correctly aligns the TypeScript expectations within `stream` or `loader` functions to match the runtime behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
