### PR TITLE
refactor(devtools): make the DevToolsNode element property optional

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
@@ -104,7 +104,7 @@ export class ComponentDataSource extends DataSource<FlatNode> {
         // based on this identifier directly, since it's a reference type
         // and the reference is preserved after transformation.
         position: node.position,
-        name: node.component ? node.component.name : node.element,
+        name: node.component ? node.component.name : (node.element ?? ''),
         directives: node.directives?.map((d) => d.name) ?? [],
         original: node,
         level,

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -123,7 +123,7 @@ export type ChangeDetection = 'ng-on-push' | 'ng-eager' | 'acx-on-push' | 'acx-d
 // TODO: refactor to remove nativeElement as it is not serializable
 // and only really exists on the ng-devtools-backend
 export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> {
-  element: string;
+  element?: string;
   directives?: DirType[];
   component: CmpType | null;
   children: DevToolsNode<DirType, CmpType>[];


### PR DESCRIPTION
The Angular DevTools Extension doesn't use the `element` property in Client-Only Wiz apps. Once the new `ng.getComponentForest` function is implemented, Client-Only Wiz could provide `ComponentTreeNode`s without an `element` property. This change supports that case by making the `element` property optional.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `element` property is required for all `DevToolsNode`s.

Issue Number: N/A

## What is the new behavior?

The `element` property of `DevToolsNode` is optional.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
