### PR TITLE
perf(forms): avoid spurious recomputation in FormField.parseErrors

### DIFF
--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -184,6 +184,7 @@ export class FormField<T> {
         fieldTree: untracked(this.state).fieldTree,
         formField: this as FormField<unknown>,
       })) ?? [],
+    {equal: shallowArrayEquals},
   );
 
   /** Errors associated with this form field. */


### PR DESCRIPTION
`parseErrors` in `FormField` always produced a new array on every recomputation, even when nothing actually changed. The `?? []` fallback created a new empty array whenever `parseErrorsSource` was undefined, and `.map()` also returned new object references each time.

Since computed signals use reference equality by default, those new arrays were treated as changed values. That caused unnecessary updates to propagate through `validationState.parseErrors` and the combined errors chain, triggering extra recomputations during change detection.

Fix this by adding `{equal: shallowArrayEquals}` to the `parseErrors` computed, matching the existing `errors` computed and the validation computeds in `field/validation.ts`.

This prevents empty arrays from triggering updates while still correctly propagating real parse-error changes.

---

Note: both old value and new value are `[]`.

<img width="754" height="237" alt="image" src="https://github.com/user-attachments/assets/be32c2d5-0699-49b1-830a-a4f1ba5e0009" />
