### PR TITLE
docs: warn against storing secrets in environment files

### DIFF
--- a/adev/src/content/tools/cli/environments.md
+++ b/adev/src/content/tools/cli/environments.md
@@ -99,6 +99,8 @@ export const environment = {
 };
 ```
 
+CRITICAL: Files in `src/environments/` are bundled into your client-side application and visible to anyone who loads the page. Never store secrets such as API keys here. Use a server-side proxy or a secrets manager instead.
+
 You can add target-specific configuration files, such as `environment.development.ts`.
 The following content sets default values for the development build target:
 


### PR DESCRIPTION
Add an IMPORTANT callout warning that files in `src/environments/` ship to the client and should not hold secrets like API keys.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The environments guide doesn't have a warning about storing secrets, API keys etc. in src/environments/ files.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The environments guide now has an CRITICAL callout warning against storing secrets, API keys etc. in src/environments/ files. 
<img width="853" height="218" alt="image" src="https://github.com/user-attachments/assets/a2eddbce-46f7-41a6-b3cf-2c0464496668" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
