### PR TITLE
docs: fix tracking expression reference in NG0955.md

### DIFF
--- a/adev/src/content/reference/errors/NG0955.md
+++ b/adev/src/content/reference/errors/NG0955.md
@@ -17,7 +17,7 @@ class Test {
 }
 ```
 
-In the provided example the `item.key` tracking expression will find two duplicate keys `a` (at index 0 and 2).
+In the provided example the `item.value` tracking expression will find two duplicate keys `a` (at index 0 and 2).
 
 Duplicate keys are problematic from the correctness point of view: since the `@for` loop can't uniquely identify items it might choose DOM nodes corresponding to _another_ item (with the same key) when performing DOM moves or destroy.
 


### PR DESCRIPTION
Correct the tracking expression reference from `item.key` to `item.value` in the explanation of duplicate keys.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
