### PR TITLE
fix(docs-infra): keep mobile nav open when closing the search dialog

### DIFF
--- a/adev/shared-docs/components/search-dialog/search-dialog.component.html
+++ b/adev/shared-docs/components/search-dialog/search-dialog.component.html
@@ -1,4 +1,4 @@
-<dialog #searchDialog>
+<dialog #searchDialog id="docsSearchDialog">
   <div class="docs-search-container" (docsClickOutside)="closeSearchDialog()">
     <docs-text-field
       [autofocus]="true"

--- a/adev/src/app/core/constants/element-ids.ts
+++ b/adev/src/app/core/constants/element-ids.ts
@@ -8,3 +8,4 @@
 
 export const PRIMARY_NAV_ID = 'primaryNav';
 export const SECONDARY_NAV_ID = 'secondaryNav';
+export const SEARCH_DIALOG_ID = 'docsSearchDialog';

--- a/adev/src/app/core/layout/navigation/navigation.component.html
+++ b/adev/src/app/core/layout/navigation/navigation.component.html
@@ -3,7 +3,7 @@
   [attr.id]="PRIMARY_NAV_ID"
   class="wrapper"
   (docsClickOutside)="closeMobileNav()"
-  [docsClickOutsideIgnore]="[SECONDARY_NAV_ID]"
+  [docsClickOutsideIgnore]="[SECONDARY_NAV_ID, SEARCH_DIALOG_ID]"
 >
   <!-- Mobile nav bar -->
   <div class="adev-mobile-nav-bar">

--- a/adev/src/app/core/layout/navigation/navigation.component.ts
+++ b/adev/src/app/core/layout/navigation/navigation.component.ts
@@ -22,7 +22,7 @@ import {
 import {NavigationEnd, Router, RouterLink} from '@angular/router';
 import {filter, map, startWith} from 'rxjs/operators';
 import {DOCS_ROUTES, REFERENCE_ROUTES, TUTORIALS_ROUTES} from '../../../routing/routes';
-import {PRIMARY_NAV_ID, SECONDARY_NAV_ID} from '../../constants/element-ids';
+import {PRIMARY_NAV_ID, SEARCH_DIALOG_ID, SECONDARY_NAV_ID} from '../../constants/element-ids';
 import {COMMAND, CONTROL, SEARCH_TRIGGER_KEY} from '../../constants/keys';
 import {ANGULAR_LINKS} from '../../constants/links';
 import {PAGE_PREFIX} from '../../constants/pages';
@@ -51,6 +51,7 @@ export class Navigation {
   protected ngLinks = ANGULAR_LINKS;
   protected readonly PRIMARY_NAV_ID = PRIMARY_NAV_ID;
   protected readonly SECONDARY_NAV_ID = SECONDARY_NAV_ID;
+  protected readonly SEARCH_DIALOG_ID = SEARCH_DIALOG_ID;
 
   // We can't use the ActivatedRouter queryParams as we're outside the router outlet
   protected readonly isUwu = 'location' in globalThis ? location.search.includes('uwu') : false;

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.html
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.html
@@ -3,7 +3,7 @@
   class="adev-secondary-nav-mask"
   [class.docs-nav-secondary--open]="isSecondaryNavVisible()"
   (docsClickOutside)="close()"
-  [docsClickOutsideIgnore]="[PRIMARY_NAV_ID]"
+  [docsClickOutsideIgnore]="[PRIMARY_NAV_ID, SEARCH_DIALOG_ID]"
 >
   <div
     class="docs-nav-secondary docs-scroll-track-transparent"

--- a/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
+++ b/adev/src/app/core/layout/secondary-navigation/secondary-navigation.component.ts
@@ -23,7 +23,7 @@ import {
 import {ActivatedRouteSnapshot, NavigationEnd, Router, RouterStateSnapshot} from '@angular/router';
 import {distinctUntilChanged, filter, map, skip, startWith} from 'rxjs/operators';
 import {SUB_NAVIGATION_DATA} from '../../../routing/sub-navigation-data';
-import {PRIMARY_NAV_ID, SECONDARY_NAV_ID} from '../../constants/element-ids';
+import {PRIMARY_NAV_ID, SEARCH_DIALOG_ID, SECONDARY_NAV_ID} from '../../constants/element-ids';
 import {PAGE_PREFIX} from '../../constants/pages';
 
 export const ANIMATION_DURATION = 500;
@@ -56,6 +56,7 @@ export class SecondaryNavigation {
 
   protected readonly PRIMARY_NAV_ID = PRIMARY_NAV_ID;
   protected readonly SECONDARY_NAV_ID = SECONDARY_NAV_ID;
+  protected readonly SEARCH_DIALOG_ID = SEARCH_DIALOG_ID;
 
   private readonly routeMap: Record<string, NavigationItem[]> = {
     [PAGE_PREFIX.REFERENCE]: getNavigationItemsTree(SUB_NAVIGATION_DATA.reference, (tree) =>


### PR DESCRIPTION
Backdrop clicks on the search dialog were also closing the open mobile nav drawers. Adds an id to `<dialog>` and references it from both navs' `docsClickOutsideIgnore` arrays.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On mobile, clicking the search dialog backdrop also collapses the open primary and secondary nav drawers — neither nav's click-outside listener recognises the click target as sitting inside the dialog.

https://github.com/user-attachments/assets/eff17d46-e4b8-4ea9-9f07-b427922bc6da

## What is the new behavior?

Backdrop clicks close only the search dialog; the open mobile nav drawers stay open.

https://github.com/user-attachments/assets/916b2636-f7bd-48e6-a523-28c13e46454a

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
