### PR TITLE
refactor(compiler-cli): Remove unused properties of IndexedComponent …

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -185,8 +185,6 @@ export interface IndexedComponent<T = DeclarationNode> {
   file: ParseSourceFile;
   template: {
     identifiers: Set<TopLevelIdentifier<T>>;
-    usedComponents: Set<T>;
-    isInline: boolean;
     file: ParseSourceFile;
   };
   errors: Error[];

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -30,14 +30,6 @@ export function generateAnalysis<T = DeclarationNode>(
     const name = adapter.getName(declaration);
     const fileName = adapter.getFileName(declaration);
 
-    const usedComponents = new Set<T>();
-    const usedDirs = boundTemplate.getUsedDirectives();
-    usedDirs.forEach((dir) => {
-      if (dir.isComponent) {
-        usedComponents.add(dir.ref.node);
-      }
-    });
-
     // Get source files for the component and the template. If the template is inline, its source
     // file is the component's.
     const componentFile = new ParseSourceFile(adapter.getContent(declaration), fileName);
@@ -55,8 +47,6 @@ export function generateAnalysis<T = DeclarationNode>(
       file: componentFile,
       template: {
         identifiers,
-        usedComponents,
-        isInline: templateMeta.isInline,
         file: templateFile,
       },
       errors,

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -70,8 +70,6 @@ runInEachFileSystem(() => {
         template: {
           identifiers: getTemplateIdentifiers(util.getBoundTemplate('<div>{{foo}}</div>'))
             .identifiers,
-          usedComponents: new Set(),
-          isInline: false,
           file: new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
         },
         errors: [],
@@ -115,38 +113,6 @@ runInEachFileSystem(() => {
       expect(info!.template.file).toEqual(
         new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
       );
-    });
-
-    it('should emit used components', () => {
-      const context = new IndexingContext();
-
-      const templateA = '<b-selector></b-selector>';
-      const declA = util.getComponentDeclaration('class A {}', 'A');
-
-      const templateB = '<a-selector></a-selector>';
-      const declB = util.getComponentDeclaration('class B {}', 'B');
-
-      const boundA = util.getBoundTemplate(templateA, {}, [
-        {selector: 'b-selector', declaration: declB},
-      ]);
-      const boundB = util.getBoundTemplate(templateB, {}, [
-        {selector: 'a-selector', declaration: declA},
-      ]);
-
-      populateContext(context, declA, 'a-selector', templateA, boundA);
-      populateContext(context, declB, 'b-selector', templateB, boundB);
-
-      const analysis = generateAnalysis(context, adapter);
-
-      expect(analysis.size).toBe(2);
-
-      const infoA = analysis.get(declA);
-      expect(infoA).toBeDefined();
-      expect(infoA!.template.usedComponents).toEqual(new Set([declB]));
-
-      const infoB = analysis.get(declB);
-      expect(infoB).toBeDefined();
-      expect(infoB!.template.usedComponents).toEqual(new Set([declA]));
     });
   });
 });

--- a/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/component_indexing_spec.ts
@@ -83,8 +83,6 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          usedComponents: new Set(),
-          isInline: true,
           file: new ParseSourceFile(componentContent, testSourceFile),
         });
       });
@@ -116,8 +114,6 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          usedComponents: new Set(),
-          isInline: false,
           file: new ParseSourceFile('{{foo}}', testTemplateFile),
         });
       });
@@ -153,8 +149,6 @@ runInEachFileSystem(() => {
               target: null,
             },
           ]),
-          usedComponents: new Set(),
-          isInline: false,
           file: new ParseSourceFile('  \n  {{foo}}', testTemplateFile),
         });
       });
@@ -205,12 +199,6 @@ runInEachFileSystem(() => {
         const testImportComp = indexedComps.find((cmp) => cmp.name === 'TestImportCmp');
         expect(testComp).toBeDefined();
         expect(testImportComp).toBeDefined();
-
-        expect(testComp!.template.usedComponents.size).toBe(0);
-        expect(testImportComp!.template.usedComponents.size).toBe(1);
-
-        const [usedComp] = Array.from(testImportComp!.template.usedComponents);
-        expect(indexed.get(usedComp)).toEqual(testComp);
       });
     });
   });


### PR DESCRIPTION
…interface

These properties aren't used in the Kythe indexer and can be removed

`isInline` is used elsewhere from template meta (to determine the file) and `usedDirectives` is exposed in the top level identifiers. They are not used in the `IndexedComponent` interface directly.