### PR TITLE
docs: document moduleResolution bundler change in v20 update guide

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2706,6 +2706,14 @@ export const RECOMMENDATIONS: Step[] = [
   {
     possibleIn: 2000,
     necessaryAsOf: 2000,
+    level: ApplicationComplexity.Medium,
+    step: '20.0.0_set_moduleResolution_to_bundler',
+    action:
+      "Set `moduleResolution` to `'bundler'` in your `tsconfig.json`. Angular CLI's `ng update` migration applies this change automatically; if you upgrade manually or override the option in a base tsconfig, set it explicitly so imports of secondary entry-points such as `@angular/core/rxjs-interop` continue to resolve correctly.",
+  },
+  {
+    possibleIn: 2000,
+    necessaryAsOf: 2000,
     level: ApplicationComplexity.Advanced,
     step: '20.0.0_review_AsyncPipe_error_handling_in_tests',
     action:


### PR DESCRIPTION
The v20 update guide doesn't flag that `ng update` switches `moduleResolution` to `'bundler'`. Add a checklist item so manual upgrades don't miss it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Angular update guide does not flag that Angular CLI's `ng update @angular/cli@20` migration changes `moduleResolution` to `'bundler'` in the project's `tsconfig.json`. Users who upgrade manually or via tooling that bypasses the CLI migration miss the change and only discover it later when secondary entry-point imports such as `@angular/core/rxjs-interop` fail to resolve in v21 once the back-compat fallback is removed.

Issue Number: #68163

## What is the new behavior?

The Angular update checklist now includes a step for upgrades that cross v20, instructing users to set `moduleResolution: 'bundler'` in their `tsconfig.json`. The step notes that `ng update` applies the change automatically and calls out that manual upgrades or base-tsconfig overrides need to set it explicitly so secondary entry-point imports such as `@angular/core/rxjs-interop` continue to resolve correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

