### PR TITLE
fix(docs-infra): improve version picker dropdown positioning

### DIFF
--- a/adev/src/app/core/layout/navigation/mini-menu.scss
+++ b/adev/src/app/core/layout/navigation/mini-menu.scss
@@ -4,6 +4,7 @@
 // ul
 .adev-mini-menu {
   padding: 0;
+  margin-block: 0;
   color: var(--primary-contrast);
   background-color: var(--page-background);
   border: 1px solid var(--senary-contrast);
@@ -86,11 +87,8 @@
 
 .adev-version-picker {
   overflow-y: auto;
-  max-height: 90vh;
-  top: 30px;
-  left: 10px;
-  position: absolute;
-  bottom: auto;
+  max-height: 70dvh;
+  margin-inline-start: 10px;
 
   li {
     padding-inline: 0;
@@ -101,9 +99,11 @@
   }
 
   @include mq.for-tablet {
-    top: 30px;
-    left: auto;
-    bottom: auto;
+    position: fixed;
+    position-anchor: --version-trigger;
+    inset-block-start: calc(anchor(bottom) + 8px);
+    justify-self: anchor-center;
+    margin-inline-start: 0;
   }
 }
 

--- a/adev/src/app/core/layout/navigation/navigation.component.scss
+++ b/adev/src/app/core/layout/navigation/navigation.component.scss
@@ -175,6 +175,7 @@
 
     // version dropdown button
     .adev-version-button {
+      anchor-name: --version-trigger;
       border: 1px solid var(--senary-contrast);
       border-radius: 0.25rem;
       width: fit-content;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

- On mobile and desktop, the version picker dropdown can't scroll to the last version, the bottom items sit below the visible viewport.
- On the tablet horizontal navbar, the dropdown opens off to the right of the trigger and overlaps the neighbouring nav items.


https://github.com/user-attachments/assets/2938f318-81d7-493f-9605-0b2c4a1e13d6

<img width="178" height="568" alt="image" src="https://github.com/user-attachments/assets/a372ec1b-2020-4aca-ba39-36cead406c73" />

<img width="282" height="825" alt="Screenshot 2026-05-08 at 00 05 48" src="https://github.com/user-attachments/assets/054eb1f4-1c1a-457a-a618-9718c1bf07f5" />


## What is the new behavior?

- Dropdown scrolls to the last version on all viewports.
- On tablet, the dropdown opens directly below the version button, horizontally centered on it.

<img width="751" height="845" alt="image" src="https://github.com/user-attachments/assets/ffca14cb-a25d-4599-b0b8-087049cbe6d5" />

<img width="287" height="830" alt="image" src="https://github.com/user-attachments/assets/587a1240-95e5-45d5-a29d-6930257c2424" />

<img width="634" height="690" alt="image" src="https://github.com/user-attachments/assets/c596109b-6b9f-4d29-aae0-451dfa4efc47" />



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No