### PR TITLE
fix(compiler): disallow i18n resource url attributes (XSS)

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -12,7 +12,10 @@ import * as i18n from '../../../i18n/i18n_ast';
 import {createI18nMessageFactory, VisitNodeFn} from '../../../i18n/i18n_parser';
 import * as html from '../../../ml_parser/ast';
 import {ParseTreeResult} from '../../../ml_parser/parser';
+import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
+import {SecurityContext} from '../../../core';
+import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
 import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
@@ -48,6 +51,25 @@ const setI18nRefs = (originalNodeMap: Map<html.Node, html.Node>): VisitNodeFn =>
     return i18nNode;
   };
 };
+
+const domSchema = new DomElementSchemaRegistry();
+
+function isSecuritySensitiveI18nAttribute(
+  node: html.Element | html.Component,
+  attrName: string,
+): boolean {
+  const tagName = node instanceof html.Component ? node.tagName : node.name;
+  if (tagName === null) {
+    return false;
+  }
+
+  const elementName = splitNsName(tagName)[1];
+  return (
+    isTrustedTypesSink(elementName, attrName) ||
+    domSchema.securityContext(elementName, attrName, /* isAttribute */ true) ===
+      SecurityContext.RESOURCE_URL
+  );
+}
 
 /**
  * This visitor walks over HTML parse tree and converts information stored in
@@ -201,14 +223,8 @@ export class I18nMetaVisitor implements html.Visitor {
         } else if (attr.name.startsWith(I18N_ATTR_PREFIX)) {
           // 'i18n-*' attributes
           const name = attr.name.slice(I18N_ATTR_PREFIX.length);
-          let isTrustedType: boolean;
-          if (node instanceof html.Component) {
-            isTrustedType = node.tagName === null ? false : isTrustedTypesSink(node.tagName, name);
-          } else {
-            isTrustedType = isTrustedTypesSink(node.name, name);
-          }
 
-          if (isTrustedType) {
+          if (isSecuritySensitiveI18nAttribute(node, name)) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -273,5 +273,18 @@ describe('security integration tests', function () {
         /Translating attribute 'innerHTML' is disallowed for security reasons./,
       );
     });
+
+    it('should throw error on translated SVG script ResourceURL attributes', () => {
+      const template = `
+        <svg>
+          <script href="/safe-svg-script.js" i18n-href></script>
+        </svg>
+      `;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'href' is disallowed for security reasons./,
+      );
+    });
   });
 });


### PR DESCRIPTION
This fix addresses a Cross-Site Scripting (XSS, CWE-79) issue in Angular's i18n compiler handling for static `ResourceURL` attributes.

The issue was found during Google OSS VRP research, and this PR follows the public maintainer PR path requested for Angular product-security fixes.

Angular already classifies SVG `script|href` as `SecurityContext.RESOURCE_URL`, but the i18n metadata gate only rejected translated attributes that appear in the Trusted Types sink list. `script|href` is not in that list, so a localized build could replace a source-approved SVG script href with a translated script resource URL.

Changes:
- Add a compiler i18n check for translated attributes whose DOM security context is `SecurityContext.RESOURCE_URL`
- Preserve the existing Trusted Types sink rejection behavior
- Add a regression test for translated SVG `<script href>` ResourceURL attributes

Security impact verified:
- A standard Angular CLI localized AOT build could emit a translated SVG `<script href>` value as a static template attribute
- In Chrome, that translated SVG script URL is fetched and executed automatically when the localized page renders
- The repro uses standard Angular CLI/i18n only, with no `bypassSecurityTrust*`, custom renderer, custom sanitizer, or direct DOM writes

Out of scope:
- This PR is intentionally limited to `SecurityContext.RESOURCE_URL` translated static attributes. Other i18n security-context hardening work can remain separate.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Angular's i18n metadata pass rejects translated attributes only when `isTrustedTypesSink()` returns true. It does not also consult Angular's DOM security schema for `SecurityContext.RESOURCE_URL` attributes. As a result, static translated SVG `script|href` attributes can be emitted into localized AOT output even though the schema classifies `script|href` as a ResourceURL sink.

## What is the new behavior?

Translated static attributes are rejected when the target DOM attribute is classified as `SecurityContext.RESOURCE_URL`, while preserving the previous Trusted Types sink rejection behavior.

This prevents localization data from replacing source-approved SVG script href values with executable script resources in localized builds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Local validation run:

```bash
pnpm install --frozen-lockfile
base=$(git merge-base origin/main HEAD)
git diff --check "$base" HEAD
pnpm ng-dev commit-message validate-range "$base" HEAD
pnpm ng-dev format changed --check
pnpm bazel test //packages/core/test:test --test_filter='security integration tests translation'
pnpm bazel test //packages/compiler/test:test
```
