### PR TITLE
docs: correct "Angular JS" to "AngularJS"

### DIFF
--- a/adev/src/content/best-practices/update.md
+++ b/adev/src/content/best-practices/update.md
@@ -6,9 +6,9 @@ Keeping your Angular application up-to-date enables you to take advantage of lea
 
 This document contains information and resources to help you keep your Angular applications and libraries up-to-date.
 
-For information about our versioning policy and practices —including support and deprecation practices, as well as the release schedule— see [Angular versioning and releases](reference/releases 'Angular versioning and releases').
+For information about our versioning policy and practices — including support and deprecation practices, as well as the release schedule — see [Angular versioning and releases](reference/releases 'Angular versioning and releases').
 
-HELPFUL: If you are currently using AngularJS, see [Upgrading from AngularJS](https://angular.io/guide/upgrade 'Upgrading from Angular JS').
+HELPFUL: If you are currently using AngularJS, see [Upgrading from AngularJS](https://angular.io/guide/upgrade 'Upgrading from AngularJS').
 _AngularJS_ is the name for all v1.x versions of Angular.
 
 ## Getting notified of new releases
@@ -30,7 +30,7 @@ To check your application's version of Angular use the `ng version` command from
 The most recent stable released version of Angular appears [on npm](https://www.npmjs.com/package/@angular/core 'Angular on npm') under "Version." For example, `16.2.4`.
 
 You can also find the most current version of Angular by using the CLI command [`ng update`](cli/update).
-By default, [`ng update`](cli/update)(without additional arguments) lists the updates that are available to you.
+By default, [`ng update`](cli/update) (without additional arguments) lists the updates that are available to you.
 
 ## Updating your environment and apps
 

--- a/adev/src/content/reference/releases.md
+++ b/adev/src/content/reference/releases.md
@@ -19,7 +19,7 @@ To make these transitions as straightforward as possible, the Angular team makes
 - We follow the deprecation policy described here, so you have time to update your applications to the latest APIs and best practices
 
 HELPFUL: The practices described in this document apply to Angular 2.0 and later.
-If you are currently using AngularJS, see [Upgrading from AngularJS](https://angular.io/guide/upgrade 'Upgrading from Angular JS').
+If you are currently using AngularJS, see [Upgrading from AngularJS](https://angular.io/guide/upgrade 'Upgrading from AngularJS').
 _AngularJS_ is the name for all v1.x versions of Angular.
 
 ## Angular versioning

--- a/packages/router/upgrade/PACKAGE.md
+++ b/packages/router/upgrade/PACKAGE.md
@@ -1,1 +1,1 @@
-Provides support for upgrading routing applications from Angular JS to Angular.
+Provides support for upgrading routing applications from AngularJS to Angular.

--- a/packages/upgrade/PACKAGE.md
+++ b/packages/upgrade/PACKAGE.md
@@ -1,4 +1,4 @@
-Provides support for upgrading applications from Angular JS to Angular.
+Provides support for upgrading applications from AngularJS to Angular.
 The primary entry point is deprecated. Use the secondary entry point,
 `upgrade/static`.
 


### PR DESCRIPTION
"AngularJS" is the official product name for the v1.x line and is written as a single word. A few places in the docs and package READMEs used "Angular JS" with a space. This normalizes those references to the canonical spelling.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Several docs and package READMEs refer to the v1.x product as
"Angular JS" (two words).

## What is the new behavior?

All references use the canonical spelling "AngularJS" (one word).
Also includes two minor docs cleanups in update.md: spacing around
em dashes, and a missing space before "(without additional
arguments)".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


