### PR TITLE
docs: update guides to use `@Service`

### DIFF
--- a/adev/shared-docs/services/navigation-state.service.ts
+++ b/adev/shared-docs/services/navigation-state.service.ts
@@ -7,8 +7,8 @@
  */
 
 import {Service, inject, linkedSignal, signal} from '@angular/core';
-import {NavigationItem} from '../interfaces/index';
 import {Router} from '@angular/router';
+import {NavigationItem} from '../interfaces/index';
 
 @Service()
 export class NavigationState {

--- a/adev/shared-docs/services/search.service.ts
+++ b/adev/shared-docs/services/search.service.ts
@@ -16,14 +16,14 @@ import {
   resource,
   signal,
 } from '@angular/core';
-import {ENVIRONMENT} from '../providers/index';
-import type {Environment, SearchResult, SearchResultItem, SnippetResult} from '../interfaces/index';
 import {
-  LiteClient,
-  liteClient as algoliasearch,
-  SearchResponses,
   SearchResult as AlgoliaSearchResult,
+  LiteClient,
+  SearchResponses,
+  liteClient as algoliasearch,
 } from 'algoliasearch/lite';
+import type {Environment, SearchResult, SearchResultItem, SnippetResult} from '../interfaces/index';
+import {ENVIRONMENT} from '../providers/index';
 
 export const SEARCH_DELAY = 200;
 // Maximum number of facet values to return for each facet during a regular search.

--- a/adev/src/app/core/services/version-manager.service.ts
+++ b/adev/src/app/core/services/version-manager.service.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DOCUMENT, Service, VERSION, computed, inject} from '@angular/core';
 import {httpResource} from '@angular/common/http';
+import {DOCUMENT, Service, VERSION, computed, inject} from '@angular/core';
 
 import versionJson from '../../../assets/others/versions.json';
 

--- a/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
+++ b/adev/src/app/features/references/api-reference-list/api-reference-manager.service.ts
@@ -10,9 +10,9 @@ import {Service, signal} from '@angular/core';
 // This file is generated at build-time, error is expected here.
 import API_MANIFEST_JSON from '../../../../../src/assets/api/manifest.json';
 import {getApiUrl} from '../helpers/manifest.helper';
+import {ApiItem} from '../interfaces/api-item';
 import {ApiItemsGroup} from '../interfaces/api-items-group';
 import {ApiManifest} from '../interfaces/api-manifest';
-import {ApiItem} from '../interfaces/api-item';
 
 const manifest = API_MANIFEST_JSON as ApiManifest;
 

--- a/adev/src/content/guide/components/programmatic-rendering.md
+++ b/adev/src/content/guide/components/programmatic-rendering.md
@@ -361,10 +361,11 @@ import {
   Injectable,
   inputBinding,
   outputBinding,
+  Service,
 } from '@angular/core';
 import {Popup} from './popup';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class PopupService {
   private readonly injector = inject(EnvironmentInjector);
   private readonly appRef = inject(ApplicationRef);

--- a/adev/src/content/guide/di/creating-and-using-services.md
+++ b/adev/src/content/guide/di/creating-and-using-services.md
@@ -12,14 +12,14 @@ ng generate service CUSTOM_NAME
 
 This command creates a dedicated `CUSTOM_NAME.ts` file in your `src` directory.
 
-You can also manually create a service by adding the `@Injectable()` decorator to a TypeScript class. This tells Angular that you can use the class as an injectable dependency.
+You can also manually create a service by adding the `@Service()` decorator to a TypeScript class. This tells Angular that you can use the class as an injectable dependency.
 
 The following example defines a service that allows users to add and retrieve data:
 
 ```ts {header: "src/app/basic-data-store.ts"}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class BasicDataStore {
   private data: string[] = [];
 
@@ -150,12 +150,10 @@ export class Example {
 ### Injecting into another service
 
 ```ts
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {AdvancedDataStore} from './advanced-data-store';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class BasicDataStore {
   private advancedDataStore = inject(AdvancedDataStore);
   private data: string[] = [];

--- a/adev/src/content/guide/di/creating-injectable-service.md
+++ b/adev/src/content/guide/di/creating-injectable-service.md
@@ -73,28 +73,21 @@ ng generate service heroes/hero
 This command creates the following default `HeroService`:
 
 ```ts {header: 'heroes/hero.service.ts (CLI-generated)'}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HeroService {}
 ```
 
-The `@Injectable()` decorator specifies that Angular can use this class in the DI system.
-The `providedIn: 'root'` metadata specifies that the `HeroService` is available throughout your application.
+The `@Service()` decorator specifies that Angular can use this class in the DI system and that the `HeroService` is available throughout your application.
 
 Add a `getHeroes()` method that returns the heroes from `mock.heroes.ts` to get the hero mock data:
 
 ```ts {header: 'hero.service.ts'}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 import {HEROES} from './mock-heroes';
 
-@Injectable({
-  // declares that this service should be created
-  // by the root application injector.
-  providedIn: 'root',
-})
+@Service()
 export class HeroService {
   getHeroes() {
     return HEROES;
@@ -133,13 +126,11 @@ When a service depends on another service, follow the same pattern as injecting 
 In the following example, `HeroService` depends on a `Logger` service to report its activities:
 
 ```ts {header: 'hero.service.ts, highlight: [[3],[9],[12]]}
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {HEROES} from './mock-heroes';
 import {Logger} from '../logger.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class HeroService {
   private logger = inject(Logger);
 

--- a/adev/src/content/guide/di/debugging-and-troubleshooting-di.md
+++ b/adev/src/content/guide/di/debugging-and-troubleshooting-di.md
@@ -42,15 +42,15 @@ Angular only searches up the hierarchy, never down. Parent components cannot acc
 **Solution:** Provide the service at a higher level (application or parent component).
 
 ```ts {prefer}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class DataStore {
   // Available everywhere
 }
 ```
 
-TIP: Use `providedIn: 'root'` by default for services that don't need component-specific state. This makes services available everywhere and enables tree-shaking.
+TIP: `@Service` makes services available everywhere and enables tree-shaking. If you don't want to scope it to the entire app, specify `autoProvided: false`.
 
 #### Services and lazy-loaded routes
 
@@ -86,12 +86,12 @@ Lazy-loaded routes create child injectors that are only available after the rout
 
 NOTE: By default, route injectors and their services persist even after navigating away from the route. They are not destroyed until the application is closed. For automatic cleanup of unused route injectors, see [customizing route behavior](guide/routing/customizing-route-behavior#experimental-automatic-cleanup-of-unused-route-injectors).
 
-**Solution:** Use `providedIn: 'root'` for services that need to be shared across lazy boundaries.
+**Solution:** Use `@Service` for services that need to be shared across lazy boundaries.
 
 ```ts {prefer, header: 'Provide at root for shared services'}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class FeatureClient {
   // Available everywhere, including before lazy load
 }
@@ -132,12 +132,12 @@ export class UserSettings {
 
 Each component gets its own `UserClient` instance. Changes in one component don't affect the other.
 
-**Solution:** Use `providedIn: 'root'` for singletons.
+**Solution:** Use `@Service` for singletons.
 
 ```ts {prefer, header: 'Root-level singleton'}
 import {Injectable} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class UserClient {
   // Single instance shared across all components
 }
@@ -517,6 +517,7 @@ Angular searches in this order:
 
 When you see a `NullInjectorError`, the service isn't provided at any level the component can access. Check that:
 
+- The service has `@Service()` or
 - The service has `@Injectable({providedIn: 'root'})`, or
 - The service is in a `providers` array the component can reach
 
@@ -530,9 +531,9 @@ When debugging DI issues, use DevTools to answer these questions:
 
 - **Is the service provided?** Select the component that fails to inject and check if the service appears in the Injector section.
 - **At what level?** Walk up the component tree to find where the service is actually provided (component, route, or application level).
-- **Multiple instances?** If a singleton service appears in multiple component injectors, it's likely provided in component `providers` arrays instead of using `providedIn: 'root'`.
+- **Multiple instances?** If a singleton service appears in multiple component injectors, it's likely provided in component `providers` arrays instead of using `@Service` or `providedIn: 'root'`.
 
-If a service never appears in any injector, verify it has the `@Injectable()` decorator with `providedIn: 'root'` or is listed in a `providers` array.
+If a service never appears in any injector, verify it has the `@Service` decorator or is listed in a `providers` array.
 
 ### Logging and tracing injection
 
@@ -543,9 +544,9 @@ When DevTools isn't enough, use logging to trace injection behavior.
 Add console logs to service constructors to see when services are created.
 
 ```ts
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class UserClient {
   constructor() {
     console.log('UserClient created');
@@ -639,8 +640,8 @@ When DI fails, follow this systematic approach:
 
 **Step 2: Check the basics**
 
-- Does the service have `@Injectable()`?
-- Is `providedIn` set correctly?
+- Does the service have `@Service` or `@Injectable()`?
+- If you use `@Injectable`, is `providedIn` set correctly?
 - Are imports correct?
 - Is the file included in compilation?
 
@@ -681,9 +682,9 @@ NullInjectorError: No provider for UserClient!
 
 The dependency path shows that `App` injected `AuthClient`, which tried to inject `UserClient`, but no provider was found.
 
-#### Missing @Injectable decorator
+#### Missing the `@Service ` or `@Injectable` decorator
 
-The most common cause is forgetting the `@Injectable()` decorator on a service class.
+The most common cause is forgetting the `@Service` or `@Injectable()` decorator on a service class.
 
 ```ts {avoid, header: 'Missing decorator'}
 export class UserClient {
@@ -693,14 +694,12 @@ export class UserClient {
 }
 ```
 
-Angular requires the `@Injectable()` decorator to generate the metadata needed for dependency injection.
+Angular requires the `@Service()` decorator to generate the metadata needed for dependency injection.
 
-```ts {prefer, header: 'Include @Injectable'}
-import {Injectable} from '@angular/core';
+```ts {prefer, header: 'Include @Service'}
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class UserClient {
   getUser() {
     return {name: 'Alice'};
@@ -708,7 +707,7 @@ export class UserClient {
 }
 ```
 
-NOTE: Classes with zero-argument constructors can work without `@Injectable()`, but this is not recommended. Always include the decorator for consistency and to avoid issues when adding dependencies later.
+NOTE: Classes with zero-argument constructors can work without `@Service()`, but this is not recommended. Always include the decorator for consistency and to avoid issues when adding dependencies later.
 
 #### Missing providedIn configuration
 
@@ -725,14 +724,12 @@ export class UserClient {
 }
 ```
 
-Specify `providedIn: 'root'` to make the service available throughout your application.
+Use the `@Service` decorator to make the service available throughout your application.
 
 ```ts {prefer, header: 'Specify providedIn'}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class UserClient {
   getUser() {
     return {name: 'Alice'};
@@ -740,7 +737,7 @@ export class UserClient {
 }
 ```
 
-The `providedIn: 'root'` configuration makes the service available application-wide and enables tree-shaking (the service is removed from the bundle if never injected).
+The `@Service` decorator makes the service available application-wide and enables tree-shaking (the service is removed from the bundle if never injected).
 
 #### Standalone component missing imports
 
@@ -760,7 +757,7 @@ export class UserProfile {
 }
 ```
 
-Ensure the service uses `providedIn: 'root'` or add it to the component's `providers` array.
+Ensure the service uses `@Service` or add it to the component's `providers` array.
 
 ```angular-ts {prefer, header: 'Service uses providedIn: root'}
 import {Component, inject} from '@angular/core';

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -10,7 +10,7 @@ Angular has two injector hierarchies:
 
 | Injector hierarchies            | Details                                                                                                                                                                   |
 | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `EnvironmentInjector` hierarchy | Configure an `EnvironmentInjector` in this hierarchy using `@Injectable()` or `providers` array in `ApplicationConfig`.                                                   |
+| `EnvironmentInjector` hierarchy | Configure an `EnvironmentInjector` in this hierarchy using `@Service()` or `providers` array in `ApplicationConfig`.                                                      |
 | `ElementInjector` hierarchy     | Created implicitly at each DOM element. An `ElementInjector` is empty by default unless you configure it in the `providers` property on `@Directive()` or `@Component()`. |
 
 <docs-callout title="NgModule Based Applications">
@@ -21,12 +21,12 @@ For `NgModule` based applications, you can provide dependencies with the `Module
 
 The `EnvironmentInjector` can be configured in one of two ways by using:
 
-- The `@Injectable()` `providedIn` property to refer to `root` or `platform`
+- The `@Service()`
 - The `ApplicationConfig` `providers` array
 
-<docs-callout title="Tree-shaking and @Injectable()">
+<docs-callout title="Tree-shaking and @Service()">
 
-Using the `@Injectable()` `providedIn` property is preferable to using the `ApplicationConfig` `providers` array. With `@Injectable()` `providedIn`, optimization tools can perform tree-shaking, which removes services that your application isn't using. This results in smaller bundle sizes.
+Using the `@Service()` decorator is preferable to using the `ApplicationConfig` `providers` array. With `@Service`, optimization tools can perform tree-shaking, which removes services that your application isn't using. This results in smaller bundle sizes.
 
 Tree-shaking is especially useful for a library because the application which uses the library may not have a need to inject it.
 
@@ -34,26 +34,24 @@ Tree-shaking is especially useful for a library because the application which us
 
 `EnvironmentInjector` is configured by the `ApplicationConfig.providers`.
 
-Provide services using `providedIn` of `@Injectable()` as follows:
+Provide services using `@Service()` as follows:
 
 ```ts {highlight:[4]}
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root', // <--provides this service in the root EnvironmentInjector
-})
+@Service() // <--provides this service in the root EnvironmentInjector
 export class ItemService {
   name = 'telephone';
 }
 ```
 
-The `@Injectable()` decorator identifies a service class.
-The `providedIn` property configures a specific `EnvironmentInjector`, here `root`, which makes the service available in the `root` `EnvironmentInjector`.
+The `@Service()` or `@Injectable()` decorators identify a service class.
 
 ### ModuleInjector
 
 In the case of `NgModule` based applications, the ModuleInjector can be configured in one of two ways by using:
 
+- The `@Service()` decorator,
 - The `@Injectable()` `providedIn` property to refer to `root` or `platform`
 - The `@NgModule()` `providers` array
 
@@ -382,9 +380,7 @@ These aren't real attributes but are here to demonstrate what is going on under 
 The example application has a `FlowerService` provided in `root` with an `emoji` value of red hibiscus <code>🌺</code>.
 
 ```ts {header:"lower.service.ts"}
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class FlowerService {
   emoji = '🌺';
 }
@@ -545,11 +541,9 @@ For demonstration, we are building an `AnimalService` to demonstrate `viewProvid
 First, create an `AnimalService` with an `emoji` property of whale <code>🐳</code>:
 
 ```typescript
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class AnimalService {
   emoji = '🐳';
 }
@@ -986,11 +980,11 @@ The `HeroTaxReturnService` caches a single `HeroTaxReturn`, tracks changes to th
 It also delegates to the application-wide singleton `HeroService`, which it gets by injection.
 
 ```typescript
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {HeroTaxReturn} from './hero';
 import {HeroesService} from './heroes.service';
 
-@Injectable()
+@Service({autoProvided: false})
 export class HeroTaxReturnService {
   private currentTaxReturn!: HeroTaxReturn;
   private originalTaxReturn!: HeroTaxReturn;

--- a/adev/src/content/guide/di/overview.md
+++ b/adev/src/content/guide/di/overview.md
@@ -32,7 +32,7 @@ Angular components and directives automatically participate in DI, meaning that 
 
 ## What are services?
 
-An Angular _service_ is a TypeScript class decorated with `@Injectable`, which allows you to inject an instance of the class as a dependency. Services are the most common way of sharing data and functionality across an application.
+An Angular _service_ is a TypeScript class decorated with `@Service`, which allows you to inject an instance of the class as a dependency. Services are the most common way of sharing data and functionality across an application.
 
 Common types of services include:
 
@@ -46,9 +46,9 @@ Common types of services include:
 The following example declares a service named `AnalyticsLogger`:
 
 ```ts
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class AnalyticsLogger {
   trackEvent(category: string, value: string) {
     console.log('Analytics event logged:', {
@@ -60,9 +60,9 @@ export class AnalyticsLogger {
 }
 ```
 
-NOTE: The `providedIn: 'root'` option makes this service available throughout your entire application as a singleton. This is the recommended approach for most services.
+NOTE: The `@Service` makes this service available throughout your entire application as a singleton. This is the recommended approach for most services.
 
-HELPFUL: You can also use the [`@Service`](guide/di/creating-and-using-services#using-the-service-decorator) decorator, a ergonomic shorthand for `@Injectable({providedIn: 'root'})`.
+HELPFUL: The [`@Service`](guide/di/creating-and-using-services#using-the-service-decorator) decorator is an ergonomic shorthand for `@Injectable({providedIn: 'root'})`.
 
 ## Injecting dependencies with `inject()`
 
@@ -121,10 +121,10 @@ export class MyDirective {
 ```
 
 ```ts
-import {Injectable, inject} from '@angular/core';
+import {Service, inject} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class MyService {
   // ✅ In a service
   private http = inject(HttpClient);

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -635,7 +635,7 @@ TIP: Using the `async` pipe or the `toSignal` operation to subscribe to `Observa
 While `HttpClient` can be injected and used directly from components, generally we recommend you create reusable, injectable services which isolate and encapsulate data access logic. For example, this `UserService` encapsulates the logic to request data for a user by their id:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class UserService {
   private http = inject(HttpClient);
 

--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -25,7 +25,7 @@ export class AppModule {}
 You can then inject the `HttpClient` service as a dependency of your components, services, or other classes:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class ConfigService {
   private http = inject(HttpClient);
   // This service can now make HTTP requests via `this.http`.

--- a/adev/src/content/guide/routing/lifecycle-and-events.md
+++ b/adev/src/content/guide/routing/lifecycle-and-events.md
@@ -109,10 +109,10 @@ Track page views for analytics:
 
 ```ts
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
-import {inject, Injectable, DestroyRef} from '@angular/core';
+import {inject, DestroyRef, Service} from '@angular/core';
 import {Router, NavigationEnd} from '@angular/router';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class AnalyticsService {
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);

--- a/adev/src/content/guide/signals/debounced.md
+++ b/adev/src/content/guide/signals/debounced.md
@@ -74,7 +74,7 @@ debouncedFilter = debounced(filter, 200, {
 To use `debounced` outside of an injection context, pass an explicit `Injector` via the options:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class SearchService {
   private injector = inject(Injector);
 

--- a/adev/src/content/guide/signals/overview.md
+++ b/adev/src/content/guide/signals/overview.md
@@ -43,7 +43,7 @@ Writable signals have the type `WritableSignal`.
 `WritableSignal` provide a `asReadonly()` method that returns a readonly version of the signal. This is useful when you want to expose a signal's value to consumers without allowing them to modify it directly:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class CounterState {
   // Private writable state
   private readonly _count = signal(0);

--- a/adev/src/content/guide/ssr.md
+++ b/adev/src/content/guide/ssr.md
@@ -345,9 +345,9 @@ export class Checkout {
 When working with server-side rendering, you should avoid directly referencing browser-specific globals like `document`. Instead, use the [`DOCUMENT`](api/core/DOCUMENT) token to access the document object in a platform-agnostic way.
 
 ```ts
-import {Injectable, inject, DOCUMENT} from '@angular/core';
+import {inject, DOCUMENT, Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class CanonicalLinkService {
   private readonly document = inject(DOCUMENT);
 

--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -166,7 +166,7 @@ You can optionally specify a timeout in milliseconds that is passed to [`request
 You can customize the `idle` trigger by providing your own `IdleService` implementation and registering it with `provideIdleServiceWith` in your application's providers.
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 class CustomIdleService implements IdleService {
   requestOnIdle(callback: (deadline?: IdleDeadline) => void, options?: IdleRequestOptions) {
     // Custom idle scheduling logic can be implemented here.

--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -1133,7 +1133,7 @@ There might not be a remote server to call.
 Fortunately, the `HeroDetailService` delegates responsibility for remote data access to an injected `HeroService`.
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class HeroDetailService {
   private heroService = inject(HeroService);
 }

--- a/adev/src/content/guide/testing/services.md
+++ b/adev/src/content/guide/testing/services.md
@@ -9,9 +9,9 @@ This guide uses [Vitest](https://vitest.dev/), which Angular CLI projects includ
 Consider a `Calculator` service that performs basic arithmetic:
 
 ```ts { header: 'calculator.ts' }
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class Calculator {
   add(a: number, b: number): number {
     return a + b;
@@ -58,9 +58,9 @@ Most services depend on other services to run properly. By default, `TestBed` pr
 Consider an `OrderTotal` service that relies on a `TaxCalculator` to compute the final price of an order:
 
 ```ts { header: 'tax-calculator.ts' }
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class TaxCalculator {
   calculate(subtotal: number): number {
     return subtotal * 0.05;
@@ -69,10 +69,10 @@ export class TaxCalculator {
 ```
 
 ```ts { header: 'order-total.ts' }
-import {inject, Injectable} from '@angular/core';
+import {inject, Service} from '@angular/core';
 import {TaxCalculator} from './tax-calculator';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class OrderTotal {
   private taxCalculator = inject(TaxCalculator);
 

--- a/adev/src/content/introduction/essentials/dependency-injection.md
+++ b/adev/src/content/introduction/essentials/dependency-injection.md
@@ -10,15 +10,15 @@ Services are reusable pieces of code that can be injected.
 
 Similar to defining a component, services are comprised of the following:
 
-- A **TypeScript decorator** that declares the class as an Angular service via `@Injectable` and allows you to define what part of the application can access the service via the `providedIn` property (which is typically `'root'`) to allow a service to be accessed anywhere within the application.
+- A **TypeScript decorator** that declares the class as an Angular service via `@Service` and allows you to define a service that can be accessed anywhere in your application.
 - A **TypeScript class** that defines the desired code that will be accessible when the service is injected
 
 Here is an example of a `Calculator` service.
 
 ```angular-ts
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class Calculator {
   add(x: number, y: number) {
     return x + y;

--- a/adev/src/content/reference/errors/NG0201.md
+++ b/adev/src/content/reference/errors/NG0201.md
@@ -10,10 +10,10 @@ Read more on providers in our [Dependency Injection guide](guide/di).
 
 Work backwards from the object where the error states that a provider is missing: `No provider for ${this}!`. This is commonly thrown in services, which require non-existing providers.
 
-To fix the error ensure that your service is registered in the list of providers of an `NgModule` or has the `@Injectable` decorator with a `providedIn` property at top.
+To fix the error ensure that your service is registered in the list of providers of an `NgModule` or has the `@Service` decorator at top.
 
-The most common solution is to add a provider in `@Injectable` using `providedIn`:
+The most common solution is to add a provider in `@Service`
 
 ```ts
-@Injectable({ providedIn: 'app' })
+@Service()
 ```

--- a/adev/src/content/reference/errors/NG0203.md
+++ b/adev/src/content/reference/errors/NG0203.md
@@ -6,7 +6,7 @@ used with `runInInjectionContext`.
 In practice the `inject()` calls are allowed in a constructor, a constructor parameter and a field initializer:
 
 ```typescript
-@Injectable({providedIn: 'root'})
+@Service()
 export class Car {
   radio: Radio | undefined;
 

--- a/adev/src/content/reference/errors/NG0204.md
+++ b/adev/src/content/reference/errors/NG0204.md
@@ -4,28 +4,28 @@ This error occurs when Angular cannot resolve a dependency for a class during de
 
 The most common causes are:
 
-1. A service class is missing the `@Injectable()` decorator
+1. A service class is missing the `@Service()` or the `@Injectable` decorator
 2. An `InjectionToken` lacks a proper provider definition
 3. A constructor parameter cannot be resolved
 
-NOTE: The `inject()` function takes an explicit token, so the "unresolvable parameter" scenario does not apply to it directly. However, if the injected class itself is missing `@Injectable()` and has its own constructor dependencies, the error can still occur.
+NOTE: The `inject()` function takes an explicit token, so the "unresolvable parameter" scenario does not apply to it directly. However, if the injected class itself is missing `@Service()` and has its own constructor dependencies, the error can still occur.
 
 ## Common scenarios
 
-### Missing `@Injectable()` decorator
+### Missing `@Service()` decorator
 
-When a class has constructor dependencies but lacks the `@Injectable()` decorator, Angular cannot resolve its parameters:
+When a class has constructor dependencies but lacks the `@Service()` decorator, Angular cannot resolve its parameters:
 
-```ts {header: 'Missing @Injectable() decorator'}
+```ts {header: 'Missing @Service() decorator'}
 export class UserClient {
   constructor(private http: HttpClient) {} // Angular can't resolve this
 }
 ```
 
-Add the `@Injectable()` decorator to fix this:
+Add the `@Service()` decorator to fix this:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class UserClient {
   constructor(private http: HttpClient) {}
 }
@@ -36,7 +36,7 @@ export class UserClient {
 This error also appears when Angular cannot determine the type of a constructor parameter:
 
 ```ts
-@Injectable({providedIn: 'root'})
+@Service()
 export class DataStore {
   // Angular can't resolve 'config' without a provider
   constructor(private config: AppConfig) {}
@@ -49,11 +49,11 @@ Ensure all constructor parameters either have providers configured or use `@Opti
 
 The error message includes details about which token could not be resolved:
 
-- `Can't resolve all parameters for X: (?, ?, ?)` — The `?` marks indicate unresolvable parameters. Check that the class has `@Injectable()` and all dependencies have providers.
+- `Can't resolve all parameters for X: (?, ?, ?)` — The `?` marks indicate unresolvable parameters. Check that the class has `@Service` or `@Injectable()` and all dependencies have providers.
 - `Token X is missing a ɵprov definition` — An `InjectionToken` was used without configuring a provider. Register the token with a value using `{provide: TOKEN, useValue: ...}` or add a default factory to the token definition.
 
 Work backwards from the error's stack trace to identify where the problematic injection occurs, then verify that:
 
-1. The class has `@Injectable()` decorator
+1. The class has a `@Service` or `@Injectable()` decorator
 2. All constructor parameters have registered providers
 3. Any `InjectionToken` has a configured provider or default value

--- a/adev/src/content/reference/errors/NG0919.md
+++ b/adev/src/content/reference/errors/NG0919.md
@@ -58,10 +58,10 @@ ComponentA -> ComponentB -> ComponentC -> ComponentA
 
 Move shared functionality to a separate file that doesn't import either component:
 
-```angular-ts {header:"shared.service.ts"}
-import {Injectable} from '@angular/core';
+```ts {header:"shared.service.ts"}
+import {Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class SharedService {
   // Shared logic here
 }

--- a/adev/src/content/tools/cli/schematics-for-libraries.md
+++ b/adev/src/content/tools/cli/schematics-for-libraries.md
@@ -144,12 +144,10 @@ Schematic templates support special syntax to execute code and variable substitu
 
    ```ts {header:projects/my-lib/schematics/my-service/files/__name@dasherize__.service.ts.template (Schematic Template)}
 
-   import { Injectable } from '@angular/core';
+   import { Service } from '@angular/core';
    import { HttpClient } from '@angular/common/http';
 
-   @Injectable({
-      providedIn: 'root'
-   })
+   @Service()
    export class <%= classify(name) %>Service {
       private http = inject(HttpClient);
    }

--- a/skills/dev-skills/angular-developer/references/cli.md
+++ b/skills/dev-skills/angular-developer/references/cli.md
@@ -25,7 +25,7 @@ Always use the CLI to generate code to ensure it adheres to Angular standards an
 | Target       | Command               | Notes                                                                                          |
 | :----------- | :-------------------- | :--------------------------------------------------------------------------------------------- |
 | Component    | `ng g c path/to/name` | Generates a component. Use `--inline-style` (`-s`) or `--inline-template` (`-t`) if requested. |
-| Service      | `ng g s path/to/name` | Generates an `@Injectable({providedIn: 'root'})` service.                                      |
+| Service      | `ng g s path/to/name` | Generates an `@Service` service.                                                               |
 | Directive    | `ng g d path/to/name` | Generates a directive.                                                                         |
 | Pipe         | `ng g p path/to/name` | Generates a pipe.                                                                              |
 | Guard        | `ng g g path/to/name` | Generates a functional route guard.                                                            |

--- a/skills/dev-skills/angular-developer/references/creating-services.md
+++ b/skills/dev-skills/angular-developer/references/creating-services.md
@@ -10,14 +10,12 @@ You can generate a service using the Angular CLI:
 ng generate service my-data
 ```
 
-Or you can manually create a TypeScript class and decorate it with `@Injectable()`.
+Or you can manually create a TypeScript class and decorate it with `@Service()`.
 
 ```ts
-import {Injectable} from '@angular/core';
+import {Service} from '@angular/core';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class BasicDataStore {
   private data: string[] = [];
 
@@ -31,13 +29,17 @@ export class BasicDataStore {
 }
 ```
 
-### The `providedIn: 'root'` Option
+### The `@Service` decorator
 
-Using `providedIn: 'root'` is the recommended approach for most services. It tells Angular to:
+Using `@Service` is the recommended approach for most services. It tells Angular to:
 
 - **Create a single instance (singleton)** for the entire application.
 - **Make it available everywhere** automatically, without needing to list it in any `providers` array.
 - **Enable tree-shaking**, meaning the service is only included in the final JavaScript bundle if it is actually injected somewhere.
+
+#### The `autoProvided` option
+
+If you don't want to create a singleton of your service, you can set `@Service({autoProvided: false})` and declare the service a `providers` array.
 
 ## Injecting a Service
 
@@ -72,9 +74,7 @@ Services can inject other services in the exact same way.
 import {Injectable, inject} from '@angular/core';
 import {AdvancedDataStore} from './advanced-data-store.service';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class BasicDataStore {
   // Injecting another service
   private advancedDataStore = inject(AdvancedDataStore);
@@ -90,8 +90,8 @@ export class BasicDataStore {
 
 ## Advanced Service Patterns
 
-While `providedIn: 'root'` covers most scenarios, you may sometimes need:
+While `@Service` covers most scenarios, you may sometimes need:
 
-- **Component-specific instances**: If a component needs its own isolated instance of a service, provide it directly in the component's `@Component({ providers: [MyService] })` array.
+- **Component-specific instances**: If a component needs its own isolated instance of a service, provide it directly in the component's `@Component({ providers: [MyService] })` array and set the `autoProvided: false` option: `@Service({autoProvided: false})`
 - **Factory providers**: For dynamic creation.
 - **Value providers**: For injecting configuration objects.

--- a/skills/dev-skills/angular-developer/references/injection-context.md
+++ b/skills/dev-skills/angular-developer/references/injection-context.md
@@ -6,7 +6,7 @@ The `inject()` function can only be used when code is executing within an **inje
 
 An injection context is automatically available in:
 
-1. **Field initializers** of classes instantiated by DI (`@Injectable`, `@Component`, `@Directive`, `@Pipe`).
+1. **Field initializers** of classes instantiated by DI (`@Service`, `@Injectable`, `@Component`, `@Directive`, `@Pipe`).
 2. **Constructors** of classes instantiated by DI.
 3. **Factory functions** specified in `useFactory` or `InjectionToken` configurations.
 4. **Functional APIs** executed by Angular (e.g., functional route guards, resolvers, interceptors).
@@ -34,9 +34,9 @@ export class Example {
 If you need to run a function within an injection context (often needed for dynamic component creation or testing), use `runInInjectionContext`. This requires access to an existing injector (like `EnvironmentInjector` or `Injector`).
 
 ```ts
-import {Injectable, inject, EnvironmentInjector, runInInjectionContext} from '@angular/core';
+import {inject, EnvironmentInjector, runInInjectionContext, Service} from '@angular/core';
 
-@Injectable({providedIn: 'root'})
+@Service()
 export class MyService {
   private injector = inject(EnvironmentInjector);
 


### PR DESCRIPTION
In the cases where it was preferable to use `@Service` in place of `@Injectable`
