### PR TITLE
docs: improve wording in reactive forms guide

### DIFF
--- a/adev/src/content/guide/forms/dynamic-forms.md
+++ b/adev/src/content/guide/forms/dynamic-forms.md
@@ -30,7 +30,7 @@ The basic version can evolve to support a richer variety of questions, more grac
 
 Dynamic forms are based on reactive forms.
 
-To give the application access reactive forms directives, import `ReactiveFormsModule` from the `@angular/forms` library into the necessary components.
+To give the application access to reactive forms directives, import `ReactiveFormsModule` from the `@angular/forms` package into the necessary components.
 
 <docs-code-multifile>
     <docs-code header="dynamic-form.component.ts" path="adev/src/content/examples/dynamic-form/src/app/dynamic-form.component.ts"/>

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -15,7 +15,7 @@ Any consumers of the streams have access to manipulate that data safely.
 Reactive forms differ from [template-driven forms](guide/forms/template-driven-forms) in distinct ways.
 Reactive forms provide synchronous access to the data model, immutability with observable operators, and change tracking through observable streams.
 
-Template-driven forms let direct access modify data in your template, but are less explicit than reactive forms because they rely on directives embedded in the template, along with mutable data to track changes asynchronously.
+Template-driven forms allow direct access to modify data in your template, but are less explicit than reactive forms because they rely on directives embedded in the template, along with mutable data to track changes asynchronously.
 See the [Forms Overview](guide/forms) for detailed comparisons between the two paradigms.
 
 ## Adding a basic form control


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (not applicable)
- [x] Docs have been added / updated

## PR Type

- [x] Documentation content changes

## What is the current behavior?

The sentence describing template-driven forms uses awkward wording:
"let direct access modify data", which reduces clarity.

## What is the new behavior?

Improves wording to:
"allow direct access to modify data"

This makes the sentence grammatically correct and clearer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Small wording improvement for better readability and consistency.