### PR TITLE
feat(angular-developer): add performance references

### DIFF
--- a/skills/dev-skills/angular-developer/SKILL.md
+++ b/skills/dev-skills/angular-developer/SKILL.md
@@ -104,6 +104,16 @@ When implementing navigation in Angular, consult the following references:
 
 If you require deeper documentation or more context, visit the [official Angular Routing guide](https://angular.dev/guide/routing).
 
+## Performance
+
+When optimizing or reviewing Angular code for performance, consult the following references:
+
+- **Core Web Vitals**: LCP, INP, and CLS targets, how Angular rendering choices affect each metric, and how to measure them. Read [core-web-vitals.md](references/core-web-vitals.md)
+- **Images**: Using `NgOptimizedImage` for LCP optimization, responsive images, and CLS prevention. Read [performance-images.md](references/performance-images.md)
+- **Defer Blocks**: All `@defer` triggers, `@placeholder`/`@loading`/`@error` blocks, and when NOT to defer. Read [defer-blocks.md](references/defer-blocks.md)
+- **Change Detection**: `OnPush` strategy, zoneless Angular, and `NgZone.runOutsideAngular()`. Read [performance-change-detection.md](references/performance-change-detection.md)
+- **Anti-patterns**: Consolidated list of performance anti-patterns with fixes. Read [performance-anti-patterns.md](references/performance-anti-patterns.md)
+
 ## Styling and Animations
 
 When implementing styling and animations in Angular, consult the following references:

--- a/skills/dev-skills/angular-developer/references/core-web-vitals.md
+++ b/skills/dev-skills/angular-developer/references/core-web-vitals.md
@@ -44,19 +44,20 @@ INP measures the time from a user interaction (click, keypress, tap) to the next
 
 ### What affects INP in Angular
 
-**Change detection cost**: The default strategy checks the entire component tree on every event. In large apps this can block the main thread for tens or hundreds of milliseconds.
+**Change detection cost**: The default strategy checks the entire component tree on every event. In large apps this can block the main thread for tens or hundreds of milliseconds. From v22, `OnPush` is the default for new components.
 
-**Zone.js overhead**: zone.js intercepts every event and triggers Angular's change detection after it completes. Third-party libraries that fire many events (maps, charts) compound this.
+**Zone.js overhead**: In Angular v21+, apps are zoneless by default — zone.js is no longer included. In older or zone-based apps, zone.js intercepts every event and triggers change detection after it completes. Third-party libraries that fire many events (maps, charts) compound this.
 
 **Long event handlers**: Synchronous work in a click handler — API calls, complex calculations, DOM measurements — blocks the main thread and delays the next paint.
 
 ### INP improvements
 
 ```ts
-// 1. OnPush on every component
+// 1. OnPush on every component (default from v22; opt-in for v21 and earlier)
 @Component({ changeDetection: ChangeDetectionStrategy.OnPush })
 
-// 2. Move expensive work outside Angular's zone
+// 2. Zone-based apps only: move expensive work outside Angular's zone
+// Not needed in zoneless apps (default from v21)
 this.ngZone.runOutsideAngular(() => {
   chart.on('mousemove', handler);
 });
@@ -71,10 +72,10 @@ async handleClick() {
 
 ### INP checklist
 
-- [ ] `OnPush` on every component
-- [ ] Third-party event-heavy libraries use `runOutsideAngular()`
+- [ ] `OnPush` on every component (automatic from v22)
+- [ ] Zone-based apps: third-party event-heavy libraries use `runOutsideAngular()`
 - [ ] Long event handlers yield with `scheduler.yield()` or `setTimeout(0)`
-- [ ] Consider zoneless Angular for new projects (`provideExperimentalZonelessChangeDetection()`)
+- [ ] New projects use zoneless Angular (default from v21)
 
 ---
 

--- a/skills/dev-skills/angular-developer/references/core-web-vitals.md
+++ b/skills/dev-skills/angular-developer/references/core-web-vitals.md
@@ -44,7 +44,7 @@ INP measures the time from a user interaction (click, keypress, tap) to the next
 
 ### What affects INP in Angular
 
-**Change detection cost**: The default strategy checks the entire component tree on every event. In large apps this can block the main thread for tens or hundreds of milliseconds. From v22, `OnPush` is the default for new components.
+**Change detection cost**: In Angular v22+, `OnPush` is the default strategy — only components with changed inputs or updated signals are checked. In earlier versions, the default strategy checks the entire component tree on every event, which can block the main thread for tens or hundreds of milliseconds in large apps.
 
 **Zone.js overhead**: In Angular v21+, apps are zoneless by default — zone.js is no longer included. In older or zone-based apps, zone.js intercepts every event and triggers change detection after it completes. Third-party libraries that fire many events (maps, charts) compound this.
 

--- a/skills/dev-skills/angular-developer/references/core-web-vitals.md
+++ b/skills/dev-skills/angular-developer/references/core-web-vitals.md
@@ -170,6 +170,29 @@ npx source-map-explorer dist/my-app/browser/*.js
 
 Identifies large dependencies and verifies code-splitting boundaries for lazy routes.
 
-### Change detection profiling
+### Change detection profiling with Angular DevTools
 
-Angular DevTools → **Profiler** tab → record an interaction → inspect which components checked and how long each took.
+Install the **Angular DevTools** browser extension from the Chrome Web Store, then open Chrome DevTools → **Angular** tab.
+
+**Profiler** — records which components were checked and how long each check took:
+
+1. Open the **Profiler** tab
+2. Click **Record**
+3. Interact with the page (click a button, type in a field)
+4. Click **Stop**
+5. Inspect the flame chart: components in red take the most time; components that shouldn't be checking (missing `OnPush`) appear unexpectedly
+
+See: [Debug change detection and OnPush components](https://next.angular.dev/tools/devtools/profiler#debug-change-detection-and-onpush-components)
+
+### Rendering timestamps with Chrome DevTools
+
+Chrome DevTools **Performance** panel records per-component and per-directive rendering timestamps via Angular's built-in performance marks:
+
+1. Open Chrome DevTools → **Performance** tab
+2. Click **Record**
+3. Interact with the page
+4. Stop and inspect the **Timings** row — Angular emits marks for each component template execution and change detection cycle
+
+This reveals which specific templates are slow during a real interaction, complementing the Angular DevTools profiler.
+
+See: [Recording a profile](https://next.angular.dev/best-practices/profiling-with-chrome-devtools#recording-a-profile)

--- a/skills/dev-skills/angular-developer/references/core-web-vitals.md
+++ b/skills/dev-skills/angular-developer/references/core-web-vitals.md
@@ -1,0 +1,174 @@
+# Core Web Vitals
+
+Core Web Vitals (CWV) are Google's user-experience metrics used for Search ranking. Angular rendering choices have a direct effect on all three.
+
+| Metric | Measures | Target |
+|---|---|---|
+| **LCP** — Largest Contentful Paint | How fast the main content appears | < 2.5 s |
+| **INP** — Interaction to Next Paint | How fast the page responds to input | < 200 ms |
+| **CLS** — Cumulative Layout Shift | How stable the layout is during load | < 0.1 |
+
+---
+
+## LCP — Largest Contentful Paint
+
+The LCP element is the largest image or text block visible in the viewport on load — typically a hero image or an `<h1>`.
+
+### What affects LCP in Angular
+
+**Rendering strategy** is the biggest factor:
+
+- **CSR**: The browser downloads the JS bundle, executes it, and then renders. LCP is delayed by bundle download + parse + execute time. Poor for content-heavy pages.
+- **SSG**: HTML is pre-rendered and served from a CDN. The LCP element is in the first HTML response. Best LCP.
+- **SSR**: HTML is rendered per-request on the server. Faster than CSR, comparable to SSG when cached.
+
+**Image loading**:
+
+- `NgOptimizedImage` with `priority` adds `fetchpriority="high"` and a `<link rel="preload">` — directly improves LCP for image candidates.
+- A hero image without `priority` competes with other resources and loads late.
+
+**`@defer` on the LCP element** is the most common Angular-specific LCP regression. A deferred block is not rendered until the trigger fires, which means the LCP candidate is invisible until the chunk downloads.
+
+### LCP checklist
+
+- [ ] Use SSG or SSR for content-visible pages
+- [ ] Add `priority` to the hero image with `NgOptimizedImage`
+- [ ] Never wrap the LCP element in `@defer`
+- [ ] Add `<link rel="preconnect">` to image CDN origins
+
+---
+
+## INP — Interaction to Next Paint
+
+INP measures the time from a user interaction (click, keypress, tap) to the next frame painted. It replaced FID as a Core Web Vital in 2024.
+
+### What affects INP in Angular
+
+**Change detection cost**: The default strategy checks the entire component tree on every event. In large apps this can block the main thread for tens or hundreds of milliseconds.
+
+**Zone.js overhead**: zone.js intercepts every event and triggers Angular's change detection after it completes. Third-party libraries that fire many events (maps, charts) compound this.
+
+**Long event handlers**: Synchronous work in a click handler — API calls, complex calculations, DOM measurements — blocks the main thread and delays the next paint.
+
+### INP improvements
+
+```ts
+// 1. OnPush on every component
+@Component({ changeDetection: ChangeDetectionStrategy.OnPush })
+
+// 2. Move expensive work outside Angular's zone
+this.ngZone.runOutsideAngular(() => {
+  chart.on('mousemove', handler);
+});
+
+// 3. Yield to the scheduler for long tasks
+async handleClick() {
+  processFirstChunk();
+  await scheduler.yield(); // yield to browser between chunks
+  processSecondChunk();
+}
+```
+
+### INP checklist
+
+- [ ] `OnPush` on every component
+- [ ] Third-party event-heavy libraries use `runOutsideAngular()`
+- [ ] Long event handlers yield with `scheduler.yield()` or `setTimeout(0)`
+- [ ] Consider zoneless Angular for new projects (`provideExperimentalZonelessChangeDetection()`)
+
+---
+
+## CLS — Cumulative Layout Shift
+
+CLS measures unexpected layout movement. Every time an element shifts position during load, CLS increases.
+
+### Common Angular CLS sources
+
+**Images without dimensions**: The browser reserves no space before the image loads. When it arrives, content below shifts down.
+
+```html
+<!-- WRONG: causes layout shift -->
+<img src="product.jpg" />
+
+<!-- CORRECT: space reserved, no shift -->
+<img ngSrc="product.jpg" width="400" height="300" />
+```
+
+**`@defer` without `@placeholder`**: Without a placeholder, the layout collapses where the deferred content will appear, then shifts when the content loads.
+
+```html
+<!-- WRONG -->
+@defer (on viewport) { <heavy-section /> }
+
+<!-- CORRECT -->
+@defer (on viewport) {
+  <heavy-section />
+} @placeholder {
+  <div style="height: 400px"></div>
+}
+```
+
+**Web fonts causing FOUT/FOIT**: Text reflows when a web font replaces the fallback font.
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('/fonts/my-font.woff2') format('woff2');
+  font-display: swap; /* prevents invisible text; may cause FOUT */
+}
+```
+
+Pair `font-display: swap` with a `<link rel="preload">` for the critical font to minimize the swap.
+
+### CLS checklist
+
+- [ ] All images use `NgOptimizedImage` with explicit `width` and `height`
+- [ ] Every `@defer` block has a same-size `@placeholder`
+- [ ] Web fonts have `font-display: swap` and critical fonts are preloaded
+- [ ] No dynamic content inserted above existing content after load
+
+---
+
+## Measurement
+
+### Lab measurement (development)
+
+```bash
+# Lighthouse via Chrome DevTools (Audits tab)
+# or via Angular DevTools MCP:
+lighthouse_audit({ url: 'http://localhost:4200', categories: ['performance'] })
+```
+
+### Field measurement (production)
+
+Install the `web-vitals` package:
+
+```bash
+npm install web-vitals
+```
+
+Report metrics from the app entry point:
+
+```ts
+// main.ts
+import { onLCP, onINP, onCLS } from 'web-vitals';
+
+onLCP(console.log);
+onINP(console.log);
+onCLS(console.log);
+```
+
+Replace `console.log` with your analytics endpoint.
+
+### Bundle analysis
+
+```bash
+ng build --stats-json
+npx source-map-explorer dist/my-app/browser/*.js
+```
+
+Identifies large dependencies and verifies code-splitting boundaries for lazy routes.
+
+### Change detection profiling
+
+Angular DevTools → **Profiler** tab → record an interaction → inspect which components checked and how long each took.

--- a/skills/dev-skills/angular-developer/references/defer-blocks.md
+++ b/skills/dev-skills/angular-developer/references/defer-blocks.md
@@ -1,0 +1,123 @@
+# Defer Blocks
+
+`@defer` is Angular's primary mechanism for deferring the loading and rendering of template sections until a condition is met. Its main use is lazy-loading below-fold content to reduce initial bundle size, defer parsing cost, and enable incremental hydration in SSR apps.
+
+## Basic Structure
+
+```html
+@defer (on viewport) {
+  <heavy-chart />
+} @placeholder {
+  <div class="chart-skeleton" style="height: 300px"></div>
+} @loading (minimum 200ms) {
+  <div class="chart-spinner"></div>
+} @error {
+  <p>Failed to load chart.</p>
+}
+```
+
+Every `@defer` block should include a `@placeholder`. Omitting it causes the space to collapse and reappear on load, causing CLS.
+
+## Triggers
+
+| Trigger | When the block loads |
+|---|---|
+| `on viewport` | Element enters the viewport |
+| `on idle` | Browser is idle (`requestIdleCallback`) |
+| `on interaction` | User clicks or focuses the placeholder |
+| `on timer(2s)` | After a fixed delay |
+| `on immediate` | Immediately after rendering (still lazy — defers from initial bundle) |
+| `when <expr>` | When a boolean expression becomes truthy |
+
+Multiple triggers can be combined:
+
+```html
+@defer (on viewport; on timer(5s)) {
+  <newsletter-signup />
+}
+```
+
+## `@placeholder` Block
+
+Renders immediately in place of the deferred content. Must match the expected layout size to prevent CLS.
+
+- Accepts `minimum` to keep it visible for a minimum duration (avoids flash):
+
+```html
+@placeholder (minimum 500ms) {
+  <div class="skeleton" style="height: 200px; width: 100%"></div>
+}
+```
+
+## `@loading` Block
+
+Renders while the deferred chunk is downloading. Accepts two parameters:
+
+- `after`: how long to wait before showing the loading state (avoids flash on fast connections)
+- `minimum`: how long to keep showing it (avoids flash on fast responses)
+
+```html
+@loading (after 100ms; minimum 200ms) {
+  <mat-spinner />
+}
+```
+
+## `@error` Block
+
+Renders if the deferred import fails (network error, module not found).
+
+```html
+@error {
+  <p>Content failed to load. <button (click)="reload()">Retry</button></p>
+}
+```
+
+## Prefetching
+
+Prefetch the chunk before the trigger fires to reduce latency:
+
+```html
+@defer (on interaction; prefetch on idle) {
+  <modal-dialog />
+} @placeholder {
+  <button>Open dialog</button>
+}
+```
+
+## `@defer` and Incremental Hydration (SSR)
+
+In SSR apps, `@defer` blocks can be used to defer hydration of server-rendered HTML:
+
+```ts
+// app.config.ts
+provideClientHydration(withIncrementalHydration())
+```
+
+The block renders on the server but hydrates lazily in the browser, reducing Time to Interactive.
+
+## Anti-Patterns
+
+**Do not defer above-the-fold content.** The LCP element must load immediately. Deferring it causes the browser to download and parse the deferred chunk before the primary content is visible, increasing LCP significantly.
+
+```html
+<!-- WRONG: hero image is the LCP candidate -->
+@defer (on viewport) {
+  <img ngSrc="hero.webp" priority width="1200" height="600" />
+}
+
+<!-- CORRECT: eager, with NgOptimizedImage priority -->
+<img ngSrc="hero.webp" priority width="1200" height="600" />
+```
+
+**Always include `@placeholder`.** A missing placeholder collapses the layout area and causes CLS when content loads.
+
+**Do not use `@defer (on immediate)` as a substitute for lazy routes.** It still fetches the chunk eagerly on idle — use lazy routes for true code splitting by page.
+
+## When to Prefer `@defer` Over Lazy Routes
+
+| Scenario | Prefer |
+|---|---|
+| Entire page / feature area | Lazy route (`loadComponent`) |
+| Part of a page (sidebar, chart, comment section) | `@defer (on viewport)` or `@defer (on idle)` |
+| Dialog / modal triggered by user action | `@defer (on interaction)` |
+| Incrementally hydrating an SSR section | `@defer` with `withIncrementalHydration()` |

--- a/skills/dev-skills/angular-developer/references/defer-blocks.md
+++ b/skills/dev-skills/angular-developer/references/defer-blocks.md
@@ -22,8 +22,8 @@ Every `@defer` block should include a `@placeholder`. Omitting it causes the spa
 
 | Trigger | When the block loads |
 |---|---|
-| `on viewport` | Element enters the viewport |
-| `on idle` | Browser is idle (`requestIdleCallback`) |
+| `on viewport` | Element enters the viewport (supports Intersection Observer options from v21: `rootMargin`, `threshold`) |
+| `on idle` | Browser is idle (`requestIdleCallback`); accepts `timeout` to cap the wait (v22+) |
 | `on interaction` | User clicks or focuses the placeholder |
 | `on timer(2s)` | After a fixed delay |
 | `on immediate` | Immediately after rendering (still lazy — defers from initial bundle) |
@@ -86,14 +86,21 @@ Prefetch the chunk before the trigger fires to reduce latency:
 
 ## `@defer` and Incremental Hydration (SSR)
 
-In SSR apps, `@defer` blocks can be used to defer hydration of server-rendered HTML:
+In SSR apps, `@defer` blocks defer hydration of server-rendered HTML — the block renders on the server but hydrates lazily in the browser, reducing Time to Interactive.
+
+From Angular v22, incremental hydration is enabled by default:
 
 ```ts
-// app.config.ts
-provideClientHydration(withIncrementalHydration())
+// app.config.ts (v22+)
+provideClientHydration()
 ```
 
-The block renders on the server but hydrates lazily in the browser, reducing Time to Interactive.
+On Angular v21 and earlier, opt in explicitly:
+
+```ts
+// app.config.ts (v21 and earlier)
+provideClientHydration(withIncrementalHydration())
+```
 
 ## Anti-Patterns
 
@@ -120,4 +127,4 @@ The block renders on the server but hydrates lazily in the browser, reducing Tim
 | Entire page / feature area | Lazy route (`loadComponent`) |
 | Part of a page (sidebar, chart, comment section) | `@defer (on viewport)` or `@defer (on idle)` |
 | Dialog / modal triggered by user action | `@defer (on interaction)` |
-| Incrementally hydrating an SSR section | `@defer` with `withIncrementalHydration()` |
+| Incrementally hydrating an SSR section | `@defer` (automatic in v22+; requires `withIncrementalHydration()` in v21 and earlier) |

--- a/skills/dev-skills/angular-developer/references/performance-anti-patterns.md
+++ b/skills/dev-skills/angular-developer/references/performance-anti-patterns.md
@@ -1,0 +1,193 @@
+# Performance Anti-Patterns
+
+A consolidated reference of Angular performance anti-patterns. Each entry covers what it is, why it hurts, and the fix.
+
+---
+
+## Images
+
+### `<img src>` without NgOptimizedImage for above-the-fold images
+
+**Impact**: LCP, CLS  
+**Why**: No `fetchpriority`, no automatic preload, no dimension enforcement.  
+**Fix**: Use `ngSrc` with `width`, `height`, and `priority` on the LCP image.
+
+```html
+<!-- WRONG -->
+<img src="hero.webp" />
+
+<!-- CORRECT -->
+<img ngSrc="hero.webp" width="1200" height="600" priority />
+```
+
+### `priority` on every image
+
+**Impact**: Competing preloads hurt LCP instead of helping it  
+**Why**: The browser fetches all preloaded resources simultaneously. Multiple `priority` images reduce the effective bandwidth available to the actual LCP candidate.  
+**Fix**: Add `priority` only to the single LCP candidate per page.
+
+---
+
+## Defer Blocks
+
+### `@defer` on above-the-fold content
+
+**Impact**: LCP regression  
+**Why**: The browser cannot render deferred content until the chunk downloads and executes. Above-fold content should be in the initial bundle.  
+**Fix**: Never wrap the LCP element or other above-fold content in `@defer`.
+
+### `@defer` without `@placeholder`
+
+**Impact**: CLS  
+**Why**: Without a placeholder, the layout collapses to zero height in that area, then shifts when the content loads.  
+**Fix**: Always include a `@placeholder` with the same height as the expected content.
+
+```html
+@defer (on viewport) {
+  <analytics-chart />
+} @placeholder {
+  <div class="chart-skeleton" style="height: 300px"></div>
+}
+```
+
+---
+
+## Change Detection
+
+### Default change detection strategy in signal-based components
+
+**Impact**: Unnecessary CPU work on every event, hurts INP  
+**Why**: The default strategy runs a full tree check on every browser event. Signals already schedule targeted updates — `OnPush` is needed for Angular to skip unconcerned branches.  
+**Fix**: Set `changeDetection: ChangeDetectionStrategy.OnPush` on every component.
+
+### Calling `markForCheck()` in signal components
+
+**Impact**: Redundant CD cycles, masks signal tracking issues  
+**Why**: Signals schedule re-renders automatically when their value changes in a template. Calling `markForCheck()` manually is a sign that a signal read is happening outside the reactive context.  
+**Fix**: Move signal reads into the template or a `computed()`. Remove the manual `markForCheck()`.
+
+### Running third-party animation or event loops inside Angular's zone
+
+**Impact**: Change detection triggered at animation frame rate (60fps), high INP  
+**Why**: zone.js patches `requestAnimationFrame` and `addEventListener`. Any callback fires Angular's change detection.  
+**Fix**: Wrap third-party code in `NgZone.runOutsideAngular()`.
+
+```ts
+this.ngZone.runOutsideAngular(() => {
+  requestAnimationFrame(this.animationLoop.bind(this));
+});
+```
+
+---
+
+## Signals and Reactivity
+
+### Using `effect()` to propagate state between signals
+
+**Impact**: Infinite update loops, stale reads, hard-to-trace bugs  
+**Why**: `effect()` is for side effects (DOM mutation, logging, storage). Using it to derive or copy signal state creates unpredictable execution order.  
+**Fix**: Use `computed()` for derived read-only state, `linkedSignal()` for writable derived state.
+
+```ts
+// WRONG
+effect(() => { this.fullName.set(`${this.first()} ${this.last()}`); });
+
+// CORRECT
+fullName = computed(() => `${this.first()} ${this.last()}`);
+```
+
+### Reading signals after `await` in reactive contexts
+
+**Impact**: Stale data, missed updates — the reactive context is lost after an async boundary  
+**Why**: Angular's reactive context (template, `computed`, `effect`) tracks signal reads synchronously. Reads after `await` happen outside this context.  
+**Fix**: Read all signals before the first `await`.
+
+```ts
+// WRONG
+async loadUser() {
+  const data = await fetch('/api/user');
+  const id = this.userId(); // read after await — not tracked
+}
+
+// CORRECT
+async loadUser() {
+  const id = this.userId(); // read before await — tracked
+  const data = await fetch(`/api/user/${id}`);
+}
+```
+
+---
+
+## RxJS
+
+### Subscriptions without `takeUntilDestroyed`
+
+**Impact**: Memory leaks, stale event handlers, incorrect behavior after component destruction  
+**Why**: Subscriptions continue emitting after a component is destroyed unless explicitly unsubscribed.  
+**Fix**: Use `takeUntilDestroyed()` from `@angular/core/rxjs-interop`.
+
+```ts
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+export class MyComponent {
+  private destroyRef = inject(DestroyRef);
+
+  ngOnInit() {
+    this.someService.data$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(data => this.data.set(data));
+  }
+}
+```
+
+---
+
+## Routing
+
+### Lazy loading the landing page route
+
+**Impact**: LCP regression — the primary route chunk must download before content renders  
+**Why**: The point of lazy loading is to defer routes the user may never visit. The first route the user always visits should be eager.  
+**Fix**: Eager load the primary route. Lazy load all others.
+
+```ts
+// WRONG
+{ path: '', loadComponent: () => import('./home/home.component') }
+
+// CORRECT
+{ path: '', component: HomeComponent }
+```
+
+### `import()` inside template expressions
+
+**Impact**: A new dynamic import fires on every render cycle  
+**Why**: Template expressions re-evaluate during change detection. Each evaluation triggers a new `import()` call.  
+**Fix**: Move dynamic imports to route loader functions or component class initialization.
+
+---
+
+## Styling
+
+### `::ng-deep` for component style overrides
+
+**Impact**: CSS bleed across component boundaries, defeats encapsulation  
+**Why**: `::ng-deep` removes Angular's view encapsulation attribute selectors, making styles global.  
+**Fix**: Use the component's public API, CSS custom properties, or `ViewEncapsulation.None` deliberately.
+
+---
+
+## Templates
+
+### `@for` without `track`
+
+**Impact**: Full DOM re-creation on list updates, poor INP for interactive lists  
+**Why**: Without `track`, Angular cannot identify which items changed and recreates all DOM nodes on every update.  
+**Fix**: Always track by a stable identity.
+
+```html
+<!-- WRONG -->
+@for (item of items) { <li>{{ item.name }}</li> }
+
+<!-- CORRECT -->
+@for (item of items; track item.id) { <li>{{ item.name }}</li> }
+```

--- a/skills/dev-skills/angular-developer/references/performance-anti-patterns.md
+++ b/skills/dev-skills/angular-developer/references/performance-anti-patterns.md
@@ -70,9 +70,10 @@ A consolidated reference of Angular performance anti-patterns. Each entry covers
 
 **Impact**: Change detection triggered at animation frame rate (60fps), high INP  
 **Why**: zone.js patches `requestAnimationFrame` and `addEventListener`. Any callback fires Angular's change detection.  
-**Fix**: Wrap third-party code in `NgZone.runOutsideAngular()`.
+**Fix**: In zone-based apps (v20 and earlier), wrap third-party code in `NgZone.runOutsideAngular()`. In zoneless apps (default from v21), zone.js is absent and this anti-pattern does not apply.
 
 ```ts
+// Zone-based apps only (v20 and earlier)
 this.ngZone.runOutsideAngular(() => {
   requestAnimationFrame(this.animationLoop.bind(this));
 });
@@ -99,22 +100,37 @@ fullName = computed(() => `${this.first()} ${this.last()}`);
 ### Reading signals after `await` in reactive contexts
 
 **Impact**: Stale data, missed updates — the reactive context is lost after an async boundary  
-**Why**: Angular's reactive context (template, `computed`, `effect`) tracks signal reads synchronously. Reads after `await` happen outside this context.  
-**Fix**: Read all signals before the first `await`.
+**Why**: Angular's reactive context (template, `computed`, `effect`) tracks signal reads synchronously. Any signal read after the first `await` happens outside this context and is not tracked.  
+**Fix**: Read all signals before the first `await`, or use `resource()` to keep async data loading reactive.
 
 ```ts
-// WRONG
-async loadUser() {
-  const data = await fetch('/api/user');
-  const id = this.userId(); // read after await — not tracked
-}
+@Component({ template: `<p>{{ user().name }}</p>` })
+class UserComponent {
+  userId = input.required<string>();
 
-// CORRECT
-async loadUser() {
-  const id = this.userId(); // read before await — tracked
-  const data = await fetch(`/api/user/${id}`);
+  // WRONG: userId() read after await — not tracked, changes ignored
+  async loadUser() {
+    const data = await fetch('/api/user');
+    const id = this.userId();
+    return data;
+  }
+
+  // CORRECT: read all signals before any await
+  async loadUser() {
+    const id = this.userId(); // tracked — read before await
+    const data = await fetch(`/api/user/${id}`);
+    return data;
+  }
+
+  // PREFERRED: use resource() — stays reactive to signal changes
+  user = resource({
+    request: () => this.userId(),
+    loader: ({ request: id }) => fetch(`/api/user/${id}`).then(r => r.json()),
+  });
 }
 ```
+
+See: [Reactive context and async operations](https://angular.dev/guide/signals#reactive-context-and-async-operations)
 
 ---
 

--- a/skills/dev-skills/angular-developer/references/performance-change-detection.md
+++ b/skills/dev-skills/angular-developer/references/performance-change-detection.md
@@ -98,13 +98,21 @@ Remove `zone.js` from `polyfills` in `angular.json` when opting in on older vers
 
 ## Angular DevTools — Change Detection Profiler
 
-The Angular DevTools browser extension includes a change detection profiler. Use it to:
+Install the **Angular DevTools** extension from the Chrome Web Store, then open Chrome DevTools → **Angular** tab.
 
+**Profiler** tab workflow:
+
+1. Click **Record**
+2. Interact with the page (click, type, scroll)
+3. Click **Stop**
+4. Inspect the flame chart: each bar is a component check; red bars are slow; unexpected bars indicate missing `OnPush`
+
+Use it to:
 - Identify which components check most frequently
-- Find components with Default strategy that should use OnPush
-- Measure the milliseconds spent in each CD cycle
+- Find components with Default strategy that should use `OnPush`
+- Measure milliseconds spent per CD cycle and per component
 
-Install: Chrome Web Store → "Angular DevTools"
+See: [Debug change detection and OnPush components](https://next.angular.dev/tools/devtools/profiler#debug-change-detection-and-onpush-components)
 
 ## Anti-Patterns
 

--- a/skills/dev-skills/angular-developer/references/performance-change-detection.md
+++ b/skills/dev-skills/angular-developer/references/performance-change-detection.md
@@ -1,0 +1,109 @@
+# Change Detection Performance
+
+Change detection determines when Angular updates the DOM. The default strategy checks the entire component tree on every event. The following approaches reduce this work significantly.
+
+## OnPush Strategy
+
+`OnPush` tells Angular to skip a component during change detection unless:
+
+- One of its `@Input` references changes
+- An event originates from within the component or its children
+- An `async` pipe emits a new value
+- A signal read within the template changes value
+
+```ts
+@Component({
+  selector: 'app-user-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<p>{{ user().name }}</p>`
+})
+export class UserCard {
+  user = input.required<User>();
+}
+```
+
+**Always use `OnPush` on new components.** The default strategy runs a full tree check on every browser event — `OnPush` makes Angular skip subtrees that cannot have changed.
+
+## Signals + OnPush
+
+Signals read inside an `OnPush` component's template automatically schedule targeted re-renders when they change — no `markForCheck()` needed.
+
+```ts
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<p>Count: {{ count() }}</p>`
+})
+export class Counter {
+  count = signal(0);
+  increment() { this.count.update(v => v + 1); }
+}
+```
+
+Do not call `markForCheck()` in signal-based components. Signals handle scheduling internally.
+
+## NgZone.runOutsideAngular()
+
+Angular's zone.js patches browser APIs (setTimeout, addEventListener, etc.) and triggers change detection after every callback. Code that does not produce UI changes should run outside the zone.
+
+```ts
+@Component({ ... })
+export class MapComponent implements AfterViewInit {
+  private ngZone = inject(NgZone);
+
+  ngAfterViewInit() {
+    this.ngZone.runOutsideAngular(() => {
+      // Map library fires thousands of events — none should trigger Angular CD
+      this.map.on('mousemove', (e) => this.updateCoordinates(e));
+    });
+  }
+
+  private updateCoordinates(e: MouseEvent) {
+    // Update a raw property, not a signal — if signals are needed,
+    // re-enter the zone explicitly for that update only
+    this.coords = { lat: e.lngLat.lat, lng: e.lngLat.lng };
+  }
+}
+```
+
+Use `runOutsideAngular` for: map libraries, WebGL/canvas animation loops, third-party charting libraries, WebSocket message handlers that batch updates.
+
+## Zoneless Angular
+
+Zoneless mode removes zone.js entirely. Angular relies purely on signals and explicit scheduling to know when to update the DOM. Available and stable in Angular 20+.
+
+```ts
+// app.config.ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideExperimentalZonelessChangeDetection()
+  ]
+};
+```
+
+Remove `zone.js` from `polyfills` in `angular.json` after enabling zoneless.
+
+**Benefits**: Smaller bundle (~12 KB removed), faster initial parse, no accidental change detection from third-party code, better SSR compatibility.
+
+**Migration path from zone.js**:
+1. Enable `provideExperimentalZonelessChangeDetection()` alongside `provideZoneChangeDetection()` during transition
+2. Audit all components for manual `detectChanges()` or `markForCheck()` calls — replace with signals
+3. Ensure all async state flows through signals or `AsyncPipe`
+4. Remove zone.js once all components pass tests in zoneless mode
+
+## Angular DevTools — Change Detection Profiler
+
+The Angular DevTools browser extension includes a change detection profiler. Use it to:
+
+- Identify which components check most frequently
+- Find components with Default strategy that should use OnPush
+- Measure the milliseconds spent in each CD cycle
+
+Install: Chrome Web Store → "Angular DevTools"
+
+## Anti-Patterns
+
+**Default change detection in signal-based components.** The default strategy runs a full tree traversal even when only a single signal changes. OnPush + signals means only the affected component re-renders.
+
+**Calling `markForCheck()` in signal components.** Signals schedule their own updates. Manual `markForCheck()` is redundant and can mask missing signal reads.
+
+**Running animation loops inside the zone.** `requestAnimationFrame` loops inside Angular's zone trigger change detection at 60fps. Always wrap animation code in `runOutsideAngular()`.

--- a/skills/dev-skills/angular-developer/references/performance-change-detection.md
+++ b/skills/dev-skills/angular-developer/references/performance-change-detection.md
@@ -22,7 +22,7 @@ export class UserCard {
 }
 ```
 
-**Always use `OnPush` on new components.** The default strategy runs a full tree check on every browser event — `OnPush` makes Angular skip subtrees that cannot have changed.
+**Use `OnPush` on every component.** From v22, it is the default for new components. In earlier versions it must be set explicitly. The default strategy runs a full tree check on every browser event — `OnPush` makes Angular skip subtrees that cannot have changed.
 
 ## Signals + OnPush
 
@@ -42,6 +42,8 @@ export class Counter {
 Do not call `markForCheck()` in signal-based components. Signals handle scheduling internally.
 
 ## NgZone.runOutsideAngular()
+
+> **Zone-based apps only.** Angular v21+ apps are zoneless by default — zone.js is not included and `NgZone` is a no-op. This pattern applies to apps on v20 or earlier, or apps that explicitly opted into zone.js.
 
 Angular's zone.js patches browser APIs (setTimeout, addEventListener, etc.) and triggers change detection after every callback. Code that does not produce UI changes should run outside the zone.
 
@@ -69,10 +71,14 @@ Use `runOutsideAngular` for: map libraries, WebGL/canvas animation loops, third-
 
 ## Zoneless Angular
 
-Zoneless mode removes zone.js entirely. Angular relies purely on signals and explicit scheduling to know when to update the DOM. Available and stable in Angular 20+.
+Zoneless mode removes zone.js entirely. Angular relies purely on signals and explicit scheduling to know when to update the DOM.
+
+**From Angular v21, zoneless is the default for new projects.** Zone.js is not included unless explicitly added back via `provideZoneChangeDetection()`.
+
+For apps on Angular v20 or earlier, opt in explicitly:
 
 ```ts
-// app.config.ts
+// app.config.ts (v20 and earlier)
 export const appConfig: ApplicationConfig = {
   providers: [
     provideExperimentalZonelessChangeDetection()
@@ -80,11 +86,11 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
-Remove `zone.js` from `polyfills` in `angular.json` after enabling zoneless.
+Remove `zone.js` from `polyfills` in `angular.json` when opting in on older versions.
 
 **Benefits**: Smaller bundle (~12 KB removed), faster initial parse, no accidental change detection from third-party code, better SSR compatibility.
 
-**Migration path from zone.js**:
+**Migration path from zone.js** (for apps upgrading from v20 or earlier):
 1. Enable `provideExperimentalZonelessChangeDetection()` alongside `provideZoneChangeDetection()` during transition
 2. Audit all components for manual `detectChanges()` or `markForCheck()` calls — replace with signals
 3. Ensure all async state flows through signals or `AsyncPipe`
@@ -106,4 +112,4 @@ Install: Chrome Web Store → "Angular DevTools"
 
 **Calling `markForCheck()` in signal components.** Signals schedule their own updates. Manual `markForCheck()` is redundant and can mask missing signal reads.
 
-**Running animation loops inside the zone.** `requestAnimationFrame` loops inside Angular's zone trigger change detection at 60fps. Always wrap animation code in `runOutsideAngular()`.
+**Running animation loops inside the zone (zone-based apps).** `requestAnimationFrame` loops inside Angular's zone trigger change detection at 60fps. Always wrap animation code in `runOutsideAngular()`. In zoneless apps (default from v21) this is not an issue.

--- a/skills/dev-skills/angular-developer/references/performance-change-detection.md
+++ b/skills/dev-skills/angular-developer/references/performance-change-detection.md
@@ -1,6 +1,6 @@
 # Change Detection Performance
 
-Change detection determines when Angular updates the DOM. The default strategy checks the entire component tree on every event. The following approaches reduce this work significantly.
+Change detection determines when Angular updates the DOM. From Angular v22, `OnPush` is the default strategy — components re-render only when their inputs change, a signal they read updates, or an event fires within them. In earlier versions the default strategy checks the entire component tree on every event. The following approaches reduce change detection cost in all versions.
 
 ## OnPush Strategy
 

--- a/skills/dev-skills/angular-developer/references/performance-images.md
+++ b/skills/dev-skills/angular-developer/references/performance-images.md
@@ -1,0 +1,117 @@
+# Image Performance with NgOptimizedImage
+
+`NgOptimizedImage` is Angular's built-in directive for performant images. It improves LCP by adding `fetchpriority` and `<link rel="preload">` for the LCP candidate, and prevents CLS by requiring explicit dimensions.
+
+## Setup
+
+```ts
+import { NgOptimizedImage } from '@angular/common';
+
+@Component({
+  imports: [NgOptimizedImage],
+  template: `<img ngSrc="hero.webp" width="1200" height="600" priority />`
+})
+```
+
+Replace `src` with `ngSrc`. The directive automatically sets `loading="lazy"` on non-priority images and `fetchpriority="high"` on the priority image.
+
+## `priority` Attribute
+
+Add `priority` to the single LCP image (typically the hero image or first product photo). This:
+
+- Sets `fetchpriority="high"` on the `<img>` tag
+- Injects a `<link rel="preload">` in the `<head>` (in SSR/SSG)
+- Disables `loading="lazy"`
+
+```html
+<img ngSrc="hero.webp" width="1200" height="600" priority />
+```
+
+Do not add `priority` to more than one image per page. Multiple high-priority preloads compete with each other and dilute the benefit.
+
+## Required Dimensions
+
+`width` and `height` are required to prevent CLS. The browser reserves the exact space before the image loads.
+
+```html
+<!-- CORRECT -->
+<img ngSrc="product.jpg" width="400" height="300" />
+
+<!-- WRONG: will trigger a dev warning and cause CLS -->
+<img ngSrc="product.jpg" />
+```
+
+## `fill` Mode
+
+For CSS-driven containers where you cannot specify fixed pixel dimensions, use `fill`. The image fills its positioned parent.
+
+```html
+<div style="position: relative; width: 100%; height: 400px;">
+  <img ngSrc="banner.webp" fill style="object-fit: cover" />
+</div>
+```
+
+The parent must have `position: relative`, `absolute`, or `fixed`.
+
+## Responsive Images with `ngSrcset` and `sizes`
+
+```html
+<img
+  ngSrc="product.jpg"
+  width="800"
+  height="600"
+  ngSrcset="400w, 800w, 1200w"
+  sizes="(max-width: 768px) 100vw, 50vw"
+/>
+```
+
+The directive generates the `srcset` attribute automatically. `sizes` tells the browser what proportion of the viewport the image occupies at each breakpoint.
+
+## Image CDN Loaders
+
+CDN loaders transform `ngSrc` values into CDN-specific URLs with automatic format negotiation (WebP/AVIF) and responsive variants.
+
+```ts
+// app.config.ts
+import { provideImageKitLoader } from '@angular/common';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideImageKitLoader('https://ik.imagekit.io/your-id')
+  ]
+};
+```
+
+Available loaders: `provideImageKitLoader`, `provideCloudinaryLoader`, `provideImgixLoader`, `provideNetlifyImageLoader`.
+
+With a loader, use the image path relative to your CDN base URL:
+
+```html
+<img ngSrc="hero.jpg" width="1200" height="600" priority />
+<!-- renders as: https://ik.imagekit.io/your-id/hero.jpg?tr=w-1200,h-600,f-auto -->
+```
+
+## Dev Warnings
+
+In development mode `NgOptimizedImage` logs warnings for:
+
+- Missing `width`/`height` (CLS risk)
+- Missing `priority` on the LCP image (detected via `IntersectionObserver`)
+- `priority` used without a preconnect to the image origin
+- Image rendered at a size significantly larger than its intrinsic dimensions
+
+## Anti-Patterns
+
+**Using `<img src>` for hero or above-the-fold images.** Without `NgOptimizedImage`, there is no automatic `fetchpriority`, no preload, and no CLS protection.
+
+```html
+<!-- WRONG -->
+<img src="hero.webp" />
+
+<!-- CORRECT -->
+<img ngSrc="hero.webp" width="1200" height="600" priority />
+```
+
+**Adding `priority` to every image.** Only the LCP candidate benefits. Additional priority attributes add unnecessary preload `<link>` tags that compete with each other.
+
+**Using `fill` without a positioned parent.** The image will collapse or overflow unpredictably.


### PR DESCRIPTION
Adds five reference files covering Angular-specific performance topics and wires them into SKILL.md under a new Performance section.

## What's added

### References

- **`core-web-vitals.md`** — LCP, INP, and CLS targets, how Angular rendering choices affect each metric (CSR vs SSG/SSR, `@defer` on LCP elements, `OnPush` for INP, image dimensions for CLS), and how to measure with Lighthouse, `web-vitals`, and Angular DevTools.

- **`defer-blocks.md`** — All `@defer` triggers (`on viewport`, `on idle`, `on interaction`, `on timer`, `when`), `@placeholder` / `@loading` / `@error` blocks, prefetching, incremental hydration in SSR, and anti-patterns (deferring above-fold/LCP content, missing placeholder).

- **`performance-images.md`** — `NgOptimizedImage` setup, the `priority` attribute for LCP images, `fill` mode, responsive images with `ngSrcset` and `sizes`, CDN loaders (`provideImageKitLoader`, etc.), and dev warnings.

- **`performance-change-detection.md`** — `ChangeDetectionStrategy.OnPush`, how signals interact with `OnPush`, `NgZone.runOutsideAngular()` for third-party libraries, and zoneless Angular (`provideExperimentalZonelessChangeDetection()`).

- **`performance-anti-patterns.md`** — Consolidated list of 13 anti-patterns (images, defer blocks, change detection, signals, RxJS, routing, styling, templates) each with impact and fix.

### SKILL.md

Adds a **Performance** section between Routing and Styling that links all five references with one-line descriptions of when to consult each.

## What's not duplicated

The new files avoid repeating content already in existing references: `rendering-strategies.md` (CSR/SSG/SSR decision), `loading-strategies.md` (lazy routes), `effects.md` (`afterRenderEffect` phases), `signals-overview.md` (computed memoization, async boundaries), `components.md` (`track` in `@for`), and `resource.md` (AbortSignal).