### PR TITLE
test: remove invalid css that was causing issues with the acx parser

### DIFF
--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -369,30 +369,30 @@ describe('ShadowCss', () => {
     // Comments should be kept in the same position as otherwise inline sourcemaps break due to
     // shift in lines.
     it('should remove inline comments without adding extra lines', () => {
-      expect(shim('/* b {c} */ b {c}', 'contenta')).toBe(' b[contenta] {c}');
+      expect(shim('/* b {} */ b {}', 'contenta')).toBe(' b[contenta] {}');
     });
 
     it('should preserve internal newlines from multiline comments', () => {
-      expect(shim('/* b {c}\n */ b {c}', 'contenta')).toBe('\n b[contenta] {c}');
+      expect(shim('/* b {}\n */ b {}', 'contenta')).toBe('\n b[contenta] {}');
     });
 
     it('should remove multiple inline comments without adding extra lines', () => {
-      expect(shim('/* b {c} */ b {c} /* a {c} */ a {c}', 'contenta')).toBe(
-        ' b[contenta] {c}  a[contenta] {c}',
+      expect(shim('/* b {} */ b {} /* a {} */ a {}', 'contenta')).toBe(
+        ' b[contenta] {}  a[contenta] {}',
       );
     });
 
     it('should keep sourceMappingURL comments', () => {
-      expect(shim('b {c} /*# sourceMappingURL=data:x */', 'contenta')).toBe(
-        'b[contenta] {c} /*# sourceMappingURL=data:x */',
+      expect(shim('b {} /*# sourceMappingURL=data:x */', 'contenta')).toBe(
+        'b[contenta] {} /*# sourceMappingURL=data:x */',
       );
-      expect(shim('b {c}/* #sourceMappingURL=data:x */', 'contenta')).toBe(
-        'b[contenta] {c}/* #sourceMappingURL=data:x */',
+      expect(shim('b {}/* #sourceMappingURL=data:x */', 'contenta')).toBe(
+        'b[contenta] {}/* #sourceMappingURL=data:x */',
       );
     });
 
     it('should handle adjacent comments', () => {
-      expect(shim('/* comment 1 */ /* comment 2 */ b {c}', 'contenta')).toBe('  b[contenta] {c}');
+      expect(shim('/* comment 1 */ /* comment 2 */ b {}', 'contenta')).toBe('  b[contenta] {}');
     });
   });
 });


### PR DESCRIPTION
These tests happened to use garbage "{c}" declaration lists which caused the parser to choke. Given that we already have tests demonstrating similar behavior and that's not what these tests were meant to demonstrate, I've updated them to use empty declaration lists.