### PR TITLE
docs: recommend output() over EventEmitter in reactive forms guide

### DIFF
--- a/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
+++ b/adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts
@@ -52,7 +52,7 @@ export class ProfileEditorComponent {
   // #enddocregion add-alias
   // #docregion on-submit
   onSubmit() {
-    // TODO: Use EventEmitter with form value
+    // TODO: Use output() with form value
     console.warn(this.profileForm.value);
   }
   // #enddocregion on-submit

--- a/adev/src/content/guide/forms/reactive-forms.md
+++ b/adev/src/content/guide/forms/reactive-forms.md
@@ -151,7 +151,7 @@ The `ProfileEditor` component accepts input from the user, but in a real scenari
 
 <docs-code header="profile-editor.component.html (submit event)" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html" region="ng-submit"/>
 
-The `onSubmit()` method in the `ProfileEditor` component captures the current value of `profileForm`. Use `EventEmitter` to keep the form encapsulated and to provide the form value outside the component. The following example uses `console.warn` to log a message to the browser console.
+The `onSubmit()` method in the `ProfileEditor` component captures the current value of `profileForm`. Use `output()` to keep the form encapsulated and to provide the form value outside the component. The following example uses `console.warn` to log a message to the browser console.
 
 <docs-code header="profile-editor.component.ts (submit method)" path="adev/src/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.ts" region="on-submit"/>
 


### PR DESCRIPTION
The "Save form data" step pointed at `EventEmitter` while the rest of the guide uses modern APIs (e.g. `inject(FormBuilder)`). Swap to `output()` and align the TODO in the profile-editor example.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

In `adev/src/content/guide/forms/reactive-forms.md`, the "Save form data" step tells readers to use `EventEmitter`, while the components/outputs guide leads with `output()` and the rest of this guide already uses modern APIs (e.g. `inject(FormBuilder)`). The example's TODO mirrored the same drift.

## What is the new behavior?

The "Save form data" step now recommends `output()`, matching the components/outputs guide. The `profile-editor` example's placeholder TODO is updated to `// TODO: Use output() with form value` so the example and the guide narration point at the same API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

