### PR TITLE
docs(router): document .. traversal and relativeTo pitfalls in router.navigate()

### DIFF
--- a/adev/src/content/guide/routing/navigate-to-routes.md
+++ b/adev/src/content/guide/routing/navigate-to-routes.md
@@ -147,6 +147,29 @@ export class UserDetail {
 }
 ```
 
+When navigating multiple levels up, all `..` segments must be in the **first element** of the commands array. The router only parses `..` from the first command string — subsequent array elements are treated as literal path segments.
+
+```angular-ts {prefer}
+// From: /team/123/users/456
+// Result: /team/123/settings
+this.router.navigate(['../../settings'], {relativeTo: this.route});
+```
+
+When using `relativeTo`, never prefix the first command with `/`. A leading `/` makes the navigation absolute and ignores `relativeTo` entirely.
+
+```angular-ts {prefer}
+// From: /team/123/users/456
+// Result: /team/123/users/456/edit
+this.router.navigate(['edit'], {relativeTo: this.route});
+```
+
+```angular-ts {avoid}
+// From: /team/123/users/456
+// Leading '/' causes absolute navigation — relativeTo is ignored
+// Result: /edit
+this.router.navigate(['/edit'], {relativeTo: this.route});
+```
+
 ### `router.navigateByUrl()`
 
 The `router.navigateByUrl()` method provides a direct way to programmatically navigate using URL path strings rather than array segments. This method is ideal when you have a full URL path and need to perform absolute navigation, especially when working with externally provided URLs or deep linking scenarios.


### PR DESCRIPTION
Explain two non-obvious behaviors of the commands array in router.navigate():

- Multiple '..' segments must be combined in the first array element (e.g. ['../../foo']), not spread across separate elements (e.g. ['..', '..', 'foo']), because the router only parses '..' from the first command string. Subsequent elements are treated as literal path segments, causing a navigation error.
- A leading '/' in the first command makes navigation absolute and silently ignores the relativeTo option entirely.

Closes #65657