### PR TITLE
docs: remove `\`'s from schematics `helloWorld` block

### DIFF
--- a/adev/src/content/tools/cli/schematics-authoring.md
+++ b/adev/src/content/tools/cli/schematics-authoring.md
@@ -41,8 +41,8 @@ import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 
 // You don't have to export the function as default.
 // You can also have more than one rule factory per file.
-export function helloWorld(\_options: any): Rule {
-   return (tree: Tree,\_context: SchematicContext) => {
+export function helloWorld(_options: any): Rule {
+   return (tree: Tree,_context: SchematicContext) => {
     return tree;
   };
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`\` is an invalid character and causes build issues when the code block is copied from the docs.

Issue Number: N/A

## What is the new behavior?

Removes two instances of `\` from the doc block. This is also aligned with the default schematic's output when generating a new schematic using instructions that are later in the doc page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
