### PR TITLE
fix(forms): ensure reset cancels pending debounce and syncs controlValue

### DIFF
--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -317,10 +317,18 @@ export class FieldNode implements FieldState<unknown> {
       this.value.set(value);
     }
 
+    // controlValue is a linkedSignal that only auto-resets when value *changes*.
+    // When the reset value equals the current value (or no value was passed),
+    // controlValue retains the typed text. Force it to match value.
+    // markAsDirty() is a side-effect of controlValue.set() but is immediately
+    // undone by markAsPristine() below, and the spawned debounce is a no-op
+    // since controlValue and value are already equal.
+    this.controlValue.set(this.value());
+
     this.nodeState.markAsUntouched();
     this.nodeState.markAsPristine();
 
-    for (const child of this.structure.children()) {
+    for (const child of this.structure.materializedChildren()) {
       child._reset();
     }
   }

--- a/packages/forms/signals/src/field/structure.ts
+++ b/packages/forms/signals/src/field/structure.ts
@@ -113,6 +113,20 @@ export abstract class FieldNodeStructure {
   }
 
   /**
+   * Gets only the child fields that have been materialized already.
+   *
+   * This is useful for iterating over children without triggering materialization of children
+   * that haven't been accessed yet.
+   */
+  materializedChildren(): readonly FieldNode[] {
+    const map = untracked(() => this.childrenMap());
+    if (map === undefined) {
+      return [];
+    }
+    return Array.from(map.byPropertyKey.values()).map((child) => untracked(child.reader)!);
+  }
+
+  /**
    * Internal method (cast to any in tests) to check if the children map has been materialized.
    * Useful for validating that fields without logic are lazily instantiated.
    *

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -8,6 +8,7 @@
 
 import {Component, computed, effect, Injector, signal, WritableSignal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {FieldNode} from '../../src/field/node';
 import {
   apply,
   applyEach,
@@ -1497,6 +1498,71 @@ describe('FieldNode', () => {
       expect(f().dirty()).toBe(false);
       expect(f.a().dirty()).toBe(false);
       expect(f.a.b().dirty()).toBe(false);
+    });
+
+    it('should immediately update value on reset even if a debounce is pending', async () => {
+      let resolveDebounce: (value: void | PromiseLike<void>) => void;
+      const debouncePromise = new Promise<void>((resolve) => {
+        resolveDebounce = resolve;
+      });
+
+      const model = signal('initial');
+      const f = form(
+        model,
+        (p) => {
+          debounce(p, () => debouncePromise);
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      // 1. Simulate user input
+      f().controlValue.set('user input');
+
+      // Value should still be 'initial' because of debounce
+      expect(f().value()).toBe('initial');
+
+      // 2. Call reset with a new value
+      f().reset('reset value');
+
+      // Value should be 'reset value' immediately
+      expect(f().value()).toBe('reset value');
+      expect(f().controlValue()).toBe('reset value');
+
+      // 3. Resolve the debounce
+      resolveDebounce!();
+      await Promise.resolve(); // Wait for promise microtasks
+
+      // Value should STILL be 'reset value', not 'user input'
+      expect(f().value()).toBe('reset value');
+    });
+
+    it('should immediately update value on reset when "blur" debounce is pending (Escape key scenario)', () => {
+      const model = signal('initial');
+      const f = form(
+        model,
+        (p) => {
+          debounce(p, 'blur');
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      // Simulate typing: controlValue is updated, but model value is not (pending blur)
+      f().controlValue.set('user input');
+      expect(f().value()).toBe('initial');
+      expect(f().controlValue()).toBe('user input');
+
+      // Simulate Escape key: call reset
+      f().reset('initial');
+
+      // Value should be reset immediately and controlValue should match
+      expect(f().value()).toBe('initial');
+      expect(f().controlValue()).toBe('initial');
+
+      // Simulate blur later
+      f().markAsTouched();
+
+      // Value should still be 'initial'
+      expect(f().value()).toBe('initial');
     });
   });
 });

--- a/packages/forms/signals/test/web/form_field.spec.ts
+++ b/packages/forms/signals/test/web/form_field.spec.ts
@@ -15,7 +15,6 @@ import {
   ElementRef,
   EventEmitter,
   inject,
-  Injectable,
   Injector,
   input,
   Input,
@@ -26,7 +25,6 @@ import {
   Output,
   resource,
   signal,
-  Type,
   viewChild,
   viewChildren,
   ViewContainerRef,
@@ -5590,6 +5588,82 @@ describe('field directive', () => {
       resolve();
       await promise;
       expect(fixture.componentInstance.f().value()).toBe('typing');
+    });
+
+    it('should reset control when debounced update is reset', async () => {
+      const {promise, resolve} = promiseWithResolvers<void>();
+
+      @Component({
+        imports: [FormField],
+        template: `<input [formField]="f" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal('initial'), (p) => {
+          debounce(p, () => promise);
+        });
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input');
+      const cmp = fixture.componentInstance;
+
+      expect(input.value).toBe('initial');
+
+      act(() => {
+        input.value = 'typing';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(cmp.f().value()).toBe('initial');
+      expect(input.value).toBe('typing');
+
+      act(() => cmp.f().reset());
+
+      expect(input.value).toBe('initial');
+      expect(cmp.f().value()).toBe('initial');
+
+      resolve();
+      await promise;
+
+      expect(input.value).toBe('initial');
+      expect(cmp.f().value()).toBe('initial');
+    });
+
+    it('should reset child control when debounced update is reset at root', async () => {
+      const {promise, resolve} = promiseWithResolvers<void>();
+
+      @Component({
+        imports: [FormField],
+        template: `<input [formField]="f.child" />`,
+      })
+      class TestCmp {
+        readonly f = form(signal({child: 'initial'}), (p) => {
+          debounce(p, () => promise);
+        });
+      }
+
+      const fixture = act(() => TestBed.createComponent(TestCmp));
+      const input = fixture.nativeElement.querySelector('input');
+      const cmp = fixture.componentInstance;
+
+      expect(input.value).toBe('initial');
+
+      act(() => {
+        input.value = 'typing';
+        input.dispatchEvent(new Event('input'));
+      });
+      expect(input.value).toBe('typing');
+      expect(cmp.f().value()).toEqual({child: 'initial'});
+
+      act(() => cmp.f().reset());
+
+      expect(input.value).toBe('initial');
+      expect(cmp.f().value()).toEqual({child: 'initial'});
+
+      resolve();
+      await promise;
+
+      expect(input.value).toBe('initial');
+      expect(cmp.f().value()).toEqual({child: 'initial'});
     });
   });
 


### PR DESCRIPTION
Adding a test case to https://github.com/angular/angular/pull/68353.