### PR TITLE
fix(core): makes resource URL sanitizer lookup case-insensitive

### DIFF
--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -233,7 +233,7 @@ const RESOURCE_MAP: Record<string, Record<string, true | undefined> | undefined>
  * If tag and prop names don't match Resource URL schema, use URL sanitizer.
  */
 export function getUrlSanitizer(tag: string, prop: string) {
-  const isResource = RESOURCE_MAP[tag]?.[prop] === true;
+  const isResource = RESOURCE_MAP[tag.toLowerCase()]?.[prop.toLowerCase()] === true;
 
   return isResource ? ɵɵsanitizeResourceUrl : ɵɵsanitizeUrl;
 }

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -131,6 +131,32 @@ describe('sanitization', () => {
     });
   });
 
+  it('should select URL sanitizer case-insensitively', () => {
+    expect(getUrlSanitizer('IFRAME', 'SRC')).toEqual(ɵɵsanitizeResourceUrl);
+    expect(getUrlSanitizer('IFRAME', 'src')).toEqual(ɵɵsanitizeResourceUrl);
+    expect(getUrlSanitizer('iframe', 'SRC')).toEqual(ɵɵsanitizeResourceUrl);
+    expect(getUrlSanitizer('ScRiPt', 'xLiNk:HrEf')).toEqual(ɵɵsanitizeResourceUrl);
+    expect(getUrlSanitizer('A', 'HREF')).toEqual(ɵɵsanitizeUrl);
+  });
+
+  it('should sanitize URL or ResourceURL case-insensitively', () => {
+    const ERROR = /NG0904: unsafe value used in a resource URL context.*/;
+
+    expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'IFRAME', 'SRC')).toThrowError(ERROR);
+
+    expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'IFRAME', 'src')).toThrowError(ERROR);
+
+    expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'iframe', 'SRC')).toThrowError(ERROR);
+
+    expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'ScRiPt', 'xLiNk:HrEf')).toThrowError(
+      ERROR,
+    );
+
+    expect(ɵɵsanitizeUrlOrResourceUrl('javascript:true', 'A', 'HREF')).toEqual(
+      'unsafe:javascript:true',
+    );
+  });
+
   it('should sanitize resourceUrls via sanitizeUrlOrResourceUrl', () => {
     const ERROR = /NG0904: unsafe value used in a resource URL context.*/;
     expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'iframe', 'src')).toThrowError(ERROR);


### PR DESCRIPTION
Ensures the resource map for URL sanitization is queried using lowercase tag and property names, improving robustness by handling case variations consistently.


## What is the current behavior?

Currently, if we use the property as UpperCase in a Host Directive ( `[attr.SRC]`) or tag UpperCase Eg `<IFRAME >` , it will bypass the current validation since the validation depends on sensitive case.

## What is the new behavior?
Change the validation to insensitive case to avoid any future problems with validations regardless of UpperCase or LowerCase.