### PR TITLE
ci: mark devversion as unavailable

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -36,8 +36,9 @@
 
 version: 3
 
-#availability:
-#  users_unavailable: []
+availability:
+  users_unavailable:
+    - devversion
 
 # Meta field that goes unused by PullApprove to allow for defining aliases to be
 # used throughout the config.


### PR DESCRIPTION
Currently OOO and I don't want reviews to be necessarily stuck for too long.