### PR TITLE
fix(forms): correct validateAsync factory parameter type inference

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -49,7 +49,7 @@ export interface AsyncValidatorOptions<TValue, TParams, TResult, TPathKind exten
     readonly factory: (params: Signal<TParams | undefined>) => Resource<TResult | undefined>;
     readonly onError: (error: unknown, ctx: FieldContext<TValue, TPathKind>) => TreeValidationResult;
     readonly onSuccess: MapToErrorsFn<TValue, TResult, TPathKind>;
-    readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams;
+    readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams | undefined;
     readonly when?: NoInfer<LogicFn<TValue, boolean, TPathKind>>;
 }
 

--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -65,11 +65,13 @@ export interface AsyncValidatorOptions<
 > {
   /**
    * A function that receives the field context and returns the params for the resource.
+   * Returning `undefined` indicates that the resource should not be run for the current state
+   * (the forms system will report the params as `undefined` to the factory's resource).
    *
    * @param ctx The field context for the field being validated.
-   * @returns The params for the resource.
+   * @returns The params for the resource, or `undefined` to skip running the resource.
    */
-  readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams;
+  readonly params: (ctx: FieldContext<TValue, TPathKind>) => TParams | undefined;
 
   /**
    * Duration in milliseconds to wait before triggering the async operation, or a function that

--- a/packages/forms/signals/test/node/resource.spec.ts
+++ b/packages/forms/signals/test/node/resource.spec.ts
@@ -238,6 +238,49 @@ describe('resources', () => {
     expect(f[1]().errors()).toEqual([]);
   });
 
+  it('should skip async validation when params function returns undefined', async () => {
+    let factoryCallCount = 0;
+    const value = signal('');
+
+    const f = form(
+      value,
+      (p) => {
+        validateAsync(p, {
+          params: ({value}) => {
+            const v = value().trim();
+            return v ? v : undefined;
+          },
+          factory: (params) => {
+            factoryCallCount++;
+            return resource({
+              params,
+              loader: async ({params}) => params !== undefined,
+            });
+          },
+          onSuccess: (exists) => (exists ? {kind: 'value-exists'} : undefined),
+          onError: () => null,
+        });
+      },
+      {injector},
+    );
+
+    // empty value: params return undefined, resource should be idle( not pending)
+    await appRef.whenStable();
+    expect(f().pending()).toBe(false);
+    expect(f().errors()).toEqual([]);
+
+    // non-empty value: params returns a string, resource should run
+    value.set('hello');
+    await appRef.whenStable();
+    expect(f().errors()).toEqual([{kind: 'value-exists', fieldTree: f} as any]);
+
+    //back to empty: resource should go idle again, no errors
+    value.set('');
+    await appRef.whenStable();
+    expect(f().errors()).toEqual([]);
+    expect(f().pending()).toBe(false);
+  });
+
   it('should support shorthand http validation', async () => {
     const usernameForm = form(
       signal('unique-user'),


### PR DESCRIPTION
The TypeScript type inference for `AsyncValidatorOptions.factory` was previously forcing `TParams` to be non-nullable, leading to a mismatch with the `params` function which returns `TParams | undefined`. This commit changes the `factory` typing to accept `ResourceRef<TResult | undefined>` to properly infer the union type and allow returning `undefined` to skip async validation requests.

Fixes #67859

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #67859

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
