### PR TITLE
fix(compiler): invalid type checking code if field name needs to be quoted

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type} from '@angular/compiler';
+import {isUnsafeObjectKey, Type} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ImportRewriter, ReferenceEmitter} from '../../imports';
@@ -175,7 +175,9 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
       markForEmitAsSingleLine(typeRef);
       return ts.factory.createPropertyDeclaration(
         /* modifiers */ modifiers,
-        /* name */ decl.name,
+        /* name */ isUnsafeObjectKey(decl.name)
+          ? ts.factory.createStringLiteral(decl.name)
+          : decl.name,
         /* questionOrExclamationToken */ undefined,
         /* type */ typeRef,
         /* initializer */ undefined,

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ConstantPool} from '@angular/compiler';
+import {ConstantPool, isUnsafeObjectKey} from '@angular/compiler';
 import ts from 'typescript';
 import {
   DefaultImportTracker,
@@ -195,7 +195,7 @@ class IvyTransformationVisitor extends Visitor {
 
       const property = ts.factory.createPropertyDeclaration(
         [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)],
-        field.name,
+        isUnsafeObjectKey(field.name) ? ts.factory.createStringLiteral(field.name) : field.name,
         undefined,
         typeNode,
         exprNode,

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {R3Identifiers, TcbExpr, TcbTypeParameter, TypeCtorMetadata} from '@angular/compiler';
+import {
+  isUnsafeObjectKey,
+  R3Identifiers,
+  TcbExpr,
+  TcbTypeParameter,
+  TypeCtorMetadata,
+} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -127,12 +133,15 @@ function constructTypeCtorParameter(
     } else if (!meta.coercedInputFields.has(classPropertyName)) {
       plainKeys.push(TcbExpr.quoteAndEscape(classPropertyName));
     } else {
+      const propName = `ngAcceptInputType_${classPropertyName}`;
+      const isUnsafe = isUnsafeObjectKey(classPropertyName);
+      const access = isUnsafe ? `[${TcbExpr.quoteAndEscape(propName)}]` : `.${propName}`;
       const coercionType =
-        transformType !== undefined
-          ? transformType
-          : `typeof ${typeRef}.ngAcceptInputType_${classPropertyName}`;
+        transformType !== undefined ? transformType : `typeof ${typeRef}${access}`;
 
-      coercedKeys.push(`${classPropertyName}: ${coercionType}`);
+      coercedKeys.push(
+        `${isUnsafe ? TcbExpr.quoteAndEscape(classPropertyName) : classPropertyName}: ${coercionType}`,
+      );
     }
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -414,6 +414,32 @@ describe('type check blocks', () => {
         'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
       );
     });
+
+    it('should handle coercion type that needs to be quoted on a generic directive', () => {
+      const TEMPLATE = `<div dir [inputA]="foo"></div>`;
+      const DIRECTIVES: TestDeclaration[] = [
+        {
+          type: 'directive',
+          name: 'Dir',
+          selector: '[dir]',
+          inputs: {
+            fieldA: 'inputA',
+            'aria-label': 'aria-label',
+          },
+          coercedInputFields: ['aria-label'],
+          isGeneric: true,
+        },
+      ];
+      const block = tcb(TEMPLATE, DIRECTIVES);
+
+      expect(block).toContain(
+        'const _ctor1: <T extends string = any>(init: Pick<i0.Dir<T>, "fieldA"> & ' +
+          '{ "aria-label": typeof i0.Dir["ngAcceptInputType_aria-label"]; }) => i0.Dir<T> = null!;',
+      );
+      expect(block).toContain(
+        'var _t1 = _ctor1({ "fieldA": (((this).foo)), "aria-label": 0 as any });',
+      );
+    });
   });
 
   it('should only generate code for DOM elements that are actually referenced', () => {
@@ -966,6 +992,25 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
     expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
+  });
+
+  it('should handle an input binding to a coerced field that needs to be quoted', () => {
+    const TEMPLATE = `<div dir [aria-label]="foo"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [
+      {
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          'aria-label': 'aria-label',
+        },
+        coercedInputFields: ['aria-label'],
+      },
+    ];
+
+    const block = tcb(TEMPLATE, DIRECTIVES);
+    expect(block).toContain('var _t1 = null! as typeof i0.Dir["ngAcceptInputType_aria-label"];');
+    expect(block).toContain('_t1 = (((this).foo));');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -11301,6 +11301,24 @@ runInEachFileSystem((os: string) => {
           'static ngAcceptInputType_element: HTMLElement | i0.ElementRef<HTMLElement>;',
         );
       });
+
+      it('should compile an input with a transform function and whose name needs to be quoted', () => {
+        env.write(
+          '/test.ts',
+          `
+          import {Directive, Input} from '@angular/core';
+
+          @Directive({selector: '[dir]'})
+          export class Dir {
+            @Input({transform: (value: string) => value}) 'aria-label': string = '';
+          }
+        `,
+        );
+
+        env.driveMain();
+        const dtsContents = env.getContents('test.d.ts');
+        expect(dtsContents).toContain('static "ngAcceptInputType_aria-label": string;');
+      });
     });
 
     describe('debug info', () => {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -229,6 +229,7 @@ export {
   MaybeForwardRefExpression,
   R3CompiledExpression,
   R3Reference,
+  isUnsafeObjectKey,
 } from './render3/util';
 export * from './render3/view/api';
 export {

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -10,16 +10,12 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {
   convertFromMaybeForwardRefExpression,
   generateForwardRef,
+  isUnsafeObjectKey,
   R3CompiledExpression,
 } from '../util';
 import {R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from '../view/api';
 import {createDirectiveType, createHostDirectivesMappingArray} from '../view/compiler';
-import {
-  asLiteral,
-  conditionallyCreateDirectiveBindingLiteral,
-  DefinitionMap,
-  UNSAFE_OBJECT_KEY_NAME_REGEXP,
-} from '../view/util';
+import {asLiteral, conditionallyCreateDirectiveBindingLiteral, DefinitionMap} from '../view/util';
 
 import {R3DeclareDirectiveMetadata, R3DeclareQueryMetadata} from './api';
 import {toOptionalLiteralMap} from './util';
@@ -286,7 +282,7 @@ function createInputsPartialMetadata(inputs: R3DirectiveMetadata['inputs']): o.E
       return {
         key: declaredName,
         // put quotes around keys that contain potentially unsafe characters
-        quoted: UNSAFE_OBJECT_KEY_NAME_REGEXP.test(declaredName),
+        quoted: isUnsafeObjectKey(declaredName),
         value: o.literalMap([
           {key: 'classPropertyName', quoted: false, value: asLiteral(value.classPropertyName)},
           {key: 'publicName', quoted: false, value: asLiteral(value.bindingPropertyName)},
@@ -340,7 +336,7 @@ function legacyInputsPartialMetadata(inputs: R3DirectiveMetadata['inputs']): o.E
       return {
         key: declaredName,
         // put quotes around keys that contain potentially unsafe characters
-        quoted: UNSAFE_OBJECT_KEY_NAME_REGEXP.test(declaredName),
+        quoted: isUnsafeObjectKey(declaredName),
         value: result,
       };
     }),

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -11,6 +11,9 @@ import * as o from '../output/output_ast';
 
 import {Identifiers} from './r3_identifiers';
 
+/** Regex that includes unsafe characters in an object literal property name. */
+const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
+
 export function typeWithParameters(type: o.Expression, numParams: number): o.ExpressionType {
   if (numParams === 0) {
     return o.expressionType(type);
@@ -91,6 +94,10 @@ export function refsToArray(refs: R3Reference[], shouldForwardDeclare: boolean):
 
 export function tsIgnoreComment(): o.LeadingComment {
   return o.leadingComment('@ts-ignore', true, true);
+}
+
+export function isUnsafeObjectKey(key: string): boolean {
+  return UNSAFE_OBJECT_KEY_NAME_REGEXP.test(key);
 }
 
 /**

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -14,16 +14,7 @@ import {CssSelector} from '../../directive_matching';
 import * as t from '../r3_ast';
 
 import {isI18nAttribute} from './i18n/util';
-
-/**
- * Checks whether an object key contains potentially unsafe chars, thus the key should be wrapped in
- * quotes. Note: we do not wrap all keys into quotes, as it may have impact on minification and may
- * not work in some cases when object keys are mangled by a minifier.
- *
- * TODO(FW-1136): this is a temporary solution, we need to come up with a better way of working with
- * inputs that contain potentially unsafe chars.
- */
-export const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
+import {isUnsafeObjectKey} from '../util';
 
 /** Name of the temporary to use during data binding */
 export const TEMPORARY_NAME = '_t';
@@ -147,7 +138,7 @@ export function conditionallyCreateDirectiveBindingLiteral(
       return {
         key: minifiedName,
         // put quotes around keys that contain potentially unsafe characters
-        quoted: UNSAFE_OBJECT_KEY_NAME_REGEXP.test(minifiedName),
+        quoted: isUnsafeObjectKey(minifiedName),
         value: expressionValue,
       };
     }),

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -26,6 +26,7 @@ import {
 } from './signal_forms';
 import {getBoundAttributes, widenBinding} from './bindings';
 import {LocalSymbol} from './references';
+import {isUnsafeObjectKey} from '../../render3/util';
 
 /**
  * Translates the given attribute binding to a `ts.Expression`.
@@ -118,12 +119,15 @@ export class TcbDirectiveInputsOp extends TcbOp {
             // with a type of `typeof Directive.ngAcceptInputType_fieldName` which is then used as
             // target of the assignment.
             const dirTypeRef = this.tcb.env.referenceTcbValue(this.dir.ref);
-            type = new TcbExpr(`typeof ${dirTypeRef.print()}.ngAcceptInputType_${fieldName}`);
+            const propName = `ngAcceptInputType_${fieldName}`;
+            const access = isUnsafeObjectKey(fieldName)
+              ? `[${TcbExpr.quoteAndEscape(propName)}]`
+              : `.${propName}`;
+            type = new TcbExpr(`typeof ${dirTypeRef.print()}${access}`);
           }
 
           const id = new TcbExpr(this.tcb.allocateId());
           this.scope.addStatement(declareVariable(id, type));
-
           target = id;
         } else if (this.dir.undeclaredInputFields.has(fieldName)) {
           // If no coercion declaration is present nor is the field declared (i.e. the input is


### PR DESCRIPTION
Fixes that we were producing invalid TypeScript if an input with an unsafe name (e.g. `aria-label`) is coerced.