### PR TITLE
fix(platform-server): guard against absolute-form URL SSRF in parseUrl

### DIFF
--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -25,11 +25,24 @@ import {INITIAL_CONFIG} from './tokens';
  * @returns The parsed URL.
  */
 function parseUrl(urlStr: string, origin: string): URL {
-  // If the URL is empty or start with a `/` it is a pathname relative to the origin
-  // otherwise it's an absolute URL.
+  // If the URL is empty or starts with `/` it is a pathname relative to the origin,
+  // otherwise treat it as an absolute URL. Protocol-relative (`//`) and backslash (`/\`)
+  // variants are normalised to relative paths by the leading-slash check above.
   const urlToParse = urlStr.length === 0 || urlStr[0] === '/' ? origin + urlStr : urlStr;
+  const parsed = new URL(urlToParse);
 
-  return new URL(urlToParse);
+  // Guard against HTTP/1.1 absolute-form request targets (e.g. `http://evil.com/`) that
+  // bypass the leading-slash check and would otherwise poison `ServerPlatformLocation`
+  // with an attacker-controlled hostname, enabling SSRF via the SSR HTTP interceptor.
+  // See: https://github.com/angular/angular/issues/68436
+  if (parsed.hostname !== new URL(origin).hostname) {
+    throw new Error(
+      `ng-platform-server: Refusing to parse "${urlStr}" — hostname "${parsed.hostname}" ` +
+        `does not match the configured origin "${origin}".`,
+    );
+  }
+
+  return parsed;
 }
 
 /**

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -159,5 +159,21 @@ import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
         expect(location.pathname).withContext(`pathname for URL: "${url}"`).toBe(url);
       }
     });
+
+    it('throws on absolute-form URLs with a foreign hostname (SSRF guard)', () => {
+      // HTTP/1.1 absolute-form request targets (e.g. `GET http://evil.com/ HTTP/1.1`)
+      // cause Express to set `req.url = "http://evil.com/"`. That string starts with `h`,
+      // not `/`, so the leading-slash guard does not apply. Without a hostname check the
+      // parsed URL would silently poison `ServerPlatformLocation.hostname`, enabling SSRF
+      // via the SSR HTTP interceptor. Ref: https://github.com/angular/angular/issues/68436
+      expect(() =>
+        platformServer([
+          {
+            provide: INITIAL_CONFIG,
+            useValue: {document: '', url: 'http://evil.com/'},
+          },
+        ]),
+      ).toThrowError(/Refusing to parse/);
+    });
   });
 })();


### PR DESCRIPTION
The fix in `ede7c58a2a` blocked SSRF via protocol-relative (`//evil.com`) and backslash
(`/\evil.com`) URLs by checking whether the incoming URL string starts with `/`. If it does,
the server origin is prepended before parsing.

HTTP/1.1 also permits absolute-form request targets (`GET http://evil.com/ HTTP/1.1`). When
a reverse proxy forwards one of these to Node.js, Express sets `req.url = "http://evil.com/"`.
That string starts with `h`, so the existing guard does not fire. `new URL("http://evil.com/")`
resolves cleanly and writes `evil.com` into `ServerPlatformLocation.hostname`. The SSR HTTP
interceptor then uses that hostname as the base for every relative `HttpClient` request made
during rendering, silently routing them to the attacker's server.

This affects any application that calls `renderApplication` or `renderModule` directly without
going through `CommonEngine` or `AngularNodeAppEngine`, which is a well-documented pattern for
custom Express servers that inject auth tokens or other request-scoped providers.

Fixes #68436
Related: https://issuetracker.google.com/issues/504429182

## Changes

**`packages/platform-server/src/location.ts`**

After the existing leading-slash normalisation, validate that the parsed URL's hostname matches
the origin. If it does not, throw — the same outcome `CommonEngine` produces via its
`allowedHosts` check, now enforced at the framework layer.

**`packages/platform-server/test/platform_location_spec.ts`**

Added a test for the absolute-form vector alongside the existing `neutralizes hostname hijack
attempts` test.

## Behaviour change

None for legitimate usage. In a correct SSR setup the parsed hostname always matches the
configured origin. The only change is that an absolute-form URL pointing to a different host
now throws instead of silently poisoning the location.
