### PR TITLE
fix(language-service): Add support for @Input with transforms

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -6,12 +6,15 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import ts from 'typescript';
+
 import {runInEachFileSystem} from '../../file_system/testing';
 import {
   resetParseTemplateAsSourceFileForTest,
   setParseTemplateAsSourceFileForTest,
 } from '../diagnostics';
 import {diagnose, ngForDeclaration, ngForDts, ngIfDeclaration, ngIfDts} from '../testing';
+import {Reference} from '../../imports';
 
 runInEachFileSystem(() => {
   describe('template diagnostics', () => {
@@ -1405,6 +1408,112 @@ class TestComponent {
             },
           },
         ],
+      );
+
+      expect(messages).toEqual([]);
+    });
+  });
+
+  describe('input with modifiers', () => {
+    it('should report readonly @input() with transform when honorAccessModifiersForInputBindings', () => {
+      const messages = diagnose(
+        `<div dir [input]="true"></div>`,
+        `
+        class Dir {
+          @Input()
+          readonly input: string;
+        }
+        class TestComponent {}
+      `,
+        [
+          {
+            type: 'directive',
+            name: 'Dir',
+            selector: '[dir]',
+            coercedInputFields: ['input'],
+            restrictedInputFields: ['input'],
+            inputs: {
+              input: {
+                classPropertyName: 'input',
+                bindingPropertyName: 'input',
+                required: false,
+                isSignal: false,
+                transform: {
+                  node: ts.factory.createFunctionDeclaration(
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    [],
+                    undefined,
+                    undefined,
+                  ),
+                  type: new Reference(
+                    ts.factory.createUnionTypeNode([
+                      ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+                      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                    ]),
+                  ),
+                },
+              },
+            },
+          },
+        ],
+        [],
+        {honorAccessModifiersForInputBindings: true},
+      );
+
+      expect(messages).toEqual([
+        `TestComponent.html(1, 11): Cannot assign to 'input' because it is a read-only property.`,
+      ]);
+    });
+
+    it('should not report readonly @input() with transform when honorAccessModifiersForInputBindings is false', () => {
+      const messages = diagnose(
+        `<div dir [input]="true"></div>`,
+        `
+        class Dir {
+          @Input()
+          readonly input: string;
+        }
+        class TestComponent {}
+      `,
+        [
+          {
+            type: 'directive',
+            name: 'Dir',
+            selector: '[dir]',
+            coercedInputFields: ['input'],
+            restrictedInputFields: ['input'],
+            inputs: {
+              input: {
+                classPropertyName: 'input',
+                bindingPropertyName: 'input',
+                required: false,
+                isSignal: false,
+                transform: {
+                  node: ts.factory.createFunctionDeclaration(
+                    undefined,
+                    undefined,
+                    undefined,
+                    undefined,
+                    [],
+                    undefined,
+                    undefined,
+                  ),
+                  type: new Reference(
+                    ts.factory.createUnionTypeNode([
+                      ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+                      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                    ]),
+                  ),
+                },
+              },
+            },
+          },
+        ],
+        [],
+        {honorAccessModifiersForInputBindings: false},
       );
 
       expect(messages).toEqual([]);

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -411,7 +411,9 @@ describe('type check blocks', () => {
         },
       ];
       expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
-        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+        'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+          'var _t2 = _ctor1({ "fieldA": (((this).foo)) }); ' +
+          '_t2.fieldA = (_t1 = (((this).foo))) as any;',
       );
     });
 
@@ -766,7 +768,7 @@ describe('type check blocks', () => {
     expect(tcb(TEMPLATE, DIRECTIVES)).toContain(
       'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_field1; ' +
         'var _t2 = null! as i0.Dir; ' +
-        '_t2.field2 = _t1 = (((this).foo));',
+        '_t2.field2 = _t2.field1 = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -805,7 +807,9 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -826,7 +830,9 @@ describe('type check blocks', () => {
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).not.toContain('var _t1 = null! as Dir;');
     expect(block).toContain(
-      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' + '_t1 = (((this).foo));',
+      'var _t1 = null! as typeof i0.Dir.ngAcceptInputType_fieldA; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).foo))) as any;',
     );
   });
 
@@ -868,7 +874,110 @@ describe('type check blocks', () => {
 
     const block = tcb(TEMPLATE, DIRECTIVES);
 
-    expect(block).toContain('var _t1 = null! as boolean | string; ' + '_t1 = (((this).expr));');
+    expect(block).toContain(
+      'var _t1 = null! as boolean | string; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).expr))) as any;',
+    );
+  });
+
+  it('should honor access modifiers for transformed restricted inputs when enabled', () => {
+    const TEMPLATE = `<div dir [fieldA]="expr"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [
+      {
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          fieldA: {
+            bindingPropertyName: 'fieldA',
+            classPropertyName: 'fieldA',
+            required: false,
+            isSignal: false,
+            transform: {
+              node: ts.factory.createFunctionDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                [],
+                undefined,
+                undefined,
+              ),
+              type: new Reference(
+                ts.factory.createUnionTypeNode([
+                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                ]),
+              ),
+            },
+          },
+        },
+        coercedInputFields: ['fieldA'],
+        restrictedInputFields: ['fieldA'],
+      },
+    ];
+
+    const block = tcb(TEMPLATE, DIRECTIVES, {
+      ...ALL_ENABLED_CONFIG,
+      honorAccessModifiersForInputBindings: true,
+    });
+
+    expect(block).toContain(
+      'var _t1 = null! as boolean | string; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        '_t2.fieldA = (_t1 = (((this).expr))) as any;',
+    );
+  });
+
+  it('should bypass access modifiers for transformed restricted inputs when disabled', () => {
+    const TEMPLATE = `<div dir [fieldA]="expr"></div>`;
+    const DIRECTIVES: TestDeclaration[] = [
+      {
+        type: 'directive',
+        name: 'Dir',
+        selector: '[dir]',
+        inputs: {
+          fieldA: {
+            bindingPropertyName: 'fieldA',
+            classPropertyName: 'fieldA',
+            required: false,
+            isSignal: false,
+            transform: {
+              node: ts.factory.createFunctionDeclaration(
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                [],
+                undefined,
+                undefined,
+              ),
+              type: new Reference(
+                ts.factory.createUnionTypeNode([
+                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
+                  ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                ]),
+              ),
+            },
+          },
+        },
+        coercedInputFields: ['fieldA'],
+        restrictedInputFields: ['fieldA'],
+      },
+    ];
+
+    const block = tcb(TEMPLATE, DIRECTIVES, {
+      ...ALL_ENABLED_CONFIG,
+      honorAccessModifiersForInputBindings: false,
+    });
+
+    expect(block).toContain(
+      'var _t1 = null! as boolean | string; ' +
+        'var _t2 = null! as i0.Dir; ' +
+        'var _t3 = null! as (typeof _t2)["fieldA"]; ' +
+        '_t3 = (_t1 = (((this).expr))) as any;',
+    );
   });
 
   it('should handle $any casts', () => {
@@ -991,7 +1100,9 @@ describe('type check blocks', () => {
     ];
     const block = tcb(TEMPLATE, DIRECTIVES);
     expect(block).toContain('var _t1 = null! as boolean | string;');
-    expect(block).toContain('_t1 = i1.ɵunwrapWritableSignal((((this).value)));');
+    expect(block).toContain(
+      '_t2.input = i1.ɵunwrapWritableSignal((_t1 = (((this).value))) as any);',
+    );
   });
 
   it('should handle an input binding to a coerced field that needs to be quoted', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -828,7 +828,7 @@ function prepareDeclarations(
   const directives: DirectiveMeta[] = [];
   const registerDirective = (decl: TestDirective) => {
     const meta = getDirectiveMetaFromDeclaration(decl, resolveDeclaration);
-    directives.push(meta as DirectiveMeta);
+    directives.push(meta);
     metadataRegistry.set(decl.name, meta);
     decl.hostDirectives?.forEach((hostDecl) => registerDirective(hostDecl.directive));
   };
@@ -883,7 +883,7 @@ export function getClass(sf: ts.SourceFile, name: string): ClassDeclaration<ts.C
 function getDirectiveMetaFromDeclaration(
   decl: TestDirective,
   resolveDeclaration: DeclarationResolver,
-) {
+): DirectiveMeta {
   return {
     name: decl.name,
     ref: new Reference(resolveDeclaration(decl), decl.bestGuessOwningModule),
@@ -910,7 +910,7 @@ function getDirectiveMetaFromDeclaration(
     ngContentSelectors: decl.ngContentSelectors || null,
     preserveWhitespaces: decl.preserveWhitespaces ?? false,
     isExplicitlyDeferred: false,
-    imports: decl.imports,
+    imports: decl.imports!,
     rawImports: null,
     matchSource: MatchSource.Selector,
     hostDirectives:
@@ -921,9 +921,18 @@ function getDirectiveMetaFromDeclaration(
               directive: new Reference(resolveDeclaration(hostDecl.directive)),
               inputs: parseInputOutputMappingArray(hostDecl.inputs || []),
               outputs: parseInputOutputMappingArray(hostDecl.outputs || []),
+              isForwardReference: false,
             };
           }),
-  } as TypeCheckableDirectiveMeta;
+    assumedToExportProviders: false,
+    deferredImports: null,
+    selectorlessEnabled: false,
+    localReferencedSymbols: null,
+    isPoisoned: false,
+    inputFieldNamesFromMetadataArray: null,
+    kind: MetaKind.Directive,
+    schemas: [],
+  };
 }
 
 /**

--- a/packages/compiler/src/typecheck/ops/inputs.ts
+++ b/packages/compiler/src/typecheck/ops/inputs.ts
@@ -8,25 +8,25 @@
 
 import {AST, BindingType} from '../../expression_parser/ast';
 import {BindingPropertyName, ClassPropertyName} from '../../property_mapping';
-import {Identifiers as R3Identifiers} from '../../render3/r3_identifiers';
 import {BoundAttribute, Component, Directive, Element, Template} from '../../render3/r3_ast';
-import type {Context} from './context';
-import type {Scope} from './scope';
+import {Identifiers as R3Identifiers} from '../../render3/r3_identifiers';
+import {isUnsafeObjectKey} from '../../render3/util';
+import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
 import {TcbDirectiveMetadata} from '../api';
 import {TcbOp} from './base';
+import {getBoundAttributes, widenBinding} from './bindings';
 import {declareVariable, TcbExpr} from './codegen';
-import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
-const REGISTRY = new DomElementSchemaRegistry();
+import type {Context} from './context';
 import {tcbExpression, unwrapWritableSignal} from './expression';
+import {LocalSymbol} from './references';
+import type {Scope} from './scope';
 import {
   checkUnsupportedFieldBindings,
-  CustomFormControlType,
   customFormControlBannedInputFields,
+  CustomFormControlType,
   expandBoundAttributesForField,
 } from './signal_forms';
-import {getBoundAttributes, widenBinding} from './bindings';
-import {LocalSymbol} from './references';
-import {isUnsafeObjectKey} from '../../render3/util';
+const REGISTRY = new DomElementSchemaRegistry();
 
 /**
  * Translates the given attribute binding to a `ts.Expression`.
@@ -128,7 +128,38 @@ export class TcbDirectiveInputsOp extends TcbOp {
 
           const id = new TcbExpr(this.tcb.allocateId());
           this.scope.addStatement(declareVariable(id, type));
+
+          // The expression is assigned to the temporary variable to perform the type check.
+          // The result is then cast to `any` and assigned to the actual property. This avoids
+          // type mismatch errors (e.g., when assigning a string to a boolean input) while also
+          // providing a TCB node that the Language Service can resolve to the actual class property.
+          assignment = new TcbExpr(`(${id.print()} = ${assignment.print()}) as any`);
+
+          if (dirId === null) {
+            dirId = this.scope.resolve(this.node, this.dir);
+          }
+
           target = id;
+
+          // If strict checking of access modifiers is disabled and the field is restricted
+          // (i.e. private/protected/readonly), generate an assignment into a temporary variable
+          // that has the type of the field. This achieves type-checking but circumvents the access
+          // modifiers.
+          if (
+            !this.tcb.env.config.honorAccessModifiersForInputBindings &&
+            this.dir.restrictedInputFields.has(fieldName)
+          ) {
+            const targetId = new TcbExpr(this.tcb.allocateId());
+            const targetType = new TcbExpr(
+              `(typeof ${dirId.print()})[${TcbExpr.quoteAndEscape(fieldName)}]`,
+            );
+            this.scope.addStatement(declareVariable(targetId, targetType));
+            target = targetId;
+          } else {
+            target = this.dir.stringLiteralInputFields.has(fieldName)
+              ? new TcbExpr(`${dirId.print()}[${TcbExpr.quoteAndEscape(fieldName)}]`)
+              : new TcbExpr(`${dirId.print()}.${fieldName}`);
+          }
         } else if (this.dir.undeclaredInputFields.has(fieldName)) {
           // If no coercion declaration is present nor is the field declared (i.e. the input is
           // declared in a `@Directive` or `@Component` decorator's `inputs` property) there is no


### PR DESCRIPTION
Prior to this change @input with transforms were not linked by language service and you couldn't navigate on it.
