### PR TITLE
fix(forms): allow numeric index access on SchemaPathTree of array types

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -598,7 +598,9 @@ export namespace SchemaPathRules {
 // @public
 export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> = ([TModel] extends [AbstractControl] ? CompatSchemaPath<TModel, TPathKind> : SchemaPath<TModel, SchemaPathRules.Supported, TPathKind>) & ([TModel] extends [AbstractControl] ? unknown : [
 TModel
-] extends [ReadonlyArray<any>] ? unknown : TModel extends Record<string, any> ? {
+] extends [ReadonlyArray<infer TItem>] ? {
+    [K: number]: MaybeSchemaPathTree<TItem, PathKind.Child>;
+} : TModel extends Record<string, any> ? {
     [K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>;
 } : unknown);
 

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -715,9 +715,9 @@ export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
     // Subpaths
     ([TModel] extends [AbstractControl]
       ? unknown
-      : // Array paths have no subpaths
-        [TModel] extends [ReadonlyArray<any>]
-        ? unknown
+      : // Array paths expose numeric element access
+        [TModel] extends [ReadonlyArray<infer TItem>]
+        ? {[K: number]: MaybeSchemaPathTree<TItem, PathKind.Child>}
         : // Object subfields
           TModel extends Record<string, any>
           ? {[K in keyof TModel]: MaybeSchemaPathTree<TModel[K], PathKind.Child>}

--- a/packages/forms/signals/test/node/field_context.spec.ts
+++ b/packages/forms/signals/test/node/field_context.spec.ts
@@ -176,4 +176,46 @@ describe('Field Context', () => {
       expect(ctx.fieldTreeOf(p.age)().value()).toEqual(5);
     });
   });
+
+  describe('fieldTreeOf with numeric index on SchemaPathTree', () => {
+    it('should resolve fieldTreeOf(path.array[n]) to the element field - mutable array', () => {
+      const data = signal({items: ['alpha', 'beta', 'gamma']});
+      testContext(data, (ctx, p) => {
+        expect(ctx.fieldTreeOf(p.items[0])().value()).toEqual('alpha');
+        expect(ctx.fieldTreeOf(p.items[1])().value()).toEqual('beta');
+        expect(ctx.fieldTreeOf(p.items[2])().value()).toEqual('gamma');
+      });
+    });
+
+    it('should resolve fieldTreeOf(path.array[n]) to the element field - readonly array', () => {
+      const data = signal({items: ['x', 'y'] as readonly string[]});
+      testContext(data, (ctx, p) => {
+        expect(ctx.fieldTreeOf(p.items[0])().value()).toEqual('x');
+        expect(ctx.fieldTreeOf(p.items[1])().value()).toEqual('y');
+      });
+    });
+
+    it('should produce the same field whether index is before or after fieldTreeOf', () => {
+      const data = signal({items: ['only']});
+      testContext(data, (ctx, p) => {
+        const beforeFieldTreeOf = ctx.fieldTreeOf(p.items[0]);
+        const afterFieldTreeOf = ctx.fieldTreeOf(p.items)[0];
+        expect(beforeFieldTreeOf).toBe(afterFieldTreeOf);
+      });
+    });
+
+    it('should resolve nested array element via chained numeric index', () => {
+      const data = signal({
+        matrix: [
+          ['a', 'b'],
+          ['c', 'd'],
+        ],
+      });
+      testContext(data, (ctx, p) => {
+        expect(ctx.fieldTreeOf(p.matrix[0])().value()).toEqual(['a', 'b']);
+        expect(ctx.fieldTreeOf(p.matrix[0][0])().value()).toEqual('a');
+        expect(ctx.fieldTreeOf(p.matrix[1][1])().value()).toEqual('d');
+      });
+    });
+  });
 });

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -8,13 +8,16 @@
 
 import {signal, WritableSignal} from '@angular/core';
 import {
+  applyEach,
   FieldTree,
   form,
   provideSignalFormsConfig,
   ReadonlyFieldState,
+  ReadonlyFieldTree,
   required,
   schema,
   SchemaFn,
+  SchemaPathTree,
   validate,
 } from '../../public_api';
 
@@ -161,6 +164,106 @@ function typeVerificationOnlyDoNotRunMe() {
             return true;
           },
         },
+      });
+    });
+
+    it('should allow numeric index on SchemaPathTree of mutable array', () => {
+      schema<{items: string[]}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // numeric index before fieldTreeOf must resolve to ReadonlyFieldTree<string>
+          const field: ReadonlyFieldTree<string> = fieldTreeOf(p.items[0]);
+          field().value();
+          return null;
+        });
+      });
+    });
+
+    it('should allow numeric index on SchemaPathTree of readonly array', () => {
+      schema<{items: readonly string[]}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          const field: ReadonlyFieldTree<string> = fieldTreeOf(p.items[0]);
+          field().value();
+          return null;
+        });
+      });
+    });
+
+    it('should allow rules to be applied directly to an element path of a mutable array', () => {
+      schema<{items: string[]}>((p) => {
+        // required() expects SchemaPath<string, Supported, Child> — must compile
+        required(p.items[0]);
+      });
+    });
+
+    it('should allow rules to be applied directly to an element path of a readonly array', () => {
+      schema<{items: readonly string[]}>((p) => {
+        required(p.items[0]);
+      });
+    });
+
+    it('should allow numeric index before and after fieldTreeOf to be equivalent', () => {
+      schema<{items: string[]}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // Both orderings must produce ReadonlyFieldTree<string>
+          const a: ReadonlyFieldTree<string> = fieldTreeOf(p.items[0]);
+          const b: ReadonlyFieldTree<string> = fieldTreeOf(p.items)[0];
+          a().value();
+          b().value();
+          return null;
+        });
+      });
+    });
+
+    it('should allow numeric index on nested arrays', () => {
+      schema<{matrix: string[][]}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // path.matrix[0] → SchemaPathTree<string[]>, path.matrix[0][0] → SchemaPathTree<string>
+          const row: ReadonlyFieldTree<string[]> = fieldTreeOf(p.matrix[0]);
+          const cell: ReadonlyFieldTree<string> = fieldTreeOf(p.matrix[0][0]);
+          row().value();
+          cell().value();
+          return null;
+        });
+      });
+    });
+
+    it('should not allow numeric index on SchemaPathTree of a plain object', () => {
+      schema<{obj: {x: number}}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // @ts-expect-error — plain objects have no numeric index
+          fieldTreeOf(p.obj[0]);
+          return null;
+        });
+      });
+    });
+
+    it('should not allow numeric index on SchemaPathTree of a primitive', () => {
+      schema<{name: string}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // @ts-expect-error — primitives have no numeric index
+          fieldTreeOf(p.name[0]);
+          return null;
+        });
+      });
+    });
+
+    it('should preserve string key access on Record after the array fix', () => {
+      schema<{lookup: Record<string, string>}>((p) => {
+        validate(p, ({fieldTreeOf}) => {
+          // Records must continue to work — no regression
+          const field: ReadonlyFieldTree<string> = fieldTreeOf(p.lookup['key']);
+          field().value();
+          return null;
+        });
+      });
+    });
+
+    it('should allow SchemaPathTree of array to be passed to applyEach', () => {
+      // applyEach takes SchemaPath<TValue>; SchemaPathTree<string[]> must remain assignable
+      schema<{items: string[]}>((p) => {
+        applyEach(p.items, (item: SchemaPathTree<string>) => {
+          required(item);
+        });
       });
     });
   });


### PR DESCRIPTION
a numeric index on a SchemaPathTree of an array type produced a TypeScript error: Property '0' does not exist on type 'SchemaPath<string[], 1, Child>' The SchemaPathTree type had the following branch for arrays:
[TModel] extends [ReadonlyArray<any>] ? unknown Returning unknown meant the path had no index signature at all, so path.items[0] was rejected by TypeScript even though the runtime proxy already handled numeric keys correctly.
This was an oversight: the parallel FieldTree type already exposed numeric element access for arrays via ReadonlyArrayLike:

  TModel extends ReadonlyArray<infer U>
    ? ReadonlyArrayLike<MaybeFieldTree<U, number, TMode>>

SchemaPathTree now mirrors this pattern with a numeric index signature:

  [TModel] extends [ReadonlyArray<infer TItem>]
    ? {[K: number]: MaybeSchemaPathTree<TItem, PathKind.Child>}

Both orderings now compile correctly:
  fieldTreeOf(path.items[0])().value()  // fixed
  fieldTreeOf(path.items)[0]().value()  // already worked

Mutable arrays, readonly arrays, and nested arrays are all supported. Records and plain objects are unaffected. No runtime code was changed.
Fixes #66564
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Using a numeric index on a SchemaPathTree of an array type produces a TypeScript compile error, even though the runtime proxy handles it correctly. This regressed between Angular 21.0.6 and 21.1.0.

Example that errors before this fix:
  fieldTreeOf(path.items[0])().value();
  // Error: Property '0' does not exist on type 'SchemaPath<string[], 1, Child>'


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #66564

## What is the new behavior?
Numeric indexing on a SchemaPathTree of an array works in both orderings:

  fieldTreeOf(path.items[0])().value();     // fixed
  fieldTreeOf(path.items)[0]().value();     // still works
  required(path.items[0]);                  // fixed
  fieldTreeOf(path.matrix[0][0])().value(); // nested arrays work

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

SchemaPathTree and FieldTree are parallel types (schema-definition time vs runtime). FieldTree correctly exposed a numeric index via ReadonlyArrayLike while SchemaPathTree returned unknown, blocking all index access. The fix brings SchemaPathTree in line with FieldTree.

Files changed:
- packages/forms/signals/src/api/types.ts — core fix (3 lines)
- goldens/public-api/forms/signals/index.api.md — golden updated
- packages/forms/signals/test/node/types.spec.ts — 9 compile-time type tests
- packages/forms/signals/test/node/field_context.spec.ts — 4 runtime tests
