### PR TITLE
refactor(language-service): add quick info for `$safeNavigationMigration`

### DIFF
--- a/packages/language-service/src/quick_info.ts
+++ b/packages/language-service/src/quick_info.ts
@@ -36,9 +36,11 @@ import ts from 'typescript';
 import {DisplayInfoKind, SYMBOL_PUNC, SYMBOL_SPACE, SYMBOL_TEXT} from './utils/display_parts';
 import {
   createDollarAnyQuickInfo,
+  createDollarSafeNavigationMigration,
   createNgTemplateQuickInfo,
   createQuickInfoForBuiltIn,
   isDollarAny,
+  isDollarSafeNavigationMigration,
 } from './quick_info_built_ins';
 import {TemplateTarget} from './template_target';
 import {
@@ -84,6 +86,18 @@ export class QuickInfoBuilder {
     // at the entire call in order to figure out if it's a call to `$any`.
     if (this.parent !== null && isDollarAny(this.parent) && this.parent.receiver === this.node) {
       return createDollarAnyQuickInfo(this.parent);
+    }
+
+    if (isDollarSafeNavigationMigration(this.node)) {
+      return createDollarSafeNavigationMigration(this.node);
+    }
+
+    if (
+      this.parent !== null &&
+      isDollarSafeNavigationMigration(this.parent) &&
+      this.parent.receiver === this.node
+    ) {
+      return createDollarSafeNavigationMigration(this.parent);
     }
 
     return undefined;

--- a/packages/language-service/src/quick_info_built_ins.ts
+++ b/packages/language-service/src/quick_info_built_ins.ts
@@ -52,6 +52,32 @@ export function createDollarAnyQuickInfo(node: Call): ts.QuickInfo {
   );
 }
 
+export function isDollarSafeNavigationMigration(node: TmplAstNode | AST): node is Call {
+  return (
+    node instanceof Call &&
+    node.receiver instanceof PropertyRead &&
+    node.receiver.receiver instanceof ImplicitReceiver &&
+    node.receiver.name === '$safeNavigationMigration' &&
+    node.args.length === 1
+  );
+}
+
+export function createDollarSafeNavigationMigration(node: Call): ts.QuickInfo {
+  return createQuickInfo(
+    '$safeNavigationMigration',
+    DisplayInfoKind.METHOD,
+    getTextSpanOfNode(node.receiver),
+    /** containerName */ undefined,
+    'null',
+    [
+      {
+        kind: SYMBOL_TEXT,
+        text: 'function to use legacy optional chaining behavior, where ?. yields `null` rather than `undefined`',
+      },
+    ],
+  );
+}
+
 // TODO(atscott): Create special `ts.QuickInfo` for `ng-template` and `ng-container` as well.
 export function createNgTemplateQuickInfo(node: TmplAstNode | AST): ts.QuickInfo {
   return createQuickInfo(


### PR DESCRIPTION
`$safeNavigationMigration` is a magic function, we need to provide a quick info for it.
