### PR TITLE
docs: use inject() in @Self example in hierarchical DI guide

### DIFF
--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -232,7 +232,7 @@ In this case, the injector looks no further than the current `ElementInjector` b
   providers: [{provide: FlowerService, useValue: {emoji: '🌷'}}],
 })
 export class Self {
-  constructor(@Self() public flower: FlowerService) {}
+  public flower = inject(FlowerService, {self: true});
 }
 ```
 


### PR DESCRIPTION
The surrounding @SkipSelf and @Host examples already use inject(), and the section intro recommends it. Align the @Self example to match.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `@Self()` example in the "Resolution modifiers" section of the hierarchical DI guide uses constructor-based injection (`constructor(@Self() public flower: FlowerService) {}`), while the section intro recommends using each modifier in the `inject()` configuration, and the surrounding `@SkipSelf` and `@Host` examples (and the other `@Self` example in the same section) already use the `inject()` form.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The `@Self()` example now uses `inject(FlowerService, {self: true})`, matching the surrounding examples and the section's stated guidance. The dedicated "Modifiers with constructor injection" subsection still documents the legacy decorator-based form.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
