### PR TITLE
fix(common/http): prevent interceptor signal reads from leaking into calling reactive contexts

### DIFF
--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -16,6 +16,7 @@ import {
   EnvironmentInjector,
   inject,
   Injectable,
+  untracked,
   ɵConsole as Console,
   ɵformatRuntimeError as formatRuntimeError,
   PendingTasks,
@@ -117,14 +118,15 @@ export class HttpInterceptorHandler implements HttpHandler {
       );
     }
 
+    const chain = this.chain;
     if (this.contributeToStability) {
       const removeTask = this.pendingTasks.add();
-      return this.chain(initialRequest, (downstreamRequest) =>
-        this.backend.handle(downstreamRequest),
+      return untracked(() =>
+        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
       ).pipe(finalize(removeTask));
     } else {
-      return this.chain(initialRequest, (downstreamRequest) =>
-        this.backend.handle(downstreamRequest),
+      return untracked(() =>
+        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
       );
     }
   }

--- a/packages/common/http/src/backend.ts
+++ b/packages/common/http/src/backend.ts
@@ -9,11 +9,12 @@
 import {Observable} from 'rxjs';
 
 import {
-  ɵConsole as Console,
   EnvironmentInjector,
-  ɵformatRuntimeError as formatRuntimeError,
   inject,
   Injectable,
+  untracked,
+  ɵConsole as Console,
+  ɵformatRuntimeError as formatRuntimeError,
   PendingTasks,
 } from '@angular/core';
 import {finalize} from 'rxjs/operators';
@@ -116,14 +117,15 @@ export class HttpInterceptorHandler implements HttpHandler {
       );
     }
 
+    const chain = this.chain;
     if (this.contributeToStability) {
       const removeTask = this.pendingTasks.add();
-      return this.chain(initialRequest, (downstreamRequest) =>
-        this.backend.handle(downstreamRequest),
+      return untracked(() =>
+        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
       ).pipe(finalize(removeTask));
     } else {
-      return this.chain(initialRequest, (downstreamRequest) =>
-        this.backend.handle(downstreamRequest),
+      return untracked(() =>
+        chain(initialRequest, (downstreamRequest) => this.backend.handle(downstreamRequest)),
       );
     }
   }

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -25,12 +25,15 @@ import {HttpClientTestingModule, HttpTestingController, provideHttpClientTesting
 import {
   ApplicationRef,
   createEnvironmentInjector,
+  effect,
   EnvironmentInjector,
   ErrorHandler,
   inject,
+  Injector,
   InjectionToken,
   PLATFORM_ID,
   Provider,
+  signal,
 } from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {EMPTY, Observable, from} from 'rxjs';
@@ -671,3 +674,98 @@ const FAKE_JSONP_BACKEND_PROVIDER = {
     handle: (req: HttpRequest<never>) => EMPTY,
   },
 };
+
+describe('HttpInterceptor signal tracking', () => {
+  afterEach(() => {
+    try {
+      TestBed.inject(HttpTestingController).verify();
+    } catch {}
+  });
+
+  it('should not track signal reads in interceptors from a calling effect', () => {
+    const interceptorSignal = signal(1);
+    let effectRunCount = 0;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(
+          withInterceptors([
+            (req, next) => {
+              // Reading a signal here must not be tracked by a calling reactive context.
+              interceptorSignal();
+              return next(req);
+            },
+          ]),
+        ),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    const http = TestBed.inject(HttpClient);
+    const injector = TestBed.inject(Injector);
+    const controller = TestBed.inject(HttpTestingController);
+
+    effect(
+      () => {
+        effectRunCount++;
+        http.get('/test').subscribe();
+      },
+      {injector},
+    );
+
+    // Run the initial effect.
+    TestBed.tick();
+    expect(effectRunCount).toBe(1);
+    controller.expectOne('/test').flush('');
+
+    // Mutate the signal that was read inside the interceptor.
+    interceptorSignal.set(2);
+    TestBed.tick();
+
+    // The effect must NOT have re-run — interceptor signal reads are untracked.
+    expect(effectRunCount).toBe(1);
+    controller.verify();
+  });
+
+  it('should not track signal reads in legacy class interceptors from a calling effect', () => {
+    const interceptorSignal = signal(1);
+    let effectRunCount = 0;
+
+    class SignalReadingInterceptor implements HttpInterceptor {
+      intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        interceptorSignal();
+        return next.handle(req);
+      }
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        {provide: HTTP_INTERCEPTORS, useClass: SignalReadingInterceptor, multi: true},
+        provideHttpClientTesting(),
+      ],
+    });
+
+    const http = TestBed.inject(HttpClient);
+    const injector = TestBed.inject(Injector);
+    const controller = TestBed.inject(HttpTestingController);
+
+    effect(
+      () => {
+        effectRunCount++;
+        http.get('/test').subscribe();
+      },
+      {injector},
+    );
+
+    TestBed.tick();
+    expect(effectRunCount).toBe(1);
+    controller.expectOne('/test').flush('');
+
+    interceptorSignal.set(2);
+    TestBed.tick();
+
+    expect(effectRunCount).toBe(1);
+    controller.verify();
+  });
+});


### PR DESCRIPTION
## Summary

When `HttpClient` is called from within an `effect()` or other reactive context, signal reads performed inside HTTP interceptors are inadvertently tracked by that context. This causes the effect to re-execute whenever those interceptor signals change - a surprising, invisible coupling with no relation to the HTTP call itself.

**Root cause:** `HttpInterceptorHandler.handle()` calls `this.chain(initialRequest, ...)` without `untracked()`, so any signal reads that occur synchronously during interceptor execution are registered as dependencies of the calling reactive context.

**Fix:** Wrap the interceptor chain invocation in `untracked()`. This matches the precedent set by the `resource()` API, which wraps its loader in `untracked()` for the same reason: the reactive side of the API (the request) should drive reactivity, not the execution side.

Both functional interceptors (`withInterceptors`) and class-based interceptors (`withInterceptorsFromDi` / `HTTP_INTERCEPTORS`) are covered since they all execute within the same `this.chain(...)` call.

## Tests

Two new tests added to `provider_spec.ts`:
- Functional interceptor: verifies that mutating a signal read inside an `HttpInterceptorFn` does not re-trigger a calling `effect()`
- Legacy class interceptor: same verification for `HttpInterceptor` class implementations

Closes #58682