### PR TITLE
refactor(compiler-cli): drop @ts-ignore around fs.readFileSync

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -94,9 +94,6 @@ export class NodeJSReadonlyFileSystem extends NodeJSPathManipulation implements 
     return fs.readFileSync(path, 'utf8');
   }
   readFileBuffer(path: AbsoluteFsPath): Uint8Array {
-    // TODO: go/ts59upgrade - Remove the suppression after TS 5.9.2 upgrade
-    //   TS2322: Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
-    // @ts-ignore
     return fs.readFileSync(path);
   }
   readdir(path: AbsoluteFsPath): PathSegment[] {


### PR DESCRIPTION
The `readFileBuffer` method in `node_js_file_system.ts` was wrapped in `@ts-ignore` to suppress a TS2322 Buffer/Uint8Array typing error that was fixed in the TypeScript 5.9.2 upgrade. The minimum supported TypeScript is now 6.0, so the suppression is dead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`readFileBuffer` in `packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts` is wrapped in `@ts-ignore` with a `TODO: go/ts59upgrade - Remove the suppression after TS 5.9.2 upgrade` comment. The minimum supported TypeScript is now 6.0, and the Buffer/Uint8Array typing issue is resolved, so the suppression is dead.

## What is the new behavior?

The `@ts-ignore` and the `TODO` comment are removed. Verified locally with a full `pnpm build` (green).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
