### PR TITLE
refactor(language-service): adapt `strictTemplates` suggestion

### DIFF
--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -892,7 +892,7 @@ export class LanguageService {
         project.readFile(path),
       );
 
-      if (!this.options.strictTemplates) {
+      if (this.options.strictTemplates === false) {
         diagnostics.push({
           messageText:
             'Some language features are not available. ' +

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -109,7 +109,9 @@ describe('language service adapter', () => {
   describe('compiler options diagnostics', () => {
     it('suggests turning on strict flag', () => {
       configFileFs.overwriteConfigFile(TSCONFIG, {
-        angularCompilerOptions: {},
+        angularCompilerOptions: {
+          strictTemplates: false,
+        },
       });
       const diags = ngLS.getCompilerOptionsDiagnostics();
       const diag = diags.find(isSuggestStrictTemplatesDiag);


### PR DESCRIPTION
In v22, `strictTemplates` is true by default. We need to adapte the LS to online report the suggestion when the option is explicitly `false`
