### PR TITLE
feat(forms): add narrowFieldTree for discriminated union support in signal forms 

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -413,6 +413,16 @@ export class MinValidationError extends BaseNgValidationError {
 }
 
 // @public
+export function narrowFieldTree<TModel, TNarrowed extends TModel>(fieldTree: {
+    (): ReadonlyFieldState<TModel, any>;
+}, predicate: (value: TModel) => value is TNarrowed): FieldTree<TNarrowed> | null;
+
+// @public
+export function narrowFieldTree<TModel>(fieldTree: {
+    (): ReadonlyFieldState<TModel, any>;
+}, predicate: (value: TModel) => boolean): FieldTree<TModel> | null;
+
+// @public
 export class NativeInputParseError extends BaseNgValidationError {
     // (undocumented)
     readonly kind = "parse";

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -33,6 +33,7 @@ import type {
   LogicFn,
   OneOrMany,
   PathKind,
+  ReadonlyFieldState,
   Schema,
   SchemaFn,
   SchemaOrSchemaFn,
@@ -336,6 +337,98 @@ export function applyWhenValue(
   schema: SchemaOrSchemaFn<unknown>,
 ) {
   applyWhen(path, ({value}) => predicate(value()), schema);
+}
+
+/**
+ * Narrows a `FieldTree<TValue>` to a `FieldTree<TNarrowed>` when a type-guard predicate is
+ * satisfied by the field's current value.
+ *
+ * This is the **template-side counterpart** to `applyWhenValue` for discriminated unions.
+ * When the current value passes the predicate the same field tree object is returned, recast to
+ * the narrower type so that variant-specific sub-fields become accessible. When the predicate
+ * fails `null` is returned.
+ *
+ * Because `narrowFieldTree` reads `fieldTree().value()` — a reactive signal read — Angular's
+ * template engine and `computed()` automatically re-evaluate whenever the value changes,
+ * keeping the narrowed reference in sync at zero extra cost.
+ *
+ * The parameter type is structural (`{(): ReadonlyFieldState<TModel>}`), so the function
+ * accepts both `FieldTree<TModel>` and `ReadonlyFieldTree<TModel>` without overloads.
+ *
+ * ### Template usage (recommended)
+ *
+ * ```ts
+ * interface TestA { type: 'a'; a: number; }
+ * interface TestB { type: 'b'; b: string; }
+ * type Tester = TestA | TestB;
+ *
+ * @Component({
+ *   template: `
+ *     @let formA = narrowFieldTree(testerForm, (v): v is TestA => v.type === 'a');
+ *     @if (formA) {
+ *       <!-- formA is FieldTree<TestA>: formA.a is correctly typed as FieldTree<number> -->
+ *       <input type="number" [formField]="formA.a" />
+ *     }
+ *   `
+ * })
+ * export class MyComponent {
+ *   readonly testerForm = form(signal<Tester>({ type: 'a', a: 0 }));
+ * }
+ * ```
+ *
+ * ### Component-class usage (pass to child components)
+ *
+ * ```ts
+ * export class ParentComponent {
+ *   readonly testerForm = form(signal<Tester>({ type: 'a', a: 0 }));
+ *
+ *   // Reactive computed — updates automatically when testerForm value changes.
+ *   readonly formA = computed(() =>
+ *     narrowFieldTree(this.testerForm, (v): v is TestA => v.type === 'a')
+ *   );
+ * }
+ * ```
+ *
+ * @param fieldTree The field tree to narrow. Accepts both `FieldTree` and `ReadonlyFieldTree`.
+ * @param predicate A type guard returning `true` if the current value is of type `TNarrowed`.
+ * @returns `FieldTree<TNarrowed>` when the predicate passes, otherwise `null`.
+ * @template TModel The model type inferred from the field tree.
+ * @template TNarrowed The narrowed variant type (must extend `TModel`).
+ *
+ * @category structure
+ * @experimental 21.2.0
+ */
+export function narrowFieldTree<TModel, TNarrowed extends TModel>(
+  fieldTree: {(): ReadonlyFieldState<TModel, any>},
+  predicate: (value: TModel) => value is TNarrowed,
+): FieldTree<TNarrowed> | null;
+
+/**
+ * Narrows a `FieldTree<TValue>` based on a boolean predicate applied to the field's current value.
+ *
+ * Returns the same field tree when the predicate passes, or `null` when it does not.
+ * Unlike the type-guard overload, the return type is not narrowed — use a type-guard predicate
+ * for full TypeScript inference.
+ *
+ * @param fieldTree The field tree to narrow.
+ * @param predicate A function returning `true` when the field tree should be returned.
+ * @returns The field tree (still typed as `FieldTree<TModel>`) when the predicate passes, otherwise `null`.
+ * @template TModel The model type inferred from the `FieldTree`.
+ *
+ * @category structure
+ * @experimental 21.2.0
+ */
+export function narrowFieldTree<TModel>(
+  fieldTree: {(): ReadonlyFieldState<TModel, any>},
+  predicate: (value: TModel) => boolean,
+): FieldTree<TModel> | null;
+
+export function narrowFieldTree<TModel>(
+  fieldTree: {(): ReadonlyFieldState<TModel, any>},
+  predicate: (value: TModel) => boolean,
+): FieldTree<unknown> | null {
+  const value = fieldTree().value();
+  return predicate(value) ? (fieldTree as unknown as FieldTree<unknown>) : null;
 }
 
 /**

--- a/packages/forms/signals/test/node/field_context.spec.ts
+++ b/packages/forms/signals/test/node/field_context.spec.ts
@@ -6,15 +6,20 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, signal, WritableSignal} from '@angular/core';
+import {computed, Injector, signal, WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {
   applyEach,
+  applyWhenValue,
   createMetadataKey,
   FieldContext,
+  FieldTree,
   form,
   metadata,
+  narrowFieldTree,
   PathKind,
+  ReadonlyFieldTree,
+  required,
   SchemaPath,
   SchemaPathTree,
   validate,
@@ -175,5 +180,195 @@ describe('Field Context', () => {
       expect(ctx.fieldTreeOf(p.name)().value()).toEqual('pirojok-the-cat');
       expect(ctx.fieldTreeOf(p.age)().value()).toEqual(5);
     });
+  });
+});
+
+interface VariantA {
+  type: 'a';
+  a: number;
+}
+interface VariantB {
+  type: 'b';
+  b: string;
+}
+type Discriminated = VariantA | VariantB;
+
+describe('narrowFieldTree', () => {
+  it('returns the field tree cast to the narrowed type when the predicate passes', () => {
+    const model = signal<Discriminated>({type: 'a', a: 42});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    const narrowed = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+
+    expect(narrowed).not.toBeNull();
+    // Access the type-specific sub-field on the narrowed tree.
+    expect(narrowed!.a().value()).toBe(42);
+  });
+
+  it('returns null when the predicate does not pass', () => {
+    const model = signal<Discriminated>({type: 'b', b: 'hello'});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    const narrowed = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+
+    expect(narrowed).toBeNull();
+  });
+
+  it('is reactive — re-evaluates when the value changes', () => {
+    const model = signal<Discriminated>({type: 'a', a: 42});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    // Initially matches variant A.
+    expect(narrowFieldTree(f, (v): v is VariantA => v.type === 'a')).not.toBeNull();
+    expect(narrowFieldTree(f, (v): v is VariantB => v.type === 'b')).toBeNull();
+
+    // Switch to variant B.
+    model.set({type: 'b', b: 'hello'});
+
+    expect(narrowFieldTree(f, (v): v is VariantA => v.type === 'a')).toBeNull();
+    expect(narrowFieldTree(f, (v): v is VariantB => v.type === 'b')).not.toBeNull();
+    expect(
+      narrowFieldTree(f, (v): v is VariantB => v.type === 'b')!
+        .b()
+        .value(),
+    ).toBe('hello');
+  });
+
+  it('works with a child field', () => {
+    const model = signal({nested: {type: 'a', a: 99} as Discriminated});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    const narrowed = narrowFieldTree(f.nested, (v): v is VariantA => v.type === 'a');
+
+    expect(narrowed).not.toBeNull();
+    expect(narrowed!.a().value()).toBe(99);
+  });
+
+  it('returns the same FieldTree instance when narrowed (no wrapping)', () => {
+    const model = signal<Discriminated>({type: 'a', a: 1});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    const narrowed = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+
+    // The narrowed result is the exact same proxy object — just retyped.
+    expect(narrowed as unknown).toBe(f as unknown);
+  });
+
+  it('works with the boolean (non-type-guard) overload', () => {
+    const model = signal<Discriminated>({type: 'a', a: 7});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    // Boolean predicate: return type is FieldTree<Discriminated> | null, not narrowed.
+    const matched = narrowFieldTree(f, (v) => v.type === 'a');
+    const unmatched = narrowFieldTree(f, (v) => v.type === 'b');
+
+    expect(matched).not.toBeNull();
+    expect(unmatched).toBeNull();
+    // The matched result is still the same object.
+    expect(matched as unknown).toBe(f as unknown);
+  });
+
+  it('accepts a ReadonlyFieldTree', () => {
+    const model = signal<Discriminated>({type: 'a', a: 55});
+    const f: ReadonlyFieldTree<Discriminated> = form(model, {injector: TestBed.inject(Injector)});
+
+    // narrowFieldTree's structural parameter type {(): ReadonlyFieldState<TModel>} must accept
+    // ReadonlyFieldTree as well as writable FieldTree.
+    const narrowed = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+
+    expect(narrowed).not.toBeNull();
+    expect(narrowed!.a().value()).toBe(55);
+  });
+
+  it('integrates with computed() — the computed re-evaluates when the value signal changes', () => {
+    const model = signal<Discriminated>({type: 'a', a: 1});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    // Wrapping in computed() is the recommended component-class usage.
+    const narrowed = TestBed.runInInjectionContext(() =>
+      computed(() => narrowFieldTree(f, (v): v is VariantA => v.type === 'a')),
+    );
+
+    // Computed resolves to the narrowed tree initially.
+    expect(narrowed()).not.toBeNull();
+    expect(narrowed()!.a().value()).toBe(1);
+
+    // Changing to variant B invalidates the computed.
+    model.set({type: 'b', b: 'world'});
+    expect(narrowed()).toBeNull();
+
+    // Switching back to variant A re-establishes the narrowed tree.
+    model.set({type: 'a', a: 99});
+    expect(narrowed()).not.toBeNull();
+    expect(narrowed()!.a().value()).toBe(99);
+  });
+
+  it('works with a three-member discriminated union', () => {
+    interface VariantC {
+      type: 'c';
+      c: boolean;
+    }
+    type ThreeWay = VariantA | VariantB | VariantC;
+
+    const model = signal<ThreeWay>({type: 'c', c: true});
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    expect(narrowFieldTree(f, (v): v is VariantA => v.type === 'a')).toBeNull();
+    expect(narrowFieldTree(f, (v): v is VariantB => v.type === 'b')).toBeNull();
+    const narrowedC = narrowFieldTree(f, (v): v is VariantC => v.type === 'c');
+    expect(narrowedC).not.toBeNull();
+    expect(narrowedC!.c().value()).toBe(true);
+
+    // Switch to variant A.
+    model.set({type: 'a', a: 5});
+    expect(narrowFieldTree(f, (v): v is VariantC => v.type === 'c')).toBeNull();
+    const narrowedA = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+    expect(narrowedA).not.toBeNull();
+    expect(narrowedA!.a().value()).toBe(5);
+  });
+
+  it('works alongside applyWhenValue — schema and template narrowing stay in sync', () => {
+    // applyWhenValue is the schema-side counterpart; narrowFieldTree is the template-side.
+    // Both must agree on which variant is active.
+    const model = signal<Discriminated>({type: 'a', a: 0});
+    const f = form(
+      model,
+      (path) => {
+        applyWhenValue(
+          path,
+          (v): v is VariantA => v.type === 'a',
+          (variantAPath) => {
+            validate(variantAPath.a, ({value}) => (value() < 1 ? {kind: 'too-small'} : undefined));
+          },
+        );
+        applyWhenValue(
+          path,
+          (v): v is VariantB => v.type === 'b',
+          (variantBPath) => {
+            validate(variantBPath.b, ({value}) =>
+              value().length === 0 ? {kind: 'empty'} : undefined,
+            );
+          },
+        );
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    // Schema fires for variant A; template can narrow to it.
+    const narrowedA = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+    expect(narrowedA).not.toBeNull();
+    expect(narrowedA!.a().errors()).toEqual([{kind: 'too-small', fieldTree: narrowedA!.a}]);
+
+    // Switch to variant B — schema switches, template narrowing switches too.
+    model.set({type: 'b', b: ''});
+    expect(narrowFieldTree(f, (v): v is VariantA => v.type === 'a')).toBeNull();
+    const narrowedB = narrowFieldTree(f, (v): v is VariantB => v.type === 'b');
+    expect(narrowedB).not.toBeNull();
+    expect(narrowedB!.b().errors()).toEqual([{kind: 'empty', fieldTree: narrowedB!.b}]);
+
+    // Fix variant B — errors clear.
+    model.set({type: 'b', b: 'hello'});
+    const narrowedB2 = narrowFieldTree(f, (v): v is VariantB => v.type === 'b');
+    expect(narrowedB2!.b().errors()).toEqual([]);
   });
 });

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -10,6 +10,7 @@ import {signal, WritableSignal} from '@angular/core';
 import {
   FieldTree,
   form,
+  narrowFieldTree,
   provideSignalFormsConfig,
   ReadonlyFieldState,
   required,
@@ -162,6 +163,47 @@ function typeVerificationOnlyDoNotRunMe() {
           },
         },
       });
+    });
+
+    it('narrowFieldTree should narrow the FieldTree type with a type guard', () => {
+      interface VariantA {
+        type: 'a';
+        a: number;
+      }
+      interface VariantB {
+        type: 'b';
+        b: string;
+      }
+      type Discriminated = VariantA | VariantB;
+
+      function testTypeNarrow(f: FieldTree<Discriminated>) {
+        const narrowed = narrowFieldTree(f, (v): v is VariantA => v.type === 'a');
+        // Verify that the narrowed type gives access to VariantA-specific sub-fields.
+        if (narrowed) {
+          const aField: FieldTree<number> = narrowed.a;
+          aField;
+        }
+      }
+      testTypeNarrow;
+    });
+
+    it('narrowFieldTree should return FieldTree<TValue> | null without a type guard', () => {
+      interface VariantA {
+        type: 'a';
+        a: number;
+      }
+      interface VariantB {
+        type: 'b';
+        b: string;
+      }
+      type Discriminated = VariantA | VariantB;
+
+      function testTypeNarrow(f: FieldTree<Discriminated>) {
+        // Without a type guard the return type stays FieldTree<Discriminated> | null.
+        const narrowed: FieldTree<Discriminated> | null = narrowFieldTree(f, (v) => v.type === 'a');
+        narrowed;
+      }
+      testTypeNarrow;
     });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

When a signal form model is a discriminated union (e.g. `FieldTree<Cat | Dog>`), there is no type-safe way to access variant-specific sub-fields in templates or component classes. Developers are forced to use `$any()` casts:

```html
@if ($any(petForm).catLives) { ... }
```

Issue Number:  #65479

## What is the new behavior?
A new narrowFieldTree function is exported from @angular/forms/signals. It accepts a FieldTree (or ReadonlyFieldTree) and a predicate, and returns the same field tree recast to the narrowed type when the predicate passes, or null when it does not.

Template usage:
@let catForm = narrowFieldTree(petForm, (v): v is Cat => v.type === 'cat');
@if (catForm) {
  <input type="number" [formField]="catForm.catLives" />
}
Component-class usage:
readonly catForm = computed(() =>
  narrowFieldTree(this.petForm, (v): v is Cat => v.type === 'cat')
);
Because narrowFieldTree reads fieldTree().value() — a reactive signal read — Angular's template engine and computed() automatically re-evaluate whenever the value changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Two overloads are provided: a type-guard overload (value is TNarrowed) that narrows the return type to FieldTree<TNarrowed> | null, and a boolean overload that returns FieldTree<TModel> | null.
The parameter type is a structural duck type {(): ReadonlyFieldState<TModel, any>} rather than FieldTree<TModel> directly, because FieldTree is a conditional type alias and TypeScript cannot infer TModel from it. This also makes the function accept ReadonlyFieldTree without an extra overload.
Tagged @experimental 21.2.0 consistent with other additions in this file.
8 runtime tests and 2 compile-time type tests added.