### PR TITLE
Revert "refactor(core): complete removal of deprecated `createNgModul…

### DIFF
--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -40,6 +40,14 @@ export function createNgModule<T>(
 ): viewEngine_NgModuleRef<T> {
   return new NgModuleRef<T>(ngModule, parentInjector ?? null, []);
 }
+
+/**
+ * The `createNgModule` function alias for backwards-compatibility.
+ * Please avoid using it directly and use `createNgModule` instead.
+ *
+ * @deprecated Use `createNgModule` instead.
+ */
+export const createNgModuleRef = createNgModule;
 export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements InternalNgModuleRef<T> {
   // tslint:disable-next-line:require-internal-with-underscore
   _bootstrapComponents: Type<any>[] = [];


### PR DESCRIPTION
…eRef` alias"

This reverts commit d88d6ed69e05decd2957e1235615926f49fb35c6. Depended on a PR that was not merged to 21.2.x
