### PR TITLE
refactor(docs-infra): simplify search label/title initialization in N…

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -77,17 +77,8 @@ export class Navigation {
   protected readonly currentDocsVersion = this.versionManager.currentDocsVersion;
   protected readonly currentDocsVersionMode = this.versionManager.currentDocsVersionMode;
 
-  // Set the values of the search label and title only on the client, because the label is user-agent specific.
-  protected searchLabel = this.isBrowser
-    ? isApple
-      ? this.APPLE_SEARCH_LABEL
-      : this.DEFAULT_SEARCH_LABEL
-    : '';
-  protected searchTitle = this.isBrowser
-    ? isApple
-      ? `${COMMAND} ${SEARCH_TRIGGER_KEY.toUpperCase()}`
-      : `${CONTROL} ${SEARCH_TRIGGER_KEY.toUpperCase()}`
-    : '';
+  protected searchLabel = '';
+  protected searchTitle = '';
   protected versions = this.versionManager.versions;
 
   protected isMobileNavigationOpened = this.navigationState.isMobileNavVisible;
@@ -95,6 +86,11 @@ export class Navigation {
   primaryRouteChanged$ = toObservable(this.activeRouteItem);
 
   constructor() {
+    // Set the search label and title only on the client, because the label is user-agent specific.
+    if (this.isBrowser) {
+      this.searchLabel = isApple ? this.APPLE_SEARCH_LABEL : this.DEFAULT_SEARCH_LABEL;
+      this.searchTitle = `${isApple ? COMMAND : CONTROL} ${SEARCH_TRIGGER_KEY.toUpperCase()}`;
+    }
     this.listenToRouteChange();
     this.preventToScrollContentWhenSecondaryNavIsOpened();
     this.closeMobileNavOnPrimaryRouteChange();


### PR DESCRIPTION
refactor(docs-infra): simplify search label/title initialization in Navigation

The search label and title fields were initialized using duplicated nested ternaries that repeated the `isBrowser ? isApple ? ... : ... : ''` pattern twice. Collapse this into plain empty-string defaults plus a single `if (this.isBrowser)` block in the constructor.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `searchLabel` and `searchTitle` fields in `Navigation` are initialized with nested ternaries that repeat the `isBrowser ? isApple ? ... : ... : ''` pattern across two property declarations.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Both fields default to empty strings and are populated in the constructor behind a single `if (this.isBrowser)` guard. The `isApple` branch is evaluated once per field rather than duplicating the browser/server split. Behavior is unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
