### PR TITLE
fix(forms):  track status signal so validity bindings refresh in the same CD pass

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -617,7 +617,7 @@ export abstract class AbstractControl<
    * both valid AND invalid or invalid AND disabled.
    */
   get status(): FormControlStatus {
-    return untracked(this.statusReactive)!;
+    return this._status()!;
   }
   private set status(v: FormControlStatus) {
     untracked(() => this.statusReactive.set(v));

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -2348,6 +2348,71 @@ describe('template-driven forms integration tests', () => {
         verifyValidatorAttrValues({min: null, max: null});
         verifyFormState({isValid: true});
       });
+
+      // Regression test for https://github.com/angular/angular/issues/14189
+      // Two-input setup faithful to the original plnkr repro: typing in the minLen
+      // input dynamically re-validates the actual input. Parent template bindings
+      // reading the actual input's validity must reflect the new state within the
+      // same CD pass, not one tick later.
+      it('reflects dynamic validator changes on parent bindings within one CD pass', async () => {
+        @Component({
+          template: `
+            <form>
+              <input name="ml" ngModel #ml="ngModel">
+              <div class="status"
+                   [class.is-valid]="ip.valid"
+                   [class.is-invalid]="ip.invalid"></div>
+              <input name="field" ngModel [minlength]="ml.value" #ip="ngModel">
+            </form>
+          `,
+          standalone: false,
+          changeDetection: ChangeDetectionStrategy.OnPush,
+        })
+        class DynamicMinLenComponent {}
+
+        const fixture = initTest(DynamicMinLenComponent);
+        fixture.detectChanges();
+        await timeout();
+
+        const minLenInput = fixture.debugElement.query(By.css('input[name=ml]')).nativeElement;
+        const fieldInput = fixture.debugElement.query(By.css('input[name=field]')).nativeElement;
+        const status = fixture.debugElement.query(By.css('div.status')).nativeElement;
+        const ngForm = fixture.debugElement.children[0].injector.get(NgForm);
+        const fieldCtrl = ngForm.control.get('field')!;
+
+        // Set minLen=1 and type 'ab' into the field input.
+        minLenInput.value = '1';
+        dispatchEvent(minLenInput, 'input');
+        fixture.detectChanges();
+        await timeout();
+        fieldInput.value = 'ab';
+        dispatchEvent(fieldInput, 'input');
+        fixture.detectChanges();
+        await timeout();
+        expect(fieldCtrl.status).toBe('VALID');
+        expect(status.classList.contains('is-valid'))
+          .withContext('field="ab", minLen="1" -> valid')
+          .toBe(true);
+
+        // Raise minLen to "12" by typing into the minLen input — same as the original
+        // plnkr repro where the user types "2" after "1". A SINGLE detectChanges()
+        // must propagate the new validity to the parent template binding.
+        minLenInput.value = '12';
+        dispatchEvent(minLenInput, 'input');
+        fixture.detectChanges();
+        await timeout();
+
+        expect(fieldCtrl.status)
+          .withContext('field re-validated to INVALID after minLen="12"')
+          .toBe('INVALID');
+        expect(fieldInput.classList.contains('ng-invalid'))
+          .withContext('field input ng-invalid (NgControlStatus host binding)')
+          .toBe(true);
+        expect(status.classList.contains('is-invalid'))
+          .withContext('parent div is-invalid via ip.invalid (must match input state)')
+          .toBe(true);
+        expect(status.classList.contains('is-valid')).toBe(false);
+      });
     });
 
     ['number', 'string'].forEach((inputType: string) => {


### PR DESCRIPTION
Track status signal so validity bindings refresh in the same CD pass - fix type, forms scope, imperative present, no caps, no period

Template bindings reading `AbstractControl.valid` / `invalid` / `pending` / `disabled` / `enabled` / `status` (and the `NgControl`/`NgModel` accessors that delegate to them) could lag one CD tick behind the actual control validity when a validator's bound input changed dynamically. With `[minlength]="x"` for example, the validator directive's `ngOnChanges` runs `updateValueAndValidity()` after the parent's `[class.is-invalid]` binding has already evaluated, so the parent reads stale validity.

The bug surfaces when the parent binding appears earlier in template source order than the validated input: Ivy evaluates template instructions top-down, so the parent reads validity first, then the input's `[minlength]` update triggers the validator's ngOnChanges, then the status signal flips — but the parent has already been checked for that pass.

`get status()` previously used `untracked(this.statusReactive)`, so template reads of `control.valid` established no consumer dependency. The `_status` computed signal was already wired up internally (used by `NgControlStatus` host bindings) but the public getters bypassed it.

Switch `get status()` to read via `_status()` so template bindings subscribe to the signal. When the validator updates the signal mid-CD, the dirty parent view is refreshed within the same `detectChanges()` pass instead of one tick later. The setter still wraps writes in `untracked()`, and existing write-side untracking on `setValue` / CVA paths is unchanged.

Fixes #14189

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

[Relevant issue. -->](https://github.com/angular/angular/issues/14189)

Issue Number: 14189

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

In abstract_model.ts:619 Track via the `_status` computed signal so template bindings (and other reactive consumers) that read `status` / `valid` / `invalid` / `pending` / `disabled` / `enabled` are notified when validity changes mid-CD — e.g. when a validator's bound input (`[minlength]="x"`) changes and `updateValueAndValidity()` runs from the validator directive's `ngOnChanges`. Without tracking, parent template bindings that evaluate BEFORE the validator's ngOnChanges (e.g. a sibling/parent `[class.is-invalid]` declared earlier in source order than the validated input) stayed one tick behind. 

Why use `_status` and not `statusReactive`?
statusReactive and _status are functionally interchangeable for fixing the bug. Both establish a consumer subscription that gets notified when statusReactive.set(...) runs, and both get the parent view marked dirty so it's refreshed in the same CD pass.

So why did I write _status() and not statusReactive() in the fix?

1. Convention. Same file already uses this private writable signal + @internal computed pattern for pristineReactive/_pristine and touchedReactive/_touched. The _status variant is the one already exposed to the rest of the forms package NgControlStatus.isValid() calls _status?.(). Reusing the same hook keeps the subscription topology consistent.
2. Read-only by contract. _status is a computed — a future maintainer can't accidentally call .set() on it. statusReactive exposes the writable surface.
3. Single point of derivation. If status ever needed to be derived from more than one underlying signal, the change happens inside the computed() and every consumer benefits. With direct statusReactive() reads scattered around, you'd need to update each call site.

Heads-up (out of scope, but worth a look): the same untracked(...) pattern is used by the pristine getter (abstract_model.ts:715) and touched getter (abstract_model.ts:742). If a template binds [class.was-touched]="control.touched" and touched flips during the same CD pass that the binding evaluated, the same one-tick-lag bug should apply. Whether to extend the fix to those is a judgment call — different trigger paths than #14189, possibly different reproductions, and arguably a separate PR.
