### PR TITLE
refactor(compiler-cli): allow external TCBs with copied content

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -61,7 +61,7 @@ export {
 } from './src/ngtsc/reflection';
 export {isFatalDiagnosticError} from './src/ngtsc/diagnostics';
 export {PerfPhase} from './src/ngtsc/perf';
-export {type FileUpdate, type ProgramDriver} from './src/ngtsc/program_driver';
+export {type FileUpdate, InliningMode, type ProgramDriver} from './src/ngtsc/program_driver';
 export {TrackedIncrementalBuildStrategy} from './src/ngtsc/incremental';
 export {isShim} from './src/ngtsc/shims';
 export {getRootDirs} from './src/ngtsc/util/src/typescript';

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -87,7 +87,7 @@ import {
   PerfEvent,
   PerfPhase,
 } from '../../perf';
-import {FileUpdate, ProgramDriver, UpdateMode} from '../../program_driver';
+import {FileUpdate, InliningMode, ProgramDriver, UpdateMode} from '../../program_driver';
 import {DeclarationNode, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {AdapterResourceLoader} from '../../resource';
 import {
@@ -1880,6 +1880,10 @@ class NotifyingProgramDriverWrapper implements ProgramDriver {
     private notifyNewProgram: (program: ts.Program) => void,
   ) {
     this.getSourceFileVersion = this.delegate.getSourceFileVersion?.bind(this);
+  }
+
+  get inliningMode(): InliningMode {
+    return this.delegate.inliningMode;
   }
 
   get supportsInlineOperations() {

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/api.ts
@@ -32,7 +32,21 @@ export interface MaybeSourceFileWithOriginalFile extends ts.SourceFile {
   [NgOriginalFile]?: ts.SourceFile;
 }
 
+/**
+ * How a type-checking context should handle operations which would require inlining.
+ */
+export enum InliningMode {
+  InlineOps,
+  Error,
+  CopySourceToTcb,
+}
+
 export interface ProgramDriver {
+  /**
+   * How this strategy handles operations that require inlining.
+   */
+  readonly inliningMode: InliningMode;
+
   /**
    * Whether this strategy supports modifying user files (inline modifications) in addition to
    * modifying type-checking shims.

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -14,6 +14,7 @@ import {RequiredDelegations, toUnredirectedSourceFile} from '../../util/src/type
 
 import {
   FileUpdate,
+  InliningMode,
   MaybeSourceFileWithOriginalFile,
   NgOriginalFile,
   ProgramDriver,
@@ -27,10 +28,10 @@ import {
  * If a new method is added to `ts.CompilerHost` which is not delegated, a type error will be
  * generated for this class.
  */
-export class DelegatingCompilerHost
-  implements
-    Omit<RequiredDelegations<ts.CompilerHost>, 'getSourceFile' | 'fileExists' | 'writeFile'>
-{
+export class DelegatingCompilerHost implements Omit<
+  RequiredDelegations<ts.CompilerHost>,
+  'getSourceFile' | 'fileExists' | 'writeFile'
+> {
   createHash;
   directoryExists;
   getCancellationToken;
@@ -212,7 +213,14 @@ export class TsCreateProgramDriver implements ProgramDriver {
     this.program = this.originalProgram;
   }
 
-  readonly supportsInlineOperations = true;
+  inliningMode = InliningMode.InlineOps;
+
+  get supportsInlineOperations(): boolean {
+    return (
+      this.inliningMode === InliningMode.InlineOps ||
+      this.inliningMode === InliningMode.CopySourceToTcb
+    );
+  }
 
   getProgram(): ts.Program {
     return this.program;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -107,7 +107,6 @@ import {makeTemplateDiagnostic} from '../diagnostics';
 
 import {CompletionEngine} from './completion';
 import {
-  InliningMode,
   ShimTypeCheckingData,
   TypeCheckData,
   TypeCheckContextImpl,
@@ -627,6 +626,9 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       }
 
       for (const [shimPath, shimRecord] of fileRecord.shimData) {
+        // TODO(atscott): Filter out diagnostics from original source in CopySourceToTcb
+        // We don't want to duplicate diagnostics from original source when copying to tcb
+
         const shimSf = getSourceFileOrError(typeCheckProgram, shimPath);
         diagnostics.push(
           ...typeCheckProgram
@@ -993,16 +995,13 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
   }
 
   private newContext(host: TypeCheckingHost): TypeCheckContextImpl {
-    const inlining = this.programDriver.supportsInlineOperations
-      ? InliningMode.InlineOps
-      : InliningMode.Error;
     return new TypeCheckContextImpl(
       this.config,
       this.compilerHost,
       this.refEmitter,
       this.reflector,
       host,
-      inlining,
+      this.programDriver.inliningMode,
       this.perf,
     );
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -30,7 +30,7 @@ import {ErrorCode, makeDiagnostic, ngErrorCode} from '../../../../src/ngtsc/diag
 import {absoluteFromSourceFile, AbsoluteFsPath} from '../../file_system';
 import {Reference, ReferenceEmitter} from '../../imports';
 import {PerfEvent, PerfRecorder} from '../../perf';
-import {FileUpdate} from '../../program_driver';
+import {FileUpdate, InliningMode} from '../../program_driver';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import {ImportManager} from '../../translator';
 import {
@@ -125,6 +125,11 @@ export interface PendingFileTypeCheckingData {
    * Map of in-progress shim data for shims generated from this input file.
    */
   shimData: Map<AbsoluteFsPath, PendingShimData>;
+
+  /**
+   * The original source file.
+   */
+  sourceFile?: ts.SourceFile;
 }
 
 export interface PendingShimData {
@@ -186,21 +191,6 @@ export interface TypeCheckingHost {
    * is, coverage for the file can be considered complete.
    */
   recordComplete(sfPath: AbsoluteFsPath): void;
-}
-
-/**
- * How a type-checking context should handle operations which would require inlining.
- */
-export enum InliningMode {
-  /**
-   * Use inlining operations when required.
-   */
-  InlineOps,
-
-  /**
-   * Produce diagnostics if an operation would require inlining.
-   */
-  Error,
 }
 
 /**
@@ -391,11 +381,16 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     this.perf.eventCount(PerfEvent.GenerateTcb);
     if (
       inliningRequirement !== TcbInliningRequirement.None &&
-      this.inlining === InliningMode.InlineOps
+      (this.inlining === InliningMode.InlineOps || this.inlining === InliningMode.CopySourceToTcb)
     ) {
-      // This class didn't meet the requirements for external type checking, so generate an inline
-      // TCB for the class.
+      // Queue operations for both inline and copy strategy!
+      // The decision on where to apply them will be made in finalize().
       this.addInlineTypeCheckBlock(fileData, shimData, ref, meta);
+
+      if (this.inlining === InliningMode.CopySourceToTcb) {
+        // Still set the original file path to force local references for symbols from this file.
+        shimData.file.copiedSourceOriginPath = absoluteFromSourceFile(sourceFile);
+      }
     } else if (
       inliningRequirement === TcbInliningRequirement.ShouldInlineForGenericBounds &&
       this.inlining === InliningMode.Error
@@ -451,18 +446,9 @@ export class TypeCheckContextImpl implements TypeCheckContext {
   }
 
   /**
-   * Transform a `ts.SourceFile` into a version that includes type checking code.
-   *
-   * If this particular `ts.SourceFile` requires changes, the text representing its new contents
-   * will be returned. Otherwise, a `null` return indicates no changes were necessary.
+   * Applies operations to a file.
    */
-  transform(sf: ts.SourceFile): string | null {
-    // If there are no operations pending for this particular file, return `null` to indicate no
-    // changes.
-    if (!this.opMap.has(sf)) {
-      return null;
-    }
-
+  private executeOperations(targetSf: ts.SourceFile, opsSourceSf: ts.SourceFile): string {
     // Use a `ts.Printer` to generate source code.
     const printer = ts.createPrinter({omitTrailingSemicolon: true});
 
@@ -479,39 +465,43 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     // Execute ops.
     // Each Op has a splitPoint index into the text where it needs to be inserted.
     const updates: {pos: number; deletePos?: number; text: string}[] = this.opMap
-      .get(sf)!
+      .get(opsSourceSf)!
       .map((op) => {
         return {
           pos: op.splitPoint,
-          text: op.execute(importManager, sf, this.refEmitter),
+          text: op.execute(importManager, targetSf, this.refEmitter),
         };
       });
 
     const {newImports, updatedImports} = importManager.finalize();
 
     // Capture new imports
-    if (newImports.has(sf.fileName)) {
-      newImports.get(sf.fileName)!.forEach((newImport) => {
+    if (newImports.has(targetSf.fileName)) {
+      newImports.get(targetSf.fileName)!.forEach((newImport) => {
         updates.push({
           pos: 0,
-          text: printer.printNode(ts.EmitHint.Unspecified, newImport, sf),
+          text: printer.printNode(ts.EmitHint.Unspecified, newImport, targetSf),
         });
       });
     }
 
     // Capture updated imports
     for (const [oldBindings, newBindings] of updatedImports.entries()) {
-      if (oldBindings.getSourceFile() !== sf) {
+      if (oldBindings.getSourceFile() !== targetSf) {
         throw new Error('Unexpected updates to unrelated source files.');
       }
       updates.push({
         pos: oldBindings.getStart(),
         deletePos: oldBindings.getEnd(),
-        text: printer.printNode(ts.EmitHint.Unspecified, newBindings, sf),
+        text: printer.printNode(ts.EmitHint.Unspecified, newBindings, targetSf),
       });
     }
 
-    const result = new MagicString(sf.text, {filename: sf.fileName});
+    // TODO: Consider generating a sourcemap here via `result.generateMap()`.
+    // This could be used in `CopySourceToTcb` mode to map positions in the shim file
+    // back to the original source file, helping with language features like "Go to Definition"
+    // and diagnostic translation.
+    const result = new MagicString(targetSf.text, {filename: targetSf.fileName});
     for (const update of updates) {
       if (update.deletePos !== undefined) {
         result.remove(update.pos, update.deletePos);
@@ -521,11 +511,35 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     return result.toString();
   }
 
+  /**
+   * Generates the transformed text for an original source file.
+   */
+  private generateTransformedOriginalFile(sf: ts.SourceFile): string | null {
+    if (this.inlining !== InliningMode.InlineOps || !this.opMap.has(sf)) {
+      return null;
+    }
+    return this.executeOperations(sf, sf);
+  }
+
+  /**
+   * Generates the content for a shim file that copies the source of the original file.
+   */
+  private generateCopiedShimContent(
+    originalSf: ts.SourceFile,
+    shimFileName: string,
+  ): string | null {
+    if (this.inlining !== InliningMode.CopySourceToTcb || !this.opMap.has(originalSf)) {
+      return null;
+    }
+    const fakeSf = ts.createSourceFile(shimFileName, originalSf.text, ts.ScriptTarget.Latest, true);
+    return this.executeOperations(fakeSf, originalSf);
+  }
+
   finalize(): Map<AbsoluteFsPath, FileUpdate> {
     // First, build the map of updates to source files.
     const updates = new Map<AbsoluteFsPath, FileUpdate>();
     for (const originalSf of this.opMap.keys()) {
-      const newText = this.transform(originalSf);
+      const newText = this.generateTransformedOriginalFile(originalSf);
       if (newText !== null) {
         updates.set(absoluteFromSourceFile(originalSf), {
           newText,
@@ -553,6 +567,19 @@ export class TypeCheckContextImpl implements TypeCheckContext {
           path: pendingShimData.file.fileName,
           data: pendingShimData.data,
         });
+
+        // Set the source content on the shim file before rendering!
+        const originalSf = pendingFileData.sourceFile;
+        if (originalSf !== undefined) {
+          const transformedText = this.generateCopiedShimContent(
+            originalSf,
+            pendingShimData.file.fileName,
+          );
+          if (transformedText !== null) {
+            pendingShimData.file.setSourceContent(transformedText);
+          }
+        }
+
         const sfText = pendingShimData.file.render();
         updates.set(pendingShimData.file.fileName, {
           newText: sfText,
@@ -587,6 +614,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         shimData.oobRecorder,
       ),
     );
+
     fileData.hasInlines = true;
   }
 
@@ -615,6 +643,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         hasInlines: false,
         sourceManager: this.host.getSourceManager(sfPath),
         shimData: new Map(),
+        sourceFile: sf,
       };
       this.fileMap.set(sfPath, data);
     }
@@ -690,8 +719,12 @@ class InlineTcbOp implements Op {
     return this.ref.node.end + 1;
   }
 
-  execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter): string {
-    const env = new Environment(this.config, im, refEmitter, sf);
+  execute(im: ImportManager, tcbSf: ts.SourceFile, refEmitter: ReferenceEmitter): string {
+    const env = new Environment(this.config, im, refEmitter, tcbSf);
+    const originalSf = this.ref.node.getSourceFile();
+    if (tcbSf !== originalSf) {
+      env.copiedSourceOriginPath = absoluteFromSourceFile(originalSf);
+    }
     const fnName = `_tcb_${this.ref.node.pos}`;
 
     const {tcbMeta, component} = adaptTypeCheckBlockMetadata(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -15,6 +15,7 @@ import {
   TypeCtorMetadata,
 } from '@angular/compiler';
 import ts from 'typescript';
+import {AbsoluteFsPath} from '../../file_system';
 
 import {ReferenceEmitter} from '../../imports';
 
@@ -46,13 +47,17 @@ export class Environment extends ReferenceEmitEnvironment {
   private pipeInsts = new Map<TcbReferenceKey, string>();
   protected pipeInstStatements: TcbExpr[] = [];
 
+  copiedSourceOriginPath?: AbsoluteFsPath;
+
   constructor(
     readonly config: TypeCheckingConfig,
     importManager: ImportManager,
     refEmitter: ReferenceEmitter,
     contextFile: ts.SourceFile,
+    copiedSourceOriginPath?: AbsoluteFsPath,
   ) {
     super(importManager, refEmitter, contextFile);
+    this.copiedSourceOriginPath = copiedSourceOriginPath;
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
@@ -89,7 +89,7 @@ export function adaptTypeCheckBlockMetadata(
     if (refCache.has(ref)) {
       return refCache.get(ref)!;
     }
-    const result = extractReferenceMetadata(ref, env.refEmitter, env.contextFile);
+    const result = extractReferenceMetadata(ref, env);
     refCache.set(ref, result);
     return result;
   };
@@ -312,15 +312,55 @@ function adaptGenerics(
 
 function extractReferenceMetadata(
   ref: Reference<ClassDeclaration>,
-  refEmitter: ReferenceEmitter,
-  contextFile: ts.SourceFile,
+  env: Environment,
 ): TcbReferenceMetadata {
   let name = ref.debugName || ref.node.name!.text;
   let moduleName = ref.ownedByModuleGuess;
   let unexportedDiagnostic: string | null = null;
   let isLocal = true;
 
-  const emitted = refEmitter.emit(ref, contextFile, ImportFlags.NoAliasing);
+  // When the compiler operates in `CopySourceToTcb` mode, it creates a separate shim file
+  // and copies the entire source content of the original file into it. From a pure text
+  // perspective in that shim file, the original classes are local.
+  //
+  // However, during the generation phase here, the compiler is still working with the
+  // AST nodes of the original file. So, `ref.node.getSourceFile()` returns the original
+  // file, not the shim file. If we fall through to standard reference resolution below,
+  // the emitter would assume it needs to generate an import (because the target file and
+  // source file don't match in AST terms). For non-exported symbols, that auto-import
+  // would fail.
+  //
+  // This condition acts as a bridge between AST reality and the physical file text:
+  // it identifies that the class is local because its text was copied to this shim,
+  // and it ensures we just output the class name directly rather than an import.
+  if (env.copiedSourceOriginPath !== undefined) {
+    const refFile = ref.node.getSourceFile().fileName;
+    if (refFile === env.copiedSourceOriginPath) {
+      const nodeName = ref.node?.name as ts.Identifier | undefined;
+      const nodeNameSpan = nodeName
+        ? new AbsoluteSourceSpan(nodeName.getStart(), nodeName.getEnd())
+        : undefined;
+
+      let key: TcbReferenceKey;
+      if (nodeNameSpan !== undefined) {
+        key = `${refFile}#${nodeNameSpan.start}` as TcbReferenceKey;
+      } else {
+        key = name as TcbReferenceKey;
+      }
+
+      return {
+        name,
+        moduleName: null,
+        isLocal: true,
+        unexportedDiagnostic: null,
+        nodeNameSpan,
+        nodeFilePath: refFile,
+        key,
+      } satisfies TcbReferenceMetadata;
+    }
+  }
+
+  const emitted = env.refEmitter.emit(ref, env.contextFile, ImportFlags.NoAliasing);
   if (emitted.kind === ReferenceEmitKind.Success) {
     if (emitted.expression instanceof ExternalExpr) {
       name = emitted.expression.value.name!;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -37,6 +37,14 @@ export class TypeCheckFile extends Environment {
   readonly isTypeCheckFile = true;
   private nextTcbId = 1;
   private tcbStatements: string[] = [];
+  private sourceContent: string = '';
+  get hasCopiedSource() {
+    return this.copiedSourceOriginPath !== undefined;
+  }
+
+  setSourceContent(text: string) {
+    this.sourceContent = text;
+  }
 
   constructor(
     readonly fileName: AbsoluteFsPath,
@@ -105,7 +113,7 @@ export class TypeCheckFile extends Environment {
     }
 
     const printer = ts.createPrinter();
-    let source = '';
+    let source = this.sourceContent;
 
     const newImports = importChanges.newImports.get(this.contextFile.fileName);
     if (newImports !== undefined) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -21,6 +21,8 @@ import {
 } from '../../imports';
 import {OptimizeFor} from '../api';
 import {ALL_ENABLED_CONFIG, diagnose, setup, tcb, TestDeclaration, TestDirective} from '../testing';
+import {InliningMode} from '../../program_driver';
+import {TypeCheckShimGenerator} from '../src/shim';
 
 describe('type check blocks', () => {
   beforeEach(() => initMockFileSystem('Native'));
@@ -2520,6 +2522,57 @@ describe('type check blocks', () => {
         `import { Component, ɵINPUT_SIGNAL_BRAND_WRITE_TYPE } from '@angular/core'; // should be re-used`,
       );
       expect(testSf.text).toContain(`[ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]`);
+    });
+
+    function removeSpans(text: string): string {
+      return text.replace(/\/\*[\s\S]*?\*\//g, '');
+    }
+
+    it('should copy source content to shim file in CopySourceToTcb mode', () => {
+      const TEMPLATE = '<div>{{hello}}</div>';
+      const {templateTypeChecker, program, programStrategy} = setup(
+        [
+          {
+            fileName: absoluteFrom('/test.ts'),
+            templates: {'AppComponent': TEMPLATE},
+            // Use non-exported class to force inlining need
+            source: `
+              import {Component} from '@angular/core';
+              class AppComponent {
+                hello = 'world';
+              }
+            `,
+          },
+        ],
+        {
+          inliningMode: InliningMode.CopySourceToTcb,
+        },
+      );
+
+      // Trigger type check block generation.
+      templateTypeChecker.getDiagnosticsForFile(
+        getSourceFileOrError(program, absoluteFrom('/test.ts')),
+        OptimizeFor.SingleFile,
+      );
+
+      const typeCheckProgram = programStrategy.getProgram();
+      const originalSf = getSourceFileOrError(typeCheckProgram, absoluteFrom('/test.ts'));
+      const shimSf = getSourceFileOrError(
+        typeCheckProgram,
+        TypeCheckShimGenerator.shimFor(absoluteFrom('/test.ts')),
+      );
+
+      // Original file should NOT contain the TCB
+      expect(originalSf.text).not.toContain('function tcb');
+
+      // Shim file SHOULD contain the copied source and the TCB
+      expect(shimSf.text).toContain('class AppComponent');
+      expect(shimSf.text).toContain('function _tcb_');
+
+      // Verify that the TCB contains the binding check
+      // The TCB contains spans in comments, so we clean them up for the assertion.
+      const cleanShimText = removeSpans(shimSf.text);
+      expect(cleanShimText).toContain('"" + (((this).hello');
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -10,6 +10,7 @@ import {ClassPropertyMapping, TcbInputMapping} from '@angular/compiler';
 
 import {
   absoluteFrom,
+  absoluteFromSourceFile,
   getFileSystem,
   getSourceFileOrError,
   LogicalFileSystem,
@@ -26,18 +27,14 @@ import {
 } from '../../imports';
 import {InputMapping} from '../../metadata';
 import {NOOP_PERF_RECORDER} from '../../perf';
-import {TsCreateProgramDriver, UpdateMode} from '../../program_driver';
+import {InliningMode, TsCreateProgramDriver, UpdateMode} from '../../program_driver';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
 import {getRootDirs} from '../../util/src/typescript';
-import {
-  InliningMode,
-  PendingFileTypeCheckingData,
-  TypeCheckContextImpl,
-  TypeCheckingHost,
-} from '../src/context';
+import {PendingFileTypeCheckingData, TypeCheckContextImpl, TypeCheckingHost} from '../src/context';
 import {DirectiveSourceManager} from '../src/source';
 import {TypeCheckFile} from '../src/type_check_file';
+import {TypeCheckShimGenerator} from '../src/shim';
 import {ALL_ENABLED_CONFIG} from '../testing';
 
 runInEachFileSystem(() => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -73,7 +73,7 @@ import {
   PipeMeta,
 } from '../../metadata';
 import {NOOP_PERF_RECORDER} from '../../perf';
-import {TsCreateProgramDriver} from '../../program_driver';
+import {InliningMode, TsCreateProgramDriver} from '../../program_driver';
 import {
   AmbientImport,
   ClassDeclaration,
@@ -520,6 +520,7 @@ export function setup(
     config?: Partial<TypeCheckingConfig>;
     options?: ts.CompilerOptions;
     inlining?: boolean;
+    inliningMode?: InliningMode;
     parseOptions?: ParseTemplateOptions;
     referenceEmitter?: ReferenceEmitter;
   } = {},
@@ -670,8 +671,12 @@ export function setup(
   });
 
   const programStrategy = new TsCreateProgramDriver(program, host, options, ['ngtypecheck']);
-  if (overrides.inlining !== undefined) {
-    (programStrategy as any).supportsInlineOperations = overrides.inlining;
+  if (overrides.inliningMode !== undefined) {
+    (programStrategy as any).inliningMode = overrides.inliningMode;
+  } else if (overrides.inlining !== undefined) {
+    (programStrategy as any).inliningMode = overrides.inlining
+      ? InliningMode.InlineOps
+      : InliningMode.Error;
   }
 
   const fakeScopeReader: ComponentScopeReader = {

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -19,6 +19,7 @@ import {
   isNamedClassDeclaration,
   ngErrorCode,
   NgCompiler,
+  InliningMode,
   OptimizeFor,
   PerfPhase,
   ProgramDriver,
@@ -1035,6 +1036,8 @@ function detectAngularCoreVersion(
 
 function createProgramDriver(project: ts.server.Project): ProgramDriver {
   return {
+    // TODO: switch to CopySourceToTcb
+    inliningMode: InliningMode.Error,
     supportsInlineOperations: false,
     getProgram(): ts.Program {
       const program = project.getLanguageService().getProgram();


### PR DESCRIPTION
This change allows environments that cannot support inline TCBs (such as the language service or source-to-source transforms where TS compilation and emit are downstream) to still perform template type checking.

Instead of inlining the TCB into the original source file when non-exported symbols are referenced, we now copy the file content to the .ngtypecheck.ts shim file and generate the external TCB there. This preserves the local scope of the original file while keeping the original file unmodified.
