### PR TITLE
fix(docs-infra): keep mobile nav drawers usable on small screens

### DIFF
--- a/adev/shared-docs/components/navigation-list/navigation-list.component.scss
+++ b/adev/shared-docs/components/navigation-list/navigation-list.component.scss
@@ -6,7 +6,7 @@
   list-style: none;
   overflow-y: auto;
   overflow-x: hidden;
-  height: 100vh;
+  height: 100dvh;
   padding: 0;
   margin: 0;
   padding-block: 1.5rem;

--- a/adev/src/app/app.component.scss
+++ b/adev/src/app/app.component.scss
@@ -40,6 +40,13 @@
     }
   }
 
+  // Lock the page behind the mobile primary-nav drawer. `clip` preserves the primary nav's sticky context.
+  @include mq.for-phone-only {
+    &:has(.adev-nav-primary--open) {
+      overflow: clip;
+    }
+  }
+
   &:has(.adev-home) {
     .adev-nav {
       width: 0;

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.scss
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.scss
@@ -35,6 +35,7 @@
 
   @include mq.for-tablet-landscape-down {
     position: absolute;
+    height: 100dvh;
   }
 
   @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other

## What is the current behavior?

https://github.com/user-attachments/assets/3657b805-608a-430b-9b9e-d58de35bef6c

https://github.com/user-attachments/assets/2edb372a-7760-4220-9acf-6820cfa4122d


On small viewports (phone-only / tablet-landscape-down), two adev nav-drawer issues:

1. With the primary-nav drawer open, the page behind it is still scrollable. The user can pan the underlying page while interacting with the drawer, leaving the screen state confusing.

2. On long submenus (e.g. Reference → Extended Ecosystem) the user can't scroll down to the last item — the drawer's mask has no explicit height so its bottom edge ends above the viewport floor.

## What is the new behavior?

- `app.component.scss`: add `:host:has(.adev-nav-primary--open) { overflow: clip }` inside the `for-phone-only` block. Locks the page behind the drawer so it can't scroll. `clip` (not `hidden`) is used because `overflow: hidden` establishes a new scroll context, which would re-anchor the primary nav's `position: sticky` and break it when opening the drawer on a deeply scrolled page.

- `secondary-navigation.component.scss`: add `height: 100dvh` to `.adev-secondary-nav-mask` inside the `for-tablet-landscape-down` block. The mask fills the visible viewport so the user can scroll down to the last item.

- `navigation-list.component.scss`: change the nav-list `:host` from `height: 100vh` to `height: 100dvh` so the inner scroll container also tracks the dynamic viewport (matches the mask), avoiding URL-bar overlap on any browser with retracting chrome (iOS Safari, iOS Chrome, Android Brave, etc.).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
