### PR TITLE
feat(forms): pass SubmitEvent to FormSubmitOptions.action

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -560,7 +560,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
+        "bzlTransitiveDigest": "3aqqHpLeqbsp4Yr/tpmCyFya2ojH4WoJ0svQv/jqp8M=",
         "usagesDigest": "PaJB/TvnSzJTbqGUeIfiFAEjGkG4FEW7es6f6MFMtq8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -586,7 +586,7 @@
     },
     "@@rules_browsers+//browsers:extensions.bzl%browsers": {
       "general": {
-        "bzlTransitiveDigest": "Bm6fiKpWy96aLohOlLCP36ARVxRLZm/R+smhsb2HzmI=",
+        "bzlTransitiveDigest": "eC73J3huWBHXDgd/j+zYZ6PiUN0uIx4EhQ1QREKVpUs=",
         "usagesDigest": "FmXYJVoVJlnfUU8x8gObSvu4qWcco/9Faw61aC/wBF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -4105,7 +4105,7 @@
     },
     "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
       "general": {
-        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
+        "bzlTransitiveDigest": "Gfwqh4WQIb7kmT5RjszNYIIVtHQNaNimdY89DHIC+yU=",
         "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -560,7 +560,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "3aqqHpLeqbsp4Yr/tpmCyFya2ojH4WoJ0svQv/jqp8M=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "PaJB/TvnSzJTbqGUeIfiFAEjGkG4FEW7es6f6MFMtq8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -586,7 +586,7 @@
     },
     "@@rules_browsers+//browsers:extensions.bzl%browsers": {
       "general": {
-        "bzlTransitiveDigest": "eC73J3huWBHXDgd/j+zYZ6PiUN0uIx4EhQ1QREKVpUs=",
+        "bzlTransitiveDigest": "Bm6fiKpWy96aLohOlLCP36ARVxRLZm/R+smhsb2HzmI=",
         "usagesDigest": "FmXYJVoVJlnfUU8x8gObSvu4qWcco/9Faw61aC/wBF0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -4105,7 +4105,7 @@
     },
     "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
       "general": {
-        "bzlTransitiveDigest": "Gfwqh4WQIb7kmT5RjszNYIIVtHQNaNimdY89DHIC+yU=",
+        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
         "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -209,7 +209,7 @@ export class FormRoot<T> {
     // (undocumented)
     readonly fieldTree: i0.InputSignal<FieldTree<T>>;
     // (undocumented)
-    protected onSubmit(event: Event): void;
+    protected onSubmit(event: SubmitEvent): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<FormRoot<any>, "form[formRoot]", never, { "fieldTree": { "alias": "formRoot"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -221,7 +221,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
     action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
         submitted: FieldTree<TSubmittedModel>;
-    }) => Promise<TreeValidationResult>;
+    }, submitEvent?: SubmitEvent) => Promise<TreeValidationResult>;
     ignoreValidators?: 'pending' | 'none' | 'all';
     onInvalid?: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
@@ -637,10 +637,10 @@ export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'
 };
 
 // @public
-export function submit<TModel>(form: FieldTree<TModel>, options?: NoInfer<FormSubmitOptions<unknown, TModel>>): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, options?: NoInfer<FormSubmitOptions<unknown, TModel>>, submitEvent?: SubmitEvent): Promise<boolean>;
 
 // @public (undocumented)
-export function submit<TModel>(form: FieldTree<TModel>, action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>, submitEvent?: SubmitEvent): Promise<boolean>;
 
 // @public
 export function transformedValue<TValue, TRaw>(value: ModelSignal<TValue>, options: TransformedValueOptions<TValue, TRaw>): TransformedValueSignal<TRaw>;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -221,7 +221,8 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
     action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
         submitted: FieldTree<TSubmittedModel>;
-    }, submitEvent?: SubmitEvent) => Promise<TreeValidationResult>;
+        submitEvent?: SubmitEvent;
+    }) => Promise<TreeValidationResult>;
     ignoreValidators?: 'pending' | 'none' | 'all';
     onInvalid?: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;

--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -224,7 +224,7 @@ export class FormRoot<T> {
     // (undocumented)
     readonly fieldTree: i0.InputSignal<FieldTree<T>>;
     // (undocumented)
-    protected onSubmit(event: Event): void;
+    protected onSubmit(event: SubmitEvent): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<FormRoot<any>, "form[formRoot]", never, { "fieldTree": { "alias": "formRoot"; "required": true; "isSignal": true; }; }, {}, never, never, true, never>;
     // (undocumented)
@@ -236,11 +236,13 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
     action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
         submitted: FieldTree<TSubmittedModel>;
+        submitEvent?: SubmitEvent;
     }) => Promise<TreeValidationResult>;
     ignoreValidators?: 'pending' | 'none' | 'all';
     onInvalid?: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
         submitted: FieldTree<TSubmittedModel>;
+        submitEvent?: SubmitEvent;
     }) => void;
 }
 
@@ -725,10 +727,10 @@ export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'
 };
 
 // @public
-export function submit<TModel>(form: FieldTree<TModel>, options?: NoInfer<FormSubmitOptions<unknown, TModel>>): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, options?: NoInfer<FormSubmitOptions<unknown, TModel>>, submitEvent?: SubmitEvent): Promise<boolean>;
 
 // @public (undocumented)
-export function submit<TModel>(form: FieldTree<TModel>, action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>): Promise<boolean>;
+export function submit<TModel>(form: FieldTree<TModel>, action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>, submitEvent?: SubmitEvent): Promise<boolean>;
 
 // @public
 export function transformedValue<TValue, TRaw>(value: ModelSignal<TValue>, options: TransformedValueOptions<TValue, TRaw>): TransformedValueSignal<TRaw>;

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -420,7 +420,12 @@ export async function submit<TModel>(
   try {
     if (shouldRun) {
       node.submitState.selfSubmitting.set(true);
-      const errors = await untracked(() => action?.(field, detail, submitEvent));
+      const detail = {
+        root: node.structure.root.fieldProxy,
+        submitted: form,
+        submitEvent,
+      };
+      const errors = await untracked(() => action?.(field, detail));
       errors && setSubmissionErrors(node, errors);
       return !errors || (isArray(errors) && errors.length === 0);
     } else {

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -378,14 +378,17 @@ export function applyWhenValue(
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   options?: NoInfer<FormSubmitOptions<unknown, TModel>>,
+  submitEvent?: SubmitEvent,
 ): Promise<boolean>;
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>,
+  submitEvent?: SubmitEvent,
 ): Promise<boolean>;
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   options?: FormSubmitOptions<unknown, TModel> | FormSubmitOptions<unknown, TModel>['action'],
+  submitEvent?: SubmitEvent,
 ): Promise<boolean> {
   const node = untracked(form) as FieldState<unknown> as FieldNode;
 
@@ -417,7 +420,7 @@ export async function submit<TModel>(
   try {
     if (shouldRun) {
       node.submitState.selfSubmitting.set(true);
-      const errors = await untracked(() => action?.(field, detail));
+      const errors = await untracked(() => action?.(field, detail, submitEvent));
       errors && setSubmissionErrors(node, errors);
       return !errors || (isArray(errors) && errors.length === 0);
     } else {

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -420,12 +420,13 @@ export async function submit<TModel>(
   try {
     if (shouldRun) {
       node.submitState.selfSubmitting.set(true);
-      const detail = {
-        root: node.structure.root.fieldProxy,
-        submitted: form,
+
+      const actionDetail = {
+        ...detail,
         submitEvent,
       };
-      const errors = await untracked(() => action?.(field, detail));
+
+      const errors = await untracked(() => action?.(field, actionDetail));
       errors && setSubmissionErrors(node, errors);
       return !errors || (isArray(errors) && errors.length === 0);
     } else {

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -440,14 +440,17 @@ export function applyWhenValue(
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   options?: NoInfer<FormSubmitOptions<unknown, TModel>>,
+  submitEvent?: SubmitEvent,
 ): Promise<boolean>;
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   action: NoInfer<FormSubmitOptions<unknown, TModel>['action']>,
+  submitEvent?: SubmitEvent,
 ): Promise<boolean>;
 export async function submit<TModel>(
   form: FieldTree<TModel>,
   options?: FormSubmitOptions<unknown, TModel> | FormSubmitOptions<unknown, TModel>['action'],
+  submitEvent?: SubmitEvent,
 ): Promise<boolean> {
   const node = untracked(form) as FieldState<unknown> as FieldNode;
 
@@ -481,13 +484,19 @@ export async function submit<TModel>(
 
   // Run the action (or alternatively the `onInvalid` callback)
   try {
+    const actionDetail = {
+      ...detail,
+      submitEvent,
+    };
+
     if (shouldRun) {
       node.submitState.selfSubmitting.set(true);
-      const errors = await untracked(() => action?.(field, detail));
+
+      const errors = await untracked(() => action?.(field, actionDetail));
       errors && setSubmissionErrors(node, errors);
       return !errors || (isArray(errors) && errors.length === 0);
     } else {
-      untracked(() => onInvalid?.(field, detail));
+      untracked(() => onInvalid?.(field, actionDetail));
     }
     return false;
   } finally {

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -50,11 +50,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
    */
   onInvalid?: (
     field: FieldTree<TRootModel & TSubmittedModel>,
-    detail: {
-      root: FieldTree<TRootModel>;
-      submitted: FieldTree<TSubmittedModel>;
-      submitEvent?: SubmitEvent;
-    },
+    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
   ) => void;
   /**
    * Whether to ignore any of the validators when submitting:

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -34,6 +34,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
   action: (
     field: FieldTree<TRootModel & TSubmittedModel>,
     detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+    submitEvent?: SubmitEvent,
   ) => Promise<TreeValidationResult>;
   /**
    * Function to run when attempting to submit the form data but validation is failing.

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -33,8 +33,11 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
    */
   action: (
     field: FieldTree<TRootModel & TSubmittedModel>,
-    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
-    submitEvent?: SubmitEvent,
+    detail: {
+      root: FieldTree<TRootModel>;
+      submitted: FieldTree<TSubmittedModel>;
+      submitEvent?: SubmitEvent;
+    },
   ) => Promise<TreeValidationResult>;
   /**
    * Function to run when attempting to submit the form data but validation is failing.

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -50,7 +50,11 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
    */
   onInvalid?: (
     field: FieldTree<TRootModel & TSubmittedModel>,
-    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+    detail: {
+      root: FieldTree<TRootModel>;
+      submitted: FieldTree<TSubmittedModel>;
+      submitEvent?: SubmitEvent;
+    },
   ) => void;
   /**
    * Whether to ignore any of the validators when submitting:

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -31,7 +31,11 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
    */
   action: (
     field: FieldTree<TRootModel & TSubmittedModel>,
-    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+    detail: {
+      root: FieldTree<TRootModel>;
+      submitted: FieldTree<TSubmittedModel>;
+      submitEvent?: SubmitEvent;
+    },
   ) => Promise<TreeValidationResult>;
   /**
    * Function to run when attempting to submit the form data but validation is failing.
@@ -44,7 +48,11 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
    */
   onInvalid?: (
     field: FieldTree<TRootModel & TSubmittedModel>,
-    detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
+    detail: {
+      root: FieldTree<TRootModel>;
+      submitted: FieldTree<TSubmittedModel>;
+      submitEvent?: SubmitEvent;
+    },
   ) => void;
   /**
    * Whether to ignore any of the validators when submitting:

--- a/packages/forms/signals/src/directive/form_root.ts
+++ b/packages/forms/signals/src/directive/form_root.ts
@@ -41,7 +41,7 @@ import {FieldNode} from '../field/node';
 export class FormRoot<T> {
   readonly fieldTree = input.required<FieldTree<T>>({alias: 'formRoot'});
 
-  protected onSubmit(event: Event): void {
+  protected onSubmit(event: SubmitEvent): void {
     event.preventDefault();
 
     untracked(() => {
@@ -49,7 +49,7 @@ export class FormRoot<T> {
       const node = fieldTree() as FieldState<unknown> as FieldNode;
 
       if (node.structure.fieldManager.submitOptions) {
-        submit(fieldTree);
+        submit(fieldTree, undefined, event);
       }
     });
   }

--- a/packages/forms/signals/src/directive/form_root.ts
+++ b/packages/forms/signals/src/directive/form_root.ts
@@ -42,7 +42,7 @@ import {FieldNode} from '../field/node';
 export class FormRoot<T> {
   readonly fieldTree = input.required<FieldTree<T>>({alias: 'formRoot'});
 
-  protected onSubmit(event: Event): void {
+  protected onSubmit(event: SubmitEvent): void {
     event.preventDefault();
 
     untracked(() => {
@@ -50,7 +50,7 @@ export class FormRoot<T> {
       const node = fieldTree() as FieldState<unknown> as FieldNode;
 
       if (node.structure.fieldManager.submitOptions) {
-        submit(fieldTree);
+        submit(fieldTree, undefined, event);
       }
     });
   }

--- a/packages/forms/signals/test/node/form_root.spec.ts
+++ b/packages/forms/signals/test/node/form_root.spec.ts
@@ -116,21 +116,20 @@ describe('FormRoot', () => {
     @Component({
       template: `
         <form [formRoot]="f">
-          <button type="submit" value="submit">Submit</button>
+          <button type="submit" value="publish">Publish</button>
         </form>
       `,
       imports: [FormRoot, ReactiveFormsModule],
     })
     class TestCmp {
       submitted = false;
-      submitterValue: string | null = null;
+      submitter: HTMLButtonElement | null = null;
 
       readonly f = form(signal({}), {
         submission: {
-          action: async (_field, _detail, event) => {
+          action: async (_field, _detail) => {
             this.submitted = true;
-            const submitter = event?.submitter as HTMLButtonElement | null;
-            this.submitterValue = submitter?.value ?? null;
+            this.submitter = _detail.submitEvent?.submitter as HTMLButtonElement | null;
           },
         },
       });
@@ -151,7 +150,7 @@ describe('FormRoot', () => {
 
     expect(event.defaultPrevented).toBe(true);
     expect(component.submitted).toBeTrue();
-    expect(component.submitterValue).toBe('submit');
+    expect(component.submitter).toBe(button);
   });
 });
 

--- a/packages/forms/signals/test/node/form_root.spec.ts
+++ b/packages/forms/signals/test/node/form_root.spec.ts
@@ -140,11 +140,7 @@ describe('FormRoot', () => {
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
     const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
 
-    const event = new Event('submit', {cancelable: true}) as SubmitEvent;
-    Object.defineProperty(event, 'submitter', {
-      value: button,
-      configurable: true,
-    });
+    const event = createSubmitEvent(button);
 
     act(() => formElement.dispatchEvent(event));
 
@@ -160,4 +156,13 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
+}
+
+function createSubmitEvent(button: HTMLButtonElement): SubmitEvent {
+  const event = new Event('submit', {cancelable: true}) as SubmitEvent;
+  Object.defineProperty(event, 'submitter', {
+    value: button,
+    configurable: true,
+  });
+  return event;
 }

--- a/packages/forms/signals/test/node/form_root.spec.ts
+++ b/packages/forms/signals/test/node/form_root.spec.ts
@@ -116,17 +116,21 @@ describe('FormRoot', () => {
     @Component({
       template: `
         <form [formRoot]="f">
-          <button type="submit">Submit</button>
+          <button type="submit" value="submit">Submit</button>
         </form>
       `,
       imports: [FormRoot, ReactiveFormsModule],
     })
     class TestCmp {
       submitted = false;
+      submitterValue: string | null = null;
+
       readonly f = form(signal({}), {
         submission: {
-          action: async () => {
+          action: async (_field, _detail, event) => {
             this.submitted = true;
+            const submitter = event?.submitter as HTMLButtonElement | null;
+            this.submitterValue = submitter?.value ?? null;
           },
         },
       });
@@ -135,12 +139,19 @@ describe('FormRoot', () => {
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const component = fixture.componentInstance;
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
 
-    const event = new Event('submit', {cancelable: true});
+    const event = new Event('submit', {cancelable: true}) as SubmitEvent;
+    Object.defineProperty(event, 'submitter', {
+      value: button,
+      configurable: true,
+    });
+
     act(() => formElement.dispatchEvent(event));
 
     expect(event.defaultPrevented).toBe(true);
     expect(component.submitted).toBeTrue();
+    expect(component.submitterValue).toBe('submit');
   });
 });
 

--- a/packages/forms/signals/test/node/form_root.spec.ts
+++ b/packages/forms/signals/test/node/form_root.spec.ts
@@ -116,17 +116,18 @@ describe('FormRoot', () => {
     @Component({
       template: `
         <form [formRoot]="f">
-          <button type="submit">Submit</button>
+          <button type="submit" value="publish">Publish</button>
         </form>
       `,
       imports: [FormRoot, ReactiveFormsModule],
     })
     class TestCmp {
-      submitted = false;
+      submitter: HTMLButtonElement | null = null;
+
       readonly f = form(signal({}), {
         submission: {
-          action: async () => {
-            this.submitted = true;
+          action: async (_, detail) => {
+            this.submitter = detail.submitEvent?.submitter as HTMLButtonElement | null;
           },
         },
       });
@@ -135,12 +136,14 @@ describe('FormRoot', () => {
     const fixture = act(() => TestBed.createComponent(TestCmp));
     const component = fixture.componentInstance;
     const formElement = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
 
-    const event = new Event('submit', {cancelable: true});
+    const event = createSubmitEvent(button);
+
     act(() => formElement.dispatchEvent(event));
 
     expect(event.defaultPrevented).toBe(true);
-    expect(component.submitted).toBeTrue();
+    expect(component.submitter).toBe(button);
   });
 });
 
@@ -150,4 +153,14 @@ function act<T>(fn: () => T): T {
   } finally {
     TestBed.tick();
   }
+}
+
+function createSubmitEvent(button: HTMLButtonElement): SubmitEvent {
+  const EventCtor = typeof SubmitEvent !== 'undefined' ? SubmitEvent : Event;
+  const event = new EventCtor('submit', {cancelable: true} as any) as SubmitEvent;
+  Object.defineProperty(event, 'submitter', {
+    value: button,
+    configurable: true,
+  });
+  return event;
 }

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -513,7 +513,7 @@ describe('submit', () => {
       }),
     ).toBe(false);
 
-    expect(onInvalidSpy).toHaveBeenCalledWith(f, {root: f, submitted: f});
+    expect(onInvalidSpy).toHaveBeenCalledWith(f, {root: f, submitted: f, submitEvent: undefined});
   });
 
   it('runs action on invalid form with ignoreValidators: all', async () => {


### PR DESCRIPTION
Allow submit action callbacks to access the SubmitEvent that triggered the form submission.

This enables identifying the submitter button via event.submitter.

Closes #67334

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The submit action defined in FormSubmitOptions does not have access
to the SubmitEvent that triggered the form submission.

This makes it impossible to determine which submit button triggered
the form when multiple submit buttons are present.

Issue Number: #67334

## What is the new behavior?

The submit action now receives the SubmitEvent as a third argument.

This allows accessing event.submitter to identify which button
triggered the form submission.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
