### PR TITLE
fix(compiler-cli): mention ngProjectAs in content projection control flow error

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/oob.ts
@@ -434,8 +434,8 @@ export class OutOfBandDiagnosticRecorderImpl implements OutOfBandDiagnosticRecor
     const blockName = controlFlowNode.nameSpan.toString().trim();
     const lines = [
       `Node matches the "${slotSelector}" slot of the "${componentName}" component, but will not be projected into the specific slot because the surrounding ${blockName} has more than one node at its root. To project the node in the right slot, you can:\n`,
-      `1. Wrap the content of the ${blockName} block in an <ng-container/> that matches the "${slotSelector}" selector.`,
-      `2. Split the content of the ${blockName} block across multiple ${blockName} blocks such that each one only has a single projectable node at its root.`,
+      `1. Wrap the content of the ${blockName} block in an <ng-container ngProjectAs="${slotSelector}"> to explicitly target the "${slotSelector}" slot. Use this when all nodes in the block should be projected into the same slot.`,
+      `2. Split the content of the ${blockName} block across multiple ${blockName} blocks such that each one only has a single projectable node at its root. Use this when nodes in the block target different slots.`,
       `3. Remove all content from the ${blockName} block, except for the node being projected.`,
     ];
 

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -6926,6 +6926,42 @@ suppress
         );
       });
 
+      it('should suggest ngProjectAs in the error message for targeted slots', () => {
+        env.write(
+          'test.ts',
+          `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'comp',
+            template: '<ng-content select="[foo]"/> <ng-content/>',
+          })
+          class Comp {}
+
+          @Component({
+            imports: [Comp],
+            template: \`
+              <comp>
+                @if (true) {
+                  <div foo></div>
+                  <span>other content</span>
+                }
+              </comp>
+            \`,
+          })
+          class TestCmp {}
+        `,
+        );
+
+        const diags = env
+          .driveDiagnostics()
+          .map((d) => ts.flattenDiagnosticMessageText(d.messageText, ''));
+        expect(diags.length).toBe(1);
+        expect(diags[0]).toContain(`ngProjectAs="[foo]"`);
+        expect(diags[0]).toContain(`all nodes in the block should be projected into the same slot`);
+        expect(diags[0]).toContain(`nodes in the block target different slots`);
+      });
+
       it('should not report when there is only one root node', () => {
         env.write(
           'test.ts',


### PR DESCRIPTION
Fixes #59398

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not required for error message improvement)

## PR Type

- [x] Bugfix

## What is the current behavior?

The diagnostic error NG8011 (`controlFlowPreventingContentProjection`) suggests wrapping content in an `<ng-container/>` but does not mention `ngProjectAs`, which is the key attribute needed to make the workaround actually work for named slots.

Users following the existing suggestion have no way to know they need `ngProjectAs="[selector]"` to target a specific slot, leading to confusion (as reported in the issue).

Additionally, the message does not clarify _when_ to use the wrapping approach vs. splitting into multiple blocks, which are solutions for different scenarios (single-slot vs. multi-slot targeting).

## What is the new behavior?

Option 1 of the diagnostic now explicitly shows `<ng-container ngProjectAs="[selector]">` with the actual slot selector interpolated, and explains this is the right approach when all nodes target the same slot.

Option 2 now clarifies it is needed when nodes target different slots.

## Example

Before:
```
1. Wrap the content of the @if block in an <ng-container/> that matches the "[foo]" selector.
2. Split the content of the @if block across multiple @if blocks such that each one only has a single projectable node at its root.
```

After:
```
1. Wrap the content of the @if block in an <ng-container ngProjectAs="[foo]"> to explicitly target the "[foo]" slot. Use this when all nodes in the block should be projected into the same slot.
2. Split the content of the @if block across multiple @if blocks such that each one only has a single projectable node at its root. Use this when nodes in the block target different slots.
```