### PR TITLE
fix(forms): place controlCreate before listeners in signal forms temp…

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/control_bindings.js
@@ -12,8 +12,9 @@ export class MyComponent {
         i0.ɵɵelementStart(1, "div");
         i0.ɵɵtext(2, "Not a form control either.");
         i0.ɵɵelementEnd();
-        i0.ɵɵelement(3, "input", 1);
+        i0.ɵɵelementStart(3, "input", 1);
         i0.ɵɵcontrolCreate();
+        i0.ɵɵelementEnd();
       }
       if (rf & 2) {
         i0.ɵɵadvance();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/radio_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/control_bindings/radio_bindings.js
@@ -8,10 +8,12 @@ export class MyComponent {
     consts: [["type", "radio", "id", "radio", 3, "formField", "value"], ["type", "radio", "id", "radio", 3, "value", "formField"]],
     template: function MyComponent_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵelement(0, "input", 0);
+        i0.ɵɵelementStart(0, "input", 0);
         i0.ɵɵcontrolCreate();
-        i0.ɵɵelement(1, "input", 1);
+        i0.ɵɵelementEnd();
+        i0.ɵɵelementStart(1, "input", 1);
         i0.ɵɵcontrolCreate();
+        i0.ɵɵelementEnd();
       }
       if (rf & 2) {
         i0.ɵɵproperty("formField", ctx.value)("value", "foo");

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/nested_two_way_template.js
@@ -2,6 +2,7 @@ function TestCmp_ng_template_1_Template(rf, ctx) {
   if (rf & 1) {
     const $_r2$ = $r3$.ɵɵgetCurrentView();
     $r3$.ɵɵelementStart(0, "input", 0);
+    $r3$.ɵɵcontrolCreate();
     $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_ng_template_1_Template_input_ngModelChange_0_listener($event) {
       $r3$.ɵɵrestoreView($_r2$);
       const $ctx_r1$ = $r3$.ɵɵnextContext();
@@ -9,7 +10,6 @@ function TestCmp_ng_template_1_Template(rf, ctx) {
       return $r3$.ɵɵresetView($event);
     });
     $r3$.ɵɵelementEnd();
-    $r3$.ɵɵcontrolCreate();
   } if (rf & 2) {
     const $ctx_r0$ = $r3$.ɵɵnextContext();
     $r3$.ɵɵtwoWayProperty("ngModel", $ctx_r0$.name);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/simple_two_way_template.js
@@ -2,12 +2,12 @@ function TestCmp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵtext(0, "Name: ");
     $r3$.ɵɵelementStart(1, "input", 0);
+    $r3$.ɵɵcontrolCreate();
     $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_1_listener($event) {
       $r3$.ɵɵtwoWayBindingSet(ctx.name, $event) || (ctx.name = $event);
       return $event;
     });
     $r3$.ɵɵelementEnd();
-    $r3$.ɵɵcontrolCreate();
   } if (rf & 2) {
     $r3$.ɵɵadvance();
     $r3$.ɵɵtwoWayProperty("ngModel", ctx.name);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_binding_to_signal_loop_variable_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_binding_to_signal_loop_variable_template.js
@@ -2,13 +2,13 @@ function TestCmp_For_1_Template(rf, ctx) {
   if (rf & 1) {
     const $_r1$ = $r3$.ɵɵgetCurrentView();
     $r3$.ɵɵelementStart(0, "input", 1);
+    $r3$.ɵɵcontrolCreate();
     $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_For_1_Template_input_ngModelChange_0_listener($event) {
       const $name_r2$ = $r3$.ɵɵrestoreView($_r1$).$implicit;
       $r3$.ɵɵtwoWayBindingSet($name_r2$, $event);
       return $r3$.ɵɵresetView($event);
     });
     $r3$.ɵɵelementEnd();
-    $r3$.ɵɵcontrolCreate();
   }
   if (rf & 2) {
     const $name_r2$ = ctx.$implicit;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/two_way_to_any_template.js
@@ -1,12 +1,12 @@
 function TestCmp_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵelementStart(0, "input", 0);
+    $r3$.ɵɵcontrolCreate();
     $r3$.ɵɵtwoWayListener("ngModelChange", function TestCmp_Template_input_ngModelChange_0_listener($event) {
       $r3$.ɵɵtwoWayBindingSet(ctx.value, $event) || (ctx.value = $event);
       return $event;
     });
     $r3$.ɵɵelementEnd();
-    $r3$.ɵɵcontrolCreate();
   }
   if (rf & 2) {
     $r3$.ɵɵtwoWayProperty("ngModel", ctx.value);

--- a/packages/compiler/src/template/pipeline/src/phases/control_directives.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/control_directives.ts
@@ -43,11 +43,8 @@ function processView(view: ViewCompilationUnit): void {
 const CONTROL_OP_CREATE_KINDS = new Set([
   ir.OpKind.Container,
   ir.OpKind.ContainerStart,
-  ir.OpKind.ContainerEnd,
   ir.OpKind.Element,
   ir.OpKind.ElementStart,
-  ir.OpKind.ElementEnd,
-  ir.OpKind.Template,
 ]);
 
 function isRelevantCreateOp(createOp: ir.CreateOp): createOp is ir.CreateOp & {xref: ir.XrefId} {
@@ -55,16 +52,13 @@ function isRelevantCreateOp(createOp: ir.CreateOp): createOp is ir.CreateOp & {x
 }
 
 function findCreateInstruction(view: ViewCompilationUnit, target: ir.XrefId): ir.CreateOp | null {
-  let lastFoundOp: ir.CreateOp | null = null;
   for (const createOp of view.create) {
-    if (!isRelevantCreateOp(createOp) || createOp.xref !== target) {
-      continue;
+    if (isRelevantCreateOp(createOp) && createOp.xref === target) {
+      return createOp;
     }
-
-    lastFoundOp = createOp;
   }
 
-  return lastFoundOp;
+  return null;
 }
 
 function addControlInstruction(

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -136,6 +136,32 @@ describe('field directive', () => {
       });
       expect(component.model()).toEqual({x: 'a', y: 'c'});
     });
+
+    it('should update field value before template (input) listener fires', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input [formField]="f.x" (input)="onInput()" />`,
+      })
+      class TestCmp {
+        readonly model = signal({x: 'a'});
+        readonly f = form(this.model);
+        observedDuringInput: string | undefined;
+
+        onInput() {
+          this.observedDuringInput = this.f.x().value();
+        }
+      }
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const component = fixture.componentInstance;
+      const input = fixture.nativeElement.firstChild as HTMLInputElement;
+
+      act(() => {
+        input.value = 'b';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(component.observedDuringInput).toBe('b');
+      expect(component.model()).toEqual({x: 'b'});
+    });
   });
 
   describe('host directive mapping', () => {

--- a/packages/forms/signals/test/web/reactive_fvc.spec.ts
+++ b/packages/forms/signals/test/web/reactive_fvc.spec.ts
@@ -71,6 +71,30 @@ describe('FormControlDirective with FVC', () => {
     expect(fixture.componentInstance.ctrl.value).toBe('from-fvc');
   });
 
+  it('should update FormControl value before template (valueChange) listener fires', () => {
+    @Component({
+      template: `<my-fvc-input [formControl]="ctrl" (valueChange)="onValueChange()" />`,
+      imports: [MyFvcInput, ReactiveFormsModule],
+    })
+    class TestCmp {
+      ctrl = new FormControl('initial');
+      observedDuringValueChange: string | null | undefined;
+
+      onValueChange() {
+        this.observedDuringValueChange = this.ctrl.value;
+      }
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const fvc = fixture.debugElement.query(By.directive(MyFvcInput)).componentInstance;
+
+    act(() => fvc.value.set('from-fvc'));
+
+    expect(component.observedDuringValueChange).toBe('from-fvc');
+    expect(component.ctrl.value).toBe('from-fvc');
+  });
+
   it('should fall back to CVA when no FVC pattern is present', () => {
     @Component({
       template: `<input [formControl]="ctrl" />`,
@@ -551,6 +575,36 @@ describe('FormControlName with FVC', () => {
     act(() => fvc.value.set('from-fvc'));
 
     expect(fixture.componentInstance.form.controls.name.value).toBe('from-fvc');
+  });
+
+  it('should update FormControl value before template (valueChange) listener fires', () => {
+    @Component({
+      template: `
+        <form [formGroup]="form">
+          <my-fvc-input formControlName="name" (valueChange)="onValueChange()" />
+        </form>
+      `,
+      imports: [MyFvcInput, ReactiveFormsModule],
+    })
+    class TestCmp {
+      form = new FormGroup({
+        name: new FormControl('initial'),
+      });
+      observedDuringValueChange: string | null | undefined;
+
+      onValueChange() {
+        this.observedDuringValueChange = this.form.controls.name.value;
+      }
+    }
+
+    const fixture = act(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const fvc = fixture.debugElement.query(By.directive(MyFvcInput)).componentInstance;
+
+    act(() => fvc.value.set('from-fvc'));
+
+    expect(component.observedDuringValueChange).toBe('from-fvc');
+    expect(component.form.controls.name.value).toBe('from-fvc');
   });
 
   it('should fall back to CVA when no FVC pattern is present', () => {

--- a/packages/forms/signals/test/web/template_fvc.spec.ts
+++ b/packages/forms/signals/test/web/template_fvc.spec.ts
@@ -73,6 +73,35 @@ describe('NgModel with FVC', () => {
     expect(fixture.componentInstance.val()).toBe('from-fvc');
   });
 
+  it('should update ngModel value before template (valueChange) listener fires', async () => {
+    @Component({
+      template: `<template-fvc-input
+        [(ngModel)]="val"
+        (valueChange)="onValueChange()"
+        #model="ngModel"
+      />`,
+      imports: [TemplateFvcInput, FormsModule],
+    })
+    class TestCmp {
+      val = signal('initial');
+      observedDuringValueChange: string | undefined;
+      @ViewChild('model') model!: NgModel;
+
+      onValueChange() {
+        this.observedDuringValueChange = this.model.control.value;
+      }
+    }
+
+    const fixture = await actAsync(() => TestBed.createComponent(TestCmp));
+    const component = fixture.componentInstance;
+    const fvc = fixture.debugElement.query(By.directive(TemplateFvcInput)).componentInstance;
+
+    act(() => fvc.value.set('from-fvc'));
+
+    expect(component.observedDuringValueChange).toBe('from-fvc');
+    expect(component.val()).toBe('from-fvc');
+  });
+
   it('should fall back to CVA when no FVC pattern is present', async () => {
     @Component({
       template: `<input [(ngModel)]="val" />`,


### PR DESCRIPTION

Fixes : #68182 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

 the ControlCreate IR op was inserted after the target element's create op (ElementStart/Element), but because the ordering phase places listeners (Listener, TwoWayListener) immediately after element-start ops, the ControlCreate op ended up being emitted after the ElementEnd instruction.

This caused a behaviour discrepancy between [formField] and [(ngModel)]: inside an (input) event handler, the field value reported by Signal Forms still held the old value while ngModel already reflected the new one. The ControlCreate runtime instruction sets up the two-way sync between the DOM control and the field signal, so it must be called early during element creation (before any listeners that may read the updated value).

Fixes #68182
Related: #63608 

## What is the new behavior?
## Does this PR introduce a breaking change?

Two compiler changes fix this:

1. control_directives.ts - findCreateInstruction now returns the *first* matching create op for a given target xref (ElementStart or Element) instead of the last one. Previously ElementEnd was in the eligible set which meant the search returned the ElementEnd op, causing ControlCreate to land after it. Removing ElementEnd and ContainerEnd from CONTROL_OP_CREATE_KINDS ensures the op is always inserted immediately after the opening tag.

2. empty_elements.ts - ElementStart+ElementEnd pairs that contain only a ControlCreate op between them can still be collapsed into a single Element instruction. Added ir.OpKind.ControlCreate to IGNORED_OP_KINDS so the collapseEmptyInstructions phase skips over it when looking for a matching start op.

Compliance test golden files for two-way binding templates updated to reflect the new (correct) instruction order: controlCreate now appears immediately after elementStart, before the twoWayListener.

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
