### PR TITLE
fix(compiler): disallow static i18n url attributes (XSS)

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -12,7 +12,11 @@ import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
 import * as html from '../../../ml_parser/ast';
 import {ParseTreeResult} from '../../../ml_parser/parser';
+import {splitNsName} from '../../../ml_parser/tags';
+import {TokenType} from '../../../ml_parser/tokens';
 import * as o from '../../../output/output_ast';
+import {SecurityContext} from '../../../core';
+import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
 import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
@@ -48,6 +52,29 @@ const setI18nRefs = (originalNodeMap: Map<html.Node, html.Node>): VisitNodeFn =>
     return i18nNode;
   };
 };
+
+const domSchema = new DomElementSchemaRegistry();
+
+function getElementName(node: html.Element | html.Component): string | null {
+  const tagName = node instanceof html.Component ? node.tagName : node.name;
+  return tagName === null ? null : splitNsName(tagName)[1];
+}
+
+function isStaticAttributeValue(attr: html.Attribute): boolean {
+  return !attr.valueTokens?.some((token) => token.type === TokenType.ATTR_VALUE_INTERPOLATION);
+}
+
+function isStaticUrlAttribute(node: html.Element | html.Component, attr: html.Attribute): boolean {
+  const elementName = getElementName(node);
+  if (elementName === null) {
+    return false;
+  }
+
+  return (
+    isStaticAttributeValue(attr) &&
+    domSchema.securityContext(elementName, attr.name, true) === SecurityContext.URL
+  );
+}
 
 /**
  * This visitor walks over HTML parse tree and converts information stored in
@@ -201,12 +228,9 @@ export class I18nMetaVisitor implements html.Visitor {
         } else if (attr.name.startsWith(I18N_ATTR_PREFIX)) {
           // 'i18n-*' attributes
           const name = attr.name.slice(I18N_ATTR_PREFIX.length);
-          let isTrustedType: boolean;
-          if (node instanceof html.Component) {
-            isTrustedType = node.tagName === null ? false : isTrustedTypesSink(node.tagName, name);
-          } else {
-            isTrustedType = isTrustedTypesSink(node.name, name);
-          }
+          const elementName = getElementName(node);
+          const isTrustedType =
+            elementName === null ? false : isTrustedTypesSink(elementName, name);
 
           if (isTrustedType) {
             this._reportError(
@@ -228,7 +252,14 @@ export class I18nMetaVisitor implements html.Visitor {
           const meta = attrsMeta[attr.name];
           // do not create translation for empty attributes
           if (meta !== undefined && attr.value) {
-            attr.i18n = this._generateI18nMessage([attr], attr.i18n || meta);
+            if (isStaticUrlAttribute(node, attr)) {
+              this._reportError(
+                attr,
+                `Translating attribute '${attr.name}' is disallowed for security reasons.`,
+              );
+            } else {
+              attr.i18n = this._generateI18nMessage([attr], attr.i18n || meta);
+            }
           }
         }
       }

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -273,5 +273,23 @@ describe('security integration tests', function () {
         /Translating attribute 'innerHTML' is disallowed for security reasons./,
       );
     });
+
+    it('should throw error on static URL attributes', () => {
+      const template = `<a href="/safe" i18n-href>Link</a>`;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'href' is disallowed for security reasons./,
+      );
+    });
+
+    it('should throw error on static form action attributes', () => {
+      const template = `<form action="/safe" i18n-action></form>`;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'action' is disallowed for security reasons./,
+      );
+    });
   });
 });


### PR DESCRIPTION
This fix addresses an XSS issue in Angular i18n where translated static URL
attributes could be emitted without going through Angular's URL sanitization.

Summary: XSS in Angular i18n: translated URL attributes bypass URL sanitization and execute javascript: href/action values.

Angular already sanitizes translated URL attributes when the value is produced
from a binding or interpolation. Static translated attributes take a separate
compiler path, so a translated `href`, `action`, or `formaction` value could be
applied as a constant URL value instead of being sanitized.

This PR follows disclosure guidance from Google OSS VRP to work with the
Angular maintainers through a public pull request.

Changes:
- Detect i18n annotations on static attributes whose DOM security context is
  `SecurityContext.URL`
- Reject those static URL attribute translations during i18n metadata
  collection
- Keep existing translated binding/interpolation sanitization behavior intact
- Add regression coverage for static `href` and `action` translations

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Static attributes marked for i18n are allowed even when Angular's DOM security
schema marks the attribute as a URL sink. Translated static URL values can be
emitted as constants instead of passing through URL sanitization.

Existing translated URL bindings and translated URL interpolations are already
sanitized, which means static translated URL attributes are the inconsistent
case.

Issue Number: N/A

## What is the new behavior?

Angular rejects static URL attributes marked for translation, for example a
static `href` or `action` with `i18n-href` or `i18n-action`.

Translated URL bindings and interpolations remain supported and continue to use
the existing sanitizer path.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This may break applications that translate static URL attributes directly. Those
applications should use a binding or interpolation so Angular can sanitize the
translated URL value at runtime.

## Other information

Validation run locally:

- `bazelisk test //packages/core/test:test --test_filter='security integration tests translation'`
- `bazelisk test //packages/core/test/acceptance:acceptance --test_filter='attribute sanitization'`
- `bazelisk test //packages/compiler/test:test --test_filter='i18n'`
- `npx --yes prettier@3.8.0 --check packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts`
- `git diff --check -- packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts`

