### PR TITLE
fix(docs-infra): fix code block deindentation in docs-code and docs-code-block

### DIFF
--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code-block.mts
@@ -48,7 +48,7 @@ export const docsCodeBlockExtension = {
       const token: DocsCodeBlock = {
         raw: match[0],
         type: 'docs-code-block',
-        code: deindent(match[3]),
+        code: match[3],
         language: match[1],
         header: headerRule.exec(metadataStr)?.[2],
         highlight: highlightRule.exec(metadataStr)?.[1],
@@ -68,20 +68,3 @@ export const docsCodeBlockExtension = {
     return formatCode(token, (this.parser.renderer as AdevDocsRenderer).context);
   },
 };
-
-/**
- * Removes leading indentation from code blocks.
- */
-function deindent(str: string): string {
-  const lines = str.split('\n');
-  let minIndent = Infinity;
-  for (const line of lines) {
-    if (!line.trim()) {
-      minIndent = Math.min(line.match(/^(\s*)/)?.[1].length ?? 0, minIndent);
-    }
-  }
-  if (minIndent === Infinity || minIndent === 0) {
-    return str;
-  }
-  return lines.map((line) => line.slice(minIndent)).join('\n');
-}

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/docs-code.mts
@@ -59,7 +59,7 @@ export const docsCodeExtension = {
       const classes = classRule.exec(attr);
       const style = preferRule.exec(attr);
 
-      let code = match[2]?.trim() ?? '';
+      let code = match[2] ?? '';
       if (path && path[1]) {
         code = loadWorkspaceRelativeFile(path[1]);
         // Remove ESLint Comments

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/index.mts
@@ -52,6 +52,7 @@ export function formatCode(token: CodeToken, context: RendererContext): string {
   }
 
   extractRegions(token);
+  token.code = deindent(token.code).trim();
   highlightCode(context.highlighter, token, context);
 
   const containerEl = JSDOM.fragment(`
@@ -152,4 +153,21 @@ function applyContainerAttributesAndClasses(el: Element, token: CodeToken) {
   if (token.classes) {
     el.classList.add(...token.classes);
   }
+}
+
+/**
+ * Removes leading indentation from code blocks.
+ */
+function deindent(str: string): string {
+  const lines = str.split('\n');
+  let minIndent = Infinity;
+  for (const line of lines) {
+    if (line.trim()) {
+      minIndent = Math.min(line.match(/^(\s*)/)?.[1].length ?? 0, minIndent);
+    }
+  }
+  if (minIndent === Infinity || minIndent === 0) {
+    return str;
+  }
+  return lines.map((line) => line.slice(minIndent)).join('\n');
 }

--- a/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/region.mts
+++ b/adev/shared-docs/pipeline/shared/marked/extensions/docs-code/format/region.mts
@@ -24,6 +24,6 @@ export function extractRegions(token: CodeToken) {
     if (!region) {
       throw new Error(`Cannot find ${token.region} in ${token.path}!`);
     }
-    token.code = region.lines.join('\n').trim();
+    token.code = region.lines.join('\n');
   }
 }

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code-block/docs-code-block.spec.mts
@@ -35,7 +35,8 @@ describe('markdown to html', () => {
 
   it('should deindent code blocks correctly', () => {
     const codeBlock = markdownDocument.querySelectorAll('code')[1];
-    expect(codeBlock.innerHTML).toContain(`  // bar`);
+    expect(codeBlock.textContent).not.toContain(`    if(foo)`);
+    expect(codeBlock.textContent).toContain(`  // bar`);
   });
 
   it('should handle code blocks without language', () => {

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.md
@@ -14,3 +14,9 @@ const form = {
 </docs-code>
 
 <docs-code hideDollar code="echo 'hello world'" />
+
+<docs-code language="typescript">
+  if (foo) {
+    // bar
+  }
+</docs-code>

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
@@ -60,7 +60,6 @@ describe('markdown to html', () => {
 
   it('should deindent inline code blocks correctly', () => {
     const codeBlock = markdownDocument.querySelectorAll('.docs-code')[6]?.querySelector('code');
-    expect(codeBlock?.textContent).not.toContain('    // bar');
-    expect(codeBlock?.textContent).toContain('  // bar');
+    expect(codeBlock?.textContent).toMatch(/^  \/\/ bar/m);
   });
 });

--- a/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
+++ b/adev/shared-docs/pipeline/shared/marked/test/docs-code/docs-code.spec.mts
@@ -57,4 +57,10 @@ describe('markdown to html', () => {
     const codeBlock = markdownDocument.querySelectorAll('.docs-code')[5];
     expect(codeBlock.getAttribute('hideDollar')).toBe('true');
   });
+
+  it('should deindent inline code blocks correctly', () => {
+    const codeBlock = markdownDocument.querySelectorAll('.docs-code')[6]?.querySelector('code');
+    expect(codeBlock?.textContent).not.toContain('    // bar');
+    expect(codeBlock?.textContent).toContain('  // bar');
+  });
 });


### PR DESCRIPTION
Consolidates deindentation logic into formatCode so both docs-code and docs-code-block are covered by a single fix. The original deindent function incorrectly iterated over blank lines instead of non-blank lines when computing minimum indentation, causing code blocks to render with excessive leading whitespace. Also fixes region extraction which had the same trim-before-deindent ordering issue.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The indentation of many of the code samples is showing up incorrectly.  For example:

<img width="566" height="385" alt="image" src="https://github.com/user-attachments/assets/8a50503d-814c-4b18-8373-9cc7afed36ee" />

Issue Number: N/A

## What is the new behavior?

Leading indentation is properly stripped from code samples

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
