### PR TITLE
fix(platform-server): ensure origin has a trailing slash when parsing url

### DIFF
--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -24,12 +24,16 @@ import {INITIAL_CONFIG} from './tokens';
  * @param origin The origin to use for resolving the URL.
  * @returns The parsed URL.
  */
-function parseUrl(urlStr: string, origin: string): URL {
-  // If the URL is empty or start with a `/` it is a pathname relative to the origin
-  // otherwise it's an absolute URL.
-  const urlToParse = urlStr.length === 0 || urlStr[0] === '/' ? origin + urlStr : urlStr;
+export function parseUrl(urlStr: string, origin: string): URL {
+  if (URL.canParse(urlStr)) {
+    return new URL(urlStr);
+  }
 
-  return new URL(urlToParse);
+  if (urlStr && urlStr[0] !== '/') {
+    urlStr = `/${urlStr}`;
+  }
+
+  return new URL(origin + urlStr);
 }
 
 /**

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -11,8 +11,25 @@ import {PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {destroyPlatform} from '@angular/core';
 import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
 
+import {parseUrl} from '../src/location';
+
 (function () {
   if (getDOM().supportsDOMEvents) return; // NODE only
+
+  describe('parseUrl', () => {
+    it('should resolve relative paths against origin', () => {
+      const url = parseUrl('/deep/path?query#hash', 'http://test.com');
+      expect(url.href).toBe('http://test.com/deep/path?query#hash');
+      expect(url.search).toBe('?query');
+      expect(url.hash).toBe('#hash');
+    });
+
+    it('should resolve absolute URLs ignoring origin', () => {
+      const url = parseUrl('http://other.com/deep/path', 'http://test.com');
+      expect(url.href).toBe('http://other.com/deep/path');
+      expect(url.origin).toBe('http://other.com');
+    });
+  });
 
   describe('PlatformLocation', () => {
     beforeEach(() => {


### PR DESCRIPTION

The origin did not have a trailing slash, which caused parsing issues for relative URLs.

Fixes #68322
