### PR TITLE
fix(compiler): expand security schema for URL sinks

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -35,6 +35,11 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'a|href',
       'a|xlink:href',
       'form|action',
+      'meta|content',
+      'body|background',
+      'table|background',
+      'td|background',
+      'th|background',
 
       // MathML namespace
       // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
@@ -123,6 +128,8 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       // See: https://developer.mozilla.org/en-US/docs/Web/API/SVGScriptElement/href
       'script|href',
       'script|xlink:href',
+      'use|href',
+      'use|xlink:href',
     ]);
 
     // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -130,6 +130,9 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       'script|xlink:href',
       'use|href',
       'use|xlink:href',
+      // HTMLMediaElement: audio/video src is a resource-loading sink
+      // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/src
+      'media|src',
     ]);
 
     // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -168,6 +168,16 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext('set', 'to', false)).toBe(SecurityContext.ATTRIBUTE_NO_BINDING);
   });
 
+  it('should return security contexts for meta, background and svg:use sinks', () => {
+    expect(registry.securityContext('meta', 'content', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('body', 'background', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('table', 'background', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('td', 'background', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('th', 'background', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext('use', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
+    expect(registry.securityContext('use', 'xlink:href', false)).toBe(SecurityContext.RESOURCE_URL);
+  });
+
   it('should detect properties on namespaced elements', () => {
     const htmlAst = new HtmlParser().parse('<svg:style>', 'TestComp');
     const nodeName = (<Element>htmlAst.rootNodes[0]).name;

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -176,6 +176,8 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext('th', 'background', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext('use', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
     expect(registry.securityContext('use', 'xlink:href', false)).toBe(SecurityContext.RESOURCE_URL);
+    // media|src: compiler schema must match runtime RESOURCE_MAP
+    expect(registry.securityContext('media', 'src', false)).toBe(SecurityContext.RESOURCE_URL);
   });
 
   it('should detect properties on namespaced elements', () => {

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -223,6 +223,7 @@ const RESOURCE_MAP: Record<string, Record<string, true | undefined> | undefined>
   'base': {'href': true},
   'link': {'href': true},
   'object': {'data': true, 'codebase': true},
+  'use': {'href': true, 'xlink:href': true},
 };
 
 /**

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -189,6 +189,10 @@ describe('sanitization', () => {
         'href',
       ).toString(),
     ).toEqual('http://safe.com');
+    // media|src should also use ResourceURL sanitizer — sync with compiler schema
+    expect(() =>
+      ɵɵsanitizeUrlOrResourceUrl('http://attacker.com/audio.mp3', 'media', 'src'),
+    ).toThrowError(ERROR);
   });
 
   it('should only trust constant strings from template literal tags without interpolation', () => {

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -118,7 +118,7 @@ describe('sanitization', () => {
       [SecurityContext.RESOURCE_URL, ɵɵsanitizeResourceUrl],
     ]);
     Object.entries(schema).forEach(([key, context]) => {
-      if (context === SecurityContext.URL || SecurityContext.RESOURCE_URL) {
+      if (context === SecurityContext.URL || context === SecurityContext.RESOURCE_URL) {
         const [tag, prop] = key.split('|');
         const contexts = contextsByProp.get(prop) || new Set<number>();
         contexts.add(context);
@@ -166,6 +166,29 @@ describe('sanitization', () => {
     expect(
       ɵɵsanitizeUrlOrResourceUrl(bypassSanitizationTrustUrl('javascript:true'), 'a', 'href'),
     ).toEqual('javascript:true');
+  });
+
+  it('should sanitize new security sinks correctly', () => {
+    // meta[content] should use URL sanitizer
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'meta', 'content')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+    // table[background] should use URL sanitizer
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:alert(1)', 'table', 'background')).toEqual(
+      'unsafe:javascript:alert(1)',
+    );
+    // use[href] should use ResourceURL sanitizer (throws if not trusted)
+    const ERROR = /NG0904: unsafe value used in a resource URL context.*/;
+    expect(() => ɵɵsanitizeUrlOrResourceUrl('http://attacker.com', 'use', 'href')).toThrowError(
+      ERROR,
+    );
+    expect(
+      ɵɵsanitizeUrlOrResourceUrl(
+        bypassSanitizationTrustResourceUrl('http://safe.com'),
+        'use',
+        'href',
+      ).toString(),
+    ).toEqual('http://safe.com');
   });
 
   it('should only trust constant strings from template literal tags without interpolation', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, several element-attribute pairs that function as URL or Resource URL sinks are not registered in the DomSanitizer security schema (SECURITY_SCHEMA). This means that values bound to these properties (e.g., meta[content], table[background], or svg:use[href]) are not automatically validated against Angular's security contexts at compile time.

Issue Number: N/A (Proactive security hardening)

## What is the new behavior?
This PR expands the dom_security_schema.ts to include these missing sinks.

meta|content and background attributes are now registered under SecurityContext.URL.
use|href and use|xlink:href are now registered under SecurityContext.RESOURCE_URL.
This ensures the framework provides "Secure by Default" protection for these attributes by generating the appropriate ɵɵsanitizeUrl or ɵɵsanitizeResourceUrl instructions.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This update aligns the Angular security schema with modern browser behaviors and MDN standards for URL-handling attributes. By registering these sinks, we provide a consistent defense-in-depth posture across all valid HTML and SVG resource-loading paths.