### PR TITLE
fix(platform-server): prevent SSRF via protocol-relative URLs in HTTP interceptor

### DIFF
--- a/packages/platform-server/src/http.ts
+++ b/packages/platform-server/src/http.ts
@@ -51,14 +51,33 @@ function relativeUrlsTransformerInterceptorFn(
     return next(request);
   }
 
+  const requestUrl = request.url;
+
+  // Reject protocol-relative URLs (e.g., //evil.com) and backslash-prefixed
+  // URLs (e.g., \evil.com) to prevent SSRF attacks. These URLs can resolve to
+  // external domains when the URL constructor processes them, potentially
+  // allowing attackers to make the server make requests to arbitrary domains.
+  if (requestUrl.startsWith('//') || requestUrl.startsWith('\\')) {
+    return next(request);
+  }
+
   let urlPrefix = `${protocol}//${hostname}`;
   if (port) {
     urlPrefix += `:${port}`;
   }
 
   const baseHref = platformLocation.getBaseHrefFromDOM() || href;
-  const baseUrl = new URL(baseHref, urlPrefix);
-  const newUrl = new URL(request.url, baseUrl).toString();
+
+  // Use URL.canParse for absolute URLs to avoid using a base URL,
+  // similar to the fix in location.ts parseUrl function.
+  let newUrl: string;
+  if (URL.canParse(requestUrl)) {
+    newUrl = new URL(requestUrl).toString();
+  } else {
+    // For relative URLs, construct the base URL and resolve.
+    const baseUrl = new URL(baseHref, urlPrefix);
+    newUrl = new URL(requestUrl, baseUrl).toString();
+  }
 
   return next(request.clone({url: newUrl}));
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -1500,6 +1500,40 @@ class HiddenModule {}
             mock.expectOne('http://localhost/testing').flush('success!');
           });
         });
+
+        it('should not resolve protocol-relative URLs (SSRF protection)', async () => {
+          ref.injector.get(NgZone).run(() => {
+            // Protocol-relative URLs (//evil.com/path) should NOT be resolved
+            // to external domains - they should be passed through as-is
+            http.get('//external-attacker.com/malicious').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            // The request should be made to the original URL (not resolved)
+            mock.expectOne('//external-attacker.com/malicious').flush('success!');
+          });
+        });
+
+        it('should not resolve backslash-prefixed URLs (SSRF protection)', async () => {
+          ref.injector.get(NgZone).run(() => {
+            // Backslash-prefixed URLs (\evil.com/path) should be passed through
+            http.get('\\external-attacker.com/malicious').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            // The request should be made to the original URL (not resolved)
+            mock.expectOne('\\external-attacker.com/malicious').flush('success!');
+          });
+        });
+
+        it('should correctly resolve relative URLs to absolute', async () => {
+          ref.injector.get(NgZone).run(() => {
+            // Relative URLs should still be resolved to the base URL
+            http.get('/api/data').subscribe((body) => {
+              expect(body).toEqual('success!');
+            });
+            // Should be resolved to http://localhost:4000/api/data
+            mock.expectOne('http://localhost:4000/api/data').flush('success!');
+          });
+        });
       });
     });
   });


### PR DESCRIPTION

This fix addresses a Server-Side Request Forgery (SSRF) vulnerability in the
relativeUrlsTransformerInterceptorFn function where protocol-relative URLs
(e.g., //evil.com/path) and backslash-prefixed URLs (e.g., \evil.com/path)
could be resolved to external domains.

Changes:
- Add validation to reject protocol-relative URLs (//) and backslash URLs (\)
- Use URL.canParse() for absolute URLs to avoid using a base URL
  (consistent with the fix in location.ts parseUrl function)
- For relative URLs, continue to use base URL resolution as before

This prevents attackers from making SSR servers request arbitrary domains
including cloud metadata endpoints (e.g., 169.254.169.254).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
