### PR TITLE
feat(migrations): preserve `paramsInheritanceStrategy` pre-v22 behavior

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -141,6 +141,10 @@ bundle_entrypoints = [
         "strict-safe-navigation-narrow",
         "packages/core/schematics/migrations/strict-safe-navigation-narrow/index.js",
     ],
+    [
+        "router-params-inheritance",
+        "packages/core/schematics/migrations/router-params-inheritance/index.js",
+    ],
 ]
 
 rollup.rollup(
@@ -156,6 +160,7 @@ rollup.rollup(
         "//packages/core/schematics/migrations/change-detection-eager",
         "//packages/core/schematics/migrations/http-xhr-backend",
         "//packages/core/schematics/migrations/incremental-hydration",
+        "//packages/core/schematics/migrations/router-params-inheritance",
         "//packages/core/schematics/migrations/strict-safe-navigation-narrow",
         "//packages/core/schematics/migrations/strict-templates-default",
         "//packages/core/schematics/ng-generate/cleanup-unused-imports",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -29,6 +29,11 @@
       "version": "22.0.0",
       "description": "Disables the 'nullishCoalescingNotNullable & optionalChainNotNullable extended diagnostics.",
       "factory": "./bundles/strict-safe-navigation-narrow.cjs#migrate"
+    },
+    "router-params-inheritance": {
+      "version": "22.0.0",
+      "description": "Adds paramsInheritanceStrategy: 'emptyOnly' to router configurations to preserve pre-v22 behavior. In v22, the default changed from 'emptyOnly' to 'always'.",
+      "factory": "./bundles/router-params-inheritance.cjs#migrate"
     }
   }
 }

--- a/packages/core/schematics/migrations/router-params-inheritance/BUILD.bazel
+++ b/packages/core/schematics/migrations/router-params-inheritance/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_project(
+    name = "router-params-inheritance",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
+    deps = [
+        "//:node_modules/@angular-devkit/schematics",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli/private",
+        "//packages/core/schematics/utils",
+        "//packages/core/schematics/utils/tsurge",
+        "//packages/core/schematics/utils/tsurge/helpers/angular_devkit",
+    ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":router-params-inheritance",
+        "//:node_modules/typescript",
+        "//packages/compiler-cli",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [":test_lib"],
+)

--- a/packages/core/schematics/migrations/router-params-inheritance/index.ts
+++ b/packages/core/schematics/migrations/router-params-inheritance/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Rule} from '@angular-devkit/schematics';
+import {runMigrationInDevkit} from '../../utils/tsurge/helpers/angular_devkit';
+import {RouterParamsInheritanceMigration} from './migration';
+
+export function migrate(): Rule {
+  return async (tree) => {
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new RouterParamsInheritanceMigration(),
+    });
+  };
+}

--- a/packages/core/schematics/migrations/router-params-inheritance/migration.spec.ts
+++ b/packages/core/schematics/migrations/router-params-inheritance/migration.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {absoluteFrom} from '@angular/compiler-cli';
+import {initMockFileSystem} from '@angular/compiler-cli/private/testing';
+import {runTsurgeMigration} from '../../utils/tsurge/testing';
+import {RouterParamsInheritanceMigration} from './migration';
+
+describe('router-params-inheritance migration', () => {
+  beforeEach(() => {
+    initMockFileSystem('Native');
+  });
+
+  async function migrate(contents: string, fileName = '/index.ts'): Promise<string> {
+    const {fs} = await runTsurgeMigration(new RouterParamsInheritanceMigration(), [
+      {name: absoluteFrom(fileName), isProgramRootFile: true, contents},
+    ]);
+    return fs.readFile(absoluteFrom(fileName));
+  }
+
+  describe('provideRouter', () => {
+    it('adds withRouterConfig when there are no features', async () => {
+      const content = await migrate(`
+        import { provideRouter } from '@angular/router';
+        export const appConfig = { providers: [provideRouter([])] };
+      `);
+
+      expect(content).toContain(`withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' })`);
+      expect(content).toMatch(/import \{[^}]*withRouterConfig[^}]*\}/);
+    });
+
+    it('adds withRouterConfig alongside existing features', async () => {
+      const content = await migrate(`
+        import { provideRouter, withHashLocation } from '@angular/router';
+        export const appConfig = { providers: [provideRouter([], withHashLocation())] };
+      `);
+
+      expect(content).toContain(`withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' })`);
+      expect(content).toContain('withHashLocation()');
+    });
+
+    it('does not add a second withRouterConfig when one is already present', async () => {
+      const content = await migrate(`
+        import { provideRouter, withRouterConfig } from '@angular/router';
+        export const appConfig = {
+          providers: [provideRouter([], withRouterConfig({ onSameUrlNavigation: 'reload' }))],
+        };
+      `);
+
+      expect(content).toContain(
+        `withRouterConfig({ onSameUrlNavigation: 'reload', paramsInheritanceStrategy: 'emptyOnly' })`,
+      );
+      expect(content).toContain(`paramsInheritanceStrategy: 'emptyOnly'`);
+    });
+
+    it('updates multiple provideRouter calls in the same file', async () => {
+      const content = await migrate(`
+        import { provideRouter } from '@angular/router';
+        const configA = { providers: [provideRouter(routesA)] };
+        const configB = { providers: [provideRouter(routesB)] };
+      `);
+
+      expect((content.match(/paramsInheritanceStrategy/g) ?? []).length).toBe(2);
+    });
+  });
+
+  describe('withRouterConfig', () => {
+    it('adds paramsInheritanceStrategy to an empty options object', async () => {
+      const content = await migrate(`
+        import { provideRouter, withRouterConfig } from '@angular/router';
+        export const appConfig = { providers: [provideRouter([], withRouterConfig({}))] };
+      `);
+
+      expect(content).toContain(`withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' })`);
+    });
+
+    it('appends paramsInheritanceStrategy to a non-empty options object', async () => {
+      const content = await migrate(`
+        import { provideRouter, withRouterConfig } from '@angular/router';
+        export const appConfig = {
+          providers: [provideRouter([], withRouterConfig({ onSameUrlNavigation: 'reload' }))],
+        };
+      `);
+
+      expect(content).toContain(
+        `withRouterConfig({ onSameUrlNavigation: 'reload', paramsInheritanceStrategy: 'emptyOnly' })`,
+      );
+    });
+
+    it('does not modify when paramsInheritanceStrategy is already set to always', async () => {
+      const content = await migrate(`
+        import { provideRouter, withRouterConfig } from '@angular/router';
+        export const appConfig = {
+          providers: [provideRouter([], withRouterConfig({ paramsInheritanceStrategy: 'always' }))],
+        };
+      `);
+
+      expect(content).toContain(`withRouterConfig({ paramsInheritanceStrategy: 'always' })`);
+    });
+
+    it('does not modify when paramsInheritanceStrategy is already set to emptyOnly', async () => {
+      const content = await migrate(`
+        import { provideRouter, withRouterConfig } from '@angular/router';
+        export const appConfig = {
+          providers: [provideRouter([], withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' }))],
+        };
+      `);
+
+      expect(content).toContain(`withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' })`);
+    });
+  });
+
+  describe('RouterModule.forRoot', () => {
+    it('adds an options object when none is present', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        @NgModule({ imports: [RouterModule.forRoot(routes)] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).toContain(`{ paramsInheritanceStrategy: 'emptyOnly' }`);
+    });
+
+    it('adds paramsInheritanceStrategy to an empty options object', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        @NgModule({ imports: [RouterModule.forRoot(routes, {})] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).toContain(`{ paramsInheritanceStrategy: 'emptyOnly' }`);
+    });
+
+    it('appends paramsInheritanceStrategy to a non-empty options object', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        @NgModule({ imports: [RouterModule.forRoot(routes, { enableTracing: true })] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).toContain(`{ enableTracing: true, paramsInheritanceStrategy: 'emptyOnly' }`);
+    });
+
+    it('does not modify when paramsInheritanceStrategy is already set to always', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        @NgModule({ imports: [RouterModule.forRoot(routes, { paramsInheritanceStrategy: 'always' })] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).toContain(`{ paramsInheritanceStrategy: 'always' }`);
+    });
+
+    it('does not modify when paramsInheritanceStrategy is already set to emptyOnly', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        @NgModule({ imports: [RouterModule.forRoot(routes, { paramsInheritanceStrategy: 'emptyOnly' })] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).toContain(`{ paramsInheritanceStrategy: 'emptyOnly' }`);
+    });
+
+    it('does not modify when options argument is a variable reference', async () => {
+      const content = await migrate(
+        `
+        import { RouterModule } from '@angular/router';
+        const routerOptions = {};
+        @NgModule({ imports: [RouterModule.forRoot(routes, routerOptions)] })
+        export class AppModule {}
+      `,
+        '/app.module.ts',
+      );
+
+      expect(content).not.toContain('paramsInheritanceStrategy');
+    });
+  });
+});

--- a/packages/core/schematics/migrations/router-params-inheritance/migration.ts
+++ b/packages/core/schematics/migrations/router-params-inheritance/migration.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ImportManager} from '@angular/compiler-cli/private/migrations';
+import ts from 'typescript';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../utils/tsurge';
+import {applyImportManagerChanges} from '../../utils/tsurge/helpers/apply_import_manager';
+import {getImportSpecifier} from '../../utils/typescript/imports';
+
+const ROUTER_PACKAGE = '@angular/router';
+const PROVIDE_ROUTER = 'provideRouter';
+const WITH_ROUTER_CONFIG = 'withRouterConfig';
+const ROUTER_MODULE = 'RouterModule';
+const FOR_ROOT = 'forRoot';
+const PARAMS_INHERITANCE_STRATEGY = 'paramsInheritanceStrategy';
+
+export interface RouterParamsInheritanceMigrationData {
+  replacements: Replacement[];
+}
+
+/**
+ * In v22, the default value of `paramsInheritanceStrategy` was changed from `'emptyOnly'` to
+ * `'always'`. This migration preserves the pre-v22 behavior by explicitly setting
+ * `paramsInheritanceStrategy: 'emptyOnly'` wherever router configuration is declared without it.
+ *
+ * The following patterns are migrated:
+ * - `RouterModule.forRoot(routes)` -> `RouterModule.forRoot(routes, { paramsInheritanceStrategy: 'emptyOnly' })`
+ * - `RouterModule.forRoot(routes, { ... })` -> adds property to existing options object
+ * - `provideRouter(routes)` -> `provideRouter(routes, withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' }))`
+ * - `withRouterConfig({ ... })` -> adds property to existing options object
+ */
+export class RouterParamsInheritanceMigration extends TsurgeFunnelMigration<
+  RouterParamsInheritanceMigrationData,
+  RouterParamsInheritanceMigrationData
+> {
+  override async analyze(
+    info: ProgramInfo,
+  ): Promise<Serializable<RouterParamsInheritanceMigrationData>> {
+    const replacements: Replacement[] = [];
+    const importManager = new ImportManager();
+    const printer = ts.createPrinter();
+
+    for (const sourceFile of info.sourceFiles) {
+      const hasProvideRouter =
+        getImportSpecifier(sourceFile, ROUTER_PACKAGE, PROVIDE_ROUTER) !== null;
+      const hasWithRouterConfig =
+        getImportSpecifier(sourceFile, ROUTER_PACKAGE, WITH_ROUTER_CONFIG) !== null;
+      const hasRouterModule =
+        getImportSpecifier(sourceFile, ROUTER_PACKAGE, ROUTER_MODULE) !== null;
+
+      if (!hasProvideRouter && !hasWithRouterConfig && !hasRouterModule) {
+        continue;
+      }
+
+      ts.forEachChild(sourceFile, function visit(node: ts.Node) {
+        ts.forEachChild(node, visit);
+
+        if (!ts.isCallExpression(node)) return;
+
+        // withRouterConfig({ ... })
+        // Add paramsInheritanceStrategy: 'emptyOnly' when the property is absent.
+        if (
+          ts.isIdentifier(node.expression) &&
+          node.expression.text === WITH_ROUTER_CONFIG &&
+          node.arguments.length === 1 &&
+          ts.isObjectLiteralExpression(node.arguments[0])
+        ) {
+          const optionsObj = node.arguments[0];
+          if (!hasProperty(optionsObj, PARAMS_INHERITANCE_STRATEGY)) {
+            insertPropertyIntoObject(optionsObj, sourceFile, info, replacements);
+          }
+          return;
+        }
+
+        // provideRouter(routes, ...features) without withRouterConfig
+        // Add withRouterConfig({ paramsInheritanceStrategy: 'emptyOnly' }) as a
+        // new feature argument.
+        if (
+          ts.isIdentifier(node.expression) &&
+          node.expression.text === PROVIDE_ROUTER &&
+          hasProvideRouter
+        ) {
+          const alreadyHasWithRouterConfig = node.arguments.some(
+            (arg) =>
+              ts.isCallExpression(arg) &&
+              ts.isIdentifier(arg.expression) &&
+              arg.expression.text === WITH_ROUTER_CONFIG,
+          );
+
+          if (!alreadyHasWithRouterConfig) {
+            const withRouterConfigExpr = importManager.addImport({
+              exportModuleSpecifier: ROUTER_PACKAGE,
+              exportSymbolName: WITH_ROUTER_CONFIG,
+              requestedFile: sourceFile,
+            });
+            const exprText = printer.printNode(
+              ts.EmitHint.Unspecified,
+              withRouterConfigExpr,
+              sourceFile,
+            );
+            const insertPos = node.arguments.end;
+            const toInsert =
+              node.arguments.length > 0
+                ? `, ${exprText}({ ${PARAMS_INHERITANCE_STRATEGY}: 'emptyOnly' })`
+                : `${exprText}({ ${PARAMS_INHERITANCE_STRATEGY}: 'emptyOnly' })`;
+
+            replacements.push(
+              new Replacement(
+                projectFile(sourceFile, info),
+                new TextUpdate({position: insertPos, end: insertPos, toInsert}),
+              ),
+            );
+          }
+          return;
+        }
+
+        // RouterModule.forRoot(routes, options?)
+        if (
+          ts.isPropertyAccessExpression(node.expression) &&
+          ts.isIdentifier(node.expression.expression) &&
+          node.expression.expression.text === ROUTER_MODULE &&
+          node.expression.name.text === FOR_ROOT
+        ) {
+          if (node.arguments.length === 0) return;
+
+          if (node.arguments.length === 1) {
+            // No options argument – append a new one.
+            const insertPos = node.arguments.end;
+            replacements.push(
+              new Replacement(
+                projectFile(sourceFile, info),
+                new TextUpdate({
+                  position: insertPos,
+                  end: insertPos,
+                  toInsert: `, { ${PARAMS_INHERITANCE_STRATEGY}: 'emptyOnly' }`,
+                }),
+              ),
+            );
+          } else {
+            // Options argument exists – only touch inline object literals so we
+            // don't accidentally mutate values held in variables.
+            const optionsArg = node.arguments[1];
+            if (
+              ts.isObjectLiteralExpression(optionsArg) &&
+              !hasProperty(optionsArg, PARAMS_INHERITANCE_STRATEGY)
+            ) {
+              insertPropertyIntoObject(optionsArg, sourceFile, info, replacements);
+            }
+          }
+        }
+      });
+    }
+
+    applyImportManagerChanges(importManager, replacements, info.sourceFiles, info);
+    return confirmAsSerializable({replacements});
+  }
+
+  override async combine(
+    unitA: RouterParamsInheritanceMigrationData,
+    unitB: RouterParamsInheritanceMigrationData,
+  ): Promise<Serializable<RouterParamsInheritanceMigrationData>> {
+    return confirmAsSerializable({
+      replacements: [...unitA.replacements, ...unitB.replacements],
+    });
+  }
+
+  override async globalMeta(
+    combinedData: RouterParamsInheritanceMigrationData,
+  ): Promise<Serializable<RouterParamsInheritanceMigrationData>> {
+    return confirmAsSerializable(combinedData);
+  }
+
+  override async stats(
+    globalMetadata: RouterParamsInheritanceMigrationData,
+  ): Promise<Serializable<unknown>> {
+    return confirmAsSerializable({});
+  }
+
+  override async migrate(
+    globalData: RouterParamsInheritanceMigrationData,
+  ): Promise<{replacements: Replacement[]}> {
+    return {replacements: globalData.replacements};
+  }
+}
+
+function hasProperty(obj: ts.ObjectLiteralExpression, name: string): boolean {
+  return obj.properties.some(
+    (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === name,
+  );
+}
+
+/**
+ * Inserts `paramsInheritanceStrategy: 'emptyOnly'` into an existing object literal.
+ *
+ * - Empty object `{}` → `{ paramsInheritanceStrategy: 'emptyOnly' }`
+ * - Non-empty object → appends after the last property
+ */
+function insertPropertyIntoObject(
+  obj: ts.ObjectLiteralExpression,
+  sourceFile: ts.SourceFile,
+  info: ProgramInfo,
+  replacements: Replacement[],
+): void {
+  const propertyText = `${PARAMS_INHERITANCE_STRATEGY}: 'emptyOnly'`;
+
+  if (obj.properties.length === 0) {
+    const insertPos = obj.getStart() + 1; // position right after '{'
+    replacements.push(
+      new Replacement(
+        projectFile(sourceFile, info),
+        new TextUpdate({
+          position: insertPos,
+          end: insertPos,
+          toInsert: ` ${propertyText} `,
+        }),
+      ),
+    );
+  } else {
+    // Append after the last existing property.
+    const lastProp = obj.properties[obj.properties.length - 1];
+    replacements.push(
+      new Replacement(
+        projectFile(sourceFile, info),
+        new TextUpdate({
+          position: lastProp.getEnd(),
+          end: lastProp.getEnd(),
+          toInsert: `, ${propertyText}`,
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add an ng update migration that preserves the pre-v22 paramsInheritanceStrategy behavior by explicitly setting it to 'emptyOnly' in router configuration when needed.

This helps existing applications keep their current route param inheritance behavior after the default changes to 'always'.
 
 Reference #68256