### PR TITLE
docs: Update error display for password field in signal forms playground

### DIFF
--- a/adev/src/content/tutorials/playground/4-signal-forms/src/main.ts
+++ b/adev/src/content/tutorials/playground/4-signal-forms/src/main.ts
@@ -33,11 +33,11 @@ interface LoginData {
         </label>
 
         @if (loginForm.password().invalid()) {
-          <div class="error">
+          <ul class="error-list">
             @for (error of loginForm.password().errors(); track error) {
-              <p>{{ error.message }}</p>
+              <li>{{ error.message }}</li>
             }
-          </div>
+          </ul>
         }
       </div>
 


### PR DESCRIPTION
Update error display for passworld field in signal forms playground.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The error display for password is different from display email field, so it was a little difficult that we cuold find error message for password.

<img width="550" height="340" alt="スクリーンショット 2026-05-05 16 39 19" src="https://github.com/user-attachments/assets/acc39507-9dc8-4e5f-b77d-988af8cc96ef" />


## What is the new behavior?

Update error display for passworld field like email field.

<img width="488" height="307" alt="スクリーンショット 2026-05-05 16 39 46" src="https://github.com/user-attachments/assets/c47ad4b9-f515-4c1c-82ed-96d5100b6335" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
