### PR TITLE
refactor(core): promote `resource`, `rxResource` & `httpResource` to stable

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1655,7 +1655,7 @@ export interface ResourceLoaderParams<R> {
     };
 }
 
-// @public (undocumented)
+// @public
 export type ResourceOptions<T, R> = (PromiseResourceOptions<T, R> | StreamingResourceOptions<T, R>) & {
     debugName?: string;
 };
@@ -1701,7 +1701,7 @@ export type ResourceStatus = 'idle' | 'error' | 'loading' | 'reloading' | 'resol
 // @public
 export type ResourceStreamingLoader<T, R> = (param: ResourceLoaderParams<R>) => Signal<ResourceStreamItem<T>> | PromiseLike<Signal<ResourceStreamItem<T>>> | undefined;
 
-// @public (undocumented)
+// @public
 export type ResourceStreamItem<T> = {
     value: T;
 } | {

--- a/packages/common/http/src/resource.ts
+++ b/packages/common/http/src/resource.ts
@@ -42,7 +42,7 @@ import {
  * based `httpRequest` as well as sub-functions for `ArrayBuffer`, `Blob`, and `string` type
  * requests.
  *
- * @experimental 19.2
+ * @publicApi 22.0
  */
 export interface HttpResourceFn {
   /**
@@ -54,7 +54,7 @@ export interface HttpResourceFn {
    * of the `HttpClient` API. Data is parsed as JSON by default - use a sub-function of
    * `httpResource`, such as `httpResource.text()`, to parse the response differently.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   <TResult = unknown>(
     url: (ctx: ResourceParamsContext) => string | undefined,
@@ -70,7 +70,7 @@ export interface HttpResourceFn {
    * of the `HttpClient` API. Data is parsed as JSON by default - use a sub-function of
    * `httpResource`, such as `httpResource.text()`, to parse the response differently.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   <TResult = unknown>(
     url: (ctx: ResourceParamsContext) => string | undefined,
@@ -86,7 +86,7 @@ export interface HttpResourceFn {
    * of the `HttpClient` API. Data is parsed as JSON by default - use a sub-function of
    * `httpResource`, such as `httpResource.text()`, to parse the response differently.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   <TResult = unknown>(
     request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined,
@@ -102,7 +102,7 @@ export interface HttpResourceFn {
    * of the `HttpClient` API. Data is parsed as JSON by default - use a sub-function of
    * `httpResource`, such as `httpResource.text()`, to parse the response differently.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   <TResult = unknown>(
     request: (ctx: ResourceParamsContext) => HttpResourceRequest | undefined,
@@ -117,7 +117,7 @@ export interface HttpResourceFn {
    * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
    * of the `HttpClient` API. Data is parsed into an `ArrayBuffer`.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   arrayBuffer: {
     <TResult = ArrayBuffer>(
@@ -149,7 +149,7 @@ export interface HttpResourceFn {
    * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
    * of the `HttpClient` API. Data is parsed into a `Blob`.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   blob: {
     <TResult = Blob>(
@@ -181,7 +181,7 @@ export interface HttpResourceFn {
    * Uses `HttpClient` to make requests and supports interceptors, testing, and the other features
    * of the `HttpClient` API. Data is parsed as a `string`.
    *
-   * @experimental 19.2
+   * @publicApi 22.0
    */
   text: {
     <TResult = string>(
@@ -212,7 +212,7 @@ export interface HttpResourceFn {
  * request that expects a different kind of data, you can use a sub-constructor of `httpResource`,
  * such as `httpResource.text`.
  *
- * @experimental 19.2
+ * @publicApi 22.0
  * @initializerApiFunction
  */
 export const httpResource: HttpResourceFn = (() => {

--- a/packages/core/rxjs-interop/src/rx_resource.ts
+++ b/packages/core/rxjs-interop/src/rx_resource.ts
@@ -24,7 +24,7 @@ import {encapsulateResourceError} from '../../src/resource/resource';
 /**
  * Like `ResourceOptions` but uses an RxJS-based `loader`.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
   stream: (params: ResourceLoaderParams<R>) => Observable<T>;
@@ -36,7 +36,7 @@ export interface RxResourceOptions<T, R> extends BaseResourceOptions<T, R> {
  *
  * @see [Using rxResource for async data](ecosystem/rxjs-interop#using-rxresource-for-async-data)
  *
- * @experimental
+ * @publicApi 22.0
  */
 export function rxResource<T, R>(
   opts: RxResourceOptions<T, R> & {defaultValue: NoInfer<T>},
@@ -46,7 +46,7 @@ export function rxResource<T, R>(
  * Like `resource` but uses an RxJS based `loader` which maps the request to an `Observable` of the
  * resource's value.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined>;
 export function rxResource<T, R>(opts: RxResourceOptions<T, R>): ResourceRef<T | undefined> {

--- a/packages/core/src/resource/api.ts
+++ b/packages/core/src/resource/api.ts
@@ -70,7 +70,7 @@ export interface ResourceParamsContext {
  *
  * `local` - The resource's value was set locally via `.set()` or `.update()`.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export type ResourceStatus = 'idle' | 'error' | 'loading' | 'reloading' | 'resolved' | 'local';
 
@@ -81,7 +81,7 @@ export type ResourceStatus = 'idle' | 'error' | 'loading' | 'reloading' | 'resol
  * The usual way of creating a `Resource` is through the `resource` function, but various other APIs
  * may present `Resource` instances to describe their own concepts.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface Resource<T> {
   /**
@@ -125,7 +125,7 @@ export interface Resource<T> {
  *
  * Overwriting the value of a resource sets it to the 'local' state.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface WritableResource<T> extends Resource<T> {
   readonly value: WritableSignal<T>;
@@ -160,7 +160,7 @@ export interface WritableResource<T> extends Resource<T> {
 /**
  * A `WritableResource` created through the `resource` function.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface ResourceRef<T> extends WritableResource<T> {
   hasValue(this: T extends undefined ? this : never): this is ResourceRef<Exclude<T, undefined>>;
@@ -176,7 +176,7 @@ export interface ResourceRef<T> extends WritableResource<T> {
  * Parameter to a `ResourceLoader` which gives the request and other options for the current loading
  * operation.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface ResourceLoaderParams<R> {
   params: NoInfer<Exclude<R, undefined>>;
@@ -189,14 +189,14 @@ export interface ResourceLoaderParams<R> {
 /**
  * Loading function for a `Resource`.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export type ResourceLoader<T, R> = (param: ResourceLoaderParams<R>) => PromiseLike<T>;
 
 /**
  * Streaming loader for a `Resource`.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export type ResourceStreamingLoader<T, R> = (
   param: ResourceLoaderParams<R>,
@@ -205,7 +205,7 @@ export type ResourceStreamingLoader<T, R> = (
 /**
  * Options to the `resource` function, for creating a resource.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface BaseResourceOptions<T, R> {
   /**
@@ -236,7 +236,7 @@ export interface BaseResourceOptions<T, R> {
 /**
  * Options to the `resource` function, for creating a resource.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> {
   /**
@@ -253,7 +253,7 @@ export interface PromiseResourceOptions<T, R> extends BaseResourceOptions<T, R> 
 /**
  * Options to the `resource` function, for creating a resource.
  *
- * @experimental
+ * @publicApi 22.0
  */
 export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R> {
   /**
@@ -269,7 +269,7 @@ export interface StreamingResourceOptions<T, R> extends BaseResourceOptions<T, R
 }
 
 /**
- * @experimental
+ * @publicApi 22.0
  */
 export type ResourceOptions<T, R> = (
   | PromiseResourceOptions<T, R>
@@ -282,14 +282,14 @@ export type ResourceOptions<T, R> = (
 };
 
 /**
- * @experimental
+ * @publicApi 22.0
  */
 export type ResourceStreamItem<T> = {value: T} | {error: Error};
 
 /**
  * An explicit representation of a resource's state.
  *
- * @experimental
+ * @publicApi 22.0
  * @see [Resource composition with snapshots](guide/signals/resource#resource-composition-with-snapshots)
  */
 export type ResourceSnapshot<T> =
@@ -302,6 +302,8 @@ export type ResourceSnapshot<T> =
  * Options for `debounced`.
  *
  * @see [Debouncing signals with `debounced`](guide/signals/debounced)
+ *
+ * @experimental 22.0
  */
 export interface DebouncedOptions<T> {
   /** The `Injector` to use for the debounced resource. */
@@ -315,6 +317,8 @@ export interface DebouncedOptions<T> {
  * Can be a number of milliseconds or a function that returns a Promise.
  *
  * @see [Debouncing signals with `debounced`](guide/signals/debounced)
+ *
+ * @experimental 22.0
  */
 export type DebounceTimer<T> =
   | number


### PR DESCRIPTION
The time has come.

Note: #67382 introduced a breaking change where you could notice some sublte timing change on how `value` is set when using `rxResource` or a `stream` on a `resource`
