### PR TITLE
docs: add angular-contributor-helper skill

### DIFF
--- a/skills/dev-skills/README.md
+++ b/skills/dev-skills/README.md
@@ -6,6 +6,7 @@ The Angular skills are designed to help coding agents create applications aligne
 
 - **`angular-developer`**: Generates Angular code and provides architectural guidance. Useful for creating components, services, or obtaining best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling, testing, or CLI tooling.
 - **`angular-new-app`**: Creates a new Angular app using the Angular CLI. Provides important guidelines for effectively setting up and structuring a modern Angular application.
+- **`angular-contributor-helper`**: Helps contributors work on the Angular framework source code. Provides references for commit conventions, coding standards, building and testing, Bazel, public API surface, and fixup commits.
 
 ## Using Agent Skills
 

--- a/skills/dev-skills/angular-contributor-helper/SKILL.MD
+++ b/skills/dev-skills/angular-contributor-helper/SKILL.MD
@@ -1,0 +1,45 @@
+---
+name: angular-contributor-helper
+description: Helps Angular contributors work on the Angular framework source code. Trigger when writing fixes, refactors, or improvements, opening issues, preparing branches, writing code that follows Angular internal conventions, running tests, and preparing PRs.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Contributor Guidelines
+
+1. Always read the relevant source files before making changes. Understand the existing patterns, naming conventions, and architecture of the package you're working in.
+
+2. Before opening an issue or PR, search the issue tracker and existing PRs to check if someone has already reported or addressed the same thing.
+
+3. Always ask before committing. Do not commit unless the user explicitly asks.
+
+## Codebase Structure
+
+The Angular monorepo has its packages under `packages/` and documentation under `adev/`. List the `packages/` directory to see all available packages. Each package typically has `src/`, `test/`, `BUILD.bazel`, and a `public_api.ts` or `index.ts` for its public API surface.
+
+## Contributing Workflow
+
+When helping an Angular contributor, consult the following references, check their work against the guidelines, and flag any issues:
+
+- **Commit Messages**: Remind the contributor to follow the strict commit message format. Read [commit-message-guidelines.md](references/commit-message-guidelines.md)
+- **Building and Testing**: Guide the contributor through prerequisites, building the repo, running tests, and formatting. Read [building-and-testing.md](references/building-and-testing.md)
+- **Public API Surface**: If the change affects public API, let the contributor know about golden file updates. Read [public-api-surface.md](references/public-api-surface.md)
+- **Coding Standards**: Remind the contributor of Angular's API design, naming, TypeScript practices, and testing style. Read [coding-standards.md](references/coding-standards.md)
+- **Building with Bazel**: Help the contributor with Bazel commands, debugging tests, and diagnosing build issues. Read [building-with-bazel.md](references/building-with-bazel.md)
+- **Fixup Commits**: When addressing review feedback, guide the contributor on using fixup commits. Read [fixup-commits.md](references/fixup-commits.md)
+
+## PR Quality Expectations
+
+When helping a contributor prepare a PR, remind them of the Angular team's minimum expectations ([full guidelines](https://github.com/angular/angular/blob/main/CONTRIBUTING.md)):
+
+1. Search [existing PRs](https://github.com/angular/angular/pulls) first to avoid duplicating work.
+2. Clearly describe the problem or feature. Issues require a minimal reproduction.
+3. Discuss design in an issue first — PRs are not the place for design work.
+4. The change should improve code quality or a feature.
+5. Micro optimizations need benchmark validation.
+6. Don't PR feature requests not labeled "help wanted" — they usually need design work first.
+7. Changes must be well tested.
+8. Sign the [CLA](https://cla.developers.google.com/about/google-individual) before sending PRs.
+9. Be aware that breaking changes may block a PR due to the level of churn they cause.

--- a/skills/dev-skills/angular-contributor-helper/references/building-and-testing.md
+++ b/skills/dev-skills/angular-contributor-helper/references/building-and-testing.md
@@ -1,0 +1,90 @@
+# Building and Testing Angular
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/building-and-testing-angular.md)
+
+## Prerequisites
+
+- [Git](https://git-scm.com/)
+- [Node.js](https://nodejs.org) (version specified in `.nvmrc`)
+- [pnpm](https://pnpm.io/) (version specified in `package.json` engines field)
+- On Windows: [MSYS2](https://www.msys2.org/) for Bazel, or consider using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+
+## Development in a Container
+
+You can use the provided [Dev Container](https://containers.dev/) configuration:
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop), [VS Code](https://code.visualstudio.com/), and the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the repo in VS Code and run **Dev Containers: Reopen in Container** from the Command Palette.
+
+## Getting the Sources
+
+```shell
+git clone git@github.com:<github-username>/angular.git
+cd angular
+git remote add upstream https://github.com/angular/angular.git
+```
+
+## Installing Dependencies
+
+```shell
+pnpm install
+```
+
+## Building
+
+```shell
+pnpm build
+```
+
+Results go in `dist/packages-dist`.
+
+## Running Tests
+
+Bazel is the primary build and test tool. Run all package tests before submitting a PR:
+
+```shell
+pnpm test //packages/...
+```
+
+For package-specific tests, refer to Bazel targets in each package's `BUILD.bazel`.
+
+### Testing Against a Local Project
+
+```shell
+pnpm ng-dev misc build-and-link <path-to-local-project-root>
+```
+
+Disable CLI cache when testing local changes:
+
+```shell
+ng cache disable
+```
+
+When invoking the Angular CLI locally, use the `--preserve-symlinks` flag:
+
+```shell
+node --preserve-symlinks --preserve-symlinks-main node_modules/@angular/cli/lib/init.js serve
+```
+
+PRs can only be merged if code is properly formatted and all tests pass. CI will run affected tests even if you forget to run them locally.
+
+## Formatting Source Code
+
+Angular uses [prettier](https://prettier.io). CI will fail if code is not properly formatted.
+
+```shell
+pnpm ng-dev format changed [shaOrRef]   # format files changed since sha/ref (default: main)
+pnpm ng-dev format all                  # format all source code
+pnpm ng-dev format files <files..>      # format specific files
+```
+
+## Linting
+
+```shell
+pnpm lint
+```
+
+## IDE Support (Bazel)
+
+- **VS Code**: Install the [Bazel extension](https://marketplace.visualstudio.com/items?itemName=BazelBuild.vscode-bazel)
+- **WebStorm/IntelliJ**: Install the [Bazel plugin](https://plugins.jetbrains.com/plugin/8609-bazel)

--- a/skills/dev-skills/angular-contributor-helper/references/building-with-bazel.md
+++ b/skills/dev-skills/angular-contributor-helper/references/building-with-bazel.md
@@ -1,0 +1,147 @@
+# Building Angular with Bazel
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/building-with-bazel.md)
+
+This is for developing Angular itself, not for building Angular applications with Bazel.
+
+## Installation
+
+Angular installs Bazel from npm via [`@bazel/bazelisk`](https://github.com/bazelbuild/bazelisk). Run Bazel with:
+
+```shell
+pnpm bazel
+```
+
+## Configuration
+
+- `WORKSPACE` file marks the root as a Bazel project.
+- `.bazelrc` contains checked-in options.
+- To hide `bazel-*` symlinks, add `build --symlink_prefix=/` to `.bazelrc`.
+
+## Building
+
+```shell
+pnpm bazel build packages/core          # build a package
+pnpm bazel build packages/...           # build all packages
+```
+
+Use [ibazel](https://github.com/bazelbuild/bazel-watcher) for watch mode.
+
+## Testing
+
+```shell
+pnpm test packages/core/test:test       # test package in node
+pnpm test packages/core/test:test_web   # test package in karma
+pnpm test packages/...                  # test all packages
+pnpm test //packages/core/...           # all tests for one package
+```
+
+### Test Flags
+
+- `--config=debug`: build and launch in debug mode
+- `--test_arg=--node_options=--inspect=9228`: change inspector port
+- `--test_tag_filters=<tag>`: filter tests by tag
+
+## Debugging Node Tests in Chrome DevTools
+
+1. Open [chrome://inspect](chrome://inspect)
+2. Click "Open dedicated DevTools for Node"
+3. Run: `pnpm bazel test packages/core/test:test --config=debug`
+4. Click "Resume script execution" to hit `debugger` statements or breakpoints
+
+To inspect generated templates, find the component in the call stack and click the source map link.
+
+## Debugging Node Tests in VSCode
+
+Add to `launch.json`:
+
+```json
+{
+  "name": "Attach to Process",
+  "type": "node",
+  "request": "attach",
+  "port": 9229,
+  "restart": true,
+  "timeout": 600000,
+  "sourceMaps": true,
+  "skipFiles": ["<node_internals>/**"],
+  "sourceMapPathOverrides": {
+    "?:*/bin/*": "${workspaceFolder}/*"
+  },
+  "resolveSourceMapLocations": ["!**/node_modules/**"]
+}
+```
+
+Then run `pnpm bazel test <target> --config=debug` and attach the debugger.
+
+## Debugging Karma Tests
+
+1. Run with `_debug` suffix: `pnpm bazel run packages/core/test:test_web_debug`
+2. Open [http://localhost:9876/debug.html](http://localhost:9876/debug.html)
+3. Use browser DevTools to debug (use `fit`/`fdescribe` to focus tests)
+
+## Debugging Bazel Rules
+
+Open external directory:
+
+```shell
+open $(pnpm -s bazel info output_base)/external
+```
+
+See subcommands:
+
+```shell
+pnpm bazel build //packages/core:package -s
+```
+
+## Diagnosing Slow Builds
+
+Generate a profile:
+
+```shell
+pnpm bazel build //packages/compiler --profile build.profile
+```
+
+Analyze in console:
+
+```shell
+pnpm bazel analyze-profile build.profile
+pnpm bazel analyze-profile build.profile --task_tree ".*" --task_tree_threshold 5000
+```
+
+Or generate an HTML report:
+
+```shell
+pnpm bazel analyze-profile build.profile --html --html_details --html_histograms
+```
+
+## Stamping
+
+Bazel supports including version control information in built artifacts. Angular configures this via:
+
+1. `tools/bazel_stamp_vars.js` runs `git` commands to generate versioning info.
+2. `.bazelrc` registers this script as the `workspace_status_command`.
+
+## Remote Cache
+
+Bazel assigns a content-based hash to all action inputs as the cache key. Because builds are hermetic, it can skip executing an action if the hash is already cached. Currently only used on CI. Angular core developers can enable remote caching for local builds.
+
+## Known Issues
+
+### Windows
+
+- `bazel run` only works with non-test targets. Use `bazel test` instead.
+- Ensure `C:\msys64\usr\bin` is in the **system** PATH (not user PATH).
+
+### Xcode (macOS)
+
+If you get `Xcode version must be specified` errors:
+
+```shell
+bazel clean --expunge
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+sudo xcodebuild -license
+pnpm bazel build //packages/core
+```
+
+In VSCode, add `"files.exclude": {"bazel-*": true}` to settings to avoid conflicts.

--- a/skills/dev-skills/angular-contributor-helper/references/coding-standards.md
+++ b/skills/dev-skills/angular-contributor-helper/references/coding-standards.md
@@ -1,0 +1,178 @@
+# Angular Framework Coding Standards
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/coding-standards.md)
+
+These apply to development on Angular itself, not applications built with Angular.
+
+## Code Style
+
+Based on the [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html) with additional TypeScript guidance. The team uses `prettier` for automatic formatting, enforced by CI.
+
+## Comments
+
+- Comments explaining _what_ code does are nice.
+- Comments explaining _why_ code exists are invaluable.
+- Use JsDoc-style comments for descriptions (classes, members, etc.) and `//` for everything else.
+
+```typescript
+// GOOD: explains why
+// Unless the user specifies otherwise, the calendar should not be a tab stop.
+// This prevents ngAria from overzealously adding a tabindex to anything with an ng-model.
+if (!attributes['tabindex']) {
+  element.setAttribute('tabindex', '-1');
+}
+```
+
+## API Design
+
+### Boolean Arguments
+
+Avoid boolean arguments that mean "do something extra". Prefer separate functions:
+
+```typescript
+// AVOID
+function getTargetElement(createIfNotFound = false) { ... }
+
+// PREFER
+function getExistingTargetElement() { ... }
+function createTargetElement() { ... }
+```
+
+### Optional Arguments
+
+Only use when the argument makes sense for the API or is required for performance. Not for implementation convenience.
+
+## TypeScript
+
+### Typing
+
+Avoid `any`. Consider `generic` or `unknown` instead.
+
+### Getters and Setters
+
+- Only use for `@Input` properties or API compatibility.
+- Avoid long or complex accessors (max ~3 lines, otherwise use a method).
+- Getter should immediately precede its setter.
+- Decorators like `@Input` go on the getter.
+- Prefer `readonly` over getter-only:
+
+```typescript
+// YES
+readonly active: boolean;
+
+// NO
+get active(): boolean { return this._active; }
+```
+
+### Iteration
+
+Prefer `for` or `for of` over `Array.prototype.forEach`.
+
+### JsDoc
+
+- All public APIs must have user-facing JsDoc comments.
+- Properties: concise description of what the property means.
+- Methods: describe what the function does, each parameter, and the return value.
+- Booleans: use "Whether..." not "True if...":
+
+```typescript
+/** Whether the button is disabled. */
+disabled: boolean = false;
+```
+
+### Try-Catch
+
+Only for legitimately unexpected errors. Each `try-catch` **must** include a comment explaining the specific error and why it cannot be prevented.
+
+### Variables
+
+Prefer `const`, use `let` only when value must change. Avoid `var`.
+
+Use `readonly` members wherever possible.
+
+## Naming
+
+### General
+
+- Write out words, avoid abbreviations.
+- Prefer exact names over short names (`labelPosition` > `align`).
+- Use `is`/`has` prefixes for booleans (except `@Input` properties).
+- Name based on responsibility, not usage:
+
+```typescript
+// NO
+class DefaultRouteReuseStrategy {}
+
+// YES
+class NonStoringRouteReuseStrategy {}
+```
+
+### Observables
+
+Don't suffix with `$`.
+
+### Classes
+
+PascalCase. Don't end with `Impl`.
+
+### Interfaces
+
+Don't prefix with `I`. Don't suffix with `Interface`.
+
+### Functions and Methods
+
+camelCase. Name should capture the action performed, not when it's called:
+
+```typescript
+// AVOID
+handleClick() { ... }
+
+// PREFER
+activateRipple() { ... }
+```
+
+### Constants and Injection Tokens
+
+UPPER_SNAKE_CASE.
+
+### Test Classes
+
+Give meaningful, descriptive names:
+
+```typescript
+// PREFER
+class FormGroupWithCheckboxAndRadios { ... }
+class InputWithNgModel { ... }
+
+// AVOID
+class Comp { ... }
+class InputComp { ... }
+```
+
+## RxJS
+
+Alias `of` as `observableOf`:
+
+```typescript
+import {of as observableOf} from 'rxjs';
+```
+
+## Testing
+
+Use descriptive test names that read as sentences, typically "it should...":
+
+```typescript
+// PREFER
+describe('Router', () => {
+  describe('with the default route reuse strategy', () => {
+    it('should not reuse routes upon location change', () => { ... });
+  });
+});
+
+// AVOID
+describe('Router', () => {
+  describe('default strategy', () => {
+    it('should work', () => { ... });
+  });
+});
+```

--- a/skills/dev-skills/angular-contributor-helper/references/commit-message-guidelines.md
+++ b/skills/dev-skills/angular-contributor-helper/references/commit-message-guidelines.md
@@ -1,0 +1,89 @@
+# Commit Message Format
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md)
+
+Each commit message has a **header**, an optional **body**, and an optional **footer**.
+
+```
+<type>(<scope>): <short summary>
+
+<body>
+
+<footer>
+```
+
+## Header
+
+```
+<type>(<scope>): <short summary>
+```
+
+- `<type>` and `<summary>` are mandatory, `(<scope>)` is optional.
+
+### Type
+
+| Type         | Description                                             |
+| ------------ | ------------------------------------------------------- |
+| **build**    | Build system or external dependency changes             |
+| **ci**       | CI configuration changes                                |
+| **docs**     | Documentation only changes                              |
+| **feat**     | A new feature                                           |
+| **fix**      | A bug fix                                               |
+| **perf**     | A performance improvement                               |
+| **refactor** | Code change that neither fixes a bug nor adds a feature |
+| **test**     | Adding or correcting tests                              |
+
+### Scope
+
+The scope is the npm package name affected. Supported scopes:
+
+`animations`, `benchpress`, `common`, `compiler`, `compiler-cli`, `core`, `dev-infra`, `devtools`, `docs-infra`, `elements`, `forms`, `http`, `language-service`, `language-server`, `localize`, `migrations`, `platform-browser`, `platform-browser-dynamic`, `platform-server`, `router`, `service-worker`, `upgrade`, `vscode-extension`, `zone.js`
+
+Exceptions:
+
+- `dev-infra`: changes in `/scripts` and `/tools`
+- `docs-infra`: infrastructure changes to the docs-app in `/adev` (for content edits, use `docs:` without scope)
+- `migrations`: changes to `ng update` migrations
+- `devtools`: changes in the browser extension
+- none/empty string: useful for `test` and `refactor` across all packages (e.g. `test: add missing unit tests`) and for docs not related to a specific package (e.g. `docs: fix typo in tutorial`)
+
+### Summary
+
+- Imperative, present tense: "change" not "changed" nor "changes"
+- Don't capitalize the first letter
+- No period at the end
+
+## Body
+
+- Mandatory for all commits except `docs` type.
+- Must be at least 20 characters.
+- Imperative, present tense.
+- Explain the motivation — _why_ you are making the change.
+
+## Footer
+
+Used for breaking changes, deprecations, and issue references.
+
+Breaking change section must start with `BREAKING CHANGE: ` followed by a summary, a blank line, and a detailed description with **migration instructions**:
+
+```
+BREAKING CHANGE: <summary>
+
+<description + migration instructions>
+
+Fixes #<issue number>
+```
+
+Deprecation section must start with `DEPRECATED: ` followed by what is deprecated, a blank line, and a detailed description with **recommended update path**:
+
+```
+DEPRECATED: <what is deprecated>
+
+<description + recommended update path>
+
+Closes #<pr number>
+```
+
+## Revert Commits
+
+Start with `revert: ` followed by the original commit header. Body must contain `This reverts commit <SHA>` and the reason for reverting.

--- a/skills/dev-skills/angular-contributor-helper/references/fixup-commits.md
+++ b/skills/dev-skills/angular-contributor-helper/references/fixup-commits.md
@@ -1,0 +1,47 @@
+# Working with Fixup Commits
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/using-fixup-commits.md)
+
+Fixup commits are used to address review feedback without amending original commits, making it easy for reviewers to see what changed.
+
+## Creating a Fixup Commit
+
+```shell
+# Fix up the last commit on the branch:
+git commit --fixup HEAD
+
+# Fix up a specific commit:
+git commit --fixup <COMMIT_SHA>
+```
+
+The commit message will be `fixup! <original-commit-subject>`.
+
+### Example
+
+```
+feat: first commit
+fix: second commit
+fixup! feat: first commit    ← this modifies the first commit
+```
+
+The fixup commit doesn't have to target the immediately preceding commit — it can fix up any earlier commit on the branch.
+
+## Why Use Fixup Commits
+
+- Reviewers can see exactly what changed since their last review
+- No need to re-review all changes on larger PRs
+- Angular's merge script automatically squashes fixup commits into the original
+
+## Squashing Manually
+
+Use interactive rebase with `--autosquash`:
+
+```shell
+git rebase --autosquash <base-branch>
+```
+
+To make autosquash the default:
+
+```shell
+git config rebase.autoSquash true
+```

--- a/skills/dev-skills/angular-contributor-helper/references/public-api-surface.md
+++ b/skills/dev-skills/angular-contributor-helper/references/public-api-surface.md
@@ -1,0 +1,49 @@
+# Public API Surface
+
+[Full source](https://github.com/angular/angular/blob/main/contributing-docs/public-api-surface.md)
+
+## Supported Packages
+
+Angular's SemVer, release schedule, and deprecation policy applies to:
+
+`@angular/animations`, `@angular/common`, `@angular/core`, `@angular/elements`, `@angular/forms`, `@angular/platform-browser-dynamic`, `@angular/platform-browser`, `@angular/platform-server`, `@angular/router`, `@angular/service-worker`, `@angular/upgrade`
+
+**Excluded**: `@angular/compiler` (considered private/internal). Only CLI usage of `@angular/compiler-cli` is covered, not direct API use.
+
+## What's Considered Public API
+
+- Symbols exported via the main entry point (e.g. `@angular/core`) and testing entry point (e.g. `@angular/core/testing`)
+- Symbols exported via global namespace `ng`
+
+## What's Excluded from Public API
+
+- File/import paths other than `/`, `/testing`, and `/bundles/*`
+- Constructors of injectable classes
+- Members marked `private` or prefixed with `_`, `ɵ`, or `ɵɵ`
+- Extending classes unless explicitly documented
+- Generated compiler code
+- `@angular/core/primitives` package
+
+## Peer Dependencies
+
+Peer dependencies (TypeScript, Zone.js, RxJS) are not part of the public API surface, but are included in SemVer policies. Updates that don't cause breaking changes for Angular applications may happen in minor releases. Breaking peer dependency updates must be deferred to major releases.
+
+## Extending Angular Classes
+
+All public API classes are `final`. Do not extend unless the API docs explicitly allow it. Extending unsupported classes is not supported since protected members and internal implementation may change outside major releases.
+
+## Golden Files
+
+Angular tracks public API status in golden files using the **public API guard**.
+
+If you modify any public API, CI will fail. To accept the new golden file:
+
+```shell
+pnpm bazel run //packages/<modified_package>:<modified_package>_api.accept
+```
+
+Example: if you changed `@angular/core`'s public API:
+
+```shell
+pnpm bazel run //packages/core:core_api.accept
+```


### PR DESCRIPTION
Adds a skill that helps contributors work on the Angular framework by checking their work against contribution guidelines and flagging issues. Includes reference docs for commit conventions, coding standards, building and testing, Bazel, public API surface, and fixup commits.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The existing skills focus on building Angular applications. This adds support for contributors working on the Angular framework itself.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

A new angular-contributor-helper skill is available that guides contributors through the Angular contribution workflow. It checks their work against the contribution guidelines and flags issues related to commit format, coding standards, testing, public API changes, and PR quality expectations.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The skill follows the same structure as the existing angular-developer skill — a SKILL.MD with frontmatter and references in a references/ directory. All reference docs are concise summaries with [Full source] links back to the originals in contributing-docs/