### PR TITLE
fix(forms): Ensure the deep signals copies over prototype functions

### DIFF
--- a/packages/forms/signals/src/util/deep_signal.ts
+++ b/packages/forms/signals/src/util/deep_signal.ts
@@ -51,6 +51,21 @@ function valueForWrite(sourceValue: unknown, newPropValue: unknown, prop: Proper
     newValue[prop as number] = newPropValue;
     return newValue;
   } else {
-    return {...(sourceValue as object), [prop]: newPropValue};
+    if (typeof sourceValue === 'object' && sourceValue !== null) {
+      const proto = Object.getPrototypeOf(sourceValue);
+      // Fast path for standard plain objects (majority of form models)
+      if (proto === Object.prototype || proto === null) {
+        return {...sourceValue, [prop]: newPropValue};
+      }
+
+      const clone = Object.assign(
+        Object.create(Object.getPrototypeOf(sourceValue)),
+        sourceValue,
+      ) as Record<PropertyKey, unknown>;
+      clone[prop] = newPropValue;
+      return clone;
+    }
+
+    return {[prop]: newPropValue};
   }
 }

--- a/packages/forms/signals/test/node/field_proxy.spec.ts
+++ b/packages/forms/signals/test/node/field_proxy.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Injector, signal, ApplicationRef, effect, untracked} from '@angular/core';
+import {ApplicationRef, effect, Injector, signal, untracked} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {form} from '../../public_api';
 
@@ -15,6 +15,48 @@ describe('FieldTree proxy', () => {
     const f = form(signal(new Date()), {injector: TestBed.inject(Injector)});
     // @ts-expect-error
     expect(f.getDate).toBe(undefined as any);
+  });
+
+  it('should preserve prototype methods on model objects read from value()', () => {
+    class Pet {
+      constructor(public name: string) {}
+
+      getName(): string {
+        return this.name;
+      }
+    }
+
+    const model = signal({
+      pet: new Pet('pirojok'),
+    });
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    // Update via child control so the form rebuilds parent objects.
+    f.pet.name().controlValue.set('murzik');
+    f.pet.name().markAsTouched();
+
+    // This expectation is intended to catch prototype stripping.
+    expect(f().value().pet.getName()).toBe('murzik');
+  });
+
+  it('should preserve prototype methods after nested reset()', () => {
+    class Pet {
+      constructor(public name: string) {}
+
+      getName(): string {
+        return this.name;
+      }
+    }
+
+    const model = signal({
+      pet: new Pet('pirojok'),
+    });
+    const f = form(model, {injector: TestBed.inject(Injector)});
+
+    // Resetting a nested child value rebuilds parent objects.
+    f.pet.name().reset('murzik');
+
+    expect(f().value().pet.getName()).toBe('murzik');
   });
 
   it('should allow spreading field arrays', () => {


### PR DESCRIPTION
Priori to this change signal model object could lose their methods.
