### PR TITLE
Fix/ngsubmit await async validators

### DIFF
--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -14,6 +14,7 @@ import {
   forwardRef,
   Inject,
   Input,
+  OnDestroy,
   Optional,
   Provider,
   Self,
@@ -21,6 +22,8 @@ import {
   untracked,
   ɵWritable as Writable,
 } from '@angular/core';
+import {Subject, Subscription} from 'rxjs';
+import {filter, map, of, switchMap, take} from 'rxjs/operators';
 
 import {AbstractControl, FormHooks, FormSubmittedEvent} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
@@ -124,7 +127,7 @@ const resolvedPromise = (() => Promise.resolve())();
   exportAs: 'ngForm',
   standalone: false,
 })
-export class NgForm extends ControlContainer implements Form, AfterViewInit {
+export class NgForm extends ControlContainer implements Form, AfterViewInit, OnDestroy {
   /**
    * @description
    * Returns whether the form submission has been triggered.
@@ -161,6 +164,23 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   @Input('ngFormOptions') options!: {updateOn?: FormHooks};
 
+  /**
+   * @description
+   * When set to `true`, the `ngSubmit` event will not emit until all pending async validators
+   * on the form have completed. Defaults to `false` to preserve existing behavior.
+   *
+   * @usageNotes
+   * ```html
+   * <form (ngSubmit)="onSubmit()" awaitAsyncValidators>
+   *   ...
+   * </form>
+   * ```
+   */
+  @Input() awaitAsyncValidators: boolean = false;
+
+  private readonly _pendingSubmit$ = new Subject<Event>();
+  private _pendingSubmitSub!: Subscription;
+
   constructor(
     @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator | ValidatorFn)[],
     @Optional()
@@ -177,6 +197,22 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
       composeValidators(validators),
       composeAsyncValidators(asyncValidators),
     );
+    this._pendingSubmitSub = this._pendingSubmit$
+      .pipe(
+        switchMap((event) =>
+          this.awaitAsyncValidators && this.form.status === 'PENDING'
+            ? this.form.statusChanges.pipe(
+                filter((status) => status !== 'PENDING'),
+                take(1),
+                map(() => event),
+              )
+            : of(event),
+        ),
+      )
+      .subscribe((event) => {
+        this.ngSubmit.emit(event);
+        this.form._events.next(new FormSubmittedEvent(this.control));
+      });
   }
 
   /** @docs-private */
@@ -334,11 +370,18 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   onSubmit($event: Event): boolean {
     this.submittedReactive.set(true);
     syncPendingControls(this.form, this._directives);
-    this.ngSubmit.emit($event);
-    this.form._events.next(new FormSubmittedEvent(this.control));
+
+    this._pendingSubmit$.next($event);
+
     // Forms with `method="dialog"` have some special behavior
     // that won't reload the page and that shouldn't be prevented.
     return ($event?.target as HTMLFormElement | null)?.method === 'dialog';
+  }
+
+  /** @nodoc */
+  ngOnDestroy(): void {
+    this._pendingSubmit$.complete();
+    this._pendingSubmitSub.unsubscribe();
   }
 
   /**

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -22,8 +22,8 @@ import {
   untracked,
   ɵWritable as Writable,
 } from '@angular/core';
-import {Subject, Subscription} from 'rxjs';
-import {filter, map, of, switchMap, take} from 'rxjs/operators';
+import {of, Subject, Subscription} from 'rxjs';
+import {filter, map, switchMap, take} from 'rxjs/operators';
 
 import {AbstractControl, FormHooks, FormSubmittedEvent} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
@@ -201,11 +201,15 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit, OnD
       .pipe(
         switchMap((event) =>
           this.awaitAsyncValidators && this.form.status === 'PENDING'
-            ? this.form.statusChanges.pipe(
-                filter((status) => status !== 'PENDING'),
-                take(1),
-                map(() => event),
-              )
+            ? (() => {
+                const statusChanges$ = this.form.statusChanges.pipe(
+                  filter((status) => status !== 'PENDING'),
+                  take(1),
+                  map(() => event),
+                );
+                this.form._updateTreeValidity({emitEvent: true});
+                return statusChanges$;
+              })()
             : of(event),
         ),
       )

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -20,8 +20,8 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import {Subject, Subscription} from 'rxjs';
-import {filter, map, of, switchMap, take} from 'rxjs/operators';
+import {of, Subject, Subscription} from 'rxjs';
+import {filter, map, switchMap, take} from 'rxjs/operators';
 
 import {FormGroup} from '../../model/form_group';
 import {FormArray} from '../../model/form_array';
@@ -139,11 +139,15 @@ export abstract class AbstractFormDirective
       .pipe(
         switchMap((event) =>
           this.awaitAsyncValidators && this.form.status === 'PENDING'
-            ? this.form.statusChanges.pipe(
-                filter((status) => status !== 'PENDING'),
-                take(1),
-                map(() => event),
-              )
+            ? (() => {
+                const statusChanges$ = this.form.statusChanges.pipe(
+                  filter((status) => status !== 'PENDING'),
+                  take(1),
+                  map(() => event),
+                );
+                this.form._updateTreeValidity({emitEvent: true});
+                return statusChanges$;
+              })()
             : of(event),
         ),
       )

--- a/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
+++ b/packages/forms/src/directives/reactive_directives/abstract_form.directive.ts
@@ -10,6 +10,7 @@ import {
   Directive,
   EventEmitter,
   Inject,
+  Input,
   OnChanges,
   OnDestroy,
   Optional,
@@ -19,6 +20,8 @@ import {
   signal,
   untracked,
 } from '@angular/core';
+import {Subject, Subscription} from 'rxjs';
+import {filter, map, of, switchMap, take} from 'rxjs/operators';
 
 import {FormGroup} from '../../model/form_group';
 import {FormArray} from '../../model/form_array';
@@ -102,6 +105,23 @@ export abstract class AbstractFormDirective
    */
   abstract ngSubmit: EventEmitter<any>;
 
+  /**
+   * @description
+   * When set to `true`, the `ngSubmit` event will not emit until all pending async validators
+   * on the form have completed. Defaults to `false` to preserve existing behavior.
+   *
+   * @usageNotes
+   * ```html
+   * <form [formGroup]="myForm" (ngSubmit)="onSubmit()" awaitAsyncValidators>
+   *   ...
+   * </form>
+   * ```
+   */
+  @Input() awaitAsyncValidators: boolean = false;
+
+  private readonly _pendingSubmit$ = new Subject<Event>();
+  private _pendingSubmitSub!: Subscription;
+
   constructor(
     @Optional() @Self() @Inject(NG_VALIDATORS) validators: (Validator | ValidatorFn)[],
     @Optional()
@@ -115,6 +135,22 @@ export abstract class AbstractFormDirective
     super();
     this._setValidators(validators);
     this._setAsyncValidators(asyncValidators);
+    this._pendingSubmitSub = this._pendingSubmit$
+      .pipe(
+        switchMap((event) =>
+          this.awaitAsyncValidators && this.form.status === 'PENDING'
+            ? this.form.statusChanges.pipe(
+                filter((status) => status !== 'PENDING'),
+                take(1),
+                map(() => event),
+              )
+            : of(event),
+        ),
+      )
+      .subscribe((event) => {
+        this.ngSubmit.emit(event);
+        this.form._events.next(new FormSubmittedEvent(this.control));
+      });
   }
 
   /** @nodoc */
@@ -140,6 +176,8 @@ export abstract class AbstractFormDirective
 
   /** @nodoc */
   protected onDestroy() {
+    this._pendingSubmit$.complete();
+    this._pendingSubmitSub.unsubscribe();
     if (this.form) {
       cleanUpValidators(this.form, this);
 
@@ -312,8 +350,8 @@ export abstract class AbstractFormDirective
   onSubmit($event: Event): boolean {
     (this as {submitted: boolean}).submitted = true;
     syncPendingControls(this.form, this.directives);
-    this.ngSubmit.emit($event);
-    this.form._events.next(new FormSubmittedEvent(this.control));
+
+    this._pendingSubmit$.next($event);
 
     // Forms with `method="dialog"` have some special behavior that won't reload the page and that
     // shouldn't be prevented. Note that we need to null check the `event` and the `target`, because

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -29,7 +29,7 @@ import {
 } from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
 import {merge, NEVER, Observable, of, Subject, Subscription, timer} from 'rxjs';
-import {map, tap} from 'rxjs/operators';
+import {map, take, tap} from 'rxjs/operators';
 import {
   AbstractControl,
   AsyncValidator,
@@ -1117,11 +1117,11 @@ describe('reactive forms integration tests', () => {
       });
 
       it('should emit ngSubmit immediately when awaitAsyncValidators is false (default)', () => {
-        const asyncValidator = () => pendingSubject.asObservable();
+        const asyncValidator = () => pendingSubject.asObservable().pipe(take(1));
         const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup(
-          {'login': new FormControl('', null, asyncValidator)},
-        );
+        fixture.componentInstance.form = new FormGroup({
+          'login': new FormControl('', null, asyncValidator),
+        });
         fixture.detectChanges();
 
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
@@ -1139,11 +1139,11 @@ describe('reactive forms integration tests', () => {
       });
 
       it('should defer ngSubmit until async validators complete when awaitAsyncValidators is true', async () => {
-        const asyncValidator = () => pendingSubject.asObservable();
+        const asyncValidator = () => pendingSubject.asObservable().pipe(take(1));
         const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup(
-          {'login': new FormControl('', null, asyncValidator)},
-        );
+        fixture.componentInstance.form = new FormGroup({
+          'login': new FormControl('', null, asyncValidator),
+        });
         fixture.detectChanges();
 
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
@@ -1171,11 +1171,11 @@ describe('reactive forms integration tests', () => {
       });
 
       it('should emit ngSubmit immediately when awaitAsyncValidators is true but form is not PENDING', async () => {
-        const asyncValidator = () => pendingSubject.asObservable();
+        const asyncValidator = () => pendingSubject.asObservable().pipe(take(1));
         const fixture = initTest(FormGroupComp);
-        fixture.componentInstance.form = new FormGroup(
-          {'login': new FormControl('', null, asyncValidator)},
-        );
+        fixture.componentInstance.form = new FormGroup({
+          'login': new FormControl('', null, asyncValidator),
+        });
         fixture.detectChanges();
 
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -1108,6 +1108,96 @@ describe('reactive forms integration tests', () => {
       form.reset();
       expect(loginEl.value).toBe('');
     });
+
+    describe('awaitAsyncValidators', () => {
+      let pendingSubject: Subject<null>;
+
+      beforeEach(() => {
+        pendingSubject = new Subject<null>();
+      });
+
+      it('should emit ngSubmit immediately when awaitAsyncValidators is false (default)', () => {
+        const asyncValidator = () => pendingSubject.asObservable();
+        const fixture = initTest(FormGroupComp);
+        fixture.componentInstance.form = new FormGroup(
+          {'login': new FormControl('', null, asyncValidator)},
+        );
+        fixture.detectChanges();
+
+        const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
+        const submitted: Event[] = [];
+        formGroupDir.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+        expect(fixture.componentInstance.form.status).toBe('PENDING');
+
+        dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+        fixture.detectChanges();
+
+        expect(submitted.length)
+          .withContext('Expected ngSubmit to fire immediately when awaitAsyncValidators is false')
+          .toBe(1);
+      });
+
+      it('should defer ngSubmit until async validators complete when awaitAsyncValidators is true', async () => {
+        const asyncValidator = () => pendingSubject.asObservable();
+        const fixture = initTest(FormGroupComp);
+        fixture.componentInstance.form = new FormGroup(
+          {'login': new FormControl('', null, asyncValidator)},
+        );
+        fixture.detectChanges();
+
+        const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
+        formGroupDir.awaitAsyncValidators = true;
+
+        const submitted: Event[] = [];
+        formGroupDir.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+        expect(fixture.componentInstance.form.status).toBe('PENDING');
+
+        dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+        fixture.detectChanges();
+
+        expect(submitted.length)
+          .withContext('Expected ngSubmit not to fire while form is PENDING')
+          .toBe(0);
+
+        pendingSubject.next(null);
+        await timeout();
+        fixture.detectChanges();
+
+        expect(submitted.length)
+          .withContext('Expected ngSubmit to fire after async validators complete')
+          .toBe(1);
+      });
+
+      it('should emit ngSubmit immediately when awaitAsyncValidators is true but form is not PENDING', async () => {
+        const asyncValidator = () => pendingSubject.asObservable();
+        const fixture = initTest(FormGroupComp);
+        fixture.componentInstance.form = new FormGroup(
+          {'login': new FormControl('', null, asyncValidator)},
+        );
+        fixture.detectChanges();
+
+        const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
+        formGroupDir.awaitAsyncValidators = true;
+
+        pendingSubject.next(null);
+        await timeout();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.form.status).not.toBe('PENDING');
+
+        const submitted: Event[] = [];
+        formGroupDir.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+        dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+        fixture.detectChanges();
+
+        expect(submitted.length)
+          .withContext('Expected ngSubmit to fire immediately when form is not PENDING')
+          .toBe(1);
+      });
+    });
   });
 
   describe('value changes and status changes', () => {

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -21,6 +21,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchEvent, sortedClassList, timeout, useAutoTick} from '@angular/private/testing';
 import {merge, Subject} from 'rxjs';
+import {take} from 'rxjs/operators';
 import {
   AbstractControl,
   AsyncValidator,
@@ -3218,7 +3219,7 @@ class NgPendingAsyncValidator implements AsyncValidator {
   static subject = new Subject<null>();
 
   validate(_c: AbstractControl) {
-    return NgPendingAsyncValidator.subject.asObservable();
+    return NgPendingAsyncValidator.subject.asObservable().pipe(take(1));
   }
 }
 

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -20,7 +20,7 @@ import {
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {dispatchEvent, sortedClassList, timeout, useAutoTick} from '@angular/private/testing';
-import {merge} from 'rxjs';
+import {merge, Subject} from 'rxjs';
 import {
   AbstractControl,
   AsyncValidator,
@@ -1163,6 +1163,84 @@ describe('template-driven forms integration tests', () => {
         fixture.detectChanges();
 
         expect(event.defaultPrevented).toBe(false);
+      });
+
+      describe('awaitAsyncValidators', () => {
+        beforeEach(() => {
+          NgPendingAsyncValidator.subject = new Subject<null>();
+        });
+
+        it('should emit ngSubmit immediately when awaitAsyncValidators is false (default)', async () => {
+          const fixture = initTest(NgModelAwaitAsyncValidatorsForm, NgPendingAsyncValidator);
+          fixture.detectChanges();
+          await timeout();
+
+          const form = fixture.debugElement.children[0].injector.get(NgForm);
+          const submitted: Event[] = [];
+          form.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+          expect(form.status).toBe('PENDING');
+
+          dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+          fixture.detectChanges();
+
+          expect(submitted.length)
+            .withContext('Expected ngSubmit to fire immediately when awaitAsyncValidators is false')
+            .toBe(1);
+        });
+
+        it('should defer ngSubmit until async validators complete when awaitAsyncValidators is true', async () => {
+          const fixture = initTest(NgModelAwaitAsyncValidatorsForm, NgPendingAsyncValidator);
+          fixture.componentInstance.awaitAsyncValidators = true;
+          fixture.detectChanges();
+          await timeout();
+
+          const form = fixture.debugElement.children[0].injector.get(NgForm);
+          const submitted: Event[] = [];
+          form.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+          expect(form.status).toBe('PENDING');
+
+          dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+          fixture.detectChanges();
+
+          expect(submitted.length)
+            .withContext('Expected ngSubmit not to fire while form is PENDING')
+            .toBe(0);
+
+          NgPendingAsyncValidator.subject.next(null);
+          await timeout();
+          fixture.detectChanges();
+
+          expect(submitted.length)
+            .withContext('Expected ngSubmit to fire after async validators complete')
+            .toBe(1);
+        });
+
+        it('should emit ngSubmit immediately when awaitAsyncValidators is true but form is not PENDING', async () => {
+          const fixture = initTest(NgModelAwaitAsyncValidatorsForm, NgPendingAsyncValidator);
+          fixture.componentInstance.awaitAsyncValidators = true;
+          fixture.detectChanges();
+          await timeout();
+
+          const form = fixture.debugElement.children[0].injector.get(NgForm);
+
+          NgPendingAsyncValidator.subject.next(null);
+          await timeout();
+          fixture.detectChanges();
+
+          expect(form.status).not.toBe('PENDING');
+
+          const submitted: Event[] = [];
+          form.ngSubmit.subscribe((e: Event) => submitted.push(e));
+
+          dispatchEvent(fixture.debugElement.query(By.css('form')).nativeElement, 'submit');
+          fixture.detectChanges();
+
+          expect(submitted.length)
+            .withContext('Expected ngSubmit to fire immediately when form is not PENDING')
+            .toBe(1);
+        });
       });
     });
 
@@ -3123,4 +3201,37 @@ class NgModelNoMinMaxValidator {
 })
 class NativeDialogForm {
   @ViewChild('form') form!: ElementRef<HTMLFormElement>;
+}
+
+@Directive({
+  selector: '[ng-pending-async-validator]',
+  providers: [
+    {
+      provide: NG_ASYNC_VALIDATORS,
+      useExisting: forwardRef(() => NgPendingAsyncValidator),
+      multi: true,
+    },
+  ],
+  standalone: false,
+})
+class NgPendingAsyncValidator implements AsyncValidator {
+  static subject = new Subject<null>();
+
+  validate(_c: AbstractControl) {
+    return NgPendingAsyncValidator.subject.asObservable();
+  }
+}
+
+@Component({
+  selector: 'ng-model-await-async-validators-form',
+  template: `
+    <form [awaitAsyncValidators]="awaitAsyncValidators">
+      <input name="value" ngModel ng-pending-async-validator />
+    </form>
+  `,
+  standalone: false,
+  changeDetection: ChangeDetectionStrategy.Eager,
+})
+class NgModelAwaitAsyncValidatorsForm {
+  awaitAsyncValidators = false;
 }


### PR DESCRIPTION
## PR Checklist                                                                                                                         
                                                                  
  - [x] The commit message follows our guidelines:
  https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
  - [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] Docs have been added / updated (for bug fixes / features)                                                                         
   
  ## PR Type                                                                                                                              
                                                                  
  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting, local variables)                                                                                   
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes                                                                                                             
  - [ ] CI related changes                                        
  - [ ] Documentation content changes
  - [ ] angular.dev application / infrastructure changes
  - [ ] Other... Please describe:                                                                                                         
   
  ## What is the current behavior?                                                                                                        
                                                                  
  `NgForm` and `FormGroupDirective` emit `ngSubmit` synchronously on form submission even when the form has pending async validators      
  (`status === 'PENDING'`). Handlers that check `form.valid` receive a false negative because async validation hasn't resolved yet.
                                                                                                                                          
  Issue Number: #31021                                            

  ## What is the new behavior?

  Adds an opt-in `awaitAsyncValidators` boolean input (default `false`) to both `NgForm` and `AbstractFormDirective`. When enabled and the
   form is `PENDING` at submission time, `ngSubmit` is deferred until `statusChanges` emits a non-`PENDING` value.
                                                                                                                                          
  **Template-driven:**                                            
  ```html
  <form (ngSubmit)="onSubmit()" awaitAsyncValidators>

  Reactive:
  <form [formGroup]="myForm" (ngSubmit)="onSubmit()" awaitAsyncValidators>
  ```

  Does this PR introduce a breaking change?                                                                                               
   
  - [ ] Yes                                                                                                                               
  - [x] No                                                       

  ```
  Other information

  Pending subscription is cancelled on directive destroy to prevent memory leaks. If submit is called again while a previous async submit 
  is still pending, the prior subscription is cancelled — only the latest submit wins.
  ```                                                                   