### PR TITLE
feat: add additional template source location metadata

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.api.md
+++ b/goldens/public-api/compiler-cli/compiler_options.api.md
@@ -7,6 +7,7 @@
 // @public
 export interface BazelAndG3Options {
     annotateForClosureCompiler?: boolean;
+    enableTemplateSourceLocations?: boolean;
     _experimentalAllowEmitDeclarationOnly?: boolean;
     generateDeepReexports?: boolean;
     generateExtraImportsInLocalMode?: boolean;

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -345,6 +345,11 @@ export interface BazelAndG3Options {
    * Defaults to `false`.
    */
   legacyOptionalChaining?: boolean;
+
+  /**
+   * Internal option for enabling template source location metadata.
+   */
+  enableTemplateSourceLocations?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -6,7 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {LEGACY_OPTIONAL_CHAINING_DEFAULT, TypeCheckingConfig} from '@angular/compiler';
+import {
+  LEGACY_OPTIONAL_CHAINING_DEFAULT,
+  setEnableTemplateSourceLocations,
+  TypeCheckingConfig,
+} from '@angular/compiler';
 import ts from 'typescript';
 
 import {
@@ -485,6 +489,9 @@ export class NgCompiler {
       ...verifyCompatibleTypeCheckOptions(this.options),
       ...verifyEmitDeclarationOnly(this.options),
     );
+    if (this.options.enableTemplateSourceLocations) {
+      setEnableTemplateSourceLocations(true);
+    }
 
     this.currentProgram = inputProgram;
     this.closureCompilerEnabled = !!this.options.annotateForClosureCompiler;

--- a/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/attach_source_location_spec.ts
@@ -45,7 +45,7 @@ runInEachFileSystem(() => {
       );
       env.driveMain();
       const content = env.getContents('test.js');
-      expect(content).toContain('ɵɵdomElementStart(0, "div")(1, "span")(2, "strong");');
+      expect(content).toContain('ɵɵdomElementStart(0, "div", 0)(1, "span", 1)(2, "strong", 2);');
       expect(content).toContain(
         'ɵɵattachSourceLocations("test.ts", [[0, 114, 5, 14], [1, 119, 5, 19], [2, 142, 6, 16]]);',
       );
@@ -72,7 +72,7 @@ runInEachFileSystem(() => {
       );
       env.driveMain();
       const content = env.getContents('test.js');
-      expect(content).toContain('ɵɵdomElementStart(0, "div")(1, "span")(2, "strong");');
+      expect(content).toContain('ɵɵdomElementStart(0, "div", 0)(1, "span", 1)(2, "strong", 2);');
       expect(content).toContain(
         'ɵɵattachSourceLocations("test.html", [[0, 9, 1, 8], [1, 14, 1, 13], [2, 31, 2, 10]]);',
       );
@@ -99,8 +99,8 @@ runInEachFileSystem(() => {
       env.driveMain();
       const content = env.getContents('test.js');
       expect(content).toContain('ɵɵtemplate(0,');
-      expect(content).toContain('ɵɵelementStart(0, "div");');
-      expect(content).toContain('ɵɵelement(1, "span");');
+      expect(content).toContain('ɵɵelementStart(0, "div", 1);');
+      expect(content).toContain('ɵɵelement(1, "span", 2);');
       expect(content).toContain(
         'ɵɵattachSourceLocations("test.ts", [[0, 207, 7, 14], [1, 242, 8, 16]]);',
       );
@@ -128,10 +128,10 @@ runInEachFileSystem(() => {
       );
       env.driveMain();
       const content = env.getContents('test.js');
-      expect(content).toContain('ɵɵdomElementContainerStart(0);');
-      expect(content).toContain('ɵɵdomElementStart(1, "div");');
-      expect(content).toContain('ɵɵdomElementContainerStart(2);');
-      expect(content).toContain('ɵɵdomElement(3, "span");');
+      expect(content).toContain('ɵɵdomElementContainerStart(0, 0);');
+      expect(content).toContain('ɵɵdomElementStart(1, "div", 1);');
+      expect(content).toContain('ɵɵdomElementContainerStart(2, 2);');
+      expect(content).toContain('ɵɵdomElement(3, "span", 3);');
       expect(content).toContain(
         'ɵɵattachSourceLocations("test.ts", [[1, 145, 6, 16], [3, 204, 8, 20]]);',
       );

--- a/packages/compiler-cli/test/ngtsc/attach_sourcecode_loc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/attach_sourcecode_loc_spec.ts
@@ -1,0 +1,51 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {setEnableTemplateSourceLocations} from '@angular/compiler';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {loadStandardTestFiles} from '../../src/ngtsc/testing';
+import {NgtscTestEnvironment} from './env';
+
+const testFiles = loadStandardTestFiles({fakeCommon: true});
+
+runInEachFileSystem(() => {
+  describe('attachSourcecodeLoc phase', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      setEnableTemplateSourceLocations(true);
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig();
+    });
+
+    afterEach(() => {
+      setEnableTemplateSourceLocations(false);
+    });
+
+    it('should attach the sourcecode location as a data attribute', () => {
+      env.write(
+        `test.ts`,
+        `
+          import {Component} from '@angular/core';
+
+          @Component({
+            template: \`<div><span>Hello</span></div>\`,
+          })
+          class Comp {}
+         `,
+      );
+      env.driveMain();
+      const content = env.getContents('test.js');
+
+      // The div
+      expect(content).toContain(`["data-sourcecode-loc", "test.ts;l=5-5;c=24-53"]`);
+      // The span
+      expect(content).toContain(`["data-sourcecode-loc", "test.ts;l=5-5;c=29-47"]`);
+    });
+  });
+});

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -90,6 +90,7 @@ import {transformTwoWayBindingSet} from './phases/transform_two_way_binding_set'
 import {countVariables} from './phases/var_counting';
 import {optimizeVariables} from './phases/variable_optimization';
 import {wrapI18nIcus} from './phases/wrap_icus';
+import {attachSourcecodeLoc} from './phases/attach_sourcecode_loc';
 
 type Phase =
   | {
@@ -106,6 +107,9 @@ type Phase =
     };
 
 const phases: Phase[] = [
+  // attachSourcecodeLoc should run before any other phases that modify the
+  // template.
+  {kind: Kind.Tmpl, fn: attachSourcecodeLoc},
   {kind: Kind.Tmpl, fn: removeContentSelectors},
   {kind: Kind.Both, fn: optimizeRegularExpressions},
   {kind: Kind.Host, fn: parseHostStyleProperties},

--- a/packages/compiler/src/template/pipeline/src/phases/attach_sourcecode_loc.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attach_sourcecode_loc.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {SecurityContext} from '../../../../core';
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {ComponentCompilationJob} from '../compilation';
+
+/**
+ * Inserts the data-sourcecode-loc attribute onto elements in templates.
+ *
+ * This is similar to the ./attach_source_locations phase, but this phase
+ * attaches more precise source locations, and it emits them directly into
+ * the HTML in a data attribute.
+ *
+ * This protocol is more useful for framework-agnostic tooling.
+ */
+export function attachSourcecodeLoc(job: ComponentCompilationJob): void {
+  if (!job.enableDebugLocations || job.relativeTemplatePath === null) {
+    return;
+  }
+
+  const fileName = job.relativeTemplatePath;
+  for (const unit of job.units) {
+    for (const op of unit.create) {
+      if (op.kind === ir.OpKind.ElementStart || op.kind === ir.OpKind.Element) {
+        const startLine = op.wholeSourceSpan.start.line + 1;
+        const startCol = op.wholeSourceSpan.start.col + 1;
+        const endLine = op.wholeSourceSpan.end.line + 1;
+        const endCol = op.wholeSourceSpan.end.col + 1;
+
+        const locString = `${fileName};l=${startLine}-${endLine};c=${startCol}-${endCol}`;
+
+        const extractedAttributeOp = ir.createExtractedAttributeOp(
+          op.xref,
+          ir.BindingKind.Attribute,
+          null,
+          'data-sourcecode-loc',
+          o.literal(locString),
+          null,
+          null,
+          SecurityContext.NONE,
+        );
+        unit.create.push(extractedAttributeOp);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of an internal project at Google, but likely useful more broadly. Similar to the existing source locations op, but this is template system agnostic and includes more precise ranges suitable for bidirectionally mapping between source code and HTML.

Doc with more internal info: go/html-source-loc.

I'm piggybacking off of job.enableDebugLocations but happy to create a new flag for this purpose instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] I didn't see any docs for the existing attachSourceLocations pass, so I whistled to that tune, if there's a place this should be documented please let me know.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

This adds a new kind of opt-in debug metadata.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

