### PR TITLE
fix(core): remove no-op [ngStyle] bindings in ngstyle-to-style migration

### DIFF
--- a/packages/core/schematics/ng-generate/ngstyle-to-style-migration/util.ts
+++ b/packages/core/schematics/ng-generate/ngstyle-to-style-migration/util.ts
@@ -268,11 +268,32 @@ class NgStyleCollector extends RecursiveVisitor {
       if (attr.name !== '[ngStyle]' && attr.name !== 'ngStyle') {
         continue;
       }
+
+      if (attr.name === '[ngStyle]' && !attr.valueSpan) {
+        this.replacements.push({
+          start: attr.sourceSpan.start.offset,
+          end: attr.sourceSpan.end.offset,
+          replacement: '',
+        });
+
+        continue;
+      }
+
       if (attr.name === '[ngStyle]' && attr.valueSpan) {
         const expr = this.originalTemplate.slice(
           attr.valueSpan.start.offset,
           attr.valueSpan.end.offset,
         );
+
+        if (expr === 'null' || expr === 'undefined') {
+          this.replacements.push({
+            start: attr.sourceSpan.start.offset,
+            end: attr.sourceSpan.end.offset,
+            replacement: '',
+          });
+
+          continue;
+        }
 
         const staticMatch = parseStaticObjectLiteral(expr);
 

--- a/packages/core/schematics/test/ngstyle_to_style_migration_spec.ts
+++ b/packages/core/schematics/test/ngstyle_to_style_migration_spec.ts
@@ -139,6 +139,73 @@ describe('NgStyle migration', () => {
       expect(content).toContain('<div ></div>');
     });
 
+    it('should remove ngStyle with no input', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]></div>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<div ></div>');
+    });
+
+    it('should remove ngStyle with undefined input', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="undefined"></div>
+          <span [ngStyle]=undefined></span>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<div ></div>');
+      expect(content).toContain('<span ></span>');
+    });
+
+    it('should remove ngStyle with null input', async () => {
+      writeFile(
+        '/app.component.ts',
+        `
+        import {Component} from '@angular/core';
+        import {NgStyle} from '@angular/common';
+        @Component({
+        imports: [NgStyle],
+        template: \`
+          <div [ngStyle]="null"></div>
+          <span [ngStyle]=null></span>
+        \` })
+        export class Cmp {}
+      `,
+      );
+
+      await runMigration();
+
+      const content = tree.readContent('/app.component.ts');
+      expect(content).toContain('<div ></div>');
+      expect(content).toContain('<span ></span>');
+    });
+
     it('should remove ngStyle with empty string', async () => {
       writeFile(
         '/app.component.ts',


### PR DESCRIPTION
Handle [ngStyle] with no value, null, or undefined — all of which apply no styles — by removing the binding rather than leaving it unmigrated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

I noticed a few edge cases with the ngstyle to style migration spec that I wanted to highlight. Apparently all of the following is valid angular syntax. See [StackBlitz](https://stackblitz.com/edit/stackblitz-starters-ncpx8cbm?file=src%2Fmain.ts)

```typescript
<div [ngStyle]>1</div>
<div [ngStyle]="undefined">2</div>
<div [ngStyle]="null">3</div>
<div [ngStyle]=undefined>4</div>
<div [ngStyle]=null>5</div>
```

I have added unit tests that cover these scenarios (as unlikely as they may be to actually occur in a real codebase) and updated the migration to remove the ngStyle directive in those scenarios

Issue Number: N/A

## What is the new behavior?

The migration schema removes the useless ngStyle directives

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
