### PR TITLE
docs: add `FormField/FormRoot` imports + move comment with ``'s

### DIFF
--- a/adev/src/content/guide/forms/signals/field-state-management.md
+++ b/adev/src/content/guide/forms/signals/field-state-management.md
@@ -228,8 +228,9 @@ import { form, FormField, disabled } from '@angular/forms/signals'
 @Component({
   selector: 'app-order',
   imports: [FormField],
+  // TIP: The `[formField]` directive automatically binds the `disabled` attribute based
+  // on the field's `disabled()` state, so you don't need to manually add `[disabled]="field().disabled()"`
   template: `
-    <!-- TIP: The `[formField]` directive automatically binds the `disabled` attribute based on the field's `disabled()` state, so you don't need to manually add `[disabled]="field().disabled()"` -->
     <input [formField]="orderForm.couponCode" />
 
     @if (orderForm.couponCode().disabled()) {
@@ -621,6 +622,8 @@ While field state typically updates through user interactions (typing, focusing,
 Signal Forms provides a `FormRoot` directive that simplifies form submission. It automatically prevents the default browser form submission behavior and sets the `novalidate` attribute on the `<form>` element.
 
 ```angular-ts
+import {FormField, FormRoot} from '@angular/forms/signals';
+
 @Component({
   imports: [FormRoot, FormField],
   template: `
@@ -691,6 +694,7 @@ import {Component, signal} from '@angular/core';
 import {form, FormField, email} from '@angular/forms/signals';
 
 @Component({
+  imports: [FormField],
   template: `
     <input
       type="email"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

1. Backticks in inline template comments were breaking the file.
1. The section dedicated to `FormRoot` was missing it's TS import
1. All TS imports are in the validation styling example, but the template import is missing

Issue Number: N/A

## What is the new behavior?

1. Rather than removing the backticks, the comment was placed between the component's `imports` and the `template`, still effectively above the reference to the `formField`. I think it looks fine and makes sense.
    - I also broke the comment into two lines because it was rather long IMO 
1. The section dedicated to `FormRoot` has its TS import too
1. One extra line to import `FormField` to the HTML makes the example file work as a valid component file in its entirety. I know the docs sometimes cut certain TS/HTML imports if they were covered and not the main focus, but IMO one line to make the full block compile is nice.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I imagine point 1 and point 3 may be a bit contentious.

Also congrats on the announcement about going stable!