### PR TITLE
fix(language-service): Add support for `@Input` with transforms

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -409,7 +409,9 @@ describe('type check blocks', () => {
         },
       ];
       expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+          'var _t2 = _ctor1({ "fieldA": (((this).foo)) }); ' +
+          '_t2.fieldA = (_t1 = (((this).foo))) as any;',
       );
     });
   });
@@ -738,7 +740,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
       'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_field1; ' +
         'var _t2 = null! as i0.Dir; ' +
-        '_t2.field2 = _t1 = (((this).foo));',
+        '_t2.field2 = _t2.field1 = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -777,7 +779,9 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -798,7 +802,9 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -840,7 +846,11 @@ describe('type check blocks', () => {
 
     const block = tcb(TEMPLATE, DIRECTIVES);
 
-    expect(block).toContain('var _t1 = null! as boolean | string; ' + '_t1 = (((this).expr));');
+    expect(block).toContain(
+      'var _t1 = null! as boolean | string; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).expr))) as any;',
+    );
   });
 
   it('should handle $any casts', () => {
@@ -963,7 +973,9 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
-    expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain(
+      '_t2.input = (_t1 = i1.ɵunwrapWritableSignal((((this).value)))) as any;',
+    );
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__get_symbol_of_template_node_spec.ts
@@ -153,6 +153,156 @@ runInEachFileSystem(() => {
       });
     });
 
+    describe('should get a symbol for coerced inputs using ngAcceptInputType', () => {
+      it('should resolve the correct symbol for a transformed input', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const dirFile = absoluteFrom('/dir.ts');
+        const templateString = `<div dir [name]="'coerced'"></div>`;
+        const targets: TypeCheckingTarget[] = [
+          {
+            fileName,
+            templates: {'Cmp': templateString} as {[key: string]: string},
+            declarations: [
+              {
+                name: 'TestDir',
+                selector: '[dir]',
+                file: dirFile,
+                type: 'directive' as const,
+                inputs: {name: 'name'},
+                coercedInputFields: ['name'],
+              },
+            ],
+          },
+          {
+            fileName: dirFile,
+            source: `export class TestDir {
+              name!: string;
+              static ngAcceptInputType_name: string | boolean;
+            }`,
+          },
+        ];
+
+        const {templateTypeChecker, program} = setup(targets);
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+        const {inputs} = getAstElements(templateTypeChecker, cmp)[0];
+        const symbol = templateTypeChecker.getSymbolOfNode(inputs[0], cmp)!;
+
+        assertInputBindingSymbol(symbol);
+        expect(
+          (
+            templateTypeChecker.getTsSymbolOfSymbol(symbol.bindings[0])!
+              .declarations![0] as ts.PropertyDeclaration
+          ).name.getText(),
+        ).toEqual('name');
+
+        // Ensure we can go back to the original location using the shim location
+        const mapping = templateTypeChecker.getSourceMappingAtTcbLocation(
+          symbol.bindings[0].tcbLocation,
+        )!;
+        expect(mapping.span.toString()).toEqual('name');
+      });
+
+      it('should resolve the correct symbol for an input with a transform function', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const dirFile = absoluteFrom('/dir.ts');
+        const templateString = `<div dir [name]="'coerced'"></div>`;
+        const targets: TypeCheckingTarget[] = [
+          {
+            fileName,
+            templates: {'Cmp': templateString} as {[key: string]: string},
+            declarations: [
+              {
+                name: 'TestDir',
+                selector: '[dir]',
+                file: dirFile,
+                type: 'directive' as const,
+                inputs: {name: 'name'},
+                // Mark this input as having a transform
+                coercedInputFields: ['name'],
+              },
+            ],
+          },
+          {
+            fileName: dirFile,
+            source: `
+              import {Input} from '@angular/core';
+              export class TestDir {
+                @Input({transform: (v: string) => true}) name!: boolean;
+              }
+            `,
+          },
+        ];
+
+        const {templateTypeChecker, program} = setup(targets);
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+        const {inputs} = getAstElements(templateTypeChecker, cmp)[0];
+        const symbol = templateTypeChecker.getSymbolOfNode(inputs[0], cmp)!;
+
+        assertInputBindingSymbol(symbol);
+        expect(
+          (
+            templateTypeChecker.getTsSymbolOfSymbol(symbol.bindings[0])!
+              .declarations![0] as ts.PropertyDeclaration
+          ).name.getText(),
+        ).toEqual('name');
+
+        // Ensure we can go back to the original location using the shim location
+        const mapping = templateTypeChecker.getSourceMappingAtTcbLocation(
+          symbol.bindings[0].tcbLocation,
+        )!;
+        expect(mapping.span.toString()).toEqual('name');
+      });
+
+      it('should resolve the correct symbol for transformed inputs from a .d.ts file', () => {
+        const fileName = absoluteFrom('/main.ts');
+        const dtsFile = absoluteFrom('/dir.d.ts');
+        const templateString = `<div dir [name]="'coerced'"></div>`;
+        const targets: TypeCheckingTarget[] = [
+          {
+            fileName,
+            templates: {'Cmp': templateString} as {[key: string]: string},
+            declarations: [
+              {
+                name: 'TestDir',
+                selector: '[dir]',
+                file: dtsFile,
+                type: 'directive' as const,
+                inputs: {name: 'name'},
+                coercedInputFields: ['name'],
+              },
+            ],
+          },
+          {
+            fileName: dtsFile,
+            source: `
+              import * as i0 from '@angular/core';
+              export declare class TestDir {
+                name: boolean;
+                static ɵdir: i0.ɵɵDirectiveDeclaration<TestDir, "[dir]", never, { "name": { "alias": "name", "required": false, "isSignal": false, "transform": typeof someTransform }; }, {}, never, never, false, never>;
+                static ngAcceptInputType_name: string | boolean;
+              }
+            `,
+          },
+        ];
+
+        const {templateTypeChecker, program} = setup(targets);
+        const sf = getSourceFileOrError(program, fileName);
+        const cmp = getClass(sf, 'Cmp');
+        const {inputs} = getAstElements(templateTypeChecker, cmp)[0];
+        const symbol = templateTypeChecker.getSymbolOfNode(inputs[0], cmp)!;
+
+        assertInputBindingSymbol(symbol);
+        expect(
+          (
+            templateTypeChecker.getTsSymbolOfSymbol(symbol.bindings[0])!
+              .declarations![0] as ts.PropertyDeclaration
+          ).name.getText(),
+        ).toEqual('name');
+      });
+    });
+
     describe('templates', () => {
       describe('ng-templates', () => {
         let templateTypeChecker: TemplateTypeChecker;

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -107,6 +107,11 @@ export class TcbDirectiveInputsOp extends TcbOp {
         // transform write type into their member type, and we extract it below when
         // setting the `WriteT` of such `InputSignalWithTransform<_, WriteT>`.
 
+        // Two-way bindings accept `T | WritableSignal<T>` so we have to unwrap the value.
+        if (isTwoWayBinding && this.tcb.env.config.allowSignalsInTwoWayBindings) {
+          assignment = unwrapWritableSignal(assignment, this.tcb);
+        }
+
         if (this.dir.coercedInputFields.has(fieldName)) {
           let type: TcbExpr;
 
@@ -115,8 +120,7 @@ export class TcbDirectiveInputsOp extends TcbOp {
           } else {
             // The input has a coercion declaration which should be used instead of assigning the
             // expression into the input field directly. To achieve this, a variable is declared
-            // with a type of `typeof Directive.ngAcceptInputType_fieldName` which is then used as
-            // target of the assignment.
+            // with a type of `typeof Directive.ngAcceptInputType_fieldName` to check the expression.
             const dirTypeRef = this.tcb.env.referenceTcbValue(this.dir.ref);
             type = new TcbExpr(`typeof ${dirTypeRef.print()}.ngAcceptInputType_${fieldName}`);
           }
@@ -124,7 +128,19 @@ export class TcbDirectiveInputsOp extends TcbOp {
           const id = new TcbExpr(this.tcb.allocateId());
           this.scope.addStatement(declareVariable(id, type));
 
-          target = id;
+          // The expression is assigned to the temporary variable to perform the type check.
+          // The result is then cast to `any` and assigned to the actual property. This avoids
+          // type mismatch errors (e.g., when assigning a string to a boolean input) while also
+          // providing a TCB node that the Language Service can resolve to the actual class property.
+          assignment = new TcbExpr(`(${id.print()} = ${assignment.print()}) as any`);
+
+          if (dirId === null) {
+            dirId = this.scope.resolve(this.node, this.dir);
+          }
+
+          target = this.dir.stringLiteralInputFields.has(fieldName)
+            ? new TcbExpr(`${dirId.print()}[${TcbExpr.quoteAndEscape(fieldName)}]`)
+            : new TcbExpr(`${dirId.print()}.${fieldName}`);
         } else if (this.dir.undeclaredInputFields.has(fieldName)) {
           // If no coercion declaration is present nor is the field declared (i.e. the input is
           // declared in a `@Directive` or `@Component` decorator's `inputs` property) there is no
@@ -178,11 +194,6 @@ export class TcbDirectiveInputsOp extends TcbOp {
 
         if (attr.keySpan !== null) {
           target.addParseSpanInfo(attr.keySpan);
-        }
-
-        // Two-way bindings accept `T | WritableSignal<T>` so we have to unwrap the value.
-        if (isTwoWayBinding && this.tcb.env.config.allowSignalsInTwoWayBindings) {
-          assignment = unwrapWritableSignal(assignment, this.tcb);
         }
 
         // Finally the assignment is extended by assigning it into the target expression.

--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -33,7 +33,6 @@ import {
 
 import ts from 'typescript';
 
-import {DisplayInfoKind, SYMBOL_PUNC, SYMBOL_SPACE, SYMBOL_TEXT} from './utils/display_parts';
 import {
   createDollarAnyQuickInfo,
   createNgTemplateQuickInfo,
@@ -48,6 +47,7 @@ import {
   getDirectiveMatchesForElementTag,
   getTextSpanOfNode,
 } from './utils';
+import {DisplayInfoKind, SYMBOL_PUNC, SYMBOL_SPACE, SYMBOL_TEXT} from './utils/display_parts';
 
 export class QuickInfoBuilder {
   private readonly typeChecker: ts.TypeChecker;
@@ -125,11 +125,70 @@ export class QuickInfoBuilder {
       return undefined;
     }
 
+    if (symbol.kind === SymbolKind.Input) {
+      const transformedQuickInfo = this.getQuickInfoForTransformedInput(symbol);
+      if (transformedQuickInfo !== null) {
+        return transformedQuickInfo;
+      }
+    }
+
     const kind =
       symbol.kind === SymbolKind.Input ? DisplayInfoKind.PROPERTY : DisplayInfoKind.EVENT;
 
     const quickInfo = this.getQuickInfoAtTcbLocation(symbol.bindings[0].tcbLocation);
     return quickInfo === undefined ? undefined : updateQuickInfoKind(quickInfo, kind);
+  }
+
+  private getQuickInfoForTransformedInput(symbol: InputBindingSymbol): ts.QuickInfo | null {
+    const binding = symbol.bindings[0];
+    const target = binding.target;
+    if (target.kind !== SymbolKind.Directive) {
+      return null;
+    }
+
+    const tsSymbol = this.compiler.getTemplateTypeChecker().getTsSymbolOfSymbol(target);
+    if (
+      tsSymbol === null ||
+      tsSymbol.valueDeclaration === undefined ||
+      !ts.isClassDeclaration(tsSymbol.valueDeclaration)
+    ) {
+      return null;
+    }
+
+    if (
+      !(this.node instanceof TmplAstBoundAttribute) &&
+      !(this.node instanceof TmplAstTextAttribute)
+    ) {
+      return null;
+    }
+
+    const dirMeta = this.compiler
+      .getTemplateTypeChecker()
+      .getDirectiveMetadata(tsSymbol.valueDeclaration);
+    const inputMappings = dirMeta?.inputs.getByBindingPropertyName(this.node.name);
+    const inputMapping = inputMappings?.[0];
+
+    if (!inputMapping || inputMapping.transform === null) {
+      return null;
+    }
+
+    // Get the transform parameter type (what the template can pass in)
+    const typeString = this.typeChecker.typeToString(
+      this.typeChecker.getTypeFromTypeNode(inputMapping.transform.type.node),
+    );
+
+    const className = tsSymbol.valueDeclaration.name?.getText() ?? '';
+    const existingQuickInfo = this.getQuickInfoAtTcbLocation(binding.tcbLocation);
+
+    return createQuickInfo(
+      inputMapping.classPropertyName,
+      DisplayInfoKind.INPUT,
+      getTextSpanOfNode(this.node),
+      className,
+      typeString,
+      existingQuickInfo?.documentation,
+      existingQuickInfo?.tags,
+    );
   }
 
   private getQuickInfoForElementSymbol(symbol: ElementSymbol): ts.QuickInfo {

--- a/packages/language-service/src/utils/display_parts.ts
+++ b/packages/language-service/src/utils/display_parts.ts
@@ -37,6 +37,7 @@ export enum DisplayInfoKind {
   COMPONENT = 'component',
   DIRECTIVE = 'directive',
   EVENT = 'event',
+  INPUT = 'input',
   REFERENCE = 'reference',
   ELEMENT = 'element',
   VARIABLE = 'variable',

--- a/packages/language-service/test/quick_info_spec.ts
+++ b/packages/language-service/test/quick_info_spec.ts
@@ -37,6 +37,9 @@ function quickInfoSkeleton(): {[fileName: string]: string} {
         })
         export class TestComponent {
           @Input('tcName') name!: string;
+          @Input() coercedInput!: string;
+          static ngAcceptInputType_coercedInput: string | boolean;
+          @Input({transform: (value: string|number) => +value}) transformedInput!: number;
           @Output('test') testEvent!: EventEmitter<string>;
         } /*EndTestComponent*/
 
@@ -241,6 +244,23 @@ describe('quick info', () => {
             templateOverride: `<test-comp [tcN¦ame]="name"></test-comp>`,
             expectedSpanText: 'tcName',
             expectedDisplayString: '(property) TestComponent.name: string',
+          });
+        });
+
+        it('should work for coerced input providers', () => {
+          expectQuickInfo({
+            templateOverride: `<test-comp [coercedI¦nput]="true"></test-comp>`,
+            expectedSpanText: 'coercedInput',
+            expectedDisplayString: '(property) TestComponent.coercedInput: string',
+          });
+        });
+
+        it('should work for inputs with transform functions', () => {
+          expectQuickInfo({
+            templateOverride: `<test-comp [transformedI¦nput]="'true'"></test-comp>`,
+            expectedSpanText: 'transformedInput',
+            // it's important here that we don't show the inner type.
+            expectedDisplayString: '(input) TestComponent.transformedInput: string | number',
           });
         });
 


### PR DESCRIPTION
Prior to this change @Input with transforms were not linked by language service and you couldn't navigate on it.
