### PR TITLE
feat(compiler-cli): detect isPlatformBrowser usage inside control flow (hydration warning)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -698,6 +698,12 @@ export enum ErrorCode {
   SUGGEST_SUBOPTIMAL_TYPE_INFERENCE = 10002,
 
   /**
+   * Warns when `isPlatformBrowser()` is used inside template control flow blocks
+   * (e.g. `@if`), which can cause hydration re-rendering and UI flicker.
+   */
+  HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW = 10003,
+
+  /**
    * In local compilation mode a const is required to be resolved statically but cannot be so since
    * it is imported from a file outside of the compilation unit. This usually happens with const
    * being used as Angular decorators parameters such as `@Component.template`,

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
@@ -34,4 +34,5 @@ export enum ExtendedTemplateDiagnosticName {
   UNPARENTHESIZED_NULLISH_COALESCING = 'unparenthesizedNullishCoalescing',
   UNINVOKED_FUNCTION_IN_TEXT_INTERPOLATION = 'uninvokedFunctionInTextInterpolation',
   DEFER_TRIGGER_MISCONFIGURATION = 'deferTriggerMisconfiguration',
+  HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW = 'hydrationPlatformBrowserInControlFlow',
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
@@ -16,6 +16,7 @@ ts_project(
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/defer_trigger_misconfiguration",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/invalid_banana_in_box",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_ngforof_let",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_structural_directive",

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools:defaults.bzl", "ts_project")
+
+ts_project(
+    name = "is_platform_browser_in_control_flow",
+    srcs = ["index.ts"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow/index.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ */
+
+import {
+  AST,
+  Call,
+  RecursiveAstVisitor,
+  TmplAstIfBlockBranch,
+  TmplAstNode,
+  TmplAstSwitchBlock,
+  TmplAstSwitchBlockCase,
+} from '@angular/compiler';
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../../../diagnostics';
+import {NgTemplateDiagnostic} from '../../../api';
+import {
+  TemplateCheckFactory,
+  TemplateCheckWithVisitor,
+  TemplateContext,
+  formatExtendedError,
+} from '../../api';
+
+/**
+ * Extract control flow expression from Angular template nodes
+ */
+function getControlFlowExpression(node: TmplAstNode): AST | null {
+  if (node instanceof TmplAstIfBlockBranch) {
+    return node.expression;
+  }
+  if (node instanceof TmplAstSwitchBlock) {
+    return node.expression;
+  }
+  if (node instanceof TmplAstSwitchBlockCase) {
+    return node.expression;
+  }
+  return null;
+}
+
+/**
+ * Visitor to detect isPlatformBrowser() calls
+ */
+class PlatformBrowserVisitor extends RecursiveAstVisitor {
+  found = false;
+
+  override visitCall(ast: Call) {
+    const receiver = ast.receiver as any;
+
+    if (receiver && receiver.name === 'isPlatformBrowser') {
+      this.found = true;
+    }
+
+    super.visitCall(ast, null);
+  }
+}
+
+/**
+ * Detects usage of `isPlatformBrowser()` inside control flow expressions
+ */
+class IsPlatformBrowserInControlFlowCheck extends TemplateCheckWithVisitor<ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW> {
+  override code = ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW as const;
+
+  override visitNode(
+    ctx: TemplateContext<ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW>,
+    component: ts.ClassDeclaration,
+    node: TmplAstNode | AST,
+  ): NgTemplateDiagnostic<ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW>[] {
+    // Only handle control flow template nodes
+    if (
+      node instanceof TmplAstIfBlockBranch ||
+      node instanceof TmplAstSwitchBlock ||
+      node instanceof TmplAstSwitchBlockCase
+    ) {
+      const expr = getControlFlowExpression(node);
+
+      if (expr !== null) {
+        const visitor = new PlatformBrowserVisitor();
+        expr.visit(visitor);
+
+        if (visitor.found) {
+          const errorString = formatExtendedError(
+            ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+            `Using isPlatformBrowser() inside control flow (e.g. @if, @switch) may cause hydration re-rendering and UI flicker.`,
+          );
+
+          return [ctx.makeTemplateDiagnostic(expr.sourceSpan as any, errorString)];
+        }
+      }
+    }
+
+    return [];
+  }
+}
+
+export const factory: TemplateCheckFactory<
+  ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+  ExtendedTemplateDiagnosticName.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW
+> = {
+  code: ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+  name: ExtendedTemplateDiagnosticName.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+  create: () => new IsPlatformBrowserInControlFlowCheck(),
+};

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
@@ -25,6 +25,7 @@ import {factory as unusedLetDeclarationFactory} from './checks/unused_let_declar
 import {factory as uninvokedTrackFunctionFactory} from './checks/uninvoked_track_function';
 import {factory as uninvokedFunctionInTextInterpolationFactory} from './checks/uninvoked_function_in_text_interpolation';
 import {factory as deferTriggerMisconfigurationFactory} from './checks/defer_trigger_misconfiguration';
+import {factory as isPlatformBrowserInControlFlowFactory} from './checks/is_platform_browser_in_control_flow';
 
 export {ExtendedTemplateCheckerImpl} from './src/extended_template_checker';
 
@@ -48,6 +49,7 @@ export const ALL_DIAGNOSTIC_FACTORIES: readonly TemplateCheckFactory<
   uninvokedTrackFunctionFactory,
   uninvokedFunctionInTextInterpolationFactory,
   deferTriggerMisconfigurationFactory,
+  isPlatformBrowserInControlFlowFactory,
 ];
 
 export const SUPPORTED_DIAGNOSTIC_NAMES = new Set<string>([

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/is_platform_browser_in_control_flow/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/is_platform_browser_in_control_flow/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["is_platform_browser_in_control_flow_spec.ts"],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/is_platform_browser_in_control_flow",
+        "//packages/compiler-cli/src/ngtsc/typecheck/testing",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [
+        ":test_lib",
+        "//packages/core:npm_package",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/is_platform_browser_in_control_flow/is_platform_browser_in_control_flow_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/is_platform_browser_in_control_flow/is_platform_browser_in_control_flow_spec.ts
@@ -1,0 +1,92 @@
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
+import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
+import {runInEachFileSystem} from '../../../../../file_system/testing';
+import {getSourceCodeForDiagnostic} from '../../../../../testing';
+import {getClass, setup} from '../../../../testing';
+
+import {factory as isPlatformBrowserInControlFlowFactory} from '../../../checks/is_platform_browser_in_control_flow';
+import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checker';
+
+runInEachFileSystem(() => {
+  describe('IsPlatformBrowserInControlFlowCheck', () => {
+    function diagnose(template: string) {
+      const fileName = absoluteFrom('/main.ts');
+
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {
+            'TestCmp': template,
+          },
+          source: `
+            import {inject, PLATFORM_ID} from '@angular/core';
+            import {isPlatformBrowser, isPlatformServer} from '@angular/common';
+
+            export class TestCmp {
+              platformId = inject(PLATFORM_ID);
+              isPlatformBrowser = isPlatformBrowser;
+              isPlatformServer = isPlatformServer;
+              enabled = true;
+            }
+          `,
+        },
+      ]);
+
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [isPlatformBrowserInControlFlowFactory],
+        {},
+      );
+
+      return extendedTemplateChecker.getDiagnosticsForComponent(component);
+    }
+
+    it('binds the error code to its extended template diagnostic name', () => {
+      expect(isPlatformBrowserInControlFlowFactory.code).toBe(
+        ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+      );
+      expect(isPlatformBrowserInControlFlowFactory.name).toBe(
+        ExtendedTemplateDiagnosticName.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW,
+      );
+    });
+
+    it('should warn when isPlatformBrowser is used inside @if', () => {
+      const diags = diagnose(`
+        @if (isPlatformBrowser(platformId)) {
+          <div>Browser</div>
+        }
+      `);
+
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.HYDRATION_PLATFORM_BROWSER_IN_CONTROL_FLOW));
+      expect(diags[0].messageText).toContain('isPlatformBrowser');
+    });
+
+    it('should warn when used inside @switch', () => {
+      const diags = diagnose(`
+        @switch (isPlatformBrowser(platformId)) {
+          @case (true) { <div>Browser</div> }
+        }
+      `);
+
+      expect(diags.length).toBe(1);
+    });
+
+    it('should NOT warn when isPlatformBrowser is not used', () => {
+      const diags = diagnose(`
+        @if (true) {
+          <div>No issue</div>
+        }
+      `);
+
+      expect(diags.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Overview

Adds an extended template diagnostic to detect usage of `isPlatformBrowser()` inside template control flow blocks (e.g. `@if`).

While this pattern is supported and does not break hydration, it can negatively impact user experience by causing a brief display of server-rendered content followed by a re-render, resulting in UI flicker.

Fixes #59223

---

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not required for this change)

---

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other...

---

## What is the current behavior?

Currently, using `isPlatformBrowser()` inside control flow blocks such as `@if` is allowed and does not break hydration, but it may cause UI flicker due to re-rendering on the client.

Issue Number: #59223

---

## What is the new behavior?

A new extended template diagnostic is introduced:

- Detects usage of `isPlatformBrowser()` inside control flow blocks
- Emits a warning to inform developers about potential hydration performance issues

Example:

```html
@if (isPlatformBrowser()) {
  <div>Browser-only content</div>
}
```

---

## Does this PR introduce a breaking change?
- [ ] yes
- [x] no

---

## Other Information
- Implementation follows existing extended template diagnostic patterns
- Integrated into `ALL_DIAGNOSTIC_FACTORIES`
- Includes unit tests covering both detection and non-detection scenarios