### PR TITLE
docs(docs-infra): add background to playground template dropdown

### DIFF
--- a/adev/src/app/features/playground/playground.component.scss
+++ b/adev/src/app/features/playground/playground.component.scss
@@ -69,6 +69,7 @@
   border-radius: 0.25rem;
   padding: 0;
   transform: translateY(-0.7rem);
+  background: var(--page-background);
 
   li {
     list-style: none;


### PR DESCRIPTION
The template dropdown menu had no background color on the container, causing page content to bleed through behind menu items.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

It can be seen in https://angular.dev/playground?templateId=0-hello-world

The playground template dropdown (`ul.adev-template-dropdown`) has no background color set on the container. Only the individual buttons inside each list item have a background. This causes page content to bleed through the dropdown, visible between menu items and at the edges.

To be honest, I first thought the separator was missing between 'Hello Word' and Signals template
<img width="339" height="330" alt="Screenshot 2026-04-15 at 14 51 18" src="https://github.com/user-attachments/assets/1a72b0b6-09e3-4a5b-bc6c-bc289182653e" />

and then I tried to check it in a smaller width (766px) then I saw that there is no actual separator between elements just a background issue. Between 'Control flow' and 'Minigame' template there is some blue can be seen because of the element behind it. 
<img width="414" height="256" alt="image" src="https://github.com/user-attachments/assets/12f6918a-b043-465e-94f5-5b7ee440dd11" />

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The dropdown container now has `background: var(--page-background)`, preventing any content behind it from showing through.

<img width="340" height="281" alt="image" src="https://github.com/user-attachments/assets/96b09cfa-1468-497d-b05b-d5517be65c26" />

<img width="281" height="263" alt="image" src="https://github.com/user-attachments/assets/e4fd7f06-31ac-4d91-9326-7f79705a5c80" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
