### PR TITLE
refactor(core): mark resource() overloads as @publicApi 22.0

### DIFF
--- a/packages/core/src/resource/resource.ts
+++ b/packages/core/src/resource/resource.ts
@@ -46,7 +46,7 @@ import {StateKey, TransferState} from '../transfer_state';
  *
  * @see [Async reactivity with resources](guide/signals/resource)
  *
- * @experimental 19.0
+ * @publicApi 22.0
  */
 export function resource<T, R>(
   options: ResourceOptions<T, R> & {defaultValue: NoInfer<T>},
@@ -60,7 +60,7 @@ export function resource<T, R>(
  * `resource` will cancel in-progress loads via the `AbortSignal` when destroyed or when a new
  * request object becomes available, which could prematurely abort mutations.
  *
- * @experimental 19.0
+ * @publicApi 22.0
  * @see [Async reactivity with resources](guide/signals/resource)
  */
 export function resource<T, R>(options: ResourceOptions<T, R>): ResourceRef<T | undefined>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

#68253 graduated `resource`, `rxResource`, and `httpResource` to stable by swapping `@experimental` tags for `@publicApi 22.0` across three files. The two `resource()` function overloads in `packages/core/src/resource/resource.ts` (lines 49 and 63) were missed and still carry `@experimental 19.0`. The public-API golden at `goldens/public-api/core/index.api.md:1660,1665` already lists both overloads as `// @public`, so the JSDoc is the only thing contradicting the rest of the codebase.

## What is the new behavior?

Both `@experimental 19.0` tags are replaced with `@publicApi 22.0`, matching the pattern #68253 used in the sibling files (`packages/common/http/src/resource.ts`, `packages/core/rxjs-interop/src/rx_resource.ts`, `packages/core/src/resource/api.ts`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
