### PR TITLE
docs: clarify class/style binding example in the style guide

### DIFF
--- a/adev/src/content/best-practices/style-guide.md
+++ b/adev/src/content/best-practices/style-guide.md
@@ -223,14 +223,19 @@ export class UserProfile {
 
 Prefer `class` and `style` bindings over using the [`NgClass`](/api/common/NgClass) and [`NgStyle`](/api/common/NgStyle) directives.
 
+When you set classes or styles one at a time, use a key-specific binding:
+
 ```html {prefer}
 <div [class.admin]="isAdmin" [class.dense]="density === 'high'">
-  <div [style.color]="textColor" [style.background-color]="backgroundColor">
-    <!-- OR -->
-    <div [class]="{admin: isAdmin, dense: density === 'high'}">
-      <div [style]="{'color': textColor, 'background-color': backgroundColor}"></div>
-    </div>
-  </div>
+  <div [style.color]="textColor" [style.background-color]="backgroundColor"></div>
+</div>
+```
+
+When you set several at once, pass an object:
+
+```html {prefer}
+<div [class]="{admin: isAdmin, dense: density === 'high'}">
+  <div [style]="{'color': textColor, 'background-color': backgroundColor}"></div>
 </div>
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In `adev/src/content/best-practices/style-guide.md`, the "prefer" example under "Prefer `class` and `style` over `ngClass` and `ngStyle`" jams two equivalent forms (single-key `[class.x]`/`[style.x]` bindings and object-literal `[class]={...}`/`[style]={...}` bindings) into one tree of four nested divs, with a small `<!-- OR -->` comment as the only marker between them. A reader has to find the comment, count the divs above and below, and work out which pair belongs to which form.

<img width="833" height="660" alt="image" src="https://github.com/user-attachments/assets/ae7b0b8d-b1c3-4cde-9514-af63cad68f4c" />

## What is the new behavior?

The two forms are now two separate `{prefer}` snippets, each preceded by a one-line intro stating when to reach for that form ("When you toggle individual classes or properties..." / "When you set several at once..."). The `{avoid}` snippet is unchanged.

<img width="833" height="781" alt="image" src="https://github.com/user-attachments/assets/c3f07832-bbcb-4a43-a60d-eade45483d27" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No