### PR TITLE
fix(core): correct generic inference for inject() and query read with instantiation expressions

### DIFF
--- a/adev/shared-docs/directives/click-outside/click-outside.directive.ts
+++ b/adev/shared-docs/directives/click-outside/click-outside.directive.ts
@@ -24,7 +24,7 @@ export class ClickOutside {
 
   onClick(event: MouseEvent): void {
     if (
-      !this.elementRef.nativeElement.contains(event.target) &&
+      !this.elementRef.nativeElement.contains(event.target as HTMLElement) &&
       !this.wasClickedOnIgnoredElement(event)
     ) {
       this.clickOutside.emit();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-manager/signal-graph-manager.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/signal-graph-manager/signal-graph-manager.ts
@@ -17,7 +17,7 @@ import {convertToDevtoolsSignalGraph} from '../../../shared/signal-graph/devtool
 @Injectable()
 export class SignalGraphManager {
   private readonly injector = inject(Injector);
-  private readonly messageBus = inject(MessageBus);
+  private readonly messageBus = inject(MessageBus<any>);
   private readonly signalGraph = signal<DevtoolsSignalGraph | null>(null);
   private unlistenFn?: () => void;
   private lastesSignalGraphMessageUnlistenFn?: () => void;

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -375,7 +375,7 @@ export interface ContentChildFunction {
     // (undocumented)
     <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
         descendants?: boolean;
-        read: ProviderToken<ReadT>;
+        read: ClassOrInjectionToken<ReadT>;
         debugName?: string;
     }): Signal<ReadT | undefined>;
     required: {
@@ -386,7 +386,7 @@ export interface ContentChildFunction {
         }): Signal<LocatorT>;
         <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
             descendants?: boolean;
-            read: ProviderToken<ReadT>;
+            read: ClassOrInjectionToken<ReadT>;
             debugName?: string;
         }): Signal<ReadT>;
     };
@@ -408,7 +408,7 @@ export function contentChildren<LocatorT>(locator: ProviderToken<LocatorT> | str
 // @public (undocumented)
 export function contentChildren<LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
     descendants?: boolean;
-    read: ProviderToken<ReadT>;
+    read: ClassOrInjectionToken<ReadT>;
     debugName?: string;
 }): Signal<ReadonlyArray<ReadT>>;
 
@@ -858,15 +858,26 @@ export interface Inject {
 export const Inject: InjectDecorator;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>): T;
+export function inject<T>(token: abstract new (...args: any[]) => T): T;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions & {
+export function inject<T>(token: abstract new (...args: any[]) => T, options: InjectOptions & {
     optional?: false;
 }): T;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T | null;
+export function inject<T>(token: abstract new (...args: any[]) => T, options: InjectOptions): T | null;
+
+// @public (undocumented)
+export function inject<T>(token: InjectionToken<T>): T;
+
+// @public (undocumented)
+export function inject<T>(token: InjectionToken<T>, options: InjectOptions & {
+    optional?: false;
+}): T;
+
+// @public (undocumented)
+export function inject<T>(token: InjectionToken<T>, options: InjectOptions): T | null;
 
 // @public (undocumented)
 export function inject(token: HostAttributeToken): string;
@@ -2035,7 +2046,7 @@ export interface ViewChildDecorator {
 // @public
 export interface ViewChildFunction {
     <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
-        read: ProviderToken<ReadT>;
+        read: ClassOrInjectionToken<ReadT>;
         debugName?: string;
     }): Signal<ReadT | undefined>;
     // (undocumented)
@@ -2047,7 +2058,7 @@ export interface ViewChildFunction {
             debugName?: string;
         }): Signal<LocatorT>;
         <LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
-            read: ProviderToken<ReadT>;
+            read: ClassOrInjectionToken<ReadT>;
             debugName?: string;
         }): Signal<ReadT>;
     };
@@ -2066,7 +2077,7 @@ export function viewChildren<LocatorT>(locator: ProviderToken<LocatorT> | string
 
 // @public (undocumented)
 export function viewChildren<LocatorT, ReadT>(locator: ProviderToken<LocatorT> | string, opts: {
-    read: ProviderToken<ReadT>;
+    read: ClassOrInjectionToken<ReadT>;
     debugName?: string;
 }): Signal<ReadonlyArray<ReadT>>;
 

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -272,7 +272,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
   private imageLoader = inject(IMAGE_LOADER);
   private config: ImageConfig = processConfig(inject(IMAGE_CONFIG));
   private renderer = inject(Renderer2);
-  private imgElement: HTMLImageElement = inject(ElementRef).nativeElement;
+  private imgElement = inject(ElementRef<HTMLImageElement>).nativeElement;
   private injector = inject(Injector);
   private destroyRef = inject(DestroyRef);
 

--- a/packages/core/src/authoring/queries.ts
+++ b/packages/core/src/authoring/queries.ts
@@ -7,7 +7,14 @@
  */
 
 import {assertInInjectionContext} from '../di';
-import {ProviderToken} from '../di/provider_token';
+import type {InjectionToken} from '../di/injection_token';
+import type {ProviderToken} from '../di/provider_token';
+
+// Use a narrower token type here so instantiation expressions preserve the specialized generic.
+// `ProviderToken<T>` includes `AbstractType<T>`, which makes TypeScript infer `T` from
+// `prototype: T` and fall back to the default generic (for example `ElementRef<any>` instead of
+// `ElementRef<HTMLElement>` in `viewChild('ref', {read: ElementRef<HTMLElement>})`).
+type ClassOrInjectionToken<T> = (abstract new (...args: any[]) => T) | InjectionToken<T>;
 import {
   createMultiResultQuerySignalFn,
   createSingleResultOptionalQuerySignalFn,
@@ -17,7 +24,7 @@ import {Signal} from '../render3/reactivity/api';
 
 function viewChildFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {read?: ProviderToken<ReadT>; debugName?: string},
+  opts?: {read?: ClassOrInjectionToken<ReadT>; debugName?: string},
 ): Signal<ReadT | undefined> {
   ngDevMode && assertInInjectionContext(viewChild);
   return createSingleResultOptionalQuerySignalFn<ReadT>(opts);
@@ -25,7 +32,7 @@ function viewChildFn<LocatorT, ReadT>(
 
 function viewChildRequiredFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
-  opts?: {read?: ProviderToken<ReadT>; debugName?: string},
+  opts?: {read?: ClassOrInjectionToken<ReadT>; debugName?: string},
 ): Signal<ReadT> {
   ngDevMode && assertInInjectionContext(viewChild);
   return createSingleResultRequiredQuerySignalFn<ReadT>(opts);
@@ -51,7 +58,7 @@ export interface ViewChildFunction {
   <LocatorT, ReadT>(
     locator: ProviderToken<LocatorT> | string,
     opts: {
-      read: ProviderToken<ReadT>;
+      read: ClassOrInjectionToken<ReadT>;
       debugName?: string;
     },
   ): Signal<ReadT | undefined>;
@@ -79,7 +86,7 @@ export interface ViewChildFunction {
     <LocatorT, ReadT>(
       locator: ProviderToken<LocatorT> | string,
       opts: {
-        read: ProviderToken<ReadT>;
+        read: ClassOrInjectionToken<ReadT>;
         debugName?: string;
       },
     ): Signal<ReadT>;
@@ -125,7 +132,7 @@ export function viewChildren<LocatorT>(
 export function viewChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts: {
-    read: ProviderToken<ReadT>;
+    read: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadonlyArray<ReadT>>;
@@ -155,7 +162,7 @@ export function viewChildren<LocatorT, ReadT>(
 export function viewChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts?: {
-    read?: ProviderToken<ReadT>;
+    read?: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadonlyArray<ReadT>> {
@@ -167,7 +174,7 @@ export function contentChildFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts?: {
     descendants?: boolean;
-    read?: ProviderToken<ReadT>;
+    read?: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadT | undefined> {
@@ -179,7 +186,7 @@ function contentChildRequiredFn<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts?: {
     descendants?: boolean;
-    read?: ProviderToken<ReadT>;
+    read?: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadT> {
@@ -216,7 +223,7 @@ export interface ContentChildFunction {
     locator: ProviderToken<LocatorT> | string,
     opts: {
       descendants?: boolean;
-      read: ProviderToken<ReadT>;
+      read: ClassOrInjectionToken<ReadT>;
       debugName?: string;
     },
   ): Signal<ReadT | undefined>;
@@ -238,7 +245,7 @@ export interface ContentChildFunction {
       locator: ProviderToken<LocatorT> | string,
       opts: {
         descendants?: boolean;
-        read: ProviderToken<ReadT>;
+        read: ClassOrInjectionToken<ReadT>;
         debugName?: string;
       },
     ): Signal<ReadT>;
@@ -290,7 +297,7 @@ export function contentChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts: {
     descendants?: boolean;
-    read: ProviderToken<ReadT>;
+    read: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadonlyArray<ReadT>>;
@@ -323,7 +330,7 @@ export function contentChildren<LocatorT, ReadT>(
   locator: ProviderToken<LocatorT> | string,
   opts?: {
     descendants?: boolean;
-    read?: ProviderToken<ReadT>;
+    read?: ClassOrInjectionToken<ReadT>;
     debugName?: string;
   },
 ): Signal<ReadonlyArray<ReadT>> {

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -168,13 +168,50 @@ Please check that 1) the type for the parameter at index ${index} is correct and
 }
 
 /**
+ * @param token A class whose instance is to be injected.
+ * @returns the injected instance.
+ * @throws if called outside of a supported context.
+ *
+ * @publicApi
+ */
+export function inject<T>(token: abstract new (...args: any[]) => T): T;
+/**
+ * @param token A class whose instance is to be injected.
+ * @param options Control how injection is executed. Options correspond to injection strategies
+ *     that can be specified with parameter decorators `@Host`, `@Self`, `@SkipSelf`, and
+ *     `@Optional`.
+ * @returns the injected instance.
+ * @throws if called outside of a supported context, or if the token is not found.
+ *
+ * @publicApi
+ */
+export function inject<T>(
+  token: abstract new (...args: any[]) => T,
+  options: InjectOptions & {optional?: false},
+): T;
+/**
+ * @param token A class whose instance is to be injected.
+ * @param options Control how injection is executed. Options correspond to injection strategies
+ *     that can be specified with parameter decorators `@Host`, `@Self`, `@SkipSelf`, and
+ *     `@Optional`.
+ * @returns the injected instance, or `null` if optional and not found.
+ * @throws if called outside of a supported context, or if the token is not found and optional
+ *     injection was not requested.
+ *
+ * @publicApi
+ */
+export function inject<T>(
+  token: abstract new (...args: any[]) => T,
+  options: InjectOptions,
+): T | null;
+/**
  * @param token A token that represents a dependency that should be injected.
  * @returns the injected value if operation is successful, `null` otherwise.
  * @throws if called outside of a supported context.
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>): T;
+export function inject<T>(token: InjectionToken<T>): T;
 /**
  * @param token A token that represents a dependency that should be injected.
  * @param options Control how injection is executed. Options correspond to injection strategies
@@ -185,7 +222,7 @@ export function inject<T>(token: ProviderToken<T>): T;
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions & {optional?: false}): T;
+export function inject<T>(token: InjectionToken<T>, options: InjectOptions & {optional?: false}): T;
 /**
  * @param token A token that represents a dependency that should be injected.
  * @param options Control how injection is executed. Options correspond to injection strategies
@@ -198,7 +235,7 @@ export function inject<T>(token: ProviderToken<T>, options: InjectOptions & {opt
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T | null;
+export function inject<T>(token: InjectionToken<T>, options: InjectOptions): T | null;
 /**
  * @param token A token that represents a static attribute on the host node that should be injected.
  * @returns Value of the attribute if it exists.

--- a/packages/core/test/authoring/signal_queries_signature_test.ts
+++ b/packages/core/test/authoring/signal_queries_signature_test.ts
@@ -41,8 +41,7 @@ export class SignalQuerySignatureTest {
   /** ElementRef<HTMLAnchorElement> | undefined */
   viewChildStringLocatorNoReadElementRefTypeHint = viewChild<ElementRef<HTMLAnchorElement>>('ref');
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> | undefined */
+  /** ElementRef<HTMLAnchorElement> | undefined */
   viewChildStringLocatorWithElementRefRead = viewChild('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -62,8 +61,7 @@ export class SignalQuerySignatureTest {
   /** ReadType | undefined */
   viewChildTypeLocatorAndRead = viewChild(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> | undefined */
+  /** ElementRef<HTMLAnchorElement> | undefined */
   viewChildTypeLocatorAndElementRefRead = viewChild(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -74,8 +72,7 @@ export class SignalQuerySignatureTest {
   viewChildStringLocatorNoReadElementRefTypeHintReq =
     viewChild.required<ElementRef<HTMLAnchorElement>>('ref');
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> */
+  /** ElementRef<HTMLAnchorElement> */
   viewChildStringLocatorWithElementRefReadReq = viewChild.required('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -89,8 +86,7 @@ export class SignalQuerySignatureTest {
   /** ReadType */
   viewChildTypeLocatorAndReadReq = viewChild.required(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> */
+  /** ElementRef<HTMLAnchorElement> */
   viewChildTypeLocatorAndElementRefReadReq = viewChild.required(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -107,8 +103,7 @@ export class SignalQuerySignatureTest {
   /** readonly ReadType[] */
   viewChildrenStringLocatorWithTypeRead = viewChildren('ref', {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** readonly ElementRef<any>[] */
+  /** readonly ElementRef<HTMLAnchorElement>[] */
   viewChildrenStringLocatorWithElementRefRead = viewChildren('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -125,8 +120,7 @@ export class SignalQuerySignatureTest {
   /** readonly ReadType[] */
   viewChildrenTypeLocatorAndRead = viewChildren(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** readonly ElementRef<any>[] */
+  /** readonly ElementRef<HTMLAnchorElement>[] */
   viewChildrenTypeLocatorAndElementRefRead = viewChildren(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -140,8 +134,7 @@ export class SignalQuerySignatureTest {
   contentChildStringLocatorNoReadElementRefTypeHint =
     contentChild<ElementRef<HTMLAnchorElement>>('ref');
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> | undefined */
+  /** ElementRef<HTMLAnchorElement> | undefined */
   contentChildStringLocatorWithElementRefRead = contentChild('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -161,8 +154,7 @@ export class SignalQuerySignatureTest {
   /** ReadType | undefined */
   contentChildTypeLocatorAndRead = contentChild(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> | undefined */
+  /** ElementRef<HTMLAnchorElement> | undefined */
   contentChildTypeLocatorAndElementRefRead = contentChild(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -173,8 +165,7 @@ export class SignalQuerySignatureTest {
   contentChildStringLocatorNoReadElementRefTypeHintReq =
     contentChild.required<ElementRef<HTMLAnchorElement>>('ref');
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> */
+  /** ElementRef<HTMLAnchorElement> */
   contentChildStringLocatorWithElementRefReadReq = contentChild.required('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -188,8 +179,7 @@ export class SignalQuerySignatureTest {
   /** ReadType */
   contentChildTypeLocatorAndReadReq = contentChild.required(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** ElementRef<any> */
+  /** ElementRef<HTMLAnchorElement> */
   contentChildTypeLocatorAndElementRefReadReq = contentChild.required(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -206,8 +196,7 @@ export class SignalQuerySignatureTest {
   /** readonly ReadType[] */
   contentChildrenStringLocatorWithTypeRead = contentChildren('ref', {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** readonly ElementRef<any>[] */
+  /** readonly ElementRef<HTMLAnchorElement>[] */
   contentChildrenStringLocatorWithElementRefRead = contentChildren('ref', {
     read: ElementRef<HTMLAnchorElement>,
   });
@@ -224,8 +213,7 @@ export class SignalQuerySignatureTest {
   /** readonly ReadType[] */
   contentChildrenTypeLocatorAndRead = contentChildren(QueryType, {read: ReadType});
 
-  // any due to https://github.com/angular/angular/issues/53894
-  /** readonly ElementRef<any>[] */
+  /** readonly ElementRef<HTMLAnchorElement>[] */
   contentChildrenTypeLocatorAndElementRefRead = contentChildren(QueryType, {
     read: ElementRef<HTMLAnchorElement>,
   });


### PR DESCRIPTION
`inject(ElementRef<HTMLElement>)` incorrectly returned `ElementRef<any>`, and the same happened for `viewChild('ref', {read: ElementRef<HTMLElement>})`.

This happened because `ProviderToken<T>` includes `AbstractType<T>`. During type inference, TypeScript picked up the default generic type from the `prototype` property (`ElementRef<any>`) instead of preserving the specialized type (`ElementRef<HTMLElement>`).

Fix this by replacing `ProviderToken<T>` with:

* `abstract new (...args: any[]) => T` for class-based tokens
* `InjectionToken<T>` for injection tokens

Apply the same change to the `read` option used by `viewChild`, `viewChildren`, `contentChild`, and `contentChildren` through a private `ClassOrInjectionToken<T>` alias.

Fixes #53894