### PR TITLE
feat(devtools): Modify buildDirectiveForest to call ng.getComponentForest if it exists.

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -651,7 +651,7 @@ const getSignalGraphCallback = (messageBus: MessageBus<Events>) => (element: Ele
     return;
   }
 
-  const injector = getInjectorFromElementNode(node.nativeElement!);
+  const injector = node.injector ?? getInjectorFromElementNode(node.nativeElement!);
 
   if (!injector) {
     messageBus.emit('latestSignalGraph', [null]);

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -629,7 +629,7 @@ const getSignalGraphCallback = (messageBus: MessageBus<Events>) => (element: Ele
     return;
   }
 
-  const injector = getInjectorFromElementNode(node.nativeElement!);
+  const injector = node.injector ?? getInjectorFromElementNode(node.nativeElement!);
 
   if (!injector) {
     messageBus.emit('latestSignalGraph', [null]);

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -117,7 +117,7 @@ export const getLatestComponentState = (
   directiveForest = directiveForest ?? buildDirectiveForest();
 
   const node = queryDirectiveForest(query.selectedElement, directiveForest);
-  if (!node || !node.nativeElement) {
+  if (!node) {
     return;
   }
 
@@ -684,6 +684,10 @@ function discoverNonApplicationRootComponents(element: Element, roots: Set<Eleme
 }
 
 export const buildDirectiveForest = (): ComponentTreeNode[] => {
+  const ng = ngDebugClient();
+  if ((ng as any).getComponentForest) {
+    return (ng as any).getComponentForest();
+  }
   return buildDirectiveForestWithStrategy(getRootElements());
 };
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -686,7 +686,18 @@ function discoverNonApplicationRootComponents(element: Element, roots: Set<Eleme
 export const buildDirectiveForest = (): ComponentTreeNode[] => {
   const ng = ngDebugClient();
   if ((ng as any).getComponentForest) {
-    return (ng as any).getComponentForest();
+    const forest: ComponentTreeNode[] = (ng as any).getComponentForest();
+    const frontier = [...forest];
+    while (frontier.length) {
+      const node = frontier.pop()!;
+      node.element ??= node.nativeElement?.nodeName.toLowerCase() ?? '';
+      node.hydration ??= null;
+      node.component!.isElement ??= false;
+      for (const child of node.children) {
+        frontier.push(child);
+      }
+    }
+    return forest;
   }
   return buildDirectiveForestWithStrategy(getRootElements());
 };

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -129,7 +129,7 @@ export const getLatestComponentState = (
   directiveForest = directiveForest ?? buildDirectiveForest();
 
   const node = queryDirectiveForest(query.selectedElement, directiveForest);
-  if (!node || !node.nativeElement) {
+  if (!node) {
     return;
   }
 
@@ -679,6 +679,10 @@ function discoverNonApplicationRootComponents(element: Element, roots: Set<Eleme
 }
 
 export const buildDirectiveForest = (): ComponentTreeNode[] => {
+  const ng = ngDebugClient();
+  if ((ng as any).getComponentForest) {
+    return (ng as any).getComponentForest();
+  }
   return buildDirectiveForestWithStrategy(getRootElements());
 };
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -681,7 +681,18 @@ function discoverNonApplicationRootComponents(element: Element, roots: Set<Eleme
 export const buildDirectiveForest = (): ComponentTreeNode[] => {
   const ng = ngDebugClient();
   if ((ng as any).getComponentForest) {
-    return (ng as any).getComponentForest();
+    const forest: ComponentTreeNode[] = (ng as any).getComponentForest();
+    const frontier = [...forest];
+    while (frontier.length) {
+      const node = frontier.pop()!;
+      node.element ??= node.nativeElement?.nodeName.toLowerCase() ?? '';
+      node.hydration ??= null;
+      node.component!.isElement ??= false;
+      for (const child of node.children) {
+        frontier.push(child);
+      }
+    }
+    return forest;
   }
   return buildDirectiveForestWithStrategy(getRootElements());
 };

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
@@ -173,6 +173,7 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
     nativeElement: node.nativeElement,
     hydration: node.hydration,
     controlFlowBlock: node.controlFlowBlock,
+    injector: node.injector,
   } as IndexedNode;
 };
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index-forest.spec.ts
@@ -142,6 +142,7 @@ describe('indexForest', () => {
             changeDetection: 'ng-on-push',
             controlFlowBlock: null,
             hasNativeElement: true,
+            injector: undefined,
           },
           {
             element: 'Child1_2',
@@ -158,11 +159,13 @@ describe('indexForest', () => {
             changeDetection: 'ng-on-push',
 
             hasNativeElement: true,
+            injector: undefined,
           },
         ],
         controlFlowBlock: null,
         changeDetection: 'ng-on-push',
         hasNativeElement: true,
+        injector: undefined,
       },
       {
         element: 'Parent2',
@@ -186,6 +189,7 @@ describe('indexForest', () => {
             changeDetection: 'ng-eager',
             controlFlowBlock: null,
             hasNativeElement: true,
+            injector: undefined,
           },
           {
             element: 'Child2_2',
@@ -206,11 +210,13 @@ describe('indexForest', () => {
             changeDetection: 'ng-eager',
             controlFlowBlock: null,
             hasNativeElement: true,
+            injector: undefined,
           },
         ],
         changeDetection: 'ng-eager',
         controlFlowBlock: null,
         hasNativeElement: true,
+        injector: undefined,
       },
     ]);
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {Injector} from '@angular/core';
 import {DevToolsNode, ElementPosition} from '../../../../../../../protocol';
 
 export interface IndexedNode extends DevToolsNode {
@@ -16,6 +17,7 @@ export interface IndexedNode extends DevToolsNode {
   nativeElement?: never;
   // Instead we will have this boolean
   hasNativeElement: boolean;
+  injector?: Injector;
 }
 
 const indexTree = (
@@ -34,6 +36,7 @@ const indexTree = (
     controlFlowBlock: node.controlFlowBlock,
     changeDetection: node.changeDetection,
     hasNativeElement: (node as any).hasNativeElement,
+    injector: node.injector,
   };
 };
 

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -132,6 +132,7 @@ export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> 
   hydration: HydrationStatus;
   controlFlowBlock: ControlFlowBlock | null;
   changeDetection?: ChangeDetection;
+  injector?: Injector;
 }
 
 export interface SerializedInjector {

--- a/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
@@ -74,7 +74,7 @@ const chromeWindowExtensions = {
       console.error(`Cannot find element associated with node ${element}`);
       return undefined;
     }
-    const injector = getInjectorFromElementNode(node.nativeElement!);
+    const injector = node.injector ?? getInjectorFromElementNode(node.nativeElement!);
     if (!injector) {
       return;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

A DOM walk is performed to determine generate the `ComponentTreeNode[]` that is displayed in the Components tab in the Angular DevTools Extension.

Issue Number: N/A

## What is the new behavior?

The `ng.getComponentForest` function allows application frameworks to return the `ComponentTreeNode[]` that is displayed in the Components tab in the Angular DevTools Extension.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
