### PR TITLE
fix(core): respect ngSkipHydration on components with projectable nodes in LContainers

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -442,10 +442,24 @@ function serializeLContainer(
       }
 
       if (!isHydrateNeverBlock) {
-        Object.assign(
-          serializedView,
-          serializeLView(lContainer[i] as LView, parentDeferBlockId, context),
-        );
+        // Skip serialization for component views that opted out of hydration via
+        // ngSkipHydration. This mirrors the guard in serializeLView for inline
+        // child components (see the Array.isArray branch below), but applies to
+        // components hosted inside an LContainer (e.g. created via
+        // ViewContainerRef.createComponent). Without this check, NG0503 is thrown
+        // when such a component receives projectable nodes even if ngSkipHydration
+        // is present on its host element (#67928).
+        const childHostElement = unwrapRNode(childLView[HOST]!);
+        if (
+          childLView[TVIEW].type !== TViewType.Component ||
+          childHostElement === null ||
+          !(childHostElement as HTMLElement).hasAttribute(SKIP_HYDRATION_ATTR_NAME)
+        ) {
+          Object.assign(
+            serializedView,
+            serializeLView(lContainer[i] as LView, parentDeferBlockId, context),
+          );
+        }
       }
     }
 

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -5859,6 +5859,36 @@ describe('platform-server full application hydration integration', () => {
         }
       });
 
+      it('should not throw when ngSkipHydration is set on a component with projectable nodes created via ViewContainerRef.createComponent', async () => {
+        // Regression test for #67928: NG0503 was thrown during serialization even
+        // when ngSkipHydration was applied to a dynamically created component that
+        // received projectable nodes, because serializeLContainer did not respect
+        // the skip-hydration flag before calling serializeLView.
+        @Component({
+          selector: 'dynamic',
+          template: `<ng-content />`,
+          host: {'ngSkipHydration': 'true'},
+        })
+        class DynamicComponent {}
+
+        @Component({
+          selector: 'app',
+          template: `<div #anchor></div>`,
+        })
+        class SimpleComponent {
+          @ViewChild('anchor', {read: ViewContainerRef}) vcr!: ViewContainerRef;
+
+          ngAfterViewInit() {
+            const div = document.createElement('div');
+            this.vcr.createComponent(DynamicComponent, {projectableNodes: [[div]]});
+          }
+        }
+
+        // Before the fix this threw NG0503. After the fix it should succeed.
+        const html = await ssr(SimpleComponent);
+        expect(html).toContain('<dynamic');
+      });
+
       it('should support cases when <ng-content> is used with *ngIf="false"', async () => {
         @Component({
           selector: 'projector-cmp',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #67928

When a component is created dynamically via `ViewContainerRef.createComponent` and receives projectable nodes, applying `ngSkipHydration` to its host element does not prevent `NG0503` from being thrown during SSR serialization. The error fires even though the developer has followed the documented workaround.

## What is the new behavior?

`ngSkipHydration` is now respected for components hosted inside an `LContainer`. When such a component's host element carries the `ngSkipHydration` attribute, `serializeLContainer` skips calling `serializeLView` for it — the same way `serializeLView` already skips inline child components with `ngSkipHydration`.

## Root cause

There is an asymmetry in the serialization pipeline between inline components and dynamically created ones:

- **Inline components** (`Array.isArray(lView[i])` branch in `serializeLView`): before calling `annotateHostElementForHydration`, the code checks whether the host element has `ngSkipHydration` and bails out early if so. The component's lView is never serialized.

- **LContainer-hosted components** (`serializeLContainer`): `serializeLView` was called unconditionally with no equivalent guard. When `serializeLView` later walked the component's projection slots and found a raw DOM node array (the projectable nodes), it threw `NG0503` — regardless of whether `ngSkipHydration` was present.

The fix adds the missing guard in `serializeLContainer`: before calling `serializeLView` for a component lView, check whether the host element opts out of hydration, and skip if it does.

## Does this PR introduce a breaking change?

- [x] No

## Other information

A regression test was added that reproduces the original failure: a component decorated with `ngSkipHydration` receives a raw DOM node as a projectable node via `ViewContainerRef.createComponent`. Before this fix the test threw `NG0503`; after the fix SSR completes successfully and the component is present in the output.