### PR TITLE
fix(core): sanitize text bindings on SVG <script> elements

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8595,7 +8595,7 @@ runInEachFileSystem((os: string) => {
         hostVars: 6,
         hostBindings: function UnsafeAttrsDirective_HostBindings(rf, ctx) {
           if (rf & 2) {
-            i0.ɵɵattribute("href", ctx.attrHref, i0.ɵɵsanitizeUrlOrResourceUrl)("src", ctx.attrSrc, i0.ɵɵsanitizeUrlOrResourceUrl)("action", ctx.attrAction, i0.ɵɵsanitizeUrl)("profile", ctx.attrProfile)("innerHTML", ctx.attrInnerHTML, i0.ɵɵsanitizeHtml)("title", ctx.attrSafeTitle);
+            i0.ɵɵattribute("href", ctx.attrHref, i0.ɵɵsanitizeUrlOrResourceUrl)("src", ctx.attrSrc, i0.ɵɵsanitizeUrlOrResourceUrl)("action", ctx.attrAction, i0.ɵɵsanitizeUrl)("profile", ctx.attrProfile)("innerHTML", ctx.attrInnerHTML, i0.ɵɵsanitizeMaybeScript)("title", ctx.attrSafeTitle);
           }
         }
       `;

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -477,6 +477,10 @@ export class Identifiers {
     name: 'ɵɵsanitizeUrlOrResourceUrl',
     moduleName: CORE,
   };
+  static sanitizeMaybeScript: o.ExternalReference = {
+    name: 'ɵɵsanitizeMaybeScript',
+    moduleName: CORE,
+  };
   static trustConstantHtml: o.ExternalReference = {name: 'ɵɵtrustConstantHtml', moduleName: CORE};
   static trustConstantResourceUrl: o.ExternalReference = {
     name: 'ɵɵtrustConstantResourceUrl',

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -28,7 +28,18 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
 
     registerContext(SecurityContext.HTML, ['iframe|srcdoc', '*|innerHTML', '*|outerHTML']);
     registerContext(SecurityContext.STYLE, ['*|style']);
-    // NB: no SCRIPT contexts here, they are never allowed due to the parser stripping them.
+    // Writes to text-like properties of a `<script>` element become live script source. SVG
+    // `<script>` is preserved by the template parser (`mergeNsAndName('svg', 'script')` produces
+    // `:svg:script`, which `preparseElement` does not strip), so this matters at runtime even
+    // though top-level HTML `<script>` is stripped at compile time. The binding parser performs
+    // schema lookups using the local tag name (`script`).
+    registerContext(SecurityContext.SCRIPT, [
+      'script|innerHTML',
+      'script|outerHTML',
+      'script|text',
+      'script|textContent',
+      'script|innerText',
+    ]);
     registerContext(SecurityContext.URL, [
       '*|formAction',
       'area|href',

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -118,19 +118,30 @@ export function ingestHostBinding(
     if (property.isAnimation) {
       bindingKind = ir.BindingKind.Animation;
     }
-    const securityContexts = bindingParser
-      .calcPossibleSecurityContexts(
-        input.componentSelector,
-        property.name,
-        bindingKind === ir.BindingKind.Attribute,
-      )
-      .filter((context) => context !== SecurityContext.NONE);
+    const rawSecurityContexts = bindingParser.calcPossibleSecurityContexts(
+      input.componentSelector,
+      property.name,
+      bindingKind === ir.BindingKind.Attribute,
+    );
+    // Preserve `NONE` when it co-occurs with `SCRIPT` so the host element's tag can be
+    // disambiguated at runtime by the `ɵɵsanitizeMaybeScript` dispatcher; otherwise filter
+    // `NONE` out as a non-sensitive context.
+    const keepNone = rawSecurityContexts.includes(SecurityContext.SCRIPT);
+    const securityContexts = rawSecurityContexts.filter(
+      (context) => keepNone || context !== SecurityContext.NONE,
+    );
     ingestDomProperty(job, property, bindingKind, securityContexts);
   }
   for (const [name, expr] of Object.entries(input.attributes) ?? []) {
-    const securityContexts = bindingParser
-      .calcPossibleSecurityContexts(input.componentSelector, name, true)
-      .filter((context) => context !== SecurityContext.NONE);
+    const rawSecurityContexts = bindingParser.calcPossibleSecurityContexts(
+      input.componentSelector,
+      name,
+      true,
+    );
+    const keepNone = rawSecurityContexts.includes(SecurityContext.SCRIPT);
+    const securityContexts = rawSecurityContexts.filter(
+      (context) => keepNone || context !== SecurityContext.NONE,
+    );
     ingestHostAttribute(job, name, expr, securityContexts);
   }
   for (const event of input.events ?? []) {

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_sanitizers.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_sanitizers.ts
@@ -70,7 +70,6 @@ export function resolveSanitizers(job: CompilationJob): void {
             sanitizerFn = Identifiers.sanitizeUrlOrResourceUrl;
           } else if (
             Array.isArray(op.securityContext) &&
-            op.securityContext.length > 1 &&
             op.securityContext.includes(SecurityContext.SCRIPT)
           ) {
             // Same reason as above: text-like properties of `<script>` (HTML or SVG) are in

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_sanitizers.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_sanitizers.ts
@@ -68,6 +68,15 @@ export function resolveSanitizers(job: CompilationJob): void {
             // sanitization function and select the actual sanitizer at runtime based on a tag name
             // that is provided while invoking sanitization function.
             sanitizerFn = Identifiers.sanitizeUrlOrResourceUrl;
+          } else if (
+            Array.isArray(op.securityContext) &&
+            op.securityContext.length > 1 &&
+            op.securityContext.includes(SecurityContext.SCRIPT)
+          ) {
+            // Same reason as above: text-like properties of `<script>` (HTML or SVG) are in
+            // SecurityContext.SCRIPT, but the same property name on any other tag is HTML or NONE.
+            // Defer the choice to runtime via a dispatcher that inspects the tag name.
+            sanitizerFn = Identifiers.sanitizeMaybeScript;
           } else {
             sanitizerFn = sanitizerFns.get(getOnlySecurityContext(op.securityContext)) ?? null;
           }

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -306,6 +306,7 @@ export {
 } from './sanitization/bypass';
 export {
   ɵɵsanitizeHtml,
+  ɵɵsanitizeMaybeScript,
   ɵɵsanitizeResourceUrl,
   ɵɵsanitizeScript,
   ɵɵsanitizeStyle,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -190,6 +190,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵvalidateAttribute': sanitization.ɵɵvalidateAttribute,
   'ɵɵsanitizeUrl': sanitization.ɵɵsanitizeUrl,
   'ɵɵsanitizeUrlOrResourceUrl': sanitization.ɵɵsanitizeUrlOrResourceUrl,
+  'ɵɵsanitizeMaybeScript': sanitization.ɵɵsanitizeMaybeScript,
   'ɵɵtrustConstantHtml': sanitization.ɵɵtrustConstantHtml,
   'ɵɵtrustConstantResourceUrl': sanitization.ɵɵtrustConstantResourceUrl,
 

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -257,6 +257,24 @@ export function ɵɵsanitizeUrlOrResourceUrl(unsafeUrl: any, tag: string, prop: 
   return getUrlSanitizer(tag, prop)(unsafeUrl);
 }
 
+/**
+ * Sanitizes a value bound to a property whose security context depends on the host tag — used
+ * for host bindings where the host element is unknown at compile time and the property may be a
+ * script-source sink on `<script>` or otherwise an HTML/text sink on any other tag.
+ *
+ * @codeGenApi
+ */
+export function ɵɵsanitizeMaybeScript(unsafeValue: any, tag: string, prop: string): any {
+  if (tag.toLowerCase() === 'script') {
+    return ɵɵsanitizeScript(unsafeValue);
+  }
+  const lowerProp = prop.toLowerCase();
+  if (lowerProp === 'innerhtml' || lowerProp === 'outerhtml') {
+    return ɵɵsanitizeHtml(unsafeValue);
+  }
+  return unsafeValue;
+}
+
 export function validateAgainstEventProperties(name: string) {
   if (name.toLowerCase().startsWith('on')) {
     const errorMessage =

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -852,3 +852,58 @@ describe('innerHTML processing', () => {
     expect(fixture.nativeElement.innerHTML).not.toContain('action');
   });
 });
+
+describe('SVG <script> bindings', () => {
+  const SCRIPT_TEXT_PROPS = ['text', 'textContent', 'innerText', 'innerHTML', 'outerHTML'];
+
+  for (const propName of SCRIPT_TEXT_PROPS) {
+    it(`should error when '${propName}' is bound on an SVG <script>`, () => {
+      @Component({
+        template: `<svg><script [${propName}]="code"></script></svg>`,
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class TestCmp {
+        code = '/* xss */';
+      }
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+      }).toThrowError(/NG0905/);
+    });
+
+    it(`should error when '${propName}' is bound on an SVG <script> via host binding`, () => {
+      @Directive({selector: '[scriptHost]', host: {[`[${propName}]`]: 'code'}})
+      class ScriptHostDir {
+        code = '/* xss */';
+      }
+
+      @Component({
+        template: '<svg><script scriptHost></script></svg>',
+        imports: [ScriptHostDir],
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class TestCmp {}
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestCmp);
+        fixture.detectChanges();
+      }).toThrowError(/NG0905/);
+    });
+  }
+
+  it('should allow values trusted via DomSanitizer.bypassSecurityTrustScript', () => {
+    @Component({
+      template: '<svg><script [textContent]="code"></script></svg>',
+      changeDetection: ChangeDetectionStrategy.Eager,
+    })
+    class TestCmp {
+      private readonly sanitizer = inject(DomSanitizer);
+      code = this.sanitizer.bypassSecurityTrustScript('/* trusted */');
+    }
+
+    const fixture = TestBed.createComponent(TestCmp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('script').textContent).toContain('/* trusted */');
+  });
+});

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -118,7 +118,7 @@ describe('sanitization', () => {
       [SecurityContext.RESOURCE_URL, ɵɵsanitizeResourceUrl],
     ]);
     Object.entries(schema).forEach(([key, context]) => {
-      if (context === SecurityContext.URL || SecurityContext.RESOURCE_URL) {
+      if (context === SecurityContext.URL || context === SecurityContext.RESOURCE_URL) {
         const [tag, prop] = key.split('|');
         const contexts = contextsByProp.get(prop) || new Set<number>();
         contexts.add(context);


### PR DESCRIPTION
## What is the current behavior?

See https://github.com/angular/angular/issues/68642

And previous reporter  https://issuetracker.google.com/u/1/issues/509941006 

## What is the new behavior?

Property bindings that set the source of a `<script>` element (`innerHTML`, `outerHTML`, `text`, `textContent`, `innerText`) were treated as plain HTML or NONE security contexts, so untrusted values could become live script. Top-level HTML `<script>` is stripped by the template parser, but SVG `<svg><script>` survives (`mergeNsAndName('svg','script')` produces `:svg:script`, which `preparseElement` does not strip).

Register these properties under `SecurityContext.SCRIPT` in the DOM security schema. The existing `ɵɵsanitizeScript` runtime guard then throws NG0905 unless the value is wrapped via `DomSanitizer.bypassSecurityTrustScript`.

Fix  #68642
 
## Other information

I believe this would be classified with the same level of importance/severity: https://github.com/angular/angular/security/advisories/GHSA-jrmj-c5cx-3cw6