### PR TITLE
feat(devtools): improve transfer state tab

### DIFF
--- a/devtools/cypress/integration/track-state.e2e.js
+++ b/devtools/cypress/integration/track-state.e2e.js
@@ -6,14 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-function showTransferState() {
-  cy.get('.main-toolbar > .settings > button:last-child').click();
-  cy.get('ng-settings #enable-transfer-state').click();
-}
-
 function goToTransferStateTab() {
-  showTransferState();
-  cy.get('body').type('{esc}');
   cy.get('a[mat-tab-link]:contains("Transfer State")').click();
   cy.get('ng-transfer-state').should('exist');
   cy.get('ng-transfer-state').should('be.visible');
@@ -25,45 +18,64 @@ describe('transfer state tab', () => {
     goToTransferStateTab();
   });
 
-  it('shows summary stats', () => {
-    cy.get('.summary-card .stat-label').contains('Keys');
-    cy.get('.summary-card .stat-label').contains('Total Size');
+  it('shows summary stats with Keys and Size labels', () => {
+    cy.get('ng-transfer-state .summary-stats .stat-label').contains('Keys');
+    cy.get('ng-transfer-state .summary-stats .stat-label').contains('Size');
   });
 
-  it('shows table headers', () => {
+  it('renders table headers', () => {
     cy.get('.transfer-state-table th').contains('Key');
     cy.get('.transfer-state-table th').contains('Type');
     cy.get('.transfer-state-table th').contains('Size');
     cy.get('.transfer-state-table th').contains('Value');
   });
 
-  it('shows the object row with correct data', () => {
+  it('renders the object row with a type badge and an expandable value', () => {
     cy.get('.transfer-state-table tr[mat-row]')
+      .filter(':contains("obj")')
       .first()
       .within(() => {
-        cy.get('td').eq(0).find('code').should('have.text', 'obj');
-        cy.get('td').eq(1).find('.type-badge').should('have.text', 'object');
-        cy.get('td').eq(2).should('have.text', '79 B');
-        cy.get('td').eq(3).find('.value-preview').should('contain.text', '"appName": "DevTools"');
-        cy.get('td').eq(3).find('.value-preview').should('contain.text', '"appVersion": "0.0.1"');
-        cy.get('td')
-          .eq(3)
-          .find('.value-preview')
-          .should('contain.text', '"appDescription": "Angular DevTools"');
+        cy.get('.key-cell code').should('have.text', 'obj');
+        cy.get('.type-badge').should('have.text', 'object');
+        cy.get('.value-cell ng-object-tree-explorer').should('exist');
       });
   });
 
-  it('shows the array row with correct data', () => {
+  it('renders the array row with a type badge', () => {
     cy.get('.transfer-state-table tr[mat-row]')
-      .last()
+      .filter(':contains("arr")')
+      .first()
       .within(() => {
-        cy.get('td').eq(0).find('code').should('have.text', 'arr');
-        cy.get('td').eq(1).find('.type-badge').should('have.text', 'array');
-        cy.get('td').eq(2).should('have.text', '11 B');
-        cy.get('td')
-          .eq(3)
-          .find('.value-preview')
-          .should('contain.text', '[\n  1,\n  2,\n  3,\n  4,\n  5\n]');
+        cy.get('.key-cell code').should('have.text', 'arr');
+        cy.get('.type-badge').should('have.text', 'array');
       });
+  });
+
+  it('filters rows by key', () => {
+    cy.get('.transfer-state-table tr[mat-row]').its('length').should('be.greaterThan', 1);
+
+    cy.get('.filter input.filter-input').type('greeting');
+
+    cy.get('.transfer-state-table tr[mat-row]').should('have.length', 1);
+    cy.get('.transfer-state-table tr[mat-row] .key-cell code').should('have.text', 'greeting');
+  });
+
+  it('clears the filter via the clear button', () => {
+    cy.get('.filter input.filter-input').type('nope-no-match');
+    cy.get('.transfer-state-table tr[mat-row]').should('have.length', 0);
+
+    cy.get('.filter .filter-clear').click();
+    cy.get('.filter input.filter-input').should('have.value', '');
+    cy.get('.transfer-state-table tr[mat-row]').its('length').should('be.greaterThan', 1);
+  });
+
+  it('sorts by key when the Key header is clicked', () => {
+    cy.get('.transfer-state-table th:contains("Key")').click();
+
+    cy.get('.transfer-state-table tr[mat-row] .key-cell code').then(($cells) => {
+      const keys = Array.from($cells, (el) => el.textContent.trim());
+      const sorted = [...keys].sort((a, b) => a.localeCompare(b));
+      expect(keys).to.deep.equal(sorted);
+    });
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -589,32 +589,26 @@ const getTransferStateCallback = (messageBus: MessageBus<Events>) => () => {
     return;
   }
 
-  const rootNode = forest[0];
-  if (!rootNode || !rootNode.nativeElement) {
-    messageBus.emit('transferStateData', [null]);
-    return;
+  const merged: Record<string, TransferStateValue> = {};
+  let collected = false;
+
+  for (const rootNode of forest) {
+    if (!rootNode?.nativeElement) continue;
+
+    const injector = getInjectorFromElementNode(rootNode.nativeElement);
+    if (!injector) continue;
+
+    const rootData = ng.ɵgetTransferState?.(injector) as
+      | Record<string, TransferStateValue>
+      | null
+      | undefined;
+    if (rootData && typeof rootData === 'object') {
+      Object.assign(merged, rootData);
+      collected = true;
+    }
   }
 
-  const injector = getInjectorFromElementNode(rootNode.nativeElement);
-  if (!injector) {
-    messageBus.emit('transferStateData', [null]);
-    return;
-  }
-
-  const transferStateData = (ng.ɵgetTransferState?.(injector) ?? null) as Record<
-    string,
-    TransferStateValue
-  > | null;
-
-  if (
-    transferStateData &&
-    typeof transferStateData === 'object' &&
-    Object.keys(transferStateData).length > 0
-  ) {
-    messageBus.emit('transferStateData', [transferStateData]);
-  } else {
-    messageBus.emit('transferStateData', [null]);
-  }
+  messageBus.emit('transferStateData', [collected ? merged : null]);
 };
 
 const getInjectorInstance = (

--- a/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-services/settings.ts
@@ -27,12 +27,6 @@ export class Settings {
     initialValue: false,
   });
 
-  readonly transferStateEnabled = this.settingsStore.create({
-    key: 'transfer_state_enabled',
-    category: 'general',
-    initialValue: false,
-  });
-
   readonly theme = this.settingsStore.create<ThemePreference>({
     key: 'theme',
     category: 'general',

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/devtools-tabs.component.ts
@@ -74,7 +74,6 @@ export class DevToolsTabsComponent {
   readonly inspectorRunning = signal(false);
 
   protected readonly signalGraphEnabled = () => this.supportedApis().signals;
-  protected readonly transferStateEnabled = this.settings.transferStateEnabled;
   protected readonly showCommentNodes = this.settings.showCommentNodes;
   protected readonly activeTab = this.settings.activeTab;
 
@@ -95,7 +94,7 @@ export class DevToolsTabsComponent {
     if (supportedApis.routes && this.routes().length > 0) {
       tabs.push('Router Tree');
     }
-    if (supportedApis.transferState && this.transferStateEnabled()) {
+    if (this.appData().hydration) {
       tabs.push('Transfer State');
     }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/settings/settings.component.html
@@ -13,18 +13,6 @@
         }
       </select>
     </li>
-
-    @if (supportedApis().transferState) {
-      <li>
-        <input
-          id="enable-transfer-state"
-          type="checkbox"
-          (change)="settings.transferStateEnabled.set($event.target.checked)"
-          [checked]="settings.transferStateEnabled()"
-        />
-        <label for="enable-transfer-state">Enable Transfer State tab</label>
-      </li>
-    }
   </ul>
 
   <h3>Components</h3>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary")
+load("//devtools/tools:defaults.bzl", "ng_project", "sass_binary", "ts_test_library", "zoneless_web_test_suite")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -14,6 +14,7 @@ ng_project(
     name = "transfer-state",
     srcs = [
         "transfer-state.component.ts",
+        "value-tree-builder.ts",
     ],
     angular_assets = [
         ":transfer-state.component.html",
@@ -22,9 +23,35 @@ ng_project(
     deps = [
         "//:node_modules/@angular/cdk",
         "//:node_modules/@angular/core",
+        "//:node_modules/@angular/forms",
         "//:node_modules/@angular/material",
         "//devtools/projects/ng-devtools/src/lib/shared/button",
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer",
+        "//devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer:types",
         "//devtools/projects/ng-devtools/src/lib/shared/utils",
         "//devtools/projects/protocol",
+    ],
+)
+
+ts_test_library(
+    name = "transfer_state_test",
+    srcs = [
+        "transfer-state.component.spec.ts",
+    ],
+    visibility = [
+        "//visibility:private",
+    ],
+    deps = [
+        ":transfer-state",
+        "//:node_modules/@angular/cdk",
+        "//:node_modules/@angular/core",
+        "//devtools/projects/protocol",
+    ],
+)
+
+zoneless_web_test_suite(
+    name = "test",
+    deps = [
+        ":transfer_state_test",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.html
@@ -11,58 +11,86 @@
       <mat-icon class="spinning">hourglass_empty</mat-icon>
       Loading transfer state...
     </div>
-  } @else if (error()) {
-    <div class="error-card">
-      <div class="card-header">
-        <mat-icon>error</mat-icon>
-        <h3>No Transfer State Found</h3>
-      </div>
-      <div class="card-content">
-        <p>{{ error() }}</p>
-        <p>
-          Transfer state is used in Server-Side Rendering (SSR) to pass data from the server to the
-          client. If you're expecting transfer state data, make sure:
-        </p>
-        <ul>
-          <li>The application is using SSR</li>
-          <li>Transfer state is being used in your components</li>
-          <li>You're inspecting the initial page load (not after client-side navigation)</li>
-        </ul>
-      </div>
-    </div>
   } @else if (!hasData()) {
-    <div class="empty-card">
-      <div class="card-header">
-        <mat-icon>info</mat-icon>
-        <h3>Transfer State is Empty</h3>
-      </div>
-      <div class="card-content">
-        <p>No transfer state data found on this page.</p>
-        <p>This could be normal if the page doesn't use SSR or doesn't transfer any state.</p>
-      </div>
+    <div class="info-card">
+      <mat-icon class="info-icon">swap_horiz</mat-icon>
+      <h3>This app isn't using Transfer State</h3>
+      <p>
+        Transfer State carries data from the server to the client during Server-Side Rendering
+        (SSR), so a hydrated app doesn't have to re-fetch it.
+      </p>
+      <p>
+        Use the <code>TransferState</code> service on the server to set values that should be
+        available on the client during hydration. Any registered values will appear here.
+      </p>
+      <p>
+        <a
+          class="info-link"
+          href="https://angular.dev/api/core/TransferState"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Read the <code>TransferState</code> API docs
+          <mat-icon class="info-link-icon">open_in_new</mat-icon>
+        </a>
+      </p>
+      @if (error()) {
+        <p class="status-note">{{ error() }}</p>
+      }
     </div>
   } @else {
     <div class="transfer-state-content">
-      <div class="summary">
-        <div class="summary-card">
-          <div class="summary-stats">
-            <div class="stat">
-              <span class="stat-value">{{ transferStateItems().length }}</span>
-              <span class="stat-label">Keys</span>
-            </div>
-            <div class="stat">
-              <span class="stat-value">{{ totalSize() }}</span>
-              <span class="stat-label">Total Size</span>
-            </div>
+      <div class="toolbar">
+        <div class="summary-stats">
+          <div class="stat">
+            <span class="stat-value">{{ visibleItems().length }}</span>
+            <span class="stat-label">
+              @if (visibleItems().length !== transferStateItems().length) {
+                of {{ transferStateItems().length }}
+              }
+              Keys
+            </span>
           </div>
+          <div class="stat">
+            <span class="stat-value">{{ visibleSize() }}</span>
+            <span class="stat-label">Size</span>
+          </div>
+        </div>
+        <div class="filter">
+          <input
+            type="text"
+            class="ng-input filter-input"
+            placeholder="Filter keys"
+            [ngModel]="filterText()"
+            (ngModelChange)="filterText.set($event)"
+            aria-label="Filter keys"
+          />
+          @if (filterText()) {
+            <button
+              ng-button
+              btnType="icon"
+              class="filter-clear"
+              (click)="clearFilter()"
+              matTooltip="Clear filter"
+              aria-label="Clear filter"
+            >
+              <mat-icon>close</mat-icon>
+            </button>
+          }
         </div>
       </div>
 
       <div class="table-container">
-        <table mat-table [dataSource]="transferStateItems()" class="transfer-state-table">
+        <table
+          mat-table
+          matSort
+          (matSortChange)="onSortChange($event)"
+          [dataSource]="visibleItems()"
+          class="transfer-state-table"
+        >
           <!-- Key Column -->
           <ng-container matColumnDef="key">
-            <th mat-header-cell *matHeaderCellDef>Key</th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Key</th>
             <td mat-cell *matCellDef="let item" class="key-cell">
               <code>{{ item.key }}</code>
             </td>
@@ -70,7 +98,7 @@
 
           <!-- Type Column -->
           <ng-container matColumnDef="type">
-            <th mat-header-cell *matHeaderCellDef>Type</th>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Type</th>
             <td mat-cell *matCellDef="let item">
               <span class="type-badge type-{{ item.type }}">{{ item.type }}</span>
             </td>
@@ -78,7 +106,7 @@
 
           <!-- Size Column -->
           <ng-container matColumnDef="size">
-            <th mat-header-cell *matHeaderCellDef>
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>
               Size
               <mat-icon class="info-icon" matTooltip="Uncompressed size">help_outline</mat-icon>
             </th>
@@ -90,35 +118,22 @@
             <th mat-header-cell *matHeaderCellDef>Value</th>
             <td mat-cell *matCellDef="let item" class="value-cell">
               <div class="value-container">
-                <pre
-                  #valuePreview
-                  class="value-preview"
-                  [class.is-expanded]="item.isExpanded"
-                ><code>{{ getFormattedValue(item.value) }}</code></pre>
-                <div class="action-buttons">
-                  @if (isValueLong(valuePreview, item.isExpanded)) {
-                    <button
-                      ng-button
-                      btnType="icon"
-                      size="compact"
-                      class="expand-button"
-                      (click)="toggleExpanded(item)"
-                      [matTooltip]="item.isExpanded ? 'Collapse value' : 'Expand value'"
-                    >
-                      <mat-icon>{{ item.isExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
-                    </button>
-                  }
-                  <button
-                    ng-button
-                    btnType="icon"
-                    size="compact"
-                    class="copy-button"
-                    (click)="copyToClipboard(item)"
-                    [matTooltip]="item.isCopied ? 'Copied!' : 'Copy value to clipboard'"
-                  >
-                    <mat-icon>{{ item.isCopied ? 'check' : 'content_copy' }}</mat-icon>
-                  </button>
-                </div>
+                <ng-object-tree-explorer
+                  class="value-tree"
+                  [dataSource]="item.tree"
+                  [childrenAccessor]="treeChildrenAccessor"
+                  [omitRootNodesNames]="true"
+                />
+                <button
+                  ng-button
+                  btnType="icon"
+                  size="compact"
+                  class="copy-button"
+                  (click)="copyToClipboard(item)"
+                  [matTooltip]="item.isCopied ? 'Copied!' : 'Copy value to clipboard'"
+                >
+                  <mat-icon>{{ item.isCopied ? 'check' : 'content_copy' }}</mat-icon>
+                </button>
               </div>
             </td>
           </ng-container>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.scss
@@ -4,6 +4,8 @@
   padding: 1rem;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
 
   .header {
     display: flex;
@@ -42,71 +44,97 @@
     }
   }
 
-  .error-card,
-  .empty-card {
-    max-width: 37.5rem;
-    margin: 0 auto;
+  .info-card {
+    max-width: 32rem;
+    margin: 2rem auto 0;
+    padding: 1.5rem;
     background: var(--color-foreground);
     border: 1px solid var(--color-separator);
-    border-radius: 0.25rem;
-    padding: 1rem;
+    border-radius: 0.5rem;
+    text-align: center;
 
-    .card-header {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      margin-bottom: 1rem;
+    .info-icon {
+      font-size: 2rem;
+      width: 2rem;
+      height: 2rem;
+      color: var(--secondary-contrast);
+      margin-bottom: 0.5rem;
+    }
 
-      h3 {
-        @extend %heading-500;
-        margin: 0;
-        padding: 0;
+    h3 {
+      @extend %heading-500;
+      margin: 0 0 0.75rem;
+      padding: 0;
+    }
+
+    p {
+      @extend %body-01;
+      margin: 0.5rem 0;
+      color: var(--secondary-contrast);
+
+      code {
+        @extend %monospaced;
+        background: var(--color-background);
+        padding: 0.0625rem 0.25rem;
+        border-radius: 0.1875rem;
+        border: 1px solid var(--color-separator);
+        color: var(--color-text);
       }
     }
 
-    .card-content {
-      @extend %body-01;
+    .info-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      color: var(--dynamic-blue-02);
+      text-decoration: none;
 
-      ul {
-        margin: 0.5rem 0;
-        padding-left: 1.25rem;
-
-        li {
-          margin: 0.25rem 0;
-        }
+      &:hover {
+        text-decoration: underline;
       }
+
+      .info-link-icon {
+        font-size: 1rem;
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+
+    .status-note {
+      margin-top: 1rem;
+      padding-top: 0.75rem;
+      border-top: 1px solid var(--color-separator);
+      @extend %caption-text;
+      color: var(--tertiary-contrast);
     }
   }
 
   .transfer-state-content {
-    flex: 0 1 auto;
+    flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: visible;
 
-    .summary {
-      margin-bottom: 1rem;
+    .toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.75rem;
       flex-shrink: 0;
-
-      .summary-card {
-        background: var(--color-foreground);
-        border: 1px solid var(--color-separator);
-        border-radius: 0.25rem;
-        padding: 0.75rem 1rem;
-      }
+      flex-wrap: wrap;
 
       .summary-stats {
         display: flex;
-        gap: 2rem;
+        gap: 1.5rem;
 
         .stat {
           display: flex;
-          flex-direction: column;
-          align-items: center;
-          gap: 0.25rem;
+          align-items: baseline;
+          gap: 0.375rem;
 
           .stat-value {
-            @extend %heading-500;
+            @extend %body-bold-01;
             padding: 0;
             margin: 0;
             color: var(--dynamic-blue-02);
@@ -120,13 +148,26 @@
           }
         }
       }
+
+      .filter {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        min-width: 12rem;
+        flex: 1;
+        max-width: 20rem;
+
+        .filter-input {
+          flex: 1;
+        }
+      }
     }
 
     .table-container {
-      flex: 0 1 auto;
+      flex: 1;
+      min-height: 0;
       border: 1px solid var(--color-separator);
       border-radius: 0.25rem;
-      max-height: 70vh;
       overflow-y: auto;
 
       .transfer-state-table {
@@ -177,65 +218,31 @@
 
         .value-cell {
           min-width: 12.5rem;
-          max-width: 31.25rem;
+          width: 100%;
 
           .value-container {
-            position: relative;
             display: flex;
             align-items: flex-start;
             gap: 0.5rem;
 
-            .value-preview {
-              @extend %monospaced;
+            .value-tree {
               flex: 1;
-              margin: 0;
-              background: var(--color-foreground);
-              border: 1px solid var(--color-foreground);
-              border-radius: 0.1875rem;
-              overflow-x: auto;
-              white-space: pre-wrap;
-              word-break: break-word;
-              color: var(--color-text);
-              display: -webkit-box;
-              -webkit-line-clamp: 5;
-              -webkit-box-orient: vertical;
-              padding: 0.25rem;
-
-              &.is-expanded {
-                -webkit-line-clamp: unset;
-                overflow-x: auto;
-              }
+              min-width: 0;
+              --ote-padding: 0;
             }
 
-            .action-buttons {
-              display: flex;
-              flex-direction: column;
-              gap: 0.125rem;
+            .copy-button {
               flex-shrink: 0;
-              margin-top: 0.25rem;
+              min-width: 1.5rem;
+              width: 1.5rem;
+              height: 1.5rem;
+              padding: 0;
+              margin-top: 0.125rem;
 
-              .expand-button,
-              .copy-button {
-                min-width: 1.5rem;
-                width: 1.5rem;
-                height: 1.5rem;
-                padding: 0;
-
-                mat-icon {
-                  font-size: 0.875rem;
-                  width: 0.875rem;
-                  height: 0.875rem;
-                }
-              }
-
-              .copy-button {
-                &.mat-icon-button {
-                  transition: all 0.2s ease;
-                }
-
-                &:has(mat-icon[data-copied='true']) {
-                  color: var(--dynamic-green-01);
-                }
+              mat-icon {
+                font-size: 0.875rem;
+                width: 0.875rem;
+                height: 0.875rem;
               }
             }
           }
@@ -249,37 +256,32 @@
           font-weight: 500;
           text-transform: uppercase;
           letter-spacing: 0.03rem;
-          color: black;
-          border: 1px solid;
+          background: transparent;
+          border: 1px solid currentColor;
 
           &.type-string {
-            background: var(--green-03);
-            border-color: var(--green-02);
+            color: var(--dynamic-green-01);
           }
 
           &.type-number {
-            background: var(--purple-03);
-            border-color: var(--purple-02);
+            color: var(--dynamic-purple-01);
           }
 
           &.type-boolean {
-            background: var(--red-06);
-            border-color: var(--red-05);
+            color: var(--dynamic-red-01);
           }
 
           &.type-object {
-            background: var(--blue-03);
-            border-color: var(--blue-02);
+            color: var(--dynamic-blue-02);
           }
 
           &.type-array {
-            background: var(--green-03);
-            border-color: var(--green-02);
+            color: var(--dynamic-orange-01);
           }
 
-          &.type-null {
-            background: white;
-            border-color: var(--quaternary-contrast);
+          &.type-null,
+          &.type-undefined {
+            color: var(--quaternary-contrast);
           }
         }
       }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {Clipboard} from '@angular/cdk/clipboard';
+
+import {Events, MessageBus, TransferStateValue} from '../../../../../protocol';
+import {LOADING_TIMEOUT, TransferStateComponent} from './transfer-state.component';
+
+type DataCallback = (data: Record<string, TransferStateValue> | null) => void;
+
+class MessageBusMock implements Pick<MessageBus<Events>, 'on' | 'emit' | 'once' | 'destroy'> {
+  readonly emit = jasmine.createSpy('emit');
+  readonly once = jasmine.createSpy('once');
+  readonly destroy = jasmine.createSpy('destroy');
+  private listeners = new Map<keyof Events, Set<Function>>();
+
+  on = jasmine.createSpy('on').and.callFake((topic: keyof Events, cb: Function) => {
+    if (!this.listeners.has(topic)) this.listeners.set(topic, new Set());
+    this.listeners.get(topic)!.add(cb);
+    return () => this.listeners.get(topic)!.delete(cb);
+  });
+
+  emitToListener(topic: keyof Events, ...args: unknown[]): void {
+    this.listeners.get(topic)?.forEach((cb) => cb(...args));
+  }
+
+  hasListener(topic: keyof Events): boolean {
+    return (this.listeners.get(topic)?.size ?? 0) > 0;
+  }
+}
+
+describe('TransferStateComponent', () => {
+  let messageBus: MessageBusMock;
+  let clipboardSpy: jasmine.SpyObj<Clipboard>;
+  let fixture: ComponentFixture<TransferStateComponent>;
+  let component: TransferStateComponent;
+  let timeoutCallback: Function | null;
+  let originalSetTimeout: typeof window.setTimeout;
+
+  async function createComponent(): Promise<void> {
+    fixture = TestBed.createComponent(TransferStateComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  }
+
+  async function emitData(data: Record<string, TransferStateValue> | null): Promise<void> {
+    messageBus.emitToListener('transferStateData', data);
+    await fixture.whenStable();
+  }
+
+  beforeEach(() => {
+    messageBus = new MessageBusMock();
+    clipboardSpy = jasmine.createSpyObj<Clipboard>('Clipboard', ['copy']);
+
+    timeoutCallback = null;
+    originalSetTimeout = window.setTimeout;
+    spyOn(window, 'setTimeout').and.callFake(((fn: Function, ms?: number) => {
+      // Only capture the component's loading timeout; let other setTimeouts pass through.
+      if (ms === LOADING_TIMEOUT) {
+        timeoutCallback = fn;
+        return 0;
+      }
+      return originalSetTimeout(fn as () => void, ms);
+    }) as typeof window.setTimeout);
+
+    TestBed.configureTestingModule({
+      imports: [TransferStateComponent],
+      providers: [
+        {provide: MessageBus, useValue: messageBus},
+        {provide: Clipboard, useValue: clipboardSpy},
+      ],
+    });
+  });
+
+  afterEach(() => {
+    window.setTimeout = originalSetTimeout;
+  });
+
+  it('creates the component and emits getTransferState on init', async () => {
+    await createComponent();
+    expect(component).toBeTruthy();
+    expect(messageBus.emit).toHaveBeenCalledWith('getTransferState');
+    expect(messageBus.hasListener('transferStateData')).toBe(true);
+  });
+
+  it('starts in the loading state until data arrives', async () => {
+    await createComponent();
+    expect(component.isLoading()).toBe(true);
+    await emitData({});
+    expect(component.isLoading()).toBe(false);
+  });
+
+  it('treats backend null as empty (educational state)', async () => {
+    await createComponent();
+    await emitData(null);
+    expect(component.isLoading()).toBe(false);
+    expect(component.hasData()).toBe(false);
+    expect(component.transferStateData()).toEqual({});
+  });
+
+  it('renders the table when data has entries', async () => {
+    await createComponent();
+    await emitData({greeting: 'hello', count: 3});
+    expect(component.hasData()).toBe(true);
+    expect(component.transferStateItems().length).toBe(2);
+  });
+
+  it('computes UTF-8 byte size of the serialized entry', async () => {
+    await createComponent();
+    await emitData({greeting: 'héllo'});
+    const item = component.transferStateItems()[0];
+    expect(item.bytes).toBe(19);
+    expect(item.size).toBe('19 B');
+  });
+
+  it('reports a non-zero size for undefined values', async () => {
+    await createComponent();
+    await emitData({thing: undefined});
+    const item = component.transferStateItems()[0];
+    expect(item.bytes).toBe(17);
+    expect(item.size).toBe('17 B');
+  });
+
+  it('does not crash on circular references and reports — for size', async () => {
+    await createComponent();
+    const circular: Record<string, unknown> = {name: 'loop'};
+    circular['self'] = circular;
+    await expectAsync(emitData({circ: circular})).not.toBeRejected();
+    const item = component.transferStateItems()[0];
+    expect(item.bytes).toBeNull();
+    expect(item.size).toBe('—');
+  });
+
+  it('filters items by key (case-insensitive substring)', async () => {
+    await createComponent();
+    await emitData({apple: 1, banana: 2, BANANA_PEEL: 3, cherry: 4});
+    component.filterText.set('banana');
+    expect(component.visibleItems().map((i) => i.key)).toEqual(['banana', 'BANANA_PEEL']);
+  });
+
+  it('sorts by raw bytes when sorting size column ascending', async () => {
+    await createComponent();
+    await emitData({large: 'xxxxxxxxxx', small: 'x', medium: 'xxxxx'});
+    component.onSortChange({active: 'size', direction: 'asc'});
+    expect(component.visibleItems().map((i) => i.key)).toEqual(['small', 'medium', 'large']);
+  });
+
+  it('sorts by key alphabetically when sorting key column ascending', async () => {
+    await createComponent();
+    await emitData({beta: 1, alpha: 2, gamma: 3});
+    component.onSortChange({active: 'key', direction: 'asc'});
+    expect(component.visibleItems().map((i) => i.key)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('reverses sort direction when descending', async () => {
+    await createComponent();
+    await emitData({beta: 1, alpha: 2, gamma: 3});
+    component.onSortChange({active: 'key', direction: 'desc'});
+    expect(component.visibleItems().map((i) => i.key)).toEqual(['gamma', 'beta', 'alpha']);
+  });
+
+  it('copies the value to clipboard when copyToClipboard is invoked', async () => {
+    await createComponent();
+    await emitData({greeting: 'hello'});
+    const item = component.transferStateItems()[0];
+    component.copyToClipboard(item);
+    expect(clipboardSpy.copy).toHaveBeenCalledWith('hello');
+    expect(component.transferStateItems()[0].isCopied).toBe(true);
+  });
+
+  it('copies non-strings as JSON', async () => {
+    await createComponent();
+    await emitData({user: {name: 'Alex'}});
+    component.copyToClipboard(component.transferStateItems()[0]);
+    const arg = clipboardSpy.copy.calls.mostRecent().args[0];
+    expect(arg).toContain('"name"');
+    expect(arg).toContain('"Alex"');
+  });
+
+  it('sets a timeout error if the backend never responds', async () => {
+    await createComponent();
+    expect(component.isLoading()).toBe(true);
+    expect(timeoutCallback).withContext('expected loading timeout to be scheduled').toBeTruthy();
+    timeoutCallback!();
+    await fixture.whenStable();
+    expect(component.isLoading()).toBe(false);
+    expect(component.error()).toContain('did not respond');
+  });
+
+  it('unsubscribes from the message bus on destroy', async () => {
+    await createComponent();
+    expect(messageBus.hasListener('transferStateData')).toBe(true);
+    fixture.destroy();
+    expect(messageBus.hasListener('transferStateData')).toBe(false);
+  });
+
+  it('clears the filter when clearFilter is invoked', async () => {
+    await createComponent();
+    component.filterText.set('hello');
+    component.clearFilter();
+    expect(component.filterText()).toBe('');
+  });
+});

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/transfer-state.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, inject, signal, computed, linkedSignal} from '@angular/core';
+import {Component, DestroyRef, inject, signal, computed, linkedSignal} from '@angular/core';
 import {Clipboard} from '@angular/cdk/clipboard';
 import {MatIcon} from '@angular/material/icon';
 import {MatTooltip} from '@angular/material/tooltip';
@@ -22,22 +22,46 @@ import {
   MatHeaderRowDef,
   MatRowDef,
 } from '@angular/material/table';
+import {MatSort, MatSortHeader, Sort} from '@angular/material/sort';
+import {FormsModule} from '@angular/forms';
 import {ButtonComponent} from '../../shared/button/button.component';
 import {Events, MessageBus, TransferStateValue} from '../../../../../protocol';
-import {formatBytes, getFormattedValue} from '../../shared/utils/formatting';
+import {formatBytes} from '../../shared/utils/formatting';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
+import {ObjectTreeExplorerComponent} from '../../shared/object-tree-explorer/object-tree-explorer.component';
+import {FlatNode} from '../../shared/object-tree-explorer/object-tree-types';
+import {buildValueTree} from './value-tree-builder';
 
 interface TransferStateItem {
   key: string;
   value: TransferStateValue;
+  tree: FlatNode[];
   type: string;
   size: string;
-  isExpanded?: boolean;
+  bytes: number | null;
   isCopied?: boolean;
 }
 
-export const LINE_CLAMP_LIMIT = 5;
 export const COPY_FEEDBACK_TIMEOUT = 2000;
+export const LOADING_TIMEOUT = 5000;
+
+// Per-entry bytes are measured as `"key":value` so summing them across the
+// table approximates the total transferred payload.
+function getByteSize(key: string, value: TransferStateValue): number | null {
+  let valueRepr: string;
+  if (value === undefined) {
+    valueRepr = 'undefined';
+  } else {
+    try {
+      const serialized = JSON.stringify(value);
+      if (serialized === undefined) return null;
+      valueRepr = serialized;
+    } catch {
+      return null;
+    }
+  }
+  return new Blob([`${JSON.stringify(key)}:${valueRepr}`]).size;
+}
 
 @Component({
   selector: 'ng-transfer-state',
@@ -54,8 +78,12 @@ export const COPY_FEEDBACK_TIMEOUT = 2000;
     MatCellDef,
     MatHeaderRowDef,
     MatRowDef,
+    MatSort,
+    MatSortHeader,
+    FormsModule,
     ButtonComponent,
     MatSnackBarModule,
+    ObjectTreeExplorerComponent,
   ],
   templateUrl: './transfer-state.component.html',
   styleUrls: ['./transfer-state.component.scss'],
@@ -67,42 +95,108 @@ export class TransferStateComponent {
 
   readonly transferStateData = signal<Record<string, TransferStateValue> | null>(null);
   readonly error = signal<string | null>(null);
-  readonly isLoading = computed(() => !this.transferStateData() && !this.error());
+  readonly isLoading = computed(() => this.transferStateData() === null);
 
   readonly transferStateItems = linkedSignal<TransferStateItem[]>(() => {
     const data = this.transferStateData();
     if (!data) return [];
 
-    return Object.entries(data).map(([key, value]) => ({
-      key,
-      value,
-      type: this.getValueType(value),
-      size: this.getValueSize(value),
-      isExpanded: false,
-      isCopied: false,
-    }));
+    return Object.entries(data).map(([key, value]) => {
+      const bytes = getByteSize(key, value);
+      return {
+        key,
+        value,
+        tree: buildValueTree(value),
+        type: this.getValueType(value),
+        size: bytes === null ? '—' : formatBytes(bytes),
+        bytes,
+        isCopied: false,
+      };
+    });
   });
 
   readonly hasData = computed(() => this.transferStateItems().length > 0);
-  readonly getFormattedValue = getFormattedValue;
 
-  readonly totalSize = computed(() => {
+  readonly filterText = signal('');
+  readonly sortState = signal<Sort>({active: '', direction: ''});
+
+  readonly visibleItems = computed<TransferStateItem[]>(() => {
     const items = this.transferStateItems();
-    if (items.length === 0) return '0 B';
+    const filter = this.filterText().trim().toLowerCase();
+    const filtered = filter
+      ? items.filter((item) => item.key.toLowerCase().includes(filter))
+      : items;
 
-    let totalBytes = 0;
-    for (const item of items) {
-      const str = typeof item.value === 'string' ? item.value : JSON.stringify(item.value);
-      totalBytes += new Blob([str]).size;
+    const {active, direction} = this.sortState();
+    if (!direction) {
+      return filtered;
     }
 
+    const sign = direction === 'asc' ? 1 : -1;
+    const compare = (a: TransferStateItem, b: TransferStateItem): number => {
+      switch (active) {
+        case 'key':
+          return sign * a.key.localeCompare(b.key);
+        case 'type':
+          return sign * a.type.localeCompare(b.type);
+        case 'size': {
+          const av = a.bytes ?? -1;
+          const bv = b.bytes ?? -1;
+          return sign * (av - bv);
+        }
+        default:
+          return 0;
+      }
+    };
+    return [...filtered].sort(compare);
+  });
+
+  readonly visibleSize = computed(() => {
+    const items = this.visibleItems();
+    if (items.length === 0) return '0 B';
+    let totalBytes = 0;
+    for (const item of items) {
+      if (item.bytes !== null) {
+        totalBytes += item.bytes;
+      }
+    }
     return formatBytes(totalBytes);
   });
 
   displayedColumns: string[] = ['key', 'type', 'size', 'value'];
 
+  readonly treeChildrenAccessor = (node: FlatNode): FlatNode[] => node.prop.descriptor.value;
+
+  private loadingTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  private readonly copyTimeoutIds = new Set<ReturnType<typeof setTimeout>>();
+
   constructor() {
-    this.loadTransferState();
+    const destroyRef = inject(DestroyRef);
+
+    const off = this.messageBus.on(
+      'transferStateData',
+      (data: Record<string, TransferStateValue> | null) => {
+        this.clearLoadingTimeout();
+        this.transferStateData.set(data ?? {});
+      },
+    );
+
+    destroyRef.onDestroy(() => {
+      off();
+      this.clearLoadingTimeout();
+      this.copyTimeoutIds.forEach(clearTimeout);
+      this.copyTimeoutIds.clear();
+    });
+
+    this.startLoadingTimeout();
+
+    try {
+      this.messageBus.emit('getTransferState');
+    } catch (err) {
+      this.clearLoadingTimeout();
+      this.transferStateData.set({});
+      this.error.set(`Error loading transfer state: ${err}`);
+    }
   }
 
   private getValueType(value: TransferStateValue): string {
@@ -111,41 +205,30 @@ export class TransferStateComponent {
     return typeof value;
   }
 
-  getValueSize(value: TransferStateValue): string {
-    const str = JSON.stringify(value);
-    const bytes = new Blob([str]).size;
-    return formatBytes(bytes);
+  onSortChange(sort: Sort): void {
+    this.sortState.set(sort);
   }
 
-  private loadTransferState(): void {
-    this.transferStateData.set(null);
-    this.error.set(null);
+  clearFilter(): void {
+    this.filterText.set('');
+  }
 
-    try {
-      this.messageBus.emit('getTransferState');
-      this.messageBus.on('transferStateData', (data: Record<string, TransferStateValue> | null) => {
-        this.transferStateData.set(data);
-        if (!data) {
-          this.error.set(
-            'No transfer state found. Make sure you are inspecting a page with Server-Side Rendering (SSR) enabled.',
-          );
-        }
-      });
-    } catch (err) {
-      this.error.set(`Error loading transfer state: ${err}`);
+  private startLoadingTimeout(): void {
+    this.clearLoadingTimeout();
+    this.loadingTimeoutId = setTimeout(() => {
+      this.loadingTimeoutId = undefined;
+      if (this.isLoading()) {
+        this.transferStateData.set({});
+        this.error.set('The DevTools backend did not respond. Try reopening DevTools.');
+      }
+    }, LOADING_TIMEOUT);
+  }
+
+  private clearLoadingTimeout(): void {
+    if (this.loadingTimeoutId !== undefined) {
+      clearTimeout(this.loadingTimeoutId);
+      this.loadingTimeoutId = undefined;
     }
-  }
-
-  isValueLong(element: HTMLElement, isExpanded: boolean = false): boolean {
-    if (isExpanded) return true;
-
-    return element.scrollHeight > element.clientHeight;
-  }
-
-  toggleExpanded(item: TransferStateItem): void {
-    this.transferStateItems.update((items) =>
-      items.map((i) => (i.key === item.key ? {...i, isExpanded: !i.isExpanded} : i)),
-    );
   }
 
   copyToClipboard(item: TransferStateItem): void {
@@ -159,11 +242,13 @@ export class TransferStateComponent {
         items.map((i) => (i.key === item.key ? {...i, isCopied: true} : i)),
       );
 
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
+        this.copyTimeoutIds.delete(timeoutId);
         this.transferStateItems.update((items) =>
           items.map((i) => (i.key === item.key ? {...i, isCopied: false} : i)),
         );
       }, COPY_FEEDBACK_TIMEOUT);
+      this.copyTimeoutIds.add(timeoutId);
     } catch (err) {
       const message = 'Failed to copy to clipboard';
       const errorDetail =

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/value-tree-builder.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/transfer-state/value-tree-builder.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {PropType, TransferStateValue} from '../../../../../protocol';
+import {FlatNode} from '../../shared/object-tree-explorer/object-tree-types';
+
+const ROOT_NAME = '_root';
+const CIRCULAR_PREVIEW = '[Circular]';
+
+export function buildValueTree(value: TransferStateValue): FlatNode[] {
+  return [createNode(ROOT_NAME, value, 0, new WeakSet())];
+}
+
+function createNode(name: string, value: unknown, level: number, seen: WeakSet<object>): FlatNode {
+  const isObj = value !== null && typeof value === 'object';
+  const circular = isObj && seen.has(value as object);
+  const expandable = isObj && !circular;
+
+  let children: FlatNode[] = [];
+  if (expandable) {
+    seen.add(value as object);
+    children = buildChildren(value as object, level + 1, seen);
+  }
+
+  return {
+    expandable,
+    level,
+    prop: {
+      name,
+      parent: null,
+      descriptor: {
+        preview: circular ? CIRCULAR_PREVIEW : getValuePreview(value),
+        value: children,
+        expandable,
+        editable: false,
+        containerType: null,
+        type: getPropType(value),
+      },
+    },
+  };
+}
+
+function buildChildren(value: object, level: number, seen: WeakSet<object>): FlatNode[] {
+  if (Array.isArray(value)) {
+    return value.map((item, i) => createNode(String(i), item, level, seen));
+  }
+  return Object.entries(value as Record<string, unknown>).map(([k, v]) =>
+    createNode(k, v, level, seen),
+  );
+}
+
+function getValuePreview(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return `Array(${value.length})`;
+  switch (typeof value) {
+    case 'string':
+      return `"${value}"`;
+    case 'bigint':
+      return `${value}n`;
+    case 'object':
+      return '{...}';
+    default:
+      return String(value);
+  }
+}
+
+function getPropType(value: unknown): PropType {
+  if (value === null) return PropType.Null;
+  if (value === undefined) return PropType.Undefined;
+  if (Array.isArray(value)) return PropType.Array;
+  switch (typeof value) {
+    case 'string':
+      return PropType.String;
+    case 'number':
+      return PropType.Number;
+    case 'boolean':
+      return PropType.Boolean;
+    case 'bigint':
+      return PropType.BigInt;
+    case 'symbol':
+      return PropType.Symbol;
+    case 'object':
+      return PropType.Object;
+    default:
+      return PropType.Unknown;
+  }
+}

--- a/devtools/src/app/transfer-state.ts
+++ b/devtools/src/app/transfer-state.ts
@@ -19,16 +19,121 @@ export async function serializeTransferState(): Promise<void> {
   const httpClient = inject(HttpClient);
 
   // Object
-  const Objkey = makeStateKey<any>('obj');
-  transferState.set(Objkey, {
+  transferState.set(makeStateKey<any>('obj'), {
     appName: 'DevTools',
     appVersion: '0.0.1',
     appDescription: 'Angular DevTools',
   });
 
-  // Array
-  const arraykey = makeStateKey<any>('arr');
-  transferState.set(arraykey, [1, 2, 3, 4, 5]);
+  // Array of primitives
+  transferState.set(makeStateKey<any>('arr'), [1, 2, 3, 4, 5]);
+
+  // Primitives — exercise each badge color and primitive renderer
+  transferState.set(makeStateKey<any>('flag'), true);
+  transferState.set(makeStateKey<any>('count'), 42);
+  transferState.set(makeStateKey<any>('largeNumber'), 1234567890);
+  transferState.set(makeStateKey<any>('greeting'), 'Hello, world!');
+  transferState.set(makeStateKey<any>('nothing'), null);
+
+  // Empty containers — exercise "{}" / "[]" preview
+  transferState.set(makeStateKey<any>('emptyObj'), {});
+  transferState.set(makeStateKey<any>('emptyArr'), []);
+
+  // Unicode — exercises UTF-8 byte size (multi-byte characters)
+  transferState.set(makeStateKey<any>('unicode'), '안녕하세요 🅰️ Angular ✨');
+
+  // Long string — exercises wrapping and size (~500 B → kilobyte threshold nearby)
+  transferState.set(
+    makeStateKey<any>('longString'),
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+      'Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ' +
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ' +
+      'ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit ' +
+      'esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non ' +
+      'proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  );
+
+  // Mixed array — primitives, null, and a nested object
+  transferState.set(makeStateKey<any>('mixedArr'), [1, 'two', true, null, {three: 3}, [4, 5, 6]]);
+
+  // Deeply nested object — exercises tree expansion levels
+  transferState.set(makeStateKey<any>('deepNested'), {
+    level1: {
+      level2: {
+        level3: {
+          level4: {
+            level5: {
+              message: 'You found me!',
+              path: ['level1', 'level2', 'level3', 'level4', 'level5'],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  // Realistic API response — paginated list of objects, ~1.5 KB
+  transferState.set(makeStateKey<any>('articles'), {
+    page: 1,
+    pageSize: 5,
+    total: 47,
+    items: [
+      {
+        id: 'a1',
+        title: 'Introducing Signals in Angular',
+        author: 'Alex',
+        published: '2024-02-12',
+        tags: ['angular', 'reactivity', 'signals'],
+        readTime: 8,
+      },
+      {
+        id: 'a2',
+        title: 'Server-Side Rendering Deep Dive',
+        author: 'Jordan',
+        published: '2024-03-04',
+        tags: ['ssr', 'hydration'],
+        readTime: 12,
+      },
+      {
+        id: 'a3',
+        title: 'Migrating to Standalone Components',
+        author: 'Riley',
+        published: '2024-04-19',
+        tags: ['migration', 'standalone'],
+        readTime: 6,
+      },
+      {
+        id: 'a4',
+        title: 'The New Control Flow Syntax',
+        author: 'Sam',
+        published: '2024-05-01',
+        tags: ['template-syntax', 'control-flow'],
+        readTime: 5,
+      },
+      {
+        id: 'a5',
+        title: 'Building Production-Grade Forms',
+        author: 'Casey',
+        published: '2024-05-22',
+        tags: ['forms', 'validation', 'a11y'],
+        readTime: 14,
+      },
+    ],
+  });
+
+  // Object with many keys — exercises long-list rendering
+  transferState.set(
+    makeStateKey<any>('featureFlags'),
+    Object.fromEntries(
+      Array.from({length: 24}, (_, i) => [`feature_${String(i).padStart(2, '0')}`, i % 3 === 0]),
+    ),
+  );
+
+  // Large array — exercises long-list rendering and Array(N) preview
+  transferState.set(
+    makeStateKey<any>('numbers'),
+    Array.from({length: 50}, (_, i) => i * i),
+  );
 
   // Serialized of the TransferState into the DOM.
   const content = transferState.toJson();
@@ -39,4 +144,11 @@ export async function serializeTransferState(): Promise<void> {
   script.setAttribute('type', 'application/json');
 
   doc.body.appendChild(script);
+
+  const root = doc.querySelector('app-root') as
+    | (Element & {__ngDebugHydrationInfo__?: unknown})
+    | null;
+  if (root) {
+    root.__ngDebugHydrationInfo__ = {};
+  }
 }


### PR DESCRIPTION
- promote to default-on (remove opt-in setting and gear-menu toggle)
- replace the `<pre>` value cell with a collapsible JSON tree
- add key filter and column sort (size sorts by raw bytes)
- show an educational empty state when the app has no transfer state
- iterate every root in the directive forest and merge their state
- guard size calculation against undefined and circular references
- register listener once with DestroyRef cleanup; add a loading timeout
- distinguish array/string badge colors via theme-aware tokens
- responsive value cell width; flex-based table scroll
- add a component spec; seed the harness fixture with more demo data


<img width="728" height="504" alt="Screenshot 2026-05-03 at 4 28 15 PM" src="https://github.com/user-attachments/assets/6e087058-60ee-4be9-a0ad-21ed4cb70114" />


<img width="724" height="723" alt="Screenshot 2026-05-03 at 4 29 15 PM" src="https://github.com/user-attachments/assets/84362829-96be-4731-8e05-46537274bcb9" />
