### PR TITLE
fix(http): prevent duplicate search params in transfer cache key generation

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -312,8 +312,9 @@ function getFilteredHeaders(
   return headersMap;
 }
 
-function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
-  return [...params.keys()]
+/** Exported for testing. */
+export function sortAndConcatParams(params: HttpParams | URLSearchParams): string {
+  return Array.from(new Set(params.keys()))
     .sort()
     .map((k) => `${k}=${params.getAll(k)}`)
     .join('&');

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -19,7 +19,7 @@ import {TestBed} from '@angular/core/testing';
 import {useAutoTick, timeout, withBody} from '@angular/private/testing';
 import {BehaviorSubject} from 'rxjs';
 
-import {HttpClient, HttpResponse, provideHttpClient} from '../public_api';
+import {HttpClient, HttpParams, HttpResponse, provideHttpClient} from '../public_api';
 import {
   BODY,
   HEADERS,
@@ -29,6 +29,7 @@ import {
   STATUS_TEXT,
   REQ_URL,
   withHttpTransferCache,
+  sortAndConcatParams,
 } from '../src/transfer_cache';
 import {HttpTestingController, provideHttpClientTesting} from '../testing';
 import {PLATFORM_BROWSER_ID, PLATFORM_SERVER_ID} from '../../src/platform_id';
@@ -690,6 +691,18 @@ describe('TransferCache', () => {
             });
         });
       });
+    });
+  });
+
+  describe('sortAndConcatParams', () => {
+    it('should normalize HttpParams', () => {
+      let params = new HttpParams({fromString: 'foo=1&bar=2&foo=3'});
+      expect(sortAndConcatParams(params)).toBe('bar=2&foo=1,3');
+    });
+
+    it('should normalize search params', () => {
+      const params = new URLSearchParams('foo=1&bar=2&foo=3');
+      expect(sortAndConcatParams(params)).toBe('bar=2&foo=1,3');
     });
   });
 });


### PR DESCRIPTION
Updates `sortAndConcatParams` in TransferCache to deduplicate search param keys before sorting and concatenating them into a string.

Also adds tests for `sortAndConcatParams` to verify that it correctly normalizes both `HttpParams` and `URLSearchParams`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since `URLSearchParams.prototype.keys()` returns all keys including duplicates, the previous implementation could produce a string of length `O(N^2)` where `N` is the number of duplicate search param keys, potentially leading to OOM and excessive CPU usage when the request body is controllable by the user.
For example, the search params `foo=1&bar=2&foo=3` would produce the string `bar=2&foo=1,3&foo=1,3` instead of the expected `bar=2&foo=1,3`.

## What is the new behavior?

`sortAndConcatParams` correctly handle duplicate search param key.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
