### PR TITLE
build: pin firebase-tools version and disable credential persistence in preview deploy workflow

### DIFF
--- a/.github/workflows/adev-preview-deploy.yml
+++ b/.github/workflows/adev-preview-deploy.yml
@@ -32,13 +32,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: '${{secrets.GITHUB_TOKEN}}'
+          persist-credentials: false
 
       - name: Configure Firebase deploy target
         working-directory: ./
         run: |
           # We can use `npx` as the Firebase deploy actions uses it too.
-          npx -y firebase-tools@latest target:clear --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs
-          npx -y firebase-tools@latest target:apply --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs ${{env.PREVIEW_SITE}}
+          # Use stable version release
+          npx -y firebase-tools@15.15.0 target:clear --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs
+          npx -y firebase-tools@15.15.0 target:apply --config adev/firebase.json --project ${{env.PREVIEW_PROJECT}} hosting angular-docs ${{env.PREVIEW_SITE}}
 
       - uses: angular/dev-infra/github-actions/previews/upload-artifacts-to-firebase@ba726e7bca0b08b125ccc6f93c233749e1213c17
         with:


### PR DESCRIPTION
## Summary

Applies two security hardening fixes to `.github/workflows/adev-preview-deploy.yml`.

## Problem

### 1. Unpinned `firebase-tools` dependency (supply chain risk)

The deploy workflow uses `npx -y firebase-tools@latest` to configure
Firebase hosting targets. Resolving `@latest` at runtime means any
compromised or hijacked future release of `firebase-tools` on npm would
execute automatically in a privileged `workflow_run` context that has:

- `pull-requests: write` via `GITHUB_TOKEN`
- `FIREBASE_PREVIEW_SERVICE_TOKEN` in scope

This is a supply chain injection point in an elevated-permission workflow.

### 2. `persist-credentials` not disabled on checkout

`actions/checkout` is called with an explicit `GITHUB_TOKEN` but without
`persist-credentials: false`, leaving credentials stored in the git config
for the remainder of the job unnecessarily.

## Fix

- Pin `firebase-tools` to `15.15.0` (current stable) in both `npx` calls
- Add `persist-credentials: false` to the checkout step

## Security Impact

- Eliminates runtime resolution of an unpinned npm package in a
  `workflow_run` privileged context
- Reduces credential exposure surface during the deploy job
- Aligns with OSSF Scorecard `Pinned-Dependencies` check
- No functional change — existing behaviour is fully preserved

## References

- [GitHub Security Lab: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- [GitHub security hardening for Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- CWE-829: Inclusion of Functionality from Untrusted Control Sphere
- OSSF Scorecard: `Pinned-Dependencies`