### PR TITLE
fix(core): i18n flags leaking on errors

### DIFF
--- a/packages/core/src/render3/i18n/i18n_apply.ts
+++ b/packages/core/src/render3/i18n/i18n_apply.ts
@@ -101,19 +101,22 @@ export function setMaskBit(hasChange: boolean) {
 }
 
 export function applyI18n(tView: TView, lView: LView, index: number) {
-  if (changeMaskCounter > 0) {
-    ngDevMode && assertDefined(tView, `tView should be defined`);
-    const tI18n = tView.data[index] as TI18n | I18nUpdateOpCodes;
-    // When `index` points to an `ɵɵi18nAttributes` then we have an array otherwise `TI18n`
-    const updateOpCodes: I18nUpdateOpCodes = Array.isArray(tI18n)
-      ? (tI18n as I18nUpdateOpCodes)
-      : (tI18n as TI18n).update;
-    const bindingsStartIndex = getBindingIndex() - changeMaskCounter - 1;
-    applyUpdateOpCodes(tView, lView, updateOpCodes, bindingsStartIndex, changeMask);
+  try {
+    if (changeMaskCounter > 0) {
+      ngDevMode && assertDefined(tView, `tView should be defined`);
+      const tI18n = tView.data[index] as TI18n | I18nUpdateOpCodes;
+      // When `index` points to an `ɵɵi18nAttributes` then we have an array otherwise `TI18n`
+      const updateOpCodes: I18nUpdateOpCodes = Array.isArray(tI18n)
+        ? (tI18n as I18nUpdateOpCodes)
+        : (tI18n as TI18n).update;
+      const bindingsStartIndex = getBindingIndex() - changeMaskCounter - 1;
+      applyUpdateOpCodes(tView, lView, updateOpCodes, bindingsStartIndex, changeMask);
+    }
+  } finally {
+    // Reset changeMask & maskBit to default for the next update cycle
+    changeMask = 0b0;
+    changeMaskCounter = 0;
   }
-  // Reset changeMask & maskBit to default for the next update cycle
-  changeMask = 0b0;
-  changeMaskCounter = 0;
 }
 
 function createNodeWithoutHydration(
@@ -237,7 +240,7 @@ export function applyCreateOpCodes(
  * @param lView Current `LView`
  * @param anchorRNode place where the i18n node should be inserted.
  */
-export function applyMutableOpCodes(
+function applyMutableOpCodes(
   tView: TView,
   mutableOpCodes: IcuCreateOpCodes,
   lView: LView,
@@ -394,7 +397,7 @@ export function applyMutableOpCodes(
  * @param changeMask Each bit corresponds to a `ɵɵi18nExp` (Counting backwards from
  *     `bindingsStartIndex`)
  */
-export function applyUpdateOpCodes(
+function applyUpdateOpCodes(
   tView: TView,
   lView: LView,
   updateOpCodes: I18nUpdateOpCodes,


### PR DESCRIPTION
The i18n sub-system has the `changeMask` and `changeMaskCounter` flags which are set by i18n-related instructions and reset once the state is applied. The problem is that if something throws within the application logic, the flags would never be reset. This is currently causing flakes in our CI runs.

These changes resolve the issue by adding a try/finally around the flags.