### PR TITLE
refactor(core): remove deprecated UNSAFE_IFRAME_ATTRS alias

### DIFF
--- a/goldens/public-api/core/errors.api.md
+++ b/goldens/public-api/core/errors.api.md
@@ -191,8 +191,6 @@ export const enum RuntimeErrorCode {
     UNKNOWN_ELEMENT = 304,
     // (undocumented)
     UNSAFE_ATTRIBUTE_BINDING = -910,
-    // @deprecated (undocumented)
-    UNSAFE_IFRAME_ATTRS = -910,
     // (undocumented)
     UNSAFE_VALUE_IN_RESOURCE_URL = 904,
     // (undocumented)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -120,11 +120,6 @@ export const enum RuntimeErrorCode {
   MISSING_ZONEJS = 908,
   UNEXPECTED_ZONE_STATE = 909,
   UNSAFE_ATTRIBUTE_BINDING = -910,
-  /**
-   * @deprecated use `UNSAFE_ATTRIBUTE_BINDING` instead.
-   */
-  // tslint:disable-next-line:no-duplicate-enum-values
-  UNSAFE_IFRAME_ATTRS = -910,
   VIEW_ALREADY_DESTROYED = 911,
   COMPONENT_ID_COLLISION = -912,
   IMAGE_PERFORMANCE_WARNING = -913,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`packages/core/src/errors.ts` declares `UNSAFE_IFRAME_ATTRS = -910` in the `RuntimeErrorCode` const enum as a `@deprecated` alias of `UNSAFE_ATTRIBUTE_BINDING` (same numeric value). It has no usages anywhere in the repo and carries a `tslint:disable-next-line:no-duplicate-enum-values` suppression to silence the duplicate-value warning. The alias is also listed in `goldens/public-api/core/errors.api.md`.

## What is the new behavior?

The alias and its paired tslint suppression are removed from `packages/core/src/errors.ts`. `UNSAFE_ATTRIBUTE_BINDING` stays. The corresponding line in `goldens/public-api/core/errors.api.md` is updated to match.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
