### PR TITLE
fix(vscode-extension): Look for tsdk override in the new js/ts.tsdk.p…

### DIFF
--- a/vscode-ng-language-service/README.md
+++ b/vscode-ng-language-service/README.md
@@ -37,11 +37,11 @@ for its backend. `@angular/language-service` is always bundled with the extensio
 the latest version at the time of the release.
 `typescript` is loaded, in order of priority, from:
 
-1. The path specified by `typescript.tsdk` in project or global settings.
+1. The path specified by `typescript.tsdk` or `js/ts.tsdk.path` in project or global settings.
 2. _(Recommended)_ The version of `typescript` bundled with the Angular Language Service extension.
 3. The version of `typescript` present in the current workspace's node_modules.
 
-We suggest **not** specifying `typescript.tsdk` in your VSCode settings
+We suggest **not** specifying `typescript.tsdk` or `js/ts.tsdk.path` in your VSCode settings
 per method (1) above. If the `typescript` package is loaded by
 methods (1) or (3), there is a potential for a mismatch between
 the API expected by `@angular/language-service` and the API provided by `typescript`. This could

--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -456,7 +456,7 @@ export class AngularLanguageClient implements vscode.Disposable {
       args.push('--suppressAngularDiagnosticCodes', suppressAngularDiagnosticCodes);
     }
 
-    const tsdk = config.get('typescript.tsdk', '');
+    const tsdk = config.get('js/ts.tsdk.path', config.get('typescript.tsdk', ''));
     if (tsdk.trim().length > 0) {
       args.push('--tsdk', tsdk);
     }


### PR DESCRIPTION
…ath setting

recent versions of vscode use js/ts.tsdk.path rather than typescript.tsdk

relates to #68423
