### PR TITLE
fix(core): allow service with factory on abstract classes

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1815,7 +1815,7 @@ export interface ServiceDecorator {
     <T>(options: {
         autoProvided?: true;
         factory: () => T;
-    }): <C extends Type<unknown>>(target: C) => Type<T>;
+    }): <C extends Type<unknown> | AbstractType<unknown>>(target: C) => C extends Type<unknown> ? Type<T> : abstract new (...args: any[]) => T;
     (options?: {
         autoProvided?: true;
     }): TypeDecorator;

--- a/packages/core/src/di/service.ts
+++ b/packages/core/src/di/service.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Type} from '../interface/type';
+import {AbstractType, Type} from '../interface/type';
 import {makeDecorator, TypeDecorator} from '../util/decorators';
 import {compileService} from './jit/service';
 
@@ -39,7 +39,9 @@ export interface ServiceDecorator {
   <T>(options: {
     autoProvided?: true;
     factory: () => T;
-  }): <C extends Type<unknown>>(target: C) => Type<T>;
+  }): <C extends Type<unknown> | AbstractType<unknown>>(
+    target: C,
+  ) => C extends Type<unknown> ? Type<T> : abstract new (...args: any[]) => T;
 
   /**
    * Creates a service that is automatically provided.


### PR DESCRIPTION
Fixes that setting a `@Service` with a `factory` on an abstract class was resulting in a compilation error.
