### PR TITLE
feat(forms): graduate signal forms APIs to public API

### DIFF
--- a/packages/forms/signals/compat/src/api/compat_form.ts
+++ b/packages/forms/signals/compat/src/api/compat_form.ts
@@ -16,7 +16,7 @@ import {CompatFieldAdapter} from '../compat_field_adapter';
  * Options that may be specified when creating a compat form.
  *
  * @category interop
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type CompatFormOptions<TModel> = Omit<FormOptions<TModel>, 'adapter'>;
 
@@ -47,7 +47,7 @@ export type CompatFormOptions<TModel> = Omit<FormOptions<TModel>, 'adapter'>;
  * the model.
  *
  * @category interop
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
 
@@ -81,7 +81,7 @@ export function compatForm<TModel>(model: WritableSignal<TModel>): FieldTree<TMo
  *   2. The form options (excluding adapter, since it's provided).
  *
  * @category interop
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function compatForm<TModel>(
   model: WritableSignal<TModel>,
@@ -117,7 +117,7 @@ export function compatForm<TModel>(
  * @param options The form options (excluding adapter, since it's provided).
  *
  * @category interop
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function compatForm<TModel>(
   model: WritableSignal<TModel>,

--- a/packages/forms/signals/compat/src/api/di.ts
+++ b/packages/forms/signals/compat/src/api/di.ts
@@ -12,7 +12,7 @@ import type {SignalFormsConfig} from '../../../src/api/di';
  * A value that can be used for `SignalFormsConfig.classes` to automatically add
  * the `ng-*` status classes from reactive forms.
  *
- * @experimental 21.0.1
+ * @publicApi 22.0
  */
 export const NG_STATUS_CLASSES: SignalFormsConfig['classes'] = {
   'ng-touched': ({state}) => state().touched(),

--- a/packages/forms/signals/compat/src/api/extract.ts
+++ b/packages/forms/signals/compat/src/api/extract.ts
@@ -29,7 +29,7 @@ export type RawValue<T> =
 /**
  * A type that recursively makes all properties of T optional.
  * Used for the result of `extractValue` when filtering is applied.
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export type DeepPartial<T> =
   | (T extends (infer U)[]
@@ -45,7 +45,7 @@ export type DeepPartial<T> =
  * Each property is optional; when provided, the field must match the specified state.
  *
  * @category interop
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export interface ExtractFilter {
   readonly dirty?: boolean;
@@ -63,7 +63,7 @@ export interface ExtractFilter {
  * @returns The raw value of the field tree.
  *
  * @category interop
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
 /**
@@ -77,7 +77,7 @@ export function extractValue<T>(field: FieldTree<T>): RawValue<T>;
  * @returns A partial value containing only the fields matching the filter, or `undefined` if none match.
  *
  * @category interop
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export function extractValue<T>(
   field: FieldTree<T>,

--- a/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
+++ b/packages/forms/signals/compat/src/signal_form_control/signal_form_control.ts
@@ -77,7 +77,7 @@ export type ValueUpdateOptions = {
  *  </form>
  * ```
  *
- * @experimental
+ * @publicApi 22.0
  */
 export class SignalFormControl<T> extends AbstractControl {
   /** Source FieldTree. */

--- a/packages/forms/signals/src/api/control.ts
+++ b/packages/forms/signals/src/api/control.ts
@@ -15,7 +15,7 @@ import type {DisabledReason} from './types';
  * The base set of properties shared by all form control contracts.
  *
  * @category control
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface FormUiControl {
   /**
@@ -144,7 +144,7 @@ type FormUiControlImplementsFormFieldBindingOptions = Check<
  * @template TValue The type of `FieldTree` that the implementing component can edit.
  *
  * @category control
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface FormValueControl<TValue> extends FormUiControl {
   /**
@@ -173,7 +173,7 @@ export interface FormValueControl<TValue> extends FormUiControl {
  * `Field` directive.
  *
  * @category control
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 // TODO: should we make this generic extends `boolean | null` so people can use `null` for parse error?
 export interface FormCheckboxControl extends FormUiControl {

--- a/packages/forms/signals/src/api/di.ts
+++ b/packages/forms/signals/src/api/di.ts
@@ -13,7 +13,7 @@ import {SIGNAL_FORMS_CONFIG} from '../field/di';
 /**
  * Configuration options for signal forms.
  *
- * @experimental 21.0.1
+ * @publicApi 22.0
  */
 export interface SignalFormsConfig {
   /** A map of CSS class names to predicate functions that determine when to apply them. */
@@ -25,7 +25,7 @@ export interface SignalFormsConfig {
 /**
  * Provides configuration options for signal forms.
  *
- * @experimental 21.0.1
+ * @publicApi 22.0
  */
 export function provideSignalFormsConfig(config: SignalFormsConfig): Provider[] {
   return [{provide: SIGNAL_FORMS_CONFIG, useValue: config}];

--- a/packages/forms/signals/src/api/rules/debounce.ts
+++ b/packages/forms/signals/src/api/rules/debounce.ts
@@ -21,7 +21,7 @@ import type {Debouncer, PathKind, SchemaPath, SchemaPathRules} from '../types';
  * @param config A debounce configuration, which can be either a debounce duration in milliseconds,
  *     `'blur'` to debounce until the field is blurred, or a custom {@link Debouncer} function.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function debounce<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/disabled.ts
+++ b/packages/forms/signals/src/api/rules/disabled.ts
@@ -21,7 +21,7 @@ import type {FieldContext, LogicFn, PathKind, SchemaPath, SchemaPathRules} from 
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function disabled<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/hidden.ts
+++ b/packages/forms/signals/src/api/rules/hidden.ts
@@ -28,7 +28,7 @@ import type {LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function hidden<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/metadata.ts
+++ b/packages/forms/signals/src/api/rules/metadata.ts
@@ -25,7 +25,7 @@ import type {FieldState, LogicFn, PathKind, SchemaPath, SchemaPathRules} from '.
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function metadata<
   TValue,
@@ -49,7 +49,7 @@ export function metadata<
  *
  * @template TAcc The accumulated type of the reduce operation.
  * @template TItem The type of the individual items that are reduced over.
- * @experimental 21.0.2
+ * @publicApi 22.0
  */
 export interface MetadataReducer<TAcc, TItem> {
   /** The reduce function. */
@@ -125,7 +125,7 @@ function override<T>(getInitial?: () => T): MetadataReducer<T | undefined, T> {
  * A symbol used to tag a `MetadataKey` as representing an asynchronous validation resource.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const IS_ASYNC_VALIDATION_RESOURCE: unique symbol = Symbol('IS_ASYNC_VALIDATION_RESOURCE');
 
@@ -139,7 +139,7 @@ export const IS_ASYNC_VALIDATION_RESOURCE: unique symbol = Symbol('IS_ASYNC_VALI
  * @template TWrite The type written to this key using the `metadata()` rule
  * @template TAcc The type of the reducer's accumulated value.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class MetadataKey<TRead, TWrite, TAcc> {
   private brand!: [TRead, TWrite, TAcc];
@@ -159,7 +159,7 @@ export class MetadataKey<TRead, TWrite, TAcc> {
  *
  * @template TKey The `MetadataKey` type
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type MetadataSetterType<TKey> =
   TKey extends MetadataKey<any, infer TWrite, any> ? TWrite : never;
@@ -170,7 +170,7 @@ export type MetadataSetterType<TKey> =
  *
  * @template TWrite The type written to this key using the `metadata()` rule
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function createMetadataKey<TWrite>(): MetadataKey<
   Signal<TWrite | undefined>,
@@ -184,7 +184,7 @@ export function createMetadataKey<TWrite>(): MetadataKey<
  * @template TWrite The type written to this key using the `metadata()` rule
  * @template TAcc The type of the reducer's accumulated value.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function createMetadataKey<TWrite, TAcc>(
   reducer: MetadataReducer<TAcc, TWrite>,
@@ -208,7 +208,7 @@ export function createMetadataKey<TWrite, TAcc>(
  * @template TRead The type read from the `FieldState` for this key
  * @template TWrite The type written to this key using the `metadata()` rule
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function createManagedMetadataKey<TRead, TWrite>(
   create: (state: FieldState<unknown>, data: Signal<TWrite | undefined>) => TRead,
@@ -226,7 +226,7 @@ export function createManagedMetadataKey<TRead, TWrite>(
  * @template TWrite The type written to this key using the `metadata()` rule
  * @template TAcc The type of the reducer's accumulated value.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function createManagedMetadataKey<TRead, TWrite, TAcc>(
   create: (state: FieldState<unknown>, data: Signal<TAcc>) => TRead,
@@ -246,7 +246,7 @@ export function createManagedMetadataKey<TRead, TWrite, TAcc>(
  * A {@link MetadataKey} representing whether the field is required.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const REQUIRED: MetadataKey<Signal<boolean>, boolean, boolean> = createMetadataKey(
   MetadataReducer.or(),
@@ -256,7 +256,7 @@ export const REQUIRED: MetadataKey<Signal<boolean>, boolean, boolean> = createMe
  * A {@link MetadataKey} representing the min value of the field.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const MIN: MetadataKey<
   Signal<number | undefined>,
@@ -268,7 +268,7 @@ export const MIN: MetadataKey<
  * A {@link MetadataKey} representing the max value of the field.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const MAX: MetadataKey<
   Signal<number | undefined>,
@@ -280,7 +280,7 @@ export const MAX: MetadataKey<
  * A {@link MetadataKey} representing the min length of the field.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const MIN_LENGTH: MetadataKey<
   Signal<number | undefined>,
@@ -292,7 +292,7 @@ export const MIN_LENGTH: MetadataKey<
  * A {@link MetadataKey} representing the max length of the field.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const MAX_LENGTH: MetadataKey<
   Signal<number | undefined>,
@@ -304,7 +304,7 @@ export const MAX_LENGTH: MetadataKey<
  * A {@link MetadataKey} representing the patterns the field must match.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const PATTERN: MetadataKey<
   Signal<RegExp[]>,

--- a/packages/forms/signals/src/api/rules/readonly.ts
+++ b/packages/forms/signals/src/api/rules/readonly.ts
@@ -20,7 +20,7 @@ import type {LogicFn, PathKind, SchemaPath, SchemaPathRules} from '../types';
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function readonly<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/email.ts
+++ b/packages/forms/signals/src/api/rules/validation/email.ts
@@ -56,7 +56,7 @@ const EMAIL_REGEXP =
  *
  * @see [Signal Form Email Validation](guide/forms/signals/validation#email)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function email<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/max.ts
+++ b/packages/forms/signals/src/api/rules/validation/max.ts
@@ -27,7 +27,7 @@ import {maxError} from './validation_errors';
  *
  * @see [Signal Form Max Validation](guide/forms/signals/validation#min-and-max)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function max<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<number | string | null, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/max_length.ts
+++ b/packages/forms/signals/src/api/rules/validation/max_length.ts
@@ -34,7 +34,7 @@ import {maxLengthError} from './validation_errors';
  *
  * @see [Signal Form Max Length Validation](guide/forms/signals/validation#minlength-and-maxlength)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function maxLength<
   TValue extends ValueWithLengthOrSize,

--- a/packages/forms/signals/src/api/rules/validation/min.ts
+++ b/packages/forms/signals/src/api/rules/validation/min.ts
@@ -27,7 +27,7 @@ import {minError} from './validation_errors';
  *
  * @see [Signal Form Min Validation](guide/forms/signals/validation#min-and-max)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function min<
   TValue extends number | string | null,

--- a/packages/forms/signals/src/api/rules/validation/min_length.ts
+++ b/packages/forms/signals/src/api/rules/validation/min_length.ts
@@ -34,7 +34,7 @@ import {minLengthError} from './validation_errors';
  *
  * @see [Signal Form Min Length Validation](guide/forms/signals/validation#minlength-and-maxlength)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function minLength<
   TValue extends ValueWithLengthOrSize,

--- a/packages/forms/signals/src/api/rules/validation/pattern.ts
+++ b/packages/forms/signals/src/api/rules/validation/pattern.ts
@@ -26,7 +26,7 @@ import {patternError} from './validation_errors';
  *
  * @see [Signal Form Pattern Validation](guide/forms/signals/validation#pattern)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function pattern<TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<string, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/required.ts
+++ b/packages/forms/signals/src/api/rules/validation/required.ts
@@ -28,7 +28,7 @@ import {requiredError} from './validation_errors';
  *
  * @see [Signal Form Required Validation](guide/forms/signals/validation#required)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function required<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/standard_schema.ts
+++ b/packages/forms/signals/src/api/rules/validation/standard_schema.ts
@@ -26,7 +26,7 @@ import {
  * i.e. `{[key: string]: unknown}`. It allows specific string keys to pass through, even if their
  * value is `unknown`, e.g. `{key: unknown}`.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type RemoveStringIndexUnknownKey<K, V> = string extends K
   ? unknown extends V
@@ -39,7 +39,7 @@ export type RemoveStringIndexUnknownKey<K, V> = string extends K
  * We use this on the `TSchema` type in `validateStandardSchema` in order to accommodate Zod's
  * `looseObject` which includes `{[key: string]: unknown}` as part of the type.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type IgnoreUnknownProperties<T> =
   T extends Record<PropertyKey, unknown>
@@ -61,7 +61,7 @@ export type IgnoreUnknownProperties<T> =
  *
  * @see [Signal Form Schema Validation](guide/forms/signals/validation#integration-with-schema-validation-libraries)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function validateStandardSchema<TSchema, TModel extends IgnoreUnknownProperties<TSchema>>(
   path: SchemaPath<TModel> & SchemaPathTree<TModel>,
@@ -126,7 +126,7 @@ export function validateStandardSchema<TSchema, TModel extends IgnoreUnknownProp
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
@@ -138,7 +138,7 @@ export function standardSchemaError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function standardSchemaError(
   issue: StandardSchemaV1.Issue,
@@ -174,7 +174,7 @@ function standardIssueToFormTreeError(
  * An error used to indicate an issue validating against a standard schema.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class StandardSchemaValidationError extends BaseNgValidationError {
   override readonly kind = 'standardSchema';

--- a/packages/forms/signals/src/api/rules/validation/validate.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate.ts
@@ -26,7 +26,7 @@ import type {
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function validate<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validate_async.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_async.ts
@@ -42,7 +42,7 @@ import {IS_ASYNC_VALIDATION_RESOURCE, createManagedMetadataKey, metadata} from '
  * @template TResult The type of result returned by the async operation
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind.Root> = (
   result: TResult,
@@ -59,7 +59,7 @@ export type MapToErrorsFn<TValue, TResult, TPathKind extends PathKind = PathKind
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
  * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface AsyncValidatorOptions<
   TValue,
@@ -122,7 +122,7 @@ export interface AsyncValidatorOptions<
  *
  * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function validateAsync<TValue, TParams, TResult, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validate_http.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_http.ts
@@ -26,7 +26,7 @@ import {MapToErrorsFn, validateAsync} from './validate_async';
  * @template TPathKind The kind of path being validated (a root path, child path, or item of an array)
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKind = PathKind.Root> {
   /**
@@ -82,7 +82,7 @@ export interface HttpValidatorOptions<TValue, TResult, TPathKind extends PathKin
  *
  * @see [Signal Form Async Validation](guide/forms/signals/validation#async-validation)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function validateHttp<TValue, TResult = unknown, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validate_tree.ts
+++ b/packages/forms/signals/src/api/rules/validation/validate_tree.ts
@@ -21,7 +21,7 @@ import type {FieldContext, PathKind, SchemaPath, SchemaPathRules, TreeValidator}
  * @template TPathKind The kind of path the logic is bound to (a root path, child path, or item of an array)
  *
  * @category logic
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function validateTree<TValue, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validation_errors.ts
+++ b/packages/forms/signals/src/api/rules/validation/validation_errors.ts
@@ -22,7 +22,7 @@ export interface ValidationErrorOptions {
  * A type that requires the given type `T` to have a `field` property.
  * @template T The type to add a `field` to.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type WithFieldTree<T> = T & {fieldTree: ReadonlyFieldTree<unknown>};
 
@@ -30,7 +30,7 @@ export type WithFieldTree<T> = T & {fieldTree: ReadonlyFieldTree<unknown>};
  * A type that allows the given type `T` to optionally have a `field` property.
  * @template T The type to optionally add a `field` to.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type WithOptionalFieldTree<T> = Omit<T, 'fieldTree'> & {
   fieldTree?: ReadonlyFieldTree<unknown>;
@@ -40,7 +40,7 @@ export type WithOptionalFieldTree<T> = Omit<T, 'fieldTree'> & {
  * A type that ensures the given type `T` does not have a `field` property.
  * @template T The type to remove the `field` from.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export type WithoutFieldTree<T> = T & {fieldTree: never};
 
@@ -48,7 +48,7 @@ export type WithoutFieldTree<T> = T & {fieldTree: never};
  * Create a required error associated with the target field
  * @param options The validation error options
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function requiredError(
   options: WithFieldTree<ValidationErrorOptions>,
@@ -58,7 +58,7 @@ export function requiredError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function requiredError(
   options?: ValidationErrorOptions,
@@ -75,7 +75,7 @@ export function requiredError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function minError(
   min: number,
@@ -87,7 +87,7 @@ export function minError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function minError(
   min: number,
@@ -106,7 +106,7 @@ export function minError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function maxError(
   max: number,
@@ -118,7 +118,7 @@ export function maxError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function maxError(
   max: number,
@@ -137,7 +137,7 @@ export function maxError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function minLengthError(
   minLength: number,
@@ -149,7 +149,7 @@ export function minLengthError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function minLengthError(
   minLength: number,
@@ -168,7 +168,7 @@ export function minLengthError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function maxLengthError(
   maxLength: number,
@@ -180,7 +180,7 @@ export function maxLengthError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function maxLengthError(
   maxLength: number,
@@ -199,7 +199,7 @@ export function maxLengthError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function patternError(
   pattern: RegExp,
@@ -211,7 +211,7 @@ export function patternError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function patternError(
   pattern: RegExp,
@@ -229,7 +229,7 @@ export function patternError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function emailError(options: WithFieldTree<ValidationErrorOptions>): EmailValidationError;
 /**
@@ -237,7 +237,7 @@ export function emailError(options: WithFieldTree<ValidationErrorOptions>): Emai
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function emailError(
   options?: ValidationErrorOptions,
@@ -259,7 +259,7 @@ export function emailError(
  * @see [Signal Form Validation](guide/forms/signals/validation)
  * @see [Signal Form Validation Errors](guide/forms/signals/validation#validation-errors)
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface ValidationError {
   /** Identifies the kind of error. */
@@ -321,7 +321,7 @@ export declare namespace ValidationError {
  * Internal version of `NgValidationError`, we create this separately so we can change its type on
  * the exported version to a type union of the possible sub-classes.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export abstract class BaseNgValidationError implements ValidationError {
   /** Brand the class to avoid Typescript structural matching */
@@ -347,7 +347,7 @@ export abstract class BaseNgValidationError implements ValidationError {
  * An error used to indicate that a required field is empty.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class RequiredValidationError extends BaseNgValidationError {
   override readonly kind = 'required';
@@ -357,7 +357,7 @@ export class RequiredValidationError extends BaseNgValidationError {
  * An error used to indicate that a value is lower than the minimum allowed.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class MinValidationError extends BaseNgValidationError {
   override readonly kind = 'min';
@@ -374,7 +374,7 @@ export class MinValidationError extends BaseNgValidationError {
  * An error used to indicate that a value is higher than the maximum allowed.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class MaxValidationError extends BaseNgValidationError {
   override readonly kind = 'max';
@@ -391,7 +391,7 @@ export class MaxValidationError extends BaseNgValidationError {
  * An error used to indicate that a value is shorter than the minimum allowed length.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class MinLengthValidationError extends BaseNgValidationError {
   override readonly kind = 'minLength';
@@ -408,7 +408,7 @@ export class MinLengthValidationError extends BaseNgValidationError {
  * An error used to indicate that a value is longer than the maximum allowed length.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class MaxLengthValidationError extends BaseNgValidationError {
   override readonly kind = 'maxLength';
@@ -425,7 +425,7 @@ export class MaxLengthValidationError extends BaseNgValidationError {
  * An error used to indicate that a value does not match the required pattern.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class PatternValidationError extends BaseNgValidationError {
   override readonly kind = 'pattern';
@@ -442,7 +442,7 @@ export class PatternValidationError extends BaseNgValidationError {
  * An error used to indicate that a value is not a valid email.
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export class EmailValidationError extends BaseNgValidationError {
   override readonly kind = 'email';
@@ -452,7 +452,7 @@ export class EmailValidationError extends BaseNgValidationError {
  * An error used to indicate that a value entered in a native input does not parse.
  *
  * @category validation
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export class NativeInputParseError extends BaseNgValidationError {
   override readonly kind = 'parse';
@@ -481,7 +481,7 @@ export class NativeInputParseError extends BaseNgValidationError {
  * ```
  *
  * @category validation
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const NgValidationError: abstract new () => NgValidationError = BaseNgValidationError as any;
 export type NgValidationError =

--- a/packages/forms/signals/src/api/structure.ts
+++ b/packages/forms/signals/src/api/structure.ts
@@ -43,7 +43,7 @@ import type {
  * Options that may be specified when creating a form.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export interface FormOptions<TModel> {
   /**
@@ -81,7 +81,7 @@ export interface FormOptions<TModel> {
  * @template TModel The type of the data model.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
 
@@ -128,7 +128,7 @@ export function form<TModel>(model: WritableSignal<TModel>): FieldTree<TModel>;
  * @template TValue The type of the data model.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function form<TModel>(
   model: WritableSignal<TModel>,
@@ -176,7 +176,7 @@ export function form<TModel>(
  * @template TModel The type of the data model.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function form<TModel>(
   model: WritableSignal<TModel>,
@@ -220,7 +220,7 @@ export function form<TModel>(...args: any[]): FieldTree<TModel> {
  * @template TValue The data type of the item field to apply the schema to.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function applyEach<TValue extends ReadonlyArray<any>>(
   path: SchemaPath<TValue>,
@@ -259,7 +259,7 @@ export function applyEach<TValue extends Object>(
  * @template TValue The data type of the field to apply the schema to.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function apply<TValue>(
   path: SchemaPath<TValue>,
@@ -280,7 +280,7 @@ export function apply<TValue>(
  * @template TValue The data type of the field to apply the schema to.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function applyWhen<TValue>(
   path: SchemaPath<TValue>,
@@ -304,7 +304,7 @@ export function applyWhen<TValue>(
  * @template TNarrowed The data type of the schema (a narrowed type of TValue).
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function applyWhenValue<TValue, TNarrowed extends TValue>(
   path: SchemaPath<TValue>,
@@ -322,7 +322,7 @@ export function applyWhenValue<TValue, TNarrowed extends TValue>(
  * @template TValue The data type of the field to apply the schema to.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function applyWhenValue<TValue>(
   path: SchemaPath<TValue>,
@@ -376,7 +376,7 @@ export function applyWhenValue(
  * @template TModel The data type of the field being submitted.
  *
  * @category submission
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export async function submit<TModel>(
   form: FieldTree<TModel>,
@@ -443,7 +443,7 @@ export async function submit<TModel>(
  * @template TValue The value type of a `FieldTree` that this schema binds to.
  *
  * @category structure
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function schema<TValue>(fn: SchemaFn<TValue>): Schema<TValue> {
   return SchemaImpl.create(fn) as unknown as Schema<TValue>;

--- a/packages/forms/signals/src/api/transformed_value.ts
+++ b/packages/forms/signals/src/api/transformed_value.ts
@@ -35,7 +35,7 @@ export interface ParseResult<TValue> {
 /**
  * Options for `transformedValue`.
  *
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export interface TransformedValueOptions<TValue, TRaw> {
   /**
@@ -58,7 +58,7 @@ export interface TransformedValueOptions<TValue, TRaw> {
  * via parse/format transformations.
  *
  * @category control
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export interface TransformedValueSignal<TRaw> extends WritableSignal<TRaw> {
   /**
@@ -86,7 +86,7 @@ export interface TransformedValueSignal<TRaw> extends WritableSignal<TRaw> {
  * @param value The model signal to synchronize with.
  * @param options Configuration including `parse` and `format` functions.
  * @returns A `TransformedValueSignal` representing the raw value with parse error tracking.
- * @experimental 21.2.0
+ * @publicApi 22.0
  *
  * @example
  * ```ts

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -19,7 +19,7 @@ declare const ɵɵTYPE: unique symbol;
 /**
  * Options that can be specified when submitting a form.
  *
- * @experimental 21.2
+ * @publicApi 22.0
  */
 export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
   /**
@@ -60,7 +60,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
 /**
  * Options for the `markAsTouched` method.
  *
- * @experimental 21.2.0
+ * @publicApi 22.0
  */
 export interface MarkAsTouchedOptions {
   /**
@@ -74,14 +74,14 @@ export interface MarkAsTouchedOptions {
  * A type that represents either a single value of type `T` or a readonly array of `T`.
  * @template T The type of the value(s).
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type OneOrMany<T> = T | readonly T[];
 
 /**
  * The kind of `FieldPath` (`Root`, `Child` of another `FieldPath`, or `Item` in a `FieldPath` array)
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type PathKind = PathKind.Root | PathKind.Child | PathKind.Item;
 export declare namespace PathKind {
@@ -116,7 +116,7 @@ export declare namespace PathKind {
  * A reason for a field's disablement.
  *
  * @category logic
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface DisabledReason {
   /** The field that is disabled. */
@@ -129,7 +129,7 @@ export interface DisabledReason {
  * The absence of an error which indicates a successful validation result.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type ValidationSuccess = null | undefined | void;
 
@@ -145,7 +145,7 @@ export type ValidationSuccess = null | undefined | void;
  * @template E the type of error (defaults to {@link ValidationError}).
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type TreeValidationResult<
   E extends ValidationError.WithOptionalFieldTree = ValidationError.WithOptionalFieldTree,
@@ -162,7 +162,7 @@ export type TreeValidationResult<
  * @template E the type of error (defaults to {@link ValidationError}).
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type ValidationResult<E extends ValidationError = ValidationError> =
   | ValidationSuccess
@@ -178,7 +178,7 @@ export type ValidationResult<E extends ValidationError = ValidationError> =
  * @template E the type of error (defaults to {@link ValidationError}).
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type AsyncValidationResult<E extends ValidationError = ValidationError> =
   | ValidationResult<E>
@@ -191,7 +191,7 @@ export type AsyncValidationResult<E extends ValidationError = ValidationError> =
  * @template TKey The type of the property key which this field resides under in its parent.
  *
  * @category types
- * @experimental 21.2
+ * @publicApi 22.0
  */
 export type Field<TValue, TKey extends string | number = string | number> = () => FieldState<
   TValue,
@@ -211,7 +211,7 @@ export type Field<TValue, TKey extends string | number = string | number> = () =
  *   For readonly, use {@link ReadonlyFieldTree}.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type FieldTree<
   TModel,
@@ -244,7 +244,7 @@ export type FieldTree<
  * A readonly {@link FieldTree}.
  *
  * @category types
- * @experimental 22.0
+ * @publicApi 22.0
  */
 export type ReadonlyFieldTree<TModel, TKey extends string | number = string | number> = FieldTree<
   TModel,
@@ -258,7 +258,7 @@ export type ReadonlyFieldTree<TModel, TKey extends string | number = string | nu
  * @template TModel The type of the data which the parent field is wrapped around.
  * @template TMode Determines whether the field state is readonly or writable.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'> = {
   readonly [K in keyof TModel as TModel[K] extends Function ? never : K]: MaybeFieldTree<
@@ -275,7 +275,7 @@ export type Subfields<TModel, TMode extends 'writable' | 'readonly' = 'writable'
  *
  * @template T The array item type.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface ReadonlyArrayLike<T> {
   readonly [n: number]: T;
@@ -294,7 +294,7 @@ export interface ReadonlyArrayLike<T> {
  * @template TKey The type of the property key which this field resides under in its parent.
  * @template TMode Determines whether the field state is readonly or writable.
  *
- * @experimental 22.0
+ * @publicApi 22.0
  */
 export type MaybeFieldTree<
   TModel,
@@ -309,7 +309,7 @@ export type MaybeFieldTree<
  * @template TKey The type of the property key which this field resides under in its parent.
  *
  * @category structure
- * @experimental 22.0
+ * @publicApi 22.0
  */
 export interface ReadonlyFieldState<TValue, TKey extends string | number = string | number> {
   /**
@@ -494,7 +494,7 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
  * @template TKey The type of the property key which this field resides under in its parent.
  *
  * @category structure
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface FieldState<
   TValue,
@@ -565,7 +565,7 @@ export interface FieldState<
  * This is FieldState also providing access to the wrapped FormControl.
  *
  * @category interop
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type CompatFieldState<
   TControl extends AbstractControl,
@@ -583,7 +583,7 @@ export type CompatFieldState<
  * A readonly {@link CompatFieldState}.
  *
  * @category interop
- * @experimental 22.0
+ * @publicApi 22.0
  */
 export type ReadonlyCompatFieldState<
   TControl extends AbstractControl,
@@ -607,7 +607,7 @@ export type FieldStateByMode<
 /**
  * Represents a binding between a field and a UI control through a {@link FormField} directive.
  *
- * @experimental 22.0
+ * @publicApi 22.0
  */
 export interface FormFieldBinding {
   /**
@@ -637,7 +637,7 @@ export interface FormFieldBinding {
 /**
  * Allows declaring whether the Rules are supported for a given path.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  **/
 export type SchemaPathRules = SchemaPathRules.Supported | SchemaPathRules.Unsupported;
 
@@ -662,7 +662,7 @@ export declare namespace SchemaPathRules {
  * @template TPathKind The kind of path (root field, child field, or item of an array)
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type SchemaPath<
   TValue,
@@ -680,7 +680,7 @@ export type SchemaPath<
  * Schema path used if the value is an AbstractControl.
  *
  * @category interop
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type CompatSchemaPath<
   TControl extends AbstractControl,
@@ -702,7 +702,7 @@ export type CompatSchemaPath<
  * It mirrors the structure of a given data structure, and allows applying rules to the appropriate
  * fields.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
   // Note: We use `[TModel]` here to avoid distributing over a union type model.
@@ -734,7 +734,7 @@ export type SchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
  * @template TValue The type of the data which the field is wrapped around.
  * @template TPathKind The kind of path (root field, child field, or item of an array)
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type MaybeSchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Root> =
   | (TModel & undefined)
@@ -779,7 +779,7 @@ export type MaybeSchemaPathTree<TModel, TPathKind extends PathKind = PathKind.Ro
  * @template TModel Data type.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type Schema<in TModel> = {
   [ɵɵTYPE]: SchemaFn<TModel, PathKind.Root>;
@@ -804,7 +804,7 @@ export type Schema<in TModel> = {
  * @template TPathKind The kind of path this schema function can be bound to.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type SchemaFn<TModel, TPathKind extends PathKind = PathKind.Root> = (
   p: SchemaPathTree<TModel, TPathKind>,
@@ -817,7 +817,7 @@ export type SchemaFn<TModel, TPathKind extends PathKind = PathKind.Root> = (
  * @template TPathKind The kind of path this schema function can be bound to.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type SchemaOrSchemaFn<TModel, TPathKind extends PathKind = PathKind.Root> =
   | Schema<TModel>
@@ -832,7 +832,7 @@ export type SchemaOrSchemaFn<TModel, TPathKind extends PathKind = PathKind.Root>
  * @template TPathKind The kind of path the logic is applied to (root field, child field, or item of an array)
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root> = (
   ctx: FieldContext<TValue, TPathKind>,
@@ -846,7 +846,7 @@ export type LogicFn<TValue, TReturn, TPathKind extends PathKind = PathKind.Root>
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
  *
  * @category validation
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -862,7 +862,7 @@ export type FieldValidator<TValue, TPathKind extends PathKind = PathKind.Root> =
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -879,7 +879,7 @@ export type TreeValidator<TValue, TPathKind extends PathKind = PathKind.Root> = 
  * @template TPathKind The kind of path being validated (root field, child field, or item of an array)
  * @see [Signal Form Validation](/guide/forms/signals/validation)
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = LogicFn<
   TValue,
@@ -892,7 +892,7 @@ export type Validator<TValue, TPathKind extends PathKind = PathKind.Root> = Logi
  * up state of other fields based on a `FieldPath`.
  *
  * @category types
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type FieldContext<
   TValue,
@@ -906,7 +906,7 @@ export type FieldContext<
 /**
  * The base field context that is available for all fields.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface RootFieldContext<TValue> {
   /** A signal containing the value of the current field. */
@@ -945,7 +945,7 @@ export interface RootFieldContext<TValue> {
  * Field context that is available for all fields that are a child of another field.
  *
  * @category structure
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface ChildFieldContext<TValue> extends RootFieldContext<TValue> {
   /** The key of the current field in its parent field. */
@@ -955,7 +955,7 @@ export interface ChildFieldContext<TValue> extends RootFieldContext<TValue> {
 /**
  * Field context that is available for all fields that are an item in an array field.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
   /** The index of the current field in its parent field. */
@@ -965,7 +965,7 @@ export interface ItemFieldContext<TValue> extends ChildFieldContext<TValue> {
 /**
  * Gets the item type of an object that is possibly an array.
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number] : T[keyof T];
 
@@ -978,7 +978,7 @@ export type ItemType<T extends Object> = T extends ReadonlyArray<any> ? T[number
  * @template TValue The type of value stored in the field.
  * @template TPathKind The kind of path the debouncer is applied to (root field, child field, or item of an array).
  *
- * @experimental 21.0
+ * @publicApi 22.0
  */
 export type Debouncer<TValue, TPathKind extends PathKind = PathKind.Root> = (
   context: FieldContext<TValue, TPathKind>,

--- a/packages/forms/signals/src/compat/validation_errors.ts
+++ b/packages/forms/signals/src/compat/validation_errors.ts
@@ -13,7 +13,7 @@ import {ReadonlyFieldTree} from '../api/types';
 /**
  * An error used for compat errors.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  * @category interop
  */
 export class CompatValidationError<T = unknown> implements ValidationError {
@@ -33,7 +33,7 @@ export class CompatValidationError<T = unknown> implements ValidationError {
 /**
  * Converts signal forms validation errors to reactive forms ValidationErrors.
  *
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export function signalErrorsToValidationErrors(errors: ValidationError[]): ValidationErrors | null {
   if (errors.length === 0) {

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -68,7 +68,7 @@ export interface FormFieldBindingOptions {
  * Lightweight DI token provided by the {@link FormField} directive.
  *
  * @category control
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 export const FORM_FIELD = new InjectionToken<FormField<unknown>>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'FORM_FIELD' : '',
@@ -91,7 +91,7 @@ export const FORM_FIELD = new InjectionToken<FormField<unknown>>(
  *    forms.
  *
  * @category control
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 @Directive({
   selector: '[formField]',

--- a/packages/forms/signals/src/directive/form_root.ts
+++ b/packages/forms/signals/src/directive/form_root.ts
@@ -28,8 +28,7 @@ import {FieldNode} from '../field/node';
  * </form>
  * ```
  *
- * @publicApi
- * @experimental 21.0.0
+ * @publicApi 22.0
  */
 @Directive({
   selector: 'form[formRoot]',


### PR DESCRIPTION
Replaced `@experimental` tags with `@publicApi 22.0` across all Signal Forms APIs under `packages/forms/signals` to mark them as ready for general use in v22.
