### PR TITLE
fix(docs-infra): avoid double counting webcontainers after reload

### DIFF
--- a/adev/shared-docs/providers/index.ts
+++ b/adev/shared-docs/providers/index.ts
@@ -12,4 +12,5 @@ export * from './example-viewer-content-loader';
 export * from './is-search-dialog-open';
 export * from './local-storage';
 export * from './previews-components';
+export * from './session-storage';
 export * from './window';

--- a/adev/shared-docs/providers/session-storage.ts
+++ b/adev/shared-docs/providers/session-storage.ts
@@ -1,0 +1,68 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {isPlatformBrowser} from '@angular/common';
+import {InjectionToken, PLATFORM_ID, inject} from '@angular/core';
+
+export const SESSION_STORAGE = new InjectionToken<Storage | null>('SESSION_STORAGE', {
+  factory: () => getStorage(inject(PLATFORM_ID)),
+});
+
+const getStorage = (platformId: Object): Storage | null => {
+  // Prerendering: sessionStorage is undefined for prerender build
+  return isPlatformBrowser(platformId) ? new SessionStorage() : null;
+};
+
+/**
+ * SessionStorage is wrapper class for sessionStorage, operations can fail due to
+ * various reasons, such as browser restrictions or storage limits being exceeded.
+ * A wrapper is providing error handling.
+ */
+class SessionStorage implements Storage {
+  get length(): number {
+    try {
+      return sessionStorage.length;
+    } catch {
+      return 0;
+    }
+  }
+
+  clear(): void {
+    try {
+      sessionStorage.clear();
+    } catch {}
+  }
+
+  getItem(key: string): string | null {
+    try {
+      return sessionStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  key(index: number): string | null {
+    try {
+      return sessionStorage.key(index);
+    } catch {
+      return null;
+    }
+  }
+
+  removeItem(key: string): void {
+    try {
+      sessionStorage.removeItem(key);
+    } catch {}
+  }
+
+  setItem(key: string, value: string): void {
+    try {
+      sessionStorage.setItem(key, value);
+    } catch {}
+  }
+}

--- a/adev/shared-docs/testing/testing-helper.ts
+++ b/adev/shared-docs/testing/testing-helper.ts
@@ -52,11 +52,15 @@ export class FakeEventTarget implements EventTarget {
   }
 }
 
-export class MockLocalStorage implements Pick<Storage, 'getItem' | 'setItem'> {
+export class MockLocalStorage implements Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> {
   private items = new Map<string, string | null>();
 
   getItem(key: string): string | null {
     return this.items.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
   }
 
   setItem(key: string, value: string | null): void {

--- a/adev/src/app/editor/alert-manager.service.spec.ts
+++ b/adev/src/app/editor/alert-manager.service.spec.ts
@@ -1,0 +1,92 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {
+  LOCAL_STORAGE,
+  MockLocalStorage,
+  SESSION_STORAGE,
+  WINDOW,
+  FakeEventTarget,
+} from '@angular/docs';
+import {MatSnackBar} from '@angular/material/snack-bar';
+
+import {
+  AlertManager,
+  WEBCONTAINERS_COUNTER_KEY,
+  WEBCONTAINER_SESSION_KEY,
+} from './alert-manager.service';
+
+describe('AlertManager', () => {
+  let localStorage: MockLocalStorage;
+  let sessionStorage: MockLocalStorage;
+  let windowTarget: FakeEventTarget;
+
+  function createService(): AlertManager {
+    return TestBed.runInInjectionContext(() => new AlertManager());
+  }
+
+  beforeEach(() => {
+    localStorage = new MockLocalStorage();
+    sessionStorage = new MockLocalStorage();
+    windowTarget = new FakeEventTarget();
+
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: LOCAL_STORAGE, useValue: localStorage},
+        {provide: SESSION_STORAGE, useValue: sessionStorage},
+        {provide: WINDOW, useValue: windowTarget as unknown as Window},
+        {
+          provide: MatSnackBar,
+          useValue: jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['openFromComponent']),
+        },
+      ],
+    });
+  });
+
+  it('should register the current tab once', () => {
+    const service = createService();
+
+    service.init();
+
+    expect(localStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('1');
+    expect(sessionStorage.getItem(WEBCONTAINER_SESSION_KEY)).toBe('true');
+  });
+
+  it('should not increase the counter again after a reload in the same tab', () => {
+    createService().init();
+
+    createService().init();
+
+    expect(localStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('1');
+  });
+
+  it('should clear the tab registration on beforeunload so the next load can increment again', () => {
+    createService().init();
+
+    windowTarget.dispatchEvent(new Event('beforeunload'));
+
+    expect(localStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('0');
+    expect(sessionStorage.getItem(WEBCONTAINER_SESSION_KEY)).toBeNull();
+
+    createService().init();
+
+    expect(localStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('1');
+    expect(sessionStorage.getItem(WEBCONTAINER_SESSION_KEY)).toBe('true');
+  });
+
+  it('should not decrement below zero on beforeunload', () => {
+    localStorage.setItem(WEBCONTAINERS_COUNTER_KEY, '0');
+    sessionStorage.setItem(WEBCONTAINER_SESSION_KEY, 'true');
+
+    createService().init();
+    windowTarget.dispatchEvent(new Event('beforeunload'));
+
+    expect(localStorage.getItem(WEBCONTAINERS_COUNTER_KEY)).toBe('0');
+  });
+});

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -7,12 +7,13 @@
  */
 
 import {inject, Service} from '@angular/core';
-import {LOCAL_STORAGE, WINDOW, isMobile} from '@angular/docs';
+import {LOCAL_STORAGE, SESSION_STORAGE, WINDOW, isMobile} from '@angular/docs';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {ErrorSnackBar, ErrorSnackBarData} from '../core/services/errors-handling/error-snack-bar';
 
 export const MAX_RECOMMENDED_WEBCONTAINERS_INSTANCES = 3;
 export const WEBCONTAINERS_COUNTER_KEY = 'numberOfWebcontainers';
+export const WEBCONTAINER_SESSION_KEY = 'hasRunningWebcontainer';
 
 export enum AlertReason {
   OUT_OF_MEMORY,
@@ -22,13 +23,14 @@ export enum AlertReason {
 @Service()
 export class AlertManager {
   private readonly localStorage = inject(LOCAL_STORAGE);
+  private readonly sessionStorage = inject(SESSION_STORAGE);
   private readonly window = inject(WINDOW);
   private snackBar = inject(MatSnackBar);
 
   init(): void {
     this.listenToLocalStorageValuesChange();
 
-    this.increaseInstancesCounter();
+    this.registerCurrentTab();
 
     this.decreaseInstancesCounterOnPageClose();
 
@@ -43,20 +45,31 @@ export class AlertManager {
     });
   }
 
-  // Increase count of the running instances of the webcontainers when user will boot the webcontainer
-  private increaseInstancesCounter(): void {
+  // Register the current tab once so automatic reloads don't double count the same tab.
+  private registerCurrentTab(): void {
+    if (this.sessionStorage?.getItem(WEBCONTAINER_SESSION_KEY) === 'true') {
+      this.validateRunningInstances(this.getStoredCountOfWebcontainerInstances());
+      return;
+    }
+
     const countOfRunningInstances = this.getStoredCountOfWebcontainerInstances() + 1;
 
     this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, countOfRunningInstances.toString());
+    this.sessionStorage?.setItem(WEBCONTAINER_SESSION_KEY, 'true');
     this.validateRunningInstances(countOfRunningInstances);
   }
 
   // Decrease count of running instances of the webcontainers when user close the app.
   private decreaseInstancesCounterOnPageClose(): void {
     this.window.addEventListener('beforeunload', () => {
-      const countOfRunningInstances = this.getStoredCountOfWebcontainerInstances() - 1;
+      if (this.sessionStorage?.getItem(WEBCONTAINER_SESSION_KEY) !== 'true') {
+        return;
+      }
+
+      const countOfRunningInstances = Math.max(this.getStoredCountOfWebcontainerInstances() - 1, 0);
 
       this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, countOfRunningInstances.toString());
+      this.sessionStorage?.removeItem(WEBCONTAINER_SESSION_KEY);
       this.validateRunningInstances(countOfRunningInstances);
     });
   }


### PR DESCRIPTION
## What changed

- add a safe `SESSION_STORAGE` provider for the docs app
- track embedded editor WebContainer registration per browser tab in `AlertManager`
- avoid incrementing the shared WebContainer counter again when the same tab reloads after an OOM-style browser refresh
- clear the per-tab registration on `beforeunload`
- add focused `AlertManager` unit coverage for same-tab reloads, unload cleanup, and counter clamping

## Why

Issue #52647 describes a stale WebContainer count in the docs app. The current implementation stores only a shared counter in `localStorage`. When Safari reloads a tab after an out-of-memory event without firing `beforeunload`, the next page load increments the same tab a second time. That leaves the shared count artificially high and causes the warning to appear even when the user no longer has too many tutorial/playground tabs open.

## Root cause

The previous implementation had no per-tab identity. It could increment the global count on every initialization, but it could only decrement when `beforeunload` fired. Any browser-driven reload path that skipped `beforeunload` caused the same tab to be counted twice.

## Impact

This keeps the existing cross-tab warning behavior for real concurrent tutorial/playground tabs, while preventing false positives caused by automatic reloads in the same tab.

## Validation

- added dedicated unit tests for `AlertManager`
- formatted the touched files with Prettier
- attempted repo test execution, but local verification is still partially blocked in this Windows clone by Angular workspace tooling constraints:
  - Bazel test startup fails because the repository lockfile is currently inconsistent for Bazel's pnpm parser in this environment
  - Angular CLI test execution originally required Node `22.22.x`; after installing that locally, the `adev` workspace test runner still did not resolve the monorepo package layout correctly in this clone

Fixes #52647