### PR TITLE
refactor(core): complete removal of deprecated `createNgModuleRef` alias

### DIFF
--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -38,14 +38,6 @@ export function createNgModule<T>(
 ): viewEngine_NgModuleRef<T> {
   return new NgModuleRef<T>(ngModule, parentInjector ?? null, []);
 }
-
-/**
- * The `createNgModule` function alias for backwards-compatibility.
- * Please avoid using it directly and use `createNgModule` instead.
- *
- * @deprecated Use `createNgModule` instead.
- */
-export const createNgModuleRef = createNgModule;
 export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements InternalNgModuleRef<T> {
   // tslint:disable-next-line:require-internal-with-underscore
   _bootstrapComponents: Type<any>[] = [];


### PR DESCRIPTION
Finalize the cleanup started in #67473 by removing the remaining `createNgModuleRef` alias.
