### PR TITLE
feat(server): Make xhr2 dependency optional

### DIFF
--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -46,6 +46,9 @@ export class PlatformState {
 export function provideServerRendering(): EnvironmentProviders;
 
 // @public
+export function provideXhrServerSupport(): Provider;
+
+// @public
 export function renderApplication(bootstrap: (context: BootstrapContext) => Promise<ApplicationRef>, options: {
     document?: string | Document;
     url?: string;

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -15,7 +15,9 @@
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
-    "tslib": "^2.3.0",
+    "tslib": "^2.3.0"
+  },
+  "optionalDependencies": {
     "xhr2": "^0.2.0"
   },
   "repository": {

--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -8,10 +8,10 @@
 
 import {PlatformLocation, XhrFactory} from '@angular/common';
 import {
+  ɵHTTP_ROOT_INTERCEPTOR_FNS as HTTP_ROOT_INTERCEPTOR_FNS,
   HttpEvent,
   HttpHandlerFn,
   HttpRequest,
-  ɵHTTP_ROOT_INTERCEPTOR_FNS as HTTP_ROOT_INTERCEPTOR_FNS,
 } from '@angular/common/http';
 import {inject, Injectable, Provider} from '@angular/core';
 import {Observable} from 'rxjs';
@@ -64,10 +64,18 @@ function relativeUrlsTransformerInterceptorFn(
 }
 
 export const SERVER_HTTP_PROVIDERS: Provider[] = [
-  {provide: XhrFactory, useClass: ServerXhr},
   {
     provide: HTTP_ROOT_INTERCEPTOR_FNS,
     useValue: relativeUrlsTransformerInterceptorFn,
     multi: true,
   },
 ];
+
+/**
+ * Enables Xhr support on the server. This is required when using `withXhr` to make HTTP requests from the server.
+ *
+ * @publicApi 22.0
+ */
+export function provideXhrServerSupport(): Provider {
+  return {provide: XhrFactory, useClass: ServerXhr};
+}

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+export {provideXhrServerSupport} from './http';
 export {PlatformState} from './platform_state';
 export {provideServerRendering} from './provide_server';
 export {platformServer, ServerModule} from './server';

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -8,14 +8,15 @@
 
 import {
   DOCUMENT,
-  PlatformLocation,
-  ViewportScroller,
   ɵgetDOM as getDOM,
   ɵNullViewportScroller as NullViewportScroller,
   ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID,
+  PlatformLocation,
+  ViewportScroller,
 } from '@angular/common';
 import {
   createPlatformFactory,
+  inject,
   Injector,
   NgModule,
   PLATFORM_ID,
@@ -23,16 +24,15 @@ import {
   platformCore,
   PlatformRef,
   Provider,
-  Testability,
-  ɵsetDocument,
-  ɵTESTABILITY as TESTABILITY,
-  inject,
   StaticProvider,
+  Testability,
+  ɵTESTABILITY as TESTABILITY,
+  ɵsetDocument,
 } from '@angular/core';
 import {
+  ɵBrowserDomAdapter as BrowserDomAdapter,
   BrowserModule,
   EVENT_MANAGER_PLUGINS,
-  ɵBrowserDomAdapter as BrowserDomAdapter,
 } from '@angular/platform-browser';
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
@@ -87,7 +87,8 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
  */
 @NgModule({
   exports: [BrowserModule],
-  providers: PLATFORM_SERVER_PROVIDERS,
+  // Note: the `HttpClientModule` still defaults on using `Xhr`, we do the same here.
+  providers: [...PLATFORM_SERVER_PROVIDERS],
 })
 export class ServerModule {}
 


### PR DESCRIPTION
With `FetchBackend` being the default `HttpBackend` it is not required anymore to use `xhr2` and have an Xhr support by default on the server.

BREAKING CHANGE: invoke `provideServerRendering()` in your server providers if you'd like to maintain Xhr support on the server.
