### PR TITLE
docs: update documentation for platform server URL token options

### DIFF
--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -21,9 +21,7 @@ export interface PlatformConfig {
   document?: string;
   /**
    * The URL for the current application state. This is used for initializing
-   * the platform's location. `protocol`, `hostname`, and `port` will be
-   * overridden if `baseUrl` is set.
-   * @default none
+   * the platform's location. `protocol`, `hostname`, and `port`.
    */
   url?: string;
 }


### PR DESCRIPTION
This `baseUrl` option is not available.
