### PR TITLE
fix(core): prevent dangling prevConsumer reference from leaking v2

### DIFF
--- a/packages/core/primitives/signals/src/graph.ts
+++ b/packages/core/primitives/signals/src/graph.ts
@@ -266,7 +266,11 @@ export function producerAccessed(node: ReactiveNode): void {
     // instead of eagerly destroying the previous link, we delay until we've finished recomputing
     // the producers list, so that we can destroy all of the old links at once.
     nextProducer: nextProducerLink,
-    prevConsumer: prevConsumerLink,
+    // Don't set prevConsumer here — it's only meaningful when the link is part of
+    // the producer's consumer list. producerAddLiveConsumer sets it correctly when
+    // the link is actually inserted. Setting it eagerly would create a dangling
+    // reference into the consumer list that prevents GC of removed entries.
+    prevConsumer: undefined,
     lastReadVersion: node.version,
     nextConsumer: undefined,
   };

--- a/packages/core/test/signals/BUILD.bazel
+++ b/packages/core/test/signals/BUILD.bazel
@@ -12,6 +12,7 @@ ts_project(
         "//packages/core",
         "//packages/core/primitives/signals",
         "//packages/core/src/util",
+        "//packages/private/testing",
     ],
 )
 
@@ -20,6 +21,7 @@ jasmine_test(
     data = [
         ":signals_lib",
     ],
+    node_options = ["--expose-gc"],
 )
 
 ng_web_test_suite(

--- a/packages/core/test/signals/signal_graph_leak_spec.ts
+++ b/packages/core/test/signals/signal_graph_leak_spec.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {computed, signal, WritableSignal} from '../../src/core';
+import {ReactiveNode, SIGNAL} from '../../primitives/signals';
+import {isBrowser, timeout} from '@angular/private/testing';
+
+import {flushEffects, resetEffects, testingEffect} from './effect_util';
+
+describe('signal graph: destroyed consumers should be GC-eligible', () => {
+  if (isBrowser) {
+    it('should pass', () => {});
+    return;
+  }
+
+  afterEach(() => {
+    resetEffects();
+  });
+
+  function setupAndReturnRef(source: WritableSignal<number>): WeakRef<object> {
+    const destroyEffect = testingEffect(() => source());
+    flushEffects();
+
+    const sourceNode = source[SIGNAL] as ReactiveNode;
+    let watchNode;
+    let link = (sourceNode as any).consumers;
+    while (link !== undefined) {
+      watchNode = link.consumer;
+      link = link.nextConsumer;
+    }
+    const ref = new WeakRef(watchNode!);
+
+    // Non-live computed that also reads source.
+    const derived = computed(() => source() + 1);
+    derived();
+
+    // Clearing the graph edges.
+    destroyEffect();
+
+    return ref;
+  }
+
+  it('should GC a destroyed effect when a non-live computed reads the same producer', async () => {
+    const source = signal(0);
+    const ref = setupAndReturnRef(source);
+
+    (globalThis as any).gc();
+    await timeout();
+    (globalThis as any).gc();
+
+    expect(ref.deref()).toBeUndefined();
+  });
+
+  it('should GC destroyed effects across repeated create/destroy cycles', async () => {
+    const source = signal(0);
+    const derived = computed(() => source() + 1);
+    derived();
+
+    const refs: WeakRef<object>[] = [];
+    for (let i = 0; i < 5; i++) {
+      refs.push(setupAndReturnRef(source));
+    }
+
+    (globalThis as any).gc();
+    await timeout();
+    (globalThis as any).gc();
+
+    for (let i = 0; i < refs.length; i++) {
+      expect(refs[i].deref()).withContext(`cycle ${i}`).toBeUndefined();
+    }
+  });
+});

--- a/packages/core/test/signals/signal_graph_leak_spec.ts
+++ b/packages/core/test/signals/signal_graph_leak_spec.ts
@@ -7,10 +7,8 @@
  */
 
 import {computed, signal, WritableSignal} from '../../src/core';
-import {ReactiveNode, SIGNAL} from '../../primitives/signals';
+import {createWatch, SIGNAL} from '../../primitives/signals';
 import {isBrowser, timeout} from '@angular/private/testing';
-
-import {flushEffects, resetEffects, testingEffect} from './effect_util';
 
 describe('signal graph: destroyed consumers should be GC-eligible', () => {
   if (isBrowser) {
@@ -18,29 +16,22 @@ describe('signal graph: destroyed consumers should be GC-eligible', () => {
     return;
   }
 
-  afterEach(() => {
-    resetEffects();
-  });
-
   function setupAndReturnRef(source: WritableSignal<number>): WeakRef<object> {
-    const destroyEffect = testingEffect(() => source());
-    flushEffects();
+    const watch = createWatch(
+      () => source(),
+      () => {},
+      true,
+    );
+    watch.run();
 
-    const sourceNode = source[SIGNAL] as ReactiveNode;
-    let watchNode;
-    let link = (sourceNode as any).consumers;
-    while (link !== undefined) {
-      watchNode = link.consumer;
-      link = link.nextConsumer;
-    }
-    const ref = new WeakRef(watchNode!);
+    const ref = new WeakRef(watch[SIGNAL]);
 
     // Non-live computed that also reads source.
     const derived = computed(() => source() + 1);
     derived();
 
     // Clearing the graph edges.
-    destroyEffect();
+    watch.destroy();
 
     return ref;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current signals implementation leaks

## What is the new behavior?

See the analysis in #68137, this is just a new PR so that I can add additional edits to the test implementation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
