### PR TITLE
Support inline TCBs in language service

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
@@ -38,6 +38,7 @@ import {
   Import,
   ImportedTypeValueReference,
   LocalTypeValueReference,
+  reflectObjectLiteral,
   ReflectionHost,
   TypeValueReference,
   TypeValueReferenceKind,
@@ -532,4 +533,27 @@ export function isAbstractClassDeclaration(clazz: ClassDeclaration): boolean {
   return ts.canHaveModifiers(clazz) && clazz.modifiers !== undefined
     ? clazz.modifiers.some((mod) => mod.kind === ts.SyntaxKind.AbstractKeyword)
     : false;
+}
+
+export function parseStandaloneOption(
+  decorator: Readonly<Decorator | null>,
+  evaluator: PartialEvaluator,
+  implicitStandaloneValue: boolean,
+): boolean {
+  if (decorator === null || decorator.args === null || decorator.args.length !== 1) {
+    return implicitStandaloneValue;
+  }
+  const meta = unwrapExpression(decorator.args[0]);
+  if (!ts.isObjectLiteralExpression(meta)) {
+    return implicitStandaloneValue;
+  }
+  const obj = reflectObjectLiteral(meta);
+  if (obj.has('standalone')) {
+    const expr = obj.get('standalone')!;
+    const resolved = evaluator.evaluate(expr);
+    // If the value is not a boolean, default to true so that it falls through to the main analysis
+    // phase which will report a proper diagnostic.
+    return typeof resolved === 'boolean' ? resolved : true;
+  }
+  return implicitStandaloneValue;
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -355,10 +355,6 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     }
   }
 
-  isStandalone(decorator: Readonly<Decorator>): boolean {
-    return parseStandaloneOption(decorator, this.evaluator, this.implicitStandaloneValue);
-  }
-
   preanalyze(node: ClassDeclaration, decorator: Readonly<Decorator>): Promise<void> | undefined {
     // In preanalyze, resource URLs associated with the component are asynchronously preloaded via
     // the resourceLoader. This is the only time async operations are allowed for a component.

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -142,6 +142,7 @@ import {
   getProviderDiagnostics,
   InjectableClassRegistry,
   isExpressionForwardReference,
+  parseStandaloneOption,
   readBaseClass,
   ReferencesRegistry,
   removeIdentifierReferences,
@@ -153,6 +154,7 @@ import {
   ResourceLoader,
   toFactoryMetadata,
   tryUnwrapForwardRef,
+  unwrapExpression,
   UndecoratedMetadataExtractor,
   validateHostDirectives,
   wrapFunctionExpressionsInParens,
@@ -351,6 +353,10 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     } else {
       return undefined;
     }
+  }
+
+  isStandalone(decorator: Readonly<Decorator>): boolean {
+    return parseStandaloneOption(decorator, this.evaluator, this.implicitStandaloneValue);
   }
 
   preanalyze(node: ClassDeclaration, decorator: Readonly<Decorator>): Promise<void> | undefined {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -48,6 +48,7 @@ import {
   ClassMemberKind,
   Decorator,
   ReflectionHost,
+  reflectObjectLiteral,
 } from '../../../reflection';
 import {LocalModuleScopeRegistry, TypeCheckScopeRegistry} from '../../../scope';
 import {
@@ -72,11 +73,13 @@ import {
   getUndecoratedClassWithAngularFeaturesDiagnostic,
   InjectableClassRegistry,
   isAngularDecorator,
+  parseStandaloneOption,
   readBaseClass,
   ReferencesRegistry,
   resolveProvidersRequiringFactory,
   toFactoryMetadata,
   UndecoratedMetadataExtractor,
+  unwrapExpression,
   validateHostDirectives,
 } from '../../common';
 
@@ -192,6 +195,10 @@ export class DirectiveDecoratorHandler implements DecoratorHandler<
       const decorator = findAngularDecorator(decorators, 'Directive', this.isCore);
       return decorator ? {trigger: decorator.node, decorator, metadata: decorator} : undefined;
     }
+  }
+
+  isStandalone(decorator: Readonly<Decorator | null>): boolean {
+    return parseStandaloneOption(decorator, this.evaluator, this.implicitStandaloneValue);
   }
 
   analyze(

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -197,10 +197,6 @@ export class DirectiveDecoratorHandler implements DecoratorHandler<
     }
   }
 
-  isStandalone(decorator: Readonly<Decorator | null>): boolean {
-    return parseStandaloneOption(decorator, this.evaluator, this.implicitStandaloneValue);
-  }
-
   analyze(
     node: ClassDeclaration,
     decorator: Readonly<Decorator | null>,

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -44,6 +44,7 @@ import {
   getValidConstructorDependencies,
   InjectableClassRegistry,
   makeDuplicateDeclarationError,
+  parseStandaloneOption,
   toFactoryMetadata,
   unwrapExpression,
   wrapTypeReference,
@@ -121,6 +122,10 @@ export class PipeDecoratorHandler implements DecoratorHandler<
     } else {
       return undefined;
     }
+  }
+
+  isStandalone(decorator: Readonly<Decorator>): boolean {
+    return parseStandaloneOption(decorator, this.evaluator, this.implicitStandaloneValue);
   }
 
   analyze(

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -93,6 +93,12 @@ export interface DecoratorHandler<D, A, S extends SemanticSymbol | null, R> {
   detect(node: ClassDeclaration, decorators: Decorator[] | null): DetectResult<D> | undefined;
 
   /**
+   * Determine whether a given class with the detected metadata is standalone.
+   * This is used to skip compilation of non-exported, non-standalone classes early.
+   */
+  isStandalone?(metadata: Readonly<D>): boolean;
+
+  /**
    * Asynchronously perform pre-analysis on the decorator/class combination.
    *
    * `preanalyze` is optional and is not guaranteed to be called through all compilation flows. It

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -93,12 +93,6 @@ export interface DecoratorHandler<D, A, S extends SemanticSymbol | null, R> {
   detect(node: ClassDeclaration, decorators: Decorator[] | null): DetectResult<D> | undefined;
 
   /**
-   * Determine whether a given class with the detected metadata is standalone.
-   * This is used to skip compilation of non-exported, non-standalone classes early.
-   */
-  isStandalone?(metadata: Readonly<D>): boolean;
-
-  /**
    * Asynchronously perform pre-analysis on the decorator/class combination.
    *
    * `preanalyze` is optional and is not guaranteed to be called through all compilation flows. It

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -267,10 +267,6 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
   private scanClassForTraits(
     clazz: ClassDeclaration,
   ): PendingTrait<unknown, unknown, SemanticSymbol | null, unknown>[] | null {
-    if (!this.compileNonExportedClasses && !this.reflector.isStaticallyExported(clazz)) {
-      return null;
-    }
-
     const decorators = this.reflector.getDecoratorsOfDeclaration(clazz);
 
     return this.detectTraits(clazz, decorators);
@@ -424,6 +420,18 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
     }
 
     for (const trait of traits) {
+      if (!this.reflector.isStaticallyExported(clazz) && !this.compileNonExportedClasses) {
+        const isStandalone =
+          trait.handler.isStandalone !== undefined
+            ? trait.handler.isStandalone(trait.detected.metadata)
+            : false;
+        if (!isStandalone) {
+          // Only compile standalone things when not exported.
+          trait.toSkipped();
+          continue;
+        }
+      }
+
       const analyze = () => this.analyzeTrait(clazz, trait);
 
       let preanalysis: Promise<void> | null = null;

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -420,18 +420,6 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
     }
 
     for (const trait of traits) {
-      if (!this.reflector.isStaticallyExported(clazz) && !this.compileNonExportedClasses) {
-        const isStandalone =
-          trait.handler.isStandalone !== undefined
-            ? trait.handler.isStandalone(trait.detected.metadata)
-            : false;
-        if (!isStandalone) {
-          // Only compile standalone things when not exported.
-          trait.toSkipped();
-          continue;
-        }
-      }
-
       const analyze = () => this.analyzeTrait(clazz, trait);
 
       let preanalysis: Promise<void> | null = null;
@@ -485,10 +473,20 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
     }
 
     const symbol = this.makeSymbolForTrait(trait.handler, clazz, result.analysis ?? null);
-    if (result.analysis !== undefined && trait.handler.register !== undefined) {
+
+    const isStaticallyExported = this.reflector.isStaticallyExported(clazz);
+    const isStandalone = (result.analysis as any)?.meta?.isStandalone ?? false;
+
+    const shouldSkipResolution =
+      !isStaticallyExported && !this.compileNonExportedClasses && !isStandalone;
+
+    let analysisResult = result.analysis ?? null;
+    if (shouldSkipResolution) {
+      analysisResult = null;
+    } else if (result.analysis !== undefined && trait.handler.register !== undefined) {
       trait.handler.register(clazz, result.analysis);
     }
-    trait = trait.toAnalyzed(result.analysis ?? null, result.diagnostics ?? null, symbol);
+    trait = trait.toAnalyzed(analysisResult, result.diagnostics ?? null, symbol);
   }
 
   resolve(): void {

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -504,7 +504,8 @@ runInEachFileSystem(() => {
         );
         expect(record).not.toBeNull();
         expect(record!.traits.length).toBe(1);
-        expect(record!.traits[0].state).toBe(TraitState.Skipped);
+        expect(record!.traits[0].state).toBe(TraitState.Analyzed);
+        expect((record!.traits[0] as {analysis: unknown}).analysis).toBeNull();
       });
 
       it('should not skip non-exported standalone components', () => {

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -18,7 +18,13 @@ import {
   TypeScriptReflectionHost,
 } from '../../reflection';
 import {getDeclaration, makeProgram} from '../../testing';
-import {CompilationMode, DetectResult, DtsTransformRegistry, TraitCompiler} from '../../transform';
+import {
+  CompilationMode,
+  DetectResult,
+  DtsTransformRegistry,
+  TraitCompiler,
+  TraitState,
+} from '../../transform';
 import {
   AnalysisOutput,
   CompileResult,
@@ -425,6 +431,153 @@ runInEachFileSystem(() => {
         compiler.updateResources(decl);
 
         expect(handler.updateResources).not.toHaveBeenCalled();
+      });
+    });
+    describe('non-exported classes', () => {
+      it('should skip non-exported non-standalone components', () => {
+        class FakeComponentHandler implements DecoratorHandler<{}, {}, null, unknown> {
+          name = 'FakeComponentHandler';
+          precedence = HandlerPrecedence.PRIMARY;
+
+          detect(
+            node: ClassDeclaration,
+            decorators: Decorator[] | null,
+          ): DetectResult<{}> | undefined {
+            if (node.name.text !== 'Cmp') return undefined;
+            return {trigger: node, decorator: null, metadata: {}};
+          }
+
+          isStandalone(): boolean {
+            return false;
+          }
+
+          analyze(node: ClassDeclaration, metadata: {}): AnalysisOutput<{}> {
+            return {
+              analysis: {
+                meta: {
+                  isStandalone: false, // Not standalone!
+                },
+              },
+            };
+          }
+
+          symbol(): null {
+            return null;
+          }
+          compileFull(): CompileResult {
+            throw new Error('Should not be called');
+          }
+          compileLocal(): CompileResult {
+            throw new Error('Should not be called');
+          }
+        }
+
+        const contents = `
+          class Cmp {} // Not exported!
+        `;
+
+        const filename = 'test.ts';
+        const {program} = makeProgram([{name: absoluteFrom('/' + filename), contents}]);
+        const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
+
+        const compiler = new TraitCompiler(
+          [new FakeComponentHandler()],
+          reflectionHost,
+          NOOP_PERF_RECORDER,
+          NOOP_INCREMENTAL_BUILD,
+          false, // compileNonExportedClasses = false!
+          CompilationMode.FULL,
+          new DtsTransformRegistry(),
+          null,
+          fakeSfTypeIdentifier,
+          false,
+          false,
+        );
+
+        const sourceFile = program.getSourceFile(filename)!;
+
+        compiler.analyzeSync(sourceFile);
+
+        const record = compiler.recordFor(
+          getDeclaration(program, absoluteFrom('/test.ts'), 'Cmp', isNamedClassDeclaration),
+        );
+        expect(record).not.toBeNull();
+        expect(record!.traits.length).toBe(1);
+        expect(record!.traits[0].state).toBe(TraitState.Skipped);
+      });
+
+      it('should not skip non-exported standalone components', () => {
+        class FakeComponentHandler implements DecoratorHandler<{}, {}, null, unknown> {
+          name = 'FakeComponentHandler';
+          precedence = HandlerPrecedence.PRIMARY;
+
+          detect(
+            node: ClassDeclaration,
+            decorators: Decorator[] | null,
+          ): DetectResult<{}> | undefined {
+            if (node.name.text !== 'Cmp') return undefined;
+            return {trigger: node, decorator: null, metadata: {}};
+          }
+
+          isStandalone(): boolean {
+            return true;
+          }
+
+          analyze(node: ClassDeclaration, metadata: {}): AnalysisOutput<{}> {
+            return {
+              analysis: {
+                meta: {
+                  isStandalone: true, // Standalone!
+                },
+              },
+            };
+          }
+
+          symbol(): null {
+            return null;
+          }
+          compileFull(): CompileResult {
+            throw new Error('Should not be called');
+          }
+          compileLocal(): CompileResult {
+            throw new Error('Should not be called');
+          }
+        }
+
+        const contents = `
+          class Cmp {} // Not exported!
+        `;
+
+        const filename = 'test.ts';
+        const {program} = makeProgram([{name: absoluteFrom('/' + filename), contents}]);
+        const checker = program.getTypeChecker();
+        const reflectionHost = new TypeScriptReflectionHost(checker);
+
+        const compiler = new TraitCompiler(
+          [new FakeComponentHandler()],
+          reflectionHost,
+          NOOP_PERF_RECORDER,
+          NOOP_INCREMENTAL_BUILD,
+          false, // compileNonExportedClasses = false!
+          CompilationMode.FULL,
+          new DtsTransformRegistry(),
+          null,
+          fakeSfTypeIdentifier,
+          false,
+          false,
+        );
+
+        const sourceFile = program.getSourceFile(filename)!;
+
+        compiler.analyzeSync(sourceFile);
+
+        const record = compiler.recordFor(
+          getDeclaration(program, absoluteFrom('/test.ts'), 'Cmp', isNamedClassDeclaration),
+        );
+        expect(record).not.toBeNull();
+        expect(record!.traits.length).toBe(1);
+        expect(record!.traits[0].state).not.toBe(TraitState.Skipped);
       });
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -52,7 +52,7 @@ import {
   PipeMeta,
 } from '../../metadata';
 import {PerfCheckpoint, PerfEvent, PerfPhase, PerfRecorder} from '../../perf';
-import {ProgramDriver, UpdateMode} from '../../program_driver';
+import {ProgramDriver, UpdateMode, InliningMode} from '../../program_driver';
 import {
   ClassDeclaration,
   DeclarationNode,
@@ -285,6 +285,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
    * destroyed and replaced.
    */
   private elementTagCache = new Map<ts.ClassDeclaration, Map<string, PotentialDirective | null>>();
+  private generatedRangeCache = new WeakMap<ts.SourceFile, ts.TextRange[]>();
 
   private isComplete = false;
   private priorResultsAdopted = false;
@@ -595,6 +596,51 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     this.ensureAllShimsForAllFiles();
   }
 
+  private getGeneratedCodeRanges(sf: ts.SourceFile): ts.TextRange[] {
+    if (this.generatedRangeCache.has(sf)) {
+      return this.generatedRangeCache.get(sf)!;
+    }
+
+    const ranges: ts.TextRange[] = [];
+    const visit = (node: ts.Node) => {
+      if (ts.isInterfaceDeclaration(node)) {
+        return;
+      }
+      if (ts.isFunctionDeclaration(node)) {
+        if (node.name !== undefined) {
+          const name = node.name.text;
+          if (name.startsWith('_tcb')) {
+            ranges.push({pos: node.getStart(), end: node.getEnd()});
+            // TCBs never contain other TCBs or generated utilities, so we can skip traversing inside them.
+            return;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    // We do a full AST traversal because TCBs can be generated inside closures (e.g. `it` blocks in tests)
+    // so a shallow scan of top-level statements is insufficient.
+    ts.forEachChild(sf, visit);
+
+    this.generatedRangeCache.set(sf, ranges);
+    return ranges;
+  }
+
+  private filterShimDiagnostics(
+    shimSf: ts.SourceFile,
+    semanticDiagnostics: readonly ts.Diagnostic[],
+  ): readonly ts.Diagnostic[] {
+    if (this.programDriver.inliningMode !== InliningMode.CopySourceToTcb) {
+      return semanticDiagnostics;
+    }
+    const ranges = this.getGeneratedCodeRanges(shimSf);
+    return semanticDiagnostics.filter((diag) => {
+      if (diag.start === undefined) return true;
+      return ranges.some((range) => diag.start! >= range.pos && diag.start! < range.end);
+    });
+  }
+
   /**
    * Retrieve type-checking and template parse diagnostics from the given `ts.SourceFile` using the
    * most recent type-checking program.
@@ -626,14 +672,13 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       }
 
       for (const [shimPath, shimRecord] of fileRecord.shimData) {
-        // TODO(atscott): Filter out diagnostics from original source in CopySourceToTcb
-        // We don't want to duplicate diagnostics from original source when copying to tcb
-
         const shimSf = getSourceFileOrError(typeCheckProgram, shimPath);
+        const semanticDiagnostics = typeCheckProgram.getSemanticDiagnostics(shimSf);
+
+        const filteredDiagnostics = this.filterShimDiagnostics(shimSf, semanticDiagnostics);
+
         diagnostics.push(
-          ...typeCheckProgram
-            .getSemanticDiagnostics(shimSf)
-            .map((diag) => convertDiagnostic(diag, fileRecord.sourceManager)),
+          ...filteredDiagnostics.map((diag) => convertDiagnostic(diag, fileRecord.sourceManager)),
         );
         diagnostics.push(...shimRecord.genesisDiagnostics);
 
@@ -715,10 +760,11 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       }
 
       const shimSf = getSourceFileOrError(typeCheckProgram, shimPath);
+      const semanticDiagnostics = typeCheckProgram.getSemanticDiagnostics(shimSf);
+      const filteredDiagnostics = this.filterShimDiagnostics(shimSf, semanticDiagnostics);
+
       diagnostics.push(
-        ...typeCheckProgram
-          .getSemanticDiagnostics(shimSf)
-          .map((diag) => convertDiagnostic(diag, fileRecord.sourceManager)),
+        ...filteredDiagnostics.map((diag) => convertDiagnostic(diag, fileRecord.sourceManager)),
       );
       diagnostics.push(...shimRecord.genesisDiagnostics);
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -118,6 +118,7 @@ import {DirectiveSourceManager} from './source';
 import {findTypeCheckBlock, getSourceMapping, TypeCheckSourceResolver} from './tcb_util';
 import {SymbolBuilder, SymbolDirectiveMeta, SymbolBoundTarget} from './template_symbol_builder';
 import {findAllMatchingNodes} from './comments';
+import {TCB_FUNCTION_PREFIX} from './type_check_file';
 
 export class TypeCheckableDirectiveMetaAdapter implements SymbolDirectiveMeta {
   constructor(
@@ -609,7 +610,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       if (ts.isFunctionDeclaration(node)) {
         if (node.name !== undefined) {
           const name = node.name.text;
-          if (name.startsWith('_tcb')) {
+          if (name.startsWith(TCB_FUNCTION_PREFIX)) {
             ranges.push({pos: node.getStart(), end: node.getEnd()});
             // TCBs never contain other TCBs or generated utilities, so we can skip traversing inside them.
             return;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -746,7 +746,9 @@ class InlineTcbOp implements Op {
       this.oobRecorder,
     );
 
-    return fn;
+    // A leading newline is required so that the generated TCB isn't accidentally
+    // appended as part of a trailing single-line comment (e.g. `// comment`).
+    return `\n${fn}`;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -52,7 +52,7 @@ import {ReferenceEmitEnvironment} from './reference_emit_environment';
 import {TypeCheckShimGenerator} from './shim';
 import {DirectiveSourceManager} from './source';
 import {requiresInlineTypeCheckBlock, TcbInliningRequirement} from './tcb_util';
-import {TypeCheckFile} from './type_check_file';
+import {TCB_FUNCTION_PREFIX, TypeCheckFile} from './type_check_file';
 import {generateInlineTypeCtor, requiresInlineTypeCtor} from './type_constructor';
 
 export interface ShimTypeCheckingData {
@@ -725,7 +725,7 @@ class InlineTcbOp implements Op {
     if (tcbSf !== originalSf) {
       env.copiedSourceOriginPath = absoluteFromSourceFile(originalSf);
     }
-    const fnName = `_tcb_${this.ref.node.pos}`;
+    const fnName = `${TCB_FUNCTION_PREFIX}_${this.ref.node.pos}`;
 
     const {tcbMeta, component} = adaptTypeCheckBlockMetadata(
       this.ref,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/tcb_adapter.ts
@@ -45,6 +45,7 @@ import {generateTcbTypeParameters} from './tcb_util';
 import {TypeParameterEmitter} from './type_parameter_emitter';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 import ts from 'typescript';
+import {absoluteFromSourceFile} from '../../file_system';
 
 /**
  * Adapts the compiler's `TypeCheckBlockMetadata` (which includes full TS AST nodes)
@@ -334,7 +335,7 @@ function extractReferenceMetadata(
   // it identifies that the class is local because its text was copied to this shim,
   // and it ensures we just output the class name directly rather than an import.
   if (env.copiedSourceOriginPath !== undefined) {
-    const refFile = ref.node.getSourceFile().fileName;
+    const refFile = absoluteFromSourceFile(ref.node.getSourceFile());
     if (refFile === env.copiedSourceOriginPath) {
       const nodeName = ref.node?.name as ts.Identifier | undefined;
       const nodeNameSpan = nodeName
@@ -382,7 +383,8 @@ function extractReferenceMetadata(
   const nodeNameSpan = nodeName
     ? new AbsoluteSourceSpan(nodeName.getStart(), nodeName.getEnd())
     : undefined;
-  const nodeFilePath = nodeName?.getSourceFile().fileName;
+  const nodeFilePath =
+    nodeName !== undefined ? absoluteFromSourceFile(nodeName.getSourceFile()) : undefined;
   let key: TcbReferenceKey;
 
   if (nodeFilePath !== undefined && nodeNameSpan !== undefined) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -25,6 +25,8 @@ import {Environment} from './environment';
 import {ensureTypeCheckFilePreparationImports} from './tcb_util';
 import {adaptTypeCheckBlockMetadata} from './tcb_adapter';
 
+export const TCB_FUNCTION_PREFIX = '_tcb';
+
 /**
  * An `Environment` representing the single type-checking file into which most (if not all) Type
  * Check Blocks (TCBs) will be generated.
@@ -79,7 +81,7 @@ export class TypeCheckFile extends Environment {
     genericContextBehavior: TcbGenericContextBehavior,
     reflector: ReflectionHost,
   ): void {
-    const fnId = `_tcb${this.nextTcbId++}`;
+    const fnId = `${TCB_FUNCTION_PREFIX}${this.nextTcbId++}`;
     const {tcbMeta, component} = adaptTypeCheckBlockMetadata(
       ref,
       meta,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -117,6 +117,9 @@ export class TypeCheckFile extends Environment {
 
     const newImports = importChanges.newImports.get(this.contextFile.fileName);
     if (newImports !== undefined) {
+      if (source.length > 0 && !source.endsWith('\n')) {
+        source += '\n';
+      }
       source += newImports
         .map((i) => printer.printNode(ts.EmitHint.Unspecified, i, this.contextFile))
         .join('\n');

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker_spec.ts
@@ -9,6 +9,7 @@
 import {ErrorCode, ngErrorCode} from '../../diagnostics';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
+import {InliningMode} from '../../program_driver';
 import {OptimizeFor} from '../api';
 
 import {getClass, setup, TestDeclaration} from '../testing';
@@ -171,7 +172,11 @@ runInEachFileSystem(() => {
           [
             {
               fileName,
-              source: `abstract class Cmp {} // not exported, so requires inline`,
+              source: `
+                abstract class Cmp {
+                  value: string = 'hello';
+                }
+              `,
               templates: {'Cmp': '<div></div>'},
             },
           ],
@@ -181,6 +186,75 @@ runInEachFileSystem(() => {
         const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
         expect(diags.length).toBe(1);
         expect(diags[0].code).toBe(ngErrorCode(ErrorCode.INLINE_TCB_REQUIRED));
+      });
+
+      it('should generate TCB in shim file when inlining is unsupported but required', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              source: `abstract class Cmp {} // not exported, so requires inline`,
+              templates: {'Cmp': '<div></div>'},
+            },
+          ],
+          {inliningMode: InliningMode.CopySourceToTcb},
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
+        expect(diags.length).toBe(0);
+
+        const cmp = getClass(sf, 'Cmp');
+        const block = templateTypeChecker.getTypeCheckBlock(cmp);
+        expect(block).not.toBeNull();
+        expect(block!.getText()).toContain(`Cmp`);
+      });
+
+      it('should filter out diagnostics from copied source in CopySourceToTcb mode', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              source: `
+                abstract class Cmp {
+                  value: string = 1; // Semantic error
+                }
+              `,
+              templates: {'Cmp': '<div></div>'},
+            },
+          ],
+          {inliningMode: InliningMode.CopySourceToTcb},
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
+        // The semantic error in the copied source should be filtered out.
+        expect(diags.length).toBe(0);
+      });
+
+      it('should not filter out template errors in CopySourceToTcb mode', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const {program, templateTypeChecker} = setup(
+          [
+            {
+              fileName,
+              source: `
+                abstract class Cmp {
+                  value: string = 'hello';
+                }
+              `,
+              templates: {'Cmp': '<div>{{nonExisting}}</div>'},
+            },
+          ],
+          {inliningMode: InliningMode.CopySourceToTcb},
+        );
+        const sf = getSourceFileOrError(program, fileName);
+        const diags = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
+        // The template error should NOT be filtered out.
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toContain(
+          "Property 'nonExisting' does not exist on type 'Cmp'",
+        );
       });
     });
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -9789,7 +9789,8 @@ runInEachFileSystem((os: string) => {
           import {Directive} from '@angular/core';
 
           @Directive({
-            selector: '[test]'
+            selector: '[test]',
+            standalone: false,
           })
           class TestDirective {}
         `,
@@ -9801,7 +9802,46 @@ runInEachFileSystem((os: string) => {
         expect(jsContents).toContain('Directive({');
       });
 
+      it('should emit directive definitions for non-exported standalone classes by default', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Directive} from '@angular/core';
+
+          @Directive({
+            selector: '[test]'
+          })
+          class TestDirective {}
+        `,
+        );
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).toContain('defineDirective(');
+      });
+
       it('should not emit component definitions for non-exported classes if configured', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test',
+            template: 'hello',
+            standalone: false,
+          })
+          class TestComponent {}
+        `,
+        );
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).not.toContain('defineComponent(');
+        expect(jsContents).toContain('Component({');
+      });
+
+      it('should emit component definitions for non-exported standalone classes by default', () => {
         env.write(
           'test.ts',
           `
@@ -9817,8 +9857,7 @@ runInEachFileSystem((os: string) => {
         env.driveMain();
         const jsContents = env.getContents('test.js');
 
-        expect(jsContents).not.toContain('defineComponent(');
-        expect(jsContents).toContain('Component({');
+        expect(jsContents).toContain('defineComponent(');
       });
 
       it('should not emit module definitions for non-exported classes if configured', () => {
@@ -9840,6 +9879,44 @@ runInEachFileSystem((os: string) => {
         expect(jsContents).toContain('NgModule({');
       });
 
+      it('should not emit pipe definitions for non-exported classes if configured', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Pipe} from '@angular/core';
+
+          @Pipe({
+            name: 'test',
+            standalone: false,
+          })
+          class TestPipe {}
+        `,
+        );
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).not.toContain('definePipe(');
+        expect(jsContents).toContain('Pipe({');
+      });
+
+      it('should emit pipe definitions for non-exported standalone classes by default', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Pipe} from '@angular/core';
+
+          @Pipe({
+            name: 'test'
+          })
+          class TestPipe {}
+        `,
+        );
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).toContain('definePipe(');
+      });
+
       it('should still compile a class that is indirectly exported', () => {
         env.write(
           'test.ts',
@@ -9849,6 +9926,7 @@ runInEachFileSystem((os: string) => {
           @Component({
             selector: 'test-cmp',
             template: 'Test Cmp',
+            standalone: false,
           })
           class TestCmp {}
 

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -1036,8 +1036,7 @@ function detectAngularCoreVersion(
 
 function createProgramDriver(project: ts.server.Project): ProgramDriver {
   return {
-    // TODO: switch to CopySourceToTcb
-    inliningMode: InliningMode.Error,
+    inliningMode: InliningMode.CopySourceToTcb,
     supportsInlineOperations: false,
     getProgram(): ts.Program {
       const program = project.getLanguageService().getProgram();

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -1284,6 +1284,148 @@ describe('quick info', () => {
         expectedDisplayString: '(reference) ref: TestDirective',
       });
     });
+
+    it('should get quick info for a component with non-exported generic bound requiring external copy', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+          import {Component, NgModule} from '@angular/core';
+
+          interface PrivateInterface {
+            title: string;
+          }
+
+          @Component({
+            selector: 'some-cmp',
+            templateUrl: './app.html',
+            standalone: false,
+          })
+          export class SomeCmp<T extends PrivateInterface> {
+            title = 'Hello';
+          }
+
+          @NgModule({
+            declarations: [SomeCmp],
+          })
+          export class AppModule {}
+        `,
+        'app.html': ``,
+      });
+
+      expectQuickInfo({
+        templateOverride: `<div>{{tit¦le}}</div>`,
+        expectedSpanText: 'title',
+        expectedDisplayString: '(property) SomeCmp<T extends PrivateInterface>.title: string',
+      });
+    });
+
+    it('should get quick info for a non-exported standalone component', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'some-cmp',
+            templateUrl: './app.html',
+            standalone: true,
+          })
+          class SomeCmp {
+            title = 'Hello';
+          }
+        `,
+        'app.html': ``,
+      });
+
+      expectQuickInfo({
+        templateOverride: `<div>{{tit¦le}}</div>`,
+        expectedSpanText: 'title',
+        expectedDisplayString: '(property) SomeCmp.title: string',
+      });
+    });
+
+    it('should get quick info for a standalone component defined in a closure', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          (function() {
+            @Component({
+              selector: 'some-cmp',
+              templateUrl: './app.html',
+              standalone: true,
+            })
+            class TestComponent {
+              value = 0;
+            }
+          })();
+        `,
+        'app.html': ``,
+      });
+
+      expectQuickInfo({
+        templateOverride: `<div>{{val¦ue}}</div>`,
+        expectedSpanText: 'value',
+        expectedDisplayString: '(property) TestComponent.value: number',
+      });
+    });
+
+    it('should get quick info for a component with constrained generic types requiring inline TCB', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+          import {Component} from '@angular/core';
+
+          interface InternalBound {}
+
+          @Component({
+            selector: 'some-cmp',
+            templateUrl: './app.html',
+            standalone: true,
+          })
+          export class SomeCmp<T extends InternalBound> {
+            title = 'Hello';
+          }
+        `,
+        'app.html': ``,
+      });
+
+      expectQuickInfo({
+        templateOverride: `<div>{{tit¦le}}</div>`,
+        expectedSpanText: 'title',
+        expectedDisplayString: '(property) SomeCmp<T extends InternalBound>.title: string',
+      });
+    });
+
+    it('should get quick info when using a non-exported pipe requiring inline TCB', () => {
+      project = env.addProject('test', {
+        'app.ts': `
+          import {Component, Pipe, PipeTransform} from '@angular/core';
+
+          @Pipe({
+            name: 'internalPipe',
+            standalone: true,
+          })
+          class InternalPipe implements PipeTransform {
+            transform(value: string): string { return value; }
+          }
+
+          @Component({
+            selector: 'some-cmp',
+            templateUrl: './app.html',
+            standalone: true,
+            imports: [InternalPipe],
+          })
+          export class SomeCmp {
+            title = 'Hello';
+          }
+        `,
+        'app.html': ``,
+      });
+
+      expectQuickInfo({
+        templateOverride: `<div>{{tit¦le | internalPipe}}</div>`,
+        expectedSpanText: 'title',
+        expectedDisplayString: '(property) SomeCmp.title: string',
+      });
+    });
   });
 
   function expectQuickInfo({


### PR DESCRIPTION
* [feat(language-service): compile non-exported classes if standalone](https://github.com/angular/angular/pull/68454/changes/1f6f7cdd32c7262c5e8600a447f8dd9103784085)
* [feat(language-service): Typecheck templates which would require inline typecheck blocks](https://github.com/angular/angular/pull/68454/changes/46c57d9dff9cb9f101a463af72d8c73874949b20)