### PR TITLE
refactor(core): add internal API for creating foreign views

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -32,6 +32,7 @@ export {
   NgModuleTransitiveScopes as ɵNgModuleTransitiveScopes,
 } from './metadata/ng_module_def';
 export {AfterRenderManager as ɵAfterRenderManager} from './render3/after_render/manager';
+export {ɵForeignViewRef, ɵcreateAndInsertForeignView} from './render3/foreign_view';
 export {inferTagNameFromDefinition as ɵinferTagNameFromDefinition} from './render3/component_ref';
 export {getLContext as ɵgetLContext} from './render3/context_discovery';
 export {depsTracker as ɵdepsTracker} from './render3/deps_tracker/deps_tracker';

--- a/packages/core/src/render3/collect_native_nodes.ts
+++ b/packages/core/src/render3/collect_native_nodes.ts
@@ -12,7 +12,7 @@ import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/containe
 import {TIcuContainerNode, TNode, TNodeType} from './interfaces/node';
 import {RNode} from './interfaces/renderer_dom';
 import {isLContainer} from './interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, HOST, LView, TVIEW, TView} from './interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, HOST, LView, TVIEW, TView, TViewType} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {getProjectionNodes} from './node_manipulation';
 import {getLViewParent, unwrapRNode} from './util/view_utils';
@@ -24,6 +24,21 @@ export function collectNativeNodes(
   result: any[],
   isProjection: boolean = false,
 ): any[] {
+  if (tView.type === TViewType.Foreign) {
+    const headTNode = tView.firstChild!;
+    const tailTNode = headTNode.next!;
+    const head = unwrapRNode(lView[headTNode.index]);
+    const tail = unwrapRNode(lView[tailTNode.index]);
+
+    let current: RNode | null = head;
+    while (current !== null) {
+      result.push(current);
+      if (current === tail) break;
+      current = current.nextSibling;
+    }
+    return result;
+  }
+
   while (tNode !== null) {
     // Let declarations don't have corresponding DOM nodes so we skip over them.
     if (tNode.type === TNodeType.LetDeclaration) {

--- a/packages/core/src/render3/foreign_view.ts
+++ b/packages/core/src/render3/foreign_view.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {createLView, createTView} from './view/construction';
+import {createTNode} from './tnode_manipulation';
+import {
+  FLAGS,
+  HEADER_OFFSET,
+  LView,
+  LViewFlags,
+  PARENT,
+  RENDERER,
+  TViewType,
+  T_HOST,
+  TVIEW,
+} from './interfaces/view';
+import {TNodeType} from './interfaces/node';
+import {LContainer} from './interfaces/container';
+import {addLViewToLContainer} from './view/container';
+import {isLContainer} from './interfaces/type_checks';
+import {ViewContainerRef} from '../linker/view_container_ref';
+import {ViewRef} from './view_ref';
+
+export class ɵForeignViewRef<T> extends ViewRef<T> {
+  get head(): any {
+    const lView = this._lView;
+    const tView = lView[TVIEW];
+    return lView[tView.firstChild!.index];
+  }
+
+  get tail(): any {
+    const lView = this._lView;
+    const tView = lView[TVIEW];
+    return lView[tView.firstChild!.next!.index];
+  }
+}
+
+/**
+ * Creates and inserts a foreign view context programmatically into a container.
+ * A foreign view is bounded by `head` and `tail` comment nodes and can hold dynamic nodes.
+ *
+ * @param container The target container (LContainer or ViewContainerRef) where the view will be inserted.
+ * @param index The index at which to insert the view.
+ */
+export function ɵcreateAndInsertForeignView(
+  container: LContainer | ViewContainerRef,
+  index: number,
+): ɵForeignViewRef<unknown> {
+  const lContainer = isLContainer(container)
+    ? container
+    : ((container as any)['_lContainer'] as LContainer);
+  const declLView = lContainer[PARENT] as LView;
+  const declTNode = lContainer[T_HOST];
+  const renderer = declLView[RENDERER];
+
+  // 1. Create TView with 3 slots (head, tail, fragment)
+  const tView = createTView(
+    TViewType.Foreign,
+    declTNode, // link to container host
+    null, // templateFn (safe! Checked by renderView)
+    3, // decls
+    0, // vars
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+
+  // 2. Create comment nodes themselves using parent's renderer
+  const headComment = renderer.createComment('');
+  const tailComment = renderer.createComment('');
+
+  // 3. Create TNodes for head and tail to make them addressable
+  const headTNode = (tView.data[HEADER_OFFSET] = createTNode(
+    tView,
+    null,
+    TNodeType.Element,
+    HEADER_OFFSET,
+    '',
+    null,
+  ));
+  const tailTNode = (tView.data[HEADER_OFFSET + 1] = createTNode(
+    tView,
+    null,
+    TNodeType.Element,
+    HEADER_OFFSET + 1,
+    '',
+    null,
+  ));
+
+  // 4. Link them in the view
+  tView.firstChild = headTNode;
+  headTNode.next = tailTNode;
+  tailTNode.prev = headTNode;
+
+  // 5. Create LView
+  const lView = createLView(
+    declLView,
+    tView,
+    null,
+    0 as LViewFlags, // Do not set CheckAlways for foreign views
+    null,
+    null,
+    null,
+    renderer, // pass it through
+    null,
+    null,
+    null,
+  );
+
+  lView[FLAGS] &= ~LViewFlags.CreationMode;
+
+  // 6. Populate slots with the created comment nodes
+  lView[headTNode.index] = headComment;
+  lView[tailTNode.index] = tailComment;
+
+  // 7. Insert the view into the container
+  const viewRef = new ɵForeignViewRef(lView);
+  if (isLContainer(container)) {
+    addLViewToLContainer(container, lView, index);
+  } else {
+    // When using ViewContainerRef, go through standard public insert() to register in VIEW_REFS cache!
+    container.insert(viewRef, index);
+  }
+
+  if (!headComment.parentNode) {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(headComment as unknown as Comment);
+    fragment.appendChild(tailComment as unknown as Comment);
+    const fragmentSlotIndex = tailTNode.index + 1;
+    lView[fragmentSlotIndex] = fragment;
+  }
+
+  return viewRef;
+}

--- a/packages/core/src/render3/foreign_view.ts
+++ b/packages/core/src/render3/foreign_view.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {createLView, createTView} from './view/construction';
+import {createTNode} from './tnode_manipulation';
+import {
+  FLAGS,
+  HEADER_OFFSET,
+  LView,
+  LViewFlags,
+  PARENT,
+  RENDERER,
+  TViewType,
+  T_HOST,
+  TVIEW,
+} from './interfaces/view';
+import {TNodeType} from './interfaces/node';
+import {LContainer} from './interfaces/container';
+import {addLViewToLContainer} from './view/container';
+import {ViewRef} from './view_ref';
+
+export class ForeignViewRef<T> extends ViewRef<T> {
+  get head(): any {
+    const lView = this._lView;
+    const tView = lView[TVIEW];
+    return lView[tView.firstChild!.index];
+  }
+
+  get tail(): any {
+    const lView = this._lView;
+    const tView = lView[TVIEW];
+    return lView[tView.firstChild!.next!.index];
+  }
+}
+
+/**
+ * Creates and inserts a foreign view context programmatically into a container.
+ * A foreign view is bounded by `head` and `tail` comment nodes and can hold dynamic nodes.
+ *
+ * @param lContainer The target container where the view will be inserted.
+ * @param index The index at which to insert the view.
+ */
+export function createForeignView(lContainer: LContainer, index: number): ForeignViewRef<unknown> {
+  const declLView = lContainer[PARENT] as LView;
+  const declTNode = lContainer[T_HOST];
+  const renderer = declLView[RENDERER];
+
+  // 1. Create TView with 3 slots (head, tail, fragment)
+  const tView = createTView(
+    TViewType.Foreign,
+    declTNode, // link to container host
+    null, // templateFn (safe! Checked by renderView)
+    3, // decls
+    0, // vars
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+
+  // 2. Create TNodes for head and tail to make them addressable
+  const headTNode = (tView.data[HEADER_OFFSET] = createTNode(
+    tView,
+    null,
+    TNodeType.Element,
+    HEADER_OFFSET,
+    '',
+    null,
+  ));
+  const tailTNode = (tView.data[HEADER_OFFSET + 1] = createTNode(
+    tView,
+    null,
+    TNodeType.Element,
+    HEADER_OFFSET + 1,
+    '',
+    null,
+  ));
+
+  // 3. Link them in the view
+  tView.firstChild = headTNode;
+  headTNode.next = tailTNode;
+  tailTNode.prev = headTNode;
+
+  // 4. Create LView
+  const lView = createLView(
+    declLView,
+    tView,
+    null,
+    0 as LViewFlags, // Do not set CheckAlways for foreign views
+    null,
+    null,
+    null,
+    renderer, // pass it through
+    null,
+    null,
+    null,
+  );
+
+  // 5. "Render" the view by creating the head and tail nodes, populating their slots, and marking
+  // the view as created. This last step is normally handled by `renderView()` for native Angular
+  // views with template functions.
+  const headComment = (lView[headTNode.index] = renderer.createComment(''));
+  const tailComment = (lView[tailTNode.index] = renderer.createComment(''));
+  lView[FLAGS] &= ~LViewFlags.CreationMode;
+
+  // 6. Insert the view into the container
+  const viewRef = new ForeignViewRef(lView);
+  addLViewToLContainer(lContainer, lView, index);
+
+  // If the head node has no parent, this means we've inserted it into a view container at the root
+  // of a view that is currently detached from the DOM. In this case, we need to eagerly create a
+  // fragment to hold the head and tail nodes to ensure that any foreign content inserted into this
+  // view is retained until attached to the DOM.
+  if (!headComment.parentNode) {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(headComment as unknown as Comment);
+    fragment.appendChild(tailComment as unknown as Comment);
+    const fragmentSlotIndex = tailTNode.index + 1;
+    lView[fragmentSlotIndex] = fragment;
+  }
+
+  return viewRef;
+}

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -599,6 +599,11 @@ export const enum TViewType {
    * can have zero or more `Embedded` `TView`s.
    */
   Embedded = 2,
+
+  /**
+   * Foreign `TView` associated with a range of nodes between `head` and `tail` comment nodes.
+   */
+  Foreign = 3,
 }
 
 /**

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -86,7 +86,7 @@ import {cancelLeavingNodes, reusedNodes, trackLeavingNodes} from '../animation/u
 import {Injector} from '../di';
 import {maybeQueueEnterAnimation, runLeaveAnimationsWithCallback} from './node_animations';
 
-const enum WalkTNodeTreeAction {
+export const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
   Create = 0,
 
@@ -871,7 +871,7 @@ function applyNodes(
  * @param parentRElement parent DOM element for insertion (Removal does not need it).
  * @param beforeNode Before which node the insertions should happen.
  */
-function applyView(
+export function applyView(
   tView: TView,
   lView: LView,
   renderer: Renderer,
@@ -879,7 +879,7 @@ function applyView(
   parentRElement: null,
   beforeNode: null,
 ): void;
-function applyView(
+export function applyView(
   tView: TView,
   lView: LView,
   renderer: Renderer,
@@ -887,7 +887,7 @@ function applyView(
   parentRElement: RElement | null,
   beforeNode: RNode | null,
 ): void;
-function applyView(
+export function applyView(
   tView: TView,
   lView: LView,
   renderer: Renderer,
@@ -895,7 +895,54 @@ function applyView(
   parentRElement: RElement | null,
   beforeNode: RNode | null,
 ): void {
-  applyNodes(renderer, action, tView.firstChild, lView, parentRElement, beforeNode, false);
+  if (tView.type === TViewType.Foreign) {
+    applyForeignNodes(renderer, action, lView, parentRElement, beforeNode);
+  } else {
+    applyNodes(renderer, action, tView.firstChild, lView, parentRElement, beforeNode, false);
+  }
+}
+
+function applyForeignNodes(
+  renderer: Renderer,
+  action: WalkTNodeTreeAction,
+  lView: LView,
+  parent: RElement | null,
+  beforeNode: RNode | null,
+) {
+  const tView = lView[TVIEW];
+  const headTNode = tView.firstChild!;
+  const tailTNode = headTNode.next!;
+  const head = unwrapRNode(lView[headTNode.index]);
+  const tail = unwrapRNode(lView[tailTNode.index]);
+
+  const fragmentSlotIndex = tailTNode.index + 1;
+  let fragment = lView[fragmentSlotIndex] as any;
+
+  if (action === WalkTNodeTreeAction.Insert || action === WalkTNodeTreeAction.Create) {
+    if (parent !== null) {
+      if (fragment && fragment.hasChildNodes()) {
+        nativeInsertBefore(renderer, parent, fragment, beforeNode, true);
+      } else {
+        nativeInsertBefore(renderer, parent, head!, beforeNode, true);
+        nativeInsertBefore(renderer, parent, tail!, beforeNode, true);
+      }
+    }
+  } else if (action === WalkTNodeTreeAction.Detach) {
+    if (!fragment) {
+      fragment = document.createDocumentFragment();
+      lView[fragmentSlotIndex] = fragment;
+    }
+    if (head && head.parentNode === fragment) {
+      return;
+    }
+    let current: RNode | null = head;
+    while (current !== null) {
+      const next: RNode | null = current.nextSibling;
+      fragment.appendChild(current);
+      if (current === tail) break;
+      current = next;
+    }
+  }
 }
 
 /**

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -328,6 +328,7 @@
       "animationFailed",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyParamDefaults",
       "applyProjectionRecursive",

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -329,6 +329,7 @@
       "animationFailed",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyParamDefaults",
       "applyProjectionRecursive",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -254,6 +254,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -255,6 +255,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -300,6 +300,7 @@
       "applyContainer",
       "applyDeferBlockState",
       "applyDeferBlockStateWithSchedulingImpl",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -301,6 +301,7 @@
       "applyContainer",
       "applyDeferBlockState",
       "applyDeferBlockStateWithSchedulingImpl",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -371,6 +371,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -372,6 +372,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -372,6 +372,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -373,6 +373,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -370,6 +370,7 @@
       "applyContainer",
       "applyDeferBlockState",
       "applyDeferBlockStateWithSchedulingImpl",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -362,6 +362,7 @@
       "applyContainer",
       "applyDeferBlockState",
       "applyDeferBlockStateWithSchedulingImpl",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -409,6 +409,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -235,6 +235,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -236,6 +236,7 @@
       "angularZoneInstanceIdProperty",
       "appendChild",
       "applyContainer",
+      "applyForeignNodes",
       "applyNodes",
       "applyProjectionRecursive",
       "applyRootElementTransform",

--- a/packages/core/test/render3/foreign_view_spec.ts
+++ b/packages/core/test/render3/foreign_view_spec.ts
@@ -6,9 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Directive, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {
+  Component,
+  Directive,
+  TemplateRef,
+  ViewChild,
+  ViewContainerRef,
+  ɵcreateAndInsertForeignView,
+} from '@angular/core';
 import {TestBed} from '../../testing';
-import {ɵcreateAndInsertForeignView} from '../../src/render3/foreign_view';
 import {HEADER_OFFSET, TVIEW, TViewType} from '../../src/render3/interfaces/view';
 
 @Component({
@@ -16,7 +22,6 @@ import {HEADER_OFFSET, TVIEW, TViewType} from '../../src/render3/interfaces/view
     <div #container></div>
     <div #container2></div>
   `,
-  standalone: true,
 })
 class TestComponent {
   @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
@@ -25,7 +30,6 @@ class TestComponent {
 
 @Directive({
   selector: '[foreign]',
-  standalone: true,
 })
 class ForeignDirective {
   constructor(vcr: ViewContainerRef) {
@@ -45,7 +49,6 @@ class ForeignDirective {
     </ng-template>
     <div #target></div>
   `,
-  standalone: true,
   imports: [ForeignDirective],
 })
 class TestTemplateComponent {

--- a/packages/core/test/render3/foreign_view_spec.ts
+++ b/packages/core/test/render3/foreign_view_spec.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, Directive, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {TestBed} from '../../testing';
+import {ɵcreateAndInsertForeignView} from '../../src/render3/foreign_view';
+import {HEADER_OFFSET, TVIEW, TViewType} from '../../src/render3/interfaces/view';
+
+@Component({
+  template: `
+    <div #container></div>
+    <div #container2></div>
+  `,
+  standalone: true,
+})
+class TestComponent {
+  @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
+  @ViewChild('container2', {read: ViewContainerRef, static: true}) vcr2!: ViewContainerRef;
+}
+
+@Directive({
+  selector: '[foreign]',
+  standalone: true,
+})
+class ForeignDirective {
+  constructor(vcr: ViewContainerRef) {
+    const viewRef = ɵcreateAndInsertForeignView(vcr, 0);
+    const head = viewRef.head;
+
+    const span = document.createElement('span');
+    span.textContent = 'foreign node';
+    head.after(span);
+  }
+}
+
+@Component({
+  template: `
+    <ng-template #tmpl>
+      <ng-container foreign></ng-container>
+    </ng-template>
+    <div #target></div>
+  `,
+  standalone: true,
+  imports: [ForeignDirective],
+})
+class TestTemplateComponent {
+  @ViewChild('tmpl', {read: TemplateRef, static: true}) tmpl!: TemplateRef<any>;
+  @ViewChild('target', {read: ViewContainerRef, static: true}) target!: ViewContainerRef;
+}
+
+describe('foreign views', () => {
+  it('should create a foreign view inside a ViewContainerRef', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    expect(vcr).toBeDefined();
+
+    const viewRef = ɵcreateAndInsertForeignView(vcr, 0);
+    const foreignLView = (viewRef as any)._lView; // internal LView!
+
+    expect(foreignLView).toBeDefined();
+    const tView = foreignLView[TVIEW];
+    expect(tView.type).toBe(TViewType.Foreign);
+
+    // Verify slots
+    const headTNode = tView.firstChild!;
+    expect(headTNode.index).toBe(HEADER_OFFSET);
+
+    const tailTNode = headTNode.next!;
+    expect(tailTNode.index).toBe(HEADER_OFFSET + 1);
+
+    const headComment = foreignLView[headTNode.index];
+    expect(headComment).toBeDefined();
+
+    const tailComment = foreignLView[tailTNode.index];
+    expect(tailComment).toBeDefined();
+  });
+
+  it('should support moving foreign views between containers', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    const vcr2 = fixture.componentInstance.vcr2;
+    expect(vcr).toBeDefined();
+    expect(vcr2).toBeDefined();
+
+    const viewRef = ɵcreateAndInsertForeignView(vcr, 0);
+    const foreignLView = (viewRef as any)._lView; // internal LView!
+
+    const tView = foreignLView[TVIEW];
+    const tailTNode = tView.firstChild!.next!;
+    const headComment = foreignLView[tView.firstChild!.index];
+    const tailComment = foreignLView[tailTNode.index];
+
+    // Mock some foreign elements between head and tail
+    const doc = (foreignLView[0] as any).ownerDocument;
+    const span1 = doc.createElement('span');
+    const span2 = doc.createElement('span');
+    const parentNode = (headComment as any).parentNode;
+
+    parentNode.insertBefore(span1, tailComment);
+    parentNode.insertBefore(span2, tailComment);
+
+    const initialParentCount = parentNode.childNodes.length;
+
+    // 1. Detach view using public API
+    const retrievedViewRef = vcr.get(0)!;
+    expect(retrievedViewRef).toBeDefined();
+    vcr.detach(0);
+
+    expect(parentNode.childNodes.length).toBe(initialParentCount - 4); // minus head, span1, span2, tail
+
+    // 2. Reattach view to container2
+    vcr2.insert(viewRef);
+
+    expect(fixture.nativeElement.innerHTML).toBe(
+      '<div></div><!--container--><div></div><!----><span></span><span></span><!----><!--container-->',
+    );
+  });
+
+  it('should not break when triggering change detection on host', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    ɵcreateAndInsertForeignView(vcr, 0);
+
+    // Trigger change detection again - should not throw
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should support foreign views inside ng-template', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestTemplateComponent);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance;
+    const viewRef = comp.target.createEmbeddedView(comp.tmpl);
+    fixture.detectChanges();
+
+    // Verify the foreign element is there
+    expect(fixture.nativeElement.innerHTML).toContain('<span>foreign node</span>');
+
+    // Verify rootNodes of the outer embedded view includes the span!
+    const rootNodes = viewRef.rootNodes;
+    const hasSpan = rootNodes.some((node: any) => node.nodeName === 'SPAN');
+    expect(hasSpan).toBeTrue();
+  });
+});

--- a/packages/core/test/render3/foreign_view_spec.ts
+++ b/packages/core/test/render3/foreign_view_spec.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, Directive, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {TestBed} from '../../testing';
+import {createForeignView} from '../../src/render3/foreign_view';
+import {HEADER_OFFSET, TVIEW, TViewType} from '../../src/render3/interfaces/view';
+
+@Component({
+  template: `
+    <div #container></div>
+    <div #container2></div>
+  `,
+})
+class TestComponent {
+  @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
+  @ViewChild('container2', {read: ViewContainerRef, static: true}) vcr2!: ViewContainerRef;
+}
+
+@Directive({
+  selector: '[foreign]',
+})
+class ForeignDirective {
+  constructor(vcr: ViewContainerRef) {
+    const lContainer = (vcr as any)._lContainer;
+    const viewRef = createForeignView(lContainer, 0);
+    const head = viewRef.head;
+
+    const span = document.createElement('span');
+    span.textContent = 'foreign node';
+    head.after(span);
+  }
+}
+
+@Component({
+  template: `
+    <ng-template #tmpl>
+      <ng-container foreign></ng-container>
+    </ng-template>
+    <div #target></div>
+  `,
+  imports: [ForeignDirective],
+})
+class TestTemplateComponent {
+  @ViewChild('tmpl', {read: TemplateRef, static: true}) tmpl!: TemplateRef<any>;
+  @ViewChild('target', {read: ViewContainerRef, static: true}) target!: ViewContainerRef;
+}
+
+describe('foreign views', () => {
+  it('should create a foreign view inside a ViewContainerRef', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    expect(vcr).toBeDefined();
+
+    const lContainer = (vcr as any)._lContainer;
+    const viewRef = createForeignView(lContainer, 0);
+    const foreignLView = (viewRef as any)._lView; // internal LView!
+
+    expect(foreignLView).toBeDefined();
+    const tView = foreignLView[TVIEW];
+    expect(tView.type).toBe(TViewType.Foreign);
+
+    // Verify slots
+    const headTNode = tView.firstChild!;
+    expect(headTNode.index).toBe(HEADER_OFFSET);
+
+    const tailTNode = headTNode.next!;
+    expect(tailTNode.index).toBe(HEADER_OFFSET + 1);
+
+    const headComment = foreignLView[headTNode.index];
+    expect(headComment).toBeDefined();
+
+    const tailComment = foreignLView[tailTNode.index];
+    expect(tailComment).toBeDefined();
+  });
+
+  it('should support moving foreign views between containers', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    const vcr2 = fixture.componentInstance.vcr2;
+    expect(vcr).toBeDefined();
+    expect(vcr2).toBeDefined();
+
+    const lContainer = (vcr as any)._lContainer;
+    const viewRef = createForeignView(lContainer, 0);
+    const foreignLView = (viewRef as any)._lView; // internal LView!
+
+    const tView = foreignLView[TVIEW];
+    const tailTNode = tView.firstChild!.next!;
+    const headComment = foreignLView[tView.firstChild!.index];
+    const tailComment = foreignLView[tailTNode.index];
+
+    // Mock some foreign elements between head and tail
+    const doc = (foreignLView[0] as any).ownerDocument;
+    const span1 = doc.createElement('span');
+    const span2 = doc.createElement('span');
+    const parentNode = (headComment as any).parentNode;
+
+    parentNode.insertBefore(span1, tailComment);
+    parentNode.insertBefore(span2, tailComment);
+
+    const initialParentCount = parentNode.childNodes.length;
+
+    // 1. Detach view using public API
+    const retrievedViewRef = vcr.get(0)!;
+    expect(retrievedViewRef).toBeDefined();
+    vcr.detach(0);
+
+    expect(parentNode.childNodes.length).toBe(initialParentCount - 4); // minus head, span1, span2, tail
+
+    // 2. Reattach view to container2
+    vcr2.insert(viewRef);
+
+    expect(fixture.nativeElement.innerHTML).toBe(
+      '<div></div><!--container--><div></div><!----><span></span><span></span><!----><!--container-->',
+    );
+  });
+
+  it('should not break when triggering change detection on host', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const vcr = fixture.componentInstance.vcr;
+    const lContainer = (vcr as any)._lContainer;
+    createForeignView(lContainer, 0);
+
+    // Trigger change detection again - should not throw
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should support foreign views inside ng-template', () => {
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(TestTemplateComponent);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance;
+    const viewRef = comp.target.createEmbeddedView(comp.tmpl);
+    fixture.detectChanges();
+
+    // Verify the foreign element is there
+    expect(fixture.nativeElement.innerHTML).toContain('<span>foreign node</span>');
+
+    // Verify rootNodes of the outer embedded view includes the span!
+    const rootNodes = viewRef.rootNodes;
+    const hasSpan = rootNodes.some((node: any) => node.nodeName === 'SPAN');
+    expect(hasSpan).toBeTrue();
+  });
+});


### PR DESCRIPTION
Introduces `createForeignView`, an internal API for creating foreign view directly inside `LContainer`s. Foreign views (`TViewType.Foreign`) are bounded by head and tail comment nodes and can contain dynamic, non-Angular DOM nodes.

Updates Render3 node manipulation to support inserting, detaching, and moving foreign views along with their internal content.