### PR TITLE
fix(compiler): disallow i18n on svg animation attributes (XSS)

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -12,7 +12,10 @@ import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
 import * as html from '../../../ml_parser/ast';
 import {ParseTreeResult} from '../../../ml_parser/parser';
+import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
+import {SecurityContext} from '../../../core';
+import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
 import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
@@ -48,6 +51,19 @@ const setI18nRefs = (originalNodeMap: Map<html.Node, html.Node>): VisitNodeFn =>
     return i18nNode;
   };
 };
+
+const domSchema = new DomElementSchemaRegistry();
+const SVG_ANIMATION_ELEMENTS = new Set(['animate', 'set', 'animatemotion', 'animatetransform']);
+
+function isSvgAnimationTranslatedAttribute(tagName: string, attrName: string): boolean {
+  const elementName = splitNsName(tagName)[1];
+
+  return (
+    SVG_ANIMATION_ELEMENTS.has(elementName.toLowerCase()) &&
+    domSchema.securityContext(elementName, attrName, /* isAttribute */ true) ===
+      SecurityContext.ATTRIBUTE_NO_BINDING
+  );
+}
 
 /**
  * This visitor walks over HTML parse tree and converts information stored in
@@ -201,14 +217,20 @@ export class I18nMetaVisitor implements html.Visitor {
         } else if (attr.name.startsWith(I18N_ATTR_PREFIX)) {
           // 'i18n-*' attributes
           const name = attr.name.slice(I18N_ATTR_PREFIX.length);
-          let isTrustedType: boolean;
+          let isSecuritySensitive: boolean;
           if (node instanceof html.Component) {
-            isTrustedType = node.tagName === null ? false : isTrustedTypesSink(node.tagName, name);
+            isSecuritySensitive =
+              node.tagName === null
+                ? false
+                : isTrustedTypesSink(node.tagName, name) ||
+                  isSvgAnimationTranslatedAttribute(node.tagName, name);
           } else {
-            isTrustedType = isTrustedTypesSink(node.name, name);
+            isSecuritySensitive =
+              isTrustedTypesSink(node.name, name) ||
+              isSvgAnimationTranslatedAttribute(node.name, name);
           }
 
-          if (isTrustedType) {
+          if (isSecuritySensitive) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -273,5 +273,27 @@ describe('security integration tests', function () {
         /Translating attribute 'innerHTML' is disallowed for security reasons./,
       );
     });
+
+    it('should throw error on SVG animation retargeting attributes', () => {
+      const template = `
+        <svg>
+          <a href="/safe">
+            <set
+              attributeName="display"
+              to="inline"
+              i18n-attributeName
+              i18n-to
+              begin="0s"
+              fill="freeze">
+            </set>
+          </a>
+        </svg>
+      `;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'attributeName' is disallowed for security reasons./,
+      );
+    });
   });
 });


### PR DESCRIPTION
This fix addresses a security issue in the Angular compiler i18n metadata pass.

Summary: Angular i18n SVG <set> retargets safe animation into executable href.

The change follows a Google OSS VRP review that asked for the issue to be
handled through the Angular GitHub workflow for disclosure and remediation.

`i18n-*` attributes were rejected when they targeted Trusted Types sinks, but
they were not rejected when they targeted SVG animation attributes that Angular's
own DOM security schema marks as `SecurityContext.ATTRIBUTE_NO_BINDING`.

This allowed localized static SVG animation attributes to bypass the same
security-sensitive attribute restrictions that Angular already enforces for
dynamic bindings. SVG animation attributes such as `attributeName` and `to` can
retarget an otherwise safe animation into a security-sensitive link target at
runtime.

Changes:
- Check translated SVG animation attributes against Angular's DOM security
  schema in addition to the existing Trusted Types sink check.
- Reject `i18n-*` metadata for SVG animation attributes whose security context
  is `SecurityContext.ATTRIBUTE_NO_BINDING`.
- Normalize namespaced element names before security-context lookup, so SVG
  elements such as `:svg:set` are checked against the same schema entries as
  dynamic bindings.
- Add regression coverage for translated SVG animation attributes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

Angular's i18n metadata visitor only rejects translated attributes when
`isTrustedTypesSink(tagName, attrName)` returns true.

SVG animation attributes that are marked in `dom_security_schema.ts` as
`SecurityContext.ATTRIBUTE_NO_BINDING` are not rejected by the i18n metadata
pass. As a result, localized static SVG animation attributes can be emitted even
though Angular blocks equivalent dynamic bindings.

## What is the new behavior?

Translated SVG animation attributes are rejected when Angular's DOM security
schema marks them as `SecurityContext.ATTRIBUTE_NO_BINDING`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated locally with:

- `bazelisk test //packages/core/test:test --test_filter='security integration tests translation'`
- `bazelisk test //packages/compiler/test:test --test_filter='i18n'`
- `npx --yes prettier@3.8.0 --check packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts`
- `git diff --check -- packages/compiler/src/render3/view/i18n/meta.ts packages/core/test/linker/security_integration_spec.ts`
