### PR TITLE
refactor(core): add actionable hydration mismatch hints

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -17,6 +17,7 @@ import {unwrapRNode} from '../render3/util/view_utils';
 import {readPatchedData} from '../render3/context_discovery';
 import {markRNodeAsHavingHydrationMismatch} from './utils';
 import {DOC_PAGE_BASE_URL} from '../../../core/src/error_details_base_url';
+import {getKnownMismatchPatternHint} from './known_mismatch_patterns';
 
 const AT_THIS_LOCATION = '<-- AT THIS LOCATION';
 
@@ -51,6 +52,21 @@ function getFriendlyStringFromTNodeType(tNodeType: TNodeType): string {
       // This should not happen as we cover all possible TNode types above.
       return '<unknown>';
   }
+}
+
+/**
+ * Walks up the TNode parent chain and returns the tag name of the
+ * nearest enclosing element, or `null` if none.
+ */
+function getExpectedParentTagName(tNode: TNode | null): string | null {
+  let parent = tNode?.parent ?? null;
+  while (parent !== null) {
+    if (parent.type === TNodeType.Element && typeof parent.value === 'string') {
+      return parent.value.toLowerCase();
+    }
+    parent = parent.parent;
+  }
+  return null;
 }
 
 /**
@@ -103,8 +119,17 @@ export function validateMatchingNode(
       markRNodeAsHavingHydrationMismatch(componentHostElement, expectedDom, actualDom);
     }
 
+    const knownPatternHint = getKnownMismatchPatternHint(
+      nodeType,
+      tagName ? tagName.toLowerCase() : null,
+      node,
+      tNode.type ? getParentRElement(lView[TVIEW], tNode, lView) : null,
+      getExpectedParentTagName(tNode),
+    );
+
     const footer = getHydrationErrorFooter(componentClassName);
-    let message = header + expected + actual + getHydrationAttributeNote() + footer;
+    let message =
+      header + expected + actual + knownPatternHint + getHydrationAttributeNote() + footer;
 
     // Check both when a mismatching node is found AND when the expected node is missing,
     // since third-party scripts can both inject extra nodes and remove existing ones.
@@ -149,10 +174,23 @@ export function validateNodeExists(
     const header =
       'During hydration, Angular expected an element to be present at this location.\n\n';
     let expected = '';
+    let knownPatternHint = '';
     let footer = '';
     if (lView !== null && tNode !== null) {
       expected = describeExpectedDom(lView, tNode, false);
       footer = getHydrationErrorFooter();
+
+      const expectedTagName =
+        tNode.type === TNodeType.Element && typeof tNode.value === 'string'
+          ? tNode.value.toLowerCase()
+          : null;
+      knownPatternHint = getKnownMismatchPatternHint(
+        Node.ELEMENT_NODE,
+        expectedTagName,
+        null,
+        null,
+        getExpectedParentTagName(tNode),
+      );
 
       // Since the node is missing, we use the closest node to attach the error to
       markRNodeAsHavingHydrationMismatch(unwrapRNode(lView[HOST]!), expected, '');
@@ -160,7 +198,7 @@ export function validateNodeExists(
 
     throw new RuntimeError(
       RuntimeErrorCode.HYDRATION_MISSING_NODE,
-      `${header}${expected}\n\n${footer}`,
+      `${header}${expected}\n\n${knownPatternHint}${footer}`,
     );
   }
 }

--- a/packages/core/src/hydration/known_mismatch_patterns.ts
+++ b/packages/core/src/hydration/known_mismatch_patterns.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {RNode} from '../render3/interfaces/renderer_dom';
+
+interface KnownMismatchContext {
+  /** The DOM `nodeType` expected at the mismatch location. */
+  expectedNodeType: number;
+  /** The lowercase tag name expected (or `null` for non-element nodes). */
+  expectedTagName: string | null;
+  /** The actual node found at the location, or `null` if no node was found. */
+  actualNode: RNode | null;
+  /** The parent RNode (already resolved by the caller), or `null` if none. */
+  parentRNode: RNode | null;
+  /**
+   * The tag name of the *expected* parent element (per the template), or `null`
+   * if the expected parent is not an element. This may differ from the actual DOM parent
+   * when the browser HTML parser has restructured the markup (for example by closing a
+   * `<p>` early when a block-level child was encountered).
+   */
+  expectedParentTagName: string | null;
+}
+
+interface KnownMismatchPattern {
+  /** Returns a tailored hint when the mismatch matches this pattern, otherwise `null`. */
+  detect(ctx: KnownMismatchContext): string | null;
+}
+
+/** Tag names that the HTML parser will move into an auto-inserted `<tbody>`. */
+const TABLE_BODY_CHILD_TAGS = new Set(['tr']);
+
+/**
+ * Detects the case where a template renders a `<table>` whose direct child is
+ * `<tr>` (or other implicit-tbody children) without an explicit `<tbody>`.
+ *
+ * The HTML parser inserts a `<tbody>` element in this case, which means the
+ * browser's actual DOM has an extra wrapping element compared to what Angular's
+ * template expected. As a result Angular either finds a `<tbody>` element where
+ * it expected a `<tr>`, or fails to find the node entirely.
+ *
+ * See https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intable.
+ */
+const tableMissingTbody: KnownMismatchPattern = {
+  detect({expectedTagName, actualNode, parentRNode}: KnownMismatchContext): string | null {
+    if (!expectedTagName || !TABLE_BODY_CHILD_TAGS.has(expectedTagName)) {
+      return null;
+    }
+    const parent = parentRNode as Element | null;
+    if (!parent || parent.nodeType !== Node.ELEMENT_NODE) {
+      return null;
+    }
+    if (parent.tagName.toLowerCase() !== 'table') {
+      return null;
+    }
+    // Either the node is missing, or the browser inserted a <tbody> at this position.
+    const actualIsTbody =
+      actualNode != null &&
+      (actualNode as Node).nodeType === Node.ELEMENT_NODE &&
+      (actualNode as Element).tagName.toLowerCase() === 'tbody';
+    if (actualNode != null && !actualIsTbody) {
+      return null;
+    }
+    return (
+      `Note: this looks like a known browser HTML normalization issue. ` +
+      `When a <table> contains a <${expectedTagName}> as a direct child without an ` +
+      `explicit <tbody>, the browser inserts a <tbody> element automatically. This ` +
+      `produces a DOM that does not match the structure declared in the template, ` +
+      `which breaks hydration.\n` +
+      `To fix this, wrap the table rows in an explicit <tbody> element in the ` +
+      `component's template.\n\n`
+    );
+  },
+};
+
+/**
+ * Detects the case where a template renders a `<table>` whose direct child is
+ * `<col>` without an explicit `<colgroup>`.
+ *
+ * The HTML parser inserts a `<colgroup>` element in this case, which means the
+ * browser's actual DOM has an extra wrapping element compared to what Angular's
+ * template expected. As a result Angular either finds a `<colgroup>` element
+ * where it expected a `<col>`, or fails to find the node entirely.
+ *
+ * See https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-intable.
+ */
+const tableMissingColgroup: KnownMismatchPattern = {
+  detect({
+    expectedTagName,
+    actualNode,
+    expectedParentTagName,
+  }: KnownMismatchContext): string | null {
+    if (expectedTagName !== 'col' || expectedParentTagName !== 'table') {
+      return null;
+    }
+    // Either the node is missing, or the browser inserted a <colgroup> at this position.
+    const actualIsColgroup =
+      actualNode != null &&
+      (actualNode as Node).nodeType === Node.ELEMENT_NODE &&
+      (actualNode as Element).tagName.toLowerCase() === 'colgroup';
+    if (actualNode != null && !actualIsColgroup) {
+      return null;
+    }
+    return (
+      `Note: this looks like a known browser HTML normalization issue. ` +
+      `When a <table> contains a <col> as a direct child without an explicit ` +
+      `<colgroup>, the browser inserts a <colgroup> element automatically. ` +
+      `This changes the DOM shape declared in the template, which breaks ` +
+      `hydration.\n` +
+      `To fix this, wrap the <col> elements in an explicit <colgroup> element ` +
+      `in the component's template.\n\n`
+    );
+  },
+};
+
+/**
+ * Block-level (and other auto-closing) elements that, when encountered as a
+ * descendant of `<p>`, cause the HTML parser to implicitly close the `<p>`
+ * before opening the descendant, splitting the paragraph into siblings.
+ *
+ * Mirrors the entries in
+ * https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
+ * (the "tag omission" rules) plus a few common block elements.
+ */
+const P_AUTO_CLOSING_CHILDREN = new Set([
+  'address',
+  'article',
+  'aside',
+  'blockquote',
+  'div',
+  'dl',
+  'fieldset',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'main',
+  'nav',
+  'ol',
+  'p',
+  'pre',
+  'section',
+  'table',
+  'ul',
+]);
+
+/**
+ * Detects nested `<a>` elements. Browsers do not allow an `<a>` element to
+ * contain another `<a>` (interactive content cannot contain interactive
+ * content). The HTML parser closes the outer `<a>` as soon as the inner one
+ * is opened, splitting them into siblings.
+ *
+ * Common reproductions: a `routerLink` inside another `routerLink`, a card
+ * component wrapped in a link with another link inside its body, etc.
+ *
+ * See https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element and
+ * See https://github.com/angular/angular/issues/57914
+ */
+const nestedAnchor: KnownMismatchPattern = {
+  detect({expectedTagName, expectedParentTagName}: KnownMismatchContext): string | null {
+    if (expectedTagName !== 'a' || expectedParentTagName !== 'a') {
+      return null;
+    }
+    return (
+      `Note: this looks like a known browser HTML normalization issue. ` +
+      `An <a> element cannot be nested inside another <a> element. The browser ` +
+      `automatically closes the outer <a> when it encounters the inner one, which ` +
+      `splits them into siblings and produces a DOM that does not match the ` +
+      `structure declared in the template.\n` +
+      `To fix this, restructure your template so that the <a> elements are ` +
+      `siblings (not nested), or replace the inner element with a non-link ` +
+      `container such as <button> or <span>.\n\n`
+    );
+  },
+};
+
+/**
+ * Detects nested `<button>` elements. Browsers do not allow a `<button>`
+ * element to contain another `<button>`. The HTML parser closes the outer
+ * `<button>` before inserting the inner one, splitting them into siblings.
+ *
+ * See https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element.
+ */
+const nestedButton: KnownMismatchPattern = {
+  detect({expectedTagName, expectedParentTagName}: KnownMismatchContext): string | null {
+    if (expectedTagName !== 'button' || expectedParentTagName !== 'button') {
+      return null;
+    }
+    return (
+      `Note: this looks like a known browser HTML normalization issue. ` +
+      `A <button> element cannot be nested inside another <button> element. ` +
+      `The browser implicitly closes the outer <button> before inserting the ` +
+      `inner <button>, which turns the expected parent-child structure into ` +
+      `siblings and produces a DOM that does not match the structure declared ` +
+      `in the template.\n` +
+      `To fix this, restructure your template so that the <button> elements are ` +
+      `siblings, or replace the outer clickable container with a non-button ` +
+      `element plus proper accessibility handling.\n\n`
+    );
+  },
+};
+
+/**
+ * Detects mismatches under a `<p>` element. The `<p>` element has an
+ * "end tag omission" rule: when the parser encounters certain block-level
+ * children (e.g. `<div>`, `<table>`, another `<p>`, headings, lists, etc.) it
+ * implicitly closes the `<p>` first. The descendant becomes a sibling of the
+ * `<p>` instead of a child, producing a DOM that does not match the template.
+ *
+ * The Angular template compiler already rejects literal block-in-`<p>` markup,
+ * so runtime mismatches under `<p>` typically come from cross-component
+ * composition (a child component renders a `<div>` / `<table>` / `<p>` / ...
+ * as its root) or from `@defer` blocks rendered inside `<p>`. In both cases
+ * Angular's mismatch fires on the *child component's host element* whose tag
+ * name is unrelated to the auto-closing list, but the underlying cause is
+ * the same. We therefore emit the hint whenever the expected parent (per
+ * template) is `<p>` and either the expected child tag is in the auto-closing
+ * set or the expected node is missing entirely from the (now-empty) `<p>`.
+ *
+ * See https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
+ * and https://github.com/angular/angular/issues/56990.
+ */
+const pBlockChild: KnownMismatchPattern = {
+  detect({
+    expectedTagName,
+    expectedParentTagName,
+    actualNode,
+  }: KnownMismatchContext): string | null {
+    if (expectedParentTagName !== 'p') {
+      return null;
+    }
+    const isKnownBlockChild = !!expectedTagName && P_AUTO_CLOSING_CHILDREN.has(expectedTagName);
+    // A missing-node case under <p> is almost always the early-close pattern
+    // because the compiler rejects literal block-in-<p> templates; mismatches
+    // here come from cross-component composition or @defer blocks.
+    const isMissingChildOfP = actualNode === null;
+    if (!isKnownBlockChild && !isMissingChildOfP) {
+      return null;
+    }
+    const childDescription = isKnownBlockChild
+      ? `The <${expectedTagName}> element`
+      : `A block-level descendant`;
+    return (
+      `Note: this looks like a known browser HTML normalization issue. ` +
+      `${childDescription} is not allowed inside a <p> element. ` +
+      `The browser automatically closes the <p> when it encounters a block-level ` +
+      `descendant, which splits the paragraph and the descendant into siblings ` +
+      `and produces a DOM that does not match the structure declared in the ` +
+      `template.\n` +
+      `To fix this, replace the surrounding <p> with a non-paragraph container ` +
+      `such as <div>, or move the descendant outside of the <p>. This commonly ` +
+      `happens with child components whose root element is a block (e.g. <div>, ` +
+      `<table>, another <p>) and with control flow blocks such as @defer ` +
+      `rendered inside <p>.\n\n`
+    );
+  },
+};
+
+const KNOWN_MISMATCH_PATTERNS: KnownMismatchPattern[] = [
+  tableMissingTbody,
+  tableMissingColgroup,
+  nestedAnchor,
+  nestedButton,
+  pBlockChild,
+];
+
+/**
+ * Returns a tailored hint string for known browser HTML-normalization mismatches,
+ * or an empty string when no known pattern applies.
+ */
+export function getKnownMismatchPatternHint(
+  expectedNodeType: number,
+  expectedTagName: string | null,
+  actualNode: RNode | null,
+  parentRNode: RNode | null,
+  expectedParentTagName: string | null,
+): string {
+  const ctx: KnownMismatchContext = {
+    expectedNodeType,
+    expectedTagName,
+    actualNode,
+    parentRNode,
+    expectedParentTagName,
+  };
+
+  for (const pattern of KNOWN_MISMATCH_PATTERNS) {
+    const hint = pattern.detect(ctx);
+    if (hint !== null) {
+      return hint;
+    }
+  }
+
+  return '';
+}

--- a/packages/core/test/hydration/known_mismatch_patterns_spec.ts
+++ b/packages/core/test/hydration/known_mismatch_patterns_spec.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {getKnownMismatchPatternHint} from '../../src/hydration/known_mismatch_patterns';
+
+describe('getKnownMismatchPatternHint', () => {
+  const ELEMENT_NODE = 1;
+
+  function el(tagName: string): any {
+    return {nodeType: ELEMENT_NODE, tagName: tagName.toUpperCase()};
+  }
+
+  describe('tableMissingTbody', () => {
+    const TABLE_BODY_CHILD_TAGS = ['tr'];
+
+    for (const childTag of TABLE_BODY_CHILD_TAGS) {
+      it(`emits hint when <${childTag}> is a direct child of <table> and the actual node is missing`, () => {
+        const hint = getKnownMismatchPatternHint(
+          ELEMENT_NODE,
+          childTag,
+          /* actualNode */ null,
+          /* parentRNode */ el('table'),
+          /* expectedParentTagName */ 'table',
+        );
+        expect(hint).toContain('known browser HTML normalization issue');
+        expect(hint).toContain(`<${childTag}>`);
+        expect(hint).toContain('<tbody>');
+      });
+
+      it(`emits hint when the browser inserted a <tbody> in place of the expected <${childTag}>`, () => {
+        const hint = getKnownMismatchPatternHint(
+          ELEMENT_NODE,
+          childTag,
+          /* actualNode */ el('tbody'),
+          /* parentRNode */ el('table'),
+          /* expectedParentTagName */ 'table',
+        );
+        expect(hint).toContain('<tbody>');
+      });
+    }
+
+    it('stays silent when the parent is not a <table>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'tr', null, el('div'), 'div');
+      expect(hint).toBe('');
+    });
+
+    it('stays silent when the actual node is a non-tbody element', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'tr', el('div'), el('table'), 'table');
+      expect(hint).toBe('');
+    });
+  });
+
+  describe('tableMissingColgroup', () => {
+    it('emits hint when <col> is a direct child of <table> and the actual node is missing', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'col',
+        /* actualNode */ null,
+        /* parentRNode */ el('table'),
+        /* expectedParentTagName */ 'table',
+      );
+      expect(hint).toContain('known browser HTML normalization issue');
+      expect(hint).toContain('<col>');
+      expect(hint).toContain('<colgroup>');
+      expect(hint).toContain('explicit <colgroup>');
+    });
+
+    it('emits hint when the browser inserted a <colgroup> in place of the expected <col>', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'col',
+        /* actualNode */ el('colgroup'),
+        /* parentRNode */ el('table'),
+        /* expectedParentTagName */ 'table',
+      );
+      expect(hint).toContain('<colgroup>');
+    });
+
+    it('stays silent when the expected parent is not a <table>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'col', null, el('div'), 'div');
+      expect(hint).toBe('');
+    });
+
+    it('stays silent when the actual node is a non-colgroup element', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'col',
+        /* actualNode */ el('div'),
+        /* parentRNode */ el('table'),
+        /* expectedParentTagName */ 'table',
+      );
+      expect(hint).toBe('');
+    });
+  });
+
+  describe('nestedAnchor', () => {
+    it('emits hint for <a> nested inside <a>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'a', null, el('a'), 'a');
+      expect(hint).toContain('<a> element cannot be nested inside another <a>');
+    });
+
+    it('stays silent for <a> with a non-<a> parent', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'a', null, el('div'), 'div');
+      expect(hint).toBe('');
+    });
+
+    it('stays silent for non-<a> child of <a>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'span', null, el('a'), 'a');
+      // Note: 'span' is not in P_AUTO_CLOSING_CHILDREN and parent isn't <p>,
+      // so pBlockChild also stays silen
+      expect(hint).toBe('');
+    });
+  });
+
+  describe('nestedButton', () => {
+    it('emits hint for <button> nested inside <button>', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'button',
+        null,
+        el('button'),
+        'button',
+      );
+      expect(hint).toContain('<button> element cannot be nested inside another <button> element');
+      expect(hint).toContain('implicitly closes the outer <button>');
+      expect(hint).toContain('parent-child structure into siblings');
+    });
+
+    it('stays silent for <button> with a non-<button> parent', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'button', null, el('div'), 'div');
+      expect(hint).toBe('');
+    });
+
+    it('stays silent for non-<button> child of <button>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'span', null, el('button'), 'button');
+      expect(hint).toBe('');
+    });
+  });
+
+  describe('pBlockChild', () => {
+    const P_AUTO_CLOSING_CHILDREN = [
+      'address',
+      'article',
+      'aside',
+      'blockquote',
+      'div',
+      'dl',
+      'fieldset',
+      'figure',
+      'footer',
+      'form',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'header',
+      'hr',
+      'main',
+      'nav',
+      'ol',
+      'p',
+      'pre',
+      'section',
+      'table',
+      'ul',
+    ];
+
+    for (const childTag of P_AUTO_CLOSING_CHILDREN) {
+      it(`emits hint for <${childTag}> as a direct child of <p>`, () => {
+        const hint = getKnownMismatchPatternHint(
+          ELEMENT_NODE,
+          childTag,
+          /* actualNode */ null,
+          /* parentRNode */ el('p'),
+          /* expectedParentTagName */ 'p',
+        );
+        expect(hint).toContain('known browser HTML normalization issue');
+        expect(hint).toContain(`The <${childTag}> element is not allowed inside a <p> element`);
+      });
+    }
+
+    it('emits the generic-block hint when the expected node under <p> is missing and tag is not in the known set', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'inner-p',
+        /* actualNode */ null,
+        /* parentRNode */ el('p'),
+        /* expectedParentTagName */ 'p',
+      );
+      expect(hint).toContain('A block-level descendant is not allowed inside a <p> element');
+    });
+
+    it('stays silent when the expected parent is not <p>', () => {
+      const hint = getKnownMismatchPatternHint(ELEMENT_NODE, 'div', null, el('div'), 'div');
+      expect(hint).toBe('');
+    });
+
+    it('stays silent when the actual node is present and the expected tag is not a known block child', () => {
+      const hint = getKnownMismatchPatternHint(
+        ELEMENT_NODE,
+        'span',
+        /* actualNode */ el('span'),
+        /* parentRNode */ el('p'),
+        /* expectedParentTagName */ 'p',
+      );
+      expect(hint).toBe('');
+    });
+  });
+});

--- a/packages/platform-server/test/full_app_hydration_spec.ts
+++ b/packages/platform-server/test/full_app_hydration_spec.ts
@@ -6653,6 +6653,128 @@ describe('platform-server full application hydration integration', () => {
         }
       });
 
+      it(
+        'should produce a known-pattern hint when a <table> is missing an explicit ' +
+          '<tbody> and the browser auto-inserted one',
+        async () => {
+          @Component({
+            selector: 'app',
+            template: `<table>
+              <tr>
+                <td>cell</td>
+              </tr>
+            </table>`,
+          })
+          class SimpleComponent {}
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          // Simulate the browser's HTML parser auto-inserting a <tbody> element
+          // around table rows that were declared as direct children of <table>.
+          const mutatedHtml = html.replace('<tr', '<tbody><tr').replace('</tr>', '</tr></tbody>');
+
+          resetTViewsFor(SimpleComponent);
+
+          await prepareEnvironmentAndHydrate(doc, mutatedHtml, SimpleComponent, {
+            envProviders: [withNoopErrorHandler()],
+          }).catch((err: Error) => {
+            const message = err.message;
+            expect(message).toContain('During hydration Angular expected <tr> but found <tbody>');
+            expect(message).toContain(
+              'When a <table> contains a <tr> as a direct child without an ' + 'explicit <tbody>',
+            );
+            expect(message).toContain(
+              "wrap the table rows in an explicit <tbody> element in the component's template",
+            );
+            verifyNodeHasMismatchInfo(doc);
+          });
+        },
+      );
+
+      it(
+        'should produce a known-pattern hint when an <a> is nested inside another <a> ' +
+          'and the browser auto-closed the outer one',
+        async () => {
+          @Component({
+            selector: 'app',
+            template: `<a href="/outer"><a href="/inner">link</a></a>`,
+          })
+          class SimpleComponent {}
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          // Simulate the browser's HTML parser auto-closing the outer <a> when
+          // it encounters the inner one (anchors cannot be nested).
+          const mutatedHtml = html.replace(
+            '<a href="/outer"><a href="/inner">link</a></a>',
+            '<a href="/outer"></a><a href="/inner">link</a>',
+          );
+
+          resetTViewsFor(SimpleComponent);
+
+          await prepareEnvironmentAndHydrate(doc, mutatedHtml, SimpleComponent, {
+            envProviders: [withNoopErrorHandler()],
+          }).catch((err: Error) => {
+            const message = err.message;
+            expect(message).toContain('An <a> element cannot be nested inside another <a> element');
+            expect(message).toContain(
+              'restructure your template so that the <a> elements are siblings',
+            );
+            verifyNodeHasMismatchInfo(doc);
+          });
+        },
+      );
+
+      it(
+        'should produce a known-pattern hint when a <div> is rendered inside a <p> ' +
+          'and the browser auto-closed the <p>',
+        async () => {
+          @Component({
+            selector: 'block-child',
+            template: `<div>block</div>`,
+          })
+          class BlockChildComponent {}
+
+          @Component({
+            selector: 'app',
+            imports: [BlockChildComponent],
+            template: `<p><block-child /></p>`,
+          })
+          class SimpleComponent {}
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          // Simulate the browser's HTML parser auto-closing the <p> when it
+          // encounters a block-level descendant rendered by the child component.
+          const mutatedHtml = html.replace(
+            /<p><block-child([\s\S]*?)<div>block<\/div><\/block-child><\/p>/,
+            '<p></p><block-child$1<div>block</div></block-child><p></p>',
+          );
+
+          resetTViewsFor(SimpleComponent, BlockChildComponent);
+
+          await prepareEnvironmentAndHydrate(doc, mutatedHtml, SimpleComponent, {
+            envProviders: [withNoopErrorHandler()],
+          }).catch((err: Error) => {
+            const message = err.message;
+            expect(message).toContain(
+              'A block-level descendant is not allowed inside a <p> element',
+            );
+            expect(message).toContain('replace the surrounding <p> with a non-paragraph');
+            verifyNodeHasMismatchInfo(doc);
+          });
+        },
+      );
+
       it('should log a warning when there was no hydration info in the TransferState', async () => {
         @Component({
           selector: 'app',


### PR DESCRIPTION
Adds targeted hints for known browser HTML normalization cases that alter the DOM before Angular hydration.

Closes #56392

## What is the current behavior?

Currently, the message may be somewhat generic and not indicate the real or complete cause of the problem.
 
## What is the new behavior?
 
### Missing explicit `<tbody>`

Spec :

> “A `tbody` element's start tag may be omitted if the first thing inside the
> `tbody` element is a `tr` element”

When a `<tr>` is written directly under `<table>`, the parser can
create the missing table body section before Angular hydrates.

See: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags

```html
<!-- User template -->
<table>
  <tr></tr>
</table>

<!-- DOM shape used for hydration -->
<table>
  <tbody>
    <tr></tr>
  </tbody>
</table>
```

### Missing explicit `<colgroup>`

Spec :

> “A `colgroup` element's start tag may be omitted if the first thing inside the
> `colgroup` element is a `col` element”

When a `<col>` is written directly under `<table>`, the parser can
create the missing column group before Angular hydrates.

See: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags

```html
<!-- User template -->
<table>
  <col>
</table>

<!-- DOM shape used for hydration -->
<table>
  <colgroup>
    <col>
  </colgroup>
</table>
```

 

### Nested anchors

Spec:

> “Transparent, but there must be no interactive content descendant, `a` element
> descendant, or descendant with the `tabindex` attribute specified.”

Parser:

> “the first `a` element would be closed upon seeing the second one”

Nested links are invalid and the parser can close/restructure the
outer anchor before Angular hydrates.

See: https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element
See: https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody

```html
<!-- User template -->
<a>
  Outside
  <a>Click me</a>
</a>

<!-- DOM shape used for hydration -->
<a>
  Outside
</a>
<a>Click me</a>
```

### Block content inside `<p>`

Spec :

> “A `p` element's end tag can be omitted if the `p` element is immediately
> followed by” elements like `div`, `table`, headings, lists, or another `p`.

The parser closes the paragraph before inserting the block, so
the block becomes a sibling instead of a child.

See: https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element

```html
<!-- User template -->
<p>
  <div>Hello world!</div>
</p>

<!-- DOM shape used for hydration -->
<p></p>
<div>Hello world!</div>
<p></p>
```

### Nested buttons

Spec :

> “Phrasing content, but there must be no interactive content descendant and no
> descendant with the `tabindex` attribute specified.”

Parser:

> “If the stack of open elements has a button element in scope” then the parser
> generates implied end tags and pops elements “until a `button` element has been
> popped”.

When the parser sees the inner `<button>`, it closes the current
button first, so the buttons become siblings instead of nested nodes.

See: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element
See: https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody

```html
<!-- User template -->
<button>
  outside button
  <button>inner button</button>
</button>

<!-- DOM shape used for hydration -->
<button>
  outside button
</button>
<button>inner button</button>
```
