### PR TITLE
fix(forms): prohibit concurrent submits in signal forms

### DIFF
--- a/adev/src/content/guide/forms/signals/form-submission.md
+++ b/adev/src/content/guide/forms/signals/form-submission.md
@@ -312,6 +312,10 @@ submission: {
 }
 ```
 
+## Concurrent submissions
+
+When a submission is in progress, subsequent calls to `submit()` for the same form or any of its parents return `false` immediately without running the action. This prevents duplicate submissions and side effects if a user triggers the submit action multiple times quickly.
+
 ## Next steps
 
 This guide covered submitting forms and handling form submission errors. Related guides explore other aspects of Signal Forms:

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -344,6 +344,9 @@ export function applyWhenValue(
  * into the field as a `ValidationError` on the sub-field indicated by the `fieldTree` property of the
  * submission error.
  *
+ * Concurrent submissions are prohibited. If a submit is already in progress for the given field or any
+ * of its parents, subsequent calls to `submit` will return `false` immediately without running the action.
+ *
  * @example
  * ```ts
  * async function registerNewUser(registrationForm: FieldTree<{username: string, password: string}>) {
@@ -388,6 +391,10 @@ export async function submit<TModel>(
   options?: FormSubmitOptions<unknown, TModel> | FormSubmitOptions<unknown, TModel>['action'],
 ): Promise<boolean> {
   const node = untracked(form) as FieldState<unknown> as FieldNode;
+
+  if (untracked(node.submitState.submitting)) {
+    return false;
+  }
 
   const field = options === undefined ? node.structure.root.fieldProxy : form;
   const detail = {root: node.structure.root.fieldProxy, submitted: form};

--- a/packages/forms/signals/test/node/submit.spec.ts
+++ b/packages/forms/signals/test/node/submit.spec.ts
@@ -295,6 +295,24 @@ describe('submit', () => {
     expect(await result).toBe(true);
   });
 
+  it('prohibits concurrent submits', async () => {
+    const f = form(signal(0), {injector});
+    const {promise, resolve} = promiseWithResolvers<undefined>();
+    const submitSpy = jasmine.createSpy('submit').and.callFake(() => promise);
+
+    const result1 = submit(f, {action: submitSpy});
+    expect(f().submitting()).toBe(true);
+
+    const result2 = submit(f, {action: submitSpy});
+    expect(await result2).toBe(false);
+
+    expect(submitSpy).toHaveBeenCalledTimes(1);
+
+    resolve(undefined);
+    expect(await result1).toBe(true);
+    expect(f().submitting()).toBe(false);
+  });
+
   it('marks descendants as submitting', async () => {
     const initialValue = {a: {b: 12}};
     const data = signal(initialValue);


### PR DESCRIPTION
Prohibit concurrent submits in signal forms to prevent duplicate actions and side effects when a submission is already in progress.

If `submit()` is called while a prior submit is in progress for the same field or any of its parents, it returns `false` immediately without running the action again.

This commit also updates the documentation in `form-submission.md` to reflect this behavior.

Fixes #68317