### PR TITLE
fix(vscode-extension): Look for tsdk override in the new js/ts.tsdk.p…

### DIFF
--- a/vscode-ng-language-service/README.md
+++ b/vscode-ng-language-service/README.md
@@ -67,11 +67,11 @@ for its backend. `@angular/language-service` is always bundled with the extensio
 the latest version at the time of the release.
 `typescript` is loaded, in order of priority, from:
 
-1. The path specified by `typescript.tsdk` in project or global settings.
+1. The path specified by `typescript.tsdk` or `js/ts.tsdk.path` in project or global settings.
 2. _(Recommended)_ The version of `typescript` bundled with the Angular Language Service extension.
 3. The version of `typescript` present in the current workspace's node_modules.
 
-We suggest **not** specifying `typescript.tsdk` in your VSCode settings
+We suggest **not** specifying `typescript.tsdk` or `js/ts.tsdk.path` in your VSCode settings
 per method (1) above. If the `typescript` package is loaded by
 methods (1) or (3), there is a potential for a mismatch between
 the API expected by `@angular/language-service` and the API provided by `typescript`. This could
@@ -109,14 +109,14 @@ The Angular Language Service provides inlay hints for templates, showing inline 
 @for (user /* : User */ of users; track user.id) { {{ user.name }} }
 
 <!-- @if aliases (simple and complex) -->
-@if (currentUser; as user) { {{ user.name }} }
-@if (currentUser.profile; as profile /* : Profile */) { {{ profile.name }} }
+@if (currentUser; as user) { {{ user.name }} } @if (currentUser.profile; as profile /* : Profile */)
+{ {{ profile.name }} }
 
 <!-- @let declarations -->
 @let count /* : number */ = items.length;
 
 <!-- Template references -->
-<input #emailInput /* : HTMLInputElement */ />
+<input #emailInput />
 
 <!-- Event bindings -->
 <button (click)="handleClick($event /* : MouseEvent */)">

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -510,7 +510,7 @@ export class AngularLanguageClient implements vscode.Disposable {
     // dynamically via workspace/configuration request by the server.
     // This allows users to change these settings without restarting.
 
-    const tsdk = config.get('typescript.tsdk', '');
+    const tsdk = config.get('js/ts.tsdk.path', config.get('typescript.tsdk', ''));
     if (tsdk.trim().length > 0) {
       args.push('--tsdk', tsdk);
     }

--- a/vscode-ng-language-service/client/src/config_change.ts
+++ b/vscode-ng-language-service/client/src/config_change.ts
@@ -11,7 +11,7 @@ export interface ConfigurationChangeLike {
 }
 
 export function shouldRestartOnConfigurationChange(e: ConfigurationChangeLike): boolean {
-  if (e.affectsConfiguration('typescript.tsdk')) {
+  if (e.affectsConfiguration('typescript.tsdk') || e.affectsConfiguration('js/ts.tsdk.path')) {
     return true;
   }
 

--- a/vscode-ng-language-service/client/src/tests/extension_spec.ts
+++ b/vscode-ng-language-service/client/src/tests/extension_spec.ts
@@ -43,6 +43,12 @@ describe('extension config restart policy', () => {
     ).toBeTrue();
   });
 
+  it('restarts for js/ts.tsdk.path changes', () => {
+    expect(
+      shouldRestartOnConfigurationChange(createConfigChangeEvent(['js/ts.tsdk.path'])),
+    ).toBeTrue();
+  });
+
   it('does not restart for unrelated settings', () => {
     expect(
       shouldRestartOnConfigurationChange(createConfigChangeEvent(['editor.fontSize'])),


### PR DESCRIPTION
…ath setting

recent versions of vscode use js/ts.tsdk.path rather than typescript.tsdk

relates to #68423
