### PR TITLE
docs(docs-infra): Add build-time validation for API and guide links u…

### DIFF
--- a/adev/scripts/routes/BUILD.bazel
+++ b/adev/scripts/routes/BUILD.bazel
@@ -51,4 +51,11 @@ js_run_binary(
     outs = ["defined-routes.json"],
     chdir = package_name(),
     tool = ":generate_route",
+    # Public so the api-gen rendering pipeline (used from //packages/...) can validate guide
+    # links against the same set of routes defined for the live site.
+    visibility = [
+        "//adev:__subpackages__",
+        "//packages:__subpackages__",
+        "//tools:__subpackages__",
+    ],
 )

--- a/adev/shared-docs/pipeline/api-gen/rendering/defined-routes-context.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/defined-routes-context.mts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Flat set of all routes (and `route#anchor` pairs) defined by the application's navigation
+ * tree. Populated once per pipeline invocation from `defined-routes.json`, which is produced
+ * by `//adev/scripts/routes:run_generate_route` from a TypeScript import of the canonical
+ * `ALL_ITEMS` navigation entries.
+ *
+ * This is the same source of truth used by the markdown -> HTML guide rendering pipeline
+ * (see `AdevDocsRenderer#isKnownRoute`), so api-gen and guide-gen agree on what counts as a
+ * valid link target.
+ *
+ * Used by the `{@link /guide/...}` and `[label](/guide/...)` validators to catch broken or
+ * stale guide links at build time.
+ */
+let definedRoutes = new Set<string>();
+
+export function setDefinedRoutes(routes: string[]): void {
+  definedRoutes = new Set(routes);
+}
+
+/**
+ * Whether the given route (e.g. `guide/signals` or `guide/signals#what-are-signals`) is one
+ * of the known navigation routes.
+ */
+export function isKnownRoute(route: string): boolean {
+  return definedRoutes.has(route);
+}
+
+/** Whether a defined-routes manifest has been loaded for this pipeline invocation. */
+export function hasDefinedRoutes(): boolean {
+  return definedRoutes.size > 0;
+}
+
+/**
+ * Returns the heading anchor IDs defined for the given route path. Used to suggest a
+ * corrected anchor when a `#fragment` doesn't match (case-insensitive lookup).
+ */
+export function getAnchorsForRoute(route: string): string[] {
+  const prefix = `${route}#`;
+  const anchors: string[] = [];
+  for (const currentRoute of definedRoutes) {
+    if (currentRoute.startsWith(prefix)) {
+      anchors.push(currentRoute.slice(prefix.length));
+    }
+  }
+  return anchors;
+}

--- a/adev/shared-docs/pipeline/api-gen/rendering/index.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/index.mts
@@ -13,7 +13,8 @@ import {DocEntry} from './entities.mjs';
 import {isCliEntry, isHiddenEntry} from './entities/categorization.mjs';
 import {getRenderable} from './processing.mjs';
 import {renderEntry} from './rendering.mjs';
-import {setCurrentSymbol, setSymbols} from './symbol-context.mjs';
+import {setCurrentSymbol, setSymbolMembers, setSymbols} from './symbol-context.mjs';
+import {setDefinedRoutes} from './defined-routes-context.mjs';
 import {CliCommandRenderable, DocEntryRenderable} from './entities/renderables.mjs';
 import {initHighlighter} from '../../shared/shiki.mjs';
 import {setHighlighterInstance} from './shiki/shiki.mjs';
@@ -94,6 +95,35 @@ function getNormalizedFilename(normalizedModuleName: string, entry: DocEntry | C
   return `${normalizedModuleName}_${entry.name}_${entry.entryType.toLowerCase()}.html`;
 }
 
+/**
+ * Build an index of `<symbol> -> Set<member name>` from a package's entries. Used to validate
+ * `#member` fragments in `{@link /api/<module>/<Symbol>#<member>}` tags at build time.
+ *
+ * Walks any entry that has a `members` array (classes, interfaces, enums, decorators, namespaces,
+ * directives, pipes), without committing to a particular concrete entry shape.
+ */
+function buildSymbolMembersIndex(entries: (DocEntry | CliCommand)[]): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const entry of entries) {
+    const members = (entry as {members?: {name: string}[]}).members;
+    if (!Array.isArray(members) || members.length === 0) {
+      continue;
+    }
+    const name = (entry as {name?: string}).name;
+    if (!name) {
+      continue;
+    }
+    const set = index.get(name) ?? new Set<string>();
+    for (const member of members) {
+      if (member?.name) {
+        set.add(member.name);
+      }
+    }
+    index.set(name, set);
+  }
+  return index;
+}
+
 async function main() {
   // Shiki highlighter needs to be setup in an async context
   setHighlighterInstance(await initHighlighter());
@@ -101,7 +131,9 @@ async function main() {
   const [paramFilePath] = process.argv.slice(2);
   const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
 
-  const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
+  const [srcs, outputFilenameExecRootRelativePath, definedRoutesPath] = rawParamLines;
+
+  setDefinedRoutes(JSON.parse(readFileSync(definedRoutesPath, {encoding: 'utf8'})) as string[]);
 
   // Docs rendering happens in three phases that occur here:
   // 1) Aggregate all the raw extracted doc info.
@@ -120,6 +152,7 @@ async function main() {
 
     // Setting the symbols are a global context for the rendering templates of this entry
     setSymbols(collection.symbols);
+    setSymbolMembers(buildSymbolMembersIndex(collection.entries));
 
     const renderableEntries: (DocEntryRenderable | CliCommandRenderable)[] = [];
     for (const entry of extractedEntries) {

--- a/adev/shared-docs/pipeline/api-gen/rendering/render_api_to_html.bzl
+++ b/adev/shared-docs/pipeline/api-gen/rendering/render_api_to_html.bzl
@@ -18,9 +18,15 @@ def _render_api_to_html(ctx):
     args.add(html_output_directory.path)
     outputs = [html_output_directory]
 
+    # Path to the defined-routes manifest used to validate guide links in JSDoc and markdown.
+    # The manifest is a flat JSON array of route paths and `route#anchor` entries derived from
+    # the application's navigation tree.
+    args.add(ctx.file.defined_routes.path)
+    inputs = ctx.files.srcs + [ctx.file.defined_routes]
+
     # Define an action that runs the executable.
     ctx.actions.run(
-        inputs = depset(ctx.files.srcs),
+        inputs = depset(inputs),
         executable = ctx.executable._render_api_to_html,
         outputs = outputs,
         arguments = [args],
@@ -44,6 +50,13 @@ render_api_to_html = rule(
     attrs = {
         # The source files for this rule. This must include one or more json data files.
         "srcs": attr.label_list(allow_empty = False, allow_files = True),
+
+        # Defined-routes manifest produced by //adev/scripts/routes:run_generate_route. Used
+        # to validate `/guide/...` URLs in `{@link}` JSDoc tags and markdown links.
+        "defined_routes": attr.label(
+            default = Label("//adev/scripts/routes:defined-routes.json"),
+            allow_single_file = [".json"],
+        ),
 
         # The executable for this rule (private).
         "_render_api_to_html": attr.label(

--- a/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/symbol-context.mts
@@ -15,6 +15,16 @@ import {getSymbolUrl as sharedGetSymbolUrl} from '../../shared/linking.mjs';
 
 let symbols: Record<string, string> = {};
 
+/**
+ * Index of known members per symbol for the currently processed package. Populated alongside
+ * `symbols` so we can validate `#member` fragments in `{@link /api/<module>/<Symbol>#<member>}`
+ * tags at build time.
+ *
+ * Per-package scope: only symbols belonging to the package currently being rendered are present;
+ * cross-package member fragments are not validated here.
+ */
+let symbolMembers: Map<string, Set<string>> = new Map();
+
 // This is used to store the currently processed symbol (usually a class or an interface)
 let currentSymbol: string | undefined;
 export function setCurrentSymbol(symbol: string): void {
@@ -38,6 +48,16 @@ export function getCurrentSymbol(): string | undefined {
 
 export function setSymbols(newSymbols: Record<string, string>): void {
   symbols = newSymbols;
+}
+
+/** Set the index of known members per symbol for the currently processed package. */
+export function setSymbolMembers(newSymbolMembers: Map<string, Set<string>>): void {
+  symbolMembers = newSymbolMembers;
+}
+
+/** Get the set of known members for a symbol, or `undefined` if the symbol isn't tracked. */
+export function getSymbolMembers(symbol: string): Set<string> | undefined {
+  return symbolMembers.get(symbol);
 }
 
 export function getSymbolUrl(symbol: string): string | undefined {

--- a/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/test/transforms/jsdoc-transforms.spec.mts
@@ -8,15 +8,25 @@
 
 import {initHighlighter} from '../../../../shared/shiki.mjs';
 import {setHighlighterInstance} from '../../shiki/shiki.mjs';
-import {setCurrentSymbol, setSymbols} from '../../symbol-context.mjs';
+import {setCurrentSymbol, setSymbolMembers, setSymbols} from '../../symbol-context.mjs';
+import {setDefinedRoutes} from '../../defined-routes-context.mjs';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
+  addHtmlUsageNotes,
   setEntryFlags,
 } from '../../transforms/jsdoc-transforms.mjs';
 
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
 describe('jsdoc transforms', () => {
+  beforeAll(async () => {
+    setHighlighterInstance(await initHighlighter());
+  });
+
+  afterEach(() => {
+    setDefinedRoutes([]);
+  });
+
   describe('addHtmlAdditionalLinks', () => {
     it('should transform links', () => {
       setCurrentSymbol('Router');
@@ -219,14 +229,251 @@ describe('jsdoc transforms', () => {
           moduleName: 'test',
         });
 
-      expect(entryFn).toThrowError(/Broken @link.*Did you mean \/api\/router\/RouterModule/);
+      expect(entryFn).toThrowError(/Broken link.*Did you mean \/api\/router\/RouterModule/);
+    });
+
+    it('should throw on an unknown #member fragment for a known API symbol', () => {
+      setSymbols({RouterModule: 'router'});
+      setSymbolMembers(new Map([['RouterModule', new Set(['forRoot', 'forChild'])]]));
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '{@link /api/router/RouterModule#forBogus forBogus}',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*RouterModule has no member named 'forBogus'/);
+    });
+
+    it('should throw on a miscased #member fragment for a known API symbol', () => {
+      setSymbols({RouterModule: 'router'});
+      setSymbolMembers(new Map([['RouterModule', new Set(['forRoot', 'forChild'])]]));
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '{@link /api/router/RouterModule#forroot forRoot}',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*Did you mean #forRoot/);
+    });
+
+    it('should accept a valid #member fragment', () => {
+      setSymbols({RouterModule: 'router'});
+      setSymbolMembers(new Map([['RouterModule', new Set(['forRoot', 'forChild'])]]));
+
+      const entry = addHtmlAdditionalLinks({
+        jsdocTags: [
+          {
+            name: 'see',
+            comment: '{@link /api/router/RouterModule#forRoot forRoot}',
+          },
+        ],
+        moduleName: 'test',
+      });
+
+      expect(entry.additionalLinks[0]).toEqual({
+        label: 'forRoot',
+        url: '/api/router/RouterModule#forRoot',
+      });
+    });
+
+    it('should accept known API section anchors as valid fragments', () => {
+      // `#usage-notes`, `#description`, `#api`, `#pipe-usage` are emitted by the API page
+      // template (`SectionHeading`) and are always present, even if they aren't members.
+      setSymbols({ChangeDetectorRef: 'core'});
+      setSymbolMembers(
+        new Map([['ChangeDetectorRef', new Set(['detectChanges', 'markForCheck'])]]),
+      );
+
+      const entry = addHtmlAdditionalLinks({
+        jsdocTags: [
+          {
+            name: 'see',
+            comment: '{@link /api/core/ChangeDetectorRef#usage-notes Change detection usage}',
+          },
+        ],
+        moduleName: 'test',
+      });
+
+      expect(entry.additionalLinks[0].url).toBe('/api/core/ChangeDetectorRef#usage-notes');
+    });
+
+    it('should throw on a /guide/ link to an unknown page', () => {
+      setDefinedRoutes(['guide/signals/effect', 'guide/signals/effect#use-cases-for-effects']);
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '{@link /guide/signals/non-existent Effect}',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*Unknown guide page guide\/signals\/non-existent/);
+    });
+
+    it('should throw on a /guide/ link with an unknown #fragment', () => {
+      setDefinedRoutes([
+        'guide/signals/effect',
+        'guide/signals/effect#use-cases-for-effects',
+        'guide/signals/effect#injection-context',
+      ]);
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '{@link /guide/signals/effect#effect-cleanup-functions Effect cleanup}',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(
+        /Broken link.*Page guide\/signals\/effect has no heading with id 'effect-cleanup-functions'/,
+      );
+    });
+
+    it('should throw on a /guide/ link with a miscased #fragment and suggest the correct id', () => {
+      setDefinedRoutes(['guide/signals/effect', 'guide/signals/effect#use-cases-for-effects']);
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '{@link /guide/signals/effect#Use-Cases-For-Effects Use cases}',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*Did you mean #use-cases-for-effects/);
+    });
+
+    it('should accept a valid /guide/ link with a known #fragment', () => {
+      setDefinedRoutes([
+        'guide/signals/effect',
+        'guide/signals/effect#use-cases-for-effects',
+        'guide/signals/effect#injection-context',
+      ]);
+
+      const entry = addHtmlAdditionalLinks({
+        jsdocTags: [
+          {
+            name: 'see',
+            comment: '{@link /guide/signals/effect#injection-context Injection context}',
+          },
+        ],
+        moduleName: 'test',
+      });
+
+      expect(entry.additionalLinks[0].url).toBe('/guide/signals/effect#injection-context');
+    });
+
+    it('should throw on a markdown @see link to an unknown /guide/ page', () => {
+      setDefinedRoutes(['guide/di', 'guide/di/creating-and-using-services']);
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '[No Existing services guide](guide/di/non-existent-page)',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*Unknown guide page guide\/di\/non-existent-page/);
+    });
+
+    it('should throw on a markdown @see link with an unknown #fragment', () => {
+      setDefinedRoutes(['guide/di', 'guide/di#dependency-injection-in-angular']);
+
+      const entryFn = () =>
+        addHtmlAdditionalLinks({
+          jsdocTags: [
+            {
+              name: 'see',
+              comment: '[DI guide](guide/di#non-existent-section)',
+            },
+          ],
+          moduleName: 'test',
+        });
+
+      expect(entryFn).toThrowError(
+        /Broken link.*Page guide\/di has no heading with id 'non-existent-section'/,
+      );
     });
   });
 
   describe('addHtmlDescription', () => {
-    it('should parse markdown in descriptions', async () => {
-      setHighlighterInstance(await initHighlighter());
+    it('should throw on a broken markdown /guide/ link in the description', () => {
+      setDefinedRoutes([
+        'guide/directives/structural-directives',
+        'guide/directives/structural-directives#structural-directive-shorthand',
+      ]);
 
+      const entryFn = () =>
+        addHtmlDescription({
+          description:
+            'See the [shorthand form](guide/directives/structural-directives#bogus-anchor) for details.',
+          moduleName: 'common',
+        });
+
+      expect(entryFn).toThrowError(
+        /Broken link.*Page guide\/directives\/structural-directives has no heading with id 'bogus-anchor'/,
+      );
+    });
+
+    it('should throw on a broken markdown /guide/ link in @usageNotes', () => {
+      setDefinedRoutes(['guide/signals', 'guide/signals#computed-signals']);
+
+      const entryFn = () =>
+        addHtmlUsageNotes({
+          jsdocTags: [
+            {
+              name: 'usageNotes',
+              comment: 'Read the [signals guide](guide/signals/non-existent) for context.',
+            },
+          ],
+        });
+
+      expect(entryFn).toThrowError(/Broken link.*Unknown guide page guide\/signals\/non-existent/);
+    });
+
+    it('should accept a valid markdown /guide/ link in the description', () => {
+      setDefinedRoutes([
+        'guide/directives/structural-directives',
+        'guide/directives/structural-directives#structural-directive-shorthand',
+      ]);
+
+      const entry = addHtmlDescription({
+        description:
+          'See the [shorthand form](guide/directives/structural-directives#structural-directive-shorthand) for details.',
+        moduleName: 'common',
+      });
+
+      expect(entry.htmlDescription).toContain('shorthand form');
+    });
+
+    it('should parse markdown in descriptions', () => {
       setSymbols(
         Object.fromEntries([
           ['Route', 'test'],

--- a/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
+++ b/adev/shared-docs/pipeline/api-gen/rendering/transforms/jsdoc-transforms.mts
@@ -29,10 +29,12 @@ import {parseMarkdown} from '../../../shared/marked/parse.mjs';
 import {getHighlighterInstance} from '../shiki/shiki.mjs';
 import {
   getCurrentSymbol,
+  getSymbolMembers,
   getSymbolsAsApiEntries,
   getSymbolUrl,
   unknownSymbolMessage,
 } from '../symbol-context.mjs';
+import {getAnchorsForRoute, hasDefinedRoutes, isKnownRoute} from '../defined-routes-context.mjs';
 import {addApiLinksToHtml} from './code-transforms.mjs';
 import {isExternalLink} from '../../../shared/marked/helpers.mjs';
 
@@ -43,6 +45,15 @@ export const JS_DOC_DESCRIPTION_TAG = 'description';
 // Some links are written in the following format: {@link Route}
 const jsDoclinkRegex = /\{\s*@link\s+([^}]+)\s*\}/;
 const jsDoclinkRegexGlobal = new RegExp(jsDoclinkRegex.source, 'g');
+
+/**
+ * Section anchors that the API page templates always emit (via `SectionHeading` /
+ * `convertSectionNameToId`). Fragments matching one of these are valid even though they don't
+ * correspond to a class/interface member.
+ *
+ * Keep in sync with `templates/section-*.tsx` and the inline `<SectionHeading name="...">` usages.
+ */
+const KNOWN_API_SECTION_ANCHORS = new Set(['description', 'usage-notes', 'api', 'pipe-usage']);
 
 /** Given an entity with a description, gets the entity augmented with an `htmlDescription`. */
 export function addHtmlDescription<T extends HasDescription & HasModuleName & MaybeJsDocTags>(
@@ -114,13 +125,109 @@ export function addHtmlUsageNotes<T extends HasJsDocTags>(entry: T): T & HasHtml
 
 /** Given a markdown JsDoc text, gets the rendered HTML. */
 export function getHtmlForJsDocText(text: string): string {
-  const mdToParse = convertLinks(wrapExampleHtmlElementsWithCode(text));
+  const escaped = wrapExampleHtmlElementsWithCode(text);
+  validateMarkdownLinks(escaped);
+  const mdToParse = convertLinks(escaped);
   const parsed = parseMarkdown(mdToParse, {
     apiEntries: getSymbolsAsApiEntries(),
     highlighter: getHighlighterInstance(),
     definedRoutes: [],
   });
   return addApiLinksToHtml(parsed);
+}
+
+// Markdown inline link: [label](url) or [label](url "title"). Used to extract URLs for
+// build-time validation against the guide/api manifests. We only care about the URL group.
+const markdownLinkUrlRegexGlobal = /\[(?:[^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+/**
+ * Walk every markdown `[label](url)` link in `text` and run the same `/api/...` and `/guide/...`
+ * validation that `{@link}` URLs are subject to. This catches broken/stale links written in
+ * plain markdown , including those in `@see` tag comments , at build time.
+ */
+function validateMarkdownLinks(text: string): void {
+  for (const match of text.matchAll(markdownLinkUrlRegexGlobal)) {
+    validateInternalUrl(match[1]);
+  }
+}
+
+/**
+ * Validate an absolute or relative internal documentation URL. Accepts URLs with or without a
+ * leading `/` since both forms are common in markdown link syntax. External URLs (`http`, `mailto`,
+ * `#`-only fragments, etc.) and unknown shapes are accepted as-is , this validator only enforces
+ * correctness for paths it knows how to check.
+ */
+function validateInternalUrl(url: string): void {
+  if (!url || url.startsWith('#') || url.startsWith('http') || url.startsWith('mailto:')) {
+    return;
+  }
+  // Normalise leading slash for prefix matching but keep the original for error messages.
+  const normalised = url.startsWith('/') ? url : `/${url}`;
+  if (normalised.startsWith('/api/')) {
+    validateApiUrl(url, normalised);
+  } else if (normalised.startsWith('/guide/')) {
+    validateGuideUrl(url, normalised);
+  }
+}
+
+function validateApiUrl(originalUrl: string, normalisedUrl: string): void {
+  const [pathPart, fragment] = normalisedUrl.split('#');
+  const segments = pathPart.split('/').filter((s) => s.length > 0);
+  const symbolName = segments.at(-1)!;
+  const knownSymbols = Object.keys(getSymbolsAsApiEntries());
+  // Prefer an exact-case match (e.g. both `inject` and `Inject` exist in core) and only fall
+  // back to a case-insensitive lookup to suggest the canonical capitalisation.
+  const canonicalSymbol = knownSymbols.includes(symbolName)
+    ? symbolName
+    : knownSymbols.find((s) => s.toLowerCase() === symbolName.toLowerCase());
+  if (canonicalSymbol && canonicalSymbol !== symbolName) {
+    const expectedUrl = getSymbolUrl(canonicalSymbol);
+    throw Error(
+      `Broken link: ${originalUrl}. Did you mean ${expectedUrl}? ` +
+        `Symbol names in API URLs are case-sensitive.`,
+    );
+  }
+  if (fragment && canonicalSymbol && !KNOWN_API_SECTION_ANCHORS.has(fragment)) {
+    const members = getSymbolMembers(canonicalSymbol);
+    if (members && !members.has(fragment)) {
+      const memberMatch = [...members].find((m) => m.toLowerCase() === fragment.toLowerCase());
+      const hint = memberMatch
+        ? `Did you mean #${memberMatch}? Member names are case-sensitive.`
+        : `${canonicalSymbol} has no member named '${fragment}'.`;
+      throw Error(`Broken link: ${originalUrl}. ${hint}`);
+    }
+  }
+}
+
+function validateGuideUrl(originalUrl: string, normalisedUrl: string): void {
+  if (!hasDefinedRoutes()) {
+    return;
+  }
+  const [pathPart, fragment] = normalisedUrl.split('#');
+  // Strip the leading `/` and any trailing `/` so the key matches the manifest entries
+  // (`guide/...`, not `/guide/...`).
+  const guidePath = pathPart.replace(/^\//, '').replace(/\/$/, '');
+  const fullKey = fragment ? `${guidePath}#${fragment}` : guidePath;
+
+  if (isKnownRoute(fullKey)) {
+    return;
+  }
+
+  if (!fragment) {
+    throw new Error(`Broken link: ${originalUrl}. Unknown guide page ${guidePath}. `);
+  }
+  // The page may exist (just not this anchor) or may itself be unknown. Distinguish so the
+  // error message can suggest a near-match anchor when possible.
+  const knownAnchors = getAnchorsForRoute(guidePath);
+  if (!isKnownRoute(guidePath) && knownAnchors.length === 0) {
+    throw new Error(`Broken link: ${originalUrl}. Unknown guide page ${guidePath}. `);
+  }
+  const anchorMatch = knownAnchors.find((a) => a.toLowerCase() === fragment.toLowerCase());
+  const hint = anchorMatch
+    ? `Did you mean #${anchorMatch}? Anchor IDs are case-sensitive.`
+    : `Page ${guidePath} has no heading with id '${fragment}'.`;
+
+  throw new Error(`Broken link: ${originalUrl}. ${hint}`);
 }
 
 export function setEntryFlags<T extends HasJsDocTags & HasModuleName>(
@@ -153,6 +260,7 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags>(entry: T): LinkEntryRend
 
       if (markdownLinkMatch) {
         const url = markdownLinkMatch[2];
+        validateInternalUrl(url);
         return {
           label: convertBackticksToCodeTags(markdownLinkMatch[1]),
           url,
@@ -224,26 +332,10 @@ function parseAtLink(link: string): {label: string; url: string} | undefined {
       );
     }
 
-    // Validate absolute `/api/...` links against the known symbol registry. This catches
-    // miscased symbol names (e.g. `/api/router/routerModule` instead of
-    // `/api/router/RouterModule`) at build time.
-    if (rawSymbol.startsWith('/api/')) {
-      const [pathPart] = rawSymbol.split('#');
-      const segments = pathPart.split('/').filter((s) => s.length > 0);
-      const symbolName = segments[segments.length - 1];
-      // Case-insensitive lookup: find the canonical symbol name in the registry.
-      const knownSymbols = Object.keys(getSymbolsAsApiEntries());
-      const canonicalSymbol = knownSymbols.find(
-        (s) => s.toLowerCase() === symbolName.toLowerCase(),
-      );
-      if (canonicalSymbol && canonicalSymbol !== symbolName) {
-        const expectedUrl = getSymbolUrl(canonicalSymbol);
-        throw Error(
-          `Broken @link: ${link}. Did you mean ${expectedUrl}? ` +
-            `Symbol names in API URLs are case-sensitive.`,
-        );
-      }
-    }
+    // Validate absolute `/api/...` and `/guide/...` URLs against the known registries. Catches
+    // miscased symbols, unknown members and stale `#fragment` anchors at build time. Same logic is
+    // also applied to plain markdown `[label](url)` links via `validateMarkdownLinks`.
+    validateInternalUrl(rawSymbol);
 
     return {
       url: rawSymbol,

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -77,7 +77,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * of the cloned templates.
  *
  * The `ngForOf` directive is generally used in the
- * [shorthand form](guide/directives/structural-directives#asterisk) `*ngFor`.
+ * [shorthand form](guide/directives/structural-directives#structural-directive-shorthand) `*ngFor`.
  * In this form, the template to be rendered for each iteration is the content
  * of an anchor element containing the directive.
  *
@@ -106,11 +106,11 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * context according to its lexical position.
  *
  * When using the shorthand syntax, Angular allows only [one structural directive
- * on an element](guide/directives/structural-directives#one-per-element).
+ * on an element](guide/directives/structural-directives#one-structural-directive-per-element).
  * If you want to iterate conditionally, for example,
  * put the `*ngIf` on a container element that wraps the `*ngFor` element.
  * For further discussion, see
- * [Structural Directives](guide/directives/structural-directives#one-per-element).
+ * [Structural Directives](guide/directives/structural-directives#one-structural-directive-per-element).
  *
  * @usageNotes
  *
@@ -151,7 +151,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
  * controls that are present, such as `<input>` elements that accept user input. Inserted rows can
  * be animated in, deleted rows can be animated out, and unchanged rows retain any unsaved state
  * such as user input.
- * For more on animations, see [Transitions and Triggers](guide/animations/transition-and-triggers).
+ * For more on animations, see [Transitions and Triggers](guide/legacy-animations/transition-and-triggers).
  *
  * The identities of elements in the iterator can change while the data does not.
  * This can happen, for example, if the iterator is produced from an RPC to the server, and that
@@ -177,7 +177,7 @@ export class NgForOfContext<T, U extends NgIterable<T> = NgIterable<T>> {
 export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
   /**
    * The value of the iterable expression, which can be used as a
-   * [template input variable](guide/directives/structural-directives#shorthand).
+   * [template input variable](guide/directives/structural-directives#structural-directive-shorthand).
    * @deprecated The `ngFor` directive is deprecated. Use the `@for` block instead.
    */
   @Input()

--- a/packages/common/src/directives/ng_if.ts
+++ b/packages/common/src/directives/ng_if.ts
@@ -26,7 +26,7 @@ import {RuntimeErrorCode} from '../errors';
  * Angular renders the template provided in an optional `else` clause. The default
  * template for the `else` clause is blank.
  *
- * A [shorthand form](guide/directives/structural-directives#asterisk) of the directive,
+ * A [shorthand form](guide/directives/structural-directives#structural-directive-shorthand) of the directive,
  * `*ngIf="condition"`, is generally used, provided
  * as an attribute of the anchor element for the inserted template.
  * Angular expands this into a more explicit version, in which the anchor element
@@ -152,7 +152,7 @@ import {RuntimeErrorCode} from '../errors';
  *
  * The presence of the implicit template object has implications for the nesting of
  * structural directives. For more on this subject, see
- * [Structural Directives](guide/directives/structural-directives#one-per-element).
+ * [Structural Directives](guide/directives/structural-directives#one-structural-directive-per-element).
  *
  * @ngModule CommonModule
  * @publicApi

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -27,8 +27,6 @@ const DEFAULT_PORTS: {[key: string]: number} = {
  * Location service that provides a drop-in replacement for the $location service
  * provided in AngularJS.
  *
- * @see [Using the Angular Unified Location Service](guide/upgrade#using-the-unified-angular-location-service)
- *
  * @publicApi
  */
 export class $locationShim {

--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -21,8 +21,7 @@ import {registerSpecialProvider} from '../render3/debug/special_providers';
  * Use the methods to add and remove views from the tree, initiate change-detection,
  * and explicitly mark views as _dirty_, meaning that they have changed and need to be re-rendered.
  *
- * @see [Using change detection hooks](guide/components/lifecycle#using-change-detection-hooks)
- * @see [Defining custom change detection](guide/components/lifecycle#defining-custom-change-detection)
+ * @see [Using change detection hooks](guide/components/lifecycle)
  *
  * @usageNotes
  *

--- a/packages/core/src/change_detection/lifecycle_hooks.ts
+++ b/packages/core/src/change_detection/lifecycle_hooks.ts
@@ -101,9 +101,6 @@ export interface OnInit {
  *
  * {@example core/ts/metadata/lifecycle_hooks_spec.ts region='DoCheck'}
  *
- * For a more complete example and discussion, see
- * [Defining custom change detection](guide/components/lifecycle#defining-custom-change-detection).
- *
  * @publicApi
  */
 export interface DoCheck {

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -350,7 +350,7 @@ export class DebugElement extends DebugNode {
    * @param eventName The name of the event to trigger
    * @param eventObj The _event object_ expected by the handler
    *
-   * @see [Testing components scenarios](guide/testing/components-scenarios#trigger-event-handler)
+   * @see [Testing components scenarios](guide/testing/components-scenarios#triggereventhandler)
    */
   triggerEventHandler(eventName: string, eventObj?: any): void {
     const node = this.nativeNode as any;

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -19,10 +19,10 @@ import {registerSpecialProvider} from '../render3/debug/special_providers';
 
 /**
  * Concrete injectors implement this interface. Injectors are configured
- * with [providers](guide/di/dependency-injection-providers) that associate
- * dependencies of various types with [injection tokens](guide/di/dependency-injection-providers).
+ * with [providers](guide/di/defining-dependency-providers) that associate
+ * dependencies of various types with [injection tokens](guide/di/defining-dependency-providers).
  *
- * @see [DI Providers](guide/di/dependency-injection-providers).
+ * @see [DI Providers](guide/di/defining-dependency-providers).
  * @see {@link StaticProvider}
  *
  * @usageNotes

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -23,7 +23,7 @@ export interface ValueSansProvider {
 
 /**
  * Configures the `Injector` to return a value for a token.
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -72,7 +72,7 @@ export interface StaticClassSansProvider {
 
 /**
  * Configures the `Injector` to return an instance of `useClass` for a token.
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -104,7 +104,7 @@ export interface StaticClassProvider extends StaticClassSansProvider {
 /**
  * Configures the `Injector` to return an instance of a token.
  *
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -125,7 +125,7 @@ export interface ConstructorSansProvider {
 /**
  * Configures the `Injector` to return an instance of a token.
  *
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -154,7 +154,7 @@ export interface ConstructorProvider extends ConstructorSansProvider {
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
  * @see {@link ExistingProvider}
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @publicApi
  */
@@ -168,7 +168,7 @@ export interface ExistingSansProvider {
 /**
  * Configures the `Injector` to return a value of another `useExisting` token.
  *
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -197,7 +197,7 @@ export interface ExistingProvider extends ExistingSansProvider {
  * Configures the `Injector` to return a value by invoking a `useFactory` function.
  *
  * @see {@link FactoryProvider}
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @publicApi
  */
@@ -217,7 +217,7 @@ export interface FactorySansProvider {
 
 /**
  * Configures the `Injector` to return a value by invoking a `useFactory` function.
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -251,7 +251,7 @@ export interface FactoryProvider extends FactorySansProvider {
  * A static provider provides tokens to an injector for various types of dependencies.
  *
  * @see {@link Injector.create()}
- * @see [Dependency Injection Guide](guide/di/dependency-injection-providers).
+ * @see [Dependency Injection Guide](guide/di/defining-dependency-providers).
  *
  * @publicApi
  */
@@ -269,7 +269,7 @@ export type StaticProvider =
  * Create an instance by invoking the `new` operator and supplying additional arguments.
  * This form is a short form of `TypeProvider`;
  *
- * For more details, see the ["Dependency Injection Guide"](guide/di/dependency-injection.
+ * For more details, see the ["Dependency Injection Guide"](guide/di).
  *
  * @usageNotes
  *
@@ -283,7 +283,7 @@ export interface TypeProvider extends Type<any> {}
  * Configures the `Injector` to return a value by invoking a `useClass` function.
  * Base for `ClassProvider` decorator.
  *
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @publicApi
  */
@@ -296,7 +296,7 @@ export interface ClassSansProvider {
 
 /**
  * Configures the `Injector` to return an instance of `useClass` for a token.
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @usageNotes
  *
@@ -327,7 +327,7 @@ export interface ClassProvider extends ClassSansProvider {
 
 /**
  * Describes how the `Injector` should be configured.
- * @see [Dependency Injection Guide](guide/di/dependency-injection)
+ * @see [Dependency Injection Guide](guide/di)
  *
  * @see {@link StaticProvider}
  *

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -38,7 +38,7 @@ export interface InjectDecorator {
    *
    * {@example core/di/ts/metadata_spec.ts region='InjectWithoutDecorator'}
    *
-   * @see [Dependency Injection Guide](guide/di/dependency-injection)
+   * @see [Dependency Injection Guide](guide/di)
    *
    */
   (token: any): any;
@@ -90,7 +90,7 @@ export interface OptionalDecorator {
    *
    * {@example core/di/ts/metadata_spec.ts region='Optional'}
    *
-   * @see [Dependency Injection Guide](guide/di/dependency-injection)
+   * @see [Dependency Injection Guide](guide/di)
    */
   (): any;
   new (): Optional;
@@ -180,7 +180,7 @@ export interface SkipSelfDecorator {
    *
    * {@example core/di/ts/metadata_spec.ts region='SkipSelf'}
    *
-   * @see [Dependency Injection guide](guide/di/di-in-action#skip).
+   * @see [Dependency Injection guide](guide/di/hierarchical-dependency-injection#skipself).
    * @see {@link Self}
    * @see {@link Optional}
    *
@@ -225,7 +225,7 @@ export interface HostDecorator {
    * {@example core/di/ts/metadata_spec.ts region='Host'}
    *
    * For an extended example, see ["Dependency Injection
-   * Guide"](guide/di/di-in-action#optional).
+   * Guide"](guide/di/hierarchical-dependency-injection#optional).
    */
   (): any;
   new (): Host;

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -35,8 +35,8 @@ export interface NgModule {
    * The set of injectable objects that are available in the injector
    * of this module.
    *
-   * @see [Dependency Injection guide](guide/di/dependency-injection)
-   * @see [NgModule guide](guide/ngmodules/providers)
+   * @see [Dependency Injection guide](guide/di)
+   * @see [NgModule guide](guide/ngmodules/overview)
    *
    * @usageNotes
    *

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -99,7 +99,7 @@ export interface CreateEffectOptions {
  * before the next effect run. The cleanup function makes it possible to "cancel" any work that the
  * previous effect run might have started.
  *
- * @see [Effect cleanup functions](guide/signals#effect-cleanup-functions)
+ * @see [Effect cleanup functions](guide/signals/effect#effect-cleanup-functions)
  *
  * @publicApi 20.0
  */
@@ -108,7 +108,7 @@ export type EffectCleanupFn = () => void;
 /**
  * A callback passed to the effect function that makes it possible to register cleanup logic.
  *
- * @see [Effect cleanup functions](guide/signals#effect-cleanup-functions)
+ * @see [Effect cleanup functions](guide/signals/effect#effect-cleanup-functions)
  *
  * @publicApi 20.0
  */
@@ -130,7 +130,7 @@ export type EffectCleanupRegisterFn = (cleanupFn: EffectCleanupFn) => void;
  *
  * `effect()` must be run in injection context, unless the `injector` option is manually specified.
  *
- * @see [Effects](guide/signals#effects)
+ * @see [Effects](guide/signals/effect#effects)
  *
  * @publicApi 20.0
  */

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -212,7 +212,7 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
    * Tracks the configuration options for this `ngModel` instance.
    *
    * **name**: An alternative to setting the name attribute on the form control element. See
-   * the [example](api/forms/NgModel#using-ngmodel-on-a-standalone-control) for using `NgModel`
+   * the [example](api/forms/NgModel) for using `NgModel`
    * as a standalone control.
    *
    * **standalone**: When set to true, the `ngModel` will not register itself with its parent form,

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -63,7 +63,7 @@ export interface BootstrapContext {
 /**
  * Bootstraps an instance of an Angular application and renders a standalone component as the
  * application's root component. More information about standalone components can be found in [this
- * guide](guide/components/importing).
+ * guide](guide/components).
  *
  * @usageNotes
  * The root component passed into this function **must** be a standalone one

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -670,7 +670,7 @@ export function isPublicRouterEvent(e: Event | PrivateRouterEvents): e is Event 
  *
  * * [NavigationStart](api/router/NavigationStart): Navigation starts.
  * * [RouteConfigLoadStart](api/router/RouteConfigLoadStart): Before
- * the router [lazy loads](guide/routing/common-router-tasks#lazy-loading) a route configuration.
+ * the router [lazy loads](guide/routing/loading-strategies) a route configuration.
  * * [RouteConfigLoadEnd](api/router/RouteConfigLoadEnd): After a route has been lazy loaded.
  * * [RoutesRecognized](api/router/RoutesRecognized): When the router parses the URL
  * and the routes are recognized.

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -81,7 +81,7 @@ export type DeprecatedResolve = DeprecatedGuard | any;
 /**
  * The supported types that can be returned from a `Router` guard.
  *
- * @see [Routing guide](guide/routing/common-router-tasks#preventing-unauthorized-access)
+ * @see [Routing guide](guide/routing/route-guards)
  * @publicApi
  */
 export type GuardResult = boolean | UrlTree | RedirectCommand;
@@ -113,7 +113,7 @@ export type GuardResult = boolean | UrlTree | RedirectCommand;
  *   ],
  * };
  * ```
- * @see [Routing guide](guide/routing/common-router-tasks#preventing-unauthorized-access)
+ * @see [Routing guide](guide/routing/route-guards)
  *
  * @publicApi
  */
@@ -138,7 +138,7 @@ export type MaybeAsync<T> = T | Observable<T> | Promise<T>;
  *
  * @see {@link Route}
  * @see {@link Router}
- * @see [Router configuration guide](guide/routing/router-reference#configuration)
+ * @see [Router configuration guide](guide/routing/router-reference)
  * @publicApi
  */
 export type Routes = Route[];
@@ -314,7 +314,7 @@ export type RedirectFunction = (
  * change or query params have changed. This does not include matrix parameters.
  *
  * @see {@link Route#runGuardsAndResolvers}
- * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior#control-when-guards-and-resolvers-execute)
+ * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior)
  * @publicApi
  */
 export type RunGuardsAndResolvers =
@@ -606,7 +606,7 @@ export interface Route {
   /**
    * An object specifying a lazy-loaded component.
    *
-   * @see [Injection context lazy loading](guide/routing/define-routes#injection-context-lazy-loading)
+   * @see [Injection context lazy loading](guide/routing/loading-strategies)
    *
    */
   loadComponent?: () =>
@@ -718,7 +718,7 @@ export interface Route {
   /**
    * An object specifying lazy-loaded child routes.
    *
-   * @see [Injection context lazy loading](guide/routing/define-routes#injection-context-lazy-loading)
+   * @see [Injection context lazy loading](guide/routing/loading-strategies)
    *
    */
   loadChildren?: LoadChildren;
@@ -739,7 +739,7 @@ export interface Route {
    * change or query params have changed. This does not include matrix parameters.
    *
    * @see {@link RunGuardsAndResolvers}
-   * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior#control-when-guards-and-resolvers-execute)
+   * @see [Control when guards and resolvers execute](guide/routing/customizing-route-behavior)
    */
   runGuardsAndResolvers?: RunGuardsAndResolvers;
 


### PR DESCRIPTION
Adds build-time validation to catch broken, stale, or miscased internal documentation links in both JSDoc and markdown, including `/api/` and `/guide/` URLs and their fragments. Updates the documentation pipeline to share the canonical route manifest, ensuring that all references are checked against the current navigation structure.

 
## What is the current behavior?

Currently, links defined in TSDoc (e.g. `@see`, `@link`) or standard markdown syntax (`[label](url)`) within Angular packages are not validated against URL fragments.

For example:

https://next.angular.dev/api/core/EffectCleanupFn

Clicking the pill navigates to:

https://next.angular.dev/guide/signals#effect-cleanup-functions

However, this fragment no longer exists after recent updates, and the link is not being validated or flagged.
 

## What is the new behavior?

Fragment URLs and URLs in markdown are now correctly validated at build time