### PR TITLE
refactor(devtools): drop the `semver-dsl` page

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/BUILD.bazel
@@ -10,7 +10,8 @@ ts_project(
     ),
     deps = [
         "//:node_modules/@angular/core",
-        "//:node_modules/semver-dsl",
+        "//:node_modules/@types/semver",
+        "//:node_modules/semver",
         "//devtools/projects/ng-devtools-backend/src/lib:highlighter",
         "//devtools/projects/ng-devtools-backend/src/lib:interfaces",
         "//devtools/projects/ng-devtools-backend/src/lib:utils",

--- a/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/directive-forest/ltree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {SemVerDSL} from 'semver-dsl';
+import semver from 'semver';
 
 import {getDirectiveName} from '../highlighter';
 import {ComponentInstanceType, ComponentTreeNode, DirectiveInstanceType} from '../interfaces';
@@ -19,10 +19,14 @@ const latest = () => {
   HEADER_OFFSET = 20;
 };
 
-SemVerDSL(VERSION).gte('10.0.0-next.4', latest);
+if (semver.gte(VERSION, '10.0.0-next.4')) {
+  latest();
+}
 
 // In g3 everyone has version 0.0.0, using the currently synced commits in the g3 codebase.
-SemVerDSL(VERSION).eq('0.0.0', latest);
+if (semver.eq(VERSION, '0.0.0')) {
+  latest();
+}
 
 const TYPE = 1;
 const ELEMENT = 0;

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "rollup-plugin-dts": "^6.1.1",
     "rxjs": "^7.0.0",
     "selenium-webdriver": "3.5.0",
-    "semver-dsl": "^1.0.1",
     "source-map": "0.7.6",
     "source-map-support": "0.5.21",
     "systemjs": "0.18.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,6 @@ importers:
       selenium-webdriver:
         specifier: 3.5.0
         version: 3.5.0
-      semver-dsl:
-        specifier: ^1.0.1
-        version: 1.0.1
       source-map:
         specifier: 0.7.6
         version: 0.7.6
@@ -10918,7 +10915,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:
@@ -11330,9 +11326,6 @@ packages:
   semver-diff@3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
-
-  semver-dsl@1.0.1:
-    resolution: {integrity: sha512-e8BOaTo007E3dMuQQTnPdalbKTABKNS7UxoBIDnwOqRa+QwMrCPjynB8zAlPF6xlqUfdLPPLIJ13hJNmhtq8Ng==}
 
   semver-greatest-satisfied-range@2.0.0:
     resolution: {integrity: sha512-lH3f6kMbwyANB7HuOWRMlLCa2itaCrZJ+SAqqkSZrZKO/cAsk2EOyaKHUtNkVLFyFW9pct22SFesFp3Z7zpA0g==}
@@ -24852,10 +24845,6 @@ snapshots:
   semver-diff@3.1.1:
     dependencies:
       semver: 6.3.1
-
-  semver-dsl@1.0.1:
-    dependencies:
-      semver: 5.7.2
 
   semver-greatest-satisfied-range@2.0.0:
     dependencies:


### PR DESCRIPTION
We can use the semver package directly.
