### PR TITLE
docs: add information about zone.js Vitest patch in the Vitest migration guide

### DIFF
--- a/adev/src/content/guide/testing/migrating-to-vitest.md
+++ b/adev/src/content/guide/testing/migrating-to-vitest.md
@@ -225,10 +225,13 @@ Provide a direct path to a Vitest configuration file in your `angular.json`:
 **2. Automatic search for base configuration:**
 If you set `runnerConfig` to `true`, the builder will automatically search for a shared `vitest-base.config.*` file in your project and workspace roots.
 
-## `zone.js` based helpers are not supported
+## `zone.js` Vitest patch
 
-The zone.js patches are not applied when running tests with Vitest, therefore you won't be able to use functions like `fakeAsync`, `flush` or `waitForAsync`.
-To migrate to Vitest you will also need to migrate your tests to native async and Vitest fake timers. See [an example here](/guide/testing/components-scenarios#async-test-with-a-vitest-fake-timers) for fake timers usages with Vitest.
+In order to use functions like `fakeAsync`, `flush` or `waitForAsync`, or to enable your existing tests to work with them, you can add `zone.js/plugins/vitest-patch` to your test target polyfills in `angular.json`.
+
+Regardless, we strongly recommend you start planning to convert your existing test suites to native `async` and Vitest fake timers, since this is the established approach.
+
+See [an example here](/guide/testing/components-scenarios#async-test-with-a-vitest-fake-timers) for fake timers usage with Vitest.
 
 ## Bug reports
 


### PR DESCRIPTION
Update the Karma to Vitest migration guide to include information about the zone.js Vitest patch that should handle `fakeAsync`.

Related to #68395.
