### PR TITLE
feat(forms): expose isNonInteractive signal on FieldState

### DIFF
--- a/goldens/public-api/forms/signals/index.api.md
+++ b/goldens/public-api/forms/signals/index.api.md
@@ -586,6 +586,7 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
     hasMetadata(key: MetadataKey<any, any, any>): boolean;
     readonly hidden: Signal<boolean>;
     readonly invalid: Signal<boolean>;
+    readonly isNonInteractive: Signal<boolean>;
     readonly keyInParent: Signal<TKey>;
     readonly max: Signal<NonNullable<TValue> | undefined> | undefined;
     readonly maxLength: Signal<number | undefined> | undefined;

--- a/packages/forms/signals/src/api/types.ts
+++ b/packages/forms/signals/src/api/types.ts
@@ -385,6 +385,16 @@ export interface ReadonlyFieldState<TValue, TKey extends string | number = strin
   readonly readonly: Signal<boolean>;
 
   /**
+   * A signal indicating whether the field is non-interactive.
+   *
+   * A field is considered non-interactive if one of the following is true:
+   * - It is hidden
+   * - It is disabled
+   * - It is readonly
+   */
+  readonly isNonInteractive: Signal<boolean>;
+
+  /**
    * A signal indicating whether the field is required.
    */
   readonly required: Signal<boolean>;

--- a/packages/forms/signals/src/field/node.ts
+++ b/packages/forms/signals/src/field/node.ts
@@ -216,6 +216,10 @@ export class FieldNode implements FieldState<unknown> {
     return this.nodeState.readonly;
   }
 
+  get isNonInteractive(): Signal<boolean> {
+    return this.nodeState.isNonInteractive;
+  }
+
   get formFieldBindings(): Signal<readonly FormField<unknown>[]> {
     return this.nodeState.formFieldBindings;
   }

--- a/packages/forms/signals/src/field/state.ts
+++ b/packages/forms/signals/src/field/state.ts
@@ -182,14 +182,15 @@ export class FieldNodeState {
       return this.node.structure.parent?.nodeState.debouncer?.();
     });
 
-  /** Whether this field is considered non-interactive.
+  /**
+   * Whether this field is considered non-interactive.
    *
    * A field is considered non-interactive if one of the following is true:
    * - It is hidden
    * - It is disabled
    * - It is readonly
    */
-  private readonly isNonInteractive = computed(
+  readonly isNonInteractive: Signal<boolean> = computed(
     () => this.hidden() || this.disabled() || this.readonly(),
   );
 }

--- a/packages/forms/signals/test/node/field_node.spec.ts
+++ b/packages/forms/signals/test/node/field_node.spec.ts
@@ -952,6 +952,24 @@ describe('FieldNode', () => {
       expect(f.b().readonly()).toBe(true);
     });
 
+    it('should expose whether a field is non-interactive', () => {
+      const isReadonly = signal(false);
+
+      const f = form(
+        signal({a: 1}),
+        (p) => {
+          readonly(p.a, {when: isReadonly});
+        },
+        {injector: TestBed.inject(Injector)},
+      );
+
+      expect(f.a().isNonInteractive()).toBe(false);
+
+      isReadonly.set(true);
+
+      expect(f.a().isNonInteractive()).toBe(true);
+    });
+
     it('should not validate readonly fields', () => {
       const isReadonly = signal(false);
       const f = form(


### PR DESCRIPTION
Expose the existing computed `isNonInteractive` signal through the public `FieldState` API.

This avoids duplicated logic when building custom controls or UI wrappers that need to derive whether a field is hidden, disabled, or readonly.

Adds public typings and tests for the exposed signal.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

`isNonInteractive` exists internally in signal forms but is not exposed through the public `FieldState` API.

As a result, consumers building custom controls or reusable UI wrappers must duplicate the same computed logic using:

* `hidden()`
* `disabled()`
* `readonly()`

Fixes #68296

## What is the new behavior?

This PR exposes `isNonInteractive` as a public readonly signal on `FieldState`.

The existing internal computed signal is now available through the public API, allowing consumers to reuse the built-in non-interactive state directly without duplicating logic.

This PR also adds typings and tests covering public access and reactivity.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

Validated with:

```bash
pnpm bazel test //packages/forms/signals/...
```
