### PR TITLE
docs(docs-infra): fix typo and malformed markdown bullet in angular-developer skill

### DIFF
--- a/skills/dev-skills/angular-developer/SKILL.md
+++ b/skills/dev-skills/angular-developer/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 
 ## Creating New Projects
 
-If no guidelines are provided by the user, here are same default rules to follow when creating a new Angular project:
+If no guidelines are provided by the user, here are some default rules to follow when creating a new Angular project:
 
 1. Use the latest stable version of Angular unless the user specifies otherwise.
 2. Use Signals Forms for form management in new projects (available in Angular v21 and newer) [Find out more](references/signal-forms.md).
@@ -65,8 +65,8 @@ When managing state and data reactivity, use Angular Signals and consult the fol
 
 In most cases for new apps, **prefer signal forms**. When making a forms decision, analyze the project and consider the following guidelines:
 
-- if the application is using v21 or newer and this is a new form, **prefer signal forms**.
-  -For older applications or when working with existing forms, use the appropriate form type that matches the applications current form strategy.
+- If the application is using v21 or newer and this is a new form, **prefer signal forms**.
+- For older applications or when working with existing forms, use the appropriate form type that matches the applications current form strategy.
 
 - **Signal Forms**: Use signals for form state management. Read [signal-forms.md](references/signal-forms.md)
 - **Template-driven forms**: Use for simple forms. Read [template-driven-forms.md](references/template-driven-forms.md)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The `angular-developer` skill definition contains a typo in the `Creating New Projects` section and a malformed bullet point in the `Forms` section.

Typo in `Creating New Projects`: here are "same" default rules should be here are "some" default rules

Malformed bullet in `Forms`: 
- `-for` is missing space after the hyphen and capitalized first letter.
- `- if` is missing capitalized first letter.

Issue Number: N/A

## What is the new behavior?
- Corrected "same" to "some" in the `Creating New Projects` section.
- Corrected `-for` (missing space after the hyphen and capitalization) to `- For` in the `Forms` section
- Corrected `- if` (missing capitalization) to  `- If` in the `Forms` section

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
