### PR TITLE
fix(router): strip null characters from serialized URLs

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -515,7 +515,8 @@ function encodeUriString(s: string): string {
     .replace(/%40/g, '@')
     .replace(/%3A/gi, ':')
     .replace(/%24/g, '$')
-    .replace(/%2C/gi, ',');
+    .replace(/%2C/gi, ',')
+    .replace(/%00/g, '');
 }
 
 /**

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -408,6 +408,28 @@ describe('url serializer', () => {
       expect(url.serialize(parsed)).toBe(`/${notEncoded}${encoded}`);
     });
 
+    // Regression test: https://github.com/angular/angular/issues/47264
+    // Null characters (\u0000) encode to %00, which browsers reject with a SecurityError
+    // in history.pushState/replaceState.
+    it('should strip null characters from path segments', () => {
+      const parsed = url.parse('/foo');
+      parsed.root.children[PRIMARY_OUTLET].segments[0].path =
+        '\u0000\u0000d\u0000\u0000\u0000\u0000Q\u0000\u0000\u0000\u0000';
+      expect(url.serialize(parsed)).not.toContain('%00');
+    });
+
+    it('should strip null characters from matrix params', () => {
+      const parsed = url.parse('/foo');
+      parsed.root.children[PRIMARY_OUTLET].segments[0].parameters = {key: '\u0000value'};
+      expect(url.serialize(parsed)).not.toContain('%00');
+    });
+
+    it('should strip null characters from query params', () => {
+      const parsed = url.parse('/foo');
+      parsed.queryParams = {key: '\u0000value'};
+      expect(url.serialize(parsed)).not.toContain('%00');
+    });
+
     it('should correctly encode ampersand in segments', () => {
       const testUrl = '/parent&child';
 


### PR DESCRIPTION
Null characters (\u0000) in route path params, matrix params, or query params were encoded to `%00` by `encodeURIComponent`. Browsers reject URLs containing `%00` with a SecurityError when passed to `history.pushState`/`replaceState`, causing an unhandled promise rejection and crashing navigation.

The fix strips `%00` from the output of `encodeUriString`, which is the shared base used by `encodeUriSegment` and `encodeUriQuery`, covering path segments, matrix params, and query params in a single change.

Closes #47264

Google Internal ref: b/239974353