### PR TITLE
ci: update PullApprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -99,7 +99,7 @@ groups:
     reviewers:
       users:
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - atscott
         - crisbeto
         - devversion
@@ -145,7 +145,7 @@ groups:
     reviewers:
       users:
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - atscott
         - crisbeto
         - devversion
@@ -200,7 +200,7 @@ groups:
       users:
         - ~JiaLiPassion
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - atscott
         - crisbeto
         - devversion
@@ -250,7 +250,7 @@ groups:
       users:
         - alan-agius4
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - atscott
         - bencodezen
         - crisbeto
@@ -369,7 +369,7 @@ groups:
         ])
     reviewers:
       users:
-        - AndrewKushnir
+        - ~AndrewKushnir
         - ~alxhub
         - atscott
         - thePunderWoman
@@ -405,7 +405,7 @@ groups:
     reviewers:
       users:
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - atscott
         - kirjs
         - thePunderWoman
@@ -453,7 +453,7 @@ groups:
     reviewers:
       users:
         - ~alxhub
-        - AndrewKushnir
+        - ~AndrewKushnir
         - andrewseguin
         - dgp1130
         - thePunderWoman
@@ -476,7 +476,7 @@ groups:
         - ~pkozlowski-opensource # Pawel Kozlowski
         - ~alxhub # Alex Rickabaugh
         - thePunderWoman # Jessica Janiuk
-        - AndrewKushnir # Andrew Kushnir
+        - ~AndrewKushnir # Andrew Kushnir
         - atscott # Andrew Scott
 
   # External team required reviews


### PR DESCRIPTION
This commit updates the PullApprove config to keep myself as a reviewer, but do not auto-assign PR reviews.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
