### PR TITLE
fix(forms/signals): surface debounce window as pending in validateAsync

### DIFF
--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebounceTimer, ResourceRef, ResourceSnapshot, Signal, debounced} from '@angular/core';
+import {
+  DebounceTimer,
+  ResourceRef,
+  Signal,
+  computed,
+  ResourceStatus,
+  debounced,
+} from '@angular/core';
 import {FieldNode} from '../../../field/node';
 import {addDefaultField} from '../../../field/validation';
 import {FieldPathNode} from '../../../schema/path_node';
@@ -126,8 +133,15 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
   const RESOURCE = createManagedMetadataKey<ReturnType<typeof opts.factory>, TParams | undefined>(
     (_state, params) => {
       if (opts.debounce !== undefined) {
-        const debouncedResource = debounced(() => params(), opts.debounce);
-        return opts.factory(debouncedResource.value);
+        const debouncedParams = debounced(() => params(), opts.debounce);
+        const res = opts.factory(debouncedParams.value);
+        return Object.create(res, {
+          status: {
+            value: computed<ResourceStatus>(() =>
+              debouncedParams.isLoading() ? 'loading' : res.status(),
+            ),
+          },
+        }) as typeof res;
       }
       return opts.factory(params);
     },

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -428,8 +428,10 @@ describe('resources', () => {
     usernameForm().value.set('taken-user');
     TestBed.tick();
 
-    // Should not have triggered a new request yet
+    // Should not have triggered a new request yet, but the field must already be pending
+    // because the debounce timer is running
     backend.expectNone('/api/check?username=taken-user');
+    expect(usernameForm().pending()).toBe(true);
 
     // Wait for debounce
     await timeout(80);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

## What is the current behavior?

When using `validateAsync` with the `debounce` option in signal forms, the form field's `pending()` state is not set during the debounce window. It only flips to `true` once the debounce duration elapses and the HTTP call actually starts.

Additionally, stale validation errors from the previously resolved value remain visible during the debounce window even after the user has already changed the input.

Issue Number: #68105

## What is the new behavior?

- `form.field().pending()` returns `true` immediately on the first keystroke, as soon as the debounce timer starts — not only after the HTTP call begins.
- Stale validation errors from the previous value are cleared immediately when the user changes the input, instead of lingering for the entire debounce duration.

This is achieved by wrapping the resource returned from `opts.factory` with a computed `status` property that returns `'loading'` while `debouncedParams.isLoading()` is `true`, falling back to the inner resource status otherwise:

```typescript
const debouncedParams = debounced(() => params(), opts.debounce);
const res = opts.factory(debouncedParams.value);
return Object.create(res, {
  status: {
    value: computed<ResourceStatus>(() =>
      debouncedParams.isLoading() ? 'loading' : res.status(),
    ),
  },
}) as typeof res;
```

### Before

| Moment | `pending()` | Error state |
|---|---|---|
| User types | `false` ❌ | Stale errors still shown ❌ |
| Debounce fires + HTTP starts | `true` | Stale errors still shown ❌ |
| HTTP resolves | `false` | Correct ✅ |

### After

| Moment | `pending()` | Error state |
|---|---|---|
| User types | `true` ✅ | Immediately cleared ✅ |
| Debounce fires + HTTP starts | `true` ✅ | None ✅ |
| HTTP resolves | `false` ✅ | Correct ✅ |

## Does this PR introduce a breaking change?
- [x] No

## Other information

Related to the `debounce` option introduced for `validateAsync` in signal forms. The fix is minimal — no public API changes, no new options added. The `debouncedParams.isLoading()` signal is already available from the `debounced()` primitive and simply needed to be surfaced through the resource's `status` computed.

Note: 
I understand the community contribution guidelines, but I felt this change might still be valuable to propose. If it’s not aligned with the project’s priorities, please feel free to close the PR. I appreciate your time and feedback. :) 