### PR TITLE
docs: release notes for the v20.3.21 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="20.3.21"></a>
+# 20.3.21 (2026-05-12)
+### platform-server
+| Commit | Type | Description |
+| -- | -- | -- |
+| [f584840e2e](https://github.com/angular/angular/commit/f584840e2e50f751397cf3fad5258e18e857427e) | fix | add `allowedHosts` option to `renderModule` and `renderApplication` |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="22.0.0-next.12"></a>
 # 22.0.0-next.12 (2026-05-08)
 ### core


### PR DESCRIPTION
Cherry-picks the changelog from the "20.3.x" branch to the next branch (main).