### PR TITLE
docs: add inject() example to "Forwarding injected dependencies"

### DIFF
--- a/adev/src/content/guide/components/inheritance.md
+++ b/adev/src/content/guide/components/inheritance.md
@@ -65,7 +65,25 @@ and their own.
 
 ### Forwarding injected dependencies
 
-If a base class injects dependencies as constructor parameters, the child class must explicitly class these dependencies to `super`.
+When a base class uses `inject()` as a property initializer, the child class inherits the property automatically. No `super` forwarding is needed.
+
+```ts
+@Component({
+  /*...*/
+})
+export class ListboxBase {
+  protected element = inject(ElementRef);
+}
+
+@Component({
+  /*...*/
+})
+export class CustomListbox extends ListboxBase {
+  // `element` is inherited from `ListboxBase`.
+}
+```
+
+If a base class injects dependencies as constructor parameters, the child class must explicitly pass these dependencies to `super`.
 
 ```ts
 @Component({


### PR DESCRIPTION
Fixes #68659 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The "Forwarding injected dependencies" section in `adev/src/content/guide/components/inheritance.md` only shows constructor DI, and line 68 has a typo where "class" should read "pass".

## What is the new behavior?

The section now leads with an `inject()` example showing the child class inherits the property automatically. The original constructor DI example is kept after it as the alternative. Typo fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

