### PR TITLE
fix(forms): prevent native clamping on range inputs by applying bound…

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -92,9 +92,6 @@ export function nativeControlCreate(
   return () => {
     const state = parent.state();
     const controlValue = state.controlValue();
-    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
-      setNativeControlValue(input, controlValue);
-    }
 
     for (const name of CONTROL_BINDING_NAMES) {
       const value = readFieldStateBindingValue(state, name);
@@ -104,6 +101,10 @@ export function nativeControlCreate(
           setNativeDomProperty(parent.renderer, input, name, value as string | number | undefined);
         }
       }
+    }
+
+    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
+      setNativeControlValue(input, controlValue);
     }
 
     updateMode = true;

--- a/packages/forms/signals/test/web/number_input.spec.ts
+++ b/packages/forms/signals/test/web/number_input.spec.ts
@@ -8,7 +8,7 @@
 
 import {Component, signal, viewChildren, Injectable} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {FormField, form} from '../../public_api';
+import {FormField, form, min, max} from '../../public_api';
 import {InputValidityMonitor} from '../../src/directive/input_validity_monitor';
 import {TestInputValidityMonitor} from './test_input_validity_monitor';
 
@@ -162,6 +162,32 @@ describe('numeric inputs', () => {
       });
 
       expect(fixture.componentInstance.f().value()).toBeNull();
+    });
+  });
+
+  describe('range inputs', () => {
+    it('should configure min and max before assigning value to prevent native clamping', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="range" [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly data = signal<number>(150);
+        // Note: The range default max is 100. If value is assigned before max is set to 200, it would clamp to 100.
+        readonly f = form(this.data, (path) => {
+          min(path, 100);
+          max(path, 200);
+        });
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+      // Ensure that the native clamping didn't occur and the input retains the original 150 value
+      expect(input.min).toBe('100');
+      expect(input.max).toBe('200');
+      expect(input.value).toBe('150');
+      expect(fixture.componentInstance.f().value()).toBe(150);
     });
   });
 });


### PR DESCRIPTION
When an input field receives a value that exceeds its bounds (like a `<input type="range">` where the default `max` is 100), the browser will natively clamp the value to fit within the valid range bounds.

Previously, `[formField]` set the native input `.value` before it configured `.max` and `.min` native properties. This meant any initial value above 100 for a range input would get clamped down to 100 before the upper bound was raised.

This commit fixes this issue by switching the order of execution in `control_native.ts`, ensuring bounds are configured on the native DOM node before the `controlValue` is applied.
Fixes #68480
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
