### PR TITLE
refactor(compiler-cli): remove deprecated MethodIdentifier from indexer

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -25,7 +25,6 @@ import {DeclarationNode} from '../../reflection';
  */
 export enum IdentifierKind {
   Property,
-  Method, // TODO: No longer being used. To be removed together with `MethodIdentifier`.
   Element,
   Template,
   Attribute,
@@ -58,14 +57,6 @@ interface ExpressionIdentifier<T = DeclarationNode> extends TemplateIdentifier {
 /** Describes a property accessed in a template. */
 export interface PropertyIdentifier<T = DeclarationNode> extends ExpressionIdentifier<T> {
   kind: IdentifierKind.Property;
-}
-
-/**
- * Describes a method accessed in a template.
- * @deprecated No longer being used. To be removed.
- */
-export interface MethodIdentifier<T = DeclarationNode> extends ExpressionIdentifier<T> {
-  kind: IdentifierKind.Method;
 }
 
 /** Describes an element attribute in a template. */
@@ -154,7 +145,6 @@ export type TopLevelIdentifier<T = DeclarationNode> =
   | TemplateNodeIdentifier<T>
   | ReferenceIdentifier<T>
   | VariableIdentifier
-  | MethodIdentifier<T>
   | LetDeclarationIdentifier
   | ComponentNodeIdentifier<T>
   | DirectiveNodeIdentifier<T>;

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -37,7 +37,6 @@ import {
   ElementIdentifier,
   IdentifierKind,
   LetDeclarationIdentifier,
-  MethodIdentifier,
   PropertyIdentifier,
   ReferenceIdentifier,
   TemplateNodeIdentifier,
@@ -45,7 +44,7 @@ import {
   VariableIdentifier,
 } from './api';
 
-type ExpressionIdentifier<T = DeclarationNode> = PropertyIdentifier<T> | MethodIdentifier<T>;
+type ExpressionIdentifier<T = DeclarationNode> = PropertyIdentifier<T>;
 type TmplTarget = TmplAstReference | TmplAstVariable | TmplAstLetDeclaration;
 type TargetIdentifier<T = DeclarationNode> =
   | ReferenceIdentifier<T>


### PR DESCRIPTION
The MethodIdentifier interface and the IdentifierKind.Method enum value in the indexer API were already marked as deprecated with "no longer being used, to be removed" notes. Nothing in the repo constructs a MethodIdentifier or narrows on IdentifierKind.Method, including the language service and devtools, so the types are dead and can go.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`packages/compiler-cli/src/ngtsc/indexer/src/api.ts` exports a `MethodIdentifier` interface and an `IdentifierKind.Method` enum value, both annotated as deprecated with "no longer being used, to be removed" notes. Nothing in the repository constructs a `MethodIdentifier`, narrows on `IdentifierKind.Method`, or otherwise depends on either. The language service and devtools also don't reference them.

## What is the new behavior?

The deprecated enum value, interface, and the `MethodIdentifier<T>` arm of the `TopLevelIdentifier` union are removed. The dead import and type-alias reference in `template.ts` are cleaned up to match. Verified locally with `tsc --noEmit -p packages/compiler-cli/tsconfig.json` (clean).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
