### PR TITLE
fix(compiler): remove dedicated support for legacy shadow DOM selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -466,7 +466,6 @@ export class ShadowCss {
     cssText = this._insertPolyfillHostInCssText(cssText);
     cssText = this._convertColonHost(cssText);
     cssText = this._convertColonHostContext(cssText);
-    cssText = this._convertShadowDOMSelectors(cssText);
     if (scopeSelector) {
       cssText = this._scopeKeyframesRelatedCss(cssText, scopeSelector);
       cssText = this._scopeSelectors(cssText, scopeSelector, hostSelector);
@@ -664,14 +663,6 @@ export class ShadowCss {
         )
         .join(', ');
     });
-  }
-
-  /*
-   * Convert combinators like ::shadow and pseudo-elements like ::content
-   * by replacing with space.
-   */
-  private _convertShadowDOMSelectors(cssText: string): string {
-    return _shadowDOMSelectorsRe.reduce((result, pattern) => result.replace(pattern, ' '), cssText);
   }
 
   // change a selector like 'div' to 'name div'
@@ -1092,13 +1083,6 @@ const _polyfillHostNoCombinatorOutsidePseudoFunction = new RegExp(
   'g',
 );
 const _polyfillHostNoCombinatorRe = /-shadowcsshost-no-combinator([^\s,]*)/;
-const _shadowDOMSelectorsRe = [
-  /::shadow/g,
-  /::content/g,
-  // Deprecated selectors
-  /\/shadow-deep\//g,
-  /\/shadow\//g,
-];
 
 // The deep combinator is deprecated in the CSS spec
 // Support for `>>>`, `deep`, `::ng-deep` is then also deprecated and will be removed in the future.

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -322,11 +322,6 @@ describe('ShadowCss', () => {
     expect(shim('.pr\\fc fung {}', 'contenta')).toEqual('.pr\\fc fung[contenta] {}');
   });
 
-  it('should handle ::shadow', () => {
-    const css = shim('x::shadow > y {}', 'contenta');
-    expect(css).toEqualCss('x[contenta] > y[contenta] {}');
-  });
-
   it('should leave calc() unchanged', () => {
     const styleStr = 'div {height:calc(100% - 55px);}';
     const css = shim(styleStr, 'contenta');


### PR DESCRIPTION
Remove `_shadowDOMSelectorsRe` and `_convertShadowDOMSelectors` from `shadow_css.ts` so that `::shadow`, `::content`, `/shadow-deep/`, and `/shadow/` are no longer treated specially or stripped from user CSS. Instead, they are naturally scoped like standard selectors. Also remove the legacy failing test from `shadow_css_spec.ts`.

Support for these selectors and combinators has existed since 2015, introduced in https://github.com/angular/angular/commit/d67f0299cd8be115150e9abb71e1298ebbc3ef4f before the Shadow DOM spec was even finalized. They were not specifically called out as features, but simply part of a port from the web component prototype. In fact, Angular today just removes them from the source. It does nothing to implement them even by their prototype specification.

This change simply updates Angular to treat these legacy selectors that never landed in the spec as if they're any other selector.