### PR TITLE
feat(router): add preserveInitialUrl config to keep text fragments on initial load

### DIFF
--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -84,6 +84,7 @@ export class DocViewer {
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   private countOfExamples = 0;
+  private firstContentRenderHandled = false;
 
   constructor() {
     effect(async () => {
@@ -97,7 +98,15 @@ export class DocViewer {
     const contentContainer = this.elementRef.nativeElement;
 
     if (content) {
-      if (this.isBrowser && !(this.document as any).startViewTransition) {
+      // On the very first non-empty render, the SSG/SSR pass has already put the
+      // same markdown into the container. Replacing `innerHTML` with identical
+      // content destroys the existing text nodes — and any browser-applied state
+      // anchored to them, notably the `Range` backing a `:~:text=` highlight.
+      // Reuse the existing DOM on this first tick instead.
+      const reuseSsgDom = !this.firstContentRenderHandled && contentContainer.childElementCount > 0;
+      this.firstContentRenderHandled = true;
+
+      if (this.isBrowser && !reuseSsgDom && !(this.document as any).startViewTransition) {
         // Apply a special class to the host node to trigger animation.
         // Note: when a page is hydrated, the `content` would be empty,
         // so we don't trigger an animation to avoid a content flickering
@@ -105,7 +114,9 @@ export class DocViewer {
         this.animateContent = true;
       }
 
-      contentContainer.innerHTML = content;
+      if (!reuseSsgDom) {
+        contentContainer.innerHTML = content;
+      }
     }
 
     if (this.isBrowser) {

--- a/adev/src/app/routing/router_providers.ts
+++ b/adev/src/app/routing/router_providers.ts
@@ -38,7 +38,7 @@ export const routerProviders = [
   provideRouter(
     routes,
     withInMemoryScrolling(),
-    withRouterConfig({canceledNavigationResolution: 'computed'}),
+    withRouterConfig({canceledNavigationResolution: 'computed', preserveInitialUrl: true}),
     withNavigationErrorHandler(({error}) => {
       if (error instanceof HttpErrorResponse) {
         // TODO: Redirect to different pages on different response codes? (e.g. 500 page)

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -136,6 +136,25 @@ export interface RouterConfigOptions {
    * if an error occurs.
    */
   resolveNavigationPromiseOnError?: boolean;
+
+  /**
+   * When `true`, the Router skips its initial same-path `replaceState` call so any
+   * browser-applied URL augmentations are preserved on first load. Most notably, this
+   * keeps Chrome's text-fragment directives (`#:~:text=...`) intact in the address
+   * bar and allows the browser's native scroll-to-text behavior to work — current
+   * Chromium strips these directives from `document.URL`, so any `history.replaceState`
+   * call (even with no URL argument) commits the stripped URL into the active history
+   * entry and wipes the directive.
+   *
+   * Trade-off: the initial history entry has `null` state instead of Router's
+   * generated `{ɵrouterPageId, navigationId}` object. Router's internals fall back
+   * to `currentPageId` when state is missing, so navigation tracking continues to
+   * work; but any code that introspects `Location.getState()` directly on the
+   * initial entry will see `null` until the user navigates.
+   *
+   * Defaults to `false` to preserve existing behavior.
+   */
+  preserveInitialUrl?: boolean;
 }
 
 /**

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -38,6 +38,7 @@ export abstract class StateManager {
   protected location = inject(Location);
   protected urlHandlingStrategy = inject(UrlHandlingStrategy);
   protected urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
+  protected readonly preserveInitialUrl = this.options.preserveInitialUrl ?? false;
 
   protected currentUrlTree = new UrlTree();
   /**
@@ -175,6 +176,7 @@ export class HistoryStateManager extends StateManager {
    */
   private currentPageId: number = 0;
   private lastSuccessfulId: number = -1;
+  private isFirstNavigation = true;
 
   /**
    * The ɵrouterPageId of whatever page is currently active in the browser history. This is
@@ -238,8 +240,23 @@ export class HistoryStateManager extends StateManager {
   private setBrowserUrl(path: string, navigation: Navigation) {
     const {extras, id} = navigation;
     const {replaceUrl, state} = extras;
+    const wasFirst = this.isFirstNavigation;
+    this.isFirstNavigation = false;
 
     if (this.location.isCurrentPathEqualTo(path) || !!replaceUrl) {
+      // Skip the very first replaceState when it's a no-op same-path call with
+      // no caller-provided state. Otherwise it overwrites the current history
+      // entry with a URL derived from `document.URL`, which current Chromium
+      // strips of `:~:text=` directives — wiping the directive from the address
+      // bar and disabling the browser's native scroll-to-text on initial load.
+      if (
+        wasFirst &&
+        this.preserveInitialUrl &&
+        state === undefined &&
+        this.location.isCurrentPathEqualTo(path)
+      ) {
+        return;
+      }
       // replacements do not update the target page
       const currentBrowserPageId = this.browserPageId;
       const newState = {

--- a/packages/router/test/initial_url_preservation.spec.ts
+++ b/packages/router/test/initial_url_preservation.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Location} from '@angular/common';
+import {Component} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {provideRouter, Router, withRouterConfig} from '../index';
+
+@Component({template: '', standalone: true})
+class Empty {}
+
+describe('withRouterConfig({preserveInitialUrl})', () => {
+  it('writes initial state by default (flag off)', async () => {
+    TestBed.configureTestingModule({
+      providers: [provideRouter([{path: '**', component: Empty}])],
+    });
+    await TestBed.inject(Router).navigateByUrl('/');
+
+    expect(TestBed.inject(Location).getState()).toEqual(
+      jasmine.objectContaining({navigationId: jasmine.any(Number)}),
+    );
+  });
+
+  it('skips the initial same-path replaceState when flag is on', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [{path: '**', component: Empty}],
+          withRouterConfig({preserveInitialUrl: true}),
+        ),
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl('/');
+
+    // No state on the initial entry — Router's `setBrowserUrl` skipped the
+    // `replaceState` so any browser-applied URL augmentation (e.g. a
+    // `:~:text=` text fragment) is preserved in the address bar.
+    expect(TestBed.inject(Location).getState()).toBeNull();
+  });
+
+  it('still writes state on subsequent navigations when flag is on', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {path: '', component: Empty},
+            {path: 'next', component: Empty},
+          ],
+          withRouterConfig({preserveInitialUrl: true}),
+        ),
+      ],
+    });
+    const router = TestBed.inject(Router);
+    const location = TestBed.inject(Location);
+
+    await router.navigateByUrl('/');
+    expect(location.getState()).toBeNull();
+
+    await router.navigateByUrl('/next');
+    expect(location.getState()).toEqual(
+      jasmine.objectContaining({navigationId: jasmine.any(Number)}),
+    );
+  });
+
+  it('writes state when caller passes extras.state, even with flag on', async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [{path: '**', component: Empty}],
+          withRouterConfig({preserveInitialUrl: true}),
+        ),
+      ],
+    });
+    await TestBed.inject(Router).navigateByUrl('/', {state: {custom: 'value'}});
+
+    expect(TestBed.inject(Location).getState()).toEqual(
+      jasmine.objectContaining({custom: 'value'}),
+    );
+  });
+
+  it("works with 'computed' canceledNavigationResolution when flag is on", async () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(
+          [
+            {path: '', component: Empty},
+            {path: 'next', component: Empty},
+          ],
+          withRouterConfig({
+            preserveInitialUrl: true,
+            canceledNavigationResolution: 'computed',
+          }),
+        ),
+      ],
+    });
+    const router = TestBed.inject(Router);
+    const location = TestBed.inject(Location);
+
+    await router.navigateByUrl('/');
+    expect(location.getState()).toBeNull();
+
+    // Subsequent navigations advance page IDs starting from 0 (the fallback
+    // value when the initial entry has no `ɵrouterPageId`).
+    await router.navigateByUrl('/next');
+    expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 1}));
+  });
+});


### PR DESCRIPTION
feat(router): add preserveInitialUrl config to keep text fragments on initial load

Adds opt-in `preserveInitialUrl` to `RouterConfigOptions`. When enabled, Router skips its initial same-path `replaceState` so browser-applied URL augmentations (notably `:~:text=` text fragments, which browsers strip from `document.URL` per the scroll-to-text-fragment spec) survive on first load. Defaults to `false`, so existing apps are unaffected.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #65119

When an Angular app is loaded with a URL containing a text fragment directive, e.g. from Chrome's "Copy link to highlight" feature, the directive is briefly applied by the browser (yellow highlight + auto-scroll to the matching text), then disappears as soon as the Router boots.

The cause is in `HistoryStateManager.setBrowserUrl`: on the initial navigation it calls `Location.replaceState(path, '', state)` to claim the URL into Router's own state object (`navigationId`, `ɵrouterPageId`). Per the HTML spec, `history.replaceState`  , with or without an explicit URL argument, commits `document.URL` to the active history entry. Browsers strip `:~:text=` directives from `document.URL` (per the scroll-to-text-fragment spec), so this otherwise-redundant claim wipes the directive from the address bar and breaks the browser's native scroll-to-text on first load.

This affects every Angular app, including angular.dev itself.

## What is the new behavior?

Adds an opt-in `preserveInitialUrl` boolean to `RouterConfigOptions`. When enabled via:

```ts
provideRouter(routes, withRouterConfig({preserveInitialUrl: true}))
```

the Router skips its first same-path `replaceState` when the caller did not pass `extras.state`. Whatever the browser delivered in the address bar — text-fragment directive included — stays as-is.

Defaults to `false`, so existing apps see no change.

**Trade-off when enabled:** the initial history entry has `null` Router state instead of `{ɵrouterPageId, navigationId}`. `browserPageId` already falls back to `currentPageId` for null state, so navigation tracking continues to work; but code that introspects `Location.getState()` directly on the initial entry will see `null` until the user navigates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified end-to-end in a clean default-mode Angular CLI app (text fragment URL preserved + native scroll fires when flag is on; default behavior unchanged when flag is off). Existing Router test suite plus 5 new specs covering the flag all pass.

