### PR TITLE
docs: improve wording in signal forms overview

### DIFF
--- a/adev/src/content/guide/forms/signals/overview.md
+++ b/adev/src/content/guide/forms/signals/overview.md
@@ -13,8 +13,8 @@ Building forms in web applications involves managing several interconnected conc
 
 Signal Forms address these challenges by:
 
-- **Synchronizing state automatically** - Automatically syncs the form data model with bound form fields
-- **Providing type safety** - Supports fully type safe schemas & bindings between your UI controls and data model
+- **Synchronizing state automatically** - Automatically synchronizes the form data model with bound form fields
+- **Providing type safety** - Supports fully type-safe schemas and bindings between your UI controls and data model
 - **Centralizing validation logic** - Define all validation rules in one place using a validation schema
 
 Signal Forms work best in new applications built with signals. If you're working with an existing application that uses reactive forms, or if you need production stability guarantees, reactive forms remain a solid choice.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Some wording and formatting in the Signal Forms overview could be improved for consistency.

Issue Number: N/A

## What is the new behavior?

* Improved wording for clarity
* Replaced informal/abbreviated terms with consistent documentation style (e.g., "synchronizes", "type-safe", "and")

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

Documentation-only changes with no impact on functionality.