### PR TITLE
refactor(compiler-cli): replace forEach with for...of in entry_point

### DIFF
--- a/packages/compiler-cli/src/ngtsc/entry_point/src/private_export_checker.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/private_export_checker.ts
@@ -53,8 +53,7 @@ export function checkForPrivateExports(
   const exportedSymbols = checker.getExportsOfModule(moduleSymbol);
 
   // Loop through the exported symbols, de-alias if needed, and add them to `topLevelExports`.
-  // TODO(alxhub): use proper iteration when build.sh is removed. (#27762)
-  exportedSymbols.forEach((symbol) => {
+  for (let symbol of exportedSymbols) {
     if (symbol.flags & ts.SymbolFlags.Alias) {
       symbol = checker.getAliasedSymbol(symbol);
     }
@@ -62,7 +61,7 @@ export function checkForPrivateExports(
     if (decl !== undefined) {
       topLevelExports.add(decl);
     }
-  });
+  }
 
   // Next, go through each exported class and expand it to the set of classes it makes Visible,
   // using the `ReferenceGraph`. For each Visible class, verify that it's also Exported, and queue
@@ -70,13 +69,12 @@ export function checkForPrivateExports(
   const checkedSet = new Set<DeclarationNode>();
 
   // Loop through each Exported class.
-  // TODO(alxhub): use proper iteration when the legacy build is removed. (#27762)
-  topLevelExports.forEach((mainExport) => {
+  for (const mainExport of topLevelExports) {
     // Loop through each class made Visible by the Exported class.
-    refGraph.transitiveReferencesOf(mainExport).forEach((transitiveReference) => {
+    for (const transitiveReference of refGraph.transitiveReferencesOf(mainExport)) {
       // Skip classes which have already been checked.
       if (checkedSet.has(transitiveReference)) {
-        return;
+        continue;
       }
       checkedSet.add(transitiveReference);
 
@@ -106,8 +104,8 @@ export function checkForPrivateExports(
 
         diagnostics.push(diagnostic);
       }
-    });
-  });
+    }
+  }
 
   return diagnostics;
 }

--- a/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
+++ b/packages/compiler-cli/src/ngtsc/entry_point/src/reference_graph.ts
@@ -45,20 +45,16 @@ export class ReferenceGraph<T = DeclarationNode> {
       return null;
     } else {
       // Look through the outgoing edges of `source`.
-      // TODO(alxhub): use proper iteration when the legacy build is removed. (#27762)
       let candidatePath: T[] | null = null;
-      this.references.get(source)!.forEach((edge) => {
-        // Early exit if a path has already been found.
-        if (candidatePath !== null) {
-          return;
-        }
+      for (const edge of this.references.get(source)!) {
         // Look for a path from this outgoing edge to `target`.
         const partialPath = this.collectPathFrom(edge, target, seen);
         if (partialPath !== null) {
           // A path exists from `edge` to `target`. Insert `source` at the beginning.
           candidatePath = [source, ...partialPath];
+          break;
         }
-      });
+      }
 
       return candidatePath;
     }
@@ -66,13 +62,12 @@ export class ReferenceGraph<T = DeclarationNode> {
 
   private collectTransitiveReferences(set: Set<T>, decl: T): void {
     if (this.references.has(decl)) {
-      // TODO(alxhub): use proper iteration when the legacy build is removed. (#27762)
-      this.references.get(decl)!.forEach((ref) => {
+      for (const ref of this.references.get(decl)!) {
         if (!set.has(ref)) {
           set.add(ref);
           this.collectTransitiveReferences(set, ref);
         }
-      });
+      }
     }
   }
 }


### PR DESCRIPTION
Convert four `.forEach()` calls in `private_export_checker.ts` and `reference_graph.ts` to `for...of`, matching the iteration style used elsewhere in the compiler. The TODOs that forced these workarounds are obsolete.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Four `.forEach()` calls in `packages/compiler-cli/src/ngtsc/entry_point/` carry TODO comments noting they're workarounds tied to an old build constraint, with an intent to switch back to proper iteration once that constraint was removed. That constraint is long gone.

## What is the new behavior?

Those calls now use `for...of`, matching the iteration style used elsewhere in the compiler. Behavior is unchanged: `continue` covers the "skip this one" cases and `break` covers the "stop searching once found" case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
