### PR TITLE
docs: normalize product name casing across docs

### DIFF
--- a/adev/src/app/core/layout/footer/footer.component.html
+++ b/adev/src/app/core/layout/footer/footer.component.html
@@ -58,7 +58,7 @@
         <li>
           <a
             href="https://github.com/angular/angular/issues"
-            title="Post issues and suggestions on github."
+            title="Post issues and suggestions on GitHub."
           >
             Report Issues
           </a>

--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -392,11 +392,11 @@
               <a
                 [href]="ngLinks.GITHUB"
                 cdkMenuItem
-                title="Angular Github"
+                title="Angular GitHub"
                 target="_blank"
                 rel="noopener"
               >
-                <!-- Github Icon -->
+                <!-- GitHub Icon -->
                 <svg
                   width="20"
                   height="20"

--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -787,7 +787,7 @@ export const RECOMMENDATIONS: Step[] = [
     possibleIn: 1000,
     necessaryAsOf: 1000,
     level: ApplicationComplexity.Basic,
-    step: 'v10 NodeJS 12',
+    step: 'v10 Node.js 12',
     action: 'Make sure you are using [Node 12 or later](https://nodejs.org/dist/latest-v12.x/).',
   },
   {
@@ -852,7 +852,7 @@ export const RECOMMENDATIONS: Step[] = [
     level: ApplicationComplexity.Advanced,
     step: 'closure-jsdoc-comments',
     action:
-      "Angular's NPM packages no longer contain jsdoc comments, which are necessary for use with closure compiler (extremely uncommon). This support was experimental and only worked in some use cases. There will be an alternative recommended path announced shortly.",
+      "Angular's npm packages no longer contain jsdoc comments, which are necessary for use with closure compiler (extremely uncommon). This support was experimental and only worked in some use cases. There will be an alternative recommended path announced shortly.",
   },
   {
     possibleIn: 1000,

--- a/adev/src/content/ecosystem/service-workers/config.md
+++ b/adev/src/content/ecosystem/service-workers/config.md
@@ -85,7 +85,7 @@ For example, an asset group that matches `/foo.js` should appear before one that
 Each asset group specifies both a group of resources and a policy that governs them.
 This policy determines when the resources are fetched and what happens when changes are detected.
 
-Asset groups follow the Typescript interface shown here:
+Asset groups follow the TypeScript interface shown here:
 
 ```ts
 interface AssetGroup {
@@ -179,7 +179,7 @@ The first data group that matches the requested resource handles the request.
 It is recommended that you put the more specific data groups higher in the list.
 For example, a data group that matches `/api/foo.json` should appear before one that matches `/api/*.json`.
 
-Data groups follow this Typescript interface:
+Data groups follow this TypeScript interface:
 
 ```ts
 export interface DataGroup {

--- a/adev/src/content/ecosystem/service-workers/devops.md
+++ b/adev/src/content/ecosystem/service-workers/devops.md
@@ -283,7 +283,7 @@ When the service worker's request for `ngsw.json` returns a `404`, then the serv
 
 <!-- vale Angular.Google_Acronyms = NO -->
 
-A small script, `safety-worker.js`, is also included in the `@angular/service-worker` NPM package.
+A small script, `safety-worker.js`, is also included in the `@angular/service-worker` npm package.
 When loaded, it un-registers itself from the browser and removes the service worker caches.
 This script can be used as a last resort to get rid of unwanted service workers already installed on client pages.
 

--- a/adev/src/content/examples/i18n/readme.md
+++ b/adev/src/content/examples/i18n/readme.md
@@ -10,9 +10,9 @@ This sample comes from the Angular documentation's "[Example Angular Internation
 
 > See the scripts in `package.json` for an explanation of these commands.
 
-## Run in Stackblitz
+## Run in StackBlitz
 
-Stackblitz compiles and runs the English version by default.
+StackBlitz compiles and runs the English version by default.
 
 To see the example translate to French with Angular i18n:
 
@@ -24,4 +24,4 @@ To see the example translate to French with Angular i18n:
   }
 ```
 
-1. Click the "Fork" button in the stackblitz header. That makes a new copy for you with this change and re-runs the example in French.
+1. Click the "Fork" button in the StackBlitz header. That makes a new copy for you with this change and re-runs the example in French.

--- a/adev/src/content/guide/components/styling.md
+++ b/adev/src/content/guide/components/styling.md
@@ -34,8 +34,8 @@ render an Angular component, the framework automatically includes its associated
 lazy-loading a component.
 
 Angular works with any tool that outputs CSS,
-including [Sass](https://sass-lang.com), [less](https://lesscss.org),
-and [stylus](https://stylus-lang.com).
+including [Sass](https://sass-lang.com), [Less](https://lesscss.org),
+and [Stylus](https://stylus-lang.com).
 
 ## Style scoping
 

--- a/adev/src/content/guide/http/making-requests.md
+++ b/adev/src/content/guide/http/making-requests.md
@@ -247,7 +247,7 @@ Each `HttpEvent` reported in the event stream has a `type` which distinguishes w
 | `HttpEventType.ResponseHeader`   | The head of the response has been received, including status and headers           |
 | `HttpEventType.DownloadProgress` | An `HttpDownloadProgressEvent` reporting progress on downloading the response body |
 | `HttpEventType.Response`         | The entire response has been received, including the response body                 |
-| `HttpEventType.User`             | A custom event from an Http interceptor.                                           |
+| `HttpEventType.User`             | A custom event from an HTTP interceptor.                                           |
 
 ## Handling request failure
 
@@ -614,7 +614,7 @@ IMPORTANT: The `integrity` option requires an exact match between the response c
 
 TIP: Use subresource integrity when loading critical resources from external sources to ensure they haven't been modified. Generate hashes using tools like `openssl`.
 
-## Http `Observable`s
+## HTTP `Observable`s
 
 Each request method on `HttpClient` constructs and returns an `Observable` of the requested response type. Understanding how these `Observable`s work is important when using `HttpClient`.
 

--- a/adev/src/content/guide/i18n/add-package.md
+++ b/adev/src/content/guide/i18n/add-package.md
@@ -9,7 +9,7 @@ To add the `@angular/localize` package, use the following command to update the 
 It adds `types: ["@angular/localize"]` in the TypeScript configuration files.
 It also adds line `/// <reference types="@angular/localize" />` at the top of the `main.ts` file which is the reference to the type definition.
 
-HELPFUL: For more information about `package.json` and `tsconfig.json` files, see [Workspace npm dependencies][GuideNpmPackages] and [TypeScript Configuration][GuideTsConfig]. To learn about Triple-slash Directives visit [Typescript Handbook](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-).
+HELPFUL: For more information about `package.json` and `tsconfig.json` files, see [Workspace npm dependencies][GuideNpmPackages] and [TypeScript Configuration][GuideTsConfig]. To learn about Triple-slash Directives visit [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-).
 
 If `@angular/localize` is not installed and you try to build a localized version of your project (for example, while using the `i18n` attributes in templates), the [Angular CLI][CliMain] will generate an error, which would contain the steps that you can take to enable i18n for your project.
 

--- a/adev/src/content/guide/image-optimization.md
+++ b/adev/src/content/guide/image-optimization.md
@@ -468,7 +468,7 @@ For maintenance reasons, we don't currently plan to support additional built-in 
 
 No, but this is on our roadmap, so stay tuned.
 
-If you're waiting on this feature, please upvote the Github issue [here](https://github.com/angular/angular/issues/56594).
+If you're waiting on this feature, please upvote the GitHub issue [here](https://github.com/angular/angular/issues/56594).
 
 ### How do I find my LCP image with Chrome DevTools?
 

--- a/adev/src/content/guide/templates/event-listeners.md
+++ b/adev/src/content/guide/templates/event-listeners.md
@@ -96,7 +96,7 @@ Angular also allows you to specify [Code values for keyboard events](https://dev
 <input type="text" (keydown.code.alt.shiftleft)="updateField($event)" />
 ```
 
-This can be useful for handling keyboard events consistently across different operating systems. For example, when using the Alt key on MacOS devices, the `key` property reports the key based on the character already modified by the Alt key. This means that a combination like Alt + S reports a `key` value of `'ß'`. The `code` property, however, corresponds to the physical or virtual button pressed rather than the character produced.
+This can be useful for handling keyboard events consistently across different operating systems. For example, when using the Alt key on macOS devices, the `key` property reports the key based on the character already modified by the Alt key. This means that a combination like Alt + S reports a `key` value of `'ß'`. The `code` property, however, corresponds to the physical or virtual button pressed rather than the character produced.
 
 ## Listening on global targets
 

--- a/adev/src/content/guide/testing/migrating-to-vitest.md
+++ b/adev/src/content/guide/testing/migrating-to-vitest.md
@@ -92,7 +92,7 @@ Choose one of the following browser providers based on your needs:
 
 - **Playwright**: `@vitest/browser-playwright` for Chromium, Firefox, and WebKit.
 - **WebdriverIO**: `@vitest/browser-webdriverio` for Chrome, Firefox, Safari, and Edge.
-- **Preview**: `@vitest/browser-preview` for Webcontainer environments (like StackBlitz).
+- **Preview**: `@vitest/browser-preview` for WebContainer environments (like StackBlitz).
 
 <docs-code-multifile>
   <docs-code header="npm" language="shell">

--- a/adev/src/content/guide/testing/overview.md
+++ b/adev/src/content/guide/testing/overview.md
@@ -188,7 +188,7 @@ Choose one of the following browser providers based on your needs:
 
 ### Preview
 
-The `@vitest/browser-preview` provider is designed for Webcontainer environments like StackBlitz and is not intended for use in CI/CD.
+The `@vitest/browser-preview` provider is designed for WebContainer environments like StackBlitz and is not intended for use in CI/CD.
 
 <docs-code-multifile>
   <docs-code header="npm" language="shell">

--- a/adev/src/content/kitchen-sink.md
+++ b/adev/src/content/kitchen-sink.md
@@ -212,7 +212,7 @@ You can create multifile examples by wrapping the examples inside a `<docs-code-
 
 ### Adding `preview` to your code example
 
-Adding the `preview` flag builds a running example of the code below the code snippet. This also automatically adds a button to open the running example in Stackblitz.
+Adding the `preview` flag builds a running example of the code below the code snippet. This also automatically adds a button to open the running example in StackBlitz.
 
 NOTE: `preview` only works with standalone.
 

--- a/adev/src/content/reference/configs/angular-compiler-options.md
+++ b/adev/src/content/reference/configs/angular-compiler-options.md
@@ -60,7 +60,7 @@ The default value is `'full'`.
 
 For most applications, `'full'` is the correct compilation mode.
 
-Use `'partial'` for independently published libraries, such as NPM packages.
+Use `'partial'` for independently published libraries, such as npm packages.
 `'partial'` compilations output a stable, intermediate format which better supports usage by applications built at different Angular versions from the library.
 Libraries built at "HEAD" alongside their applications and using the same version of Angular such as in a mono-repository can use `'full'` since there is no risk of version skew.
 

--- a/adev/src/content/reference/migrations/outputs.md
+++ b/adev/src/content/reference/migrations/outputs.md
@@ -16,7 +16,7 @@ ng generate @angular/core:output-migration
 ## What does the migration change?
 
 1. `@Output()` class members are updated to their `output()` equivalent.
-2. Imports in the file of components or directives, at Typescript module level, are updated as well.
+2. Imports in the file of components or directives, at TypeScript module level, are updated as well.
 3. Migrates API calls like `event.next()`, whose use is not recommended, to `event.emit()` and removes `event.complete()` calls.
 
 **Before**

--- a/adev/src/content/tools/cli/cli-builder.md
+++ b/adev/src/content/tools/cli/cli-builder.md
@@ -56,7 +56,7 @@ To create a builder, use the `createBuilder()` CLI Builder function, and return 
 <docs-code header="src/my-builder.ts (builder skeleton)" path="adev/src/content/examples/cli-builder/src/my-builder.ts" region="builder-skeleton"/>
 
 Now let's add some logic to it.
-The following code retrieves the source and destination file paths from user options and copies the file from the source to the destination \(using the [Promise version of the built-in NodeJS `copyFile()` function](https://nodejs.org/api/fs.html#fs_fspromises_copyfile_src_dest_mode)\).
+The following code retrieves the source and destination file paths from user options and copies the file from the source to the destination \(using the [Promise version of the built-in Node.js `copyFile()` function](https://nodejs.org/api/fs.html#fs_fspromises_copyfile_src_dest_mode)\).
 If the copy operation fails, it returns an error with a message about the underlying problem.
 
 <docs-code header="src/my-builder.ts (builder)" path="adev/src/content/examples/cli-builder/src/my-builder.ts" region="builder"/>

--- a/adev/src/content/tools/cli/deployment.md
+++ b/adev/src/content/tools/cli/deployment.md
@@ -33,7 +33,7 @@ You can read more by following the links associated with the package names below
 | [Firebase hosting](https://firebase.google.com/docs/hosting)      | [`ng add @angular/fire`](https://npmjs.org/package/@angular/fire)                           |
 | [Vercel](https://vercel.com/solutions/angular)                    | [`vercel init angular`](https://github.com/vercel/vercel/tree/main/examples/angular)        |
 | [Netlify](https://www.netlify.com)                                | [`ng add @netlify-builder/deploy`](https://npmjs.org/package/@netlify-builder/deploy)       |
-| [GitHub pages](https://pages.github.com)                          | [`ng add angular-cli-ghpages`](https://npmjs.org/package/angular-cli-ghpages)               |
+| [GitHub Pages](https://pages.github.com)                          | [`ng add angular-cli-ghpages`](https://npmjs.org/package/angular-cli-ghpages)               |
 | [Amazon Cloud S3](https://aws.amazon.com/s3/?nc2=h_ql_prod_st_s3) | [`ng add @jefiozie/ngx-aws-deploy`](https://www.npmjs.com/package/@jefiozie/ngx-aws-deploy) |
 
 If you're deploying to a self-managed server or there's no builder for your favorite cloud platform, you can either [create a builder](tools/cli/cli-builder) that allows you to use the `ng deploy` command, or read through this guide to learn how to manually deploy your application.

--- a/adev/src/content/tools/cli/schematics-for-libraries.md
+++ b/adev/src/content/tools/cli/schematics-for-libraries.md
@@ -63,7 +63,7 @@ Possible values are:
 To bundle your schematics together with your library, you must configure the library to build the schematics separately, then add them to the bundle.
 You must build your schematics _after_ you build your library, so they are placed in the correct directory.
 
-- Your library needs a custom Typescript configuration file with instructions on how to compile your schematics into your distributed library
+- Your library needs a custom TypeScript configuration file with instructions on how to compile your schematics into your distributed library
 - To add the schematics to the library bundle, add scripts to the library's `package.json` file
 
 Assume you have a library project `my-lib` in your Angular workspace.

--- a/adev/src/content/tools/libraries/angular-package-format.md
+++ b/adev/src/content/tools/libraries/angular-package-format.md
@@ -280,7 +280,7 @@ In this section are the definitions of all of them to provide additional clarity
 
 ### Package
 
-The smallest set of files that are published to NPM and installed together, for example `@angular/core`.
+The smallest set of files that are published to npm and installed together, for example `@angular/core`.
 This package includes a manifest called package.json, compiled source code, typescript definition files, source maps, metadata, etc.
 The package is installed with `npm install @angular/core`.
 

--- a/adev/src/content/tools/libraries/creating-libraries.md
+++ b/adev/src/content/tools/libraries/creating-libraries.md
@@ -242,7 +242,7 @@ TypeScript path mappings should _not_ point to the library source `.ts` files.
 
 This section explains how to use your package manager's local linking feature
 (such as [`npm link`](https://docs.npmjs.com/cli/v11/commands/npm-link) or [`pnpm link`](https://pnpm.io/cli/link)) to test a standalone Angular library with an external application during
-local development, without relying on the monorepo workspace structure or publishing to the NPM registry.
+local development, without relying on the monorepo workspace structure or publishing to the npm registry.
 
 NOTE: If your library and application are in the same Angular workspace (a monorepo setup), the standard monorepo workflow automatically handles the linking and is generally more efficient. This local linking approach is best when:
 

--- a/adev/src/content/tools/libraries/using-libraries.md
+++ b/adev/src/content/tools/libraries/using-libraries.md
@@ -120,7 +120,7 @@ import * as $ from 'jquery';
 ```
 
 If you import it using import statements, you have two different copies of the library: one imported as a global library, and one imported as a module.
-This is especially bad for libraries with plugins, like JQuery, because each copy includes different plugins.
+This is especially bad for libraries with plugins, like jQuery, because each copy includes different plugins.
 
 Instead, run the `npm install @types/jquery` Angular CLI command to download typings for your library and then follow the library installation steps.
 This gives you access to the global variables exposed by that library.
@@ -135,7 +135,7 @@ For example:
 declare var libraryName: any;
 ```
 
-Some scripts extend other libraries; for instance with JQuery plugins:
+Some scripts extend other libraries; for instance with jQuery plugins:
 
 ```ts
 $('.test').myPlugin();

--- a/adev/src/content/tutorials/first-app/intro/README.md
+++ b/adev/src/content/tutorials/first-app/intro/README.md
@@ -23,7 +23,7 @@ The lessons in this tutorial assume that you have experience with the following:
 
 ### Your equipment
 
-These lessons can be completed using a local installation of the Angular tools or in our embedded editor. Local Angular development can be completed on Windows, MacOS or Linux based systems.
+These lessons can be completed using a local installation of the Angular tools or in our embedded editor. Local Angular development can be completed on Windows, macOS or Linux based systems.
 
 NOTE: Look for alerts like this one, which call out steps that may only be for your local editor.
 

--- a/adev/src/content/tutorials/first-app/steps/14-http/README.md
+++ b/adev/src/content/tutorials/first-app/steps/14-http/README.md
@@ -198,7 +198,7 @@ The server is now reading data from the HTTP request but the components that rel
 
 </docs-workflow>
 
-NOTE: This lesson relies on the `fetch` browser API. For the support of interceptors, please refer to the [Http Client documentation](/guide/http)
+NOTE: This lesson relies on the `fetch` browser API. For the support of interceptors, please refer to the [HTTP client documentation](/guide/http)
 
 SUMMARY: In this lesson, you updated your app to use a local web server (`json-server`), and use asynchronous service methods to retrieve data.
 

--- a/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/5-control-flow-for/README.md
@@ -22,7 +22,7 @@ Here's an example of how to use the `@for` syntax in a component:
   `,
 })
 export class App {
-  operatingSystems = [{id: 'win', name: 'Windows'}, {id: 'osx', name: 'MacOS'}, {id: 'linux', name: 'Linux'}];
+  operatingSystems = [{id: 'win', name: 'Windows'}, {id: 'osx', name: 'macOS'}, {id: 'linux', name: 'Linux'}];
 }
 ```
 

--- a/contributing-docs/building-and-testing-angular.md
+++ b/contributing-docs/building-and-testing-angular.md
@@ -8,7 +8,7 @@ It also explains the basic mechanics of using `git`, `node`, and `pnpm`.
   - [Development in a Container](#development-in-a-container)
   - [Experimenting in dev-app](#experimenting-in-dev-app)
   - [Getting the Sources](#getting-the-sources)
-  - [Installing NPM Modules](#installing-npm-modules)
+  - [Installing npm Modules](#installing-npm-modules)
   - [Building](#building)
   - [Running Tests Locally](#running-tests-locally)
     - [Testing changes against a local library/project](#testing-changes-against-a-local-libraryproject)
@@ -95,7 +95,7 @@ cd angular
 git remote add upstream https://github.com/angular/angular.git
 ```
 
-## Installing NPM Modules
+## Installing npm Modules
 
 Next, install the JavaScript modules needed to build and test Angular:
 

--- a/contributing-docs/saved-issue-replies.md
+++ b/contributing-docs/saved-issue-replies.md
@@ -78,7 +78,7 @@ If the problem still exists in your application, please [open a new issue](https
 ## Angular: Support Request (v1)
 
 ```
-Hello, we reviewed this issue and determined that it doesn't fall into the bug report or feature request category. This issue tracker is not suitable for support requests, please repost your issue on [StackOverflow](https://stackoverflow.com/) using tag `angular`.
+Hello, we reviewed this issue and determined that it doesn't fall into the bug report or feature request category. This issue tracker is not suitable for support requests, please repost your issue on [Stack Overflow](https://stackoverflow.com/) using tag `angular`.
 
 If you are wondering why we don't resolve support issues via the issue tracker, please [check out this explanation](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#question).
 ```

--- a/contributing-docs/spam.md
+++ b/contributing-docs/spam.md
@@ -21,5 +21,5 @@ limited resources across all contributors and projects.
 ## Exceptions
 
 If you plan to undertake more significant work that you anticipate will generate
-many individual PRs, please reach out to the team in a Github issue first to
+many individual PRs, please reach out to the team in a GitHub issue first to
 validate that Angular will be able to support and accept your contributions.

--- a/packages/misc/angular-in-memory-web-api/README.md
+++ b/packages/misc/angular-in-memory-web-api/README.md
@@ -28,7 +28,7 @@ preferably with a small repro.
 - Whip up prototypes and proofs of concept.
 
 - Share examples with the community in a web coding environment such as Plunker or CodePen.
-  Create Angular issues and StackOverflow answers supported by live code.
+  Create Angular issues and Stack Overflow answers supported by live code.
 
 - Simulate operations against data collections that aren't yet implemented on your dev/test server.
   You can pass requests thru to the dev/test server for collections that are supported.


### PR DESCRIPTION
Several user-facing docs, tooltips, and tutorial code samples used non-canonical spellings of product names. This normalizes them to the form each project uses for its own brand.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Several user-facing docs, tooltips, and tutorial code samples use
non-canonical spellings of product names:

## What is the current behavior?

Several user-facing docs, tooltips, and tutorial code samples use
non-canonical spellings of product names:

- `github` (lowercase) in a footer tooltip → should be `GitHub`
- `Typescript` in prose → should be `TypeScript`
- `NodeJS` in a tutorial doc and in an update-guide step label →
  should be `Node.js`
- `StackOverflow` in a saved issue reply and a package README →
  should be `Stack Overflow`
- `MacOS` in prose and in a `@for` tutorial code sample (which
  renders to the DOM) → should be `macOS`
- `NPM` in prose, including a section heading and an update-guide
  step label → should be `npm`
- `JQuery` in prose (TS type names from `@types/jquery` left
  untouched) → should be `jQuery`
- `[less]` and `[stylus]` link text in the CSS preprocessor list →
  should be `[Less]` and `[Stylus]`
- `Http` Title-Cased in a section heading, table cell, and link
  text even though HTTP is an uppercase acronym and the rest of
  the docs consistently say "HTTP client" / "HTTP interceptor"
- `GitHub pages` (lowercase 'p') in the deployment table → should
  be `GitHub Pages`
- `Stackblitz` in prose across the kitchen-sink page and an
  example readme → should be `StackBlitz`
- `Webcontainer` in two testing docs → should be `WebContainer`

## What is the new behavior?

Each reference uses the canonical spelling each project publishes for itself:

- [GitHub](https://github.com/logos) / [GitHub Pages](https://pages.github.com)
- [TypeScript](https://www.typescriptlang.org)
- [Node.js](https://nodejs.org)
- [Stack Overflow](https://stackoverflow.com) → logo renders as two words
- [macOS](https://www.apple.com/macos) → lowercase 'm'
- [npm](https://www.npmjs.com) → registry brands itself lowercase
- [jQuery](https://jquery.com) → lowercase 'j' (prose only; the `JQuery` TypeScript type from `@types/jquery` is left untouched)
- [Less](https://lesscss.org) / [Stylus](https://stylus-lang.com)
- [StackBlitz](https://stackblitz.com)
- [WebContainer](https://webcontainers.io)
- HTTP → uppercase acronym; matches existing "HTTP client" / "HTTP interceptor" usage in `adev/src/content/guide/http/overview.md`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No