### PR TITLE
refactor(compiler-cli): remove reflectionhost from environment

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -285,7 +285,10 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         const dirRef = dir.ref as Reference<ClassDeclaration<ts.ClassDeclaration>>;
         const dirNode = dirRef.node;
 
-        if (!dir.isGeneric || !requiresInlineTypeCtor(dirNode, this.reflector, shimData.file)) {
+        if (
+          !dir.isGeneric ||
+          !requiresInlineTypeCtor(dirNode, this.reflector, (r) => shimData.file.canReferenceType(r))
+        ) {
           // inlining not required
           continue;
         }
@@ -408,6 +411,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         shimData.domSchemaChecker,
         shimData.oobRecorder,
         TcbGenericContextBehavior.FallbackToAny,
+        this.reflector,
       );
     } else {
       shimData.file.addTypeCheckBlock(
@@ -416,6 +420,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         shimData.domSchemaChecker,
         shimData.oobRecorder,
         TcbGenericContextBehavior.UseEmitter,
+        this.reflector,
       );
     }
   }
@@ -594,13 +599,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
         oobRecorder: new OutOfBandDiagnosticRecorderImpl(fileData.sourceManager, (name) =>
           this.compilerHost.getSourceFile(name, ts.ScriptTarget.Latest),
         ),
-        file: new TypeCheckFile(
-          shimPath,
-          this.config,
-          this.refEmitter,
-          this.reflector,
-          this.compilerHost,
-        ),
+        file: new TypeCheckFile(shimPath, this.config, this.refEmitter, this.compilerHost),
         data: new Map<TypeCheckId, TypeCheckData>(),
         shimDiagnostics: null,
       });
@@ -692,13 +691,14 @@ class InlineTcbOp implements Op {
   }
 
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter): string {
-    const env = new Environment(this.config, im, refEmitter, this.reflector, sf);
+    const env = new Environment(this.config, im, refEmitter, sf);
     const fnName = `_tcb_${this.ref.node.pos}`;
 
     const {tcbMeta, component} = adaptTypeCheckBlockMetadata(
       this.ref,
       this.meta,
       env,
+      this.reflector,
       TcbGenericContextBehavior.CopyClassNodes,
     );
 
@@ -735,7 +735,7 @@ class TypeCtorOp implements Op {
   }
 
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter): string {
-    const emitEnv = new ReferenceEmitEnvironment(im, refEmitter, this.reflector, sf);
+    const emitEnv = new ReferenceEmitEnvironment(im, refEmitter, sf);
     return generateInlineTypeCtor(emitEnv, this.ref.node, this.meta);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -17,7 +17,7 @@ import {
 import ts from 'typescript';
 
 import {ReferenceEmitter} from '../../imports';
-import {ReflectionHost} from '../../reflection';
+
 import {ImportManager} from '../../translator';
 
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
@@ -50,10 +50,9 @@ export class Environment extends ReferenceEmitEnvironment {
     readonly config: TypeCheckingConfig,
     importManager: ImportManager,
     refEmitter: ReferenceEmitter,
-    reflector: ReflectionHost,
     contextFile: ts.SourceFile,
   ) {
-    super(importManager, refEmitter, reflector, contextFile);
+    super(importManager, refEmitter, contextFile);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/reference_emit_environment.ts
@@ -17,7 +17,7 @@ import {
   ReferenceEmitKind,
   ReferenceEmitter,
 } from '../../imports';
-import {ReflectionHost} from '../../reflection';
+
 import {ImportManager, translateType} from '../../translator';
 
 /**
@@ -30,7 +30,6 @@ export class ReferenceEmitEnvironment {
   constructor(
     readonly importManager: ImportManager,
     public refEmitter: ReferenceEmitter,
-    readonly reflector: ReflectionHost,
     public contextFile: ts.SourceFile,
   ) {}
 
@@ -42,31 +41,6 @@ export class ReferenceEmitEnvironment {
   ): boolean {
     const result = this.refEmitter.emit(ref, this.contextFile, flags);
     return result.kind === ReferenceEmitKind.Success;
-  }
-
-  /**
-   * Generate a `ts.TypeNode` that references the given node as a type.
-   *
-   * This may involve importing the node into the file if it's not declared there already.
-   */
-  referenceType(
-    ref: Reference,
-    flags: ImportFlags = ImportFlags.NoAliasing |
-      ImportFlags.AllowTypeImports |
-      ImportFlags.AllowRelativeDtsImports,
-  ): ts.TypeNode {
-    const ngExpr = this.refEmitter.emit(ref, this.contextFile, flags);
-    assertSuccessfulReferenceEmit(ngExpr, this.contextFile, 'symbol');
-
-    // Create an `ExpressionType` from the `Expression` and translate it via `translateType`.
-    // TODO(alxhub): support references to types with generic arguments in a clean way.
-    return translateType(
-      new ExpressionType(ngExpr.expression),
-      this.contextFile,
-      this.reflector,
-      this.refEmitter,
-      this.importManager,
-    );
   }
 
   /**
@@ -102,20 +76,5 @@ export class ReferenceEmitEnvironment {
     }
 
     throw new Error('Unexpected value returned by import manager');
-  }
-
-  /**
-   * Generates a `ts.TypeNode` representing a type that is being referenced from a different place
-   * in the program. Any type references inside the transplanted type will be rewritten so that
-   * they can be imported in the context file.
-   */
-  referenceTransplantedType(type: TransplantedType<Reference<ts.TypeNode>>): ts.TypeNode {
-    return translateType(
-      type,
-      this.contextFile,
-      this.reflector,
-      this.refEmitter,
-      this.importManager,
-    );
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
@@ -8,10 +8,18 @@
 
 import {TypeCheckBlockMetadata, TypeCheckableDirectiveMeta} from '../api';
 import {Environment} from './environment';
-import {ImportFlags, ReferenceEmitKind, Reference} from '../../imports';
+import {
+  ImportFlags,
+  ReferenceEmitKind,
+  Reference,
+  ReferenceEmitter,
+  assertSuccessfulReferenceEmit,
+} from '../../imports';
+import {ImportManager, translateType} from '../../translator';
 import {
   AbsoluteSourceSpan,
   ExternalExpr,
+  ExpressionType,
   TransplantedType,
   BoundTarget,
   ReferenceTarget,
@@ -35,7 +43,7 @@ import {requiresInlineTypeCtor} from './type_constructor';
 import {tempPrint} from './tcb_print';
 import {generateTcbTypeParameters} from './tcb_util';
 import {TypeParameterEmitter} from './type_parameter_emitter';
-import {ClassDeclaration} from '../../reflection';
+import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import ts from 'typescript';
 
 /**
@@ -46,16 +54,42 @@ export function adaptTypeCheckBlockMetadata(
   ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
   meta: TypeCheckBlockMetadata,
   env: Environment,
+  reflector: ReflectionHost,
   genericContextBehavior: TcbGenericContextBehavior,
 ): {tcbMeta: TcbTypeCheckBlockMetadata; component: TcbComponentMetadata} {
   const refCache = new Map<Reference<ClassDeclaration>, TcbReferenceMetadata>();
   const dirCache = new Map<TypeCheckableDirectiveMeta, TcbDirectiveMetadata>();
 
+  const canReferenceType = (r: Reference) => {
+    const result = env.refEmitter.emit(
+      r,
+      env.contextFile,
+      ImportFlags.NoAliasing | ImportFlags.AllowTypeImports | ImportFlags.AllowRelativeDtsImports,
+    );
+    return result.kind === ReferenceEmitKind.Success;
+  };
+
+  const referenceType = (r: Reference) => {
+    const ngExpr = env.refEmitter.emit(
+      r,
+      env.contextFile,
+      ImportFlags.NoAliasing | ImportFlags.AllowTypeImports | ImportFlags.AllowRelativeDtsImports,
+    );
+    assertSuccessfulReferenceEmit(ngExpr, env.contextFile, 'symbol');
+    return translateType(
+      new ExpressionType(ngExpr.expression),
+      env.contextFile,
+      reflector,
+      env.refEmitter,
+      env.importManager,
+    );
+  };
+
   const extractRef = (ref: Reference<ClassDeclaration>) => {
     if (refCache.has(ref)) {
       return refCache.get(ref)!;
     }
-    const result = extractReferenceMetadata(ref, env);
+    const result = extractReferenceMetadata(ref, env.refEmitter, env.contextFile);
     refCache.set(ref, result);
     return result;
   };
@@ -77,8 +111,12 @@ export function adaptTypeCheckBlockMetadata(
             isSignal: input.isSignal,
             transformType: (() => {
               if (input.transform != null) {
-                const node = env.referenceTransplantedType(
+                const node = translateType(
                   new TransplantedType(input.transform.type),
+                  env.contextFile,
+                  reflector,
+                  env.refEmitter,
+                  env.importManager,
                 );
                 return tempPrint(node, env.contextFile);
               }
@@ -116,17 +154,20 @@ export function adaptTypeCheckBlockMetadata(
       isGeneric: dir.isGeneric,
       requiresInlineTypeCtor: requiresInlineTypeCtor(
         dir.ref.node as ClassDeclaration<ts.ClassDeclaration>,
-        env.reflector,
-        env,
+        reflector,
+        canReferenceType,
       ),
       ...adaptGenerics(
         dir.ref.node as ClassDeclaration<ts.ClassDeclaration>,
         env,
+        reflector,
         // The directive that we're processing is its own dependency
         // so we should the same generic context behavior.
         extractRef(dir.ref).key === extractRef(ref).key
           ? genericContextBehavior
           : TcbGenericContextBehavior.UseEmitter,
+        canReferenceType,
+        referenceType,
       ),
     };
 
@@ -210,7 +251,14 @@ export function adaptTypeCheckBlockMetadata(
     },
     component: {
       ref: extractRef(ref as Reference<ClassDeclaration>),
-      ...adaptGenerics(ref.node, env, genericContextBehavior),
+      ...adaptGenerics(
+        ref.node,
+        env,
+        reflector,
+        genericContextBehavior,
+        canReferenceType,
+        referenceType,
+      ),
     },
   };
 }
@@ -218,7 +266,10 @@ export function adaptTypeCheckBlockMetadata(
 function adaptGenerics(
   node: ClassDeclaration<ts.ClassDeclaration>,
   env: Environment,
+  reflector: ReflectionHost,
   genericContextBehavior: TcbGenericContextBehavior,
+  canReferenceType: (ref: Reference) => boolean,
+  referenceType: (ref: Reference) => ts.TypeNode,
 ): {
   typeParameters: TcbTypeParameter[] | null;
   typeArguments: string[] | null;
@@ -233,9 +284,9 @@ function adaptGenerics(
 
     switch (genericContextBehavior) {
       case TcbGenericContextBehavior.UseEmitter:
-        const emitter = new TypeParameterEmitter(node.typeParameters, env.reflector);
-        const emittedParams = emitter.canEmit((r) => env.canReferenceType(r))
-          ? emitter.emit((typeRef) => env.referenceType(typeRef))
+        const emitter = new TypeParameterEmitter(node.typeParameters, reflector);
+        const emittedParams = emitter.canEmit(canReferenceType)
+          ? emitter.emit(referenceType)
           : undefined;
         typeParameters = generateTcbTypeParameters(
           emittedParams || node.typeParameters,
@@ -261,14 +312,15 @@ function adaptGenerics(
 
 function extractReferenceMetadata(
   ref: Reference<ClassDeclaration>,
-  env: Environment,
+  refEmitter: ReferenceEmitter,
+  contextFile: ts.SourceFile,
 ): TcbReferenceMetadata {
   let name = ref.debugName || ref.node.name!.text;
   let moduleName = ref.ownedByModuleGuess;
   let unexportedDiagnostic: string | null = null;
   let isLocal = true;
 
-  const emitted = env.refEmitter.emit(ref, env.contextFile, ImportFlags.NoAliasing);
+  const emitted = refEmitter.emit(ref, contextFile, ImportFlags.NoAliasing);
   if (emitted.kind === ReferenceEmitKind.Success) {
     if (emitted.expression instanceof ExternalExpr) {
       name = emitted.expression.value.name!;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_util.ts
@@ -111,7 +111,9 @@ export function requiresInlineTypeCheckBlock(
   if (!env.canReferenceType(ref)) {
     // Condition 1 is false, the class is not exported.
     return TcbInliningRequirement.MustInline;
-  } else if (!checkIfGenericTypeBoundsCanBeEmitted(ref.node, reflector, env)) {
+  } else if (
+    !checkIfGenericTypeBoundsCanBeEmitted(ref.node, reflector, (r) => env.canReferenceType(r))
+  ) {
     // Condition 2 is false, the class has constrained generic types. It should be checked with an
     // inline TCB if possible, but can potentially use fallbacks to avoid inlining if not.
     return TcbInliningRequirement.ShouldInlineForGenericBounds;
@@ -276,11 +278,11 @@ export function ensureTypeCheckFilePreparationImports(env: ReferenceEmitEnvironm
 export function checkIfGenericTypeBoundsCanBeEmitted(
   node: ClassDeclaration<ts.ClassDeclaration>,
   reflector: ReflectionHost,
-  env: ReferenceEmitEnvironment,
+  canReferenceType: (ref: Reference) => boolean,
 ): boolean {
   // Generic type parameters are considered context free if they can be emitted into any context.
   const emitter = new TypeParameterEmitter(node.typeParameters, reflector);
-  return emitter.canEmit((ref) => env.canReferenceType(ref));
+  return emitter.canEmit(canReferenceType);
 }
 
 export function findNodeInFile<T extends ts.Node>(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -42,7 +42,6 @@ export class TypeCheckFile extends Environment {
     readonly fileName: AbsoluteFsPath,
     config: TypeCheckingConfig,
     refEmitter: ReferenceEmitter,
-    reflector: ReflectionHost,
     compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
   ) {
     super(
@@ -55,7 +54,6 @@ export class TypeCheckFile extends Environment {
         shouldUseSingleQuotes: () => true,
       }),
       refEmitter,
-      reflector,
       ts.createSourceFile(
         compilerHost.getCanonicalFileName(fileName),
         '',
@@ -71,12 +69,14 @@ export class TypeCheckFile extends Environment {
     domSchemaChecker: DomSchemaChecker<unknown>,
     oobRecorder: OutOfBandDiagnosticRecorder<unknown>,
     genericContextBehavior: TcbGenericContextBehavior,
+    reflector: ReflectionHost,
   ): void {
     const fnId = `_tcb${this.nextTcbId++}`;
     const {tcbMeta, component} = adaptTypeCheckBlockMetadata(
       ref,
       meta,
       this,
+      reflector,
       genericContextBehavior,
     );
     const fn = generateTypeCheckBlock(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -9,6 +9,7 @@
 import {R3Identifiers, TcbExpr, TcbTypeParameter, TypeCtorMetadata} from '@angular/compiler';
 import ts from 'typescript';
 
+import {Reference} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 
 import {ReferenceEmitEnvironment} from './reference_emit_environment';
@@ -179,11 +180,11 @@ function generateGenericArgs(typeParameters: ReadonlyArray<TcbTypeParameter> | u
 export function requiresInlineTypeCtor(
   node: ClassDeclaration<ts.ClassDeclaration>,
   host: ReflectionHost,
-  env: ReferenceEmitEnvironment,
+  canReferenceType: (ref: Reference) => boolean,
 ): boolean {
   // The class requires an inline type constructor if it has generic type bounds that can not be
   // emitted into the provided type-check environment.
-  return !checkIfGenericTypeBoundsCanBeEmitted(node, host, env);
+  return !checkIfGenericTypeBoundsCanBeEmitted(node, host, canReferenceType);
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/BUILD.bazel
@@ -25,6 +25,7 @@ ts_project(
         "//packages/compiler-cli/src/ngtsc/scope",
         "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/translator",
         "//packages/compiler-cli/src/ngtsc/typecheck",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "//packages/compiler-cli/src/ngtsc/typecheck/diagnostics",

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_constructor_spec.ts
@@ -62,7 +62,6 @@ runInEachFileSystem(() => {
         _('/_typecheck_.ts'),
         ALL_ENABLED_CONFIG,
         new ReferenceEmitter([]),
-        /* reflector */ null!,
         host,
       );
       const sf = file.render();

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_parameter_emitter_spec.ts
@@ -5,20 +5,23 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
+import {ExpressionType} from '@angular/compiler';
 import ts from 'typescript';
 
 import {absoluteFrom, LogicalFileSystem} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {
   AbsoluteModuleStrategy,
+  assertSuccessfulReferenceEmit,
   ImportFlags,
   LocalIdentifierStrategy,
   LogicalProjectStrategy,
   ModuleResolver,
   ReferenceEmitter,
 } from '../../imports';
-import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
+import {isNamedClassDeclaration, ReflectionHost, TypeScriptReflectionHost} from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
+import {translateType} from '../../translator';
 import {Environment} from '../src/environment';
 import {TypeCheckFile} from '../src/type_check_file';
 import {TypeParameterEmitter} from '../src/type_parameter_emitter';
@@ -59,22 +62,41 @@ runInEachFileSystem(() => {
         absoluteFrom('/app/main.ngtypecheck.ts'),
         ALL_ENABLED_CONFIG,
         refEmitter,
-        reflector,
         host,
       );
       const emitter = new TypeParameterEmitter(TestClass.typeParameters, reflector);
-      return {emitter, env};
+      return {emitter, env, reflector};
     }
 
     function emit(
-      {emitter, env}: {emitter: TypeParameterEmitter; env: Environment},
+      {
+        emitter,
+        env,
+        reflector,
+      }: {emitter: TypeParameterEmitter; env: TypeCheckFile; reflector: ReflectionHost},
       flags?: ImportFlags,
     ) {
       const canEmit = emitter.canEmit((ref) => env.canReferenceType(ref, flags));
 
       let emitted: ts.TypeParameterDeclaration[] | undefined;
       try {
-        emitted = emitter.emit((ref) => env.referenceType(ref, flags));
+        emitted = emitter.emit((ref) => {
+          const combinedFlags =
+            flags !== undefined
+              ? flags
+              : ImportFlags.NoAliasing |
+                ImportFlags.AllowTypeImports |
+                ImportFlags.AllowRelativeDtsImports;
+          const ngExpr = env.refEmitter.emit(ref, env.contextFile, combinedFlags);
+          assertSuccessfulReferenceEmit(ngExpr, env.contextFile, 'symbol');
+          return translateType(
+            new ExpressionType(ngExpr.expression),
+            env.contextFile,
+            reflector,
+            env.refEmitter,
+            env.importManager,
+          );
+        });
         expect(canEmit).toBe(true);
       } catch (e) {
         expect(canEmit).toBe(false);

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -458,7 +458,7 @@ export function tcb(
     new RelativePathStrategy(reflectionHost),
   ]);
 
-  const env = new TypeCheckFile(fileName, fullConfig, refEmmiter, reflectionHost, host);
+  const env = new TypeCheckFile(fileName, fullConfig, refEmmiter, host);
 
   env.addTypeCheckBlock(
     new Reference(clazz),
@@ -466,6 +466,7 @@ export function tcb(
     new NoopSchemaChecker(),
     new NoopOobRecorder(),
     TcbGenericContextBehavior.UseEmitter,
+    reflectionHost,
   );
 
   let rendered = env.render();


### PR DESCRIPTION
all necessary info is already available in the tcb meta objects. environments without full ts program no longer need a reflectionhost for tcb generation
