### PR TITLE
perf(forms): shortcut deepSignal writes if value is unchanged

### DIFF
--- a/packages/forms/signals/src/util/deep_signal.ts
+++ b/packages/forms/signals/src/util/deep_signal.ts
@@ -27,6 +27,9 @@ export function deepSignal<S, K extends keyof S>(
 
   read[SIGNAL] = source[SIGNAL];
   read.set = (value: S[K]) => {
+    if (Object.is(untracked(read), value)) {
+      return;
+    }
     source.update((current) => valueForWrite(current, value, prop()) as S);
   };
 

--- a/packages/forms/signals/test/node/deep_signal.spec.ts
+++ b/packages/forms/signals/test/node/deep_signal.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {computed, signal} from '@angular/core';
+import {deepSignal} from '../../src/util/deep_signal';
+
+describe('deepSignal', () => {
+  it('should allow reading and writing', () => {
+    const source = signal({foo: 'bar'});
+    const prop = signal('foo' as const);
+    const deep = deepSignal(source, prop);
+
+    expect(deep()).toBe('bar');
+    deep.set('baz');
+    expect(deep()).toBe('baz');
+    expect(source().foo).toBe('baz');
+  });
+
+  it('should optimize sets with same value on objects', () => {
+    const source = signal({foo: 'bar'});
+    const prop = signal('foo' as const);
+    const deep = deepSignal(source, prop);
+
+    let sourceTriggerCount = 0;
+    const derived = computed(() => {
+      source();
+      sourceTriggerCount++;
+      return source().foo;
+    });
+
+    // Initial evaluation
+    derived();
+    expect(sourceTriggerCount).toBe(1);
+
+    // Set to different value
+    deep.set('baz');
+    derived();
+    expect(deep()).toBe('baz');
+    expect(source().foo).toBe('baz');
+    expect(sourceTriggerCount).toBe(2);
+
+    // Set to SAME value
+    deep.set('baz');
+    derived();
+    expect(sourceTriggerCount).toBe(2); // Should STILL be 2 if optimization works
+  });
+
+  it('should optimize sets with same value on arrays', () => {
+    const source = signal(['a', 'b', 'c']);
+    const prop = signal(1); // index 1, value 'b'
+    const deep = deepSignal(source, prop);
+
+    let sourceTriggerCount = 0;
+    const derived = computed(() => {
+      source();
+      sourceTriggerCount++;
+      return source()[1];
+    });
+
+    // Initial evaluation
+    derived();
+    expect(sourceTriggerCount).toBe(1);
+
+    // Set to different value
+    deep.set('x');
+    derived();
+    expect(deep()).toBe('x');
+    expect(source()[1]).toBe('x');
+    expect(sourceTriggerCount).toBe(2);
+
+    // Set to SAME value
+    deep.set('x');
+    derived();
+    expect(sourceTriggerCount).toBe(2); // Should STILL be 2 if optimization works
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [x] Other... Please describe: Performance optimization (`perf`)

## What is the current behavior?

Currently, calling `deepSignal.set(value)` triggers a full deep write path traversal (creating new arrays/objects copies) and forces the `source` signal to update and notify its consumers, even if the new `value` is identical to the current property value.

Issue Number: N/A

## What is the new behavior?

Adds an early `Object.is(untracked(read), value)` check to shortcut the write path if the new value matches the current value exactly. This avoids `source.update` overhead, closure allocation, and unnecessary cloning and change notifications.

This relies on the existing design guarantee that `source`'s value is non-nullable when a `deepSignal` path is resolved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

TAG=agy
CONV=9e5bd277-0d0a-466c-be36-5e3a8e6910be
