### PR TITLE
fix(docs-infra): exempt form validator names from API auto-linking

### DIFF
--- a/adev/shared-docs/pipeline/shared/linking.mts
+++ b/adev/shared-docs/pipeline/shared/linking.mts
@@ -32,6 +32,13 @@ const LINK_EXEMPT = new Set([
   'type',
   'Host',
   'filter',
+  'required',
+  'pattern',
+  'min',
+  'max',
+  'minLength',
+  'maxLength',
+  'query',
 ]);
 
 export function shouldLinkSymbol(symbol: string): boolean {


### PR DESCRIPTION
Add required, pattern, min, max, minLength and maxLength to LINK_EXEMPT so FieldState property names stop auto-linking to the validator functions of the same name.

fixes: #68479 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

On `FieldState` (and similar) API pages, clicking property names like `required` and `pattern` navigates to the unrelated `required()` / `pattern()` validator functions instead of the property's anchor on the same page. The shiki transformer auto-links any identifier matching a known API symbol, so member names get hijacked when they share a name with an exported function.

Issue Number: #68479 


## What is the new behavior?

Adds `required`, `pattern`, `min`, `max`, `minLength`, `maxLength` to the existing `LINK_EXEMPT` set in `adev/shared-docs/pipeline/shared/linking.mts`, consistent with how `disabled`, `readonly`, `hidden`, `style`, etc. are already handled.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


