### PR TITLE
docs: fix minor grammar issues in forms overview guide

### DIFF
--- a/adev/src/content/guide/forms/overview.md
+++ b/adev/src/content/guide/forms/overview.md
@@ -86,7 +86,7 @@ The following component implements the same input field for a single control, us
 
 <docs-code language="angular-ts" path="adev/src/content/examples/forms-overview/src/app/template/favorite-color/favorite-color.component.ts"/>
 
-IMPORTANT: In a template-driven form the source of truth is the template. The `NgModel` directive automatically manages the `FormControl` instance for you.
+IMPORTANT: In a template-driven form, the source of truth is the template. The `NgModel` directive automatically manages the `FormControl` instance for you.
 
 ## Data flow in forms
 
@@ -99,7 +99,7 @@ The following diagrams illustrate both kinds of data flow for each type of form,
 
 ### Data flow in reactive forms
 
-In reactive forms each form element in the view is directly linked to the form model (a `FormControl` instance).
+In reactive forms, each form element in the view is directly linked to the form model (a `FormControl` instance).
 Updates from the view to the model and from the model to the view are synchronous and do not depend on how the UI is rendered.
 
 The view-to-model diagram shows how data flows when an input field's value is changed from the view through the following steps.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Some sentences in the forms overview guide are missing commas, which slightly affects readability.

Issue Number: N/A

## What is the new behavior?

* Added missing commas for improved readability and grammatical correctness
* Maintained original meaning and structure

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

These changes are limited to documentation and do not affect functionality.