### PR TITLE
fix(forms): Add support for range type with outside of native bounds

### DIFF
--- a/packages/forms/signals/src/directive/control_native.ts
+++ b/packages/forms/signals/src/directive/control_native.ts
@@ -23,8 +23,8 @@ import type {FormField} from './form_field';
 import {InputValidityMonitor} from './input_validity_monitor';
 import {
   getNativeControlValue,
-  isInput,
   inputRequiresValidityTracking,
+  isInput,
   setNativeControlValue,
   setNativeDomProperty,
 } from './native';
@@ -91,10 +91,6 @@ export function nativeControlCreate(
 
   return () => {
     const state = parent.state();
-    const controlValue = state.controlValue();
-    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
-      setNativeControlValue(input, controlValue);
-    }
 
     for (const name of CONTROL_BINDING_NAMES) {
       const value = readFieldStateBindingValue(state, name);
@@ -104,6 +100,12 @@ export function nativeControlCreate(
           setNativeDomProperty(parent.renderer, input, name, value as string | number | undefined);
         }
       }
+    }
+
+    // We need to update the value after setting the attributes as some attributes like min/max might prevent from setting the value
+    const controlValue = state.controlValue();
+    if (bindingUpdated(bindings, 'controlValue', controlValue)) {
+      setNativeControlValue(input, controlValue);
     }
 
     updateMode = true;

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -15,7 +15,6 @@ import {
   ElementRef,
   EventEmitter,
   inject,
-  Injectable,
   Injector,
   input,
   Input,
@@ -26,7 +25,6 @@ import {
   Output,
   resource,
   signal,
-  Type,
   viewChild,
   viewChildren,
   ViewContainerRef,
@@ -5322,6 +5320,44 @@ describe('field directive', () => {
         input.dispatchEvent(new Event('input'));
       });
       expect(cmp.f().value()).toBe('abc');
+    });
+
+    it('should sync number with range type input', () => {
+      @Component({
+        imports: [FormField],
+        template: `<input type="range" [formField]="form.range" />`,
+      })
+      class TestCmp {
+        min = signal<number | undefined>(undefined);
+        max = signal<number | undefined>(undefined);
+
+        form = form(signal({range: 80}), (path) => {
+          min(path.range, this.min);
+          max(path.range, this.max);
+        });
+      }
+
+      const fix = act(() => TestBed.createComponent(TestCmp));
+      const input = fix.nativeElement.firstChild as HTMLInputElement;
+      const cmp = fix.componentInstance as TestCmp;
+
+      // Initial state
+      expect(input.value).toBe('80');
+
+      // Model -> View
+      act(() => cmp.form().value.set({range: 150}));
+      // Value is caped to max
+      expect(input.value).toBe('100');
+
+      cmp.min.set(0);
+      cmp.max.set(200);
+
+      act(() => cmp.form().value.set({range: 101}));
+      expect(input.value).toBe('101');
+
+      act(() => cmp.form().value.set({range: 220}));
+      // Value is caped to max
+      expect(input.value).toBe('200');
     });
   });
 


### PR DESCRIPTION
range inputs don't allow value that are outside their min/max ranges.
