### PR TITLE
refactor(core): Split the ng global into internal and external objects

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, ɵGlobalDevModeUtils} from '@angular/core';
+import {Injector, ɵExternalCoreGlobalUtils} from '@angular/core';
 import {
   getInjectorFromElementNode,
   getRootElements,
   serializeProviderRecord,
 } from './component-tree';
 
-type Ng = ɵGlobalDevModeUtils['ng'];
+type Ng = ɵExternalCoreGlobalUtils;
 const NG_VERSION = 'ng-version';
 const VERSION = '0.0.0-PLACEHOLDER';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.spec.ts
@@ -8,7 +8,7 @@
 
 import {
   Injector,
-  ɵGlobalDevModeUtils,
+  ɵExternalCoreGlobalUtils,
   ɵProviderRecord as ProviderRecord,
   InjectionToken,
 } from '@angular/core';
@@ -18,7 +18,7 @@ import {
   serializeProviderRecord,
 } from './component-tree';
 
-type Ng = ɵGlobalDevModeUtils['ng'];
+type Ng = ɵExternalCoreGlobalUtils;
 const NG_VERSION = 'ng-version';
 const VERSION = '0.0.0-PLACEHOLDER';
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -112,7 +112,7 @@ export {
   twoWayBinding,
 } from './render3/dynamic_bindings';
 export {createEnvironmentInjector, createNgModule} from './render3/ng_module_ref';
-export {publishExternalGlobalUtil as ɵpublishExternalGlobalUtil} from './render3/util/global_utils';
+export {publishNonCoreGlobalUtil as ɵpublishNonCoreGlobalUtil} from './render3/util/global_utils';
 export * from './resource';
 export {Sanitizer} from './sanitization/sanitizer';
 export {SecurityContext} from './sanitization/security';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -286,8 +286,8 @@ export {
   ForLoopBlockData as ɵForLoopBlockData,
 } from './render3/util/control_flow_types';
 export {
+  ExternalCoreGlobalUtils as ɵExternalCoreGlobalUtils,
   FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
-  GlobalDevModeUtils as ɵGlobalDevModeUtils,
 } from './render3/util/global_utils';
 export {getTransferState as ɵgetTransferState} from './render3/util/transfer_state_utils';
 export {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -288,8 +288,8 @@ export {
   ForLoopBlockData as ɵForLoopBlockData,
 } from './render3/util/control_flow_types';
 export {
+  ExternalCoreGlobalUtils as ɵExternalCoreGlobalUtils,
   FrameworkAgnosticGlobalUtils as ɵFrameworkAgnosticGlobalUtils,
-  GlobalDevModeUtils as ɵGlobalDevModeUtils,
 } from './render3/util/global_utils';
 export {getTransferState as ɵgetTransferState} from './render3/util/transfer_state_utils';
 export {

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -12,12 +12,15 @@ import {assertDefined} from '../../util/assert';
 import {global} from '../../util/global';
 import {setupFrameworkInjectorProfiler} from '../debug/framework_injector_profiler';
 import {setProfiler} from '../profiler';
-import {isSignal} from '../reactivity/api';
+import {Signal, isSignal} from '../reactivity/api';
 
 import {applyChanges} from './change_detection_utils';
 import {getControlFlowBlocks} from './control_flow';
 import {
+  AngularComponentDebugMetadata,
+  AngularDirectiveDebugMetadata,
   DirectiveDebugMetadata,
+  Listener,
   getComponent,
   getContext,
   getDirectiveMetadata,
@@ -34,10 +37,18 @@ import {
   getInjectorProviders,
   getInjectorResolutionPath,
 } from './injector_discovery_utils';
-import {getSignalGraph} from './signal_debug';
+import {DebugSignalGraph, getSignalGraph} from './signal_debug';
 
 import {enableProfiling} from '../debug/chrome_dev_tools_performance';
 import {getTransferState} from './transfer_state_utils';
+import {InjectionToken} from '../../di/injection_token';
+import {Injector} from '../../di/injector';
+import {InjectedService, ProviderRecord} from '../debug/injector_profiler';
+
+import {Type} from '../../interface/type';
+import {RElement} from '../interfaces/renderer_dom';
+import {type Profiler} from '../../../primitives/devtools';
+import {ControlFlowBlock} from './control_flow_types';
 
 /**
  * This file introduces series of globally accessible debug tools
@@ -57,15 +68,73 @@ import {getTransferState} from './transfer_state_utils';
 export const GLOBAL_PUBLISH_EXPANDO_KEY = 'ng';
 
 // Typing for externally published global util functions
-// Ideally we should be able to use `NgGlobalPublishUtils` using declaration merging but that doesn't work with API extractor yet.
-// Have included the typings to have type safety when working with editors that support it (VSCode).
-export interface ExternalGlobalUtils {
+interface NonCoreGlobalUtils {
   ɵgetLoadedRoutes(route: any): any;
   ɵnavigateByUrl(router: any, url: string): any;
   ɵgetRouterInstance(injector: any): any;
 }
 
-const globalUtilsFunctions = {
+/**
+ * A type of the internal (meaning inside google3) global utils. This definition needs to exist
+ * in a place where it can be used by DevTools and also synced into google3 and consumed internally.
+ *
+ * Since versioning in google3 works differently, we do not have the same constraint as
+ * {@link ExternalCoreGlobalUtils}. We can change these definitions more or less as much as we want
+ * without fear of breaking applications on older framework versions (note that http://go/build-horizon
+ * does technically apply). The trade-off is that external Angular developers cannot use such APIs,
+ * as they would be broken whenever the APIs changed.
+ *
+ * `InternalCoreGlobalUtils` serves as a "beta" channel for new APIs which can be implemented and supported
+ * in DevTools. We can then iterate and change these APIs, landing whatever breaking changes necessary,
+ * and update DevTools accordingly without actually breaking any users. Once a given function's design
+ * fully validated, we can move it to {@link ExternalCoreGlobalUtils} and ship the function externally in
+ * Angular. This allows fast iteration on new global utils and only applies Angular's long-lived
+ * versioning constraint when we are ready to accept it.
+ */
+interface InternalCoreGlobalUtils {}
+
+/**
+ * The set of external (meaning outside google3) global utils implemented by `@angular/core`.
+ * Other packages may provided their own global utilities with their own types. Any functions
+ * which have *ever* been in this set exist in long-lived public Angular versions which DevTools
+ * needs to support.
+ */
+export interface ExternalCoreGlobalUtils {
+  ɵgetDependenciesFromInjectable<T>(
+    injector: Injector,
+    token: Type<T> | InjectionToken<T>,
+  ): {instance: T; dependencies: Omit<InjectedService, 'injectedIn'>[]} | undefined;
+  ɵgetInjectorProviders(injector: Injector): ProviderRecord[];
+  ɵgetInjectorResolutionPath(injector: Injector): Injector[];
+  ɵgetInjectorMetadata(
+    injector: Injector,
+  ):
+    | {type: 'element'; source: RElement}
+    | {type: 'environment'; source: string | null}
+    | {type: 'null'; source: null}
+    | null;
+  ɵsetProfiler(profiler: Profiler | null): () => void;
+  ɵgetSignalGraph(injector: Injector): DebugSignalGraph;
+  ɵgetControlFlowBlocks(node: Node): ControlFlowBlock[];
+  ɵgetTransferState(injector: Injector): Record<string, unknown>;
+
+  getDirectiveMetadata(
+    directiveOrComponentInstance: any,
+  ): AngularComponentDebugMetadata | AngularDirectiveDebugMetadata | null;
+  getComponent<T>(element: Element): T | null;
+  getContext<T extends {}>(element: Element): T | null;
+  getListeners(element: Element): Listener[];
+  getOwningComponent<T>(elementOrDir: Element | {}): T | null;
+  getHostElement(componentOrDirective: {}): Element;
+  getInjector(elementOrDir: Element | {}): Injector;
+  getRootComponents(elementOrDir: Element | {}): {}[];
+  getDirectives(node: Node): {}[];
+  applyChanges(component: {}): void;
+  isSignal(value: unknown): value is Signal<unknown>;
+  enableProfiling(): void;
+}
+
+const externalCoreGlobalUtils: ExternalCoreGlobalUtils = {
   /**
    * Warning: functions that start with `ɵ` are considered *INTERNAL* and should not be relied upon
    * in application's code. The contract of those functions might be changed in any release and/or a
@@ -80,21 +149,20 @@ const globalUtilsFunctions = {
   'ɵgetControlFlowBlocks': getControlFlowBlocks,
   'ɵgetTransferState': getTransferState,
 
-  'getDirectiveMetadata': getDirectiveMetadata,
-  'getComponent': getComponent,
-  'getContext': getContext,
-  'getListeners': getListeners,
-  'getOwningComponent': getOwningComponent,
-  'getHostElement': getHostElement,
-  'getInjector': getInjector,
-  'getRootComponents': getRootComponents,
-  'getDirectives': getDirectives,
-  'applyChanges': applyChanges,
-  'isSignal': isSignal,
+  getDirectiveMetadata,
+  getComponent,
+  getContext,
+  getListeners,
+  getOwningComponent,
+  getHostElement,
+  getInjector,
+  getRootComponents,
+  getDirectives,
+  applyChanges,
+  isSignal,
 
-  'enableProfiling': enableProfiling,
+  enableProfiling,
 };
-type CoreGlobalUtilsFunctions = keyof typeof globalUtilsFunctions;
 
 let _published = false;
 /**
@@ -112,26 +180,19 @@ export function publishDefaultGlobalUtils() {
       setupFrameworkInjectorProfiler();
     }
 
-    for (const [methodName, method] of Object.entries(globalUtilsFunctions)) {
-      publishGlobalUtil(methodName as CoreGlobalUtilsFunctions, method);
+    for (const [methodName, method] of Object.entries(externalCoreGlobalUtils)) {
+      publishGlobalUtil(methodName as keyof ExternalCoreGlobalUtils, method);
     }
   }
 }
 
 /**
- * Default debug tools available under `window.ng`.
- */
-export type GlobalDevModeUtils = {
-  [GLOBAL_PUBLISH_EXPANDO_KEY]: typeof globalUtilsFunctions;
-};
-
-/**
  * Publishes the given function to `window.ng` so that it can be
  * used from the browser console when an application is not in production.
  */
-export function publishGlobalUtil<K extends CoreGlobalUtilsFunctions>(
+export function publishGlobalUtil<K extends keyof ExternalCoreGlobalUtils>(
   name: K,
-  fn: (typeof globalUtilsFunctions)[K],
+  fn: ExternalCoreGlobalUtils[K],
 ): void {
   publishUtil(name, fn);
 }
@@ -139,25 +200,21 @@ export function publishGlobalUtil<K extends CoreGlobalUtilsFunctions>(
 /**
  * Defines the framework-agnostic `ng` global type, not just the `@angular/core` implementation.
  *
- * `typeof globalUtilsFunctions` is specifically the `@angular/core` implementation, so we
- * overwrite some properties to make them more framework-agnostic. Longer term, we should define
- * the `ng` global type as an interface implemented by `globalUtilsFunctions` rather than a type
- * derived from it.
+ * ExternalCoreGlobalUtils is specifically the `@angular/core` implementation, so we
+ * overwrite some properties to make them more framework-agnostic.
  */
-export type FrameworkAgnosticGlobalUtils = Omit<
-  typeof globalUtilsFunctions,
-  'getDirectiveMetadata'
-> & {
+export type FrameworkAgnosticGlobalUtils = Omit<ExternalCoreGlobalUtils, 'getDirectiveMetadata'> & {
   getDirectiveMetadata(directiveOrComponentInstance: any): DirectiveDebugMetadata | null;
-} & ExternalGlobalUtils;
+} & InternalCoreGlobalUtils &
+  NonCoreGlobalUtils;
 
 /**
  * Publishes the given function to `window.ng` from package other than @angular/core
  * So that it can be used from the browser console when an application is not in production.
  */
-export function publishExternalGlobalUtil<K extends keyof ExternalGlobalUtils>(
+export function publishNonCoreGlobalUtil<K extends keyof NonCoreGlobalUtils>(
   name: K,
-  fn: ExternalGlobalUtils[K],
+  fn: NonCoreGlobalUtils[K],
 ): void {
   publishUtil(name, fn);
 }

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -118,9 +118,7 @@ export interface ExternalCoreGlobalUtils {
   ɵgetControlFlowBlocks(node: Node): ControlFlowBlock[];
   ɵgetTransferState(injector: Injector): Record<string, unknown>;
 
-  getDirectiveMetadata(
-    directiveOrComponentInstance: any,
-  ): AngularComponentDebugMetadata | AngularDirectiveDebugMetadata | null;
+  getDirectiveMetadata(directiveOrComponentInstance: any): DirectiveDebugMetadata | null;
   getComponent<T>(element: Element): T | null;
   getContext<T extends {}>(element: Element): T | null;
   getListeners(element: Element): Listener[];
@@ -203,9 +201,8 @@ export function publishGlobalUtil<K extends keyof ExternalCoreGlobalUtils>(
  * ExternalCoreGlobalUtils is specifically the `@angular/core` implementation, so we
  * overwrite some properties to make them more framework-agnostic.
  */
-export type FrameworkAgnosticGlobalUtils = Omit<ExternalCoreGlobalUtils, 'getDirectiveMetadata'> & {
-  getDirectiveMetadata(directiveOrComponentInstance: any): DirectiveDebugMetadata | null;
-} & InternalCoreGlobalUtils &
+export type FrameworkAgnosticGlobalUtils = ExternalCoreGlobalUtils &
+  InternalCoreGlobalUtils &
   NonCoreGlobalUtils;
 
 /**

--- a/packages/core/test/render3/global_utils_spec.ts
+++ b/packages/core/test/render3/global_utils_spec.ts
@@ -19,8 +19,7 @@ import {
   getRootComponents,
 } from '../../src/render3/util/discovery_utils';
 import {
-  GLOBAL_PUBLISH_EXPANDO_KEY,
-  GlobalDevModeUtils,
+  ExternalCoreGlobalUtils,
   publishDefaultGlobalUtils,
   publishGlobalUtil,
 } from '../../src/render3/util/global_utils';
@@ -28,17 +27,15 @@ import {setProfiler} from '../../src/render3/profiler';
 import {global} from '../../src/util/global';
 import {getControlFlowBlocks} from '../../src/render3/util/control_flow';
 
-type GlobalUtilFunctions = keyof GlobalDevModeUtils['ng'];
-
 describe('global utils', () => {
   describe('publishGlobalUtil', () => {
     it('should publish a function to the window', () => {
-      const w = global as any as GlobalDevModeUtils;
-      const foo = 'foo' as GlobalUtilFunctions;
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBeFalsy();
+      const ng = (global as any).ng as ExternalCoreGlobalUtils;
+      const foo = 'foo' as keyof ExternalCoreGlobalUtils;
+      expect(ng[foo]).toBeFalsy();
       const fooFn = () => {};
       publishGlobalUtil(foo, fooFn);
-      expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][foo]).toBe(fooFn);
+      expect(ng[foo]).toBe(fooFn);
     });
   });
 
@@ -95,7 +92,7 @@ describe('global utils', () => {
   });
 });
 
-function assertPublished(name: GlobalUtilFunctions, value: Function) {
-  const w = global as any as GlobalDevModeUtils;
-  expect(w[GLOBAL_PUBLISH_EXPANDO_KEY][name]).toBe(value);
+function assertPublished(name: keyof ExternalCoreGlobalUtils, value: Function) {
+  const w = (global as any).ng as ExternalCoreGlobalUtils;
+  expect(w[name]).toBe(value);
 }

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -31,7 +31,7 @@ import {
   Provider,
   runInInjectionContext,
   Type,
-  ɵpublishExternalGlobalUtil,
+  ɵpublishNonCoreGlobalUtil,
 } from '@angular/core';
 import {of, Subject} from 'rxjs';
 
@@ -104,9 +104,9 @@ import {
 export function provideRouter(routes: Routes, ...features: RouterFeatures[]): EnvironmentProviders {
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     // Publish this util when the router is provided so that the devtools can use it.
-    ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);
-    ɵpublishExternalGlobalUtil('ɵgetRouterInstance', getRouterInstance);
-    ɵpublishExternalGlobalUtil('ɵnavigateByUrl', navigateByUrl);
+    ɵpublishNonCoreGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);
+    ɵpublishNonCoreGlobalUtil('ɵgetRouterInstance', getRouterInstance);
+    ɵpublishNonCoreGlobalUtil('ɵnavigateByUrl', navigateByUrl);
   }
 
   return makeEnvironmentProviders([


### PR DESCRIPTION
Split the `ng` global interface into two interfaces:
* `ExternalCoreGlobalUtils` includes all the functionality which has been shipped in a long-lived Angular version externally and which is subject to the versioning constraints described above.
* `InternalCoreGlobalUtils` includes internal-only functionality which has **not** been shipped in a long-lived Angular version.

This split means that all APIs in `InternalCoreGlobalUtils` can be iterated and evolved at a much faster pace. Angular DevTools can support those features, and we can make breaking changes more-or-less whenever we want. The downside is that external Angular developers cannot take advantage of those APIs or else we would be subject to the same versioning constraint we're trying to avoid here.

This means we can use `InternalCoreGlobalUtils` as a kind of "beta" channel for new DevTools APIs. Once that functionality is validated and the design is stabilized, the feature can be moved into `ExternalCoreGlobalUtils` and made available for external Angular developers when we're ready to commit to the long-lived version constraint. This will hopefully help us strike a better balance between iterating on new APIs quickly and maintaining stable APIs for external Angular users.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

There is one `CoreGlobalUtilsFunctions` interface that includes all functions that are part of the `ng` global and released externally in Angular 3P.

Issue Number: N/A

## What is the new behavior?

There are two interfaces, `InternalCoreGlobalUtils` and `ExternalCoreGlobalUtils`, that together include all functions that are part of the `ng` global. Only the functions in `ExternalCoreGlobalUtils` have been released externally in Angular 3P. This means new `ng` global functions can be initially defined in `InternalCoreGlobalUtils` and iterated upon until they're ready for release externally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

CARETAKER NOTE: This PR requires patch CL: [cl/918081864](https://critique.corp.google.com/cl/918081864). Note, [presubmits](https://fusion2.corp.google.com/presubmit/917988379/OCL:917988379:BASE:918069755:1779230972239:cd99e37a;groups=PossiblyNewlyFailing,PossiblyAlreadyFailing/targets) failed due to flaky or already broken targets.
