### PR TITLE
docs(aria): improve grammar and clarity in accordion, autocomplete, and combobox guides

### DIFF
--- a/adev/src/content/guide/aria/accordion.md
+++ b/adev/src/content/guide/aria/accordion.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-An accordion organizes related content into expandable and collapsible sections, reducing page scrolling and helping users focus on relevant information. Each section has a trigger button and a content panel. Clicking a trigger toggles the visibility of its associated panel.
+An accordion organizes related content into expandable and collapsible sections, reducing page scrolling and helping users focus on relevant information. Each section includes a trigger button and a content panel. Clicking a trigger toggles the visibility of its associated panel.
 
 <docs-code-multifile preview hideCode path="adev/src/content/examples/aria/accordion/src/single-expansion/basic/app/app.ts">
   <docs-code header="TS" path="adev/src/content/examples/aria/accordion/src/single-expansion/basic/app/app.ts"/>
@@ -22,23 +22,23 @@ Accordions work well for organizing content into logical groups where users typi
 
 **Use accordions when:**
 
-- Displaying FAQs with multiple questions and answers
-- Organizing long forms into manageable sections
-- Reducing scrolling on content-heavy pages
-- Progressively disclosing related information
+- Display FAQs with multiple questions and answers
+- Organize long forms into manageable sections
+- Reduce scrolling on content-heavy pages
+- Progressively disclose related information
 
 **Avoid accordions when:**
 
-- Building navigation menus (use the [Menu](guide/aria/menu) component instead)
-- Creating tabbed interfaces (use the [Tabs](guide/aria/tabs) component instead)
-- Showing a single collapsible section (use a disclosure pattern instead)
+- Build navigation menus (use the [Menu](guide/aria/menu) component instead)
+- Create tabbed interfaces (use the [Tabs](guide/aria/tabs) component instead)
+- Show a single collapsible section (use a disclosure pattern instead)
 - Users need to see multiple sections simultaneously (consider a different layout)
 
 ## Features
 
 - **Expansion modes** - Control whether one or multiple panels can be open at the same time
 - **Keyboard navigation** - Navigate between triggers using arrow keys, Home, and End
-- **Lazy rendering** - Content is only created when a panel first expands, improving initial load performance
+- **Lazy rendering** - Content is created only when a panel first expands, improving initial load performance
 - **Disabled states** - Disable the entire group or individual triggers
 - **Focus management** - Control whether disabled items can receive keyboard focus
 - **Programmatic control** - Expand, collapse, or toggle panels from your component code
@@ -157,7 +157,7 @@ Use the `ngAccordionContent` directive on an `ng-template` to defer rendering co
 </div>
 ```
 
-By default, content remains in the DOM after the panel collapses. Set `[preserveContent]="false"` to remove the content from the DOM when the panel closes.
+By default, content remains in the DOM after the panel collapses. Set `[preserveContent]="false"` to remove content from the DOM when the panel closes.
 
 ## APIs
 

--- a/adev/src/content/guide/aria/autocomplete.md
+++ b/adev/src/content/guide/aria/autocomplete.md
@@ -36,26 +36,26 @@ An accessible input field that filters and suggests options as users type, helpi
 Autocomplete works best when users need to select from a large set of options where typing is faster than scrolling. Consider using autocomplete when:
 
 - **The option list is long** (more than 20 items) - Typing narrows down choices faster than scrolling through a dropdown
-- **Users know what they're looking for** - They can type part of the expected value (like a state name, product, or username)
+- **Users know what they are looking for** - They can type part of the expected value (like a state name, product, or username)
 - **Options follow predictable patterns** - Users can guess partial matches (like country codes, email domains, or categories)
 - **Speed matters** - Forms benefit from quick selection without extensive navigation
 
-Avoid autocomplete when:
+Avoid using autocomplete when:
 
 - The list has fewer than 10 options - A regular dropdown or radio group provides better visibility
 - Users need to browse options - If discovery is important, show all options upfront
-- Options are unfamiliar - Users can't type what they don't know exists in the list
+- Options are unfamiliar - Users cannot type what they do not know exists in the list
 
 ## Features
 
 Angular's autocomplete provides a fully accessible combobox implementation with:
 
-- **Keyboard Navigation** - Navigate options with arrow keys, select with Enter, close with Escape
-- **Screen Reader Support** - Built-in ARIA attributes for assistive technologies
-- **Three Filter Modes** - Choose between auto-select, manual selection, or highlighting behavior
-- **Signal-Based Reactivity** - Reactive state management using Angular signals
-- **Popover API Integration** - Leverages the native HTML Popover API for optimal positioning
-- **Bidirectional Text Support** - Automatically handles right-to-left (RTL) languages
+- **Keyboard navigation** - Navigate options with arrow keys, select with Enter, and close with Escape
+- **Screen reader support** - Built-in ARIA attributes for assistive technologies
+- **Three filter modes** - Choose between auto-select, manual selection, or highlighting behavior
+- **Signal-based reactivity** - Reactive state management using Angular signals
+- **Popover API integration** - Leverages the native HTML Popover API for optimal positioning
+- **Bidirectional text support** - Automatically handles right-to-left (RTL) languages
 
 ## Examples
 
@@ -121,7 +121,7 @@ Manual selection mode keeps the typed text unchanged while users navigate the su
 
 ### Highlight mode
 
-Highlight mode allows the user to navigate options with arrow keys without changing the input value as they browse until they explicitly select a new option with Enter or click.
+Highlight mode allows users to navigate options with arrow keys without changing the input value as they browse, until they explicitly select a new option with Enter or click.
 
 <docs-tab-group>
   <docs-tab label="Basic">

--- a/adev/src/content/guide/aria/combobox.md
+++ b/adev/src/content/guide/aria/combobox.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-A directive that coordinates a text input with a popup, providing the primitive directive for autocomplete, select, and multiselect patterns.
+A directive that coordinates a text input with a popup, providing a primitive directive for autocomplete, select, and multiselect patterns.
 
 <docs-tab-group>
   <docs-tab label="Basic">
@@ -38,12 +38,12 @@ A directive that coordinates a text input with a popup, providing the primitive 
 
 ## Usage
 
-Combobox is the primitive directive that coordinates a text input with a popup. It provides the foundation for autocomplete, select, and multiselect patterns. Consider using combobox directly when:
+Combobox is a primitive directive that coordinates a text input with a popup. It provides the foundation for autocomplete, select, and multiselect patterns. Consider using combobox directly when:
 
-- **Building custom autocomplete patterns** - Creating specialized filtering or suggestion behavior
-- **Creating custom selection components** - Developing dropdowns with unique requirements
-- **Coordinating input with popup** - Pairing text input with listbox, tree, or dialog content
-- **Implementing specific filter modes** - Using manual, auto-select, or highlight behaviors
+- **Build custom autocomplete patterns** - Create specialized filtering or suggestion behavior
+- **Create custom selection components** - Develop dropdowns with unique requirements
+- **Coordinate input with popup** - Pair text input with listbox, tree, or dialog content
+- **Implement specific filter modes** - Use manual, auto-select, or highlight behaviors
 
 Use documented patterns instead when:
 
@@ -57,12 +57,12 @@ NOTE: The [Autocomplete](guide/aria/autocomplete), [Select](guide/aria/select), 
 
 Angular's combobox provides a fully accessible input-popup coordination system with:
 
-- **Text Input with Popup** - Coordinates input field with popup content
-- **Three Filter Modes** - Manual, auto-select, or highlight behaviors
-- **Keyboard Navigation** - Arrow keys, Enter, Escape handling
-- **Screen Reader Support** - Built-in ARIA attributes including role="combobox" and aria-expanded
-- **Popup Management** - Automatic show/hide based on user interaction
-- **Signal-Based Reactivity** - Reactive state management using Angular signals
+- **Text input with popup** - Coordinates input field with popup content
+- **Three filter modes** - Manual, auto-select, or highlight behaviors
+- **Keyboard navigation** - Arrow keys, Enter, and Escape handling
+- **Screen reader support** - Built-in ARIA attributes including role="combobox" and aria-expanded
+- **Popup management** - Automatic show/hide based on user interaction
+- **Signal-based reactivity** - Reactive state management using Angular signals
 
 ## Examples
 
@@ -128,7 +128,7 @@ A pattern that combines a readonly combobox with listbox to create single-select
   </docs-tab>
 </docs-tab-group>
 
-The `readonly` attribute prevents typing in the input field. The popup opens on click or arrow keys. Users navigate options with keyboard and select with Enter or click.
+The `readonly` attribute prevents typing in the input field. The popup opens on click or arrow keys. Users navigate options with the keyboard and select with Enter or click.
 
 This configuration provides the foundation for the [Select](guide/aria/select) and [Multiselect](guide/aria/multiselect) patterns. See those guides for complete dropdown implementations with triggers and overlay positioning.
 
@@ -182,7 +182,7 @@ The `ngCombobox` directive coordinates a text input with a popup.
 
 **Filter Modes:**
 
-- **`'manual'`** - User controls filtering and selection explicitly. The popup shows options based on your filtering logic. Users select with Enter or click. This mode provides the most flexibility.
+- **`'manual'`** - Users control filtering and selection explicitly. The popup shows options based on your filtering logic. Users select with Enter or click. This mode provides the most flexibility.
 - **`'auto-select'`** - Input value automatically updates to the first matching option as users type. Requires the `firstMatch` input for coordination. See the [Autocomplete guide](guide/aria/autocomplete#auto-select-mode) for examples.
 - **`'highlight'`** - Highlights matching text without changing the input value. Users navigate with arrow keys and select with Enter.
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Some ARIA guide files contain minor grammar issues, inconsistent phrasing, and small clarity issues.

Issue Number: N/A

## What is the new behavior?

This PR improves grammar, wording consistency, and sentence clarity across the following files:
- `accordion.md`
- `autocomplete.md`
- `combobox.md`

Changes include:
- Improving sentence clarity without altering meaning
- Ensuring consistent tone (imperative style in lists)
- Removing contractions (e.g., "can't" → "cannot")
- Standardizing sentence casing in feature descriptions

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Changes are minimal and limited to wording improvements only
- No functional, structural, or behavioral changes are introduced
- Keeps alignment with Angular documentation style guidelines