### PR TITLE
docs: improve wording and consistency in http documentation

### DIFF
--- a/adev/src/content/guide/http/interceptors.md
+++ b/adev/src/content/guide/http/interceptors.md
@@ -8,7 +8,7 @@ TLDR: Interceptors are middleware that allows common patterns around retrying, c
 
 ## Interceptors
 
-Interceptors are generally functions which you can run for each request, and have broad capabilities to affect the contents and overall flow of requests and responses. You can install multiple interceptors, which form an interceptor chain where each interceptor processes the request or response before forwarding it to the next interceptor in the chain.
+Interceptors are generally functions that you can run for each request and have broad capabilities to affect the contents and overall flow of requests and responses. You can install multiple interceptors, which form an interceptor chain where each interceptor processes the request or response before forwarding it to the next interceptor in the chain.
 
 You can use interceptors to implement a variety of common patterns, such as:
 
@@ -16,7 +16,7 @@ You can use interceptors to implement a variety of common patterns, such as:
 - Retrying failed requests with exponential backoff.
 - Caching responses for a period of time, or until invalidated by mutations.
 - Customizing the parsing of responses.
-- Measuring server response times and log them.
+- Measuring server response times and logging them.
 - Driving UI elements such as a loading spinner while network operations are in progress.
 - Collecting and batch requests made within a certain timeframe.
 - Automatically failing requests after a configurable deadline or timeout.
@@ -172,7 +172,7 @@ const resp = new HttpResponse({
 
 ## Working with redirect information
 
-When `HttpClient` uses the fetch backend , responses include a `redirected` property that indicates whether the response was the result of a redirect. This property aligns with the native Fetch API specification and can be useful in interceptors for handling redirect scenarios.
+When `HttpClient` uses the fetch backend, responses include a `redirected` property that indicates whether the response was the result of a redirect. This property aligns with the native Fetch API specification and can be useful in interceptors for handling redirect scenarios.
 
 An interceptor can access and act upon the redirect information:
 
@@ -215,7 +215,7 @@ export function authRedirectInterceptor(
 
 ## Working with response types
 
-When `HttpClient` uses the fetch backend , responses include a `type` property that indicates how the browser handled the response based on CORS policies and request mode. This property aligns with the native Fetch API specification and provides valuable insights for debugging CORS issues and understanding response accessibility.
+When `HttpClient` uses the fetch backend, responses include a `type` property that indicates how the browser handled the response based on CORS policies and request mode. This property aligns with the native Fetch API specification and provides valuable insights for debugging CORS issues and understanding response accessibility.
 
 The response `type` property can have the following values:
 

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -18,7 +18,7 @@ http.get<Config>('/api/config').subscribe((config) => {
 });
 ```
 
-Note the generic type argument which specifies that the data returned by the server will be of type `Config`. This argument is optional, and if you omit it then the returned data will have type `Object`.
+Note the generic type argument which specifies that the data returned by the server will be of type `Config`. This argument is optional, and if you omit it, the returned data will have type `Object`.
 
 TIP: When dealing with data of uncertain structure and potential `undefined` or `null` values, consider using the `unknown` type instead of `Object` as the response type.
 
@@ -26,7 +26,7 @@ CRITICAL: The generic type of request methods is a type **assertion** about the 
 
 ## Fetching other types of data
 
-By default, `HttpClient` assumes that servers will return JSON data. When interacting with a non-JSON API, you can tell `HttpClient` what response type to expect and return when making the request. This is done with the `responseType` option.
+By default, `HttpClient` assumes that servers will return JSON data. When interacting with a non-JSON API, you can tell `HttpClient` what response type to expect when making the request. This is done with the `responseType` option.
 
 | **`responseType` value** | **Returned response type**                                                                                                                |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -51,7 +51,7 @@ This happens automatically if the options object passed to the request method is
 
 ## Mutating server state
 
-Server APIs which perform mutations often require making POST requests with a request body specifying the new state or the change to be made.
+Server APIs that perform mutations often require making POST requests with a request body specifying the new state or the change to be made.
 
 The [`HttpClient.post()`](api/common/http/HttpClient#post) method behaves similarly to `get()`, and accepts an additional `body` argument before its options:
 
@@ -169,7 +169,7 @@ http
   });
 ```
 
-Alternatively, pass an instance of `HttpHeaders` if you need more control over the construction of headers
+Alternatively, pass an instance of `HttpHeaders` if you need more control over the construction of headers.
 
 IMPORTANT: Instances of `HttpHeaders` are _immutable_ and cannot be directly changed. Instead, mutation methods such as `append()` return a new instance of `HttpHeaders` with the mutation applied.
 
@@ -206,7 +206,7 @@ This happens automatically if the options object passed to the request method is
 
 ## Receiving raw progress events
 
-In addition to the response body or response object, `HttpClient` can also return a stream of raw _events_ corresponding to specific moments in the request lifecycle. These events include when the request is sent, when the response header is returned, and when the body is complete. These events can also include _progress events_ which report upload and download status for large request or response bodies.
+In addition to the response body or response object, `HttpClient` can also return a stream of raw _events_ corresponding to specific moments in the request lifecycle. These events include when the request is sent, when the response header is returned, and when the body is complete. These events can also include _progress events_ that report upload and download status for large request or response bodies.
 
 Progress events are disabled by default (as they have a performance cost) but can be enabled with the `reportProgress` option.
 

--- a/adev/src/content/guide/http/overview.md
+++ b/adev/src/content/guide/http/overview.md
@@ -1,6 +1,6 @@
-# Understanding communicating with backend services using HTTP
+# Understanding communication with backend services using HTTP
 
-Most front-end applications need to communicate with a server over the HTTP protocol, to download or upload data and access other back-end services. Angular provides a client HTTP API for Angular applications, the `HttpClient` service class in `@angular/common/http`.
+Most front-end applications need to communicate with a server over the HTTP protocol to download or upload data and access other back-end services. Angular provides a client HTTP API for Angular applications, the `HttpClient` service class in `@angular/common/http`.
 
 ## HTTP client service features
 

--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -34,7 +34,7 @@ export class ConfigService {
 
 ## Configuring features of `HttpClient`
 
-`provideHttpClient` accepts a list of optional feature configurations, to enable or configure the behavior of different aspects of the client. This section details the optional features and their usages.
+`provideHttpClient` accepts a list of optional feature configurations to enable or configure different aspects of the client. This section details the optional features and their usage.
 
 ### `withXhr`
 
@@ -62,7 +62,7 @@ HELPFUL: Functional interceptors (through `withInterceptors`) have more predicta
 
 By default, when you configure `HttpClient` using `provideHttpClient` within a given injector, this configuration overrides any configuration for `HttpClient` which may be present in the parent injector.
 
-When you add `withRequestsMadeViaParent()`, `HttpClient` is configured to instead pass requests up to the `HttpClient` instance in the parent injector, once they've passed through any configured interceptors at this level. This is useful if you want to _add_ interceptors in a child injector, while still sending the request through the parent injector's interceptors as well.
+When you add `withRequestsMadeViaParent()`, `HttpClient` is configured to instead pass requests up to the `HttpClient` instance in the parent injector, once they've passed through any configured interceptors at this level. This is useful if you want to _add_ interceptors in a child injector while still sending the request through the parent injector's interceptors.
 
 CRITICAL: You must configure an instance of `HttpClient` above the current injector, or this option is not valid and you'll get a runtime error when you try to use it.
 
@@ -74,7 +74,7 @@ HELPFUL: Prefer using [CORS](https://developer.mozilla.org/docs/Web/HTTP/CORS) t
 
 ### `withXsrfConfiguration(...)`
 
-Including this option allows for customization of `HttpClient`'s built-in XSRF security functionality. See the [security guide](best-practices/security) for more information.
+Including this option allows customization of `HttpClient`'s built-in XSRF security functionality. See the [security guide](best-practices/security) for more information.
 
 ### `withNoXsrfProtection()`
 

--- a/adev/src/content/guide/http/testing.md
+++ b/adev/src/content/guide/http/testing.md
@@ -2,9 +2,9 @@
 
 As for any external dependency, you must mock the HTTP backend so your tests can simulate interaction with a remote server. The `@angular/common/http/testing` library provides tools to capture requests made by the application, make assertions about them, and mock the responses to emulate your backend's behavior.
 
-The testing library is designed for a pattern in which the app executes code and makes requests first. The test then expects that certain requests have or have not been made, performs assertions against those requests, and finally provides responses by "flushing" each expected request.
+The testing library is designed for a pattern where the app executes code and makes requests first. The test then expects that certain requests have or have not been made, performs assertions against those requests, and finally provides responses by "flushing" each expected request.
 
-At the end, tests can verify that the app made no unexpected requests.
+Finally, tests can verify that the app made no unexpected requests.
 
 ## Setup for testing
 
@@ -174,7 +174,7 @@ TestBed.configureTestingModule({
 });
 ```
 
-The `HttpTestingController` can retrieve the request instance which can then be inspected to ensure that the request was modified.
+The `HttpTestingController` can retrieve the request instance that can then be inspected to ensure that the request was modified.
 
 ```ts
 const service = TestBed.inject(AuthService);
@@ -183,7 +183,7 @@ const req = httpTesting.expectOne('/api/config');
 expect(req.request.headers.get('X-Authentication-Token')).toEqual(service.getAuthToken());
 ```
 
-A similar interceptor could be implemented with class based interceptors:
+A similar interceptor could be implemented with class-based interceptors:
 
 ```ts
 @Injectable()


### PR DESCRIPTION
## PR Type
- [x] Documentation content changes

## What is the current behavior?
Some wording, grammar, and minor inconsistencies exist across HTTP documentation files.

## What is the new behavior?
- Improved grammar and punctuation
- Removed redundant phrasing
- Standardized wording (e.g., "that" vs "which", improved sentence flow)
- Fixed minor formatting inconsistencies

## Scope
- guide/http/overview.md
- guide/http/setup.md
- guide/http/making-requests.md
- guide/http/interceptors.md
- guide/http/testing.md

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Documentation-only changes with no impact on functionality.