### PR TITLE
docs: capitalize `FormField` imports in `form-logic.md`

### DIFF
--- a/adev/src/content/guide/forms/signals/form-logic.md
+++ b/adev/src/content/guide/forms/signals/form-logic.md
@@ -516,7 +516,7 @@ import {form, FormField, min, max, validate} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-custom',
-  imports: [formField],
+  imports: [FormField],
   template: ` <input [formField]="customForm.score" /> `,
 })
 export class Custom {
@@ -643,7 +643,7 @@ import {form, FormField, max} from '@angular/forms/signals';
 
 @Component({
   selector: 'app-inventory',
-  imports: [formField],
+  imports: [FormField],
   template: `
     <label>
       Item
@@ -742,7 +742,7 @@ import {
 
 @Component({
   selector: 'app-promo',
-  imports: [formField],
+  imports: [FormField],
   template: `
     @if (!promoForm.promoCode().hidden()) {
       <label>
@@ -787,7 +787,7 @@ import {form, FormField, applyWhen, required, pattern} from '@angular/forms/sign
 
 @Component({
   selector: 'app-address',
-  imports: [formField],
+  imports: [FormField],
   template: `
     <label>
       Country


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Uncapitalized `imports: [formField]` for a few cases

Issue Number: N/A

## What is the new behavior?

`imports: [FormField]` consistently

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
