### PR TITLE
docs(compiler-cli): fix 'wether' typo in properties_extractor

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/properties_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/properties_extractor.ts
@@ -364,7 +364,7 @@ export abstract class PropertiesExtractor {
   }
 
   /**
-   * Check wether a member has a private computed property name like [ɵWRITABLE_SIGNAL]
+   * Check whether a member has a private computed property name like [ɵWRITABLE_SIGNAL]
    *
    * This will prevent exposing private computed properties in the docs.
    */


### PR DESCRIPTION

**Repo:** angular/angular (⭐ 95000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes a misspelling in a JSDoc comment in `packages/compiler-cli/src/ngtsc/docs/src/properties_extractor.ts`. The word "wether" is corrected to "whether" on the doc comment for the `hasPrivateComputedProperty` method.

## Why
The misspelled word appeared in a code comment within the docs extractor used by the compiler-cli. While not a functional bug, fixing typos in code comments improves readability and code quality, especially in a heavily-read repo like Angular. The fix is the single instance of this misspelling found across `packages/`.

## Testing
No runtime behavior is affected — change is comment-only. Verification: `git diff` shows a one-character change inside a JSDoc block; the surrounding TypeScript is untouched.

## Risk
Low — comment-only change, no code paths affected.
