### PR TITLE
feat(core): Update Testability to use PendingTasks for stability indi…

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -159,7 +159,9 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
-export function provideProtractorTestingSupport(): Provider[];
+export function provideProtractorTestingSupport(options?: {
+    usePendingTasksForStability?: boolean;
+}): Provider[];
 
 // @public
 export const REMOVE_STYLES_ON_COMPONENT_DESTROY: InjectionToken<boolean>;

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -153,6 +153,7 @@ export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
 export {
   TESTABILITY as ɵTESTABILITY,
   TESTABILITY_GETTER as ɵTESTABILITY_GETTER,
+  USE_PENDING_TASKS as ɵUSE_PENDING_TASKS,
 } from './testability/testability';
 export {booleanAttribute, numberAttribute} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Inject, Injectable, InjectionToken} from '../di';
+import {Inject, Injectable, InjectionToken, inject} from '../di';
 import {isInInjectionContext} from '../di/contextual';
 import {DestroyRef} from '../linker/destroy_ref';
+import {PendingTasksInternal} from '../pending_tasks_internal';
 import {NgZone} from '../zone/ng_zone';
 
 /**
@@ -62,6 +63,14 @@ export const TESTABILITY = new InjectionToken<Testability>('');
 export const TESTABILITY_GETTER = new InjectionToken<GetTestability>('');
 
 /**
+ * Internal injection token to signal whether to use pending tasks for stability.
+ */
+export const USE_PENDING_TASKS = new InjectionToken<boolean>('USE_PENDING_TASKS', {
+  providedIn: 'root',
+  factory: () => typeof Zone === 'undefined',
+});
+
+/**
  * The Testability service provides testing hooks that can be accessed from
  * the browser.
  *
@@ -90,6 +99,8 @@ export class Testability implements PublicTestability {
 
   private _destroyRef?: DestroyRef;
 
+  private readonly pendingTasksInternal = inject(PendingTasksInternal);
+  private readonly _usePendingTasks = inject(USE_PENDING_TASKS);
   constructor(
     private _ngZone: NgZone,
     private registry: TestabilityRegistry,
@@ -121,8 +132,23 @@ export class Testability implements PublicTestability {
       },
     });
 
-    const onStableSubscription = this._ngZone.runOutsideAngular(() =>
-      this._ngZone.onStable.subscribe({
+    let pendingTasksSubscription: any;
+    let onStableSubscription: any;
+
+    this._ngZone.runOutsideAngular(() => {
+      if (this._usePendingTasks) {
+        pendingTasksSubscription = this.pendingTasksInternal.hasPendingTasksObservable.subscribe(
+          () => {
+            if (this.isStable()) {
+              this._ngZone.runOutsideAngular(() => {
+                this._runCallbacksIfReady();
+              });
+            }
+          },
+        );
+      }
+
+      onStableSubscription = this._ngZone.onStable.subscribe({
         next: () => {
           NgZone.assertNotInAngularZone();
           queueMicrotask(() => {
@@ -130,11 +156,12 @@ export class Testability implements PublicTestability {
             this._runCallbacksIfReady();
           });
         },
-      }),
-    );
+      });
+    });
 
     this._destroyRef?.onDestroy(() => {
       onUnstableSubscription.unsubscribe();
+      pendingTasksSubscription?.unsubscribe();
       onStableSubscription.unsubscribe();
     });
   }
@@ -143,7 +170,11 @@ export class Testability implements PublicTestability {
    * Whether an associated application is stable
    */
   isStable(): boolean {
-    return this._isZoneStable && !this._ngZone.hasPendingMacrotasks;
+    return (
+      this._isZoneStable &&
+      !this._ngZone.hasPendingMacrotasks &&
+      (!this._usePendingTasks || !this.pendingTasksInternal.hasPendingTasks)
+    );
   }
 
   private _runCallbacksIfReady(): void {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -267,6 +267,7 @@
       "TracingAction",
       "TracingService",
       "UNSET",
+      "USE_PENDING_TASKS",
       "USE_VALUE",
       "UnsubscriptionError",
       "VALID",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -261,6 +261,7 @@
       "TracingAction",
       "TracingService",
       "UNSET",
+      "USE_PENDING_TASKS",
       "USE_VALUE",
       "UnsubscriptionError",
       "VALID",

--- a/packages/core/test/testability/testability_spec.ts
+++ b/packages/core/test/testability/testability_spec.ts
@@ -8,15 +8,18 @@
 
 import {EventEmitter} from '../../src/core';
 import {Injectable} from '../../src/di';
+import {PendingTasks} from '../../src/pending_tasks';
 import {
   GetTestability,
   PendingMacrotask,
+  TESTABILITY_GETTER,
   Testability,
   TestabilityRegistry,
+  USE_PENDING_TASKS,
   setTestabilityGetter,
 } from '../../src/testability/testability';
 import {NgZone} from '../../src/zone/ng_zone';
-import {fakeAsync, tick, waitForAsync} from '../../testing';
+import {fakeAsync, tick, waitForAsync, TestBed} from '../../testing';
 
 // Schedules a microtasks (using queueMicrotask)
 function microTask(fn: Function): void {
@@ -61,183 +64,6 @@ class MockNgZone extends NgZone {
   }
 }
 
-describe('Testability', () => {
-  let testability: Testability;
-  let execute: any;
-  let execute2: any;
-  let updateCallback: any;
-  let ngZone: MockNgZone;
-
-  beforeEach(waitForAsync(() => {
-    ngZone = new MockNgZone();
-    testability = new Testability(ngZone, new TestabilityRegistry(), new NoopGetTestability());
-    execute = jasmine.createSpy('execute');
-    execute2 = jasmine.createSpy('execute');
-    updateCallback = jasmine.createSpy('execute');
-  }));
-  afterEach(() => {
-    // Instantiating the Testability (via `new Testability` above) has a side
-    // effect of defining the testability getter globally to a specified value.
-    // This call resets that reference after each test to make sure it does not
-    // get leaked between tests. In real scenarios this is not a problem, since
-    // the `Testability` is created via DI and uses the same testability getter
-    // (injected into a constructor) across all instances.
-    setTestabilityGetter(null! as GetTestability);
-  });
-
-  describe('NgZone callback logic', () => {
-    describe('whenStable with timeout', () => {
-      it('should fire if Angular is already stable', waitForAsync(() => {
-        testability.whenStable(execute, 200);
-
-        microTask(() => {
-          expect(execute).toHaveBeenCalled();
-        });
-      }));
-
-      it('should fire when macroTasks are cancelled', fakeAsync(() => {
-        const id = ngZone.run(() => setTimeout(() => {}, 1000));
-        testability.whenStable(execute, 500);
-
-        tick(200);
-        ngZone.run(() => clearTimeout(id));
-        // fakeAsync doesn't trigger NgZones whenStable
-        ngZone.stable();
-
-        tick(1);
-        expect(execute).toHaveBeenCalled();
-      }));
-
-      it('calls the done callback when angular is stable', fakeAsync(() => {
-        let timeout1Done = false;
-        ngZone.run(() => setTimeout(() => (timeout1Done = true), 500));
-        testability.whenStable(execute, 1000);
-
-        tick(600);
-        ngZone.stable();
-        tick();
-
-        expect(timeout1Done).toEqual(true);
-        expect(execute).toHaveBeenCalled();
-
-        // Should cancel the done timeout.
-        tick(500);
-        ngZone.stable();
-        tick();
-        expect(execute.calls.count()).toEqual(1);
-      }));
-
-      it('calls update when macro tasks change', fakeAsync(() => {
-        let timeout1Done = false;
-        let timeout2Done = false;
-        ngZone.run(() => setTimeout(() => (timeout1Done = true), 500));
-        tick();
-        testability.whenStable(execute, 1000, updateCallback);
-
-        tick(100);
-        ngZone.run(() => setTimeout(() => (timeout2Done = true), 300));
-        expect(updateCallback.calls.count()).toEqual(1);
-        tick(600);
-
-        expect(timeout1Done).toEqual(true);
-        expect(timeout2Done).toEqual(true);
-        expect(updateCallback.calls.count()).toEqual(3);
-        expect(execute).toHaveBeenCalled();
-
-        const update1 = updateCallback.calls.all()[0].args[0] as PendingMacrotask[];
-        expect(update1[0].data!.delay).toEqual(500);
-
-        const update2 = updateCallback.calls.all()[1].args[0] as PendingMacrotask[];
-        expect(update2[0].data!.delay).toEqual(500);
-        expect(update2[1].data!.delay).toEqual(300);
-      }));
-
-      it('cancels the done callback if the update callback returns true', fakeAsync(() => {
-        let timeoutDone = false;
-        ngZone.unstable();
-        execute2.and.returnValue(true);
-        testability.whenStable(execute, 1000, execute2);
-
-        tick(100);
-        ngZone.run(() => setTimeout(() => (timeoutDone = true), 500));
-        ngZone.stable();
-        expect(execute2).toHaveBeenCalled();
-
-        tick(500);
-        ngZone.stable();
-        tick();
-
-        expect(execute).not.toHaveBeenCalled();
-      }));
-    });
-
-    it('should fire whenstable callback if event is already finished', fakeAsync(() => {
-      ngZone.unstable();
-      ngZone.stable();
-      testability.whenStable(execute);
-
-      tick();
-      expect(execute).toHaveBeenCalled();
-    }));
-
-    it('should not fire whenstable callbacks synchronously if event is already finished', () => {
-      ngZone.unstable();
-      ngZone.stable();
-      testability.whenStable(execute);
-
-      expect(execute).not.toHaveBeenCalled();
-    });
-
-    it('should fire whenstable callback when event finishes', fakeAsync(() => {
-      ngZone.unstable();
-      testability.whenStable(execute);
-
-      tick();
-      expect(execute).not.toHaveBeenCalled();
-      ngZone.stable();
-
-      tick();
-      expect(execute).toHaveBeenCalled();
-    }));
-
-    it('should not fire whenstable callbacks synchronously when event finishes', () => {
-      ngZone.unstable();
-      testability.whenStable(execute);
-      ngZone.stable();
-
-      expect(execute).not.toHaveBeenCalled();
-    });
-
-    it('should fire whenstable callback with didWork if event is already finished', fakeAsync(() => {
-      ngZone.unstable();
-      ngZone.stable();
-      testability.whenStable(execute);
-
-      tick();
-      expect(execute).toHaveBeenCalled();
-      testability.whenStable(execute2);
-
-      tick();
-      expect(execute2).toHaveBeenCalled();
-    }));
-
-    it('should fire whenstable callback with didwork when event finishes', fakeAsync(() => {
-      ngZone.unstable();
-      testability.whenStable(execute);
-
-      tick();
-      ngZone.stable();
-
-      tick();
-      expect(execute).toHaveBeenCalled();
-      testability.whenStable(execute2);
-
-      tick();
-      expect(execute2).toHaveBeenCalled();
-    }));
-  });
-});
-
 describe('TestabilityRegistry', () => {
   let testability1: Testability;
   let testability2: Testability;
@@ -247,8 +73,14 @@ describe('TestabilityRegistry', () => {
   beforeEach(waitForAsync(() => {
     ngZone = new MockNgZone();
     registry = new TestabilityRegistry();
-    testability1 = new Testability(ngZone, registry, new NoopGetTestability());
-    testability2 = new Testability(ngZone, registry, new NoopGetTestability());
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: NgZone, useValue: ngZone},
+        {provide: TESTABILITY_GETTER, useValue: new NoopGetTestability()},
+      ],
+    });
+    testability1 = TestBed.inject(Testability);
+    testability2 = TestBed.inject(Testability);
   }));
   afterEach(() => {
     // Instantiating the Testability (via `new Testability` above) has a side
@@ -285,4 +117,225 @@ describe('TestabilityRegistry', () => {
       expect(registry.getAllTestabilities().length).toEqual(0);
     });
   });
+});
+
+describe('Testability with PendingTasks', () => {
+  let testability: Testability;
+  let execute: any;
+  let execute2: any;
+  let updateCallback: any;
+  let pendingTasks: PendingTasks;
+  let ngZone: MockNgZone;
+
+  beforeEach(waitForAsync(() => {
+    ngZone = new MockNgZone();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: NgZone, useValue: ngZone},
+        {provide: TestabilityRegistry, useValue: new TestabilityRegistry()},
+        {provide: TESTABILITY_GETTER, useValue: new NoopGetTestability()},
+        {provide: USE_PENDING_TASKS, useValue: true},
+      ],
+    });
+    pendingTasks = TestBed.inject(PendingTasks);
+    testability = TestBed.inject(Testability);
+    execute = jasmine.createSpy('execute');
+    execute2 = jasmine.createSpy('execute2');
+    updateCallback = jasmine.createSpy('updateCallback');
+  }));
+
+  describe('NgZone callback logic', () => {
+    describe('whenStable with timeout', () => {
+      it('should fire if Angular is already stable', waitForAsync(() => {
+        testability.whenStable(execute, 200);
+
+        microTask(() => {
+          expect(execute).toHaveBeenCalled();
+        });
+      }));
+
+      it('should fire when macroTasks are cancelled', fakeAsync(() => {
+        const id = ngZone.run(() => setTimeout(() => {}, 1000));
+        testability.whenStable(execute, 500);
+
+        tick(200);
+        ngZone.run(() => clearTimeout(id));
+        // fakeAsync doesn't trigger NgZones whenStable
+        pendingTasks.add()();
+
+        tick(1);
+        expect(execute).toHaveBeenCalled();
+      }));
+
+      it('calls the done callback when angular is stable', fakeAsync(() => {
+        let timeout1Done = false;
+        ngZone.run(() => setTimeout(() => (timeout1Done = true), 500));
+        testability.whenStable(execute, 1000);
+
+        tick(600);
+        pendingTasks.add()();
+        tick();
+
+        expect(timeout1Done).toEqual(true);
+        expect(execute).toHaveBeenCalled();
+
+        // Should cancel the done timeout.
+        tick(500);
+        pendingTasks.add()();
+        tick();
+        expect(execute.calls.count()).toEqual(1);
+      }));
+
+      it('calls update when macro tasks change', fakeAsync(() => {
+        let timeout1Done = false;
+        let timeout2Done = false;
+        ngZone.run(() => setTimeout(() => (timeout1Done = true), 500));
+        tick();
+        testability.whenStable(execute, 1000, updateCallback);
+
+        tick(100);
+        ngZone.run(() => setTimeout(() => (timeout2Done = true), 300));
+        expect(updateCallback.calls.count()).toEqual(1);
+        tick(600);
+
+        expect(timeout1Done).toEqual(true);
+        expect(timeout2Done).toEqual(true);
+        expect(updateCallback.calls.count()).toEqual(3);
+        expect(execute).toHaveBeenCalled();
+
+        const update1 = updateCallback.calls.all()[0].args[0] as PendingMacrotask[];
+        expect(update1[0].data!.delay).toEqual(500);
+
+        const update2 = updateCallback.calls.all()[1].args[0] as PendingMacrotask[];
+        expect(update2[0].data!.delay).toEqual(500);
+        expect(update2[1].data!.delay).toEqual(300);
+      }));
+
+      it('cancels the done callback if the update callback returns true', fakeAsync(() => {
+        let timeoutDone = false;
+        const task = pendingTasks.add();
+        execute2.and.returnValue(true);
+        testability.whenStable(execute, 1000, execute2);
+
+        tick(100);
+        ngZone.run(() => setTimeout(() => (timeoutDone = true), 500));
+        task();
+        expect(execute2).toHaveBeenCalled();
+
+        tick(500);
+        pendingTasks.add()();
+        tick();
+
+        expect(execute).not.toHaveBeenCalled();
+      }));
+    });
+
+    it('should fire whenstable callback if event is already finished', fakeAsync(() => {
+      const task = pendingTasks.add();
+      task();
+      testability.whenStable(execute);
+
+      tick();
+      expect(execute).toHaveBeenCalled();
+    }));
+
+    it('should not fire whenstable callbacks synchronously if event is already finished', () => {
+      const task = pendingTasks.add();
+      task();
+      testability.whenStable(execute);
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('should fire whenstable callback when event finishes', fakeAsync(() => {
+      const task = pendingTasks.add();
+      testability.whenStable(execute);
+
+      tick();
+      expect(execute).not.toHaveBeenCalled();
+      task();
+
+      tick();
+      expect(execute).toHaveBeenCalled();
+    }));
+
+    it('should not fire whenstable callbacks synchronously when event finishes', () => {
+      const task = pendingTasks.add();
+      testability.whenStable(execute);
+      task();
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('should fire whenstable callback with didWork if event is already finished', fakeAsync(() => {
+      const task = pendingTasks.add();
+      task();
+      testability.whenStable(execute);
+
+      tick();
+      expect(execute).toHaveBeenCalled();
+      testability.whenStable(execute2);
+
+      tick();
+      expect(execute2).toHaveBeenCalled();
+    }));
+
+    it('should fire whenstable callback with didwork when event finishes', fakeAsync(() => {
+      const task = pendingTasks.add();
+      testability.whenStable(execute);
+
+      tick();
+      task();
+
+      tick();
+      expect(execute).toHaveBeenCalled();
+      testability.whenStable(execute2);
+
+      tick();
+      expect(execute2).toHaveBeenCalled();
+    }));
+  });
+
+  it('should consider pending tasks when enabled', fakeAsync(() => {
+    const task = pendingTasks.add();
+    testability.whenStable(execute);
+
+    tick();
+    expect(execute).not.toHaveBeenCalled();
+    task();
+
+    tick();
+    expect(execute).toHaveBeenCalled();
+  }));
+});
+
+describe('Testability with PendingTasks disabled', () => {
+  let testability: Testability;
+  let execute: any;
+  let pendingTasks: PendingTasks;
+  let ngZone: MockNgZone;
+
+  beforeEach(waitForAsync(() => {
+    ngZone = new MockNgZone();
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: NgZone, useValue: ngZone},
+        {provide: TestabilityRegistry, useValue: new TestabilityRegistry()},
+        {provide: TESTABILITY_GETTER, useValue: new NoopGetTestability()},
+        // USE_PENDING_TASKS defaults to false
+      ],
+    });
+    pendingTasks = TestBed.inject(PendingTasks);
+    testability = TestBed.inject(Testability);
+    execute = jasmine.createSpy('execute');
+  }));
+
+  it('should ignore pending tasks when Zone is present by default', fakeAsync(() => {
+    const task = pendingTasks.add();
+    testability.whenStable(execute);
+
+    tick();
+    expect(execute).toHaveBeenCalled();
+    task();
+  }));
 });

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -28,9 +28,12 @@ import {
   ɵRuntimeError as RuntimeError,
   ɵSHARED_STYLES_HOST as SHARED_STYLES_HOST,
   StaticProvider,
+  NgZone,
   Testability,
+  TestabilityRegistry,
   ɵTESTABILITY as TESTABILITY,
   ɵTESTABILITY_GETTER as TESTABILITY_GETTER,
+  ɵUSE_PENDING_TASKS,
   Type,
   ɵsetDocument,
 } from '@angular/core';
@@ -190,11 +193,18 @@ async function resolveJitResources(): Promise<void> {
  *
  * @publicApi
  */
-export function provideProtractorTestingSupport(): Provider[] {
+export function provideProtractorTestingSupport(
+  options: {usePendingTasksForStability?: boolean} = {},
+): Provider[] {
   // Return a copy to prevent changes to the original array in case any in-place
   // alterations are performed to the `provideProtractorTestingSupport` call results in app
   // code.
-  return [...TESTABILITY_PROVIDERS];
+  return [
+    ...TESTABILITY_PROVIDERS,
+    options?.usePendingTasksForStability !== undefined
+      ? {provide: ɵUSE_PENDING_TASKS, useValue: options.usePendingTasksForStability ?? false}
+      : [],
+  ];
 }
 
 export function initDomAdapter() {
@@ -244,10 +254,12 @@ const TESTABILITY_PROVIDERS = [
   {
     provide: TESTABILITY,
     useClass: Testability,
+    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
   },
   {
     provide: Testability, // Also provide as `Testability` for backwards-compatibility.
     useClass: Testability,
+    deps: [NgZone, TestabilityRegistry, TESTABILITY_GETTER],
   },
 ];
 


### PR DESCRIPTION
…cator

Since angular@12181b9, zone stability
contributes to the PendingTasks. There is now a single source of truth for application stability tracked in PendingTasks. This change makes protractor's whenStable compatible with zoneless. The `Router` and `HttpClient` also contribute to stability using the `PendingTasks` injectable. There will likely be more updates in the future to have more features contribute to stableness in a zoneless compatible way.

This update uses PendingTasks for stability by default when ZoneJS is not present or can be enabled with an option when ZoneJS is present (but otherwise ignored with ZoneJS).

fixes #68180
