### PR TITLE
fix(router): Only bind 'undefined' to components if input was previou…

### DIFF
--- a/adev/src/content/guide/routing/common-router-tasks.md
+++ b/adev/src/content/guide/routing/common-router-tasks.md
@@ -68,22 +68,21 @@ provideRouter(appRoutes, withComponentInputBinding({queryParams: false}));
 
 ### Configure behavior for inputs not available in router data
 
-By default, the router sets an input to `undefined` if it was not available in the router data during a navigation. This ensures that stale data is not retained.
+By default, the router sets an input to `undefined` only if it was previously available in the router data during the lifetime of the active route in the outlet (`unmatchedInputBehavior: 'undefinedIfStale'`). This ensures that stale data is cleared when a parameter is removed, while preserving the initial value of the input if it was never targeted by the router.
 
-If you want to avoid setting `undefined` for inputs that have _never_ been available in the router data for the active component instance, you can set the `unmatchedInputBehavior` option to `'undefinedIfStale'`:
+If you want to instruct the Router to always set unmatched inputs to `undefined` (overriding any initial values in the component), you can set the `unmatchedInputBehavior` option to `'alwaysUndefined'`:
 
 ```ts
-provideRouter(appRoutes, withComponentInputBinding({unmatchedInputBehavior: 'undefinedIfStale'}));
+provideRouter(appRoutes, withComponentInputBinding({unmatchedInputBehavior: 'alwaysUndefined'}));
 ```
 
-When you combine `unmatchedInputBehavior: 'undefinedIfStale'` with `queryParams: false`, inputs retain their initial values unless they are explicitly provided by the router. The exception is matrix parameters: if a matrix parameter is provided in one navigation and removed in a subsequent one, the router will set the input to `undefined` to avoid retaining stale data.
+With `queryParams: false`, inputs retain their initial values unless they are explicitly provided by the router. The exception is matrix parameters: if a matrix parameter is provided in one navigation and removed in a subsequent one, the router will set the input to `undefined` to avoid retaining stale data.
 
 ```ts
 provideRouter(
   appRoutes,
   withComponentInputBinding({
     queryParams: false,
-    unmatchedInputBehavior: 'undefinedIfStale',
   }),
 );
 ```

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -37,6 +37,8 @@ import {ActivatedRoute} from '../router_state';
 import {Params, PRIMARY_OUTLET} from '../shared';
 import {ComponentInputBindingOptions} from '../router_config';
 
+const UNMATCHED_INPUT_DEFAULT = 'undefinedIfStale';
+
 /**
  * An `InjectionToken` provided by the `RouterOutlet` and can be set using the `routerOutletData`
  * input.
@@ -525,12 +527,11 @@ export class RoutedComponentInputBinder {
           seenKeys.add(key);
         }
 
-        const behavior = this.options.unmatchedInputBehavior ?? 'alwaysUndefined';
+        const behavior = this.options.unmatchedInputBehavior ?? UNMATCHED_INPUT_DEFAULT;
 
         for (const {templateName} of mirror.inputs) {
-          const value = data[templateName];
-          if (value !== undefined || behavior === 'alwaysUndefined' || seenKeys.has(templateName)) {
-            outlet.activatedComponentRef.setInput(templateName, value);
+          if (behavior === 'alwaysUndefined' || seenKeys.has(templateName)) {
+            outlet.activatedComponentRef.setInput(templateName, data[templateName]);
           }
         }
       });

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -813,10 +813,11 @@ export type ViewTransitionsFeature = RouterFeature<RouterFeatureKind.ViewTransit
  * from the route.
  *
  * Importantly, when an input does not have an item in the route data with a matching key, this
- * input is set to `undefined`. This prevents previous information from being
- * retained if the data got removed from the route (i.e. if a query parameter is removed).
- * Default values can be provided with a resolver on the route to ensure the value is always present
- * or an input and use an input transform in the component.
+ * input is set to `undefined` by default only if it was previously available in the router data
+ * during the lifetime of the active route in the outlet. This prevents previous information from
+ * being retained if the data got removed from the route (i.e. if a query parameter is removed)
+ * while preserving the initial value of the input if it was never set by the router.
+ * This behavior can be configured using the `unmatchedInputBehavior` option.
  *
  * Advanced example of how you can disable binding from certain sources:
  * ```ts

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -427,7 +427,10 @@ describe('component input binding', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        provideRouter([{path: '**', component: MyComponent}], withComponentInputBinding()),
+        provideRouter(
+          [{path: '**', component: MyComponent}],
+          withComponentInputBinding({unmatchedInputBehavior: 'alwaysUndefined'}),
+        ),
       ],
     });
     const harness = await RouterTestingHarness.create();


### PR DESCRIPTION
…sly bound

This updates Router input binding feature to only bind `undefined` to an input it it previously matched to some router information that no longer appears. Prior to this, Router would bind all inputs unconditionally, including those which did not have matching keys in the router params, data, or query params.

The prior behavior was to prevent the scenario where something like queryParams was initially bound, and then its associated key got removed on subsequent navigations. Failing to bind `undefined` would have resulted in stale data. This update ensures the Router only binds `undefined` in the specific scenario where stale data was actually present.

This change allows component inputs with initial values to retain their intial values if there is no matching key in the Router information.

fixes  #63835 and #52946

BREAKING CHANGE: The Router no longer binds `undefined` to inputs that do not have matching keys in the query parameters, data, or params. `undefined` is now only bound when the input previously _did_ match Router information but no longer does. This prevents stale information from being retained in the component inputs.
