### PR TITLE
feat(core): Introduce `splitEffect`, an `effect` with an untracked effect body.

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -741,6 +741,9 @@ export interface ExistingSansProvider {
     useExisting: any;
 }
 
+// @public (undocumented)
+export function splitEffect<T>(reactiveFn: () => T, effectFn: (params: T, onCleanup: EffectCleanupRegisterFn) => void, options?: CreateEffectOptions): EffectRef;
+
 // @public
 export interface FactoryProvider extends FactorySansProvider {
     multi?: boolean;

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -8,23 +8,24 @@
 
 export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
 
+export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
 export {isSignal, isWritableSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
+export {assertNotInReactiveContext} from './render3/reactivity/asserts';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
+export {
+  CreateEffectOptions,
+  effect,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+  EffectRef,
+  splitEffect,
+} from './render3/reactivity/effect';
+export {linkedSignal} from './render3/reactivity/linked_signal';
+export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
 export {
   CreateSignalOptions,
   signal,
   WritableSignal,
   ɵunwrapWritableSignal,
 } from './render3/reactivity/signal';
-export {linkedSignal} from './render3/reactivity/linked_signal';
 export {untracked} from './render3/reactivity/untracked';
-export {
-  CreateEffectOptions,
-  effect,
-  EffectRef,
-  EffectCleanupFn,
-  EffectCleanupRegisterFn,
-} from './render3/reactivity/effect';
-export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
-export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
-export {assertNotInReactiveContext} from './render3/reactivity/asserts';

--- a/packages/core/src/render3/reactivity/after_render_effect.ts
+++ b/packages/core/src/render3/reactivity/after_render_effect.ts
@@ -16,8 +16,6 @@ import {
   SIGNAL_NODE,
   type SignalNode,
 } from '../../../primitives/signals';
-import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';
-import {type Signal} from '../reactivity/api';
 import {TracingService, TracingSnapshot} from '../../application/tracing';
 import {
   ChangeDetectionScheduler,
@@ -35,13 +33,15 @@ import {
   AfterRenderManager,
   AfterRenderSequence,
 } from '../after_render/manager';
-import {LView} from '../interfaces/view';
-import {ViewContext} from '../view_context';
-import {assertNotInReactiveContext} from './asserts';
 import {
   emitAfterRenderEffectPhaseCreatedEvent,
   setInjectorProfilerContext,
 } from '../debug/injector_profiler';
+import {LView} from '../interfaces/view';
+import {type Signal} from '../reactivity/api';
+import {ViewContext} from '../view_context';
+import {assertNotInReactiveContext} from './asserts';
+import {type EffectCleanupFn, type EffectCleanupRegisterFn} from './effect';
 
 const NOT_SET = /* @__PURE__ */ Symbol('NOT_SET');
 const EMPTY_CLEANUP_SET = /* @__PURE__ */ new Set<() => void>();

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -7,28 +7,29 @@
  */
 
 import {
+  BASE_EFFECT_NODE,
+  BaseEffectNode,
   SIGNAL,
   consumerDestroy,
   isInNotificationPhase,
-  setActiveConsumer,
-  BaseEffectNode,
-  BASE_EFFECT_NODE,
   runEffect,
+  setActiveConsumer,
 } from '../../../primitives/signals';
-import {FLAGS, LViewFlags, LView, EFFECTS} from '../interfaces/view';
-import {markAncestorsForTraversal} from '../util/view_utils';
-import {inject} from '../../di/injector_compatibility';
-import {Injector} from '../../di/injector';
-import {assertNotInReactiveContext} from './asserts';
-import {assertInInjectionContext} from '../../di/contextual';
-import {DestroyRef, NodeInjectorDestroyRef} from '../../linker/destroy_ref';
-import {ViewContext} from '../view_context';
 import {
   ChangeDetectionScheduler,
   NotificationSource,
 } from '../../change_detection/scheduling/zoneless_scheduling';
+import {assertInInjectionContext} from '../../di/contextual';
+import {Injector} from '../../di/injector';
+import {inject} from '../../di/injector_compatibility';
+import {DestroyRef, NodeInjectorDestroyRef} from '../../linker/destroy_ref';
+import {EFFECTS, FLAGS, LView, LViewFlags} from '../interfaces/view';
 import {setIsRefreshingViews} from '../state';
+import {markAncestorsForTraversal} from '../util/view_utils';
+import {ViewContext} from '../view_context';
+import {assertNotInReactiveContext} from './asserts';
 import {EffectScheduler, SchedulableEffect} from './root_effect_scheduler';
+import {untracked} from './untracked';
 
 import {emitEffectCreatedEvent, setInjectorProfilerContext} from '../debug/injector_profiler';
 
@@ -331,4 +332,29 @@ function createEffectFn(node: EffectNode, fn: (onCleanup: EffectCleanupRegisterF
   return () => {
     fn((cleanupFn) => (node.cleanupFns ??= []).push(cleanupFn));
   };
+}
+
+/**
+ * A reactive effect that separates tracking and side-effects.
+ *
+ * `splitEffect` behaves similarly to `effect`, but completely separates the tracking of
+ * reactive dependencies from the execution of the side-effect. The `reactiveFn` is executed
+ * in a reactive context to track inputs, and its result is passed to `effectFn`, which runs
+ * asynchronously in a non-reactive context.
+ *
+ * @param reactiveFn The tracking phase computations.
+ * @param effectFn The side-effect phase execution.
+ * @param options Effect creation options.
+ *
+ * @publicApi 22.1
+ */
+export function splitEffect<T>(
+  reactiveFn: () => T,
+  effectFn: (params: T, onCleanup: EffectCleanupRegisterFn) => void,
+  options?: CreateEffectOptions,
+): EffectRef {
+  return effect((onCleanup) => {
+    const params = reactiveFn();
+    untracked(() => effectFn(params, onCleanup));
+  }, options);
 }

--- a/packages/core/test/acceptance/after_render_effect_spec.ts
+++ b/packages/core/test/acceptance/after_render_effect_spec.ts
@@ -14,11 +14,11 @@ import {
   provideZonelessChangeDetection,
   signal,
 } from '../../src/core';
+import {AfterRenderPhase} from '../../src/render3/after_render/api';
 import {
   afterRenderEffect,
   AfterRenderEffectSequence,
 } from '../../src/render3/reactivity/after_render_effect';
-import {AfterRenderPhase} from '../../src/render3/after_render/api';
 import {TestBed} from '../../testing';
 
 describe('afterRenderEffect', () => {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -38,6 +38,7 @@ import {
   QueryList,
   signal,
   SimpleChanges,
+  splitEffect,
   TemplateRef,
   untracked,
   ViewChild,
@@ -238,6 +239,34 @@ describe('reactivity', () => {
       // Destroy triggers a cleanup
       fixture.destroy();
       expect(fixture.componentInstance.counter()).toBe(2);
+    });
+
+    it('should support explicit tracking with untracked effect callback', () => {
+      const tracked = signal(0);
+      const untrackedSignal = signal(0);
+      const log: number[] = [];
+
+      TestBed.runInInjectionContext(() => {
+        splitEffect(
+          () => tracked(),
+          (value: number) => {
+            log.push(value);
+            // This read should not be tracked as a dependency.
+            untrackedSignal();
+          },
+        );
+      });
+
+      TestBed.tick();
+      expect(log).toEqual([0]);
+
+      untrackedSignal.set(1);
+      TestBed.tick();
+      expect(log).toEqual([0]);
+
+      tracked.set(1);
+      TestBed.tick();
+      expect(log).toEqual([0, 1]);
     });
 
     it('should run effects created in ngAfterViewInit', () => {


### PR DESCRIPTION
This is a mere exploration:

This commit introduces `splitEffect`, a new reactivity primitive that explicitly
separates the tracking phase from the execution (side-effect) phase.

In a standard `effect`, all signal reads are automatically tracked as dependencies.
This often forces developers to manually wrap their side-effects in `untracked()`
to avoid accidentally tracking signals, which causes unnecessary re-evaluations
or circular updates.

`splitEffect` solves this by accepting two functions:
1. A **tracking function**, where dependencies are explicitly read and returned.
2. An **execution function**, which receives the values and is guaranteed to run
   in an untracked context.

```ts
splitEffect(
    () => {
        val1: tracked1(),
        val2: tracked2(),
    },
    ({val1, val2}) => {
        log.push(val1,val2);

        // This read should not be tracked as a dependency.
        untrackedSignal();
    },
);
```

fixes #56155

Curious about what the community would think of it. 