### PR TITLE
fix(docs-infra): prevent copy button from overlapping code

### DIFF
--- a/adev/shared-docs/components/copy-source-code-button/BUILD.bazel
+++ b/adev/shared-docs/components/copy-source-code-button/BUILD.bazel
@@ -16,6 +16,7 @@ ng_project(
         "//adev:node_modules/@angular/cdk",
         "//adev:node_modules/@angular/common",
         "//adev:node_modules/@angular/core",
+        "//adev:node_modules/@angular/material",
         "//adev/shared-docs/components/icon",
     ],
 )

--- a/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.ts
+++ b/adev/shared-docs/components/copy-source-code-button/copy-source-code-button.component.ts
@@ -15,6 +15,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
+import {MatTooltip} from '@angular/material/tooltip';
 import {IconComponent} from '../icon/icon.component';
 
 export const REMOVED_LINE_CLASS_NAME = '.line.remove';
@@ -24,10 +25,15 @@ export const CONFIRMATION_DISPLAY_TIME_MS = 2000;
   selector: 'button[docs-copy-source-code]',
   imports: [IconComponent],
   templateUrl: './copy-source-code-button.component.html',
+  hostDirectives: [
+    {
+      directive: MatTooltip,
+      inputs: ['matTooltip', 'matTooltipPosition'],
+    },
+  ],
   host: {
     'type': 'button',
     'aria-label': 'Copy example source to clipboard',
-    'title': 'Copy example source',
     '(click)': 'copySourceCode()',
     '[class.docs-copy-source-code-button-success]': 'showCopySuccess()',
     '[class.docs-copy-source-code-button-failed]': 'showCopyFailure()',
@@ -43,9 +49,10 @@ export class CopySourceCodeButton {
 
   copySourceCode(): void {
     try {
-      const codeElement = this.elementRef.nativeElement.parentElement.querySelector(
-        'code',
-      ) as HTMLElement;
+      const host =
+        this.elementRef.nativeElement.closest('.docs-code, .docs-example-viewer') ??
+        this.elementRef.nativeElement.parentElement;
+      const codeElement = host!.querySelector('code') as HTMLElement;
       const sourceCode = this.getSourceCode(codeElement);
       this.clipboard.copy(sourceCode);
       this.showResult(this.showCopySuccess);

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -181,6 +181,32 @@ describe('DocViewer', () => {
     expect(copySourceCodeButton).toBeTruthy();
   });
 
+  it('should mount copy source code button inside .docs-code-header when present', async () => {
+    const fixture = TestBed.createComponent(DocViewer);
+    fixture.componentRef.setInput(
+      'docContent',
+      `<div class="docs-code">
+        <div class="docs-code-header"><h3>file.ts</h3></div>
+        <code></code>
+      </div>`,
+    );
+
+    await fixture.whenStable();
+
+    const button = fixture.nativeElement.querySelector('button[docs-copy-source-code]');
+    expect(button.parentElement).toHaveClass('docs-code-header');
+  });
+
+  it('should mount copy source code button on .docs-code root when no header is present', async () => {
+    const fixture = TestBed.createComponent(DocViewer);
+    fixture.componentRef.setInput('docContent', `<div class="docs-code"><code></code></div>`);
+
+    await fixture.whenStable();
+
+    const button = fixture.nativeElement.querySelector('button[docs-copy-source-code]');
+    expect(button.parentElement).toHaveClass('docs-code');
+  });
+
   it('should render ToC', async () => {
     const fixture = TestBed.createComponent(DocViewer);
     const renderComponentSpy = spyOn(fixture.componentInstance, 'renderComponent' as any);

--- a/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/adev/shared-docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -264,8 +264,8 @@ export class DocViewer {
     };
   }
 
-  // If the content contains static code snippets, we should add buttons to copy
-  // the code
+  // Mount the copy button inside `.docs-code-header` when present so it doesn't
+  // overlap horizontally-scrollable code.
   private loadCopySourceCodeButtons(): void {
     const staticCodeSnippets = <Element[]>(
       Array.from(
@@ -277,7 +277,10 @@ export class DocViewer {
 
     for (let codeSnippet of staticCodeSnippets) {
       const copySourceCodeButton = this.viewContainer.createComponent(CopySourceCodeButton);
-      codeSnippet.appendChild(copySourceCodeButton.location.nativeElement);
+      copySourceCodeButton.setInput('matTooltip', 'Copy example source');
+      copySourceCodeButton.setInput('matTooltipPosition', 'above');
+      const header = codeSnippet.querySelector('.docs-code-header');
+      (header ?? codeSnippet).appendChild(copySourceCodeButton.location.nativeElement);
     }
   }
 

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.html
@@ -14,6 +14,13 @@
     }
 
     <div class="docs-example-viewer-icons">
+      @if (showCode()) {
+        <button
+          docs-copy-source-code
+          matTooltip="Copy example source"
+          matTooltipPosition="above"
+        ></button>
+      }
       <button
         type="button"
         role="switch"
@@ -100,7 +107,6 @@
 
   @if (showCode()) {
     <div class="docs-example-viewer-code-wrapper" [class.shell]="snippetCode()?.shell">
-      <button docs-copy-source-code></button>
       @if (snippetCode()?.sanitizedContent; as content) {
         <div class="docs-example-code-block" [innerHTML]="content"></div>
       }

--- a/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
+++ b/adev/shared-docs/components/viewers/example-viewer/example-viewer.component.scss
@@ -85,6 +85,19 @@
       }
     }
 
+    button[docs-copy-source-code] {
+      position: relative;
+      top: auto;
+      right: auto;
+      background: transparent;
+      border: 0;
+      padding: 0;
+
+      .docs-check {
+        top: 0;
+      }
+    }
+
     .docs-example-code-toggle {
       display: flex;
       align-items: center;
@@ -101,17 +114,12 @@
 
 // Example viewer code
 .docs-example-viewer-code-wrapper {
-  position: relative;
   font-size: 0.875rem;
   // TODO: only show this if there is a preview
   // border-block-end: 1px solid var(--senary-contrast);
   transition: border-color 0.3s ease;
   container: viewerblock / inline-size;
   background-color: var(--octonary-contrast);
-
-  button[docs-copy-source-code] {
-    top: 0.31rem;
-  }
 
   .docs-example-code-block {
     overflow: auto;

--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -238,7 +238,7 @@ $code-font-size: 0.875rem;
   button[docs-copy-source-code] {
     padding: 0.375rem 0.4rem 0.15rem 0.5rem;
     position: absolute;
-    top: 3.1rem;
+    top: 0.2rem;
     right: 0.2rem;
     border-radius: 0.25rem;
     cursor: pointer;
@@ -264,7 +264,7 @@ $code-font-size: 0.875rem;
       color: var(--primary-contrast);
       position: absolute;
       inset: 0;
-      top: 0.35rem;
+      top: 0.1rem;
       path {
         transition: fill 0.3s ease;
       }
@@ -308,11 +308,26 @@ $code-font-size: 0.875rem;
 
   .docs-code-header {
     display: flex;
+    align-items: center;
     padding: 0.75rem;
 
     background: var(--subtle-purple);
     border-radius: 0.25rem 0.25rem 0 0;
     transition: background 0.3s ease;
+
+    button[docs-copy-source-code] {
+      position: relative;
+      margin-inline-start: auto;
+      top: auto;
+      right: auto;
+      padding: 0;
+      background: transparent;
+      border: 0;
+
+      .docs-check {
+        top: 0;
+      }
+    }
 
     .docs-code-avoid &,
     .docs-code-prefer & {
@@ -352,14 +367,6 @@ $code-font-size: 0.875rem;
           content: 'dangerous';
         }
       }
-    }
-  }
-
-  // Single line docs-code elements, without headers, shell code
-  .docs-code:not(:has(.docs-code-header)) {
-    button[docs-copy-source-code] {
-      top: 0.2rem;
-      right: 0.2rem;
     }
   }
 


### PR DESCRIPTION
Mount the copy button inside `.docs-code-header` when present, and in the example viewer toolbar, so it no longer covers code on horizontally scrollable blocks.

fixes : #68534 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<img width="759" height="126" alt="image" src="https://github.com/user-attachments/assets/c5b6289a-70dc-4d3d-bb10-8c1ac5816e10" />

<img width="766" height="123" alt="image" src="https://github.com/user-attachments/assets/51cac761-c4b5-467a-8367-78f6bdfd59f5" />


## What is the new behavior?

<img width="821" height="193" alt="image" src="https://github.com/user-attachments/assets/aae6d53c-019b-49c1-814d-14e489a33dfe" />

<img width="849" height="91" alt="image" src="https://github.com/user-attachments/assets/53c7a857-4f91-4037-8a20-834e88deb5ec" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

