### PR TITLE
fix(forms/signals): surface debounce window as pending in validateAsync

### DIFF
--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -6,7 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebounceTimer, ResourceRef, ResourceSnapshot, Signal, debounced} from '@angular/core';
+import {
+  DebounceTimer,
+  Resource,
+  ResourceRef,
+  ResourceSnapshot,
+  Signal,
+  debounced,
+} from '@angular/core';
 import {FieldNode} from '../../../field/node';
 import {addDefaultField} from '../../../field/validation';
 import {FieldPathNode} from '../../../schema/path_node';
@@ -121,12 +128,13 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
   opts: AsyncValidatorOptions<TValue, TParams, TResult, TPathKind>,
 ): void {
   assertPathIsCurrent(path);
+  let debouncedResource: Resource<TParams | undefined> | undefined = undefined;
   const pathNode = FieldPathNode.unwrapFieldPath(path);
 
   const RESOURCE = createManagedMetadataKey<ReturnType<typeof opts.factory>, TParams | undefined>(
     (_state, params) => {
       if (opts.debounce !== undefined) {
-        const debouncedResource = debounced(() => params(), opts.debounce);
+        debouncedResource = debounced(() => params(), opts.debounce);
         return opts.factory(debouncedResource.value);
       }
       return opts.factory(params);
@@ -145,6 +153,11 @@ export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKi
 
   pathNode.builder.addAsyncErrorRule((ctx) => {
     const res = ctx.state.metadata(RESOURCE)!;
+
+    if (debouncedResource?.isLoading()) {
+      return 'pending';
+    }
+
     let errors;
     switch (res.status()) {
       case 'idle':

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -507,4 +507,69 @@ describe('resources', () => {
 
     expect(success).toBeTrue();
   });
+
+  it('should report pending during debounce window', async () => {
+    const model = signal({username: ''});
+    const f = form(
+      model,
+      (path) => {
+        validateAsync(path.username, {
+          params: ({value}) => value(),
+          factory: (params) => resource({params, loader: async () => true}),
+          debounce: 500,
+          onSuccess: () => ({kind: 'invalid'}),
+          onError: () => null,
+        });
+      },
+      {injector},
+    );
+
+    model.set({username: 'john'});
+    TestBed.tick();
+
+    // During debounce window — should already be pending
+    expect(f.username().pending()).toBe(true);
+
+    await timeout(500);
+    TestBed.tick();
+    await appRef.whenStable();
+
+    expect(f.username().pending()).toBe(false);
+  });
+
+  it('should stay pending if multiple changes happen within debounce window', async () => {
+    const model = signal({username: ''});
+    const f = form(
+      model,
+      (path) => {
+        validateAsync(path.username, {
+          params: ({value}) => value(),
+          factory: (params) => resource({params, loader: async () => true}),
+          debounce: 50,
+          onSuccess: () => ({kind: 'invalid'}),
+          onError: () => null,
+        });
+      },
+      {injector},
+    );
+
+    model.set({username: 'j'});
+    TestBed.tick();
+    expect(f.username().pending()).toBe(true);
+
+    await timeout(200);
+    model.set({username: 'jo'});
+    TestBed.tick();
+    expect(f.username().pending()).toBe(true);
+
+    await timeout(200);
+    model.set({username: 'joh'});
+    TestBed.tick();
+    expect(f.username().pending()).toBe(true);
+
+    await timeout(500);
+    TestBed.tick();
+    await appRef.whenStable();
+    expect(f.username().pending()).toBe(false);
+  });
 });


### PR DESCRIPTION
Previously, the pending state on a form field using validateAsync with debounce option was only set once the debounce duration elapsed and the HTTP call started. During the debounce window the field incorrectly reported pending as false, and stale validation errors from the previous value lingered until the debounce fired.

Fix by wrapping the resource returned from the factory with a computed status that returns 'loading' while the debounced params signal is still catching up (debouncedParams.isLoading()), falling back to the inner resource status otherwise.

This means:
- form.field().pending() === true immediately on the first keystroke
- Stale errors from the previous value disappear as soon as the user changes the input, not after the debounce duration

Fixes #68105

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #68105

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
