### PR TITLE
docs: update `@Service` remove preview warning

### DIFF
--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -45,8 +45,6 @@ This is the recommended approach for most services.
 
 ## Using the `@Service` decorator
 
-IMPORTANT: The `@Service` decorator is in [developer preview](reference/releases#developer-preview). Its API may change before becoming stable.
-
 For the common case of a singleton service available throughout your application, Angular provides the `@Service` decorator as a more ergonomic alternative to `@Injectable({providedIn: 'root'})`.
 
 The earlier `BasicDataStore` example can be rewritten with `@Service`:

--- a/adev/src/content/guide/di/defining-dependency-providers.md
+++ b/adev/src/content/guide/di/defining-dependency-providers.md
@@ -2,7 +2,7 @@
 
 Angular provides two ways to make services available for injection:
 
-1. **Automatic provision** - Using `providedIn` in the `@Injectable` decorator, the developer-preview [`@Service`](guide/di/creating-and-using-services#using-the-service-decorator) decorator, or by providing a factory in the `InjectionToken` configuration
+1. **Automatic provision** - Using `providedIn` in the `@Injectable` decorator, the [`@Service`](guide/di/creating-and-using-services#using-the-service-decorator) decorator, or by providing a factory in the `InjectionToken` configuration
 2. **Manual provision** - Using the `providers` array in components, directives, routes, or application config
 
 In the [previous guide](/guide/di/creating-and-using-services), you learned how to create services using `providedIn: 'root'`, which handles most common use cases. This guide explores additional patterns for both automatic and manual provider configuration.


### PR DESCRIPTION
Since https://github.com/angular/angular/pull/68470 marked `@Service` as stable, we updated the documentation.