### PR TITLE
refactor(core): add "experimental" to WebMCP API names.

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -541,7 +541,7 @@ export class DebugNode {
 }
 
 // @public
-export function declareWebMcpTool<const InputSchema extends JsonSchemaForInference>(tool: WebMcpToolDescriptor<InputSchema>, injector?: Injector): void;
+export function declareExperimentalWebMcpTool<const InputSchema extends JsonSchemaForInference>(tool: WebMcpToolDescriptor<InputSchema>, injector?: Injector): void;
 
 // @public
 export const DEFAULT_CURRENCY_CODE: InjectionToken<string>;
@@ -1500,6 +1500,9 @@ export function provideCheckNoChangesConfig(options: {
 export function provideEnvironmentInitializer(initializerFn: () => void): EnvironmentProviders;
 
 // @public
+export function provideExperimentalWebMcpTools<const InputSchema extends JsonSchemaForInference>(tools: WebMcpToolDescriptor<InputSchema>[]): EnvironmentProviders;
+
+// @public
 export function provideIdleServiceWith(useExisting: AbstractType<IdleService> | InjectionToken<IdleService>): EnvironmentProviders;
 
 // @public
@@ -1516,9 +1519,6 @@ export type ProviderToken<T> = Type<T> | AbstractType<T> | InjectionToken<T>;
 
 // @public
 export function provideStabilityDebugging(): EnvironmentProviders;
-
-// @public
-export function provideWebMcpTools<const InputSchema extends JsonSchemaForInference>(tools: WebMcpToolDescriptor<InputSchema>[]): EnvironmentProviders;
 
 // @public
 export function provideZoneChangeDetection(options?: NgZoneOptions): EnvironmentProviders;

--- a/packages/core/src/webmcp/declare_tool.ts
+++ b/packages/core/src/webmcp/declare_tool.ts
@@ -18,7 +18,7 @@ import {DestroyRef} from '../linker';
  * the associated injection context is destroyed.
  *
  * The `tool.execute` function is invoked in the injection context of the provided
- * {@link Injector}, or the injection context of `declareWebMcpTool` itself.
+ * {@link Injector}, or the injection context of `declareExperimentalWebMcpTool` itself.
  *
  * @param tool The tool to register and execute when invoked by an AI agent.
  * @param injector Optional {@link Injector} which will automatically
@@ -28,7 +28,7 @@ import {DestroyRef} from '../linker';
  *     `injector` argument provided.
  * @experimental
  */
-export function declareWebMcpTool<const InputSchema extends JsonSchemaForInference>(
+export function declareExperimentalWebMcpTool<const InputSchema extends JsonSchemaForInference>(
   tool: ToolDescriptor<InputSchema>,
   injector?: Injector,
 ): void {
@@ -40,7 +40,7 @@ export function declareWebMcpTool<const InputSchema extends JsonSchemaForInferen
   if (!modelContext) return;
 
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-    if (!injector) assertInInjectionContext(declareWebMcpTool);
+    if (!injector) assertInInjectionContext(declareExperimentalWebMcpTool);
   }
 
   // Inject the `DestroyRef` and `Injector` immediately, so if it fails we abort

--- a/packages/core/src/webmcp/index.ts
+++ b/packages/core/src/webmcp/index.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {declareWebMcpTool} from './declare_tool';
-export {provideWebMcpTools} from './provide_tools';
+export {declareExperimentalWebMcpTool} from './declare_tool';
+export {provideExperimentalWebMcpTools} from './provide_tools';
 export type {
   Execute as WebMcpToolExecute,
   Client as WebMcpClient,

--- a/packages/core/src/webmcp/provide_tools.ts
+++ b/packages/core/src/webmcp/provide_tools.ts
@@ -8,7 +8,7 @@
 
 import type {JsonSchemaForInference} from '../../third_party/@mcp-b/webmcp-types';
 import {EnvironmentProviders, makeEnvironmentProviders, provideEnvironmentInitializer} from '../di';
-import {declareWebMcpTool} from './declare_tool';
+import {declareExperimentalWebMcpTool} from './declare_tool';
 import type {ToolDescriptor} from './types';
 
 /**
@@ -25,12 +25,12 @@ import type {ToolDescriptor} from './types';
  *     or route providers.
  * @experimental
  */
-export function provideWebMcpTools<const InputSchema extends JsonSchemaForInference>(
+export function provideExperimentalWebMcpTools<const InputSchema extends JsonSchemaForInference>(
   tools: ToolDescriptor<InputSchema>[],
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     provideEnvironmentInitializer(() => {
-      for (const tool of tools) declareWebMcpTool(tool);
+      for (const tool of tools) declareExperimentalWebMcpTool(tool);
     }),
   ]);
 }

--- a/packages/core/test/webmcp/declare_tool_spec.ts
+++ b/packages/core/test/webmcp/declare_tool_spec.ts
@@ -8,8 +8,8 @@
 
 import {initializeWebMCPPolyfill, cleanupWebMCPPolyfill} from '@mcp-b/webmcp-polyfill';
 import type {JsonSchemaForInference} from '../../third_party/@mcp-b/webmcp-types';
-import {inject, Injectable, InjectionToken, Injector, runInInjectionContext} from '../../src/di';
-import {declareWebMcpTool} from '../../src/webmcp/declare_tool';
+import {inject, Injectable, Injector, runInInjectionContext} from '../../src/di';
+import {declareExperimentalWebMcpTool} from '../../src/webmcp/declare_tool';
 import {Execute} from '../../src/webmcp/types';
 import {RuntimeErrorCode} from '../../src/errors';
 
@@ -19,7 +19,7 @@ type IsAny<T> = 0 extends 1 & T ? true : false;
 // Whether or not the type has an index signature.
 type HasIndexSignature<T> = string extends keyof T ? true : false;
 
-describe('declareWebMcpTool', () => {
+describe('declareExperimentalWebMcpTool', () => {
   beforeEach(() => {
     initializeWebMCPPolyfill({installTestingShim: true});
   });
@@ -33,7 +33,7 @@ describe('declareWebMcpTool', () => {
       content: [{type: 'text', text: 'Hello!'}],
     });
 
-    declareWebMcpTool(
+    declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -65,7 +65,7 @@ describe('declareWebMcpTool', () => {
   it('should throw if the tool is already registered', () => {
     const injector = Injector.create({providers: []});
 
-    declareWebMcpTool(
+    declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -76,7 +76,7 @@ describe('declareWebMcpTool', () => {
     );
 
     expect(() => {
-      declareWebMcpTool(
+      declareExperimentalWebMcpTool(
         {
           name: 'testTool',
           description: 'Another test tool',
@@ -91,7 +91,7 @@ describe('declareWebMcpTool', () => {
   it('should unregister the tool when its `Injector` is destroyed', () => {
     const injector = Injector.create({providers: []});
 
-    declareWebMcpTool(
+    declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -114,7 +114,7 @@ describe('declareWebMcpTool', () => {
     const injector = Injector.create({providers: []});
 
     runInInjectionContext(injector, () => {
-      declareWebMcpTool({
+      declareExperimentalWebMcpTool({
         name: 'testTool',
         description: 'A test tool',
         inputSchema: {type: 'object', properties: {}},
@@ -133,7 +133,7 @@ describe('declareWebMcpTool', () => {
 
   it('should throw when called outside an injection context and no `injector` is provided', () => {
     expect(() => {
-      declareWebMcpTool({
+      declareExperimentalWebMcpTool({
         name: 'testTool',
         description: 'A test tool',
         inputSchema: {type: 'object', properties: {}},
@@ -148,7 +148,7 @@ describe('declareWebMcpTool', () => {
       .createSpy<Execute<JsonSchemaForInference>>('execute')
       .and.returnValue({content: []});
 
-    declareWebMcpTool(
+    declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -175,7 +175,7 @@ describe('declareWebMcpTool', () => {
     });
 
     let injectedService!: TestService;
-    declareWebMcpTool(
+    declareExperimentalWebMcpTool(
       {
         name: 'testTool',
         description: 'A test tool',
@@ -196,7 +196,7 @@ describe('declareWebMcpTool', () => {
   it('should infer correct types from schema', () => {
     // Type-only test, only needs to compile, not execute.
     () => {
-      declareWebMcpTool(
+      declareExperimentalWebMcpTool(
         {
           name: 'testTool',
           description: 'A test tool',

--- a/packages/core/test/webmcp/provide_tools_spec.ts
+++ b/packages/core/test/webmcp/provide_tools_spec.ts
@@ -10,11 +10,11 @@ import {initializeWebMCPPolyfill, cleanupWebMCPPolyfill} from '@mcp-b/webmcp-pol
 import type {JsonSchemaForInference} from '../../third_party/@mcp-b/webmcp-types';
 import {Component, createEnvironmentInjector, EnvironmentInjector} from '../../src/core';
 import {provideRouter, Router, withExperimentalAutoCleanupInjectors} from '@angular/router';
-import {provideWebMcpTools} from '../../src/webmcp/provide_tools';
+import {provideExperimentalWebMcpTools} from '../../src/webmcp/provide_tools';
 import {Execute} from '../../src/webmcp/types';
 import {TestBed} from '../../testing';
 
-describe('provideWebMcpTools', () => {
+describe('provideExperimentalWebMcpTools', () => {
   beforeEach(() => {
     initializeWebMCPPolyfill({installTestingShim: true});
   });
@@ -30,7 +30,7 @@ describe('provideWebMcpTools', () => {
 
     const envInjector = createEnvironmentInjector(
       [
-        provideWebMcpTools([
+        provideExperimentalWebMcpTools([
           {
             name: 'testTool',
             description: 'A test tool',
@@ -55,7 +55,7 @@ describe('provideWebMcpTools', () => {
   it('should unregister tools when the injector is destroyed', () => {
     const envInjector = createEnvironmentInjector(
       [
-        provideWebMcpTools([
+        provideExperimentalWebMcpTools([
           {
             name: 'testTool',
             description: 'A test tool',
@@ -92,7 +92,7 @@ describe('provideWebMcpTools', () => {
               path: 'test',
               component: TestComp,
               providers: [
-                provideWebMcpTools([
+                provideExperimentalWebMcpTools([
                   {
                     name: 'routeTool',
                     description: 'A route tool',


### PR DESCRIPTION
WebMCP is still an experimental standard and going through frequent changes in the Chrome implementation and the standards process. As a result, we should be clear about the support status of this API and its overall stability guarantees.