### PR TITLE
refactor(http): update HTTP resource options APIs to stable

### DIFF
--- a/packages/common/http/src/resource_api.ts
+++ b/packages/common/http/src/resource_api.ts
@@ -15,7 +15,7 @@ import {HttpContext} from './context';
 /**
  * The structure of an `httpResource` request which will be sent to the backend.
  *
- * @experimental 19.2
+ * @publicApi 22.0
  */
 export interface HttpResourceRequest {
   /**
@@ -139,7 +139,7 @@ export interface HttpResourceRequest {
 /**
  * Options for creating an `httpResource`.
  *
- * @experimental 19.2
+ * @publicApi 22.0
  */
 export interface HttpResourceOptions<TResult, TRaw> {
   /**
@@ -184,7 +184,7 @@ export interface HttpResourceOptions<TResult, TRaw> {
  * `HttpResource`s are backed by `HttpClient`, including support for interceptors, testing, and the
  * other features of the `HttpClient` API.
  *
- * @experimental 19.2
+ * @publicApi 22.0
  */
 export interface HttpResourceRef<T> extends WritableResource<T>, ResourceRef<T> {
   /**


### PR DESCRIPTION
Marks `HttpResourceRequest`, `HttpResourceOptions`, and `HttpResourceRef` as public APIs following the stabilization of the Resource API in https://github.com/angular/angular/pull/68253
