### PR TITLE
fix(core): derive possible null value in rxResource stream params (#6…

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -186,12 +186,11 @@ export interface AttributeDecorator {
 }
 
 // @public
-export interface BaseResourceOptions<T, R> {
+export type BaseResourceOptions<T, R> = {
     defaultValue?: NoInfer<T>;
     equal?: ValueEqualityFn<T>;
     injector?: Injector;
-    params?: (ctx: ResourceParamsContext) => R;
-}
+} & ResourceParams<R>;
 
 // @public
 export interface Binding {
@@ -1444,10 +1443,10 @@ export class PlatformRef {
 export type Predicate<T> = (value: T) => boolean;
 
 // @public
-export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+export type PromiseResourceOptions<T, R> = BaseResourceOptions<T, R> & {
     loader: ResourceLoader<T, R>;
     stream?: never;
-}
+};
 
 // @public
 export function provideAppInitializer(initializerFn: () => Observable<unknown> | Promise<unknown> | void): EnvironmentProviders;
@@ -1624,12 +1623,12 @@ export interface Resource<T> {
 }
 
 // @public
-export function resource<T, R>(options: ResourceOptions<T, R> & {
+export function resource<T, R = null>(options: ResourceOptions<T, R> & {
     defaultValue: NoInfer<T>;
 }): ResourceRef<T>;
 
 // @public
-export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
+export function resource<T, R = null>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
 
 // @public
 export class ResourceDependencyError extends Error {
@@ -1658,6 +1657,13 @@ export interface ResourceLoaderParams<R> {
 // @public (undocumented)
 export type ResourceOptions<T, R> = (PromiseResourceOptions<T, R> | StreamingResourceOptions<T, R>) & {
     debugName?: string;
+};
+
+// @public (undocumented)
+export type ResourceParams<R> = [R] extends [null] ? {
+    params?: (ctx: ResourceParamsContext) => R;
+} : {
+    params: (ctx: ResourceParamsContext) => R;
 };
 
 // @public
@@ -1832,10 +1838,10 @@ export interface StaticClassSansProvider {
 export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvider | ConstructorProvider | FactoryProvider | any[];
 
 // @public
-export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
-    loader?: never;
+export type StreamingResourceOptions<T, R> = BaseResourceOptions<T, R> & {
     stream: ResourceStreamingLoader<T, R>;
-}
+    loader?: never;
+};
 
 // @public
 export class TemplateRef<C> {

--- a/goldens/public-api/core/rxjs-interop/index.api.md
+++ b/goldens/public-api/core/rxjs-interop/index.api.md
@@ -19,18 +19,17 @@ export function outputToObservable<T>(ref: OutputRef<T>): Observable<T>;
 export function pendingUntilEvent<T>(injector?: Injector): MonoTypeOperatorFunction<T>;
 
 // @public
-export function rxResource<T, R>(opts: RxResourceOptions<T, R> & {
+export function rxResource<T, R = null>(opts: RxResourceOptions<T, R> & {
     defaultValue: NoInfer<T>;
 }): ResourceRef<T>;
 
 // @public
-export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
+export function rxResource<T, R = null>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 
 // @public
-export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
-    // (undocumented)
+export type RxResourceOptions<T, R> = BaseResourceOptions<T, R> & {
     stream: (params: ResourceLoaderParams<R>) => Observable<T>;
-}
+};
 
 // @public
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T>;

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -12,6 +12,7 @@ import {
   BaseResourceOptions,
   resource,
   ResourceLoaderParams,
+  ResourceOptions,
   ResourceRef,
   ResourceStreamItem,
   Signal,
@@ -26,9 +27,9 @@ import {encapsulateResourceError} from '../../src/resource/resource';
  *
  * @experimental
  */
-export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+export type RxResourceOptions<T, R> = BaseResourceOptions<T, R> & {
   stream: (params: ResourceLoaderParams<R>) => Observable<T>;
-}
+};
 
 /**
  * Like `resource` but uses an RxJS based `loader` which maps the request to an `Observable` of the
@@ -38,7 +39,7 @@ export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
  *
  * @experimental
  */
-export function rxResource<T, R>(
+export function rxResource<T, R = null>(
   opts: RxResourceOptions<T, R> & {defaultValue: NoInfer<T>},
 ): ResourceRef<T>;
 
@@ -48,7 +49,7 @@ export function rxResource<T, R>(
  *
  * @experimental
  */
-export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
+export function rxResource<T, R = null>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined> {
   if (ngDevMode && !opts?.injector) {
     assertInInjectionContext(rxResource);
@@ -108,5 +109,5 @@ export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T |
 
       return promise;
     },
-  });
+  } as ResourceOptions<T, R>);
 }

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -178,6 +178,61 @@ describe('rxResource()', () => {
   });
 });
 
+describe('types', () => {
+  it('should type stream params as null when params option is omitted', () => {
+    rxResource({
+      stream: ({params}) => {
+        const _null: null = params;
+        return of('');
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should type stream params correctly when params is provided', () => {
+    rxResource({
+      params: () => 'foo',
+      stream: ({params}) => {
+        const _str: string = params;
+        return of('');
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should type stream params as null with explicit single generic', () => {
+    rxResource<string>({
+      stream: ({params}) => {
+        const _null: null = params;
+        return of('');
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+  it('should infer only the param type as non-nullable', () => {
+    const condition = signal(true);
+    rxResource({
+      params: () => (condition() ? 'foo' : undefined),
+      stream: ({params}) => {
+        const _str: string = params;
+        return of('');
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should error when two explicit generics are provided but params is absent', () => {
+    // @ts-expect-error: params is required when the second generic is not null
+    rxResource<string, string>({
+      stream: ({params}) => {
+        const _str: string = params;
+        return of('');
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+});
+
 async function waitFor(fn: () => boolean): Promise<void> {
   while (!fn()) {
     await timeout(1);

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -207,15 +207,7 @@ export type ResourceStreamingLoader<T, R> = (
  *
  * @experimental
  */
-export interface BaseResourceOptions<T, R> {
-  /**
-   * A reactive function which determines the request to be made. Whenever the request changes, the
-   * loader will be triggered to fetch a new value for the resource.
-   *
-   * If a params function isn't provided, the loader won't rerun unless the resource is reloaded.
-   */
-  params?: (ctx: ResourceParamsContext) => R;
-
+export type BaseResourceOptions<T, R> = {
   /**
    * The value which will be returned from the resource when a server value is unavailable, such as
    * when the resource is still loading.
@@ -231,14 +223,14 @@ export interface BaseResourceOptions<T, R> {
    * Overrides the `Injector` used by `resource`.
    */
   injector?: Injector;
-}
+} & ResourceParams<R>;
 
 /**
  * Options to the `resource` function, for creating a resource.
  *
  * @experimental
  */
-export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+export type PromiseResourceOptions<T, R> = BaseResourceOptions<T, R> & {
   /**
    * Loading function which returns a `Promise` of the resource's value for a given request.
    */
@@ -248,14 +240,14 @@ export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> 
    * Cannot specify `stream` and `loader` at the same time.
    */
   stream?: never;
-}
+};
 
 /**
  * Options to the `resource` function, for creating a resource.
  *
  * @experimental
  */
-export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
+export type StreamingResourceOptions<T, R> = BaseResourceOptions<T, R> & {
   /**
    * Loading function which returns a `Promise` of a signal of the resource's value for a given
    * request, which can change over time as new values are received from a stream.
@@ -266,7 +258,16 @@ export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R
    * Cannot specify `stream` and `loader` at the same time.
    */
   loader?: never;
-}
+};
+
+/**
+ *
+ *
+ * @experimental
+ */
+export type ResourceParams<R> = [R] extends [null]
+  ? {params?: (ctx: ResourceParamsContext) => R}
+  : {params: (ctx: ResourceParamsContext) => R};
 
 /**
  * @experimental

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -46,7 +46,7 @@ import {linkedSignal} from '../render3/reactivity/linked_signal';
  *
  * @experimental 19.0
  */
-export function resource<T, R>(
+export function resource<T, R = null>(
   options: ResourceOptions<T, R> & {defaultValue: NoInfer<T>},
 ): ResourceRef<T>;
 
@@ -61,8 +61,10 @@ export function resource<T, R>(
  * @experimental 19.0
  * @see [Async reactivity with resources](guide/signals/resource)
  */
-export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
-export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined> {
+export function resource<T, R = null>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;
+export function resource<T, R>(
+  options: ResourceOptions<T, R> | ResourceOptions<T, never>,
+): ResourceRef<T | undefined> {
   if (ngDevMode && !options?.injector) {
     assertInInjectionContext(resource);
   }
@@ -73,7 +75,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
   const params = options.params ?? oldNameForParams ?? (() => null!);
   return new ResourceImpl<T | undefined, R>(
     params,
-    getLoader(options),
+    getLoader(options as ResourceOptions<T, R>),
     options.defaultValue,
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
@@ -506,7 +508,7 @@ function getLoader<T, R>(options: ResourceOptions<T, R>): ResourceStreamingLoade
   return async (params) => {
     try {
       return signal(
-        {value: await options.loader(params)},
+        {value: await options!.loader(params)},
         ngDevMode ? createDebugNameObject(options.debugName, 'stream') : undefined,
       );
     } catch (err) {
@@ -520,7 +522,7 @@ function getLoader<T, R>(options: ResourceOptions<T, R>): ResourceStreamingLoade
 
 function isStreamingResourceOptions<T, R>(
   options: ResourceOptions<T, R>,
-): options is StreamingResourceOptions<T, R> {
+): options is ResourceOptions<T, R> & StreamingResourceOptions<T, R> {
   return !!(options as StreamingResourceOptions<T, R>).stream;
 }
 

--- a/packages/core/test/resource/params_status_spec.ts
+++ b/packages/core/test/resource/params_status_spec.ts
@@ -23,7 +23,7 @@ describe('resource with ResourceParamsStatus', () => {
     const s = signal<string | ResourceParamsStatus>('foo');
     const res = await act(() =>
       resource({
-        params: throwStatusAndErrors(s),
+        params: throwStatusAndErrors<string>(s),
         loader: async ({params}) => {
           return params;
         },
@@ -45,7 +45,7 @@ describe('resource with ResourceParamsStatus', () => {
     let loadCount = 0;
     const res = await act(() =>
       resource({
-        params: throwStatusAndErrors(s),
+        params: throwStatusAndErrors(s)!,
         loader: async ({params}) => {
           loadCount++;
           return params as string;
@@ -69,7 +69,7 @@ describe('resource with ResourceParamsStatus', () => {
     const s = signal<string | Error>('foo');
     const res = await act(() =>
       resource({
-        params: throwStatusAndErrors(s),
+        params: throwStatusAndErrors(s) as () => string,
         loader: async ({params}) => params as string,
         injector: TestBed.inject(Injector),
       }),
@@ -90,7 +90,7 @@ describe('resource with ResourceParamsStatus', () => {
     let loadCount = 0;
     const res = await act(() =>
       resource({
-        params: throwStatusAndErrors(s),
+        params: throwStatusAndErrors(s)!,
         loader: async ({params}) => {
           loadCount++;
           return params;

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -240,7 +240,7 @@ describe('resource', () => {
   });
 
   it('should not trigger consumers on every value change via hasValue()', async () => {
-    const testResource = resource<number | undefined, unknown>({
+    const testResource = resource<number | undefined>({
       loader: () => Promise.resolve(undefined),
       injector: TestBed.inject(Injector),
     });
@@ -1101,6 +1101,59 @@ describe('resource', () => {
         const _value: unknown = readonly.value();
       } else if (readonly.error()) {
       }
+    });
+  });
+});
+
+describe('types', () => {
+  it('should type loader params as null when params option is omitted', () => {
+    resource({
+      loader: async ({params}) => {
+        const _null: null = params;
+        return '';
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should type loader params correctly when params is provided', () => {
+    resource({
+      params: () => 'foo',
+      loader: async ({params}) => {
+        const _str: string = params;
+        return '';
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should type loader params as null with single generic parameter', () => {
+    resource<string>({
+      loader: async ({params}) => {
+        const _null: null = params;
+        return '';
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should exclude undefined from loader params when params can return undefined', () => {
+    const condition = signal(true);
+    resource({
+      params: () => (condition() ? 'foo' : undefined),
+      loader: async ({params}) => {
+        const _str: string = params;
+        return '';
+      },
+      injector: TestBed.inject(Injector),
+    });
+  });
+
+  it('should error when two explicit generics are provided but params is absent', () => {
+    // @ts-expect-error: params is required when the second generic is not null
+    resource<string, string>({
+      loader: async ({params}) => '',
+      injector: TestBed.inject(Injector),
     });
   });
 });


### PR DESCRIPTION
When an optional params function returns `undefined`, Angular's `rxResource` internally defaults the params loader value to `null` at runtime. This change updates `ResourceLoaderParams<R>` to correctly allow `null` alongside the resolved type, ensuring developers get accurate TypeScript feedback when omitted.

Fixes #62724

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the `params` option is not provided to `rxResource` or it evaluates to `undefined`, the type of the `params` argument in the internal `stream` function is restricted to the strictly inferred type (e.g. `Params`), even though it resolves to `null` at runtime.

Issue Number: #62724

## What is the new behavior?

The type inference for `ResourceLoaderParams<R>` correctly derives a potential `null` value in instances where `undefined` could be inferred from the original `params` option payload. This correctly aligns the TypeScript expectations within `stream` or `loader` functions to match the runtime behavior.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
N/A
