### PR TITLE
fix(compiler): let declaration span not including end character

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unused_let_declaration/unused_let_declaration_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/unused_let_declaration/unused_let_declaration_spec.ts
@@ -61,7 +61,7 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.UNUSED_LET_DECLARATION));
-      expect(getSourceCodeForDiagnostic(diags[0])).toBe('@let unused = 2');
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('@let unused = 2;');
     });
 
     it('should report a solo @let declaration that is not used', () => {
@@ -77,7 +77,7 @@ runInEachFileSystem(() => {
       expect(diags.length).toBe(1);
       expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
       expect(diags[0].code).toBe(ngErrorCode(ErrorCode.UNUSED_LET_DECLARATION));
-      expect(getSourceCodeForDiagnostic(diags[0])).toBe('@let foo = 1');
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('@let foo = 1;');
     });
 
     it('should not report a @let declaration that is only used in other @let declarations', () => {

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -423,8 +423,8 @@ class _Tokenizer {
     const endChar = this._cursor.peek();
     if (endChar === chars.$SEMICOLON) {
       this._beginToken(TokenType.LET_END);
-      this._endToken([]);
       this._cursor.advance();
+      this._endToken([]);
     } else {
       startToken.type = TokenType.INCOMPLETE_LET;
       startToken.sourceSpan = this._cursor.getSpan(start);

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -843,7 +843,7 @@ class _TreeBuilder {
       endToken = this._advance();
     }
 
-    const end = endToken.sourceSpan.fullStart;
+    const end = endToken.sourceSpan.end;
     const span = new ParseSourceSpan(
       startToken.sourceSpan.start,
       end,

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -1283,7 +1283,7 @@ describe('HtmlParser', () => {
 
       it('should store the source location of a @let declaration', () => {
         expect(humanizeDomSourceSpans(parser.parse('@let foo = 123 + 456;', 'TestCmp'))).toEqual([
-          [html.LetDeclaration, 'foo', '123 + 456', '@let foo = 123 + 456', 'foo', '123 + 456'],
+          [html.LetDeclaration, 'foo', '123 + 456', '@let foo = 123 + 456;', 'foo', '123 + 456'],
         ]);
       });
 

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -964,7 +964,7 @@ describe('R3 AST source spans', () => {
   describe('@let declaration', () => {
     it('is correct for a let declaration', () => {
       expectFromHtml('@let foo = 123;').toEqual([
-        ['LetDeclaration', '@let foo = 123', 'foo', '123'],
+        ['LetDeclaration', '@let foo = 123;', 'foo', '123'],
       ]);
     });
   });

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -510,7 +510,7 @@ describe('definitions', () => {
     const {definitions} = getDefinitionsAndAssertBoundSpan(env, template);
     expect(definitions[0].name).toEqual('foo');
     expect(definitions[0].kind).toBe(ts.ScriptElementKind.variableElement);
-    expect(definitions[0].textSpan).toBe('@let foo = {value: 123}');
+    expect(definitions[0].textSpan).toBe('@let foo = {value: 123};');
     assertFileNames(Array.from(definitions), ['app.html']);
   });
 

--- a/packages/language-service/test/legacy/definitions_spec.ts
+++ b/packages/language-service/test/legacy/definitions_spec.ts
@@ -292,7 +292,7 @@ describe('definitions', () => {
 
       expect(definitions.length).toBe(1);
       const [def] = definitions;
-      expect(def.textSpan).toBe('@let value = 42');
+      expect(def.textSpan).toBe('@let value = 42;');
     });
   });
 

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -877,7 +877,7 @@ describe('quick info', () => {
       it('should get quick info for a let declaration', () => {
         expectQuickInfo({
           templateOverride: `@let na¦me = 'Frodo'; {{name}}`,
-          expectedSpanText: `@let name = 'Frodo'`,
+          expectedSpanText: `@let name = 'Frodo';`,
           expectedDisplayString: `(let) name: "Frodo"`,
         });
       });
@@ -885,7 +885,7 @@ describe('quick info', () => {
       it('should get quick info for a let declaration initialized with a narrowed property', () => {
         expectQuickInfo({
           templateOverride: `@if (signalValue) { @let na¦me = signalValue; {{name}} }`,
-          expectedSpanText: `@let name = signalValue`,
+          expectedSpanText: `@let name = signalValue;`,
           expectedDisplayString: `(let) name: string`,
         });
       });


### PR DESCRIPTION
Fixes that the span for `@let` declarations didn't include the end token.
