### PR TITLE
fix(forms/signals): make extractValue reactive for compat AbstractControl values

### DIFF
--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -96,7 +96,6 @@ function visitFieldTree(
 ): RawValue<unknown> | DeepPartial<RawValue<unknown>> {
   const state = field();
   const value = state.value();
-  console.log('value', value);
 
   const matchingChildren = extractChildren(field, value, filter);
 

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -87,7 +87,7 @@ export function extractValue<T>(
   field: FieldTree<T>,
   filter?: ExtractFilter,
 ): RawValue<T> | DeepPartial<RawValue<T>> {
-  return untracked(() => visitFieldTree(field, filter)) as RawValue<T> | DeepPartial<RawValue<T>>;
+  return visitFieldTree(field, filter) as RawValue<T> | DeepPartial<RawValue<T>>;
 }
 
 function visitFieldTree(
@@ -96,6 +96,7 @@ function visitFieldTree(
 ): RawValue<unknown> | DeepPartial<RawValue<unknown>> {
   const state = field();
   const value = state.value();
+  console.log('value', value);
 
   const matchingChildren = extractChildren(field, value, filter);
 

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, signal} from '@angular/core';
+import {computed, effect, Injector, runInInjectionContext, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormControl, FormGroup} from '@angular/forms';
 import {applyEach, disabled, form} from '@angular/forms/signals';
@@ -58,6 +58,43 @@ describe('extractValue', () => {
     expect(extractValue(f)).toEqual({
       firstName: 'John',
       lastName: 'Smith',
+    });
+  });
+
+  it('should notify reactive consumers when AbstractControl value changes', () => {
+    const formGroup = new FormGroup({
+      firstName: new FormControl('Max'),
+      lastName: new FormControl('Maxer'),
+    });
+
+    const f = compatForm(signal(formGroup), {injector});
+    const unwrapped = computed(() => extractValue(f));
+
+    let runs = 0;
+    let latest: unknown;
+
+    runInInjectionContext(injector, () => {
+      effect(() => {
+        runs++;
+        latest = unwrapped();
+      });
+    });
+
+    TestBed.tick();
+
+    expect(runs).toBe(1);
+    expect(latest).toEqual({
+      firstName: 'Max',
+      lastName: 'Maxer',
+    });
+
+    formGroup.get('lastName')?.setValue('NotMaxer');
+    TestBed.tick();
+
+    expect(runs).toBe(2);
+    expect(latest).toEqual({
+      firstName: 'Max',
+      lastName: 'NotMaxer',
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

extractValue no longer uses untracked, allowing signal reads during traversal to be tracked.
result:
computed(() => extractValue(...)) becomes reactive
effect re-runs when underlying AbstractControl values change
compat form values behave consistently with signal-based expectations

Reactive consumers are now correctly notified when control values update.

Issue Number: #68097

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This change makes extractValue reactive, which may cause additional re-computations in cases where it was previously used as a purely imperative helper. However, this aligns better with expected signal behavior, especially in compatForm scenarios.

## Other information

The issue was traced to the use of untracked in extractValue, which prevents dependency tracking. Removing it restores the reactive chain.

It is possible that extractValue was originally intended to be non-reactive. If so, an alternative approach could be to introduce a separate reactive API. However, this change fixes the current inconsistency where compat form values do not propagate updates through the signal graph.

A new test has been added to verify that reactive consumers are notified when AbstractControl values change.
