### PR TITLE
docs: add response types for form async `onSuccess`

### DIFF
--- a/adev/src/content/guide/forms/signals/async-operations.md
+++ b/adev/src/content/guide/forms/signals/async-operations.md
@@ -53,7 +53,7 @@ export class Registration {
         const username = value();
         return username ? `/api/users/check?username=${username}` : undefined;
       },
-      onSuccess: (response) => {
+      onSuccess: (response: {available: boolean}) => {
         return response.available
           ? null
           : {
@@ -114,7 +114,7 @@ export class Registration {
 
         return `/api/users/check?username=${username}`;
       },
-      onSuccess: (response, {value}) => {
+      onSuccess: (response: {available: boolean}, {value}) => {
         if (response.available) {
           // Cache successful validations
           this.validatedUsernames.add(value());
@@ -149,7 +149,7 @@ request: ({value}) => ({
 The `onSuccess` function receives the HTTP response and returns validation errors or `undefined` for valid values:
 
 ```ts
-onSuccess: (response) => {
+onSuccess: (response: { valid: boolean; message?: string }) => {
   if (response.valid) return undefined;
 
   return {
@@ -162,7 +162,7 @@ onSuccess: (response) => {
 Return multiple errors when needed:
 
 ```ts
-onSuccess: (response) => {
+onSuccess: (response: { usernameTaken: boolean; profanity: boolean }) => {
   const errors = [];
   if (response.usernameTaken) {
     errors.push({
@@ -207,7 +207,7 @@ validateHttp(schemaPath.field, {
     }),
     timeout: 5000,
   },
-  onSuccess: (response) =>
+  onSuccess: (response: {valid: boolean}) =>
     response.valid
       ? null
       : {
@@ -281,7 +281,7 @@ export class Registration {
     validateAsync(schemaPath.username, {
       params: ({value}) => {
         const username = value();
-        return username.length >= 3 ? username : undefined;
+        return username.length >= 3 ? username : undefined!;
       },
       factory: this.createUsernameResource,
       onSuccess: (result) => {
@@ -390,7 +390,7 @@ export class Registration {
         // Skip the request for blank values
         return username ? `/api/users/check?username=${username}` : undefined;
       },
-      onSuccess: (response) =>
+      onSuccess: (response: {available: boolean}) =>
         response.available ? null : {kind: 'usernameTaken', message: 'Username is already taken'},
       onError: () => ({
         kind: 'serverError',
@@ -447,7 +447,7 @@ const shorterWhenLonger: Debouncer<string> = ({value}, abortSignal) => {
   });
 };
 
-form(this.registrationModel, (schemaPath) => {
+const registrationForm = form(registrationModel, (schemaPath) => {
   debounce(schemaPath.username, shorterWhenLonger);
 });
 ```
@@ -468,7 +468,7 @@ form(this.registrationModel, (schemaPath) => {
       // Skip the request for blank values
       return username ? `/api/users/check?username=${username}` : undefined;
     },
-    onSuccess: (response) =>
+    onSuccess: (response: {available: boolean}) =>
       response.available ? null : {kind: 'usernameTaken', message: 'Username is already taken'},
     onError: () => ({
       kind: 'serverError',
@@ -512,7 +512,7 @@ export class Registration {
       params: ({value}) => {
         const username = value();
         // Skip validation for short usernames
-        return username.length >= 3 ? username : undefined;
+        return username.length >= 3 ? username : undefined!;
       },
       debounce: 300,
       // Reference to the factory defined above
@@ -627,7 +627,7 @@ form(model, (schemaPath) => {
   // 2. This async validation rule only runs if synchronous validation passes
   validateHttp(schemaPath.username, {
     request: ({value}) => `/api/check?username=${value()}`,
-    onSuccess: (result) =>
+    onSuccess: (result: {valid: boolean}) =>
       result.valid
         ? null
         : {
@@ -665,7 +665,7 @@ form(model, (schemaPath) => {
   // Then check availability
   validateHttp(schemaPath.email, {
     request: ({value}) => `/api/emails/check?email=${value()}`,
-    onSuccess: (result) =>
+    onSuccess: (result: {available: boolean}) =>
       result.available
         ? null
         : {
@@ -695,7 +695,7 @@ validateHttp(schemaPath.username, {
 
     return `/api/users/check?username=${username}`;
   },
-  onSuccess: (result) =>
+  onSuccess: (result: {valid: boolean}) =>
     result.valid
       ? null
       : {
@@ -718,7 +718,7 @@ import {validateHttp} from '@angular/forms/signals';
 
 validateHttp(schemaPath.field, {
   request: ({value}) => `/api/validate?field=${value()}`,
-  onSuccess: (result) => {
+  onSuccess: (result: {valid: boolean; message?: string}) => {
     if (result.valid) return null;
     // Use server message when available
     return {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- `onSuccess` results lack typing
- `undefined` uses as a fallback when only `string` works
- Class and non-class fields mixture

Issue Number: N/A

## What is the new behavior?

- `onSuccess` typed
- ~`''` fallback~ `undefined!` as per comment
- `const`/ no `this.` in an otherwise `const` field example

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

1. ~I think the empty string fallback which was added twice should be fine, but I wonder if that was the original intent.~ changed to `undefined!` as per relevant issue
1. Disclaimer: I did this all in the GitHub basic markdown editor on one screen and a little repro project of my own on another, as I cannot run adev locally at the moment.
