### PR TITLE
docs: remove note regarding lack of support for ng test --debug in browser mode

### DIFF
--- a/adev/src/content/guide/testing/migrating-to-vitest.md
+++ b/adev/src/content/guide/testing/migrating-to-vitest.md
@@ -132,8 +132,6 @@ Add the `browsers` option to your `test` target's options. The browser name depe
 
 Headless mode is enabled automatically if the `CI` environment variable is set or if a browser name includes "Headless" (e.g., `ChromeHeadless`). Otherwise, tests will run in a headed browser.
 
-NOTE: Debugging with `ng test --debug` is not supported by browser mode.
-
 ## Automated test refactoring with schematics
 
 IMPORTANT: The `refactor-jasmine-vitest` schematic is experimental and may not cover all possible test patterns. Always review the changes made by the schematic.


### PR DESCRIPTION

This is no longer the case.

Closes #68621
