### PR TITLE
fix(docs-infra): mask page content leak at mobile nav right edge

### DIFF
--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -140,7 +140,7 @@
     position: absolute;
     top: 0;
     background-color: var(--page-background);
-    box-shadow: 10px 4px 3px 0 rgba(0, 0, 0, 0.001);
+    box-shadow: 2px 0 0 0 var(--page-background);
 
     transform: translateX(-100%);
     // primary nav: exit delayed


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

On phones, the page content behind the primary-nav drawer leaks 1–2px past its right edge. Only reproducible on physical devices.

<img width="597" height="1280" alt="photo_2026-05-02_21-02-09" src="https://github.com/user-attachments/assets/951023c6-bb19-411d-bf95-c0b5e4e60659" />


## What is the new behavior?

A 2px var(--page-background) box-shadow on the drawer's right edge paints over the leak.

<img width="597" height="1280" alt="photo_2026-05-03_00-23-59" src="https://github.com/user-attachments/assets/b54cb9bb-8f75-4549-a960-bd9decc53614" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

