### PR TITLE
fix(migrations): remove compiler import from safe optional chaining migration

### DIFF
--- a/packages/core/schematics/migrations/safe-optional-chaining/migration.ts
+++ b/packages/core/schematics/migrations/safe-optional-chaining/migration.ts
@@ -57,8 +57,6 @@ import {
 } from '../../utils/tsurge';
 import {getPropertyNameText} from '../../utils/typescript/property_name';
 
-import('@angular/compiler');
-
 export interface CompilationUnitData {
   replacements: Replacement[];
 }


### PR DESCRIPTION


Removes the @angular/compiler import from the safe optional chaining migration. This import is not needed as the compiler package import is side-effectful and has no functional use here.
