### PR TITLE
docs: add component method track example to @for block

### DIFF
--- a/tools/manual_api_docs/blocks/for.md
+++ b/tools/manual_api_docs/blocks/for.md
@@ -4,9 +4,9 @@ The `@for` block repeatedly renders content of a block for each item in a collec
 
 ```angular-html
 @for (item of items; track item.name) {
-<li>{{ item.name }}</li>
+  <li>{{ item.name }}</li>
 } @empty {
-<li>There are no items.</li>
+  <li>There are no items.</li>
 }
 ```
 
@@ -35,7 +35,7 @@ For collections that remain static , `track $index` provides a straightforward t
 collections experiencing additions, deletions, or reordering, opt for a
 unique property of each item as the tracking key.
 
-Track expressions can only reference `$index`, the item, and fields from the component class. If the `let` segment of the `@for` block introduced an alias for `$index`, that alias may also be referenced.
+Track expressions can only reference `$index`, the item, and properties and methods of the component class. If the `let` segment of the `@for` block introduced an alias for `$index`, that alias may also be referenced.
 
 ### `$index` and other contextual variables
 
@@ -54,7 +54,7 @@ These variables are always available with these names, but can be aliased via a 
 
 ```angular-html
 @for (item of items; track item.id; let idx = $index, e = $even) {
-Item #{{ idx }}: {{ item.name }}
+  Item #{{ idx }}: {{ item.name }}
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

The current documentation for `@for` states:

_Track expressions can only reference $index, the item, and fields from the component class._ 

This is perhaps a bit misleading, because a component method can also be invoked in the track expression.  This change introduces the following:
1) Change "fields" to "members"
2) Introduce a minimal example of a component method being invoked in the track expression
3) Small whitespace changes that appear to have been added via the commit hook

The `ngFor` documentation makes it clear that a method can be used

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
