### PR TITLE
fix(forms): ensure reset cancels pending debounce and syncs controlValue

### DIFF
--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -313,9 +313,22 @@ export class FieldNode implements FieldState<unknown> {
   }
 
   private _reset(value?: unknown) {
+    // Abort the pending debounce. pendingSync.set(undefined) is NOT enough — it
+    // doesn't call .abort(), so debounceSync's `controller.signal.aborted` stays
+    // false and sync() fires after the debounce, overwriting the reset.
+    this.pendingSync()?.abort();
+
     if (value !== undefined) {
       this.value.set(value);
     }
+
+    // controlValue is a linkedSignal that only auto-resets when value *changes*.
+    // When the reset value equals the current value (or no value was passed),
+    // controlValue retains the typed text. Force it to match value.
+    // markAsDirty() is a side-effect of controlValue.set() but is immediately
+    // undone by markAsPristine() below, and the spawned debounce is a no-op
+    // since controlValue and value are already equal.
+    this.controlValue.set(this.value());
 
     this.nodeState.markAsUntouched();
     this.nodeState.markAsPristine();

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -8,6 +8,7 @@
 
 import {Component, computed, effect, Injector, signal, WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {FieldNode} from '../../src/field/node';
 import {
   apply,
   applyEach,
@@ -1497,6 +1498,71 @@ describe('FieldNode', () => {
       expect(f().dirty()).toBe(false);
       expect(f.a().dirty()).toBe(false);
       expect(f.a.b().dirty()).toBe(false);
+    });
+
+    it('should immediately update value on reset even if a debounce is pending', async () => {
+      let resolveDebounce: (value: void | PromiseLike<void>) => void;
+      const debouncePromise = new Promise<void>((resolve) => {
+        resolveDebounce = resolve;
+      });
+
+      const model = signal('initial');
+      const f = form(
+        model,
+        (p) => {
+          debounce(p, () => debouncePromise);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      // 1. Simulate user input
+      f().controlValue.set('user input');
+
+      // Value should still be 'initial' because of debounce
+      expect(f().value()).toBe('initial');
+
+      // 2. Call reset with a new value
+      f().reset('reset value');
+
+      // Value should be 'reset value' immediately
+      expect(f().value()).toBe('reset value');
+      expect(f().controlValue()).toBe('reset value');
+
+      // 3. Resolve the debounce
+      resolveDebounce!();
+      await Promise.resolve(); // Wait for promise microtasks
+
+      // Value should STILL be 'reset value', not 'user input'
+      expect(f().value()).toBe('reset value');
+    });
+
+    it('should immediately update value on reset when "blur" debounce is pending (Escape key scenario)', () => {
+      const model = signal('initial');
+      const f = form(
+        model,
+        (p) => {
+          debounce(p, 'blur');
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      // Simulate typing: controlValue is updated, but model value is not (pending blur)
+      f().controlValue.set('user input');
+      expect(f().value()).toBe('initial');
+      expect(f().controlValue()).toBe('user input');
+
+      // Simulate Escape key: call reset
+      f().reset('initial');
+
+      // Value should be reset immediately and controlValue should match
+      expect(f().value()).toBe('initial');
+      expect(f().controlValue()).toBe('initial');
+
+      // Simulate blur later
+      f().markAsTouched();
+
+      // Value should still be 'initial'
+      expect(f().value()).toBe('initial');
     });
   });
 });


### PR DESCRIPTION
Abort any pending debounce before resetting to prevent stale sync() from overwriting the reset value.

Force controlValue to match value during reset, even when the value has not changed, ensuring the UI does not retain stale user input.

markAsDirty() triggered by controlValue.set() is neutralized by markAsPristine(), and no unnecessary sync is triggered since values are already aligned.

Fixes: #68076

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #68076

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
