### PR TITLE
refactor: export analyzeTemplateForSelectorless for external tool use

### DIFF
--- a/packages/compiler-cli/private/hybrid_analysis.ts
+++ b/packages/compiler-cli/private/hybrid_analysis.ts
@@ -28,3 +28,4 @@ export {
   SymbolBoundTarget,
   SymbolDirectiveMeta,
 } from '../src/ngtsc/typecheck/src/template_symbol_builder';
+export {analyzeTemplateForSelectorless} from '../src/ngtsc/annotations/component/src/selectorless';


### PR DESCRIPTION
export analyzeTemplateForSelectorless for use by other tools
