### PR TITLE
fix(compiler): ignore host-context when invoked without parentheses

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -1081,7 +1081,7 @@ const nthRegex = new RegExp(String.raw`(:nth-[-\w]+)` + _parenSuffix, 'g');
 const _cssColonHostRe = new RegExp(_polyfillHost + _parenSuffix + '?([^,{]*)', 'gim');
 // note: :host-context patterns are terminated with `{`, as opposed to :host which
 // is both `{` and `,` because :host-context handles top-level commas differently.
-const _hostContextPattern = _polyfillHostContext + _parenSuffix + '?([^{]*)';
+const _hostContextPattern = _polyfillHostContext + _parenSuffix + '([^{]*)';
 const _cssColonHostContextReGlobal = new RegExp(
   `${_cssScopedPseudoFunctionPrefix}(${_hostContextPattern})`,
   'gim',
@@ -1106,8 +1106,8 @@ const _shadowDOMSelectorsRe = [
 const _shadowDeepSelectors = /(?:>>>)|(?:\/deep\/)|(?:::ng-deep)/g;
 const _selectorReSuffix = '([>\\s~+[.,{:][\\s\\S]*)?$';
 const _polyfillHostRe = /-shadowcsshost/gim;
-const _colonHostRe = /:host/gim;
-const _colonHostContextRe = /:host-context/gim;
+const _colonHostRe = /:host(?!\-context)/gim;
+const _colonHostContextRe = /:host-context(?=\(\s*[^)\s])/gim;
 
 const _newLinesRe = /\r?\n/g;
 const _commentRe = /\/\*[\s\S]*?\*\//g;

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -262,18 +262,17 @@ describe('ShadowCss, :host and :host-context', () => {
       );
     });
 
-    // It is not clear what the behavior should be for a `:host-context` with no selectors.
     // This test is checking that the result is backward compatible with previous behavior.
     // Arguably it should actually be an error that should be reported.
     it('should handle :host-context with no ancestor selectors', () => {
       expect(shim(':host-context .inner {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host] .inner[contenta] {}',
+        '[contenta]:host-context .inner[contenta] {}',
       );
       expect(shim(':host-context() .inner {}', 'contenta', 'a-host')).toEqualCss(
-        '[a-host] .inner[contenta] {}',
+        '[contenta]:host-context() .inner[contenta] {}',
       );
       expect(shim(':host-context :host-context(.a) {}', 'contenta', 'host-a')).toEqualCss(
-        '.a[host-a], .a [host-a] {}',
+        ':host-context .a[host-a], .a [host-a] {}',
       );
     });
 


### PR DESCRIPTION
Modify `_colonHostContextRe` and `_hostContextPattern` to strictly process `:host-context` only when parentheses are present. When invoked without parentheses ([which is invalid](https://drafts.csswg.org/css-shadow/#host-selector)), the selector is ignored and preserved in the source text. Also remove the legacy test case from `host_and_host_context_spec.ts`.

Support for this behavior was introduced in 2021 in https://github.com/angular/angular/pull/40494 with the following comment:

> It is not clear what the behavior should be for a `:host-context` with no selectors.
> This test is checking that the result is backward compatible with previous behavior.
> Arguably it should actually be an error that should be reported.

I believe giving this invalid selector special meaning was a mistake, and that Angular should not diverge from the spec in this particular case. Any code this impacts can be trivially migrated to use `:host` to produce the same result.