### PR TITLE
Revert "refactor(compiler-cli): drop @ts-ignore around fs.readFileSync"

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -94,6 +94,9 @@ export class NodeJSReadonlyFileSystem extends NodeJSPathManipulation implements 
     return fs.readFileSync(path, 'utf8');
   }
   readFileBuffer(path: AbsoluteFsPath): Uint8Array {
+    // TODO: go/ts59upgrade - Remove the suppression after TS 5.9.2 upgrade
+    //   TS2322: Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
+    // @ts-ignore
     return fs.readFileSync(path);
   }
   readdir(path: AbsoluteFsPath): PathSegment[] {


### PR DESCRIPTION
This reverts commit e0593ecc8bf2ba0b9a1d8d39f8d2721d361b6c24.

This change broke tests in g3. I likely missed the warning before merging.