### PR TITLE
docs: use contentChildren() in component harness example

### DIFF
--- a/adev/src/content/guide/testing/creating-component-harnesses.md
+++ b/adev/src/content/guide/testing/creating-component-harnesses.md
@@ -133,7 +133,7 @@ class MyMenuItem {}
 class MyMenu {
   triggerText = input('');
 
-  @ContentChildren(MyMenuItem) items: QueryList<MyMenuItem>;
+  items = contentChildren(MyMenuItem);
 }
 ```
 


### PR DESCRIPTION
The example already uses the signal-based input() but still declares items with the `@ContentChildren` decorator. Convert to the signal-based contentChildren() query for consistency.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `MyMenu` example in the component harness guide uses the signal-based `input()` but declares its content query with the decorator-based `@ContentChildren`, mixing the two styles in the same example

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The query now uses the signal-based `contentChildren()` function (`items = contentChildren(MyMenuItem)`), matching the modern style of the surrounding `input()` call.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

