### PR TITLE
fix(docs-infra): reset webcontainer count from warning action Fixes #52647

### DIFF
--- a/adev/src/app/editor/alert-manager.service.spec.ts
+++ b/adev/src/app/editor/alert-manager.service.spec.ts
@@ -1,0 +1,62 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {LOCAL_STORAGE, WINDOW} from '@angular/docs';
+import {MatSnackBar, MatSnackBarRef} from '@angular/material/snack-bar';
+import {Subject} from 'rxjs';
+
+import {AlertManager, WEBCONTAINERS_COUNTER_KEY} from './alert-manager.service';
+
+describe('AlertManager', () => {
+  let service: AlertManager;
+  let localStorage: Map<string, string>;
+  let action$: Subject<void>;
+  let snackBar: jasmine.SpyObj<MatSnackBar>;
+  let windowMock: Pick<Window, 'addEventListener'>;
+
+  beforeEach(() => {
+    localStorage = new Map([[WEBCONTAINERS_COUNTER_KEY, '3']]);
+    action$ = new Subject<void>();
+    snackBar = jasmine.createSpyObj<MatSnackBar>('MatSnackBar', ['openFromComponent']);
+    snackBar.openFromComponent.and.returnValue({
+      onAction: () => action$,
+    } as unknown as MatSnackBarRef<unknown>);
+    windowMock = {
+      addEventListener: jasmine.createSpy('addEventListener'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AlertManager,
+        {provide: MatSnackBar, useValue: snackBar},
+        {
+          provide: LOCAL_STORAGE,
+          useValue: {
+            getItem: (key: string) => localStorage.get(key) ?? null,
+            setItem: (key: string, value: string) => localStorage.set(key, value),
+          },
+        },
+        {provide: WINDOW, useValue: windowMock},
+      ],
+    });
+
+    service = TestBed.inject(AlertManager);
+  });
+
+  it('resets the stale webcontainer count when the out of memory warning action is clicked', () => {
+    service.init();
+
+    expect(localStorage.get(WEBCONTAINERS_COUNTER_KEY)).toBe('4');
+    expect(snackBar.openFromComponent).toHaveBeenCalled();
+
+    action$.next();
+
+    expect(localStorage.get(WEBCONTAINERS_COUNTER_KEY)).toBe('1');
+  });
+});

--- a/adev/src/app/editor/alert-manager.service.ts
+++ b/adev/src/app/editor/alert-manager.service.ts
@@ -77,6 +77,10 @@ export class AlertManager {
     }
   }
 
+  private resetInstancesCounter(): void {
+    this.localStorage?.setItem(WEBCONTAINERS_COUNTER_KEY, '1');
+  }
+
   private checkDevice() {
     if (isMobile) {
       this.openSnackBar(AlertReason.MOBILE);
@@ -94,12 +98,16 @@ export class AlertManager {
         break;
     }
 
-    this.snackBar.openFromComponent(ErrorSnackBar, {
+    const snackBarRef = this.snackBar.openFromComponent(ErrorSnackBar, {
       panelClass: 'docs-invert-mode',
       data: {
         message,
         actionText: 'I understand',
       } satisfies ErrorSnackBarData,
     });
+
+    if (reason === AlertReason.OUT_OF_MEMORY) {
+      snackBarRef.onAction().subscribe(() => this.resetInstancesCounter());
+    }
   }
 }


### PR DESCRIPTION
Reset the stale webcontainer instance counter when users dismiss the out-of-memory warning.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Fixes #52647

This resets the stale webcontainer instance counter when users dismiss the out-of-memory warning.

Tests:
- pnpm ng-dev format changed --check
- pnpm test -- //adev:test

Issue Number:  #52647

## What is the new behavior?
Resets web container count from warning

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
