### PR TITLE
fix(forms): disable PatternValidator gracefully for invalid input types

### DIFF
--- a/packages/forms/signals/test/web/interop.spec.ts
+++ b/packages/forms/signals/test/web/interop.spec.ts
@@ -13,6 +13,7 @@ import {
   forwardRef,
   inject,
   input,
+  Input,
   provideZonelessChangeDetection,
   resource,
   signal,
@@ -27,6 +28,7 @@ import {
   NG_VALUE_ACCESSOR,
   NgControl,
   ReactiveFormsModule,
+  FormsModule,
   ValidationErrors,
   Validator,
 } from '@angular/forms';
@@ -1228,6 +1230,61 @@ describe('ControlValueAccessor', () => {
 
         act(() => fixture.componentInstance.pattern.set(/b*/));
         expect(dir.pattern()).toEqual([/b*/]);
+      });
+
+      it('should not crash when a CVA has an @Input() pattern and internally uses PatternValidator', () => {
+        // Regression test for https://github.com/angular/angular/issues/68246
+        // When using [formField] on a CVA that has an \`@Input() pattern\` and uses
+        // \`[pattern]\` + \`[ngModel]\` internally, the binding loop in control_cva.ts
+        // propagates \`[]\` (empty array) to the \`@Input() pattern\`.
+        // The internal \`PatternValidator\` then receives \`[]\` and, before the fix,
+        // it crashed with \`TypeError: regex.test is not a function\`.
+        @Component({
+          selector: 'custom-control-with-pattern',
+          template: `<input [pattern]="pattern" [ngModel]="value" (ngModelChange)="onInput($event)" />`,
+          imports: [FormsModule],
+          providers: [
+            {
+              provide: NG_VALUE_ACCESSOR,
+              useExisting: CustomControlWithPattern,
+              multi: true,
+            },
+          ],
+        })
+        class CustomControlWithPattern implements ControlValueAccessor {
+          // Typed as "any" to simulate that at runtime, regardless of compile-time types
+          // (or if a UI library uses lax typings), the framework will imperatively inject
+          // an empty array [] into this input, bypassing template type checking.
+          @Input() pattern: any = null;
+          value = '';
+          private onChangeFn?: (value: string) => void;
+
+          writeValue(newValue: string): void {
+            this.value = newValue;
+          }
+          registerOnChange(fn: (value: string) => void): void {
+            this.onChangeFn = fn;
+          }
+          registerOnTouched(fn: () => void): void {}
+
+          onInput(newValue: string) {
+            this.value = newValue;
+            this.onChangeFn?.(newValue);
+          }
+        }
+
+        @Component({
+          imports: [CustomControlWithPattern, FormField],
+          template: `<custom-control-with-pattern [formField]="f" />`,
+        })
+        class TestCmp {
+          // No pattern() rule configured on this field.
+          // FieldNode.pattern defaults to EMPTY ([]).
+          readonly f = form(signal('abc'));
+        }
+
+        // Should not throw TypeError: regex.test is not a function
+        expect(() => act(() => TestBed.createComponent(TestCmp))).not.toThrow();
       });
     });
   });

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -693,4 +693,9 @@ export class PatternValidator extends AbstractValidatorDirective {
 
   /** @internal */
   override createValidator = (input: string | RegExp): ValidatorFn => patternValidator(input);
+
+  /** @docs-private */
+  override enabled(input: unknown): boolean {
+    return typeof input === 'string' || input instanceof RegExp;
+  }
 }

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -568,6 +568,7 @@ export function maxLengthValidator(maxLength: number): ValidatorFn {
  */
 export function patternValidator(pattern: string | RegExp): ValidatorFn {
   if (!pattern) return nullValidator;
+  if (typeof pattern !== 'string' && !(pattern instanceof RegExp)) return nullValidator;
   let regex: RegExp;
   let regexStr: string;
   if (typeof pattern === 'string') {

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -428,6 +428,12 @@ import {useAutoTick, timeout} from '@angular/private/testing';
       it('should not error on "undefined" pattern', () =>
         expect(Validators.pattern(undefined!)(new FormControl('aaAA'))).toBeNull());
 
+      it('should not error on an empty array pattern', () =>
+        expect(Validators.pattern([] as any)(new FormControl('aaAA'))).toBeNull());
+
+      it('should not error on an object pattern', () =>
+        expect(Validators.pattern({} as any)(new FormControl('aaAA'))).toBeNull());
+
       it('should work with pattern string containing both boundary symbols', () =>
         expect(Validators.pattern('^[aA]*$')(new FormControl('aaAA'))).toBeNull());
 


### PR DESCRIPTION
When using Signal Forms (`[formField]`) with a ControlValueAccessor that exposes an `@Input() pattern`, the framework's internal bindings loop propagates an empty array (`[]`) to the input when no pattern is defined on the field.

Previously, this caused the legacy `PatternValidator` to crash with `TypeError: regex.test is not a function` because it attempted to execute `[].test(value)`.

This commit improves `PatternValidator` by overriding the `enabled()` method to explicitly require a `string` or `RegExp`. Invalid input types will now gracefully disable the validator rather than causing a runtime crash. Additionally, `patternValidator()` adds a defensive type guard for further stability.

Closes #68246

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?

When a control value accessor is used with `[formField]` and provides a custom `pattern` input internally, Signal Forms propagates an empty array binding (`[]`) to the control. The `PatternValidator` blindly consumes this non-string array and crashes the entire application throwing a `TypeError: regex.test is not a function` when it tries to run the validation check.

Issue Number: #68246

## What is the new behavior?

The `PatternValidator` logic incorporates an `enabled()` method override to selectively intercept inputs (similar to what `RequiredValidator` and `EmailValidator` currently do). If the bound pattern type isn't a string or a RegExp, the validator smoothly disables itself and returns `nullValidator` instead of executing and causing a runtime exception.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (I Think)

