### PR TITLE
refactor(devtools): make the DevToolsNode directives property optional

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -241,7 +241,7 @@ const getNestedPropertiesCallback =
       return emitEmpty();
     }
     const current =
-      position.directive === undefined ? node.component : node.directives[position.directive];
+      position.directive === undefined ? node.component : node.directives?.[position.directive];
     if (!current) {
       return emitEmpty();
     }
@@ -432,7 +432,7 @@ const prepareForestForSerialization = (
             id: initializeOrGetDirectiveForestHooks().getDirectiveId(node.component.instance)!,
           }
         : null,
-      directives: node.directives.map((d) => ({
+      directives: node.directives?.map((d) => ({
         name: d.name,
         id: initializeOrGetDirectiveForestHooks().getDirectiveId(d.instance)!,
       })),

--- a/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/component-tree/component-tree.ts
@@ -161,7 +161,7 @@ export const getLatestComponentState = (
     }
   };
 
-  node.directives.forEach((dir) => populateResultSet(dir));
+  node.directives?.forEach((dir) => populateResultSet(dir));
   if (node.component) {
     populateResultSet(node.component);
   }
@@ -736,7 +736,7 @@ export const updateState = (updatedStateData: UpdatedStateData): void => {
     );
     return;
   }
-  if (updatedStateData.directiveId.directive !== undefined) {
+  if (node.directives && updatedStateData.directiveId.directive !== undefined) {
     const directive = node.directives[updatedStateData.directiveId.directive].instance;
     mutateNestedProp(directive, updatedStateData.keyPath, updatedStateData.newValue);
     if (ngDebugApiIsSupported(ng, 'getOwningComponent')) {
@@ -766,7 +766,7 @@ export function logValue(valueInfo: {
     return;
   }
 
-  if (valueInfo.directiveId.directive !== undefined) {
+  if (node.directives && valueInfo.directiveId.directive !== undefined) {
     const directiveInstance = node.directives[valueInfo.directiveId.directive].instance;
     if (valueInfo.keyPath === null) {
       logToConsole(directiveInstance);

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -138,7 +138,7 @@ export class LTreeStrategy {
         const node = this._getNode(lView, tView.data, i);
 
         // TODO(mgechev): verify if this won't make us skip projected content.
-        if (node.component || node.directives.length) {
+        if (node.component || node.directives?.length) {
           nodes.push(node);
           this._extract(lViewItem, node.children);
         }

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.spec.ts
@@ -79,7 +79,8 @@ describe('render tree extraction', () => {
     expect(rtree[0].children.length).toBe(2);
     expect(rtree[0].children[0].component?.instance).toBe(childComponent);
     expect(rtree[0].children[1].component).toBe(null);
-    expect(rtree[0].children[1].directives[0].instance).toBe(childDirective);
+    expect(rtree[0].children[1].directives).toBeDefined();
+    expect(rtree[0].children[1].directives![0].instance).toBe(childDirective);
   });
 
   it('should skip nodes without directives', () => {

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/render-tree.ts
@@ -80,7 +80,8 @@ function extractViewTree(
     };
   }
 
-  const isDisplayableNode = component || componentTreeNode.directives.length || isDehydratedElement;
+  const isDisplayableNode =
+    component || componentTreeNode.directives?.length || isDehydratedElement;
   if (isDisplayableNode) {
     result.push(componentTreeNode);
   }

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/capture.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/capture.ts
@@ -299,7 +299,7 @@ const prepareInitialFrame = (source: string, duration: number) => {
     let position: ElementPosition | undefined;
     if (node.component) {
       position = directiveForestHooks.getDirectivePosition(node.component.instance);
-    } else if (node.directives[0]) {
+    } else if (node.directives?.[0]) {
       position = directiveForestHooks.getDirectivePosition(node.directives[0].instance);
     } else if (node.controlFlowBlock) {
       position = directiveForestHooks.getDirectivePosition(node.controlFlowBlock);
@@ -308,15 +308,16 @@ const prepareInitialFrame = (source: string, duration: number) => {
     if (position === undefined) {
       return;
     }
-    const directives = node.directives.map((d) => {
-      return {
-        isComponent: false,
-        isElement: false,
-        name: getDirectiveName(d.instance),
-        outputs: {},
-        lifecycle: {},
-      };
-    });
+    const directives =
+      node.directives?.map((d) => {
+        return {
+          isComponent: false,
+          isElement: false,
+          name: getDirectiveName(d.instance),
+          outputs: {},
+          lifecycle: {},
+        };
+      }) ?? [];
     if (node.component) {
       directives.push({
         isElement: node.component.isElement,

--- a/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/hooks/identity-tracker.ts
@@ -168,7 +168,7 @@ const indexTree = <T extends DevToolsNode<DirectiveInstanceType, ComponentInstan
     position,
     element: node.element,
     component: node.component,
-    directives: node.directives.map((d) => ({position, ...d})),
+    directives: node.directives?.map((d) => ({position, ...d})),
     children: node.children.map((n, i) => indexTree(n, i, position)),
     nativeElement: node.nativeElement,
     hydration: node.hydration,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.component.ts
@@ -68,7 +68,13 @@ const sameDirectives = (a: IndexedNode, b: IndexedNode) => {
   if (a.component && b.component && a.component.id !== b.component.id) {
     return false;
   }
-  const aDirectives = new Set(a.directives.map((d) => d.id));
+  if (!a.directives && !b.directives) {
+    return true;
+  }
+  if (!a.directives || !b.directives) {
+    return false;
+  }
+  const aDirectives = new Set(a.directives.map((d) => d.id) ?? []);
   for (const dir of b.directives) {
     if (!aDirectives.has(dir.id)) {
       return false;
@@ -233,9 +239,8 @@ export class DirectiveExplorerComponent {
     const selectedEl = this.currentSelectedElement();
     if (!selectedEl) return;
 
-    const directiveIndex = selectedEl.directives.findIndex(
-      (directive) => directive.name === directiveName,
-    );
+    const directiveIndex =
+      selectedEl.directives?.findIndex((directive) => directive.name === directiveName) ?? -1;
 
     const selectedFrame = this._frameManager.selectedFrame();
     if (!this._frameManager.activeFrameHasUniqueUrl()) {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/component-data-source/index.ts
@@ -54,11 +54,12 @@ const getId = (node: IndexedNode) => {
   if (node.component) {
     prefix = node.component.id.toString();
   }
-  const dirIds = node.directives
-    .map((d) => d.id)
-    .sort((a, b) => {
-      return a - b;
-    });
+  const dirIds =
+    node.directives
+      ?.map((d) => d.id)
+      .sort((a, b) => {
+        return a - b;
+      }) ?? [];
   return prefix + '-' + dirIds.join('-');
 };
 
@@ -104,7 +105,7 @@ export class ComponentDataSource extends DataSource<FlatNode> {
         // and the reference is preserved after transformation.
         position: node.position,
         name: node.component ? node.component.name : node.element,
-        directives: node.directives.map((d) => d.name),
+        directives: node.directives?.map((d) => d.name) ?? [],
         original: node,
         level,
         hydration: node.hydration,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-forest/index-forest/index.ts
@@ -28,7 +28,7 @@ const indexTree = (
     position,
     element: node.element,
     component: node.component,
-    directives: node.directives.map((d) => ({name: d.name, id: d.id})),
+    directives: node.directives?.map((d) => ({name: d.name, id: d.id})),
     children: node.children.map((n, i) => indexTree(n, i, position)),
     hydration: node.hydration,
     controlFlowBlock: node.controlFlowBlock,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/property-pane.component.ts
@@ -47,7 +47,9 @@ export class PropertyPaneComponent {
     if (selected.component) {
       directives.push(selected.component);
     }
-    directives.push(...selected.directives);
+    if (selected.directives) {
+      directives.push(...selected.directives);
+    }
 
     return directives;
   });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.ts
@@ -43,7 +43,7 @@ export class ElementPropertyResolver {
         directive: undefined,
       };
       if (!indexedNode.component || indexedNode.component.name !== key) {
-        position.directive = indexedNode.directives.findIndex((d) => d.name === key);
+        position.directive = indexedNode.directives?.findIndex((d) => d.name === key) ?? -1;
       }
       this._directivePropertiesController.set(
         key,

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -124,7 +124,7 @@ export type ChangeDetection = 'ng-on-push' | 'ng-eager' | 'acx-on-push' | 'acx-d
 // and only really exists on the ng-devtools-backend
 export interface DevToolsNode<DirType = DirectiveType, CmpType = ComponentType> {
   element: string;
-  directives: DirType[];
+  directives?: DirType[];
   component: CmpType | null;
   children: DevToolsNode<DirType, CmpType>[];
   nativeElement?: Node;

--- a/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-window-extensions.ts
@@ -42,7 +42,7 @@ const chromeWindowExtensions = {
       return;
     }
     if (directiveIndex !== undefined) {
-      if (node.directives[directiveIndex]) {
+      if (node.directives?.[directiveIndex]) {
         return node.directives[directiveIndex].instance.constructor;
       } else {
         console.error(
@@ -102,10 +102,10 @@ const chromeWindowExtensions = {
 
     const isDirective =
       directivePosition.directive !== undefined &&
-      node.directives[directivePosition.directive] &&
+      node.directives?.[directivePosition.directive] &&
       typeof node.directives[directivePosition.directive] === 'object';
     if (isDirective) {
-      return traverseDirective(node.directives[directivePosition.directive].instance, objectPath);
+      return traverseDirective(node.directives![directivePosition.directive].instance, objectPath);
     }
     if (node.component) {
       return traverseDirective(node.component.instance, objectPath);


### PR DESCRIPTION
Client-Only Wiz doesn't have the concept of a directive. Once the new ng.getComponentForest function is implemented, Client-Only Wiz cowilluld provide `ComponentTreeNode`s without a `directives`` property. This change supports that case by making the `directives` property optional.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `directives` property is required for all `DevToolsNode`s.

Issue Number: N/A

## What is the new behavior?

The `directives` property of `DevToolsNode` is optional.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
