### PR TITLE
docs(docs-infra): add Angular Aria accordion playground template

### DIFF
--- a/adev/src/app/editor/typings-loader.service.ts
+++ b/adev/src/app/editor/typings-loader.service.ts
@@ -25,6 +25,7 @@ export class TypingsLoader {
     '@angular/platform-browser',
     '@angular/material',
     '@angular/cdk',
+    '@angular/aria',
   ];
 
   private webContainer: WebContainer | undefined;

--- a/adev/src/content/tutorials/playground/5-aria-accordion/config.json
+++ b/adev/src/content/tutorials/playground/5-aria-accordion/config.json
@@ -1,0 +1,5 @@
+{
+  "type": "editor-only",
+  "title": "Angular Aria Template",
+  "openFiles": ["src/main.ts", "src/main.css"]
+}

--- a/adev/src/content/tutorials/playground/5-aria-accordion/src/main.css
+++ b/adev/src/content/tutorials/playground/5-aria-accordion/src/main.css
@@ -1,0 +1,101 @@
+h2 {
+  margin-left: 1rem;
+}
+
+[ngAccordionGroup] {
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+  margin: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  overflow: hidden;
+  font-family:
+    Inter,
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+
+h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+h3:not(:first-of-type) {
+  border-top: 1px solid #ccc;
+}
+
+[ngAccordionTrigger] {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  transition: background-color 0.2s;
+}
+
+[ngAccordionTrigger]:hover {
+  background-color: #f6f8fa;
+}
+
+[ngAccordionTrigger]:focus-visible {
+  outline: 2px solid #4285f4;
+  outline-offset: -2px;
+}
+
+[ngAccordionTrigger][aria-expanded='true'] {
+  color: #4285f4;
+}
+
+.expand-icon {
+  position: relative;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  margin-left: 1rem;
+}
+
+.expand-icon::before,
+.expand-icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 100%;
+  height: 2px;
+  background-color: #333;
+  transition: 0.3s ease-out;
+}
+
+.expand-icon::after {
+  transform: rotate(90deg);
+}
+
+.expand-icon__expanded::before {
+  transform: translateY(-50%) rotate(-90deg);
+  opacity: 0;
+}
+
+.expand-icon__expanded::after {
+  transform: translateY(-50%) rotate(0);
+  background-color: #4285f4;
+}
+
+[ngAccordionPanel] p {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #ccc;
+  font-size: 0.875rem;
+}
+
+code {
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+  background-color: #f6f8fa;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.875em;
+}

--- a/adev/src/content/tutorials/playground/5-aria-accordion/src/main.ts
+++ b/adev/src/content/tutorials/playground/5-aria-accordion/src/main.ts
@@ -1,0 +1,76 @@
+import {Component} from '@angular/core';
+import {
+  AccordionGroup,
+  AccordionTrigger,
+  AccordionPanel,
+  AccordionContent,
+} from '@angular/aria/accordion';
+import {bootstrapApplication} from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <h2>Frequently asked questions</h2>
+
+    <div ngAccordionGroup class="basic-accordion" [multiExpandable]="false">
+      <h3>
+        <span ngAccordionTrigger [panel]="panel1" #trigger1="ngAccordionTrigger" [expanded]="true">
+          How do I start a new Angular project?
+          <span
+            aria-hidden="true"
+            class="expand-icon"
+            [class.expand-icon__expanded]="trigger1.expanded()"
+          ></span>
+        </span>
+      </h3>
+      <div ngAccordionPanel #panel1="ngAccordionPanel">
+        <ng-template ngAccordionContent>
+          <p>
+            Install the CLI with <code>npm install -g &#64;angular/cli</code>, then run
+            <code>ng new &lt;project-name&gt;</code>.
+          </p>
+        </ng-template>
+      </div>
+
+      <h3>
+        <span ngAccordionTrigger [panel]="panel2" #trigger2="ngAccordionTrigger">
+          What are signals?
+          <span
+            aria-hidden="true"
+            class="expand-icon"
+            [class.expand-icon__expanded]="trigger2.expanded()"
+          ></span>
+        </span>
+      </h3>
+      <div ngAccordionPanel #panel2="ngAccordionPanel">
+        <ng-template ngAccordionContent>
+          <p>Signals are reactive values that track reads and notify dependents on write.</p>
+        </ng-template>
+      </div>
+
+      <h3>
+        <span ngAccordionTrigger [panel]="panel3" #trigger3="ngAccordionTrigger">
+          What is zoneless?
+          <span
+            aria-hidden="true"
+            class="expand-icon"
+            [class.expand-icon__expanded]="trigger3.expanded()"
+          ></span>
+        </span>
+      </h3>
+      <div ngAccordionPanel #panel3="ngAccordionPanel">
+        <ng-template ngAccordionContent>
+          <p>
+            Zoneless is a mode where Angular drops its Zone.js dependency and relies on signals to
+            schedule change detection, reducing bundle size and making reactivity explicit.
+          </p>
+        </ng-template>
+      </div>
+    </div>
+  `,
+  styleUrl: 'main.css',
+  imports: [AccordionGroup, AccordionTrigger, AccordionPanel, AccordionContent],
+})
+export class AccordionApp {}
+
+bootstrapApplication(AccordionApp);

--- a/adev/src/content/tutorials/playground/common/package-lock.json
+++ b/adev/src/content/tutorials/playground/common/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^22.0.0-next",
+        "@angular/aria": "^22.0.0-next",
         "@angular/cdk": "^22.0.0-next",
         "@angular/common": "^22.0.0-next",
         "@angular/compiler": "^22.0.0-next",
@@ -329,6 +330,19 @@
       },
       "peerDependencies": {
         "@angular/core": "22.0.0-next.6"
+      }
+    },
+    "node_modules/@angular/aria": {
+      "version": "22.0.0-next.3",
+      "resolved": "https://registry.npmjs.org/@angular/aria/-/aria-22.0.0-next.3.tgz",
+      "integrity": "sha512-4W1Hav9tJ54cUwsCOyy8CC60QJyTeK2KrG6zLGK2mBNa756oUGJ8kKv7D9VG+eR3TujutGel2jneexRB1uZ1fA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "22.0.0-next.3",
+        "@angular/core": "^22.0.0-0 || ^22.1.0-0 || ^22.2.0-0 || ^22.3.0-0 || ^23.0.0-0"
       }
     },
     "node_modules/@angular/build": {

--- a/adev/src/content/tutorials/playground/common/package.json
+++ b/adev/src/content/tutorials/playground/common/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^22.0.0-next",
+    "@angular/aria": "^22.0.0-next",
     "@angular/cdk": "^22.0.0-next",
     "@angular/common": "^22.0.0-next",
     "@angular/compiler": "^22.0.0-next",


### PR DESCRIPTION
Adds a single-expansion accordion playground template under adev/src/content/tutorials/playground/5-aria-accordion demonstrating the Angular Aria primitives. Wires @angular/aria into the editor TypingsLoader so imports resolve in the sandbox.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The playground has no template for the Angular Aria.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

New playground template `5-aria-accordion` ("Angular Aria Template") ported from the guide's single-expansion basic example, using `ngAccordionGroup`, `ngAccordionTrigger`, `ngAccordionPanel`, and lazy `ngAccordionContent` — single-file `main.ts` + `main.css` matching existing playground conventions. 

<img width="1118" height="784" alt="image" src="https://github.com/user-attachments/assets/1d9010d8-0f04-4351-9be3-5e21bd917985" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
