### PR TITLE
feat(forms): add toValueSignal to derive a reactive signal from a Fie…

### DIFF
--- a/goldens/public-api/forms/signals/compat/index.api.md
+++ b/goldens/public-api/forms/signals/compat/index.api.md
@@ -51,6 +51,12 @@ export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
 export function extractValue<T>(field: FieldTree<T>, filter: ExtractFilter): DeepPartial<RawValue<T>>;
 
 // @public
+export function toValueSignal<T>(field: FieldTree<T>): Signal<RawValue<T>>;
+
+// @public
+export function toValueSignal<T>(field: FieldTree<T>, filter: ExtractFilter): Signal<DeepPartial<RawValue<T>>>;
+
+// @public
 export const NG_STATUS_CLASSES: SignalFormsConfig['classes'];
 
 // @public

--- a/packages/forms/signals/compat/public_api.ts
+++ b/packages/forms/signals/compat/public_api.ts
@@ -12,7 +12,7 @@
  * Entry point for all public APIs of this package.
  */
 export * from './src/api/compat_form';
-export {extractValue} from './src/api/extract';
+export {extractValue, toValueSignal} from './src/api/extract';
 export {CompatValidationError} from '../src/compat/validation_errors';
 export * from './src/api/di';
 export {SignalFormControl} from './src/signal_form_control/signal_form_control';

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {untracked} from '@angular/core';
+import {computed, Signal, untracked} from '@angular/core';
 import {AbstractControl} from '@angular/forms';
 import {FieldState, FieldTree} from '../../../src/api/types';
 import {isArray, isObject} from '../../../src/util/type_guards';
@@ -89,6 +89,51 @@ export function extractValue<T>(
 ): RawValue<T> | DeepPartial<RawValue<T>> {
   return untracked(() => visitFieldTree(field, filter)) as RawValue<T> | DeepPartial<RawValue<T>>;
 }
+
+/**
+ * Returns a reactive {@link Signal} that tracks the raw value of a {@link FieldTree},
+ * unwrapping any `AbstractControl` instances found in a compat form.
+ *
+ * Unlike {@link extractValue}, the returned signal automatically re-evaluates whenever
+ * any underlying field value changes (including values proxied from `FormControl`),
+ * making it suitable for templates (`@let`), `computed()`, or any other reactive context.
+ *
+ * @param field The field tree to derive the value signal from.
+ * @returns A reactive signal of the raw form value.
+ *
+ * @category interop
+ * @experimental 21.2.0
+ */
+export function toValueSignal<T>(field: FieldTree<T>): Signal<RawValue<T>>;
+
+/**
+ * Returns a reactive {@link Signal} that tracks the raw value of a {@link FieldTree},
+ * including only fields that match the provided filter criteria.
+ *
+ * Unlike {@link extractValue}, the returned signal automatically re-evaluates whenever
+ * any underlying field value changes.
+ *
+ * @param field The field tree to derive the value signal from.
+ * @param filter Criteria to include only fields matching certain state (dirty, touched, enabled).
+ * @returns A reactive signal of the filtered partial raw value.
+ *
+ * @category interop
+ * @experimental 21.2.0
+ */
+export function toValueSignal<T>(
+  field: FieldTree<T>,
+  filter: ExtractFilter,
+): Signal<DeepPartial<RawValue<T>>>;
+
+export function toValueSignal<T>(
+  field: FieldTree<T>,
+  filter?: ExtractFilter,
+): Signal<RawValue<T>> | Signal<DeepPartial<RawValue<T>>> {
+  return computed(
+    () => visitFieldTree(field, filter),
+  ) as Signal<RawValue<T>> | Signal<DeepPartial<RawValue<T>>>;
+}
+
 
 function visitFieldTree(
   field: FieldTree<unknown>,

--- a/packages/forms/signals/test/node/compat/extract_value.spec.ts
+++ b/packages/forms/signals/test/node/compat/extract_value.spec.ts
@@ -10,7 +10,7 @@ import {Injector, signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {FormControl, FormGroup} from '@angular/forms';
 import {applyEach, disabled, form} from '@angular/forms/signals';
-import {compatForm, extractValue, SignalFormControl} from '@angular/forms/signals/compat';
+import {compatForm, extractValue, SignalFormControl, toValueSignal} from '@angular/forms/signals/compat';
 
 describe('extractValue', () => {
   let injector: Injector;
@@ -290,3 +290,65 @@ describe('extractValue', () => {
     });
   });
 });
+
+describe('toValueSignal', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    injector = TestBed.inject(Injector);
+  });
+
+  it('should return a reactive signal unwrapping FormControl values', () => {
+    const ctrl = new FormControl('initial');
+    const model = signal({email: '', password: ctrl});
+    const f = compatForm(model, {injector});
+
+    const valueSignal = toValueSignal(f);
+    expect(valueSignal()).toEqual({email: '', password: 'initial'});
+
+    ctrl.setValue('updated');
+    expect(valueSignal()).toEqual({email: '', password: 'updated'});
+  });
+
+  it('should react to model signal changes for pure signal forms', () => {
+    const model = signal({a: 1, b: 'two'});
+    const f = form(model, {injector});
+
+    const valueSignal = toValueSignal(f);
+    expect(valueSignal()).toEqual({a: 1, b: 'two'});
+
+    model.set({a: 2, b: 'three'});
+    expect(valueSignal()).toEqual({a: 2, b: 'three'});
+  });
+
+  it('should support the dirty filter reactively', () => {
+    const model = {a: 1, b: 2};
+    const f = form(signal(model), {injector});
+
+    const dirtySignal = toValueSignal(f, {dirty: true});
+    expect(dirtySignal()).toBeUndefined();
+
+    f.a().markAsDirty();
+    expect(dirtySignal()).toEqual({a: 1});
+  });
+
+  it('should unwrap nested FormGroup reactively', () => {
+    const innerCtrl = new FormControl('hello');
+    const group = new FormGroup({inner: innerCtrl});
+    const model = signal({group});
+    const f = compatForm(model, {injector});
+
+    const valueSignal = toValueSignal(f);
+    expect(valueSignal()).toEqual({group: {inner: 'hello'}});
+
+    innerCtrl.setValue('world');
+    expect(valueSignal()).toEqual({group: {inner: 'world'}});
+  });
+
+  it('should return the primitive value for a leaf field', () => {
+    const f = form(signal(42), {injector});
+    const valueSignal = toValueSignal(f);
+    expect(valueSignal()).toBe(42);
+  });
+});
+


### PR DESCRIPTION
…ldTree

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

now we can get the signal value by direct calling the function example 

toValueSignal(f)

```
  passwordControl = new FormControl('', {
    validators: [Validators.required],
    nonNullable: true,
  });

  // 2. Wrap it inside your form state signal
  user = signal({
    email: '',
    password: this.passwordControl, // Nest the existing control directly
  });

  // 3. Create the form
  f = compatForm(this.user);

  constructor() {}

  ngOnInit() {
    // Access values via the signal tree
    console.log('email value:', this.f.email().value()); // Current email value
    console.log('password value:', this.f.password().value()); // Current value of passwordControl
    console.log('function', this.f().value())
   
  
    const valueSignal = toValueSignal(this.f);
    console.log('toValueSignal form value:', valueSignal());
  }
  ```
  
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

currently you do not get the form value if you call
```
f().value();
```
currently you get:
```
{
  email: '',
  password: FromControl2
}
```
Issue Number: #66544 

## What is the new behavior?

Developers can now use toValueSignal to get a reactive Signal representation of the unwrapped form structure. The returned signal automatically re-evaluates whenever any underlying FormControl value updates or the core model signal changes. This makes it extremely well-suited for reactive Angular templates and seamless integration into other signal graphs.

now : 

```
toValueSignal(function )

output :

{
  email: '',
  password:''
}

```
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
