### PR TITLE
fix(platform-server): close absolute-form request-target bypass of GHSA-45q2-gjvg-7973

### DIFF
--- a/goldens/public-api/platform-server/index.api.md
+++ b/goldens/public-api/platform-server/index.api.md
@@ -25,6 +25,7 @@ export const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 // @public
 export interface PlatformConfig {
     document?: string;
+    publicOrigin?: string;
     url?: string;
 }
 
@@ -49,6 +50,7 @@ export function provideServerRendering(): EnvironmentProviders;
 export function renderApplication(bootstrap: (context: BootstrapContext) => Promise<ApplicationRef>, options: {
     document?: string | Document;
     url?: string;
+    publicOrigin?: string;
     platformProviders?: Provider[];
 }): Promise<string>;
 
@@ -56,6 +58,7 @@ export function renderApplication(bootstrap: (context: BootstrapContext) => Prom
 export function renderModule<T>(moduleType: Type<T>, options: {
     document?: string | Document;
     url?: string;
+    publicOrigin?: string;
     extraProviders?: StaticProvider[];
 }): Promise<string>;
 

--- a/integration/platform-server-zoneless/projects/standalone/server.ts
+++ b/integration/platform-server-zoneless/projects/standalone/server.ts
@@ -38,11 +38,15 @@ app.get('/api-2', (req, res) => {
 
 // All regular routes use the Universal engine
 app.use((req, res) => {
-  const {protocol, originalUrl, baseUrl, headers} = req;
+  const {originalUrl, baseUrl} = req;
 
   renderApplication(bootstrap, {
     document: indexHtml,
-    url: `${protocol}://${headers.host}${originalUrl}`,
+    url: originalUrl,
+    // `publicOrigin` must be a server-controlled constant, never derived from
+    // request headers, to avoid reintroducing the SSRF class closed by
+    // GHSA-45q2-gjvg-7973.
+    publicOrigin: 'http://localhost:4209',
     platformProviders: [{provide: APP_BASE_HREF, useValue: baseUrl}],
   }).then((response: string) => {
     res.send(response);

--- a/integration/platform-server/projects/ngmodule/server.ts
+++ b/integration/platform-server/projects/ngmodule/server.ts
@@ -38,11 +38,15 @@ app.get('/api-2', (req, res) => {
 
 // All regular routes use the Universal engine
 app.use((req, res) => {
-  const {protocol, originalUrl, baseUrl, headers} = req;
+  const {originalUrl, baseUrl} = req;
 
   renderModule(AppServerModule, {
     document: indexHtml,
-    url: `${protocol}://${headers.host}${originalUrl}`,
+    url: originalUrl,
+    // `publicOrigin` must be a server-controlled constant, never derived from
+    // request headers, to avoid reintroducing the SSRF class closed by
+    // GHSA-45q2-gjvg-7973.
+    publicOrigin: 'http://localhost:4206',
     extraProviders: [{provide: APP_BASE_HREF, useValue: baseUrl}],
   }).then((response: string) => {
     res.send(response);

--- a/integration/platform-server/projects/standalone/server.ts
+++ b/integration/platform-server/projects/standalone/server.ts
@@ -38,11 +38,15 @@ app.get('/api-2', (req, res) => {
 
 // All regular routes use the Universal engine
 app.use((req, res) => {
-  const {protocol, originalUrl, baseUrl, headers} = req;
+  const {originalUrl, baseUrl} = req;
 
   renderApplication(bootstrap, {
     document: indexHtml,
-    url: `${protocol}://${headers.host}${originalUrl}`,
+    url: originalUrl,
+    // `publicOrigin` must be a server-controlled constant, never derived from
+    // request headers, to avoid reintroducing the SSRF class closed by
+    // GHSA-45q2-gjvg-7973.
+    publicOrigin: 'http://localhost:4206',
     platformProviders: [{provide: APP_BASE_HREF, useValue: baseUrl}],
   }).then((response: string) => {
     res.send(response);

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -19,17 +19,51 @@ import {Subject} from 'rxjs';
 import {INITIAL_CONFIG} from './tokens';
 
 /**
- * Parses a URL string and returns a URL object.
- * @param urlStr The string to parse.
- * @param origin The origin to use for resolving the URL.
- * @returns The parsed URL.
+ * Returns the path + query + fragment portion of an untrusted URL-or-path
+ * input, discarding any authority the input carries.
+ *
+ * Security: `INITIAL_CONFIG.url` is populated from `req.url` in SSR handlers.
+ * Node preserves absolute-form request-targets (RFC 9112 §3.2.2) in `req.url`
+ * verbatim, so attacker-controlled cross-origin inputs (`http://attacker/...`,
+ * `//evil/...`, `\\evil/...`) can reach here. The hard-coded `http://localhost/`
+ * base is a scaffold for the WHATWG URL parser only; its host never appears in
+ * the return value.
+ */
+export function sanitizeConfigUrl(raw: string | undefined): string {
+  try {
+    const u = new URL(raw || '/', 'http://localhost/');
+    const path = u.pathname.startsWith('/') ? u.pathname : '/' + u.pathname;
+    return path + u.search + u.hash;
+  } catch {
+    return '/';
+  }
+}
+
+/**
+ * Normalizes a trusted-origin configuration string (such as
+ * `INITIAL_CONFIG.publicOrigin`) to a bare `scheme://host[:port]` origin.
+ *
+ * Returns `null` for inputs that are empty, unparseable, or whose scheme is
+ * not `http:`/`https:`. Any path, query, fragment, or credentials present in
+ * the input are discarded — only the origin is retained.
+ */
+export function sanitizeOrigin(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+    return u.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves a same-origin path within the platform origin.
+ * The input is first sanitized to drop any cross-origin authority.
  */
 function parseUrl(urlStr: string, origin: string): URL {
-  // If the URL is empty or start with a `/` it is a pathname relative to the origin
-  // otherwise it's an absolute URL.
-  const urlToParse = urlStr.length === 0 || urlStr[0] === '/' ? origin + urlStr : urlStr;
-
-  return new URL(urlToParse);
+  return new URL(sanitizeConfigUrl(urlStr), origin);
 }
 
 /**
@@ -47,16 +81,23 @@ export class ServerPlatformLocation implements PlatformLocation {
   public readonly hash: string = '';
   private _hashUpdate = new Subject<LocationChangeEvent>();
   private _doc = inject(DOCUMENT);
+  // Authority reflected on `PlatformLocation` and used by the SSR HTTP
+  // interceptor comes from the operator-supplied `publicOrigin` only.
+  // `INITIAL_CONFIG.url` is considered untrusted (attacker-controlled via
+  // `req.url`) and never contributes to authority, even in absolute form.
+  private _trustedOrigin =
+    sanitizeOrigin(inject(INITIAL_CONFIG, {optional: true})?.publicOrigin) ??
+    this._doc.location.origin;
 
   constructor() {
     const config = inject(INITIAL_CONFIG, {optional: true});
     if (!config) {
       return;
     }
-    if (config.url) {
+    if (config.url || config.publicOrigin) {
       const {protocol, hostname, port, pathname, search, hash, href} = parseUrl(
-        config.url,
-        this._doc.location.origin,
+        config.url ?? '',
+        this._trustedOrigin,
       );
       this.protocol = protocol;
       this.hostname = hostname;
@@ -106,7 +147,7 @@ export class ServerPlatformLocation implements PlatformLocation {
 
   replaceState(state: any, title: string, newUrl: string): void {
     const oldUrl = this.url;
-    const {pathname, search, hash, href, protocol} = parseUrl(newUrl, this._doc.location.origin);
+    const {pathname, search, hash, href, protocol} = parseUrl(newUrl, this._trustedOrigin);
     const writableThis = this as Writable<this>;
     writableThis.pathname = pathname;
     writableThis.search = search;

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -37,7 +37,7 @@ import {
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
 import {SERVER_HTTP_PROVIDERS} from './http';
-import {ServerPlatformLocation} from './location';
+import {sanitizeConfigUrl, ServerPlatformLocation} from './location';
 import {enableDomEmulation, PlatformState} from './platform_state';
 import {ServerEventManagerPlugin} from './server_events';
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
@@ -100,7 +100,7 @@ function _document() {
     document =
       typeof config.document === 'string'
         ? _enableDomEmulation
-          ? parseDocument(config.document, config.url)
+          ? parseDocument(config.document, sanitizeConfigUrl(config.url))
           : window.document
         : config.document;
   } else {

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -20,12 +20,35 @@ export interface PlatformConfig {
    */
   document?: string;
   /**
-   * The URL for the current application state. This is used for initializing
-   * the platform's location. `protocol`, `hostname`, and `port` will be
-   * overridden if `baseUrl` is set.
+   * The request target for the current application state (path, query, and
+   * fragment). This is used for initializing the router's URL.
+   *
+   * Security: any authority (scheme, host, port, credentials) present in this
+   * value is stripped before use, because SSR handlers typically populate it
+   * from `req.url`, which an attacker can control via absolute-form
+   * request-targets (RFC 9112 §3.2.2). Use `publicOrigin` to configure the
+   * trusted origin of the server instead.
    * @default none
    */
   url?: string;
+  /**
+   * The trusted origin (scheme + host + port) of the server that clients
+   * reach — for example `'https://my-site.com'` or `'http://localhost:4200'`.
+   * Populates `PlatformLocation.{protocol, hostname, port, href}` and is used
+   * by the SSR HTTP interceptor as the base when rewriting relative
+   * `HttpClient` URLs.
+   *
+   * Security: this MUST be a server-controlled constant (env var, deployment
+   * config). NEVER derive it from request headers, `req.url`, or any other
+   * value an HTTP client can influence, or you reintroduce SSRF.
+   *
+   * Accepted values are parsed with the WHATWG URL parser. Any path, query,
+   * fragment, credentials, or non-`http(s)` scheme present in the input is
+   * discarded and, if the remainder isn't a valid origin, the property falls
+   * back to the platform default.
+   * @default none
+   */
+  publicOrigin?: string;
 }
 
 /**

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -42,6 +42,7 @@ export const EVENT_DISPATCH_SCRIPT_ID = 'ng-event-dispatch-contract';
 interface PlatformOptions {
   document?: string | Document;
   url?: string;
+  publicOrigin?: string;
   platformProviders?: Provider[];
 }
 
@@ -55,7 +56,14 @@ function createServerPlatform(options: PlatformOptions): PlatformRef {
   startMeasuring(measuringLabel);
 
   const platform = platformServer([
-    {provide: INITIAL_CONFIG, useValue: {document: options.document, url: options.url}},
+    {
+      provide: INITIAL_CONFIG,
+      useValue: {
+        document: options.document,
+        url: options.url,
+        publicOrigin: options.publicOrigin,
+      },
+    },
     extraProviders,
   ]);
 
@@ -263,17 +271,27 @@ function sanitizeServerContext(serverContext: string): string {
  * @param options Additional configuration for the render operation:
  *  - `document` - the document of the page to render, either as an HTML string or
  *                 as a reference to the `document` instance.
- *  - `url` - the URL for the current render request.
+ *  - `url` - the request target (path, query, fragment) for the current render.
+ *                 Authority from this value is stripped; use `publicOrigin` for a
+ *                 trusted origin.
+ *  - `publicOrigin` - trusted origin of the server (`scheme://host[:port]`). Used
+ *                 for `PlatformLocation.{protocol, hostname, port, href}` and the
+ *                 SSR HTTP interceptor. Must be a server-controlled constant.
  *  - `extraProviders` - set of platform level providers for the current render request.
  *
  * @publicApi
  */
 export async function renderModule<T>(
   moduleType: Type<T>,
-  options: {document?: string | Document; url?: string; extraProviders?: StaticProvider[]},
+  options: {
+    document?: string | Document;
+    url?: string;
+    publicOrigin?: string;
+    extraProviders?: StaticProvider[];
+  },
 ): Promise<string> {
-  const {document, url, extraProviders: platformProviders} = options;
-  const platformRef = createServerPlatform({document, url, platformProviders});
+  const {document, url, publicOrigin, extraProviders: platformProviders} = options;
+  const platformRef = createServerPlatform({document, url, publicOrigin, platformProviders});
   try {
     const moduleRef = await platformRef.bootstrapModule(moduleType);
     const applicationRef = moduleRef.injector.get(ApplicationRef);
@@ -313,7 +331,12 @@ export async function renderModule<T>(
  * @param options Additional configuration for the render operation:
  *  - `document` - the document of the page to render, either as an HTML string or
  *                 as a reference to the `document` instance.
- *  - `url` - the URL for the current render request.
+ *  - `url` - the request target (path, query, fragment) for the current render.
+ *                 Authority from this value is stripped; use `publicOrigin` for a
+ *                 trusted origin.
+ *  - `publicOrigin` - trusted origin of the server (`scheme://host[:port]`). Used
+ *                 for `PlatformLocation.{protocol, hostname, port, href}` and the
+ *                 SSR HTTP interceptor. Must be a server-controlled constant.
  *  - `platformProviders` - the platform level providers for the current render request.
  *
  * @returns A Promise, that returns serialized (to a string) rendered page, once resolved.
@@ -322,7 +345,12 @@ export async function renderModule<T>(
  */
 export async function renderApplication(
   bootstrap: (context: BootstrapContext) => Promise<ApplicationRef>,
-  options: {document?: string | Document; url?: string; platformProviders?: Provider[]},
+  options: {
+    document?: string | Document;
+    url?: string;
+    publicOrigin?: string;
+    platformProviders?: Provider[];
+  },
 ): Promise<string> {
   const renderAppLabel = 'renderApplication';
   const bootstrapLabel = 'bootstrap';

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1462,7 +1462,7 @@ class HiddenModule {}
         });
       });
 
-      describe(`given 'url' is provided in 'INITIAL_CONFIG'`, () => {
+      describe(`given 'publicOrigin' is provided in 'INITIAL_CONFIG'`, () => {
         let mock: HttpTestingController;
         let ref: NgModuleRef<HttpInterceptorExampleModule>;
         let http: HttpClient;
@@ -1473,7 +1473,13 @@ class HiddenModule {}
               provide: INITIAL_CONFIG,
               useValue: {
                 document: '<app></app>',
-                url: 'http://localhost:4000/foo',
+                // `publicOrigin` is the trusted server origin used by the SSR
+                // HTTP interceptor to prefix relative requests. The `url`
+                // field carries only the request target (path), since its
+                // authority is stripped by the sanitizer — see
+                // GHSA-45q2-gjvg-7973 and `sanitizeConfigUrl` / `sanitizeOrigin`.
+                publicOrigin: 'http://localhost:4000',
+                url: '/foo',
               },
             },
           ]);

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -50,12 +50,16 @@ import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
     });
 
     it('parses component pieces of a URL', async () => {
+      // Authority now comes from `publicOrigin` (trusted, operator-supplied),
+      // not from the `url` field (which is sanitized to path-only because it
+      // is typically populated from `req.url`).
       const platform = platformServer([
         {
           provide: INITIAL_CONFIG,
           useValue: {
             document: '<app></app>',
-            url: 'http://test.com:80/deep/path?query#hash',
+            publicOrigin: 'http://test.com:80',
+            url: '/deep/path?query#hash',
           },
         },
       ]);
@@ -104,7 +108,8 @@ import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
           provide: INITIAL_CONFIG,
           useValue: {
             document: '<app></app>',
-            url: 'http://test.com/deep/path?query#hash',
+            publicOrigin: 'http://test.com',
+            url: '/deep/path?query#hash',
           },
         },
       ]);
@@ -139,25 +144,191 @@ import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
       const urls = ['/\\attacker.com/deep/path', '//attacker.com/deep/path'];
 
       for (const url of urls) {
+        const platform = platformServer([{provide: INITIAL_CONFIG, useValue: {document: '', url}}]);
+
+        const location = platform.injector.get(PlatformLocation);
+        platform.destroy();
+
+        expect(location.hostname).withContext(`hostname for URL: "${url}"`).toBe('');
+        expect(location.pathname).withContext(`pathname for URL: "${url}"`).toBe('/deep/path');
+      }
+    });
+
+    it('neutralizes absolute-form request-target hostname hijack attempts', async () => {
+      // GHSA-45q2-gjvg-7973 bypass: absolute-form request-target (RFC 9112 §3.2.2)
+      // in `req.url` flows into `INITIAL_CONFIG.url` and previously leaked authority.
+      const urls = [
+        'http://attacker.example/deep/path',
+        'https://attacker.example/deep/path',
+        'http://169.254.169.254/latest/meta-data/',
+        'http://10.0.0.1:8080/admin',
+      ];
+
+      for (const url of urls) {
+        const platform = platformServer([{provide: INITIAL_CONFIG, useValue: {document: '', url}}]);
+
+        const location = platform.injector.get(PlatformLocation);
+        platform.destroy();
+
+        const parsed = new URL(url);
+        const attackerHost = parsed.hostname;
+        expect(location.hostname).withContext(`hostname for URL: "${url}"`).not.toBe(attackerHost);
+        // Only assert port divergence when the attacker URL specified a
+        // non-default port — `new URL('http://host/').port` is `''`, which
+        // would trivially equal the post-fix `location.port`.
+        if (parsed.port !== '') {
+          expect(location.port).withContext(`port for URL: "${url}"`).not.toBe(parsed.port);
+        }
+        expect(location.href).withContext(`href for URL: "${url}"`).not.toContain(attackerHost);
+      }
+    });
+
+    it('publicOrigin populates authority; url supplies path', async () => {
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '',
+            publicOrigin: 'https://my-site.com',
+            url: '/page?x=1#top',
+          },
+        },
+      ]);
+
+      const location = platform.injector.get(PlatformLocation);
+      platform.destroy();
+
+      expect(location.protocol).toBe('https:');
+      expect(location.hostname).toBe('my-site.com');
+      expect(location.port).toBe('');
+      expect(location.pathname).toBe('/page');
+      expect(location.search).toBe('?x=1');
+      expect(location.hash).toBe('#top');
+      expect(location.href).toBe('https://my-site.com/page?x=1#top');
+    });
+
+    it('publicOrigin beats an attacker-controlled absolute url', async () => {
+      // With both set, authority must come from publicOrigin; the path (and
+      // only the path) is carried over from url.
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '',
+            publicOrigin: 'https://victim.example.com',
+            url: 'http://attacker.example/admin',
+          },
+        },
+      ]);
+
+      const location = platform.injector.get(PlatformLocation);
+      platform.destroy();
+
+      expect(location.hostname).toBe('victim.example.com');
+      expect(location.protocol).toBe('https:');
+      expect(location.pathname).toBe('/admin');
+      expect(location.href).not.toContain('attacker.example');
+      expect(location.href).toBe('https://victim.example.com/admin');
+    });
+
+    it('publicOrigin falls back to the platform default when invalid', async () => {
+      // Non-http(s) schemes, unparseable strings, and empty values all map to
+      // the DOMINO default origin, matching the behavior of no publicOrigin.
+      for (const publicOrigin of ['javascript:void(0)', 'data:text/html,x', 'not a url', '']) {
         const platform = platformServer([
           {
             provide: INITIAL_CONFIG,
-            useValue: {
-              document: '',
-              // This should be treated as relative URL.
-              // Example: `req.url: '//attacker.com/deep/path'` where request
-              // to express server is 'http://localhost:4200//attacker.com/deep/path'.
-              url,
-            },
+            useValue: {document: '', publicOrigin, url: '/page'},
           },
         ]);
 
         const location = platform.injector.get(PlatformLocation);
         platform.destroy();
 
-        expect(location.hostname).withContext(`hostname for URL: "${url}"`).toBe('');
-        expect(location.pathname).withContext(`pathname for URL: "${url}"`).toBe(url);
+        expect(location.hostname)
+          .withContext(`hostname for publicOrigin: ${JSON.stringify(publicOrigin)}`)
+          .toBe('');
+        expect(location.pathname)
+          .withContext(`pathname for publicOrigin: ${JSON.stringify(publicOrigin)}`)
+          .toBe('/page');
       }
+    });
+
+    it('non-http(s) scheme in url never leaks to location.protocol', async () => {
+      // A malformed or malicious `url` carrying an opaque scheme
+      // (`javascript:`, `data:`, `blob:`) must not override the protocol
+      // derived from `publicOrigin`. The sanitizer discards the scheme; only
+      // the path portion reaches `parseUrl`.
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '',
+            publicOrigin: 'https://victim.example.com',
+            url: 'javascript:alert(1)',
+          },
+        },
+      ]);
+
+      const location = platform.injector.get(PlatformLocation);
+      platform.destroy();
+
+      expect(location.protocol).toBe('https:');
+      expect(location.hostname).toBe('victim.example.com');
+      expect(location.href).not.toContain('javascript:');
+    });
+
+    it('userinfo and port in url are discarded when publicOrigin is set', async () => {
+      // Parser-confusion vector: `http://attacker:443@attacker-host/admin`
+      // puts `attacker:443` in userinfo and `attacker-host` as host. The
+      // sanitizer must strip both — only `/admin` should cross the trust
+      // boundary into `PlatformLocation`.
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '',
+            publicOrigin: 'https://victim.example.com',
+            url: 'http://attacker:443@attacker-host/admin',
+          },
+        },
+      ]);
+
+      const location = platform.injector.get(PlatformLocation);
+      platform.destroy();
+
+      expect(location.hostname).toBe('victim.example.com');
+      expect(location.port).toBe('');
+      expect(location.pathname).toBe('/admin');
+      expect(location.href).toBe('https://victim.example.com/admin');
+      expect(location.href).not.toContain('attacker');
+      expect(location.href).not.toContain(':443');
+    });
+
+    it('publicOrigin discards path, query, fragment, and credentials', async () => {
+      // Only scheme+host+port are retained from publicOrigin.
+      const platform = platformServer([
+        {
+          provide: INITIAL_CONFIG,
+          useValue: {
+            document: '',
+            publicOrigin: 'https://user:pass@my-site.com/ignored?x=1#frag',
+            url: '/page',
+          },
+        },
+      ]);
+
+      const location = platform.injector.get(PlatformLocation);
+      platform.destroy();
+
+      expect(location.hostname).toBe('my-site.com');
+      expect(location.protocol).toBe('https:');
+      expect(location.href).toBe('https://my-site.com/page');
+      expect(location.href).not.toContain('user');
+      expect(location.href).not.toContain('pass');
+      expect(location.href).not.toContain('ignored');
+      expect(location.href).not.toContain('?x=1');
+      expect(location.href).not.toContain('#frag');
     });
   });
 })();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: **Security fix** — closes an SSRF bypass of [GHSA-45q2-gjvg-7973](https://github.com/advisories/GHSA-45q2-gjvg-7973) and restructures `INITIAL_CONFIG` to separate request-controlled input from trusted server origin.

## What is the current behavior?

Issue Number: https://issuetracker.google.com/issues/504514297
Related advisory: [GHSA-45q2-gjvg-7973](https://github.com/advisories/GHSA-45q2-gjvg-7973) (published 2026-04-16)

The original advisory addressed an SSRF in `@angular/platform-server` where protocol-relative (`//evil/...`) and backslash-variant (`\\evil/...`, `/\evil/...`) inputs in `INITIAL_CONFIG.url` hijacked `PlatformLocation.hostname`, causing the SSR HTTP interceptor to redirect relative `HttpClient` calls to attacker-controlled hosts.

The patch that shipped only re-rooted inputs whose first character was `/` or empty. **Absolute-form request-targets ([RFC 9112 §3.2.2](https://www.rfc-editor.org/rfc/rfc9112#section-3.2.2)) still bypass it.** An attacker sending:

```
GET http://attacker.example/ HTTP/1.1
Host: victim.example.com
```

causes Node to preserve `'http://attacker.example/'` verbatim in `req.url`. The idiomatic SSR pattern `renderApplication(bootstrap, {url: req.url, ...})` forwards this to `INITIAL_CONFIG.url`. The existing guard (`urlStr[0] === '/' ? origin + urlStr : urlStr`) does not re-root scheme-prefixed inputs, so the attacker's authority reaches `PlatformLocation.{hostname, protocol, port, href}`, DOMINO's `window.location` (via `parseDocument`), and `relativeUrlsTransformerInterceptorFn` — which then prefixes every relative `HttpClient` call with the attacker's origin.

Net effect: any SSR app calling `http.get('/api/...')` from a component redirects to the attacker host, enabling exfiltration of cookies, tokens, or internal endpoints.

### Root cause

`INITIAL_CONFIG.url` has been carrying two incompatible responsibilities:

| Responsibility | Trust boundary |
|---|---|
| Request target (path + query + fragment) consumed by the Router | **Untrusted** — sourced from `req.url` |
| Server origin consumed by the SSR HTTP interceptor | **Trusted** — must be a deployment constant |

Every sanitization attempt has been bypassable because any rule that preserves authority for legitimate inputs preserves it for the attacker too — the two cases are indistinguishable at the URL level.

## What is the new behavior?

This PR separates the two responsibilities into distinct fields.

1. **`url` is now a request target only.** A new internal `sanitizeConfigUrl` helper discards any authority (scheme, host, port, credentials) unconditionally, regardless of URL shape (protocol-relative, backslash, absolute-form, userinfo-bearing, opaque-scheme). Applied at both consumers: `ServerPlatformLocation` and `parseDocument`.

2. **`publicOrigin` is a new optional `PlatformConfig` field** carrying the trusted server origin (`scheme + host + port`). Operator-supplied only; never derived from request-controlled input. `ServerPlatformLocation` populates its authority-bearing properties from this value, which keeps `relativeUrlsTransformerInterceptorFn` working transparently. A companion `sanitizeOrigin` helper validates `publicOrigin`, rejecting non-`http(s)` schemes and falling back silently to the platform default when invalid.

`renderApplication` and `renderModule` accept the new option and forward it through `INITIAL_CONFIG`.

### API changes (additive — no compile break)

```diff
 export interface PlatformConfig {
     document?: string;
+    publicOrigin?: string;
     url?: string;
 }
```

Same additive change on `renderApplication` / `renderModule` options objects.

## Does this PR introduce a breaking change?

- [x] Yes

**Types**: purely additive — no compile-time break.

**Runtime**: `INITIAL_CONFIG.url` no longer reflects authority into `PlatformLocation.{hostname, protocol, port, href}`. Callers relying on this — notably apps using `HttpClient` with relative URLs during SSR (default from `ng add @angular/ssr`) — must set `publicOrigin`:

```ts
// Before
renderApplication(bootstrap, {
  url: req.url,
  document: template,
});

// After
renderApplication(bootstrap, {
  url: req.url,
  publicOrigin: process.env.PUBLIC_ORIGIN, // e.g. 'https://my-site.com'
  document: template,
});
```

`publicOrigin` **must** be a server-controlled constant. Deriving it from request headers (`Host`, `X-Forwarded-Host`) or from `req.url` reintroduces the SSRF class this PR closes. The JSDoc on `PlatformConfig.publicOrigin` states this explicitly.

The commit footer carries `BREAKING CHANGE:` per conventional-commits.

## Other information

### Test coverage

`//packages/platform-server/test:test` passes locally (1/1, 8.4s). `platform_location_spec.ts` adds:

- **Original advisory vectors** (regression): `//attacker.com/...`, `/\attacker.com/...`
- **New bypass class**: absolute-form `http(s)://attacker/...`, including `169.254.169.254` (AWS IMDS) and RFC 1918 ranges with explicit ports
- **Parser confusion**: userinfo + port (`http://attacker:443@attacker-host/admin`)
- **Opaque schemes**: `javascript:`, `data:` in `url` never leak to `location.protocol`
- **`publicOrigin` contract**:
  - Populates authority with relative `url`
  - Wins over an attacker-controlled absolute `url` (combined vector)
  - Invalid values (non-`http(s)` scheme, unparseable, empty) fall back to the DOMINO default
  - Path / query / fragment / credentials in `publicOrigin` itself are discarded

`integration_spec.ts`'s `given 'url' is provided in 'INITIAL_CONFIG'` block is migrated to use `publicOrigin` + path-only `url`, demonstrating the new contract end-to-end against the actual HTTP interceptor.