### PR TITLE
refactor(compiler-cli): drop @ts-ignore around jsDocParsingMode

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -35,9 +35,10 @@ import {
  * If a new method is added to `ts.CompilerHost` which is not delegated, a type error will be
  * generated for this class.
  */
-export class DelegatingCompilerHost
-  implements Omit<RequiredDelegations<ExtendedTsCompilerHost>, 'getSourceFile' | 'fileExists'>
-{
+export class DelegatingCompilerHost implements Omit<
+  RequiredDelegations<ExtendedTsCompilerHost>,
+  'getSourceFile' | 'fileExists'
+> {
   createHash;
   directoryExists;
   fileNameToModuleName;
@@ -69,13 +70,10 @@ export class DelegatingCompilerHost
   resolveTypeReferenceDirectiveReferences;
 
   // jsDocParsingMode is not a method like the other elements above
-  // TODO: ignore usage can be dropped once 5.2 support is dropped
   get jsDocParsingMode() {
-    // @ts-ignore
     return this.delegate.jsDocParsingMode;
   }
   set jsDocParsingMode(mode) {
-    // @ts-ignore
     this.delegate.jsDocParsingMode = mode;
   }
 

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -57,13 +57,10 @@ export class DelegatingCompilerHost implements Omit<
   resolveTypeReferenceDirectiveReferences;
 
   // jsDocParsingMode is not a method like the other elements above
-  // TODO: ignore usage can be dropped once 5.2 support is dropped
   get jsDocParsingMode() {
-    // @ts-ignore
     return this.delegate.jsDocParsingMode;
   }
   set jsDocParsingMode(mode) {
-    // @ts-ignore
     this.delegate.jsDocParsingMode = mode;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`jsDocParsingMode` getters and setters in `host.ts` and `ts_create_program_driver.ts` are wrapped in `@ts-ignore` to support TypeScript 5.2, where the property wasn't on `ts.CompilerHost`. The minimum supported TypeScript is now 6.0 and `jsDocParsingMode` is part of the public API, so the suppressions are dead — the IDE flags them as unused directives.

## What is the new behavior?

The `@ts-ignore` lines and the `TODO` comment are removed in both files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
