### PR TITLE
perf(compiler): reuse temporary variable slots across non-overlapping safe navigation expressions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -343,3 +343,56 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_cross_instruction_reuse.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+// Two safe navigation chains in separate instructions. Their temporary
+// variables have non-overlapping lifetimes, so the optimizer should
+// assign both to the same slot (tmp_0) instead of tmp_0_0 and tmp_1_0.
+export class MyApp {
+    a() { return null; }
+    c() { return null; }
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: false, selector: "ng-component", ngImport: i0, template: `
+  <span>{{ a()?.b }}</span>
+  <span>{{ c()?.d }}</span>
+`, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+  <span>{{ a()?.b }}</span>
+  <span>{{ c()?.d }}</span>
+`,
+                    standalone: false
+                }]
+        }] });
+export class MyModule {
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+    static ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+    static ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_cross_instruction_reuse.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    a(): any;
+    c(): any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -98,6 +98,21 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should reuse temporary variable slots across non-overlapping safe navigation instructions",
+      "inputFiles": ["safe_access_cross_instruction_reuse.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_access_cross_instruction_reuse_template.js",
+              "generated": "safe_access_cross_instruction_reuse.js"
+            }
+          ],
+          "failureMessage": "Temporary variables not reused across instructions"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse.ts
@@ -1,0 +1,19 @@
+import {Component, NgModule} from '@angular/core';
+
+// Two safe navigation chains in separate instructions. Their temporary
+// variables have non-overlapping lifetimes, so the optimizer should
+// assign both to the same slot (tmp_0) instead of tmp_0_0 and tmp_1_0.
+@Component({
+    template: `
+  <span>{{ a()?.b }}</span>
+  <span>{{ c()?.d }}</span>
+`,
+    standalone: false
+})
+export class MyApp {
+  a(): any { return null; }
+  c(): any { return null; }
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse_template.js
@@ -1,0 +1,7 @@
+if (rf & 2) {
+  let $tmp_0$;
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(" ", ($tmp_0$ = ctx.a()) == null ? null : $tmp_0$.b, " ");
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(" ", ($tmp_0$ = ctx.c()) == null ? null : $tmp_0$.d, " ");
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse_template.js
@@ -1,7 +1,7 @@
 if (rf & 2) {
   let $tmp_0$;
   i0.ɵɵadvance();
-  i0.ɵɵtextInterpolate(" ", ($tmp_0$ = ctx.a()) == null ? null : $tmp_0$.b, " ");
-  i0.ɵɵadvance();
-  i0.ɵɵtextInterpolate(" ", ($tmp_0$ = ctx.c()) == null ? null : $tmp_0$.d, " ");
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.a()) == null ? null : $tmp_0$.b);
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.c()) == null ? null : $tmp_0$.d);
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js
@@ -1,18 +1,14 @@
 } if (rf & 2) {
-  let $tmp_0_0$;
-  let $tmp_1_0$;
-  let $tmp_2_0$;
-  let $tmp_2_1$;
-  let $tmp_3_0$;
-  let $tmp_3_1$;
-  let $tmp_3_2$;
-  let $tmp_3_3$;
+  let $tmp_0$;
+  let $tmp_1$;
+  let $tmp_2$;
+  let $tmp_3$;
   i0.ɵɵadvance();
-  i0.ɵɵtextInterpolate1("Safe Property with Calls: ", ($tmp_0_0$ = ctx.p()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.a()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.b()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.c()) == null ? null : $tmp_0_0$.d());
+  i0.ɵɵtextInterpolate1("Safe Property with Calls: ", ($tmp_0$ = ctx.p()) == null ? null : ($tmp_0$ = $tmp_0$.a()) == null ? null : ($tmp_0$ = $tmp_0$.b()) == null ? null : ($tmp_0$ = $tmp_0$.c()) == null ? null : $tmp_0$.d());
   i0.ɵɵadvance(2);
-  i0.ɵɵtextInterpolate1("Safe and Unsafe Property with Calls: ", ctx.p == null ? null : ($tmp_1_0$ = ctx.p.a()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.b().c().d()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.e()) == null ? null : $tmp_1_0$.f == null ? null : $tmp_1_0$.f.g.h == null ? null : ($tmp_1_0$ = $tmp_1_0$.f.g.h.i()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.j()) == null ? null : $tmp_1_0$.k().l);
+  i0.ɵɵtextInterpolate1("Safe and Unsafe Property with Calls: ", ctx.p == null ? null : ($tmp_0$ = ctx.p.a()) == null ? null : ($tmp_0$ = $tmp_0$.b().c().d()) == null ? null : ($tmp_0$ = $tmp_0$.e()) == null ? null : $tmp_0$.f == null ? null : $tmp_0$.f.g.h == null ? null : ($tmp_0$ = $tmp_0$.f.g.h.i()) == null ? null : ($tmp_0$ = $tmp_0$.j()) == null ? null : $tmp_0$.k().l);
   i0.ɵɵadvance(2);
-  i0.ɵɵtextInterpolate1("Nested Safe with Calls: ", ($tmp_2_0$ = ctx.f1()) == null ? null : $tmp_2_0$[($tmp_2_1$ = ctx.f2()) == null ? null : $tmp_2_1$.a] == null ? null : $tmp_2_0$[($tmp_2_1$ = $tmp_2_1$) == null ? null : $tmp_2_1$.a].b);
+  i0.ɵɵtextInterpolate1("Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : $tmp_1$.a] == null ? null : $tmp_0$[($tmp_1$ = $tmp_1$) == null ? null : $tmp_1$.a].b);
   i0.ɵɵadvance(2);
-  i0.ɵɵtextInterpolate1("Deep Nested Safe with Calls: ", ($tmp_3_0$ = ctx.f1()) == null ? null : $tmp_3_0$[($tmp_3_1$ = ctx.f2()) == null ? null : ($tmp_3_2$ = $tmp_3_1$.f3()) == null ? null : $tmp_3_2$[($tmp_3_3$ = ctx.f4()) == null ? null : $tmp_3_3$.f5()]] == null ? null : $tmp_3_0$[($tmp_3_1$ = $tmp_3_1$) == null ? null : ($tmp_3_2$ = $tmp_3_2$) == null ? null : $tmp_3_2$[($tmp_3_3$ = $tmp_3_3$) == null ? null : $tmp_3_3$.f5()]].f6());
+  i0.ɵɵtextInterpolate1("Deep Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : ($tmp_2$ = $tmp_1$.f3()) == null ? null : $tmp_2$[($tmp_3$ = ctx.f4()) == null ? null : $tmp_3$.f5()]] == null ? null : $tmp_0$[($tmp_1$ = $tmp_1$) == null ? null : ($tmp_2$ = $tmp_2$) == null ? null : $tmp_2$[($tmp_3$ = $tmp_3$) == null ? null : $tmp_3$.f5()]].f6());
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js
@@ -8,7 +8,7 @@
   i0.ɵɵadvance(2);
   i0.ɵɵtextInterpolate1("Safe and Unsafe Property with Calls: ", ctx.p == null ? null : ($tmp_0$ = ctx.p.a()) == null ? null : ($tmp_0$ = $tmp_0$.b().c().d()) == null ? null : ($tmp_0$ = $tmp_0$.e()) == null ? null : $tmp_0$.f == null ? null : $tmp_0$.f.g.h == null ? null : ($tmp_0$ = $tmp_0$.f.g.h.i()) == null ? null : ($tmp_0$ = $tmp_0$.j()) == null ? null : $tmp_0$.k().l);
   i0.ɵɵadvance(2);
-  i0.ɵɵtextInterpolate1("Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : $tmp_1$.a] == null ? null : $tmp_0$[($tmp_1$ = $tmp_1$) == null ? null : $tmp_1$.a].b);
+  i0.ɵɵtextInterpolate1("Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : $tmp_1$.a] == null ? null : $tmp_0$[$tmp_1$ == null ? null : $tmp_1$.a].b);
   i0.ɵɵadvance(2);
-  i0.ɵɵtextInterpolate1("Deep Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : ($tmp_2$ = $tmp_1$.f3()) == null ? null : $tmp_2$[($tmp_3$ = ctx.f4()) == null ? null : $tmp_3$.f5()]] == null ? null : $tmp_0$[($tmp_1$ = $tmp_1$) == null ? null : ($tmp_2$ = $tmp_2$) == null ? null : $tmp_2$[($tmp_3$ = $tmp_3$) == null ? null : $tmp_3$.f5()]].f6());
+  i0.ɵɵtextInterpolate1("Deep Nested Safe with Calls: ", ($tmp_0$ = ctx.f1()) == null ? null : $tmp_0$[($tmp_1$ = ctx.f2()) == null ? null : ($tmp_2$ = $tmp_1$.f3()) == null ? null : $tmp_2$[($tmp_3$ = ctx.f4()) == null ? null : $tmp_3$.f5()]] == null ? null : $tmp_0$[$tmp_1$ == null ? null : $tmp_2$ == null ? null : $tmp_2$[$tmp_3$ == null ? null : $tmp_3$.f5()]].f6());
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.js
@@ -3,17 +3,15 @@ template: function MyApp_Template(rf, $ctx$) {
     // ...
   }
   if (rf & 2) {
-    let $tmp_0_0$;
-    let $tmp_1_0$;
-    let $tmp_2_0$;
+    let $tmp_0$;
     $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(false));
     $i0$.ɵɵadvance();
     $i0$.ɵɵproperty("title", ($ctx$.person == null ? null : $ctx$.person.getName(false)) || "");
     $i0$.ɵɵadvance();
-    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : ($tmp_0_0$ = $ctx$.person.getName(false)) == null ? null : $tmp_0_0$.toLowerCase());
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : ($tmp_0$ = $ctx$.person.getName(false)) == null ? null : $tmp_0$.toLowerCase());
     $i0$.ɵɵadvance();
-    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(($tmp_1_0$ = $ctx$.config.get("title")) == null ? null : $tmp_1_0$.enabled));
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(($tmp_0$ = $ctx$.config.get("title")) == null ? null : $tmp_0$.enabled));
     $i0$.ɵɵadvance();
-    i0.ɵɵproperty("title", ctx.person == null ? null : ctx.person.getName(((tmp_4_0 = ctx.config.get("title")) == null ? null : tmp_4_0.enabled) ?? true));
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName((($tmp_0$ = $ctx$.config.get("title")) == null ? null : $tmp_0$.enabled) ?? true));
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_multiple_cases_template.js
@@ -26,10 +26,10 @@ function MyApp_Template(rf, ctx) {
     $r3$.ɵɵelementEnd();
   }
   if (rf & 2) {
-  let $MyApp_contFlowTmp$;
+  let $tmp_0$;
     $r3$.ɵɵadvance();
     $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
     $r3$.ɵɵadvance();
-    $r3$.ɵɵconditional((tmp_1_0 = ctx.value()) === -1 ? 2 : tmp_1_0 === 0 ? 3 : tmp_1_0 === 1 ? 3 : tmp_1_0 === 2 ? 4 : 5);
+    $r3$.ɵɵconditional(($tmp_0$ = ctx.value()) === -1 ? 2 : $tmp_0$ === 0 ? 3 : $tmp_0$ === 1 ? 3 : $tmp_0$ === 2 ? 4 : 5);
   }
 }

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -80,6 +80,7 @@ import {optimizeStoreLet} from './phases/store_let_optimization';
 import {stripNonrequiredParentheses} from './phases/strip_nonrequired_parentheses';
 import {specializeStyleBindings} from './phases/style_binding_specialization';
 import {generateTemporaryVariables} from './phases/temporary_variables';
+import {optimizeTemporaries} from './phases/optimize_temporaries';
 import {optimizeTrackFns} from './phases/track_fn_optimization';
 import {generateTrackVariables} from './phases/track_variables';
 import {transformTwoWayBindingSet} from './phases/transform_two_way_binding_set';
@@ -145,6 +146,7 @@ const phases: Phase[] = [
   {kind: Kind.Both, fn: expandSafeReads},
   {kind: Kind.Both, fn: stripNonrequiredParentheses},
   {kind: Kind.Both, fn: generateTemporaryVariables},
+  {kind: Kind.Both, fn: optimizeTemporaries},
   {kind: Kind.Both, fn: optimizeVariables},
   {kind: Kind.Both, fn: optimizeStoreLet},
   {kind: Kind.Tmpl, fn: convertI18nText},

--- a/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
@@ -101,12 +101,9 @@ function eliminateTemporaryAssignments(
     e,
     (e) => {
       if (e instanceof ir.AssignTemporaryExpr && tmps.has(e.xref)) {
-        const read = new ir.ReadTemporaryExpr(e.xref);
-        // `TemplateDefinitionBuilder` has the (accidental?) behavior of generating assignments of
-        // temporary variables to themselves. This happens because some subexpression that the
-        // temporary refers to, possibly through nested temporaries, has a function call. We copy that
-        // behavior here.
-        return new ir.AssignTemporaryExpr(read, read.xref);
+        // The guard side already computed and stored this temporary. The expression side
+        // only needs to read its value — no re-assignment necessary.
+        return new ir.ReadTemporaryExpr(e.xref);
       }
       return e;
     },

--- a/packages/compiler/src/template/pipeline/src/phases/optimize_temporaries.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/optimize_temporaries.ts
@@ -89,13 +89,11 @@ function optimizeBlock(ops: ir.OpList<ir.CreateOp | ir.UpdateOp>): void {
 
   for (const xref of xrefs) {
     const start = startPos.get(xref)!;
-    const end = endPos.get(xref);
-    if (end === undefined) {
-      // A temporary was assigned but never read — this should not occur given
-      // the invariants enforced by expandSafeReads and generateTemporaryVariables,
-      // but skip rather than corrupt the output.
-      continue;
-    }
+    // A temporary may be assigned but never read (e.g. a switch with a single
+    // case, where the test is assigned for side-effects but never referenced
+    // again). Treat those as live for a single point so they still get a slot
+    // and are correctly renamed/declared in the output.
+    const end = endPos.get(xref) ?? start;
 
     // Release slots for intervals that finished before this one starts.
     // active is kept sorted ascending by end, so we can stop at the first non-expired entry.

--- a/packages/compiler/src/template/pipeline/src/phases/optimize_temporaries.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/optimize_temporaries.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+/**
+ * Reduces the number of temporary variable declarations emitted into compiled
+ * view functions by reusing slot names across instructions whose live ranges do
+ * not overlap.
+ *
+ * `generateTemporaryVariables` assigns a unique name per temporary per
+ * instruction (e.g. `tmp_0_0`, `tmp_1_0`). This phase performs linear-scan
+ * register allocation across the entire block, compacting those names to the
+ * minimum set (e.g. `tmp_0`, `tmp_1`). Fewer declarations = smaller bundles.
+ */
+export function optimizeTemporaries(job: CompilationJob): void {
+  for (const unit of job.units) {
+    optimizeBlock(unit.create);
+    optimizeBlock(unit.update);
+    for (const fn of unit.functions) {
+      optimizeBlock(fn.ops);
+    }
+  }
+}
+
+function optimizeBlock(ops: ir.OpList<ir.CreateOp | ir.UpdateOp>): void {
+  // Pass 1: record the live range [startPos, endPos] of every temporary in
+  // this block. Position is a monotonically increasing counter over the
+  // left-to-right, top-to-bottom expression visit order — matching JS
+  // evaluation order.
+  const startPos = new Map<ir.XrefId, number>();
+  const endPos = new Map<ir.XrefId, number>();
+  const oldNames = new Set<string>();
+  let pos = 0;
+
+  for (const op of ops) {
+    if (op.kind === ir.OpKind.Statement) {
+      continue;
+    }
+    ir.visitExpressionsInOp(op, (expr, flags) => {
+      if (flags & ir.VisitorContextFlag.InChildOperation) {
+        return;
+      }
+      if (expr instanceof ir.AssignTemporaryExpr) {
+        if (!startPos.has(expr.xref)) {
+          startPos.set(expr.xref, pos);
+          oldNames.add(expr.name!);
+        }
+        pos++;
+      } else if (expr instanceof ir.ReadTemporaryExpr) {
+        endPos.set(expr.xref, pos);
+        pos++;
+      }
+    });
+
+    // Recurse into nested op blocks — they are independent scopes and must be
+    // optimized separately (same pattern as generateTemporaryVariables).
+    if (
+      op.kind === ir.OpKind.Listener ||
+      op.kind === ir.OpKind.Animation ||
+      op.kind === ir.OpKind.AnimationListener ||
+      op.kind === ir.OpKind.TwoWayListener
+    ) {
+      optimizeBlock(op.handlerOps);
+    } else if (op.kind === ir.OpKind.RepeaterCreate && op.trackByOps !== null) {
+      optimizeBlock(op.trackByOps);
+    }
+  }
+
+  if (startPos.size === 0) {
+    return; // No temporaries in this block — nothing to do.
+  }
+
+  // Pass 2: greedy linear-scan slot allocation (Poletto–Sarkar, 1999).
+  // Sort temporaries by their start position, then assign the lowest available
+  // slot, releasing slots whose intervals ended before the current one starts.
+  const xrefs = [...startPos.keys()].sort((a, b) => startPos.get(a)! - startPos.get(b)!);
+  const freeSlots: number[] = []; // Kept sorted ascending; shift() returns lowest.
+  let nextSlot = 0;
+  const slotByXref = new Map<ir.XrefId, number>();
+  const active: Array<{xref: ir.XrefId; end: number}> = [];
+
+  for (const xref of xrefs) {
+    const start = startPos.get(xref)!;
+    const end = endPos.get(xref);
+    if (end === undefined) {
+      // A temporary was assigned but never read — this should not occur given
+      // the invariants enforced by expandSafeReads and generateTemporaryVariables,
+      // but skip rather than corrupt the output.
+      continue;
+    }
+
+    // Release slots for intervals that finished before this one starts.
+    // active is kept sorted ascending by end, so we can stop at the first non-expired entry.
+    while (active.length > 0 && active[0].end < start) {
+      const {xref: expiredXref} = active.shift()!;
+      const freed = slotByXref.get(expiredXref)!;
+      const insertAt = freeSlots.findIndex((s) => s > freed);
+      if (insertAt === -1) {
+        freeSlots.push(freed);
+      } else {
+        freeSlots.splice(insertAt, 0, freed);
+      }
+    }
+
+    const slot = freeSlots.length > 0 ? freeSlots.shift()! : nextSlot++;
+    slotByXref.set(xref, slot);
+
+    // Insert into active keeping it sorted by end position (ascending).
+    const insertActiveAt = active.findIndex((a) => a.end > end);
+    if (insertActiveAt === -1) {
+      active.push({xref, end});
+    } else {
+      active.splice(insertActiveAt, 0, {xref, end});
+    }
+  }
+
+  // Pass 3: rename expressions and replace DeclareVarStmt nodes.
+  const newNameByXref = new Map<ir.XrefId, string>();
+  for (const [xref, slot] of slotByXref) {
+    newNameByXref.set(xref, `tmp_${slot}`);
+  }
+
+  // 3a: Rename every AssignTemporaryExpr and ReadTemporaryExpr in the block.
+  for (const op of ops) {
+    ir.visitExpressionsInOp(op, (expr, flags) => {
+      if (flags & ir.VisitorContextFlag.InChildOperation) {
+        return;
+      }
+      if (
+        (expr instanceof ir.AssignTemporaryExpr || expr instanceof ir.ReadTemporaryExpr) &&
+        newNameByXref.has(expr.xref)
+      ) {
+        expr.name = newNameByXref.get(expr.xref)!;
+      }
+    });
+  }
+
+  // 3b: Remove old per-instruction DeclareVarStmt nodes for temporaries.
+  const toRemove: Array<ir.CreateOp | ir.UpdateOp> = [];
+  for (const op of ops) {
+    if (
+      op.kind === ir.OpKind.Statement &&
+      (op as ir.StatementOp<ir.UpdateOp>).statement instanceof o.DeclareVarStmt &&
+      oldNames.has(((op as ir.StatementOp<ir.UpdateOp>).statement as o.DeclareVarStmt).name)
+    ) {
+      toRemove.push(op);
+    }
+  }
+  for (const op of toRemove) {
+    ir.OpList.remove(op);
+  }
+
+  // 3c: Prepend the minimal set of declarations in ascending slot order.
+  const newDecls = [...new Set(newNameByXref.values())]
+    .sort((a, b) => parseInt(a.slice(4), 10) - parseInt(b.slice(4), 10))
+    .map((name) =>
+      ir.createStatementOp<ir.CreateOp | ir.UpdateOp>(new o.DeclareVarStmt(name)),
+    ) as Array<ir.CreateOp | ir.UpdateOp>;
+  ops.prepend(newDecls);
+}

--- a/packages/compiler/test/template/pipeline/optimize_temporaries_spec.ts
+++ b/packages/compiler/test/template/pipeline/optimize_temporaries_spec.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {SecurityContext} from '../../../src/core';
+import * as o from '../../../src/output/output_ast';
+import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../../src/parse_util';
+import * as ir from '../../../src/template/pipeline/ir';
+import {
+  HostBindingCompilationJob,
+  TemplateCompilationMode,
+} from '../../../src/template/pipeline/src/compilation';
+import {ConstantPool} from '../../../src/constant_pool';
+import {optimizeTemporaries} from '../../../src/template/pipeline/src/phases/optimize_temporaries';
+import {generateTemporaryVariables} from '../../../src/template/pipeline/src/phases/temporary_variables';
+
+// --- Helpers ---
+
+function fakeSpan(): ParseSourceSpan {
+  const file = new ParseSourceFile('', 'test.html');
+  const loc = new ParseLocation(file, 0, 0, 0);
+  return new ParseSourceSpan(loc, loc);
+}
+
+function makeJob(): HostBindingCompilationJob {
+  return new HostBindingCompilationJob('Test', new ConstantPool(), TemplateCompilationMode.Full);
+}
+
+/**
+ * Creates a BindingOp whose expression contains a simulated safe-navigation pattern:
+ *   (tmp = source) == null ? null : tmp.prop
+ *
+ * This embeds one AssignTemporaryExpr and one ReadTemporaryExpr for the given xref.
+ */
+function bindingWithSafeNav(xref: ir.XrefId, source: o.Expression): ir.BindingOp {
+  const assign = new ir.AssignTemporaryExpr(source, xref);
+  const read = new ir.ReadTemporaryExpr(xref);
+  const expr = new o.ConditionalExpr(
+    new o.BinaryOperatorExpr(o.BinaryOperator.Equals, assign, o.NULL_EXPR),
+    o.NULL_EXPR,
+    new o.ReadPropExpr(read, 'prop'),
+  );
+  return ir.createBindingOp(
+    0 as ir.XrefId,
+    ir.BindingKind.Property,
+    'value',
+    expr,
+    null,
+    SecurityContext.NONE,
+    false,
+    false,
+    null,
+    null,
+    fakeSpan(),
+  );
+}
+
+/**
+ * Creates a BindingOp that simulates a double safe-navigation chain `a()?.b?.c`:
+ *   (tmp0 = source) == null ? null :
+ *     (tmp1 = tmp0.prop) == null ? null : tmp1.prop
+ *
+ * xref0 ends before xref1 begins, so the two live ranges are non-overlapping.
+ */
+function bindingWithNestedSafeNav(
+  xref0: ir.XrefId,
+  xref1: ir.XrefId,
+  source: o.Expression,
+): ir.BindingOp {
+  const assign0 = new ir.AssignTemporaryExpr(source, xref0);
+  const read0 = new ir.ReadTemporaryExpr(xref0);
+  const assign1 = new ir.AssignTemporaryExpr(new o.ReadPropExpr(read0, 'prop'), xref1);
+  const read1 = new ir.ReadTemporaryExpr(xref1);
+
+  const inner = new o.ConditionalExpr(
+    new o.BinaryOperatorExpr(o.BinaryOperator.Equals, assign1, o.NULL_EXPR),
+    o.NULL_EXPR,
+    new o.ReadPropExpr(read1, 'prop'),
+  );
+  const outer = new o.ConditionalExpr(
+    new o.BinaryOperatorExpr(o.BinaryOperator.Equals, assign0, o.NULL_EXPR),
+    o.NULL_EXPR,
+    inner,
+  );
+
+  return ir.createBindingOp(
+    0 as ir.XrefId,
+    ir.BindingKind.Property,
+    'value',
+    outer,
+    null,
+    SecurityContext.NONE,
+    false,
+    false,
+    null,
+    null,
+    fakeSpan(),
+  );
+}
+
+/** Collect all DeclareVarStmt names from the update list in order. */
+function collectDecls(job: HostBindingCompilationJob): string[] {
+  const decls: string[] = [];
+  for (const op of job.root.update) {
+    if (op.kind === ir.OpKind.Statement && op.statement instanceof o.DeclareVarStmt) {
+      decls.push(op.statement.name);
+    }
+  }
+  return decls;
+}
+
+interface TempNames {
+  assigns: string[];
+  reads: string[];
+}
+
+/** Collect the names assigned to all AssignTemporaryExpr and ReadTemporaryExpr in the update list. */
+function collectTempNames(job: HostBindingCompilationJob): TempNames {
+  const assigns: string[] = [];
+  const reads: string[] = [];
+  for (const op of job.root.update) {
+    ir.visitExpressionsInOp(op, (expr) => {
+      if (expr instanceof ir.AssignTemporaryExpr) assigns.push(expr.name!);
+      else if (expr instanceof ir.ReadTemporaryExpr) reads.push(expr.name!);
+    });
+  }
+  return {assigns, reads};
+}
+
+// --- Tests ---
+
+describe('optimizeTemporaries', () => {
+  describe('cross-instruction slot reuse', () => {
+    it('should reuse a single slot for two non-overlapping safe navigation expressions', () => {
+      const job = makeJob();
+      const xref0 = 0 as ir.XrefId;
+      const xref1 = 1 as ir.XrefId;
+
+      job.root.update.push(bindingWithSafeNav(xref0, new o.ReadVarExpr('a')));
+      job.root.update.push(bindingWithSafeNav(xref1, new o.ReadVarExpr('c')));
+
+      generateTemporaryVariables(job);
+      // Before optimization: two declarations (tmp_0_0, tmp_1_0)
+      expect(collectDecls(job).length).toBe(2);
+
+      optimizeTemporaries(job);
+
+      // After optimization: one declaration shared across both expressions
+      expect(collectDecls(job)).toEqual(['tmp_0']);
+      const {assigns, reads} = collectTempNames(job);
+      expect(assigns).toEqual(['tmp_0', 'tmp_0']);
+      expect(reads).toEqual(['tmp_0', 'tmp_0']);
+    });
+
+    it('should use independent slots for three non-overlapping safe navigation expressions', () => {
+      const job = makeJob();
+      const xref0 = 0 as ir.XrefId;
+      const xref1 = 1 as ir.XrefId;
+      const xref2 = 2 as ir.XrefId;
+
+      job.root.update.push(bindingWithSafeNav(xref0, new o.ReadVarExpr('a')));
+      job.root.update.push(bindingWithSafeNav(xref1, new o.ReadVarExpr('b')));
+      job.root.update.push(bindingWithSafeNav(xref2, new o.ReadVarExpr('c')));
+
+      generateTemporaryVariables(job);
+      expect(collectDecls(job).length).toBe(3);
+
+      optimizeTemporaries(job);
+
+      // All three reuse the same slot since none overlap
+      expect(collectDecls(job)).toEqual(['tmp_0']);
+      const {assigns} = collectTempNames(job);
+      expect(assigns).toEqual(['tmp_0', 'tmp_0', 'tmp_0']);
+    });
+  });
+
+  describe('within-instruction slot reuse', () => {
+    it('should preserve single-declaration output for a double safe navigation chain (a?.b?.c)', () => {
+      const job = makeJob();
+      const xref0 = 0 as ir.XrefId;
+      const xref1 = 1 as ir.XrefId;
+
+      job.root.update.push(bindingWithNestedSafeNav(xref0, xref1, new o.ReadVarExpr('a')));
+
+      generateTemporaryVariables(job);
+      // generateTemporaryVariables already reuses slots within a single op via its stack
+      // counter: xref0 is released before xref1 is assigned, so both receive the same name.
+      expect(collectDecls(job).length).toBe(1);
+
+      optimizeTemporaries(job);
+
+      // optimizeTemporaries should produce a single compact slot name
+      expect(collectDecls(job)).toEqual(['tmp_0']);
+      const {assigns, reads} = collectTempNames(job);
+      // Both expressions are named consistently
+      expect(new Set(assigns).size).toBe(1);
+      expect(new Set(reads).size).toBe(1);
+    });
+  });
+
+  describe('no-op cases', () => {
+    it('should leave an op list with no temporaries unchanged', () => {
+      const job = makeJob();
+      // A binding with a plain expression — no safe navigation
+      job.root.update.push(
+        ir.createBindingOp(
+          0 as ir.XrefId,
+          ir.BindingKind.Property,
+          'value',
+          new o.ReadVarExpr('x'),
+          null,
+          SecurityContext.NONE,
+          false,
+          false,
+          null,
+          null,
+          fakeSpan(),
+        ),
+      );
+
+      generateTemporaryVariables(job);
+      optimizeTemporaries(job);
+
+      expect(collectDecls(job)).toEqual([]);
+      const {assigns, reads} = collectTempNames(job);
+      expect(assigns).toEqual([]);
+      expect(reads).toEqual([]);
+    });
+
+    it('should handle an empty op list without errors', () => {
+      const job = makeJob();
+      generateTemporaryVariables(job);
+      expect(() => optimizeTemporaries(job)).not.toThrow();
+      expect(collectDecls(job)).toEqual([]);
+    });
+  });
+
+  describe('assign-only temporaries', () => {
+    it('should correctly rename a temporary that is assigned but never read', () => {
+      const job = makeJob();
+      const xref0 = 0 as ir.XrefId;
+      const xref1 = 1 as ir.XrefId;
+
+      // xref0: a normal safe-nav (assign + read)
+      job.root.update.push(bindingWithSafeNav(xref0, new o.ReadVarExpr('a')));
+
+      // xref1: assign-only — no ReadTemporaryExpr referencing it
+      const assignOnly = new ir.AssignTemporaryExpr(new o.ReadVarExpr('b'), xref1);
+      job.root.update.push(
+        ir.createBindingOp(
+          0 as ir.XrefId,
+          ir.BindingKind.Property,
+          'value2',
+          assignOnly,
+          null,
+          SecurityContext.NONE,
+          false,
+          false,
+          null,
+          null,
+          fakeSpan(),
+        ),
+      );
+
+      generateTemporaryVariables(job);
+      optimizeTemporaries(job);
+
+      // Both should be renamed — assign-only gets a single-point live range
+      const {assigns} = collectTempNames(job);
+      for (const name of assigns) {
+        expect(name).toMatch(/^tmp_\d+$/);
+      }
+      // Declarations should exist for all used slots
+      const decls = collectDecls(job);
+      expect(decls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('declaration compaction', () => {
+    it('should reduce declaration count proportionally to reuse', () => {
+      const job = makeJob();
+      const count = 5;
+      const xrefs = Array.from({length: count}, (_, i) => i as ir.XrefId);
+
+      for (const xref of xrefs) {
+        job.root.update.push(bindingWithSafeNav(xref, new o.ReadVarExpr(`a${xref}`)));
+      }
+
+      generateTemporaryVariables(job);
+      const before = collectDecls(job).length;
+      expect(before).toBe(count);
+
+      optimizeTemporaries(job);
+      const after = collectDecls(job).length;
+
+      // All five temporaries are non-overlapping, so they should all share slot 0
+      expect(after).toBe(1);
+      expect(after).toBeLessThan(before);
+    });
+  });
+});

--- a/packages/core/test/bundling/safe_nav/BUILD.bazel
+++ b/packages/core/test/bundling/safe_nav/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_angular//src/optimization:index.bzl", "optimize_angular_app")
+
+package(default_visibility = ["//visibility:public"])
+
+optimize_angular_app(
+    name = "bundles",
+    srcs = [
+        "main.ts",
+    ],
+    env = {
+        "NG_BUILD_MANGLE": "0",
+    },
+    deps = [
+        "//:node_modules/rxjs",
+        "//:node_modules/tslib",
+        "//packages/core/test/bundling:node_modules/@angular/build",
+        "//packages/core/test/bundling:node_modules/@angular/common",
+        "//packages/core/test/bundling:node_modules/@angular/core",
+        "//packages/core/test/bundling:node_modules/@angular/platform-browser",
+    ],
+)

--- a/packages/core/test/bundling/safe_nav/main.ts
+++ b/packages/core/test/bundling/safe_nav/main.ts
@@ -1,0 +1,389 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Benchmark for the optimizeTemporaries and self-assignment-elimination compiler phases.
+ *
+ * Simulates a realistic Angular Material admin dashboard using modern Angular Signals.
+ * Signal reads (user(), order(), etc.) are function calls — bundlers cannot inline them —
+ * so the compiler's temporary variable output appears directly in the final bundle.
+ *
+ * Each component reads a nullable signal input across many bindings: before this
+ * optimization every binding got its own `let` slot; after, all bindings in a component
+ * share a single slot per signal.
+ *
+ * Covers three valid function-call-in-template patterns:
+ *   1. Signal inputs   — input<T | null>()       — user()?.name
+ *   2. Computed signals — computed(() => ...)     — revenue()?.today
+ *   3. Store-style signals — signal exposed as readonly — product()?.sku
+ */
+
+import {Component, computed, input, signal} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
+
+// ─── Domain interfaces ──────────────────────────────────────────────────────
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  avatar: string;
+  role: string;
+  department: string;
+  phone: string;
+  joinedAt: string;
+  lastActiveAt: string;
+  address: {street: string; city: string; state: string; country: string; zip: string} | null;
+  manager: {id: string; name: string; email: string} | null;
+}
+
+interface Order {
+  id: string;
+  reference: string;
+  total: number;
+  tax: number;
+  status: string;
+  placedAt: string;
+  updatedAt: string;
+  customer: {name: string; email: string; phone: string} | null;
+  shipping: {carrier: string; tracking: string; estimatedAt: string; address: string} | null;
+  payment: {method: string; last4: string; brand: string} | null;
+}
+
+interface Product {
+  sku: string;
+  name: string;
+  description: string;
+  price: number;
+  comparePrice: number;
+  stock: number;
+  category: {id: string; name: string; slug: string} | null;
+  brand: {id: string; name: string; logo: string} | null;
+  rating: {average: number; count: number; breakdown: string} | null;
+}
+
+interface Analytics {
+  revenue: {today: number; week: number; month: number; year: number; growth: string} | null;
+  orders: {today: number; pending: number; completed: number; cancelled: number} | null;
+  customers: {total: number; new: number; returning: number; churn: string} | null;
+  conversion: {rate: number; trend: string; sessions: number} | null;
+}
+
+interface Notification {
+  id: string;
+  title: string;
+  body: string;
+  type: string;
+  createdAt: string;
+  actor: {name: string; avatar: string} | null;
+  action: {label: string; url: string} | null;
+}
+
+// ─── Pattern 1: Signal inputs — canonical Angular 17+ pattern ───────────────
+
+/**
+ * Top navigation bar — shows current user identity.
+ * 10 bindings on user() signal input.
+ */
+@Component({
+  selector: 'app-nav-header',
+  standalone: true,
+  template: `
+    <header class="nav-header">
+      <img class="avatar" [src]="user()?.avatar" [alt]="user()?.name" />
+      <span class="name">{{ user()?.name }}</span>
+      <span class="role">{{ user()?.role }}</span>
+      <span class="department">{{ user()?.department }}</span>
+      <a [href]="'mailto:' + user()?.email">{{ user()?.email }}</a>
+      <span class="phone">{{ user()?.phone }}</span>
+      <span class="manager">Reports to: {{ user()?.manager?.name }}</span>
+      <span class="joined">Joined: {{ user()?.joinedAt }}</span>
+      <span class="last-active">Active: {{ user()?.lastActiveAt }}</span>
+    </header>
+  `,
+})
+class NavHeaderComponent {
+  readonly user = input<User | null>(null);
+}
+
+/**
+ * User profile card — full detail view.
+ * 12 bindings on user() signal input, including nested address and manager.
+ */
+@Component({
+  selector: 'user-profile',
+  standalone: true,
+  template: `
+    <section class="profile">
+      <img [src]="user()?.avatar" [alt]="user()?.name" />
+      <h2>{{ user()?.name }}</h2>
+      <p>{{ user()?.email }}</p>
+      <p>{{ user()?.phone }}</p>
+      <p>{{ user()?.role }} · {{ user()?.department }}</p>
+      <address>
+        {{ user()?.address?.street }}<br />
+        {{ user()?.address?.city }}, {{ user()?.address?.state }}<br />
+        {{ user()?.address?.zip }} {{ user()?.address?.country }}
+      </address>
+      <p>Manager: {{ user()?.manager?.name }} ({{ user()?.manager?.email }})</p>
+      <p>Member since {{ user()?.joinedAt }}</p>
+    </section>
+  `,
+})
+class UserProfileComponent {
+  readonly user = input<User | null>(null);
+}
+
+/**
+ * Order detail panel — shows full order information.
+ * 13 bindings on order() signal input, three levels of nullable nesting.
+ */
+@Component({
+  selector: 'order-detail',
+  standalone: true,
+  template: `
+    <article class="order-detail">
+      <h3>Order {{ order()?.reference }}</h3>
+      <p>Status: {{ order()?.status }}</p>
+      <p>Total: {{ order()?.total }} (tax: {{ order()?.tax }})</p>
+      <p>Placed: {{ order()?.placedAt }} · Updated: {{ order()?.updatedAt }}</p>
+      <section>
+        <h4>Customer</h4>
+        <p>{{ order()?.customer?.name }}</p>
+        <p>{{ order()?.customer?.email }}</p>
+        <p>{{ order()?.customer?.phone }}</p>
+      </section>
+      <section>
+        <h4>Shipping</h4>
+        <p>{{ order()?.shipping?.carrier }} — {{ order()?.shipping?.tracking }}</p>
+        <p>ETA: {{ order()?.shipping?.estimatedAt }}</p>
+        <p>{{ order()?.shipping?.address }}</p>
+      </section>
+      <section>
+        <h4>Payment</h4>
+        <p>{{ order()?.payment?.brand }} ending {{ order()?.payment?.last4 }}</p>
+        <p>Method: {{ order()?.payment?.method }}</p>
+      </section>
+    </article>
+  `,
+})
+class OrderDetailComponent {
+  readonly order = input<Order | null>(null);
+}
+
+/**
+ * Order summary row — used inside a data table.
+ * 8 bindings on order() signal input.
+ */
+@Component({
+  selector: 'order-row',
+  standalone: true,
+  template: `
+    <tr>
+      <td>{{ order()?.reference }}</td>
+      <td>{{ order()?.customer?.name }}</td>
+      <td>{{ order()?.total }}</td>
+      <td>{{ order()?.status }}</td>
+      <td>{{ order()?.placedAt }}</td>
+      <td>{{ order()?.shipping?.carrier }}</td>
+      <td>{{ order()?.shipping?.tracking }}</td>
+      <td>{{ order()?.payment?.brand }}</td>
+    </tr>
+  `,
+})
+class OrderRowComponent {
+  readonly order = input<Order | null>(null);
+}
+
+/**
+ * Product card — used in a product grid.
+ * 11 bindings on product() signal input.
+ */
+@Component({
+  selector: 'product-card',
+  standalone: true,
+  template: `
+    <div class="product-card">
+      <h3>{{ product()?.name }}</h3>
+      <p>{{ product()?.description }}</p>
+      <code>{{ product()?.sku }}</code>
+      <p class="price">
+        \${{ product()?.price }} <s>\${{ product()?.comparePrice }}</s>
+      </p>
+      <p>Stock: {{ product()?.stock }}</p>
+      <span>{{ product()?.category?.name }}</span>
+      <small>{{ product()?.category?.slug }}</small>
+      <span>{{ product()?.brand?.name }}</span>
+      <div class="rating">
+        <span>{{ product()?.rating?.average }} / 5</span>
+        <span>({{ product()?.rating?.count }} reviews)</span>
+        <span>{{ product()?.rating?.breakdown }}</span>
+      </div>
+    </div>
+  `,
+})
+class ProductCardComponent {
+  readonly product = input<Product | null>(null);
+}
+
+/**
+ * Notification item — shows actor and action for each notification.
+ * 8 bindings on notification() signal input.
+ */
+@Component({
+  selector: 'notification-item',
+  standalone: true,
+  template: `
+    <li class="notification">
+      <img [src]="notification()?.actor?.avatar" [alt]="notification()?.actor?.name" />
+      <div>
+        <strong>{{ notification()?.actor?.name }}</strong>
+        <p>{{ notification()?.title }}</p>
+        <small>{{ notification()?.body }}</small>
+        <time>{{ notification()?.createdAt }}</time>
+      </div>
+      <a [href]="notification()?.action?.url">{{ notification()?.action?.label }}</a>
+    </li>
+  `,
+})
+class NotificationItemComponent {
+  readonly notification = input<Notification | null>(null);
+}
+
+// ─── Pattern 2: Computed signals — derived nullable slices ───────────────────
+
+/**
+ * Analytics dashboard — slices one analytics signal into computed sub-signals.
+ * revenue(), orders(), customers(), conversion() are all computed signals
+ * (function calls in the template).
+ */
+@Component({
+  selector: 'analytics-dashboard',
+  standalone: true,
+  template: `
+    <div class="analytics">
+      <section>
+        <h4>Revenue</h4>
+        <p>Today: {{ revenue()?.today }}</p>
+        <p>This week: {{ revenue()?.week }}</p>
+        <p>This month: {{ revenue()?.month }}</p>
+        <p>This year: {{ revenue()?.year }}</p>
+        <p>Growth: {{ revenue()?.growth }}</p>
+      </section>
+      <section>
+        <h4>Orders</h4>
+        <p>Today: {{ orders()?.today }}</p>
+        <p>Pending: {{ orders()?.pending }}</p>
+        <p>Completed: {{ orders()?.completed }}</p>
+        <p>Cancelled: {{ orders()?.cancelled }}</p>
+      </section>
+      <section>
+        <h4>Customers</h4>
+        <p>Total: {{ customers()?.total }}</p>
+        <p>New: {{ customers()?.new }}</p>
+        <p>Returning: {{ customers()?.returning }}</p>
+        <p>Churn: {{ customers()?.churn }}</p>
+      </section>
+      <section>
+        <h4>Conversion</h4>
+        <p>Rate: {{ conversion()?.rate }}</p>
+        <p>Trend: {{ conversion()?.trend }}</p>
+        <p>Sessions: {{ conversion()?.sessions }}</p>
+      </section>
+    </div>
+  `,
+})
+class AnalyticsDashboardComponent {
+  readonly analytics = input<Analytics | null>(null);
+
+  readonly revenue = computed(() => this.analytics()?.revenue ?? null);
+  readonly orders = computed(() => this.analytics()?.orders ?? null);
+  readonly customers = computed(() => this.analytics()?.customers ?? null);
+  readonly conversion = computed(() => this.analytics()?.conversion ?? null);
+}
+
+// ─── Pattern 3: Store-style readonly signals ─────────────────────────────────
+
+/**
+ * Sidebar user summary — models a component reading from a signal store.
+ * Simulates NgRx/NGXS signal store pattern: store exposes signals as readonly.
+ * 9 bindings on selectedUser() store signal.
+ */
+@Component({
+  selector: 'sidebar-user',
+  standalone: true,
+  template: `
+    <aside class="sidebar-user">
+      <img [src]="selectedUser()?.avatar" [alt]="selectedUser()?.name" />
+      <h3>{{ selectedUser()?.name }}</h3>
+      <p>{{ selectedUser()?.email }}</p>
+      <p>{{ selectedUser()?.role }}</p>
+      <p>{{ selectedUser()?.department }}</p>
+      <p>{{ selectedUser()?.phone }}</p>
+      <p>{{ selectedUser()?.address?.city }}, {{ selectedUser()?.address?.country }}</p>
+      <p>Manager: {{ selectedUser()?.manager?.name }}</p>
+    </aside>
+  `,
+})
+class SidebarUserComponent {
+  private readonly _store = signal<User | null>(null);
+  readonly selectedUser = this._store.asReadonly();
+}
+
+// ─── Root dashboard ──────────────────────────────────────────────────────────
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [
+    NavHeaderComponent,
+    UserProfileComponent,
+    OrderDetailComponent,
+    OrderRowComponent,
+    ProductCardComponent,
+    NotificationItemComponent,
+    AnalyticsDashboardComponent,
+    SidebarUserComponent,
+  ],
+  template: `
+    <app-nav-header [user]="currentUser()" />
+    <div class="layout">
+      <sidebar-user />
+      <main>
+        <analytics-dashboard [analytics]="analytics()" />
+        <user-profile [user]="currentUser()" />
+        <order-detail [order]="selectedOrder()" />
+        <table>
+          @for (order of recentOrders(); track order?.id) {
+            <order-row [order]="order" />
+          }
+        </table>
+        <div class="product-grid">
+          @for (product of featuredProducts(); track product?.sku) {
+            <product-card [product]="product" />
+          }
+        </div>
+        <ul>
+          @for (n of notifications(); track n?.id) {
+            <notification-item [notification]="n" />
+          }
+        </ul>
+      </main>
+    </div>
+  `,
+})
+class DashboardComponent {
+  readonly currentUser = signal<User | null>(null);
+  readonly analytics = signal<Analytics | null>(null);
+  readonly selectedOrder = signal<Order | null>(null);
+  readonly recentOrders = signal<(Order | null)[]>([]);
+  readonly featuredProducts = signal<(Product | null)[]>([]);
+  readonly notifications = signal<(Notification | null)[]>([]);
+}
+
+bootstrapApplication(DashboardComponent);

--- a/scripts/perf/measure-temp-savings.mjs
+++ b/scripts/perf/measure-temp-savings.mjs
@@ -1,8 +1,24 @@
 #!/usr/bin/env node
+
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 /**
  * Measures the bundle size impact of the optimizeTemporaries compiler phase.
  * Usage: node scripts/perf/measure-temp-savings.mjs
+ *
+ * Two benchmarks:
+ *   1. safe_access_temporaries — the existing compliance test case (4 chains, deep nesting)
+ *   2. data_dashboard — simulated realistic component with 16 safe navigation chains
+ *      across separate template instructions (typical data-display component)
  */
+
+/* tslint:disable:no-console */
 
 import {gzipSync} from 'zlib';
 import {readFileSync} from 'fs';
@@ -24,24 +40,25 @@ function report(before, after) {
   const rawPct = ((rawSaved / before.raw) * 100).toFixed(1);
   const gzPct = ((gzSaved / before.gz) * 100).toFixed(1);
 
-  console.log('\n' + '='.repeat(72));
-  console.log(`  ${before.label}`);
+  console.log('\n' + '─'.repeat(72));
+  console.log(`  BEFORE: ${before.label}`);
   console.log(`    raw: ${before.raw} bytes    gzip: ${before.gz} bytes`);
-  console.log(`  ${after.label}`);
+  console.log(`  AFTER:  ${after.label}`);
   console.log(`    raw: ${after.raw} bytes    gzip: ${after.gz} bytes`);
-  console.log(`  Savings: ${rawSaved} bytes raw (${rawPct}%), ${gzSaved} bytes gzip (${gzPct}%)`);
-  console.log('='.repeat(72));
+  console.log(`  Saved:  ${rawSaved} bytes raw (${rawPct}%)  /  ${gzSaved} bytes gzip (${gzPct}%)`);
+  console.log('─'.repeat(72));
+  return {rawSaved, gzSaved, rawPct, gzPct, before, after};
 }
 
-// Read the updated (optimized) golden file.
+// ─── Benchmark 1: existing compliance golden ───────────────────────────────
+
 const goldenPath = join(
   repoRoot,
   'packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js',
 );
-const optimized = readFileSync(goldenPath, 'utf8');
+const b1_after = readFileSync(goldenPath, 'utf8');
 
-// The original golden before this optimization (8 declarations, original names).
-const originalGolden = `} if (rf & 2) {
+const b1_before = `} if (rf & 2) {
   let $tmp_0_0$;
   let $tmp_1_0$;
   let $tmp_2_0$;
@@ -61,14 +78,139 @@ const originalGolden = `} if (rf & 2) {
 }
 `;
 
-report(
-  measure('Before optimizeTemporaries (8 declarations)', originalGolden),
-  measure('After  optimizeTemporaries (4 declarations)', optimized),
+console.log('\n══════════════════════════════════════════════════════════════════════');
+console.log('  Benchmark 1: safe_access_temporaries (4 chains, deep nesting)');
+console.log('══════════════════════════════════════════════════════════════════════');
+const r1 = report(
+  measure('8 declarations (unoptimized)', b1_before),
+  measure('4 declarations (optimized)', b1_after),
 );
 
-const b = measure('before', originalGolden);
-const a = measure('after', optimized);
-console.log('\nPR description table row:');
-console.log(
-  `| safe_access_temporaries (4 chains) | ${b.raw} | ${a.raw} | ${b.gz} | ${a.gz} | ${(((b.raw - a.raw) / b.raw) * 100).toFixed(1)}% raw / ${(((b.gz - a.gz) / b.gz) * 100).toFixed(1)}% gz |`,
+// ─── Benchmark 2: realistic data dashboard component ──────────────────────
+//
+// Simulates a component that displays a user profile, statistics, an article,
+// and pagination — all read from nullable API responses. Each property access
+// is on a separate template instruction (property binding or text interpolation),
+// so all 16 temporaries are cross-instruction non-overlapping.
+//
+// Pattern: obj?.prop across 16 bindings → 16 declarations before, 1 after.
+
+// "Before" output: each instruction generates its own tmp_N_0 slot.
+const b2_before = `} if (rf & 2) {
+  let $tmp_0_0$;
+  let $tmp_1_0$;
+  let $tmp_2_0$;
+  let $tmp_3_0$;
+  let $tmp_4_0$;
+  let $tmp_5_0$;
+  let $tmp_6_0$;
+  let $tmp_7_0$;
+  let $tmp_8_0$;
+  let $tmp_9_0$;
+  let $tmp_10_0$;
+  let $tmp_11_0$;
+  let $tmp_12_0$;
+  let $tmp_13_0$;
+  let $tmp_14_0$;
+  let $tmp_15_0$;
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("src", ($tmp_0_0$ = ctx.user) == null ? null : $tmp_0_0$.avatar);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("alt", ($tmp_1_0$ = ctx.user) == null ? null : $tmp_1_0$.username);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_2_0$ = ctx.user) == null ? null : $tmp_2_0$.username);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_3_0$ = ctx.user) == null ? null : $tmp_3_0$.bio);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_4_0$ = ctx.stats) == null ? null : $tmp_4_0$.followers);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_5_0$ = ctx.stats) == null ? null : $tmp_5_0$.following);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_6_0$ = ctx.stats) == null ? null : $tmp_6_0$.repos);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_7_0$ = ctx.article) == null ? null : $tmp_7_0$.title);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_8_0$ = ctx.article) == null ? null : ($tmp_8_0$ = $tmp_8_0$.author) == null ? null : $tmp_8_0$.name);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("src", ($tmp_9_0$ = ctx.article) == null ? null : ($tmp_9_0$ = $tmp_9_0$.author) == null ? null : $tmp_9_0$.avatar);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_10_0$ = ctx.article) == null ? null : $tmp_10_0$.readTime);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_11_0$ = ctx.article) == null ? null : $tmp_11_0$.views);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_12_0$ = ctx.page) == null ? null : $tmp_12_0$.current);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_13_0$ = ctx.page) == null ? null : $tmp_13_0$.total);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("href", ($tmp_14_0$ = ctx.page) == null ? null : $tmp_14_0$.next);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("href", ($tmp_15_0$ = ctx.page) == null ? null : $tmp_15_0$.prev);
+}
+`;
+
+// "After" output: all 16 instructions share a single slot (tmp_0).
+const b2_after = `} if (rf & 2) {
+  let $tmp_0$;
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("src", ($tmp_0$ = ctx.user) == null ? null : $tmp_0$.avatar);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("alt", ($tmp_0$ = ctx.user) == null ? null : $tmp_0$.username);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.user) == null ? null : $tmp_0$.username);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.user) == null ? null : $tmp_0$.bio);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.stats) == null ? null : $tmp_0$.followers);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.stats) == null ? null : $tmp_0$.following);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.stats) == null ? null : $tmp_0$.repos);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.article) == null ? null : $tmp_0$.title);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.article) == null ? null : ($tmp_0$ = $tmp_0$.author) == null ? null : $tmp_0$.name);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("src", ($tmp_0$ = ctx.article) == null ? null : ($tmp_0$ = $tmp_0$.author) == null ? null : $tmp_0$.avatar);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.article) == null ? null : $tmp_0$.readTime);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.article) == null ? null : $tmp_0$.views);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.page) == null ? null : $tmp_0$.current);
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate(($tmp_0$ = ctx.page) == null ? null : $tmp_0$.total);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("href", ($tmp_0$ = ctx.page) == null ? null : $tmp_0$.next);
+  i0.ɵɵadvance();
+  i0.ɵɵproperty("href", ($tmp_0$ = ctx.page) == null ? null : $tmp_0$.prev);
+}
+`;
+
+console.log('\n══════════════════════════════════════════════════════════════════════');
+console.log('  Benchmark 2: data-display component (16 safe navigation chains)');
+console.log('  Simulates: user profile + stats + article + pagination, all from');
+console.log('  nullable API responses — each binding on a separate instruction.');
+console.log('══════════════════════════════════════════════════════════════════════');
+const r2 = report(
+  measure('16 declarations (unoptimized)', b2_before),
+  measure(' 1 declaration  (optimized)', b2_after),
 );
+
+// ─── Summary table ──────────────────────────────────────────────────────────
+
+console.log('\n\nSummary (for PR description):\n');
+console.log(
+  '| Benchmark                        | Before raw | After raw | Before gz | After gz | Raw saved | GZ saved |',
+);
+console.log(
+  '|----------------------------------|------------|-----------|-----------|----------|-----------|----------|',
+);
+console.log(
+  `| safe_access_temporaries (4 deep) | ${r1.before.raw} B | ${r1.after.raw} B | ${r1.before.gz} B | ${r1.after.gz} B | ${r1.rawSaved} B (${r1.rawPct}%) | ${r1.gzSaved} B (${r1.gzPct}%) |`,
+);
+console.log(
+  `| data-display component (16 wide) | ${r2.before.raw} B | ${r2.after.raw} B | ${r2.before.gz} B | ${r2.after.gz} B | ${r2.rawSaved} B (${r2.rawPct}%) | ${r2.gzSaved} B (${r2.gzPct}%) |`,
+);
+console.log('');
+console.log('Note: Savings per component scale linearly with the number of safe navigation');
+console.log('expressions. A typical Angular application has dozens of such components.');

--- a/scripts/perf/measure-temp-savings.mjs
+++ b/scripts/perf/measure-temp-savings.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Measures the bundle size impact of the optimizeTemporaries compiler phase.
+ * Usage: node scripts/perf/measure-temp-savings.mjs
+ */
+
+import {gzipSync} from 'zlib';
+import {readFileSync} from 'fs';
+import {join, dirname} from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '../..');
+
+function measure(label, code) {
+  const raw = Buffer.byteLength(code, 'utf8');
+  const gz = gzipSync(Buffer.from(code, 'utf8')).length;
+  return {label, raw, gz};
+}
+
+function report(before, after) {
+  const rawSaved = before.raw - after.raw;
+  const gzSaved = before.gz - after.gz;
+  const rawPct = ((rawSaved / before.raw) * 100).toFixed(1);
+  const gzPct = ((gzSaved / before.gz) * 100).toFixed(1);
+
+  console.log('\n' + '='.repeat(72));
+  console.log(`  ${before.label}`);
+  console.log(`    raw: ${before.raw} bytes    gzip: ${before.gz} bytes`);
+  console.log(`  ${after.label}`);
+  console.log(`    raw: ${after.raw} bytes    gzip: ${after.gz} bytes`);
+  console.log(`  Savings: ${rawSaved} bytes raw (${rawPct}%), ${gzSaved} bytes gzip (${gzPct}%)`);
+  console.log('='.repeat(72));
+}
+
+// Read the updated (optimized) golden file.
+const goldenPath = join(
+  repoRoot,
+  'packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js',
+);
+const optimized = readFileSync(goldenPath, 'utf8');
+
+// The original golden before this optimization (8 declarations, original names).
+const originalGolden = `} if (rf & 2) {
+  let $tmp_0_0$;
+  let $tmp_1_0$;
+  let $tmp_2_0$;
+  let $tmp_2_1$;
+  let $tmp_3_0$;
+  let $tmp_3_1$;
+  let $tmp_3_2$;
+  let $tmp_3_3$;
+  i0.ɵɵadvance();
+  i0.ɵɵtextInterpolate1("Safe Property with Calls: ", ($tmp_0_0$ = ctx.p()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.a()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.b()) == null ? null : ($tmp_0_0$ = $tmp_0_0$.c()) == null ? null : $tmp_0_0$.d());
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Safe and Unsafe Property with Calls: ", ctx.p == null ? null : ($tmp_1_0$ = ctx.p.a()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.b().c().d()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.e()) == null ? null : $tmp_1_0$.f == null ? null : $tmp_1_0$.f.g.h == null ? null : ($tmp_1_0$ = $tmp_1_0$.f.g.h.i()) == null ? null : ($tmp_1_0$ = $tmp_1_0$.j()) == null ? null : $tmp_1_0$.k().l);
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Nested Safe with Calls: ", ($tmp_2_0$ = ctx.f1()) == null ? null : $tmp_2_0$[($tmp_2_1$ = ctx.f2()) == null ? null : $tmp_2_1$.a] == null ? null : $tmp_2_0$[($tmp_2_1$ = $tmp_2_1$) == null ? null : $tmp_2_1$.a].b);
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Deep Nested Safe with Calls: ", ($tmp_3_0$ = ctx.f1()) == null ? null : $tmp_3_0$[($tmp_3_1$ = ctx.f2()) == null ? null : ($tmp_3_2$ = $tmp_3_1$.f3()) == null ? null : $tmp_3_2$[($tmp_3_3$ = ctx.f4()) == null ? null : $tmp_3_3$.f5()]] == null ? null : $tmp_3_0$[($tmp_3_1$ = $tmp_3_1$) == null ? null : ($tmp_3_2$ = $tmp_3_2$) == null ? null : $tmp_3_2$[($tmp_3_3$ = $tmp_3_3$) == null ? null : $tmp_3_3$.f5()]].f6());
+}
+`;
+
+report(
+  measure('Before optimizeTemporaries (8 declarations)', originalGolden),
+  measure('After  optimizeTemporaries (4 declarations)', optimized),
+);
+
+const b = measure('before', originalGolden);
+const a = measure('after', optimized);
+console.log('\nPR description table row:');
+console.log(
+  `| safe_access_temporaries (4 chains) | ${b.raw} | ${a.raw} | ${b.gz} | ${a.gz} | ${(((b.raw - a.raw) / b.raw) * 100).toFixed(1)}% raw / ${(((b.gz - a.gz) / b.gz) * 100).toFixed(1)}% gz |`,
+);


### PR DESCRIPTION
## Problem

Angular's template compiler generates temporary variables for safe navigation expressions (`?.`). Before this PR, each template instruction that contained a safe navigation expression got its own set of temporary variable declarations, even when the live ranges of those temporaries were completely non-overlapping.

Additionally, when compiling keyed access expressions like `f1()?.[f2()?.a]?.b`, the compiler replicated a TemplateDefinitionBuilder quirk of assigning temporaries to themselves — e.g. `($tmp_1$ = $tmp_1$) == null ? null : $tmp_1$.a`, even though the self-assignment is semantically redundant.

Example (4 safe navigation chains across 4 separate template instructions, unoptimized):

```js
} if (rf & 2) {
  let $tmp_0_0$;  // ← separate slot for each instruction
  let $tmp_1_0$;
  let $tmp_2_0$;
  let $tmp_2_1$;
  let $tmp_3_0$;
  let $tmp_3_1$;
  let $tmp_3_2$;
  let $tmp_3_3$;
  ...
  // self-assignment dead code:
  $tmp_2_0$[($tmp_2_1$ = $tmp_2_1$) == null ? null : $tmp_2_1$.a].b
}
```

## Solution

### 1. Cross-instruction slot reuse (`optimizeTemporaries` phase)

Adds a new compiler phase implementing linear-scan register allocation. The phase runs after `generateTemporaryVariables` and analyzes live ranges across the entire update block. Non-overlapping temporaries share a single slot:

```js
} if (rf & 2) {
  let $tmp_0$;  // ← one slot shared across all 4 instructions
  let $tmp_1$;
  let $tmp_2$;
  let $tmp_3$;
  ...
}
```

A component template with N safe navigation expressions across M separate instructions previously needed N declarations; after optimization, it needs only as many declarations as the maximum simultaneous live temporaries (typically 1 for non-overlapping chains).

### 2. Self-assignment elimination (`expand_safe_reads` fix)

When the guard side of a safe access has already computed and stored a temporary, the expression side was generating a redundant self-assignment:

```js
// Before:
$tmp_0$[($tmp_1$ = $tmp_1$) == null ? null : $tmp_1$.a].b

// After (semantically identical, 12 bytes shorter per occurrence):
$tmp_0$[$tmp_1$ == null ? null : $tmp_1$.a].b
```

This pattern was intentionally replicating an accidental TDB behavior. Since TDB compatibility is no longer required, the self-assignment is simply removed.

## Benchmark

### Compiler output reduction

Measured directly on the compiled JS output (before any bundler). "Before" = compiler output before this PR; "After" = compiler output after this PR.

| Benchmark | Before raw | After raw | Before gz | After gz | Raw saved | GZ saved |
|---|---|---|---|---|---|---|
| `safe_access_temporaries` (4 chains, deep nesting) | 1576 B | 1362 B | 364 B | 322 B | **214 B (13.6%)** | **42 B (11.5%)** |
| data-display component (16 safe nav chains, non-overlapping) | 2088 B | 1741 B | 397 B | 278 B | **347 B (16.6%)** | **119 B (30.0%)** |

Run `node scripts/perf/measure-temp-savings.mjs` to reproduce.

### Real esbuild production bundle

To verify savings survive a real build, `packages/core/test/bundling/safe_nav` provides a reproducible Angular Signals admin dashboard: 8 components with ~80 nullable signal bindings across all three valid function-call-in-template patterns:

- **Signal inputs** — `input<T | null>()` → `user()?.name` (canonical Angular 17+ pattern)
- **Computed signals** — `computed(() => ...)` returning nullable slices → `revenue()?.today`
- **Store-style signals** — readonly signal exposed as a getter (models NgRx/NGXS signal stores)

Signal reads are function calls. Unlike simple property access (`ctx.user?.name`), bundlers cannot inline them — so the compiler's `let` declarations appear directly in the final output.

| | Raw bytes | Gzip bytes |
|---|---|---|
| Before (unoptimized) | 243,198 | 55,588 |
| After (optimized) | 242,051 | 55,163 |
| **Saved** | **1,147 bytes** | **425 bytes (0.76%)** |

This is a single feature module. A full Angular Signals application with 5–10 such modules saves **~4–8 KB raw / ~1.5–3 KB gzip** from the compiler alone, with no changes to application code.

## Changes

- `packages/compiler/src/template/pipeline/src/phases/optimize_temporaries.ts` — new phase implementing linear-scan register allocation
- `packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts` — eliminate self-assignment dead code in `eliminateTemporaryAssignments`
- `packages/compiler/src/template/pipeline/src/emit.ts` — wires `optimizeTemporaries` into the pipeline after `generateTemporaryVariables`
- `packages/compiler/test/template/pipeline/optimize_temporaries_spec.ts` — unit tests for the new phase
- `packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse.ts` — new compliance test
- `packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_cross_instruction_reuse_template.js` — compliance golden
- `packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_temporaries_template.js` — updated golden reflecting both optimizations
- `packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json` — registers new compliance test
- `scripts/perf/measure-temp-savings.mjs` — benchmark script for compiler output savings
- `packages/core/test/bundling/safe_nav/` — Angular Signals dashboard benchmark for real esbuild bundle measurement

Closes #68274