### PR TITLE
refactor(forms): replace `any` with  `unknown` in interop control value types

### DIFF
--- a/packages/forms/signals/src/controls/interop_ng_control.ts
+++ b/packages/forms/signals/src/controls/interop_ng_control.ts
@@ -36,7 +36,7 @@ import type {ReadonlyFieldState} from '../api/types';
  * because it confuses the internal JS minifier which can cause collisions in field names.
  */
 interface CombinedControl {
-  value: any;
+  value: unknown;
   valid: boolean;
   invalid: boolean;
   touched: boolean;
@@ -65,7 +65,7 @@ export class InteropNgControl implements CombinedControl {
 
   readonly control: AbstractControl<any, any> = this as unknown as AbstractControl<any, any>;
 
-  get value(): any {
+  get value(): unknown {
     // CVA controls are not aware of user debouncing and will expect `NgControl.value` to reflect their latest writes.
     return this.field().controlValue();
   }

--- a/packages/forms/signals/src/directive/control_cva.ts
+++ b/packages/forms/signals/src/directive/control_cva.ts
@@ -42,7 +42,7 @@ export function cvaControlCreate(
     // `bindingUpdated` sees that the model value matches the last seen view value.
     // This prevents the framework from writing the same value back to the CVA (CVA loopback).
     bindings['controlValue'] = value;
-    parent.state().controlValue.set(value as any);
+    parent.state().controlValue.set(value);
   });
   parent.controlValueAccessor!.registerOnTouched(() => parent.state().markAsTouched());
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

`CombinedControl.value` and `InteropNgControl.value` getter now return `unknown` instead of `any`, matching the actual `ReadonlyFieldState<unknown>` return type of `controlValue()`

