### PR TITLE
feat(core): introduce `@repeat` control flow block

### DIFF
--- a/adev/src/content/guide/components/content-projection.md
+++ b/adev/src/content/guide/components/content-projection.md
@@ -74,7 +74,7 @@ placeholder that tells Angular where to render content. Angular's compiler proce
 all `<ng-content>` elements at build-time. You cannot insert, remove, or modify `<ng-content>` at
 run time. You cannot add directives, styles, or arbitrary attributes to `<ng-content>`.
 
-IMPORTANT: You should not conditionally include `<ng-content>` with `@if`, `@for`, or `@switch`. Angular always
+IMPORTANT: You should not conditionally include `<ng-content>` with `@if`, `@for`, `@repeat`, or `@switch`. Angular always
 instantiates and creates DOM nodes for content rendered to a `<ng-content>` placeholder, even if
 that `<ng-content>` placeholder is hidden. For conditional rendering of component content,
 see [Template fragments](api/core/ng-template).

--- a/adev/src/content/guide/templates/control-flow.md
+++ b/adev/src/content/guide/templates/control-flow.md
@@ -105,6 +105,57 @@ You can optionally include an `@empty` section immediately after the `@for` bloc
 }
 ```
 
+## Repeat content with the `@repeat` block
+
+The `@repeat` block repeatedly renders the content of a block for a numeric count. Use `@repeat` when you need a fixed number of views and do not have a collection to loop over.
+
+```angular-html
+@repeat (2) {
+  <button>Click me</button>
+}
+```
+
+The count expression can be dynamic. Angular updates the repeated views when the expression value changes:
+
+```angular-html
+@repeat (columns(); let col = $index) {
+  <div class="skeleton-cell" [style.grid-column]="col + 1"></div>
+}
+```
+
+Values of zero render no views. `null` and `undefined` also render no views. Non-integer values are truncated toward zero, matching the behavior of `String.prototype.repeat`. Negative counts and `Infinity` throw [NG0957](errors/NG0957).
+
+Unlike `@for`, `@repeat` does not require or support a `track` expression. The identity of each view is its `$index`.
+
+### Contextual variables in `@repeat` blocks
+
+Inside `@repeat` blocks, several implicit variables are always available:
+
+| Variable | Meaning                                   |
+| -------- | ----------------------------------------- |
+| `$count` | Number of views rendered by the block     |
+| `$index` | Index of the current view                 |
+| `$first` | Whether the current view is the first one |
+| `$last`  | Whether the current view is the last one  |
+| `$even`  | Whether the current view index is even    |
+| `$odd`   | Whether the current view index is odd     |
+
+These variables are always available with these names, but can be aliased via a `let` segment:
+
+```angular-html
+@repeat (rows(); let row = $index) {
+  @repeat (columns(); let col = $index) {
+    <cell-component [row]="row" [col]="col" />
+  }
+}
+```
+
+When blocks are nested, contextual variables follow normal template scoping rules. An inner `@repeat` shadows `$index` from an outer `@repeat`; alias the outer value when it needs to be read inside the inner block.
+
+Queries such as `viewChild`, `viewChildren`, `contentChild`, and `contentChildren` update when `@repeat` creates or removes embedded views. Use required queries only when the count is guaranteed to be greater than zero.
+
+IMPORTANT: Do not place `<ng-content>` directly inside an `@repeat` block. Angular processes content projection at build-time and projected content is not cloned for each repeated view. For conditional or repeated rendering of component content, use [Template fragments](api/core/ng-template).
+
 ## Conditionally display content with the `@switch` block
 
 While the `@if` block is great for most scenarios, the `@switch` block provides an alternate syntax to conditionally render data. Its syntax closely resembles JavaScript's `switch` statement.

--- a/adev/src/content/reference/errors/NG0957.md
+++ b/adev/src/content/reference/errors/NG0957.md
@@ -1,0 +1,46 @@
+# Invalid `@repeat` count.
+
+The `@repeat` block received a count value that is negative or infinite.
+
+```angular-ts
+@Component({
+  template: `
+    @repeat (columns()) {
+      <div class="skeleton-cell"></div>
+    }
+  `,
+})
+class Test {
+  columns = signal(-1);
+}
+```
+
+In this example, `columns()` evaluates to `-1`. Angular cannot render a negative number of
+embedded views, so the `@repeat` block throws this error.
+
+## Fixing the error
+
+Make sure the `@repeat` expression evaluates to a non-negative finite number. Non-integer values
+are truncated toward zero, matching the behavior of `String.prototype.repeat`.
+
+```angular-ts
+@Component({
+  template: `
+    @repeat (columns()) {
+      <div class="skeleton-cell"></div>
+    }
+  `,
+})
+class Test {
+  // 3.5 is valid and renders 3 views
+  columns = signal(3.5);
+}
+```
+
+If the value comes from user input or another calculation, clamp it before passing it to `@repeat`.
+
+```angular-ts
+columns = computed(() => Math.max(0, Math.floor(Number(this.rawColumns()) || 0)));
+```
+
+Values of zero render no views. `null` and `undefined` also render no views.

--- a/adev/src/content/reference/errors/overview.md
+++ b/adev/src/content/reference/errors/overview.md
@@ -36,6 +36,7 @@
 | `NG0951`  | [Child query result is required but no value is available](errors/NG0951)            |
 | `NG0955`  | [Track expression resulted in duplicated keys for a given collection](errors/NG0955) |
 | `NG0956`  | [Tracking expression caused re-creation of the DOM structure](errors/NG0956)         |
+| `NG0957`  | [Invalid `@repeat` count](errors/NG0957)                                             |
 | `NG01002` | [Missing Control Value](errors/NG01002)                                              |
 | `NG01101` | [Wrong Async Validator Return Type](errors/NG01101)                                  |
 | `NG01203` | [Missing value accessor](errors/NG01203)                                             |

--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -160,6 +160,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     RENDERER_NOT_FOUND = 407,
     // (undocumented)
+    REPEAT_INVALID_COUNT = 957,
+    // (undocumented)
     REQUIRE_SYNC_WITHOUT_SYNC_EMIT = 601,
     // (undocumented)
     REQUIRED_INPUT_NO_VALUE = -950,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -28,6 +28,7 @@ import {
   TmplAstInteractionDeferredTrigger,
   TmplAstLetDeclaration,
   TmplAstReference,
+  TmplAstRepeatBlock,
   TmplAstSwitchBlockCase,
   TmplAstTemplate,
   TmplAstTextAttribute,
@@ -44,7 +45,9 @@ import {makeTemplateDiagnostic} from '../diagnostics';
 import {TypeCheckSourceResolver} from './tcb_util';
 import {DOC_PAGE_BASE_URL} from '../../diagnostics/src/error_details_base_url';
 
-export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecorder<TemplateDiagnostic> {
+export class OutOfBandDiagnosticRecorderImpl
+  implements OutOfBandDiagnosticRecorder<TemplateDiagnostic>
+{
   private readonly _diagnostics: TemplateDiagnostic[] = [];
 
   /**
@@ -428,7 +431,8 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
       | TmplAstIfBlockBranch
       | TmplAstSwitchBlockCase
       | TmplAstForLoopBlock
-      | TmplAstForLoopBlockEmpty,
+      | TmplAstForLoopBlockEmpty
+      | TmplAstRepeatBlock,
     preservesWhitespaces: boolean,
   ): void {
     const blockName = controlFlowNode.nameSpan.toString().trim();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -783,6 +783,51 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should generate a basic repeat block",
+      "inputFiles": ["basic_repeat.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_repeat_template.js",
+              "generated": "basic_repeat.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should generate repeat block context variables ($index, $count, $first, $last, $even, $odd)",
+      "inputFiles": ["repeat_template_variables.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "repeat_template_variables_template.js",
+              "generated": "repeat_template_variables.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should generate nested repeat blocks with shadowed $index variables",
+      "inputFiles": ["nested_repeat.ts"],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "nested_repeat_template.js",
+              "generated": "nested_repeat.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_repeat.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_repeat.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    @repeat (3; let col = $index) {
+      {{col}}
+    }
+  `,
+    standalone: false
+})
+export class MyApp {}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_repeat_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_repeat_template.js
@@ -1,0 +1,18 @@
+function $repeatFn$(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $colVar$ = ctx.$index;
+    $r3$.ɵɵtextInterpolate1(" ", $colVar$, " ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, $repeatFn$, 1, 1, null, null, $r3$.ɵɵrepeaterTrackByIndex);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater($r3$.ɵɵrepeatCount(3));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_repeat.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_repeat.ts
@@ -1,0 +1,16 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    @repeat (rows; let row = $index) {
+      @repeat (cols; let col = $index) {
+        {{row}}:{{col}}
+      }
+    }
+  `,
+    standalone: false
+})
+export class MyApp {
+  rows = 2;
+  cols = 3;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_repeat_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_repeat_template.js
@@ -1,0 +1,28 @@
+function $innerRepeatFn$(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $rowVar$ = $r3$.ɵɵnextContext().$index;
+    const $colVar$ = ctx.$index;
+    $r3$.ɵɵtextInterpolate2(" ", $rowVar$, ":", $colVar$, " ");
+  }
+}
+…
+function $outerRepeatFn$(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, $innerRepeatFn$, 1, 2, null, null, $r3$.ɵɵrepeaterTrackByIndex);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater($r3$.ɵɵrepeatCount(ctx.cols));
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, $outerRepeatFn$, …, null, null, $r3$.ɵɵrepeaterTrackByIndex);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater($r3$.ɵɵrepeatCount(ctx.rows));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/repeat_template_variables.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/repeat_template_variables.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+@Component({
+    template: `
+    @repeat (columns; let i = $index, co = $count, f = $first, l = $last, ev = $even, o = $odd) {
+      {{i}}/{{co}}/{{f}}/{{l}}/{{ev}}/{{o}}
+    }
+  `,
+    standalone: false
+})
+export class MyApp {
+  columns = 4;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/repeat_template_variables_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/repeat_template_variables_template.js
@@ -1,0 +1,19 @@
+function $repeatFn$(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $idxVar$ = ctx.$index;
+    const $cntVar$ = ctx.$count;
+    $r3$.ɵɵtextInterpolate6(" ", $idxVar$, "/", $cntVar$, "/", $idxVar$ === 0, "/", $idxVar$ === $cntVar$ - 1, "/", $idxVar$ % 2 === 0, "/", $idxVar$ % 2 !== 0, " ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵrepeaterCreate(0, $repeatFn$, 1, 6, null, null, $r3$.ɵɵrepeaterTrackByIndex);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵrepeater($r3$.ɵɵrepeatCount(ctx.columns));
+  }
+}

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -115,6 +115,12 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
     this.visitAllTemplateNodes(block.children);
   }
 
+  visitRepeatBlock(block: t.RepeatBlock): void {
+    this.visit(block.expression);
+    this.visitAllTemplateNodes(block.contextVariables);
+    this.visitAllTemplateNodes(block.children);
+  }
+
   visitIfBlock(block: t.IfBlock): void {
     this.visitAllTemplateNodes(block.branches);
   }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -163,6 +163,7 @@ export {
   Element as TmplAstElement,
   ForLoopBlock as TmplAstForLoopBlock,
   ForLoopBlockEmpty as TmplAstForLoopBlockEmpty,
+  RepeatBlock as TmplAstRepeatBlock,
   HoverDeferredTrigger as TmplAstHoverDeferredTrigger,
   Icu as TmplAstIcu,
   IdleDeferredTrigger as TmplAstIdleDeferredTrigger,

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -145,6 +145,7 @@ const SUPPORTED_BLOCKS = [
   '@if',
   '@else', // Covers `@else if` as well
   '@for',
+  '@repeat',
   '@switch',
   '@case',
   '@default',

--- a/packages/compiler/src/render3/partial/component.ts
+++ b/packages/compiler/src/render3/partial/component.ts
@@ -274,6 +274,10 @@ class BlockPresenceVisitor extends RecursiveVisitor {
     this.hasBlocks = true;
   }
 
+  override visitRepeatBlock(): void {
+    this.hasBlocks = true;
+  }
+
   override visitSwitchBlock(): void {
     this.hasBlocks = true;
   }

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -526,6 +526,26 @@ export class ForLoopBlockEmpty extends BlockNode implements Node {
   }
 }
 
+export class RepeatBlock extends BlockNode implements Node {
+  constructor(
+    public expression: ASTWithSource,
+    public contextVariables: Variable[],
+    public children: Node[],
+    sourceSpan: ParseSourceSpan,
+    public mainBlockSpan: ParseSourceSpan,
+    startSourceSpan: ParseSourceSpan,
+    endSourceSpan: ParseSourceSpan | null,
+    nameSpan: ParseSourceSpan,
+    public i18n?: I18nMeta,
+  ) {
+    super(nameSpan, sourceSpan, startSourceSpan, endSourceSpan);
+  }
+
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitRepeatBlock(this);
+  }
+}
+
 export class IfBlock extends BlockNode implements Node {
   constructor(
     public branches: IfBlockBranch[],
@@ -756,6 +776,7 @@ export interface Visitor<Result = any> {
   visitSwitchExhaustiveCheck(block: SwitchExhaustiveCheck): Result;
   visitForLoopBlock(block: ForLoopBlock): Result;
   visitForLoopBlockEmpty(block: ForLoopBlockEmpty): Result;
+  visitRepeatBlock(block: RepeatBlock): Result;
   visitIfBlock(block: IfBlock): Result;
   visitIfBlockBranch(block: IfBlockBranch): Result;
   visitUnknownBlock(block: UnknownBlock): Result;
@@ -810,6 +831,10 @@ export class RecursiveVisitor implements Visitor<void> {
   }
   visitForLoopBlockEmpty(block: ForLoopBlockEmpty): void {
     visitAll(this, block.children);
+  }
+  visitRepeatBlock(block: RepeatBlock): void {
+    const blockItems = [...block.contextVariables, ...block.children];
+    visitAll(this, blockItems);
   }
   visitIfBlock(block: IfBlock): void {
     visitAll(this, block.branches);

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -8,6 +8,7 @@
 
 import {AST, ASTWithSource, EmptyExpr, RecursiveAstVisitor} from '../expression_parser/ast';
 import * as html from '../ml_parser/ast';
+import {isNgContent} from '../ml_parser/tags';
 import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
 
@@ -217,6 +218,47 @@ export function createForLoop(
   return {node, errors};
 }
 
+/** Creates a `repeat` block from an HTML AST node. */
+export function createRepeatBlock(
+  ast: html.Block,
+  visitor: html.Visitor,
+  bindingParser: BindingParser,
+): {node: t.RepeatBlock | null; errors: ParseError[]} {
+  const errors: ParseError[] = validateRepeatBlock(ast);
+  const params = parseRepeatParameters(ast, errors, bindingParser);
+  let node: t.RepeatBlock | null = null;
+
+  if (params !== null) {
+    node = new t.RepeatBlock(
+      params.expression,
+      params.context,
+      html.visitAll(visitor, ast.children, ast.children),
+      ast.sourceSpan,
+      ast.sourceSpan,
+      ast.startSourceSpan,
+      ast.endSourceSpan,
+      ast.nameSpan,
+      ast.i18n,
+    );
+  }
+
+  return {node, errors};
+}
+
+function validateRepeatBlock(ast: html.Block): ParseError[] {
+  const errors: ParseError[] = [];
+
+  for (const child of ast.children) {
+    if (child instanceof html.Element && isNgContent(child.name)) {
+      errors.push(
+        new ParseError(child.sourceSpan, '<ng-content> cannot be used inside an @repeat block'),
+      );
+    }
+  }
+
+  return errors;
+}
+
 /** Creates a switch block from an HTML AST node. */
 export function createSwitchBlock(
   ast: html.Block,
@@ -359,6 +401,67 @@ export function createSwitchBlock(
   return {node, errors};
 }
 
+/** Parses the parameters of a `repeat` block. */
+function parseRepeatParameters(
+  block: html.Block,
+  errors: ParseError[],
+  bindingParser: BindingParser,
+) {
+  if (block.parameters.length === 0) {
+    errors.push(
+      new ParseError(block.startSourceSpan, '@repeat block does not have a count expression'),
+    );
+    return null;
+  }
+
+  const [expressionParam, ...secondaryParams] = block.parameters;
+  const rawExpression = stripOptionalParentheses(expressionParam, errors);
+
+  if (rawExpression === null) {
+    return null;
+  }
+
+  if (rawExpression.trim().length === 0) {
+    errors.push(new ParseError(expressionParam.sourceSpan, '@repeat block expression is empty'));
+    return null;
+  }
+
+  const result = {
+    expression: parseBlockParameterToBinding(expressionParam, bindingParser, rawExpression),
+    context: createRepeaterContextVariables(block),
+  };
+
+  for (const param of secondaryParams) {
+    const letMatch = param.expression.match(FOR_LOOP_LET_PATTERN);
+
+    if (letMatch !== null) {
+      const variablesSpan = new ParseSourceSpan(
+        param.sourceSpan.start.moveBy(letMatch[0].length - letMatch[1].length),
+        param.sourceSpan.end,
+      );
+      parseLetParameter(
+        param.sourceSpan,
+        letMatch[1],
+        variablesSpan,
+        null,
+        result.context,
+        errors,
+        '@repeat block',
+      );
+      continue;
+    }
+
+    errors.push(
+      new ParseError(
+        param.sourceSpan,
+        `Unrecognized @repeat block parameter "${param.expression}"`,
+      ),
+    );
+  }
+
+  return result;
+}
+
 /** Parses the parameters of a `for` loop block. */
 function parseForLoopParameters(
   block: html.Block,
@@ -409,20 +512,7 @@ function parseForLoopParameters(
     itemName: new t.Variable(itemName, '$implicit', variableSpan, variableSpan),
     trackBy: null as {expression: ASTWithSource; keywordSpan: ParseSourceSpan} | null,
     expression: parseBlockParameterToBinding(expressionParam, bindingParser, rawExpression),
-    context: Array.from(ALLOWED_FOR_LOOP_LET_VARIABLES, (variableName) => {
-      // Give ambiently-available context variables empty spans at the end of
-      // the start of the `for` block, since they are not explicitly defined.
-      const emptySpanAfterForBlockStart = new ParseSourceSpan(
-        block.startSourceSpan.end,
-        block.startSourceSpan.end,
-      );
-      return new t.Variable(
-        variableName,
-        variableName,
-        emptySpanAfterForBlockStart,
-        emptySpanAfterForBlockStart,
-      );
-    }),
+    context: createRepeaterContextVariables(block),
   };
 
   for (const param of secondaryParams) {
@@ -440,6 +530,7 @@ function parseForLoopParameters(
         itemName,
         result.context,
         errors,
+        '@for loop',
       );
       continue;
     }
@@ -487,14 +578,32 @@ function validateTrackByExpression(
   }
 }
 
-/** Parses the `let` parameter of a `for` loop block. */
+function createRepeaterContextVariables(block: html.Block): t.Variable[] {
+  return Array.from(ALLOWED_FOR_LOOP_LET_VARIABLES, (variableName) => {
+    // Give ambiently-available context variables empty spans at the end of
+    // the start of the block, since they are not explicitly defined.
+    const emptySpanAfterBlockStart = new ParseSourceSpan(
+      block.startSourceSpan.end,
+      block.startSourceSpan.end,
+    );
+    return new t.Variable(
+      variableName,
+      variableName,
+      emptySpanAfterBlockStart,
+      emptySpanAfterBlockStart,
+    );
+  });
+}
+
+/** Parses the `let` parameter of a `for` loop or `repeat` block. */
 function parseLetParameter(
   sourceSpan: ParseSourceSpan,
   expression: string,
   span: ParseSourceSpan,
-  loopItemName: string,
+  loopItemName: string | null,
   context: t.Variable[],
   errors: ParseError[],
+  blockName: '@for loop' | '@repeat block',
 ): void {
   const parts = expression.split(',');
   let startSpan = span.start;
@@ -507,7 +616,7 @@ function parseLetParameter(
       errors.push(
         new ParseError(
           sourceSpan,
-          `Invalid @for loop "let" parameter. Parameter should match the pattern "<name> = <variable name>"`,
+          `Invalid ${blockName} "let" parameter. Parameter should match the pattern "<name> = <variable name>"`,
         ),
       );
     } else if (!ALLOWED_FOR_LOOP_LET_VARIABLES.has(variableName)) {
@@ -519,11 +628,11 @@ function parseLetParameter(
           ).join(', ')}`,
         ),
       );
-    } else if (name === loopItemName) {
+    } else if (loopItemName !== null && name === loopItemName) {
       errors.push(
         new ParseError(
           sourceSpan,
-          `Invalid @for loop "let" parameter. Variable cannot be called "${loopItemName}"`,
+          `Invalid ${blockName} "let" parameter. Variable cannot be called "${loopItemName}"`,
         ),
       );
     } else if (context.some((v) => v.name === name)) {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -196,6 +196,7 @@ export class Identifiers {
   static conditional: o.ExternalReference = {name: 'ɵɵconditional', moduleName: CORE};
   static repeater: o.ExternalReference = {name: 'ɵɵrepeater', moduleName: CORE};
   static repeaterCreate: o.ExternalReference = {name: 'ɵɵrepeaterCreate', moduleName: CORE};
+  static repeatCount: o.ExternalReference = {name: 'ɵɵrepeatCount', moduleName: CORE};
   static repeaterTrackByIndex: o.ExternalReference = {
     name: 'ɵɵrepeaterTrackByIndex',
     moduleName: CORE,

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -28,6 +28,7 @@ import * as t from './r3_ast';
 import {
   createForLoop,
   createIfBlock,
+  createRepeatBlock,
   createSwitchBlock,
   isConnectedForLoopBlock,
   isConnectedIfLoopBlock,
@@ -492,6 +493,10 @@ class HtmlAstToIvyAst implements html.Visitor {
           this,
           this.bindingParser,
         );
+        break;
+
+      case 'repeat':
+        result = createRepeatBlock(block, this, this.bindingParser);
         break;
 
       case 'if':

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -27,6 +27,7 @@ import {
   LetDeclaration,
   Node,
   Reference,
+  RepeatBlock,
   SwitchBlockCaseGroup,
   Template,
   TextAttribute,
@@ -40,6 +41,7 @@ export type ScopedNode =
   | IfBlockBranch
   | ForLoopBlock
   | ForLoopBlockEmpty
+  | RepeatBlock
   | DeferredBlock
   | DeferredBlockError
   | DeferredBlockLoading

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -39,6 +39,7 @@ import {
   LetDeclaration,
   Node,
   Reference,
+  RepeatBlock,
   SwitchBlock,
   SwitchBlockCase,
   SwitchBlockCaseGroup,
@@ -338,6 +339,9 @@ class Scope implements Visitor {
       this.visitVariable(nodeOrNodes.item);
       nodeOrNodes.contextVariables.forEach((v) => this.visitVariable(v));
       nodeOrNodes.children.forEach((node) => node.visit(this));
+    } else if (nodeOrNodes instanceof RepeatBlock) {
+      nodeOrNodes.contextVariables.forEach((v) => this.visitVariable(v));
+      nodeOrNodes.children.forEach((node) => node.visit(this));
     } else if (
       nodeOrNodes instanceof SwitchBlockCaseGroup ||
       nodeOrNodes instanceof ForLoopBlockEmpty ||
@@ -416,6 +420,10 @@ class Scope implements Visitor {
   }
 
   visitForLoopBlockEmpty(block: ForLoopBlockEmpty) {
+    this.ingestScopedNode(block);
+  }
+
+  visitRepeatBlock(block: RepeatBlock) {
     this.ingestScopedNode(block);
   }
 
@@ -621,6 +629,11 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   visitForLoopBlockEmpty(block: ForLoopBlockEmpty) {
+    block.children.forEach((node) => node.visit(this));
+  }
+
+  visitRepeatBlock(block: RepeatBlock) {
+    block.contextVariables.forEach((v) => v.visit(this));
     block.children.forEach((node) => node.visit(this));
   }
 
@@ -997,6 +1010,11 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
       nodeOrNodes.trackBy.visit(this);
       nodeOrNodes.children.forEach(this.visitNode);
       this.nestingLevel.set(nodeOrNodes, this.level);
+    } else if (nodeOrNodes instanceof RepeatBlock) {
+      nodeOrNodes.contextVariables.forEach((v) => this.visitNode(v));
+      nodeOrNodes.expression.visit(this);
+      nodeOrNodes.children.forEach(this.visitNode);
+      this.nestingLevel.set(nodeOrNodes, this.level);
     } else if (nodeOrNodes instanceof DeferredBlock) {
       if (this.scope.rootNode !== nodeOrNodes) {
         throw new Error(
@@ -1094,6 +1112,11 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
   }
 
   override visitForLoopBlockEmpty(block: ForLoopBlockEmpty) {
+    this.ingestScopedNode(block);
+  }
+
+  override visitRepeatBlock(block: RepeatBlock) {
+    block.expression.visit(this);
     this.ingestScopedNode(block);
   }
 

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -14,6 +14,7 @@ import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import * as t from '../../../render3/r3_ast';
+import {Identifiers} from '../../../render3/r3_identifiers';
 import {DeferBlockDepsEmitMode, R3ComponentDeferMetadata} from '../../../render3/view/api';
 import {icuFromI18nMessage} from '../../../render3/view/i18n/util';
 import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
@@ -255,6 +256,8 @@ function ingestNodes(unit: ViewCompilationUnit, template: t.Node[]): void {
       ingestIcu(unit, node);
     } else if (node instanceof t.ForLoopBlock) {
       ingestForBlock(unit, node);
+    } else if (node instanceof t.RepeatBlock) {
+      ingestRepeatBlock(unit, node);
     } else if (node instanceof t.LetDeclaration) {
       ingestLetDeclaration(unit, node);
     } else if (node instanceof t.Component) {
@@ -986,6 +989,72 @@ function ingestForBlock(unit: ViewCompilationUnit, forBlock: t.ForLoopBlock): vo
     repeaterCreate.handle,
     expression,
     forBlock.sourceSpan,
+  );
+  unit.update.push(repeater);
+}
+
+/**
+ * Ingest a `@repeat` block into the given `ViewCompilation`.
+ */
+function ingestRepeatBlock(unit: ViewCompilationUnit, repeatBlock: t.RepeatBlock): void {
+  const repeaterView = unit.job.allocateView(unit.xref);
+  const indexName = `ɵ$index_${repeaterView.xref}`;
+  const countName = `ɵ$count_${repeaterView.xref}`;
+  const indexVarNames = new Set<string>();
+
+  for (const variable of repeatBlock.contextVariables) {
+    if (variable.value === '$index') {
+      indexVarNames.add(variable.name);
+    }
+    if (variable.name === '$index') {
+      repeaterView.contextVariables.set('$index', variable.value).set(indexName, variable.value);
+    } else if (variable.name === '$count') {
+      repeaterView.contextVariables.set('$count', variable.value).set(countName, variable.value);
+    } else {
+      repeaterView.aliases.add({
+        kind: ir.SemanticVariableKind.Alias,
+        name: null,
+        identifier: variable.name,
+        expression: getComputedForLoopVariableExpression(variable, indexName, countName),
+      });
+    }
+  }
+
+  ingestNodes(repeaterView, repeatBlock.children);
+
+  const varNames: ir.RepeaterVarNames = {
+    $index: indexVarNames,
+    $implicit: `ɵ$repeat_${repeaterView.xref}`,
+  };
+
+  if (repeatBlock.i18n !== undefined && !(repeatBlock.i18n instanceof i18n.BlockPlaceholder)) {
+    throw Error('AssertionError: Unhandled i18n metadata type or @repeat');
+  }
+
+  const tagName = ingestControlFlowInsertionPoint(unit, repeaterView.xref, repeatBlock);
+  const repeaterCreate = ir.createRepeaterCreateOp(
+    repeaterView.xref,
+    null,
+    tagName,
+    new ir.LexicalReadExpr('$index'),
+    varNames,
+    null,
+    repeatBlock.i18n,
+    undefined,
+    repeatBlock.startSourceSpan,
+    repeatBlock.sourceSpan,
+  );
+  repeaterCreate.functionNameSuffix = 'Repeat';
+  unit.create.push(repeaterCreate);
+
+  const sourceSpan = convertSourceSpan(repeatBlock.expression.span, repeatBlock.sourceSpan);
+  const expression = convertAst(repeatBlock.expression, unit.job, sourceSpan);
+  const rangeExpression = o.importExpr(Identifiers.repeatCount).callFn([expression], sourceSpan);
+  const repeater = ir.createRepeaterOp(
+    repeaterCreate.xref,
+    repeaterCreate.handle,
+    rangeExpression,
+    repeatBlock.sourceSpan,
   );
   unit.update.push(repeater);
 }
@@ -1828,7 +1897,12 @@ function convertSourceSpan(
 function ingestControlFlowInsertionPoint(
   unit: ViewCompilationUnit,
   xref: ir.XrefId,
-  node: t.IfBlockBranch | t.SwitchBlockCaseGroup | t.ForLoopBlock | t.ForLoopBlockEmpty,
+  node:
+    | t.IfBlockBranch
+    | t.SwitchBlockCaseGroup
+    | t.ForLoopBlock
+    | t.ForLoopBlockEmpty
+    | t.RepeatBlock,
 ): string | null {
   let root: t.Element | t.Template | null = null;
 

--- a/packages/compiler/src/typecheck/api.ts
+++ b/packages/compiler/src/typecheck/api.ts
@@ -285,7 +285,8 @@ export interface TypeCheckingConfig {
   allowDomEventAssertion: boolean;
 
   /**
-   * Whether to descend into the bodies of control flow blocks (`@if`, `@switch` and `@for`).
+   * Whether to descend into the bodies of control flow blocks
+   * (`@if`, `@switch`, `@for` and `@repeat`).
    */
   checkControlFlowBodies: boolean;
 

--- a/packages/compiler/src/typecheck/oob.ts
+++ b/packages/compiler/src/typecheck/oob.ts
@@ -21,6 +21,7 @@ import {
   InteractionDeferredTrigger,
   LetDeclaration,
   Reference,
+  RepeatBlock,
   SwitchBlockCase,
   Template,
   TextAttribute,
@@ -143,7 +144,12 @@ export interface OutOfBandDiagnosticRecorder<T> {
     projectionNode: Element | Template,
     componentName: string,
     slotSelector: string,
-    controlFlowNode: IfBlockBranch | SwitchBlockCase | ForLoopBlock | ForLoopBlockEmpty,
+    controlFlowNode:
+      | IfBlockBranch
+      | SwitchBlockCase
+      | ForLoopBlock
+      | ForLoopBlockEmpty
+      | RepeatBlock,
     preservesWhitespaces: boolean,
   ): void;
 

--- a/packages/compiler/src/typecheck/ops/content_projection.ts
+++ b/packages/compiler/src/typecheck/ops/content_projection.ts
@@ -15,6 +15,7 @@ import {
   IfBlock,
   IfBlockBranch,
   Node,
+  RepeatBlock,
   SwitchBlock,
   SwitchBlockCaseGroup,
   Template,
@@ -30,8 +31,9 @@ import {OutOfBandDiagnosticCategory} from '../oob';
  *
  * Context:
  * Control flow blocks try to emulate the content projection behavior of `*ngIf` and `*ngFor`
- * in order to reduce breakages when moving from one syntax to the other (see #52414), however the
- * approach only works if there's only one element at the root of the control flow expression.
+ * in order to reduce breakages when moving from one syntax to the other (see #52414). `@repeat`
+ * follows the same projection model. The approach only works if there's only one element at the
+ * root of the control flow expression.
  * This means that a stray sibling node (e.g. text) can prevent an element from being projected
  * into the right slot. The purpose of the `TcbOp` is to find any places where a node at the root
  * of a control flow expression *would have been projected* into a specific slot, if the control
@@ -94,8 +96,9 @@ export class TcbControlFlowContentProjectionOp extends TcbOp {
   }
 
   private findPotentialControlFlowNodes() {
-    const result: Array<IfBlockBranch | SwitchBlockCaseGroup | ForLoopBlock | ForLoopBlockEmpty> =
-      [];
+    const result: Array<
+      IfBlockBranch | SwitchBlockCaseGroup | ForLoopBlock | ForLoopBlockEmpty | RepeatBlock
+    > = [];
 
     for (const child of this.element.children) {
       if (child instanceof ForLoopBlock) {
@@ -104,6 +107,10 @@ export class TcbControlFlowContentProjectionOp extends TcbOp {
         }
         if (child.empty !== null && this.shouldCheck(child.empty)) {
           result.push(child.empty);
+        }
+      } else if (child instanceof RepeatBlock) {
+        if (this.shouldCheck(child)) {
+          result.push(child);
         }
       } else if (child instanceof IfBlock) {
         for (const branch of child.branches) {

--- a/packages/compiler/src/typecheck/ops/for_block.ts
+++ b/packages/compiler/src/typecheck/ops/for_block.ts
@@ -7,7 +7,7 @@
  */
 
 import {AST, ImplicitReceiver, PropertyRead, ThisReceiver} from '../../expression_parser/ast';
-import {ForLoopBlock, Variable} from '../../render3/r3_ast';
+import {ForLoopBlock, RepeatBlock, Variable} from '../../render3/r3_ast';
 import {tcbExpression, TcbExpressionTranslator} from './expression';
 import type {Context} from './context';
 import type {Scope} from './scope';
@@ -53,6 +53,45 @@ export class TcbForOfOp extends TcbOp {
     const block = getStatementsBlock([...loopScope.render(), trackExpression]);
     this.scope.addStatement(
       new TcbExpr(`for (${initializer.print()} of ${expression.print()}) {\n${block} }`),
+    );
+    return null;
+  }
+}
+
+/**
+ * A `TcbOp` which renders a repeat block as a TypeScript numeric loop.
+ */
+export class TcbRepeatOp extends TcbOp {
+  constructor(
+    private tcb: Context,
+    private scope: Scope,
+    private block: RepeatBlock,
+  ) {
+    super();
+  }
+
+  override get optional() {
+    return false;
+  }
+
+  override execute(): null {
+    const loopScope = this.scope.createChildScope(
+      this.scope,
+      this.block,
+      this.tcb.env.config.checkControlFlowBodies ? this.block.children : [],
+      null,
+    );
+    const countId = new TcbExpr(this.tcb.allocateId());
+    const expression = tcbExpression(this.block.expression, this.tcb, this.scope);
+    const initializer = new TcbExpr(
+      `var ${countId.print()}: number | null | undefined = ${expression.print()}`,
+    );
+    const indexId = this.tcb.allocateId();
+    const block = getStatementsBlock(loopScope.render());
+    this.scope.addStatement(
+      new TcbExpr(
+        `${initializer.print()};\nfor (let ${indexId} = 0; ${countId.print()} != null && ${indexId} < ${countId.print()}; ${indexId}++) {\n${block} }`,
+      ),
     );
     return null;
   }

--- a/packages/compiler/src/typecheck/ops/scope.ts
+++ b/packages/compiler/src/typecheck/ops/scope.ts
@@ -26,6 +26,7 @@ import {
   InteractionDeferredTrigger,
   LetDeclaration,
   Node,
+  RepeatBlock,
   Reference,
   SwitchBlock,
   Template,
@@ -45,7 +46,7 @@ import {TcbComponentContextCompletionOp} from './completions';
 import {LocalSymbol, TcbInvalidReferenceOp, TcbReferenceOp} from './references';
 import {TcbIfBlockOp} from './if_block';
 import {TcbSwitchOp} from './switch_block';
-import {TcbForOfOp} from './for_block';
+import {TcbForOfOp, TcbRepeatOp} from './for_block';
 import {TcbLetDeclarationOp} from './let';
 import {TcbDirectiveInputsOp, TcbUnclaimedInputsOp} from './inputs';
 import {TcbDomSchemaCheckerOp} from './schema';
@@ -184,7 +185,7 @@ export class Scope {
   static forNodes(
     tcb: Context,
     parentScope: Scope | null,
-    scopedNode: Template | IfBlockBranch | ForLoopBlock | HostElement | null,
+    scopedNode: Template | IfBlockBranch | ForLoopBlock | RepeatBlock | HostElement | null,
     children: Node[] | null,
     guard: TcbExpr | null,
   ): Scope {
@@ -237,6 +238,21 @@ export class Scope {
       for (const variable of scopedNode.contextVariables) {
         if (!forLoopContextVariableTypes.has(variable.value)) {
           throw new Error(`Unrecognized for loop context variable ${variable.name}`);
+        }
+
+        const type = new TcbExpr(forLoopContextVariableTypes.get(variable.value)!);
+        Scope.registerVariable(
+          scope,
+          variable,
+          new TcbBlockImplicitVariableOp(tcb, scope, type, variable),
+        );
+      }
+    } else if (scopedNode instanceof RepeatBlock) {
+      const forLoopContextVariableTypes = Scope.getForLoopContextVariableTypes();
+
+      for (const variable of scopedNode.contextVariables) {
+        if (!forLoopContextVariableTypes.has(variable.value)) {
+          throw new Error(`Unrecognized repeat block context variable ${variable.name}`);
         }
 
         const type = new TcbExpr(forLoopContextVariableTypes.get(variable.value)!);
@@ -374,7 +390,7 @@ export class Scope {
    */
   createChildScope(
     parentScope: Scope,
-    scopedNode: Template | IfBlockBranch | ForLoopBlock | HostElement | null,
+    scopedNode: Template | IfBlockBranch | ForLoopBlock | RepeatBlock | HostElement | null,
     children: Node[] | null,
     guard: TcbExpr | null,
   ): Scope {
@@ -502,6 +518,8 @@ export class Scope {
     } else if (node instanceof ForLoopBlock) {
       this.opQueue.push(new TcbForOfOp(this.tcb, this, node));
       node.empty && this.tcb.env.config.checkControlFlowBodies && this.appendChildren(node.empty);
+    } else if (node instanceof RepeatBlock) {
+      this.opQueue.push(new TcbRepeatOp(this.tcb, this, node));
     } else if (node instanceof BoundText) {
       this.opQueue.push(new TcbExpressionOp(this.tcb, this, node.value));
     } else if (node instanceof Icu) {

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -187,6 +187,17 @@ class R3AstSourceSpans implements t.Visitor<void> {
     this.visitAll([block.children]);
   }
 
+  visitRepeatBlock(block: t.RepeatBlock): void {
+    this.result.push([
+      'RepeatBlock',
+      humanizeSpan(block.sourceSpan),
+      humanizeSpan(block.startSourceSpan),
+      humanizeSpan(block.endSourceSpan),
+    ]);
+    this.visitAll([block.contextVariables]);
+    this.visitAll([block.children]);
+  }
+
   visitIfBlock(block: t.IfBlock): void {
     this.result.push([
       'IfBlock',

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -130,6 +130,11 @@ class R3AstHumanizer implements t.Visitor<void> {
     this.visitAll([block.children]);
   }
 
+  visitRepeatBlock(block: t.RepeatBlock): void {
+    this.result.push(['RepeatBlock', unparse(block.expression)]);
+    this.visitAll([block.contextVariables, block.children]);
+  }
+
   visitIfBlock(block: t.IfBlock): void {
     this.result.push(['IfBlock']);
     this.visitAll([block.branches]);
@@ -2070,6 +2075,86 @@ describe('R3 template transform', () => {
           }
         `),
         ).toThrowError(/Incomplete block "default never"/);
+      });
+    });
+  });
+
+  describe('repeat blocks', () => {
+    it('should parse a repeat block', () => {
+      expectFromHtml(`
+        @repeat (columns(); let col = $index) {
+          {{ col }}
+        }
+      `).toEqual([
+        ['RepeatBlock', 'columns()'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
+        ['Variable', 'col', '$index'],
+        ['BoundText', ' {{ col }} '],
+      ]);
+    });
+
+    it('should parse nested repeat blocks with shadowed context variables', () => {
+      expectFromHtml(`
+        @repeat (2; let row = $index) {
+          @repeat (3; let col = $index) {
+            {{ row }}:{{ col }}:{{ $index }}
+          }
+        }
+      `).toEqual([
+        ['RepeatBlock', '2'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
+        ['Variable', 'row', '$index'],
+        ['RepeatBlock', '3'],
+        ['Variable', '$index', '$index'],
+        ['Variable', '$first', '$first'],
+        ['Variable', '$last', '$last'],
+        ['Variable', '$even', '$even'],
+        ['Variable', '$odd', '$odd'],
+        ['Variable', '$count', '$count'],
+        ['Variable', 'col', '$index'],
+        ['BoundText', ' {{ row }}:{{ col }}:{{ $index }} '],
+      ]);
+    });
+
+    describe('validations', () => {
+      it('should report if repeat does not have a count expression', () => {
+        expect(() => parse(`@repeat {hello}`)).toThrowError(
+          /@repeat block does not have a count expression/,
+        );
+      });
+
+      it('should report an empty repeat expression', () => {
+        expect(() => parse(`@repeat (( )) {hello}`)).toThrowError(
+          /@repeat block expression is empty/,
+        );
+      });
+
+      it('should report unrecognized repeat parameters', () => {
+        expect(() => parse(`@repeat (2; track $index) {hello}`)).toThrowError(
+          /Unrecognized @repeat block parameter "track \$index"/,
+        );
+      });
+
+      it('should report an invalid `let` parameter', () => {
+        expect(() => parse(`@repeat (2; let i = $index, $odd) {}`)).toThrowError(
+          /Invalid @repeat block "let" parameter. Parameter should match the pattern "<name> = <variable name>"/,
+        );
+      });
+
+      it('should report ng-content inside repeat blocks', () => {
+        expect(() => parse(`@repeat (2) {<ng-content />}`)).toThrowError(
+          /<ng-content> cannot be used inside an @repeat block/,
+        );
       });
     });
   });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -233,6 +233,12 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     t.visitAll(this, block.children);
   }
 
+  visitRepeatBlock(block: t.RepeatBlock) {
+    block.expression.visit(this);
+    t.visitAll(this, block.contextVariables);
+    t.visitAll(this, block.children);
+  }
+
   visitIfBlock(block: t.IfBlock) {
     t.visitAll(this, block.branches);
   }

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -28,6 +28,7 @@ import type {
   TmplAstNode,
   TmplAstRecursiveVisitor,
   TmplAstReference,
+  TmplAstRepeatBlock,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
@@ -83,6 +84,7 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitSwitchBlockCaseGroup(block: TmplAstSwitchBlockCaseGroup): void {}
   visitForLoopBlock(block: TmplAstForLoopBlock): void {}
   visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty): void {}
+  visitRepeatBlock(block: TmplAstRepeatBlock): void {}
   visitIfBlock(block: TmplAstIfBlock): void {}
   visitIfBlockBranch(block: TmplAstIfBlockBranch): void {}
   visitLetDeclaration(decl: TmplAstLetDeclaration): void {}

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -211,6 +211,7 @@ export {
   ɵɵqueryRefresh,
   ɵɵreadContextLet,
   ɵɵreference,
+  ɵɵrepeatCount,
   ɵɵrepeater,
   ɵɵrepeaterCreate,
   ɵɵrepeaterTrackByIdentity,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -149,6 +149,7 @@ export const enum RuntimeErrorCode {
   // Repeater errors
   LOOP_TRACK_DUPLICATE_KEYS = -955,
   LOOP_TRACK_RECREATE = -956,
+  REPEAT_INVALID_COUNT = 957,
 
   // Runtime dependency tracker errors
   RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 980,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -105,6 +105,7 @@ export {
   ɵɵviewQuery,
   ɵɵviewQuerySignal,
   ɵɵreference,
+  ɵɵrepeatCount,
   ɵɵrepeater,
   ɵɵrepeaterCreate,
   ɵɵrepeaterTrackByIdentity,

--- a/packages/core/src/render3/instructions/control_flow.ts
+++ b/packages/core/src/render3/instructions/control_flow.ts
@@ -9,7 +9,7 @@
 import {setActiveConsumer} from '../../../primitives/signals';
 
 import {TrackByFunction} from '../../change_detection';
-import {formatRuntimeError, RuntimeErrorCode} from '../../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DehydratedContainerView} from '../../hydration/interfaces';
 import {
   findAndReconcileMatchingDehydratedViews,
@@ -39,6 +39,7 @@ import {destroyLView} from '../node_manipulation';
 import {getLView, getSelectedIndex, getTView, nextBindingIndex} from '../state';
 import {NO_CHANGE} from '../tokens';
 import {getConstant, getTNode} from '../util/view_utils';
+import {stringifyForError} from '../util/stringify_utils';
 import {createAndRenderEmbeddedLView, shouldAddViewToDom} from '../view_manipulation';
 
 import {AnimationLViewData} from '../../animation/interfaces';
@@ -251,6 +252,47 @@ export function ɵɵrepeaterTrackByIndex(index: number) {
  */
 export function ɵɵrepeaterTrackByIdentity<T>(_: number, value: T) {
   return value;
+}
+
+class RepeatCountIterable implements Iterable<number> {
+  constructor(private readonly count: number) {}
+
+  [Symbol.iterator](): Iterator<number> {
+    let index = 0;
+    const count = this.count;
+
+    return {
+      next(): IteratorResult<number> {
+        if (index < count) {
+          return {value: index++, done: false};
+        }
+        return {value: undefined, done: true};
+      },
+    };
+  }
+}
+
+/**
+ * Converts a `@repeat` count into an iterable range consumed by the repeater instruction.
+ *
+ * @codeGenApi
+ */
+export function ɵɵrepeatCount(count: number | null | undefined): Iterable<number> | null {
+  if (count == null) {
+    return null;
+  }
+
+  if (typeof count !== 'number' || count < 0 || count === Infinity) {
+    throw new RuntimeError(
+      RuntimeErrorCode.REPEAT_INVALID_COUNT,
+      ngDevMode &&
+        `The \`@repeat\` count must be a non-negative finite number, but received ${stringifyForError(count)}.`,
+    );
+  }
+
+  const n = Math.trunc(count);
+
+  return n > 0 ? new RepeatCountIterable(n) : null;
 }
 
 class RepeaterMetadata {

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -135,6 +135,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵdeferHydrateOnInteraction': r3.ɵɵdeferHydrateOnInteraction,
   'ɵɵdeferHydrateOnViewport': r3.ɵɵdeferHydrateOnViewport,
   'ɵɵdeferEnableTimerScheduling': r3.ɵɵdeferEnableTimerScheduling,
+  'ɵɵrepeatCount': r3.ɵɵrepeatCount,
   'ɵɵrepeater': r3.ɵɵrepeater,
   'ɵɵrepeaterCreate': r3.ɵɵrepeaterCreate,
   'ɵɵrepeaterTrackByIndex': r3.ɵɵrepeaterTrackByIndex,

--- a/packages/core/test/acceptance/authoring/signal_queries_spec.ts
+++ b/packages/core/test/acceptance/authoring/signal_queries_spec.ts
@@ -16,6 +16,7 @@ import {
   Directive,
   ElementRef,
   EnvironmentInjector,
+  Input,
   QueryList,
   viewChild,
   ViewChildren,
@@ -119,6 +120,54 @@ describe('queries as signals', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.componentInstance.foundEl()).toBe(1);
+    });
+
+    it('should update view queries inside repeat blocks', () => {
+      @Component({
+        template: `
+          @repeat (count; let index = $index) {
+            <button #button [attr.data-index]="index">Button {{ index }}</button>
+          }
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class AppComponent {
+        count = 0;
+        firstButton = viewChild('button', {read: ElementRef});
+        buttons = viewChildren('button', {read: ElementRef});
+      }
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      expect(fixture.componentInstance.firstButton()).toBeUndefined();
+      expect(fixture.componentInstance.buttons()).toEqual([]);
+
+      fixture.componentInstance.count = 3;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(
+        fixture.componentInstance.firstButton()!.nativeElement.getAttribute('data-index'),
+      ).toBe('0');
+      expect(
+        fixture.componentInstance
+          .buttons()
+          .map((button) => button.nativeElement.getAttribute('data-index')),
+      ).toEqual(['0', '1', '2']);
+
+      fixture.componentInstance.count = 1;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(
+        fixture.componentInstance
+          .buttons()
+          .map((button) => button.nativeElement.getAttribute('data-index')),
+      ).toEqual(['0']);
+
+      fixture.componentInstance.count = 0;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.firstButton()).toBeUndefined();
+      expect(fixture.componentInstance.buttons()).toEqual([]);
     });
 
     it('should return an empty array when reading children query in the constructor', () => {
@@ -319,6 +368,62 @@ describe('queries as signals', () => {
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('3');
+    });
+
+    it('should update content queries for projected repeat blocks', () => {
+      @Directive({selector: '[repeatQueryItem]'})
+      class RepeatQueryItem {
+        @Input() index = -1;
+      }
+
+      @Component({
+        selector: 'repeat-content-query-target',
+        template: '<ng-content />',
+      })
+      class ContentQueryTarget {
+        firstItem = contentChild(RepeatQueryItem);
+        items = contentChildren(RepeatQueryItem);
+      }
+
+      @Component({
+        imports: [ContentQueryTarget, RepeatQueryItem],
+        template: `
+          <repeat-content-query-target>
+            @repeat (itemCount; let index = $index) {
+              <div repeatQueryItem [index]="index"></div>
+            }
+          </repeat-content-query-target>
+        `,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class AppComponent {
+        itemCount = 0;
+      }
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const target = fixture.debugElement
+        .query(By.directive(ContentQueryTarget))
+        .injector.get(ContentQueryTarget);
+      expect(target.firstItem()).toBeUndefined();
+      expect(target.items()).toEqual([]);
+
+      fixture.componentInstance.itemCount = 2;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(target.firstItem()?.index).toBe(0);
+      expect(target.items().map((item) => item.index)).toEqual([0, 1]);
+
+      fixture.componentInstance.itemCount = 1;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(target.items().map((item) => item.index)).toEqual([0]);
+
+      fixture.componentInstance.itemCount = 0;
+      fixture.changeDetectorRef.markForCheck();
+      fixture.detectChanges();
+      expect(target.firstItem()).toBeUndefined();
+      expect(target.items()).toEqual([]);
     });
 
     it('should run content queries defined on directives', () => {

--- a/packages/core/test/acceptance/control_flow_repeat_spec.ts
+++ b/packages/core/test/acceptance/control_flow_repeat_spec.ts
@@ -1,0 +1,555 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {CommonModule} from '@angular/common';
+import {
+  Component,
+  ContentChild,
+  ContentChildren,
+  Directive,
+  ElementRef,
+  Input,
+  provideZonelessChangeDetection,
+  QueryList,
+  signal,
+  Type,
+  ViewChild,
+  ViewChildren,
+} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+
+import {ComponentFixture, TestBed} from '../../testing';
+
+describe('control flow - repeat', () => {
+  async function createFixture<T>(type: Type<T>): Promise<ComponentFixture<T>> {
+    const fixture = TestBed.createComponent(type);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  function textContent(element: Element): string {
+    return element.textContent!.replace(/\s+/g, ' ').trim();
+  }
+
+  function queryTexts(element: Element, selector: string): string[] {
+    return Array.from(element.querySelectorAll(selector), (node) => node.textContent!.trim());
+  }
+
+  function nativeElement<T extends Element>(value: ElementRef<T> | T): T {
+    return value instanceof ElementRef ? value.nativeElement : value;
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+  });
+
+  it('should render static counts with contextual variables', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (2; let index = $index) {
+          <div [attr.id]="index">
+            {{ $index }}/{{ $count }}/{{ $first }}/{{ $last }}/{{ $even }}/{{ $odd }}
+          </div>
+        }
+      `,
+    })
+    class TestComponent {}
+
+    const fixture = await createFixture(TestComponent);
+    const divs = Array.from(fixture.nativeElement.querySelectorAll('div')) as Element[];
+
+    expect(divs.map((div) => div.getAttribute('id'))).toEqual(['0', '1']);
+    expect(fixture.nativeElement.textContent).toContain('0/2/true/false/true/false');
+    expect(fixture.nativeElement.textContent).toContain('1/2/false/true/false/true');
+  });
+
+  it('should make $index and other context variables available without a let alias', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (3) {
+          <span>{{ $index }}/{{ $count }}/{{ $first }}/{{ $last }}/{{ $even }}/{{ $odd }}</span>
+        }
+      `,
+    })
+    class TestComponent {}
+
+    const fixture = await createFixture(TestComponent);
+    const spans = Array.from(fixture.nativeElement.querySelectorAll('span')) as Element[];
+
+    expect(spans.length).toBe(3);
+    expect(spans[0].textContent!.trim()).toBe('0/3/true/false/true/false');
+    expect(spans[1].textContent!.trim()).toBe('1/3/false/false/false/true');
+    expect(spans[2].textContent!.trim()).toBe('2/3/false/true/true/false');
+  });
+
+  it('should expose $count, $first, $last, $even, $odd context variables', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (4; let i = $index) {
+          <span
+            [attr.data-index]="i"
+            [attr.data-count]="$count"
+            [attr.data-first]="$first"
+            [attr.data-last]="$last"
+            [attr.data-even]="$even"
+            [attr.data-odd]="$odd"
+          ></span>
+        }
+      `,
+    })
+    class TestComponent {}
+
+    const fixture = await createFixture(TestComponent);
+    const spans = Array.from(fixture.nativeElement.querySelectorAll('span')) as HTMLSpanElement[];
+
+    expect(spans.length).toBe(4);
+
+    const attr = (span: HTMLSpanElement, name: string) => span.getAttribute(name);
+
+    expect(spans.map((s) => attr(s, 'data-count'))).toEqual(['4', '4', '4', '4']);
+    expect(spans.map((s) => attr(s, 'data-first'))).toEqual(['true', 'false', 'false', 'false']);
+    expect(spans.map((s) => attr(s, 'data-last'))).toEqual(['false', 'false', 'false', 'true']);
+    expect(spans.map((s) => attr(s, 'data-even'))).toEqual(['true', 'false', 'true', 'false']);
+    expect(spans.map((s) => attr(s, 'data-odd'))).toEqual(['false', 'true', 'false', 'true']);
+  });
+
+  it('should update when a signal count changes', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (columns(); let col = $index) {
+          <div class="skeleton-cell" [style.grid-column]="col + 1"></div>
+        }
+      `,
+    })
+    class TestComponent {
+      columns = signal(2);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(fixture.nativeElement.querySelectorAll('.skeleton-cell').length).toBe(2);
+
+    fixture.componentInstance.columns.set(4);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('.skeleton-cell').length).toBe(4);
+
+    fixture.componentInstance.columns.set(0);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('.skeleton-cell').length).toBe(0);
+  });
+
+  it('should update when an async pipe count changes', async () => {
+    @Component({
+      standalone: true,
+      imports: [CommonModule],
+      template: `
+        @repeat (count$ | async; let index = $index) {
+          <span>{{ index }}</span>
+        }
+      `,
+    })
+    class TestComponent {
+      count$ = new BehaviorSubject<number | null>(2);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(queryTexts(fixture.nativeElement, 'span')).toEqual(['0', '1']);
+
+    fixture.componentInstance.count$.next(4);
+    await fixture.whenStable();
+    expect(queryTexts(fixture.nativeElement, 'span')).toEqual(['0', '1', '2', '3']);
+
+    fixture.componentInstance.count$.next(null);
+    await fixture.whenStable();
+    expect(textContent(fixture.nativeElement)).toBe('');
+  });
+
+  it('should support nested repeat blocks and shadow inner contextual variables', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (2; let outerIndex = $index) {
+          @repeat (3; let innerIndex = $index) {
+            <button [attr.id]="outerIndex + '-' + innerIndex">{{ $index }}</button>
+          }
+        }
+      `,
+    })
+    class TestComponent {}
+
+    const fixture = await createFixture(TestComponent);
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+
+    expect(buttons.map((button) => button.id)).toEqual(['0-0', '0-1', '0-2', '1-0', '1-1', '1-2']);
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual([
+      '0',
+      '1',
+      '2',
+      '0',
+      '1',
+      '2',
+    ]);
+  });
+
+  it('should render nothing for null and zero counts', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count()) {
+          <span></span>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal<number | null>(null);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(fixture.nativeElement.querySelectorAll('span').length).toBe(0);
+
+    fixture.componentInstance.count.set(0);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('span').length).toBe(0);
+  });
+
+  it('should truncate non-integer counts like String.prototype.repeat', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count()) {
+          <span></span>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(2.5);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(fixture.nativeElement.querySelectorAll('span').length).toBe(2);
+
+    fixture.componentInstance.count.set(3.9);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('span').length).toBe(3);
+  });
+
+  it('should throw a RangeError for negative counts', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count()) {
+          <span></span>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(-1);
+    }
+
+    await expectAsync(createFixture(TestComponent)).toBeRejectedWithError(
+      /The `@repeat` count must be a non-negative finite number/,
+    );
+  });
+
+  it('should throw a RangeError for Infinity', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count()) {
+          <span></span>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(Infinity);
+    }
+
+    await expectAsync(createFixture(TestComponent)).toBeRejectedWithError(
+      /The `@repeat` count must be a non-negative finite number/,
+    );
+  });
+
+  it('should render nothing for NaN counts like String.prototype.repeat', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count()) {
+          <span></span>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal<number>(NaN);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(fixture.nativeElement.querySelectorAll('span').length).toBe(0);
+  });
+
+  it('should project repeated content into ng-content slots', async () => {
+    @Component({
+      standalone: true,
+      selector: 'repeat-projection-target',
+      template: 'Main: <ng-content/> Slot: <ng-content select="[slot]"/>',
+    })
+    class ProjectionTarget {}
+
+    @Component({
+      standalone: true,
+      imports: [ProjectionTarget],
+      template: `
+        <repeat-projection-target>
+          Before
+          @repeat (count(); let index = $index) {
+            <span slot>{{ index }}</span>
+          }
+          After
+        </repeat-projection-target>
+      `,
+    })
+    class TestComponent {
+      count = signal(2);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(textContent(fixture.nativeElement)).toBe('Main: Before After Slot: 01');
+
+    fixture.componentInstance.count.set(0);
+    await fixture.whenStable();
+    expect(textContent(fixture.nativeElement)).toBe('Main: Before After Slot:');
+  });
+
+  it('should render templates from NgTemplateOutlet inside repeat blocks', async () => {
+    @Component({
+      standalone: true,
+      imports: [CommonModule],
+      template: `
+        <ng-template #template let-index="index">
+          <span class="outlet">{{ index }}</span>
+        </ng-template>
+
+        @repeat (count(); let index = $index) {
+          <ng-container *ngTemplateOutlet="template; context: {index: index}"></ng-container>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(3);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(queryTexts(fixture.nativeElement, '.outlet')).toEqual(['0', '1', '2']);
+
+    fixture.componentInstance.count.set(1);
+    await fixture.whenStable();
+    expect(queryTexts(fixture.nativeElement, '.outlet')).toEqual(['0']);
+  });
+
+  it('should update decorator view queries inside repeat blocks', async () => {
+    @Component({
+      standalone: true,
+      template: `
+        @repeat (count(); let index = $index) {
+          <button #button [attr.data-index]="index">Button {{ index }}</button>
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(2);
+
+      @ViewChild('button') firstButton?: ElementRef<HTMLButtonElement> | HTMLButtonElement;
+      @ViewChildren('button') buttons!: QueryList<
+        ElementRef<HTMLButtonElement> | HTMLButtonElement
+      >;
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(nativeElement(fixture.componentInstance.firstButton!).getAttribute('data-index')).toBe(
+      '0',
+    );
+    expect(fixture.componentInstance.buttons.length).toBe(2);
+
+    fixture.componentInstance.count.set(0);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.firstButton).toBeUndefined();
+    expect(fixture.componentInstance.buttons.length).toBe(0);
+
+    fixture.componentInstance.count.set(3);
+    await fixture.whenStable();
+    expect(nativeElement(fixture.componentInstance.firstButton!).getAttribute('data-index')).toBe(
+      '0',
+    );
+    expect(
+      fixture.componentInstance.buttons.map((button) =>
+        nativeElement(button).getAttribute('data-index'),
+      ),
+    ).toEqual(['0', '1', '2']);
+  });
+
+  it('should update decorator content queries for projected repeat blocks', async () => {
+    @Directive({
+      standalone: true,
+      selector: '[repeatQueryItem]',
+    })
+    class RepeatQueryItem {
+      @Input() index = -1;
+    }
+
+    @Component({
+      standalone: true,
+      selector: 'repeat-decorator-content-query-target',
+      template: '<ng-content/>',
+    })
+    class ContentQueryTarget {
+      @ContentChild(RepeatQueryItem) firstItem?: RepeatQueryItem;
+      @ContentChildren(RepeatQueryItem) items!: QueryList<RepeatQueryItem>;
+    }
+
+    @Component({
+      standalone: true,
+      imports: [ContentQueryTarget, RepeatQueryItem],
+      template: `
+        <repeat-decorator-content-query-target>
+          @repeat (itemCount(); let index = $index) {
+            <div repeatQueryItem [index]="index"></div>
+          }
+        </repeat-decorator-content-query-target>
+      `,
+    })
+    class TestComponent {
+      itemCount = signal(2);
+
+      @ViewChild(ContentQueryTarget) target!: ContentQueryTarget;
+    }
+
+    const fixture = await createFixture(TestComponent);
+    const target = fixture.componentInstance.target;
+    expect(target.firstItem?.index).toBe(0);
+    expect(target.items.map((item) => item.index)).toEqual([0, 1]);
+
+    fixture.componentInstance.itemCount.set(0);
+    await fixture.whenStable();
+    expect(target.firstItem).toBeUndefined();
+    expect(target.items.length).toBe(0);
+
+    fixture.componentInstance.itemCount.set(3);
+    await fixture.whenStable();
+    expect(target.firstItem?.index).toBe(0);
+    expect(target.items.map((item) => item.index)).toEqual([0, 1, 2]);
+  });
+
+  it('should support nested if and for blocks inside repeat blocks', async () => {
+    @Component({
+      standalone: true,
+      selector: 'even-row',
+      template: 'even',
+    })
+    class EvenRow {}
+
+    @Component({
+      standalone: true,
+      selector: 'odd-row',
+      template: 'odd',
+    })
+    class OddRow {}
+
+    @Component({
+      standalone: true,
+      imports: [EvenRow, OddRow],
+      template: `
+        @repeat (count(); let index = $index) {
+          @if (index % 2 === 0) {
+            <even-row />
+          } @else {
+            <odd-row />
+          }
+
+          @for (item of items(); track item.id) {
+            <button>{{ index }}:{{ item.label }}</button>
+          }
+        }
+      `,
+    })
+    class TestComponent {
+      count = signal(3);
+      items = signal([
+        {id: 1, label: 'A'},
+        {id: 2, label: 'B'},
+      ]);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(fixture.nativeElement.querySelectorAll('even-row').length).toBe(2);
+    expect(fixture.nativeElement.querySelectorAll('odd-row').length).toBe(1);
+    expect(queryTexts(fixture.nativeElement, 'button')).toEqual([
+      '0:A',
+      '0:B',
+      '1:A',
+      '1:B',
+      '2:A',
+      '2:B',
+    ]);
+
+    fixture.componentInstance.count.set(2);
+    fixture.componentInstance.items.set([{id: 1, label: 'A'}]);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelectorAll('even-row').length).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('odd-row').length).toBe(1);
+    expect(queryTexts(fixture.nativeElement, 'button')).toEqual(['0:A', '1:A']);
+  });
+
+  it('should support nested repeat grids', async () => {
+    @Component({
+      standalone: true,
+      selector: 'cell-component',
+      template: '{{ row }}:{{ col }}',
+    })
+    class CellComponent {
+      @Input() row = -1;
+      @Input() col = -1;
+    }
+
+    @Component({
+      standalone: true,
+      imports: [CellComponent],
+      template: `
+        @repeat (rows(); let row = $index) {
+          @repeat (columns(); let col = $index) {
+            <cell-component [row]="row" [col]="col" />
+          }
+        }
+      `,
+    })
+    class TestComponent {
+      rows = signal(2);
+      columns = signal(3);
+    }
+
+    const fixture = await createFixture(TestComponent);
+    expect(queryTexts(fixture.nativeElement, 'cell-component')).toEqual([
+      '0:0',
+      '0:1',
+      '0:2',
+      '1:0',
+      '1:1',
+      '1:2',
+    ]);
+
+    fixture.componentInstance.rows.set(1);
+    fixture.componentInstance.columns.set(2);
+    await fixture.whenStable();
+    expect(queryTexts(fixture.nativeElement, 'cell-component')).toEqual(['0:0', '0:1']);
+  });
+});

--- a/packages/language-service/src/semantic_tokens.ts
+++ b/packages/language-service/src/semantic_tokens.ts
@@ -28,6 +28,7 @@ import {
   TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
+  TmplAstRepeatBlock,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
@@ -189,6 +190,10 @@ class ClassificationVisitor implements TmplAstVisitor {
   }
 
   visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty) {
+    this.visitAll(block.children);
+  }
+
+  visitRepeatBlock(block: TmplAstRepeatBlock) {
     this.visitAll(block.children);
   }
 

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -40,6 +40,7 @@ import {
   TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstReference,
+  TmplAstRepeatBlock,
   TmplAstSwitchBlock,
   TmplAstSwitchBlockCase,
   TmplAstSwitchBlockCaseGroup,
@@ -685,6 +686,12 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   }
 
   visitForLoopBlockEmpty(block: TmplAstForLoopBlockEmpty) {
+    this.visitAll(block.children);
+  }
+
+  visitRepeatBlock(block: TmplAstRepeatBlock) {
+    this.visitAll(block.contextVariables);
+    this.visitBinding(block.expression);
     this.visitAll(block.children);
   }
 

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -7707,6 +7707,140 @@ describe('platform-server full application hydration integration', () => {
       });
     });
 
+    describe('@repeat', () => {
+      it('should hydrate @repeat block content', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            @repeat (3; let i = $index) {
+              <div>Item #{{ i }}</div>
+            }
+          `,
+        })
+        class SimpleComponent {}
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should hydrate @repeat block and update count reactively', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            @repeat (count(); let i = $index) {
+              <span>{{ i }}</span>
+            }
+          `,
+        })
+        class SimpleComponent {
+          count = signal(3);
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+
+        // Update count on the client after hydration
+        compRef.instance.count.set(5);
+        compRef.changeDetectorRef.detectChanges();
+        expect(clientRootNode.querySelectorAll('span').length).toBe(5);
+      });
+
+      it('should hydrate @repeat with zero count rendering nothing', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            @repeat (count()) {
+              <div>item</div>
+            }
+          `,
+        })
+        class SimpleComponent {
+          count = signal(0);
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+        expect(ssrContents).not.toContain('<div>item</div>');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should hydrate @repeat exposing $count, $first, $last, $even, $odd correctly', async () => {
+        @Component({
+          selector: 'app',
+          template: `
+            @repeat (3; let i = $index) {
+              <span
+                [attr.data-first]="$first"
+                [attr.data-last]="$last"
+                [attr.data-even]="$even"
+                [attr.data-odd]="$odd"
+                [attr.data-count]="$count"
+              >{{ i }}</span>
+            }
+          `,
+        })
+        class SimpleComponent {}
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await prepareEnvironmentAndHydrate(doc, html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+
+        const spans = Array.from(clientRootNode.querySelectorAll('span')) as Element[];
+        expect(spans.length).toBe(3);
+        expect(spans.map((s) => s.getAttribute('data-count'))).toEqual(['3', '3', '3']);
+        expect(spans.map((s) => s.getAttribute('data-first'))).toEqual(['true', 'false', 'false']);
+        expect(spans.map((s) => s.getAttribute('data-last'))).toEqual(['false', 'false', 'true']);
+        expect(spans.map((s) => s.getAttribute('data-even'))).toEqual(['true', 'false', 'true']);
+        expect(spans.map((s) => s.getAttribute('data-odd'))).toEqual(['false', 'true', 'false']);
+      });
+    });
+
     describe('Router', () => {
       it('should wait for lazy routes before triggering post-hydration cleanup', async () => {
         const ngZone = TestBed.inject(NgZone);

--- a/tools/manual_api_docs/blocks/repeat.md
+++ b/tools/manual_api_docs/blocks/repeat.md
@@ -1,0 +1,72 @@
+The `@repeat` block repeatedly renders content for a numeric count.
+
+## Syntax
+
+```angular-html
+@repeat (columns(); let col = $index) {
+  <div class="cell" [style.grid-column]="col + 1"></div>
+}
+```
+
+## Description
+
+The `@repeat` block renders its content once for each integer index from `0` to `count - 1`.
+It is useful when the template needs a fixed number of views and there is no collection to iterate
+over.
+
+```angular-html
+@repeat (2) {
+  <button>Click me</button>
+}
+```
+
+The count expression can be dynamic. When the value changes, Angular creates or removes embedded
+views using the index as the identity for each view:
+
+```angular-html
+@repeat (columns(); let col = $index) {
+  <div class="skeleton-cell" [style.grid-column]="col + 1"></div>
+}
+```
+
+Values of zero render no views. `null` and `undefined` also render no views.
+Non-integer values are truncated toward zero, matching the behavior of `String.prototype.repeat`.
+Negative counts and `Infinity` throw a runtime error ([NG0957](https://angular.dev/errors/NG0957)).
+
+Unlike `@for`, `@repeat` does not have a `track` expression. The identity of each repeated view is
+the contextual `$index`.
+
+### Contextual variables
+
+Inside `@repeat` contents, several implicit variables are always available:
+
+| Variable | Meaning                                    |
+| -------- | ------------------------------------------ |
+| `$count` | Number of views rendered by the block      |
+| `$index` | Index of the current view                  |
+| `$first` | Whether the current view is the first view |
+| `$last`  | Whether the current view is the last view  |
+| `$even`  | Whether the current view index is even     |
+| `$odd`   | Whether the current view index is odd      |
+
+These variables are always available with these names, but can be aliased via a `let` segment:
+
+```angular-html
+@repeat (rows(); let row = $index) {
+  @repeat (columns(); let col = $index) {
+    <cell-component [row]="row" [col]="col" />
+  }
+}
+```
+
+When blocks are nested, contextual variables follow normal template scoping rules. An inner
+`@repeat` shadows `$index` from an outer `@repeat`; alias the outer value when it needs to be read
+inside the inner block.
+
+Queries such as `viewChild`, `viewChildren`, `contentChild`, and `contentChildren` update when
+`@repeat` creates or removes embedded views. Use required queries only when the count is guaranteed
+to be greater than zero.
+
+Do not place `<ng-content>` directly inside an `@repeat` block. Content projection is processed by
+the compiler and does not have cloning semantics. Use template fragments when projected content
+needs conditional or repeated rendering.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: https://github.com/angular/angular/issues/61292

## What is the new behavior?

Adds a new `@repeat` control flow block that renders a template N times without requiring an iterable source.

#### Why `@repeat` matters for enterprise grid UIs                                                                                                                                    
                                                                                                                                                                                 
Spreadsheet-style layouts — skeleton loaders, fixed column headers, paginated grids — need a fixed number of views rendered without any backing collection. Today, Angular developers work around this with a string-based hack:                                                                                                                          
   
```html
@for (_ of '-'.repeat(30); track $index) {                                                                                                                                     
  <div class="skeleton-cell"></div>                             
}
```

This is awkward: the string `'-'.repeat(30)` carries no semantic meaning, the `_` variable is noise, and the pattern surprises anyone reading the code for the first time.         
   
#### `@repeat` makes the intent explicit:                                                                                                                                             
 
```html                                                                 
@repeat (30) {
  <div class="skeleton-cell"></div>
}                                                                                                                                                                                 
```

For enterprise applications — dashboards, data grids, calendar views — where the number of columns or skeleton rows comes from a signal or a config value rather than from actual data, `@repeat` is the right primitive. It removes a category of workaround code that is currently widespread in production Angular apps.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
