### PR TITLE
fix(core): visit ng-let expression value in signal migration schematics

### DIFF
--- a/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
+++ b/packages/core/schematics/migrations/signal-migration/src/passes/reference_resolution/template_reference_visitor.ts
@@ -26,6 +26,7 @@ import {
   TmplAstDeferredBlock,
   TmplAstForLoopBlock,
   TmplAstIfBlockBranch,
+  TmplAstLetDeclaration,
   TmplAstNode,
   TmplAstRecursiveVisitor,
   TmplAstSwitchBlock,
@@ -222,6 +223,10 @@ export class TemplateReferenceVisitor<
     if (this.templateAttributeReferencedFields !== null) {
       this.templateAttributeReferencedFields.push(...referencedFields);
     }
+  }
+
+  override visitLetDeclaration(decl: TmplAstLetDeclaration): void {
+    this.checkExpressionForReferencedFields(decl, decl.value);
   }
 }
 

--- a/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_let.ts
+++ b/packages/core/schematics/migrations/signal-migration/test/golden-test/template_ng_let.ts
@@ -1,0 +1,16 @@
+// tslint:disable
+
+import {Component, Input} from '@angular/core';
+
+@Component({
+  template: `
+    @let sum = one + two;
+    @let three = this.three;
+    {{ sum }} {{ three }}
+  `,
+})
+export class MyComp {
+  @Input() one = 1;
+  @Input() two = 2;
+  @Input() three = 3;
+}

--- a/packages/core/schematics/migrations/signal-migration/test/golden.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden.txt
@@ -1257,6 +1257,24 @@ export class MyComp {
   readonly fourth = input(true);
   readonly fifth = input(true);
 }
+@@@@@@ template_ng_let.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    @let sum = one() + two();
+    @let three = this.three();
+    {{ sum }} {{ three }}
+  `,
+})
+export class MyComp {
+  readonly one = input(1);
+  readonly two = input(2);
+  readonly three = input(3);
+}
 @@@@@@ template_object_shorthand.ts @@@@@@
 
 // tslint:disable

--- a/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
+++ b/packages/core/schematics/migrations/signal-migration/test/golden_best_effort.txt
@@ -1211,6 +1211,24 @@ export class MyComp {
   readonly fourth = input(true);
   readonly fifth = input(true);
 }
+@@@@@@ template_ng_let.ts @@@@@@
+
+// tslint:disable
+
+import {Component, input} from '@angular/core';
+
+@Component({
+  template: `
+    @let sum = one() + two();
+    @let three = this.three();
+    {{ sum }} {{ three }}
+  `,
+})
+export class MyComp {
+  readonly one = input(1);
+  readonly two = input(2);
+  readonly three = input(3);
+}
 @@@@@@ template_object_shorthand.ts @@@@@@
 
 // tslint:disable


### PR DESCRIPTION
Before this fix, references to inputs inside @let statements were not accounted for.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

References to inputs inside @let statements are not accounted for.

Issue Number: N/A

## What is the new behavior?

References to inputs inside @let statements are accounted for.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A