### PR TITLE
fix(core): revert some services back to injectable

### DIFF
--- a/packages/animations/src/animation_builder.ts
+++ b/packages/animations/src/animation_builder.ts
@@ -7,7 +7,6 @@
  */
 import {
   ANIMATION_MODULE_TYPE,
-  ɵAnimationRendererType as AnimationRendererType,
   DOCUMENT,
   Inject,
   inject,
@@ -15,9 +14,9 @@ import {
   Renderer2,
   RendererFactory2,
   RendererType2,
-  ɵRuntimeError as RuntimeError,
-  Service,
   ViewEncapsulation,
+  ɵAnimationRendererType as AnimationRendererType,
+  ɵRuntimeError as RuntimeError,
 } from '@angular/core';
 
 import {AnimationMetadata, AnimationOptions, sequence} from './animation_metadata';
@@ -72,7 +71,7 @@ import {AnimationPlayer} from './players/animation_player';
  *
  * @deprecated 20.2 Use `animate.enter` or `animate.leave` instead. Intent to remove in v23
  */
-@Service({factory: () => inject(BrowserAnimationBuilder)})
+@Injectable({providedIn: 'root', useFactory: () => inject(BrowserAnimationBuilder)})
 export abstract class AnimationBuilder {
   /**
    * Builds a factory for producing a defined animation.

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -6,22 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  inject,
-  Inject,
-  Injectable,
-  LOCALE_ID,
-  ɵRuntimeError as RuntimeError,
-  Service,
-} from '@angular/core';
+import {inject, Inject, Injectable, LOCALE_ID, ɵRuntimeError as RuntimeError} from '@angular/core';
 
-import {RuntimeErrorCode} from '../errors';
 import {getLocalePluralCase, Plural} from './locale_data_api';
+import {RuntimeErrorCode} from '../errors';
 
 /**
  * @publicApi
  */
-@Service({factory: () => new NgLocaleLocalization(inject(LOCALE_ID))})
+@Injectable({
+  providedIn: 'root',
+  useFactory: () => new NgLocaleLocalization(inject(LOCALE_ID)),
+})
 export abstract class NgLocalization {
   abstract getPluralCategory(value: number, locale?: string): string;
 }

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Service} from '@angular/core';
+import {inject, Injectable, Service} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {AbstractControl, AbstractControlOptions} from './model/abstract_model';
@@ -415,7 +415,10 @@ export class FormBuilder {
  *
  * @publicApi
  */
-@Service({factory: () => inject(FormBuilder).nonNullable})
+@Injectable({
+  providedIn: 'root',
+  useFactory: () => inject(FormBuilder).nonNullable,
+})
 export abstract class NonNullableFormBuilder {
   /**
    * Similar to `FormBuilder#group`, except any implicitly constructed `FormControl`

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Injectable, Service} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
@@ -35,7 +35,7 @@ import {PRIMARY_OUTLET, RouteTitleKey} from './shared';
  * @publicApi
  * @see [Page title guide](guide/routing/define-routes#using-titlestrategy-for-page-titles)
  */
-@Service({factory: () => inject(DefaultTitleStrategy)})
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultTitleStrategy)})
 export abstract class TitleStrategy {
   /** Performs the application title update. */
   abstract updateTitle(snapshot: RouterStateSnapshot): void;

--- a/packages/router/src/route_reuse_strategy.ts
+++ b/packages/router/src/route_reuse_strategy.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ComponentRef, inject, Service} from '@angular/core';
+import {ComponentRef, inject, Injectable, Service} from '@angular/core';
 
-import {Route} from './models';
 import {OutletContext} from './router_outlet_context';
 import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
+import {Route} from './models';
 import {TreeNode} from './utils/tree';
 
 /**
@@ -64,7 +64,7 @@ export interface ExperimentalRouteReuseStrategy {
  *
  * @publicApi
  */
-@Service({factory: () => inject(DefaultRouteReuseStrategy)})
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultRouteReuseStrategy)})
 export abstract class RouteReuseStrategy {
   /** Determines if this route (and its subtree) should be detached to be reused later */
   abstract shouldDetach(route: ActivatedRouteSnapshot): boolean;

--- a/packages/router/src/statemanager/state_manager.ts
+++ b/packages/router/src/statemanager/state_manager.ts
@@ -7,7 +7,7 @@
  */
 
 import {Location} from '@angular/common';
-import {EnvironmentInjector, inject, Service} from '@angular/core';
+import {EnvironmentInjector, inject, Injectable, Service} from '@angular/core';
 import {SubscriptionLike} from 'rxjs';
 
 import {
@@ -29,7 +29,7 @@ import {createEmptyState, RouterState} from '../router_state';
 import {UrlHandlingStrategy} from '../url_handling_strategy';
 import {UrlSerializer, UrlTree} from '../url_tree';
 
-@Service({factory: () => inject(HistoryStateManager)})
+@Injectable({providedIn: 'root', useFactory: () => inject(HistoryStateManager)})
 export abstract class StateManager {
   protected readonly urlSerializer = inject(UrlSerializer);
   private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};

--- a/packages/router/src/url_handling_strategy.ts
+++ b/packages/router/src/url_handling_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {inject, Service} from '@angular/core';
+import {inject, Injectable, Service} from '@angular/core';
 
 import {UrlTree} from './url_tree';
 
@@ -19,7 +19,7 @@ import {UrlTree} from './url_tree';
  *
  * @publicApi
  */
-@Service({factory: () => inject(DefaultUrlHandlingStrategy)})
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultUrlHandlingStrategy)})
 export abstract class UrlHandlingStrategy {
   /**
    * Tells the router if this URL should be processed.

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, ɵRuntimeError as RuntimeError, Service, Signal} from '@angular/core';
+import {computed, Injectable, ɵRuntimeError as RuntimeError, Signal} from '@angular/core';
 
 import {RuntimeErrorCode} from './errors';
 import type {Router} from './router';
@@ -417,7 +417,7 @@ export function mapChildrenIntoArray<T>(
  *
  * @publicApi
  */
-@Service({factory: () => new DefaultUrlSerializer()})
+@Injectable({providedIn: 'root', useFactory: () => new DefaultUrlSerializer()})
 export abstract class UrlSerializer {
   /** Parse a url into a `UrlTree` */
   abstract parse(url: string): UrlTree;


### PR DESCRIPTION
The `@Service` types don't allow `factory` to be set when the decorator is on an abstract class. These changes revert some of our usages to fix the CI.

I'll send a follow-up to fix the signature.
