### PR TITLE
fix(compiler): disallow i18n on security-sensitive attributes

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -12,7 +12,10 @@ import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
 import * as html from '../../../ml_parser/ast';
 import {ParseTreeResult} from '../../../ml_parser/parser';
+import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
+import {SecurityContext} from '../../../core';
+import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
 import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
@@ -48,6 +51,18 @@ const setI18nRefs = (originalNodeMap: Map<html.Node, html.Node>): VisitNodeFn =>
     return i18nNode;
   };
 };
+
+const domSchema = new DomElementSchemaRegistry();
+
+function isSecuritySensitiveTranslatedAttribute(tagName: string, attrName: string): boolean {
+  const elementName = splitNsName(tagName)[1];
+
+  return (
+    isTrustedTypesSink(elementName, attrName) ||
+    domSchema.securityContext(elementName, attrName, /* isAttribute */ true) ===
+      SecurityContext.ATTRIBUTE_NO_BINDING
+  );
+}
 
 /**
  * This visitor walks over HTML parse tree and converts information stored in
@@ -201,14 +216,17 @@ export class I18nMetaVisitor implements html.Visitor {
         } else if (attr.name.startsWith(I18N_ATTR_PREFIX)) {
           // 'i18n-*' attributes
           const name = attr.name.slice(I18N_ATTR_PREFIX.length);
-          let isTrustedType: boolean;
+          let isSecuritySensitive: boolean;
           if (node instanceof html.Component) {
-            isTrustedType = node.tagName === null ? false : isTrustedTypesSink(node.tagName, name);
+            isSecuritySensitive =
+              node.tagName === null
+                ? false
+                : isSecuritySensitiveTranslatedAttribute(node.tagName, name);
           } else {
-            isTrustedType = isTrustedTypesSink(node.name, name);
+            isSecuritySensitive = isSecuritySensitiveTranslatedAttribute(node.name, name);
           }
 
-          if (isTrustedType) {
+          if (isSecuritySensitive) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -752,7 +752,7 @@ describe('iframe processing', () => {
           },
         );
 
-        it('should work when a security-sensitive attributes are marked for translation', () => {
+        it('should error when security-sensitive attributes are marked for translation', () => {
           @Component({
             selector: 'my-comp',
             template: ` <iframe src="${TEST_IFRAME_URL}" i18n-sandbox sandbox=""> </iframe> `,
@@ -761,7 +761,9 @@ describe('iframe processing', () => {
           })
           class IframeComp {}
 
-          expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+          expect(() => TestBed.createComponent(IframeComp)).toThrowError(
+            /Translating attribute 'sandbox' is disallowed for security reasons./,
+          );
         });
       });
     });

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -273,5 +273,27 @@ describe('security integration tests', function () {
         /Translating attribute 'innerHTML' is disallowed for security reasons./,
       );
     });
+
+    it('should throw error on security-sensitive SVG animation attributes', () => {
+      const template = `
+        <svg>
+          <a href="/safe">
+            <set
+              attributeName="display"
+              i18n-attributeName
+              to="inline"
+              i18n-to
+              begin="0s"
+              fill="freeze">
+            </set>
+          </a>
+        </svg>
+      `;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'attributeName' is disallowed for security reasons./,
+      );
+    });
   });
 });


### PR DESCRIPTION
This fix addresses a security issue in the Angular compiler i18n metadata pass.

This PR covers the iframe policy attribute case: Angular i18n allowed translated iframe policy attributes to relax sandbox, CSP, referrerPolicy, and Permissions Policy controls.
The change follows a Google OSS VRP review that asked for the issue to be
handled through the Angular GitHub workflow for disclosure and remediation.

`i18n-*` attributes were rejected when they targeted Trusted Types sinks, but
they were not rejected when they targeted attributes that Angular's own DOM
security schema marks as `SecurityContext.ATTRIBUTE_NO_BINDING`.

This allowed localized static attributes to bypass the same security-sensitive
attribute restrictions that Angular already enforces for dynamic bindings. In
particular, SVG animation attributes such as `attributeName` and `to` can affect
security-sensitive link targets at runtime, and iframe policy attributes such as
`sandbox` are also marked as non-bindable by the DOM security schema.

Changes:
- Check translated attributes against Angular's DOM security schema in addition
  to the existing Trusted Types sink check.
- Reject `i18n-*` metadata for attributes whose security context is
  `SecurityContext.ATTRIBUTE_NO_BINDING`.
- Normalize namespaced element names before security-context lookup, so SVG
  elements such as `:svg:set` are checked against the same schema entries as
  dynamic bindings.
- Add regression coverage for translated SVG animation attributes.
- Update iframe security-sensitive i18n coverage to assert that such translated
  attributes are rejected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Angular's i18n metadata visitor only rejects translated attributes when
`isTrustedTypesSink(tagName, attrName)` returns true.

Attributes that are marked in `dom_security_schema.ts` as
`SecurityContext.ATTRIBUTE_NO_BINDING` are not rejected by the i18n metadata
pass. As a result, localized static attributes can be emitted for security-
sensitive SVG animation attributes and iframe policy attributes even though
Angular blocks equivalent dynamic bindings.

## What is the new behavior?

Translated attributes are rejected when they target either:

- a Trusted Types sink, or
- an attribute marked by the DOM security schema as
  `SecurityContext.ATTRIBUTE_NO_BINDING`.

This aligns i18n translated attributes with Angular's existing DOM security
schema and prevents localized static attributes from bypassing security-
sensitive attribute restrictions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Validated locally with:

- `bazelisk test //packages/core/test:test --test_filter='security integration tests translation'`
- `bazelisk test //packages/core/test/acceptance:acceptance --test_filter='iframe processing'`
- `bazelisk test //packages/compiler/test:test --test_filter='i18n'`
- `npx --yes prettier@3.8.0 --check packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts packages/core/test/acceptance/security_spec.ts`
- `git diff --check -- packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts packages/core/test/acceptance/security_spec.ts`

