### PR TITLE
refactor(forms): improve clarity in SelectMultipleControlValueAccessor.writeValue

### DIFF
--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -126,15 +126,15 @@ export class SelectMultipleControlValueAccessor
    */
   writeValue(value: any): void {
     this.value = value;
-    let optionSelectedStateSetter: (opt: ɵNgSelectMultipleOption, o: any) => void;
+    let optionSelectedStateSetter: (opt: ɵNgSelectMultipleOption, id: string) => void;
     if (Array.isArray(value)) {
       // convert values to ids
       const ids = value.map((v) => this._getOptionId(v));
-      optionSelectedStateSetter = (opt, o) => {
-        opt._setSelected(ids.indexOf(o.toString()) > -1);
+      optionSelectedStateSetter = (opt, id) => {
+        opt._setSelected(ids.indexOf(id) > -1);
       };
     } else {
-      optionSelectedStateSetter = (opt, o) => {
+      optionSelectedStateSetter = (opt) => {
         opt._setSelected(false);
       };
     }


### PR DESCRIPTION
Within `SelectMultipleControlValueAccessor` the `writeValue` method has a few small issues:

Consider the following callback:

```typescript
let optionSelectedStateSetter: (opt: ɵNgSelectMultipleOption, o: any) => void;
``` 

It is invoked via:
```typescript
this._optionMap.forEach(optionSelectedStateSetter);
```

However, we already know the type of the options map to be:
```typescript
// key is the id of the option
_optionMap: Map<string, ɵNgSelectMultipleOption> = new Map<string, ɵNgSelectMultipleOption>();
```

Therefore, the callback can be refactored to the following by changing `o` to `id` and its type from `any` to `string`
```typescript
let optionSelectedStateSetter: (opt: ɵNgSelectMultipleOption, id: string) => void;
```

Then the redundant `toString()` call can be removed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

SelectMultipleControlValueAccessor.writeValue() behaves as intended but the code is a little unclear and has a small redundancy. 

Issue Number: N/A

## What is the new behavior?

No visible changes to user

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
