### PR TITLE
docs(docs-infra): guard sandbox reset before initialization in playground

### DIFF
--- a/adev/src/app/features/playground/playground.component.spec.ts
+++ b/adev/src/app/features/playground/playground.component.spec.ts
@@ -33,6 +33,7 @@ describe('TutorialPlayground', () => {
 
     class FakeNodeRuntimeSandbox {
       init() {}
+      reset() {}
     }
 
     TestBed.configureTestingModule({
@@ -55,5 +56,23 @@ describe('TutorialPlayground', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should not call reset on the sandbox before it is initialized', async () => {
+    const fakeSandbox = {reset: jasmine.createSpy('reset')} as any;
+    component['nodeRuntimeSandbox'] = fakeSandbox;
+    component['isSandboxReady'].set(false);
+    spyOn<any>(component, 'loadTemplate').and.resolveTo();
+    await component.changeTemplate(component.templates[1]);
+    expect(fakeSandbox.reset).not.toHaveBeenCalled();
+  });
+
+  it('should call reset on the sandbox after it is initialized', async () => {
+    const fakeSandbox = {reset: jasmine.createSpy('reset')} as any;
+    component['nodeRuntimeSandbox'] = fakeSandbox;
+    component['isSandboxReady'].set(true);
+    spyOn<any>(component, 'loadTemplate').and.resolveTo();
+    await component.changeTemplate(component.templates[1]);
+    expect(fakeSandbox.reset).toHaveBeenCalled();
   });
 });

--- a/adev/src/app/features/playground/playground.component.ts
+++ b/adev/src/app/features/playground/playground.component.ts
@@ -17,6 +17,7 @@ import {
   inject,
   input,
   PLATFORM_ID,
+  signal,
   Type,
 } from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
@@ -53,6 +54,7 @@ export default class PlaygroundComponent {
   protected nodeRuntimeSandbox?: NodeRuntimeSandbox;
   protected embeddedEditorComponent?: Type<unknown>;
   protected selectedTemplate: PlaygroundTemplate = this.defaultTemplate;
+  private readonly isSandboxReady = signal(false);
 
   constructor() {
     if (this.isServer) {
@@ -82,6 +84,7 @@ export default class PlaygroundComponent {
       .subscribe(() => {
         this.changeDetectorRef.markForCheck();
         this.nodeRuntimeSandbox?.init();
+        this.isSandboxReady.set(true);
       });
   }
 
@@ -97,7 +100,9 @@ export default class PlaygroundComponent {
     });
     this.selectedTemplate = template;
     await this.loadTemplate(template.path);
-    await this.nodeRuntimeSandbox?.reset();
+    if (this.isSandboxReady()) {
+      await this.nodeRuntimeSandbox?.reset();
+    }
   }
 
   private async loadTemplate(tutorialPath: string) {


### PR DESCRIPTION
docs(docs-infra): guard sandbox reset before initialization in playground

changeTemplate() was calling reset() on the sandbox before init() completed, causing a TypeError when spawning processes on an uninitialized WebContainer. Add isSandboxReady signal to skip reset until the sandbox is fully initialized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When the playground component initializes, an `effect` fires `changeTemplate()` which calls `reset()` on the `NodeRuntimeSandbox` before `init()` has completed. This causes a `TypeError: Cannot read properties of undefined (reading 'spawn')` because the WebContainer instance hasn't been created yet. This error is reproducible on angular.dev/playground in production.

<img width="1403" height="299" alt="image" src="https://github.com/user-attachments/assets/81bf5823-a0ca-4f73-a794-8d618496d024" />


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

A `isSandboxReady` signal is added that is set to `true` only after `init()` completes. `changeTemplate()` now checks this signal before calling `reset()`, preventing the TypeError during initial load.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

