### PR TITLE
fix(compiler): ignore :host with a list of selectors

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -511,20 +511,20 @@ export class ShadowCss {
   private _convertColonHost(cssText: string): string {
     return cssText.replace(_cssColonHostRe, (_, hostSelectors: string, otherSelectors: string) => {
       if (hostSelectors) {
-        const convertedSelectors: string[] = [];
-        for (const hostSelector of this._splitOnTopLevelCommas(hostSelectors, true)) {
-          const trimmedHostSelector = hostSelector.trim();
-          if (!trimmedHostSelector) break;
-          const convertedSelector =
+        const parts = [...this._splitOnTopLevelCommas(hostSelectors, true)];
+        if (parts.length > 1) {
+          return ':host(' + hostSelectors + ')' + otherSelectors;
+        }
+        const trimmedHostSelector = parts[0].trim();
+        if (trimmedHostSelector) {
+          return (
             _polyfillHostNoCombinator +
             trimmedHostSelector.replace(_polyfillHost, '') +
-            otherSelectors;
-          convertedSelectors.push(convertedSelector);
+            otherSelectors
+          );
         }
-        return convertedSelectors.join(',');
-      } else {
-        return _polyfillHostNoCombinator + otherSelectors;
       }
+      return _polyfillHostNoCombinator + otherSelectors;
     });
   }
 

--- a/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
+++ b/packages/compiler/test/shadow_css/host_and_host_context_spec.ts
@@ -41,27 +41,16 @@ describe('ShadowCss, :host and :host-context', () => {
       expect(shim(':host.pr\\fc fung {}', 'contenta', 'a-host')).toEqual('.pr\\fc fung[a-host] {}');
     });
 
-    it('should handle multiple tag selectors', () => {
-      expect(shim(':host(ul,li) {}', 'contenta', 'a-host')).toEqualCss('ul[a-host], li[a-host] {}');
-      expect(shim(':host(ul,li) > .z {}', 'contenta', 'a-host')).toEqualCss(
-        'ul[a-host] > .z[contenta], li[a-host] > .z[contenta] {}',
-      );
-    });
-
     it('should handle compound class selectors', () => {
       expect(shim(':host(.a.b) {}', 'contenta', 'a-host')).toEqualCss('.a.b[a-host] {}');
     });
 
-    it('should handle multiple class selectors', () => {
-      expect(shim(':host(.x,.y) {}', 'contenta', 'a-host')).toEqualCss('.x[a-host], .y[a-host] {}');
-      expect(shim(':host(.x,.y) > .z {}', 'contenta', 'a-host')).toEqualCss(
-        '.x[a-host] > .z[contenta], .y[a-host] > .z[contenta] {}',
+    it('should ignore :host with a selector list containing top-level commas', () => {
+      expect(shim(':host(.a, .b) {}', 'contenta', 'a-host')).toEqualCss(
+        '[contenta]:host(.a, .b) {}',
       );
-    });
-
-    it('should handle multiple attribute selectors', () => {
-      expect(shim(':host([a="b"],[c=d]) {}', 'contenta', 'a-host')).toEqualCss(
-        '[a="b"][a-host], [c=d][a-host] {}',
+      expect(shim('.outer :host(.a, .b) .inner {}', 'contenta', 'a-host')).toEqualCss(
+        '.outer[contenta] [contenta]:host(.a, .b) .inner[contenta] {}',
       );
     });
 


### PR DESCRIPTION
Update `_convertColonHost` to extract and use only the first argument from a `:host(...)` selector list, ignoring subsequent arguments instead of splitting and duplicating the selector list. Also remove the obsolete test cases from `host_and_host_context_spec.ts`.

Support for `:host(.a, .b)` has existed since https://github.com/angular/angular/commit/d67f0299cd8be115150e9abb71e1298ebbc3ef4f when the webcomponent polyfill was first designed, before the Shadow DOM spec was finalized. Selector lists in `:host()` never landed in the final spec, and it's a relic that Angular supports it today.

It's my belief that Angular should not have a special syntax here. I also believe that it's trivial for users of this syntax use `:host(.a), :host(.b)` or even `:host(:is(.a, .b))` instead. This change updates the compiler to simply ignore all additional selectors in the `:host()`.