### PR TITLE
feat(forms): Add support for non-async form submission action

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -216,7 +216,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
     action: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;
         submitted: FieldTree<TSubmittedModel>;
-    }) => Promise<TreeValidationResult>;
+    }) => TreeValidationResult | Promise<TreeValidationResult>;
     ignoreValidators?: 'pending' | 'none' | 'all';
     onInvalid?: (field: FieldTree<TRootModel & TSubmittedModel>, detail: {
         root: FieldTree<TRootModel>;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -34,7 +34,7 @@ export interface FormSubmitOptions<TRootModel, TSubmittedModel> {
   action: (
     field: FieldTree<TRootModel & TSubmittedModel>,
     detail: {root: FieldTree<TRootModel>; submitted: FieldTree<TSubmittedModel>},
-  ) => Promise<TreeValidationResult>;
+  ) => TreeValidationResult | Promise<TreeValidationResult>;
   /**
    * Function to run when attempting to submit the form data but validation is failing.
    *


### PR DESCRIPTION
Allow signal forms to handle submission action without having to return a promise

Fixes #67755

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Submission action for signal forms needs to be async:

```ts
const action = async () => { /* do something ASYNC */ };
form(signal(state), { submission: { action } });
```

So when you have a non-async action:

```ts
const action = () => { /* do something SYNC */ };
form(signal(state), { submission: { action } });
```

You get the following error:

```
Type '() => void' is not assignable to type '(field: FieldTree<FormModel, string | number>, detail: { root: FieldTree<FormModel, string | number>; submitted: FieldTree<...>; }) => Promise<...>'.
  Type 'void' is not assignable to type 'Promise<TreeValidationResult<WithOptionalFieldTree>>'.
```

Which means you have to return an empty promise to make the linter/typing happy:

```ts
const action = () => {
  /* do something SYNC */
  return Promise.resolve();
};
form(signal(state), { submission: { action } });
```

Issue Number: https://github.com/angular/angular/issues/67755

## What is the new behavior?

With this PR it becomes much simpler to make non-async submission action, as you non longer have to return an empty promise.

Which means you can now do this without any issue:

```ts
const action = () => { /* do something SYNC */ };
form(signal(state), { submission: { action } });
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
