### PR TITLE
feat(core): add ability to cache resources for SSR

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -189,9 +189,9 @@ export interface AttributeDecorator {
 export interface BaseResourceOptions<T, R> {
     defaultValue?: NoInfer<T>;
     equal?: ValueEqualityFn<T>;
+    id?: string;
     injector?: Injector;
     params?: (ctx: ResourceParamsContext) => R;
-    transferCacheKey?: (params: R) => StateKey<T>;
 }
 
 // @public

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -191,6 +191,7 @@ export interface BaseResourceOptions<T, R> {
     equal?: ValueEqualityFn<T>;
     injector?: Injector;
     params?: (ctx: ResourceParamsContext) => R;
+    transferCacheKey?: (params: R) => StateKey<T>;
 }
 
 // @public

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -434,6 +434,7 @@ class HttpResourceImpl<T>
       equal,
       debugName,
       injector,
+      undefined,
       getInitialStream,
     );
     this.client = injector.get(HttpClient);

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -8,11 +8,24 @@
 
 import {timeout} from '@angular/private/testing';
 import {BehaviorSubject, EMPTY, Observable, of, Subscriber, throwError} from 'rxjs';
-import {ApplicationRef, Injector, makeStateKey, signal, TransferState} from '../../src/core';
+import {
+  ApplicationRef,
+  ɵCACHE_ACTIVE as CACHE_ACTIVE,
+  Injector,
+  makeStateKey,
+  signal,
+  TransferState,
+} from '../../src/core';
 import {TestBed} from '../../testing';
 import {rxResource} from '../src';
 
 describe('rxResource()', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [{provide: CACHE_ACTIVE, useValue: {isActive: true}}],
+    });
+  });
+
   it('should fetch data using an observable loader', async () => {
     const injector = TestBed.inject(Injector);
     const res = rxResource({
@@ -196,7 +209,7 @@ describe('rxResource()', () => {
       const injector = TestBed.inject(Injector);
       const testResource = rxResource({
         stream: () => of(456),
-        transferCacheKey: () => key,
+        id: key,
         injector,
       });
 
@@ -216,7 +229,7 @@ describe('rxResource()', () => {
       const injector = TestBed.inject(Injector);
       const testResource = rxResource({
         stream: () => of(789),
-        transferCacheKey: () => key,
+        id: key,
         injector,
       });
 
@@ -242,7 +255,7 @@ describe('rxResource()', () => {
               sub.complete();
             });
           }),
-        transferCacheKey: () => key,
+        id: key,
         injector,
       });
 
@@ -261,7 +274,7 @@ describe('rxResource()', () => {
       const injector = TestBed.inject(Injector);
       const testResource = rxResource({
         stream: () => of(131415),
-        transferCacheKey: () => key,
+        id: key,
         injector,
       });
 

--- a/packages/core/rxjs-interop/test/rx_resource_spec.ts
+++ b/packages/core/rxjs-interop/test/rx_resource_spec.ts
@@ -8,7 +8,7 @@
 
 import {timeout} from '@angular/private/testing';
 import {BehaviorSubject, EMPTY, Observable, of, Subscriber, throwError} from 'rxjs';
-import {ApplicationRef, Injector, signal} from '../../src/core';
+import {ApplicationRef, Injector, makeStateKey, signal, TransferState} from '../../src/core';
 import {TestBed} from '../../testing';
 import {rxResource} from '../src';
 
@@ -176,10 +176,110 @@ describe('rxResource()', () => {
     expect(res.error()).toBeInstanceOf(Error);
     expect(() => res.value()).toThrowError(/bad news/);
   });
+
+  describe('with TransferState', () => {
+    let transferState: TransferState;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({providers: [TransferState]});
+      transferState = TestBed.inject(TransferState);
+    });
+
+    afterEach(() => {
+      (globalThis as any).ngServerMode = undefined;
+    });
+
+    it('should read from TransferState if a key is present', async () => {
+      const key = makeStateKey<number>('test-key');
+      transferState.set(key, 123);
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(456),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      // Should be synchronously resolved from cache
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(123);
+
+      // Should prevent loader from running
+      await flushMicrotasks();
+      expect(testResource.value()).toBe(123);
+    });
+
+    it('should write to TransferState on server when resolved (sync)', async () => {
+      (globalThis as any).ngServerMode = true;
+      const key = makeStateKey<number>('server-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(789),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      expect(testResource.status()).toBe('loading');
+
+      await flushMicrotasks();
+
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(789);
+      expect(transferState.get(key, null!)).toBe(789);
+    });
+
+    it('should write to TransferState on server when resolved (async)', async () => {
+      (globalThis as any).ngServerMode = true;
+      const key = makeStateKey<number>('server-async-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () =>
+          new Observable<number>((sub) => {
+            Promise.resolve().then(() => {
+              sub.next(101112);
+              sub.complete();
+            });
+          }),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      expect(testResource.status()).toBe('loading');
+
+      await waitFor(() => testResource.status() === 'resolved');
+
+      expect(testResource.value()).toBe(101112);
+      expect(transferState.get(key, null!)).toBe(101112);
+    });
+
+    it('should not write to TransferState on client when resolved', async () => {
+      (globalThis as any).ngServerMode = false;
+      const key = makeStateKey<number>('client-key');
+
+      const injector = TestBed.inject(Injector);
+      const testResource = rxResource({
+        stream: () => of(131415),
+        transferCacheKey: () => key,
+        injector,
+      });
+
+      await flushMicrotasks();
+
+      expect(testResource.status()).toBe('resolved');
+      expect(testResource.value()).toBe(131415);
+      expect(transferState.hasKey(key)).toBeFalse();
+    });
+  });
 });
 
 async function waitFor(fn: () => boolean): Promise<void> {
   while (!fn()) {
     await timeout(1);
   }
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -92,6 +92,7 @@ export {
   withIncrementalHydration as ɵwithIncrementalHydration,
   CLIENT_RENDER_MODE_FLAG as ɵCLIENT_RENDER_MODE_FLAG,
 } from './hydration/api';
+export {CACHE_ACTIVE as ɵCACHE_ACTIVE} from './hydration/cache';
 export {withEventReplay as ɵwithEventReplay} from './hydration/event_replay';
 export {JSACTION_EVENT_CONTRACT as ɵJSACTION_EVENT_CONTRACT} from './event_delegation_utils';
 export {

--- a/packages/core/src/hydration/cache.ts
+++ b/packages/core/src/hydration/cache.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '../di';
+
+/**
+ * Token used to the determine if the transfer cache should be used, for example for resources.
+ */
+export const CACHE_ACTIVE = new InjectionToken<{isActive: boolean}>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'STATE_CACHE_ACTIVE' : '',
+);

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -9,6 +9,7 @@
 import {Injector} from '../di/injector';
 import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {WritableSignal} from '../render3/reactivity/signal';
+import {StateKey} from '../transfer_state';
 
 /** Error thrown when a `Resource` dependency of another resource errors. */
 export class ResourceDependencyError extends Error {
@@ -231,6 +232,11 @@ export interface BaseResourceOptions<T, R> {
    * Overrides the `Injector` used by `resource`.
    */
   injector?: Injector;
+
+  /**
+   * The transfer cache key used to cache the resource data in the `TransferState` during server-side rendering and to retrieve it on the client side.
+   */
+  transferCacheKey?: (params: R) => StateKey<T>;
 }
 
 /**

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -9,7 +9,6 @@
 import {Injector} from '../di/injector';
 import {Signal, ValueEqualityFn} from '../render3/reactivity/api';
 import {WritableSignal} from '../render3/reactivity/signal';
-import {StateKey} from '../transfer_state';
 
 /** Error thrown when a `Resource` dependency of another resource errors. */
 export class ResourceDependencyError extends Error {
@@ -234,9 +233,10 @@ export interface BaseResourceOptions<T, R> {
   injector?: Injector;
 
   /**
-   * The transfer cache key used to cache the resource data in the `TransferState` during server-side rendering and to retrieve it on the client side.
+   * Identifier used to cache the resource data in the `TransferState` during server-side rendering and to retrieve it on the client side.
+   * This value value needs to be identical for both the client and server.
    */
-  transferCacheKey?: (params: R) => StateKey<T>;
+  id?: string;
 }
 
 /**

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -30,6 +30,7 @@ import {assertInInjectionContext} from '../di/contextual';
 import {Injector} from '../di/injector';
 import {inject} from '../di/injector_compatibility';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {CACHE_ACTIVE} from '../hydration/cache';
 import {DestroyRef} from '../linker/destroy_ref';
 import {PendingTasks} from '../pending_tasks';
 import {linkedSignal} from '../render3/reactivity/linked_signal';
@@ -79,7 +80,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
     options.injector ?? inject(Injector),
-    options.transferCacheKey,
+    options.id as StateKey<T>,
   );
 }
 
@@ -206,7 +207,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     private readonly equal: ValueEqualityFn<T> | undefined,
     private readonly debugName: string | undefined,
     injector: Injector,
-    private transferCacheKey: ((request: R) => StateKey<T>) | undefined,
+    private transferCacheKey: StateKey<T> | undefined,
     getInitialStream?: (request: R) => Signal<ResourceStreamItem<T>> | undefined,
   ) {
     if (isInParamsFunction()) {
@@ -239,6 +240,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       ),
       debugName,
     );
+
+    const cacheState = injector.get(CACHE_ACTIVE, undefined, {optional: true}) ?? {isActive: false};
 
     this.transferState = injector.get(TransferState, undefined, {optional: true}) ?? undefined;
 
@@ -280,11 +283,13 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           );
         } else if (!status) {
           if (!previous) {
-            if (this.transferCacheKey && this.transferState && request !== undefined) {
-              const key = this.transferCacheKey(request as R);
-              if (this.transferState.hasKey(key)) {
+            const transferState = this.transferState;
+            const cacheKey = this.transferCacheKey;
+            if (cacheState.isActive && cacheKey && transferState && request !== undefined) {
+              const key = this.transferCacheKey;
+              if (transferState.hasKey(cacheKey)) {
                 stream = signal(
-                  {value: this.transferState.get(key, null!)},
+                  {value: transferState.get(cacheKey, defaultValue)},
                   ngDevMode ? createDebugNameObject(this.debugName, 'stream') : undefined,
                 );
               }
@@ -466,15 +471,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
         });
 
         const result = untracked(stream);
-        if (
-          typeof ngServerMode !== 'undefined' &&
-          ngServerMode &&
-          this.transferCacheKey &&
-          this.transferState &&
-          isResolved(result)
-        ) {
-          const key = this.transferCacheKey(extRequest.request as R);
-          this.transferState.set(key, result.value);
+        if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+          saveToTransferState(result, this.transferCacheKey, this.transferState);
         }
       } else {
         const resolvedStream = await stream;
@@ -491,16 +489,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
 
         // Use a local variable for the result so TypeScript can narrow `resolvedStream` correctly.
         const result = resolvedStream ? untracked(resolvedStream) : undefined;
-        if (
-          typeof ngServerMode !== 'undefined' &&
-          ngServerMode &&
-          this.transferCacheKey &&
-          this.transferState &&
-          result &&
-          isResolved(result)
-        ) {
-          const key = this.transferCacheKey(extRequest.request as R);
-          this.transferState.set(key, result.value);
+        if (typeof ngServerMode !== 'undefined' && ngServerMode) {
+          saveToTransferState(result, this.transferCacheKey, this.transferState);
         }
       }
     } catch (err) {
@@ -532,6 +522,16 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     // Once the load is aborted, we no longer want to block stability on its resolution.
     this.resolvePendingTask?.();
     this.resolvePendingTask = undefined;
+  }
+}
+
+function saveToTransferState<R, T>(
+  result: ResourceStreamItem<T> | undefined,
+  transferCacheKey: StateKey<T> | undefined,
+  transferState: TransferState | undefined,
+): void {
+  if (transferCacheKey && transferState && result && isResolved(result)) {
+    transferState.set(transferCacheKey, result.value);
   }
 }
 

--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -33,6 +33,7 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {DestroyRef} from '../linker/destroy_ref';
 import {PendingTasks} from '../pending_tasks';
 import {linkedSignal} from '../render3/reactivity/linked_signal';
+import {StateKey, TransferState} from '../transfer_state';
 
 /**
  * Constructs a `Resource` that projects a reactive request to an asynchronous operation defined by
@@ -78,6 +79,7 @@ export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | 
     options.equal ? wrapEqualityFn(options.equal) : undefined,
     options.debugName,
     options.injector ?? inject(Injector),
+    options.transferCacheKey,
   );
 }
 
@@ -195,6 +197,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
 
   override readonly status: Signal<ResourceStatus>;
   override readonly error: Signal<Error | undefined>;
+  private readonly transferState: TransferState | undefined;
 
   constructor(
     request: (ctx: ResourceParamsContext) => R,
@@ -203,6 +206,7 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
     private readonly equal: ValueEqualityFn<T> | undefined,
     private readonly debugName: string | undefined,
     injector: Injector,
+    private transferCacheKey: ((request: R) => StateKey<T>) | undefined,
     getInitialStream?: (request: R) => Signal<ResourceStreamItem<T>> | undefined,
   ) {
     if (isInParamsFunction()) {
@@ -235,6 +239,8 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
       ),
       debugName,
     );
+
+    this.transferState = injector.get(TransferState, undefined, {optional: true}) ?? undefined;
 
     this.extRequest = linkedSignal<WrappedRequest>(
       () => {
@@ -274,7 +280,19 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           );
         } else if (!status) {
           if (!previous) {
-            stream = getInitialStream?.(extRequest.request as R);
+            if (this.transferCacheKey && this.transferState && request !== undefined) {
+              const key = this.transferCacheKey(request as R);
+              if (this.transferState.hasKey(key)) {
+                stream = signal(
+                  {value: this.transferState.get(key, null!)},
+                  ngDevMode ? createDebugNameObject(this.debugName, 'stream') : undefined,
+                );
+              }
+            }
+
+            if (!stream) {
+              stream = getInitialStream?.(extRequest.request as R);
+            }
             // Clear getInitialStream so it doesn't hold onto memory
             getInitialStream = undefined;
             status = request === undefined ? 'idle' : stream ? 'resolved' : 'loading';
@@ -446,6 +464,18 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           previousStatus: 'resolved',
           stream,
         });
+
+        const result = untracked(stream);
+        if (
+          typeof ngServerMode !== 'undefined' &&
+          ngServerMode &&
+          this.transferCacheKey &&
+          this.transferState &&
+          isResolved(result)
+        ) {
+          const key = this.transferCacheKey(extRequest.request as R);
+          this.transferState.set(key, result.value);
+        }
       } else {
         const resolvedStream = await stream;
         if (shouldDiscard()) {
@@ -458,6 +488,20 @@ export class ResourceImpl<T, R> extends BaseWritableResource<T> implements Resou
           previousStatus: 'resolved',
           stream: resolvedStream,
         });
+
+        // Use a local variable for the result so TypeScript can narrow `resolvedStream` correctly.
+        const result = resolvedStream ? untracked(resolvedStream) : undefined;
+        if (
+          typeof ngServerMode !== 'undefined' &&
+          ngServerMode &&
+          this.transferCacheKey &&
+          this.transferState &&
+          result &&
+          isResolved(result)
+        ) {
+          const key = this.transferCacheKey(extRequest.request as R);
+          this.transferState.set(key, result.value);
+        }
       }
     } catch (err) {
       rethrowFatalErrors(err);

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -29,6 +29,7 @@
       "BUBBLE_EVENT_TYPES",
       "BehaviorSubject",
       "BrowserDomAdapter",
+      "CACHE_ACTIVE",
       "CACHE_OPTIONS",
       "CAPTURE_EVENT_TYPES",
       "CHILD_HEAD",

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -8,6 +8,7 @@
 
 import {
   ApplicationRef,
+  ɵCACHE_ACTIVE as CACHE_ACTIVE,
   Component,
   computed,
   createEnvironmentInjector,
@@ -1124,7 +1125,9 @@ describe('with TransferState', () => {
   let transferState: TransferState;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({providers: [TransferState]});
+    TestBed.configureTestingModule({
+      providers: [TransferState, {provide: CACHE_ACTIVE, useValue: {isActive: true}}],
+    });
     transferState = TestBed.inject(TransferState);
   });
 
@@ -1134,7 +1137,7 @@ describe('with TransferState', () => {
 
     const testResource = resource({
       loader: async () => 456,
-      transferCacheKey: () => key,
+      id: key,
       injector: TestBed.inject(Injector),
     });
 
@@ -1149,11 +1152,11 @@ describe('with TransferState', () => {
 
   it('should write to TransferState on server when resolved', async () => {
     (globalThis as any).ngServerMode = true;
-    const key = makeStateKey<number>('server-key');
+    const key = 'server-key';
 
     const testResource = resource({
       loader: async () => 789,
-      transferCacheKey: () => key,
+      id: key,
       injector: TestBed.inject(Injector),
     });
 
@@ -1163,16 +1166,16 @@ describe('with TransferState', () => {
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(789);
-    expect(transferState.get(key, null!)).toBe(789);
+    expect(transferState.get(makeStateKey<number>(key), null!)).toBe(789);
     (globalThis as any).ngServerMode = undefined;
   });
 
   it('should not write to TransferState on client when resolved', async () => {
-    const key = makeStateKey<number>('client-key');
+    const key = 'client-key';
 
     const testResource = resource({
       loader: async () => 101112,
-      transferCacheKey: () => key,
+      id: key,
       injector: TestBed.inject(Injector),
     });
 
@@ -1180,6 +1183,6 @@ describe('with TransferState', () => {
 
     expect(testResource.status()).toBe('resolved');
     expect(testResource.value()).toBe(101112);
-    expect(transferState.hasKey(key)).toBeFalse();
+    expect(transferState.hasKey(makeStateKey(key))).toBeFalse();
   });
 });

--- a/packages/core/test/resource/resource_spec.ts
+++ b/packages/core/test/resource/resource_spec.ts
@@ -16,10 +16,12 @@ import {
   Injector,
   Input,
   inputBinding,
+  makeStateKey,
   resource,
   ResourceRef,
   ResourceStatus,
   signal,
+  TransferState,
 } from '../../src/core';
 import {promiseWithResolvers} from '../../src/util/promise_with_resolvers';
 import {TestBed} from '../../testing';
@@ -1117,3 +1119,67 @@ function extractError(fn: () => unknown): Error | undefined {
     return err as Error;
   }
 }
+
+describe('with TransferState', () => {
+  let transferState: TransferState;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [TransferState]});
+    transferState = TestBed.inject(TransferState);
+  });
+
+  it('should read from TransferState if a key is present', async () => {
+    const key = makeStateKey<number>('test-key');
+    transferState.set(key, 123);
+
+    const testResource = resource({
+      loader: async () => 456,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    // Should be synchronously resolved from cache
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(123);
+
+    // Should prevent loader from running
+    await flushMicrotasks();
+    expect(testResource.value()).toBe(123);
+  });
+
+  it('should write to TransferState on server when resolved', async () => {
+    (globalThis as any).ngServerMode = true;
+    const key = makeStateKey<number>('server-key');
+
+    const testResource = resource({
+      loader: async () => 789,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    expect(testResource.status()).toBe('loading');
+
+    await flushMicrotasks();
+
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(789);
+    expect(transferState.get(key, null!)).toBe(789);
+    (globalThis as any).ngServerMode = undefined;
+  });
+
+  it('should not write to TransferState on client when resolved', async () => {
+    const key = makeStateKey<number>('client-key');
+
+    const testResource = resource({
+      loader: async () => 101112,
+      transferCacheKey: () => key,
+      injector: TestBed.inject(Injector),
+    });
+
+    await flushMicrotasks();
+
+    expect(testResource.status()).toBe('resolved');
+    expect(testResource.value()).toBe(101112);
+    expect(transferState.hasKey(key)).toBeFalse();
+  });
+});

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -8,20 +8,23 @@
 
 import {HttpTransferCacheOptions, ɵwithHttpTransferCache} from '@angular/common/http';
 import {
+  APP_BOOTSTRAP_LISTENER,
+  ApplicationRef,
+  ɵCACHE_ACTIVE as CACHE_ACTIVE,
+  ɵConsole as Console,
   ENVIRONMENT_INITIALIZER,
   EnvironmentProviders,
+  ɵformatRuntimeError as formatRuntimeError,
   inject,
+  ɵIS_ENABLED_BLOCKING_INITIAL_NAVIGATION as IS_ENABLED_BLOCKING_INITIAL_NAVIGATION,
   makeEnvironmentProviders,
   Provider,
-  ɵConsole as Console,
+  provideStabilityDebugging,
   ɵRuntimeError as RuntimeError,
-  ɵformatRuntimeError as formatRuntimeError,
   ɵwithDomHydration as withDomHydration,
   ɵwithEventReplay,
   ɵwithI18nSupport,
   ɵwithIncrementalHydration,
-  ɵIS_ENABLED_BLOCKING_INITIAL_NAVIGATION as IS_ENABLED_BLOCKING_INITIAL_NAVIGATION,
-  provideStabilityDebugging,
 } from '@angular/core';
 import {RuntimeErrorCode} from './errors';
 
@@ -287,5 +290,23 @@ export function provideClientHydration(
       ? []
       : ɵwithIncrementalHydration(),
     providers,
+    {
+      provide: CACHE_ACTIVE,
+      useValue: {isActive: true},
+    },
+    {
+      provide: APP_BOOTSTRAP_LISTENER,
+      multi: true,
+      useFactory: () => {
+        const appRef = inject(ApplicationRef);
+        const cacheState = inject(CACHE_ACTIVE);
+
+        return () => {
+          appRef.whenStable().then(() => {
+            cacheState.isActive = false;
+          });
+        };
+      },
+    },
   ]);
 }


### PR DESCRIPTION
This commit adds a `transferCacheKey` option to enable easy caching for `resource`/ `rxResource`.

By caching resource data we make sure that resources are not in a loading state during hydration on the client side and responsible for destroying server hydrated DOM.

fixes #62897
