### PR TITLE
fix(core): normalize tag casing in getUrlSanitizer

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -233,7 +233,7 @@ const RESOURCE_MAP: Record<string, Record<string, true | undefined> | undefined>
  * If tag and prop names don't match Resource URL schema, use URL sanitizer.
  */
 export function getUrlSanitizer(tag: string, prop: string) {
-  const isResource = RESOURCE_MAP[tag]?.[prop] === true;
+  const isResource = RESOURCE_MAP[tag.toLowerCase()]?.[prop] === true;
 
   return isResource ? ɵɵsanitizeResourceUrl : ɵɵsanitizeUrl;
 }


### PR DESCRIPTION
Standard HTML tags are case-insensitive, and the Angular compiler preserves the exact casing used in templates. However, `getUrlSanitizer` queries the strictly lowercase `RESOURCE_MAP` without normalizing the `tag` argument first. 

If a resource tag is authored with uppercase characters, the dictionary lookup fails to match the existing rules. 

This PR adds a `.toLowerCase()` normalization step to ensure that `getUrlSanitizer` correctly identifies tags regardless of how the casing was authored in the template, bringing it inline with how `ɵɵvalidateAttribute` and other internal sanitization functions handle tag names.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
When a resource tag is authored with uppercase characters in a template, `getUrlSanitizer` fails to locate it in the strictly lowercase `RESOURCE_MAP` dictionary.

Issue Number: N/A

## What is the new behavior?
The `tag` argument is normalized using `.toLowerCase()` before querying `RESOURCE_MAP`, ensuring consistent and correct evaluation regardless of how the tag casing was authored.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
This resolves an internal framework correctness issue identified during code review.