### PR TITLE
fix(http): Don't on Passthru outside of reactive context

### DIFF
--- a/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
@@ -16,7 +16,7 @@ import {
   HttpResponse,
   HttpXhrBackend,
 } from '@angular/common/http';
-import {Inject, Injectable, Optional} from '@angular/core';
+import {inject, Inject, Injectable, Injector, Optional, runInInjectionContext} from '@angular/core';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -58,6 +58,8 @@ import {
  */
 @Injectable()
 export class HttpClientBackendService extends BackendService implements HttpBackend {
+  private injector = inject(Injector);
+
   constructor(
     inMemDbService: InMemoryDbService,
     @Inject(InMemoryBackendConfig) @Optional() config: InMemoryBackendConfigArgs,
@@ -109,7 +111,7 @@ export class HttpClientBackendService extends BackendService implements HttpBack
 
   protected override createPassThruBackend() {
     try {
-      return new HttpXhrBackend(this.xhrFactory);
+      return runInInjectionContext(this.injector, () => new HttpXhrBackend(this.xhrFactory));
     } catch (ex: any) {
       ex.message = 'Cannot create passThru404 backend; ' + (ex.message || '');
       throw ex;

--- a/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
+++ b/packages/misc/angular-in-memory-web-api/test/http-client-backend-service_spec.ts
@@ -24,7 +24,7 @@ import {
 import {importProvidersFrom, Injectable} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {HttpClientBackendService, HttpClientInMemoryWebApiModule} from 'angular-in-memory-web-api';
-import {Observable, zip, of} from 'rxjs';
+import {Observable, of, zip} from 'rxjs';
 import {concatMap, map, tap} from 'rxjs/operators';
 
 import {Hero} from './fixtures/hero';
@@ -555,7 +555,6 @@ describe('HttpClient Backend Service', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [
-          HttpClientModule,
           HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {
             delay,
             passThruUnknownUrl: true,
@@ -591,6 +590,21 @@ describe('HttpClient Backend Service', () => {
         expect(passthru.id).toBe(42, 'passthru object should have id 42');
       }, failRequest);
     }));
+  });
+
+  describe('HttpClient passThru creation', () => {
+    it('should create the passThru backend', () => {
+      TestBed.configureTestingModule({
+        imports: [
+          HttpClientInMemoryWebApiModule.forRoot(HeroInMemDataService, {
+            delay,
+            passThruUnknownUrl: true,
+          }),
+        ],
+      });
+      const httpBackend = TestBed.inject<any>(HttpBackend);
+      expect(() => httpBackend.createPassThruBackend()).not.toThrow();
+    });
   });
 
   describe('Http dataEncapsulation = true', () => {


### PR DESCRIPTION
Priori to this change, the InMemory API threw when request was emited outside an injection context and that request hit the passThru. This commit fixes this.
