### PR TITLE
docs: document allowedHosts SSR requirement in v21 update guide

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2912,4 +2912,12 @@ export const RECOMMENDATIONS: Step[] = [
     action:
       'The `lastSuccessfulNavigation` property on the Router has been converted to a signal. To get its value, you now need to invoke it as a function: `router.lastSuccessfulNavigation()`.',
   },
+  {
+    possibleIn: 2100,
+    necessaryAsOf: 2100,
+    level: ApplicationComplexity.Medium,
+    step: '21.0.0-configure-commonengine-allowed-hosts',
+    action:
+      "Starting `@angular/ssr` 21.1.5, if your application uses SSR with `CommonEngine`, set the `allowedHosts` option in your `server.ts` (for example, `new CommonEngine({allowedHosts: ['localhost', '*.yourdomain.com']})`). Without it, SSR silently falls back to client-side rendering. This requirement comes from security advisory [GHSA-x288-3778-4hhx](https://github.com/angular/angular-cli/security/advisories/GHSA-x288-3778-4hhx) (also backported to 20.3.17 and 19.2.21).",
+  },
 ];


### PR DESCRIPTION
The GHSA-x288-3778-4hhx patch requires `allowedHosts` on `CommonEngine` or SSR silently falls back to CSR. Add a checklist item to the v21 update guide.

fixes #68391 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The Angular update guide does not mention that security patch GHSA-x288-3778-4hhx makes `allowedHosts` mandatory on `CommonEngine`. Apps that upgrade without setting it see SSR silently fall back to CSR — HTTP 200 with an empty `<app-root></app-root>` and only a `console.error` that's easy to miss.

Issue Number: #68391 

## What is the new behavior?

The update checklist now includes a step for upgrades that cross v21, instructing SSR users to set `allowedHosts` on `CommonEngine` in `server.ts` and pointing to security advisory GHSA-x288-3778-4hhx as the rationale.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Addresses ask (a) from the issue. The other two asks,  an `ng update` `ACTION REQUIRED` warning and a more visible runtime fallback, involve CLI migration scripts and `@angular/ssr` runtime behavior, so they're out of scope for this docs PR.
