### PR TITLE
fix(core): validate security-sensitive attributes in i18n bindings

### DIFF
--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -18,6 +18,10 @@ import {
 import {getInertBodyHelper} from '../../sanitization/inert_body';
 import {_sanitizeUrl} from '../../sanitization/url_sanitizer';
 import {
+  ɵɵvalidateAttribute as _validateAttribute,
+  SECURITY_SENSITIVE_ELEMENTS,
+} from '../../sanitization/sanitization';
+import {
   assertDefined,
   assertEqual,
   assertGreaterThanOrEqual,
@@ -388,7 +392,7 @@ export function i18nAttributesFirstPass(tView: TView, index: number, values: str
           previousElementIndex,
           attrName,
           countBindings(updateOpCodes),
-          SENSITIVE_ATTRS[attrName.toLowerCase()] ? _sanitizeUrl : null,
+          i18nSanitizeAttribute(attrName),
         );
       }
     }
@@ -816,7 +820,7 @@ function walkIcuTree(
                   newIndex,
                   attr.name,
                   0,
-                  SENSITIVE_ATTRS[lowerAttrName] ? _sanitizeUrl : null,
+                  i18nSanitizeAttribute(lowerAttrName),
                 );
               } else {
                 ngDevMode &&
@@ -968,4 +972,34 @@ function addCreateAttribute(
   attrValue: string,
 ) {
   create.push((newIndex << IcuCreateOpCode.SHIFT_REF) | IcuCreateOpCode.Attr, attrName, attrValue);
+}
+
+/**
+ * Caches all keys of `SECURITY_SENSITIVE_ELEMENTS` in a Set to avoid recomputing
+ * or scanning them on every invocation.
+ */
+const SECURITY_SENSITIVE_ATTRS: ReadonlySet<string> = /* @__PURE__ */ (() =>
+  new Set(
+    Object.values(SECURITY_SENSITIVE_ELEMENTS).flatMap((attrs) =>
+      attrs ? Object.keys(attrs) : [],
+    ),
+  ))();
+
+/**
+ * Returns a sanitizer for the given attribute name or null if the attribute is not security sensitive.
+ *
+ * @param attrName The name of the attribute to sanitize.
+ * @returns The sanitizer for the given attribute name.
+ */
+function i18nSanitizeAttribute(attrName: string): SanitizerFn | null {
+  const lowerAttrName = attrName.toLowerCase();
+  if (SENSITIVE_ATTRS[lowerAttrName]) {
+    return _sanitizeUrl;
+  }
+
+  if (SECURITY_SENSITIVE_ATTRS.has(lowerAttrName)) {
+    return _validateAttribute;
+  }
+
+  return null;
 }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -291,7 +291,7 @@ const SECURITY_SENSITIVE_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set(['href',
  * @remarks Keep this in sync with DOM Security Schema.
  * @see [SECURITY_SCHEMA](../../../compiler/src/schema/dom_security_schema.ts)
  */
-const SECURITY_SENSITIVE_ELEMENTS: Record<
+export const SECURITY_SENSITIVE_ELEMENTS: Record<
   string,
   Record<string, true | undefined | ReadonlySet<string>> | undefined
 > = {

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -314,6 +314,27 @@ describe('iframe processing', () => {
         });
       });
 
+      it('should error when a translated security-sensitive attribute contains bindings', () => {
+        @Component({
+          selector: 'my-comp',
+          template: `
+            <iframe
+              src="${TEST_IFRAME_URL}"
+              i18n-sandbox
+              sandbox="allow-forms {{ extraPrivileges }}"
+            >
+            </iframe>
+          `,
+
+          changeDetection: ChangeDetectionStrategy.Eager,
+        })
+        class IframeComp {
+          extraPrivileges = 'allow-scripts allow-same-origin';
+        }
+
+        expectIframeCreationToFail(IframeComp);
+      });
+
       it('should work when a directive sets a security-sensitive attribute as a static attribute', () => {
         @Directive({
           selector: '[dir]',


### PR DESCRIPTION
Ensures that security-sensitive attributes (e.g., sandbox, allow) are correctly validated when applied through i18n-* dynamic attribute bindings, preventing potential policy bypasses.

Closes #68418