### PR TITLE
docs: fix `rxResource` example of `validateAsync`

### DIFF
--- a/adev/src/content/guide/forms/signals/async-operations.md
+++ b/adev/src/content/guide/forms/signals/async-operations.md
@@ -329,13 +329,13 @@ export class Registration {
   private createUsernameResource = (usernameSignal: Signal<string | undefined>) => {
     return rxResource({
       params: () => usernameSignal(),
-      stream: ({request: username}) => this.usernameService.checkUsername(username),
+      stream: ({params: username}) => this.usernameService.checkUsername(username),
     });
   };
 
   registrationForm = form(this.registrationModel, (schemaPath) => {
     validateAsync(schemaPath.username, {
-      params: ({value}) => value() || undefined,
+      params: ({value}) => value(),
       factory: this.createUsernameResource,
       onSuccess: (result) =>
         result?.available ? null : {kind: 'usernameTaken', message: 'Username taken'},


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Invalid destructured `stream > request` for the `rxResource`, and the respective `validateAsync` has an invalid fallback onto `|| undefined` when the schema's `value()` will be a defined `string` already.

Issue Number: N/A

## What is the new behavior?

`stream > params` and no `|| undefined` fallback for the `validateAsync`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
