### PR TITLE
fix(common): do not warn about missing preconnect hints for same-origin images

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
+++ b/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
@@ -19,6 +19,7 @@ import {RuntimeErrorCode} from '../../errors';
 import {assertDevMode} from './asserts';
 import {imgDirectiveDetails} from './error_helper';
 import {getUrl} from './url';
+import {PlatformLocation} from '../../location';
 
 interface ObservedImageState {
   priority: boolean;
@@ -43,7 +44,7 @@ export class LCPImageObserver implements OnDestroy {
   // Map of full image URLs -> original `ngSrc` values.
   private images = new Map<string, ObservedImageState>();
 
-  private window: Window | null = inject(DOCUMENT).defaultView;
+  private platformLocation = inject(PlatformLocation);
   private observer: PerformanceObserver | null = null;
 
   constructor() {
@@ -95,7 +96,7 @@ export class LCPImageObserver implements OnDestroy {
 
   registerImage(rewrittenSrc: string, isPriority: boolean) {
     if (!this.observer) return;
-    const url = getUrl(rewrittenSrc, this.window!).href;
+    const url = getUrl(rewrittenSrc, this.platformLocation).href;
     const existingState = this.images.get(url);
 
     if (existingState) {
@@ -116,7 +117,7 @@ export class LCPImageObserver implements OnDestroy {
 
   unregisterImage(rewrittenSrc: string) {
     if (!this.observer) return;
-    const url = getUrl(rewrittenSrc, this.window!).href;
+    const url = getUrl(rewrittenSrc, this.platformLocation).href;
     const existingState = this.images.get(url);
 
     if (existingState) {
@@ -129,8 +130,8 @@ export class LCPImageObserver implements OnDestroy {
 
   updateImage(originalSrc: string, newSrc: string) {
     if (!this.observer) return;
-    const originalUrl = getUrl(originalSrc, this.window!).href;
-    const newUrl = getUrl(newSrc, this.window!).href;
+    const originalUrl = getUrl(originalSrc, this.platformLocation).href;
+    const newUrl = getUrl(newSrc, this.platformLocation).href;
 
     // URL hasn't changed
     if (originalUrl === newUrl) return;

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -20,6 +20,7 @@ import {RuntimeErrorCode} from '../../errors';
 import {assertDevMode} from './asserts';
 import {imgDirectiveDetails} from './error_helper';
 import {extractHostname, getUrl} from './url';
+import {PlatformLocation} from '../../location';
 
 // Set of origins that are always excluded from the preconnect checks.
 const INTERNAL_PRECONNECT_CHECK_BLOCKLIST = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]']);
@@ -56,6 +57,7 @@ export const PRECONNECT_CHECK_BLOCKLIST = new InjectionToken<Array<string | stri
 @Service()
 export class PreconnectLinkChecker implements OnDestroy {
   private document = inject(DOCUMENT);
+  private platformLocation = inject(PlatformLocation);
 
   /**
    * Set of <link rel="preconnect"> tags found on this page.
@@ -67,8 +69,6 @@ export class PreconnectLinkChecker implements OnDestroy {
    * Keep track of all already seen origin URLs to avoid repeating the same check.
    */
   private alreadySeen = new Set<string>();
-
-  private window: Window | null = this.document.defaultView;
 
   private blocklist = new Set<string>(INTERNAL_PRECONNECT_CHECK_BLOCKLIST);
 
@@ -100,7 +100,12 @@ export class PreconnectLinkChecker implements OnDestroy {
   assertPreconnect(rewrittenSrc: string, originalNgSrc: string): void {
     if (typeof ngServerMode !== 'undefined' && ngServerMode) return;
 
-    const imgUrl = getUrl(rewrittenSrc, this.window!);
+    const imgUrl = getUrl(rewrittenSrc, this.platformLocation);
+
+    // Do not check preconnect hints for same-origin URLs as the browser already
+    // establishes a connection to the origin of the page.
+    if (imgUrl.origin === new URL(this.platformLocation.href).origin) return;
+
     if (this.blocklist.has(imgUrl.hostname) || this.alreadySeen.has(imgUrl.origin)) return;
 
     // Register this origin as seen, so we don't check it again later.
@@ -130,7 +135,7 @@ export class PreconnectLinkChecker implements OnDestroy {
     const preconnectUrls = new Set<string>();
     const links = this.document.querySelectorAll<HTMLLinkElement>('link[rel=preconnect]');
     for (const link of links) {
-      const url = getUrl(link.href, this.window!);
+      const url = getUrl(link.href, this.platformLocation);
       preconnectUrls.add(url.origin);
     }
     return preconnectUrls;

--- a/packages/common/src/directives/ng_optimized_image/url.ts
+++ b/packages/common/src/directives/ng_optimized_image/url.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {PlatformLocation} from '../../location';
+
 // Converts a string that represents a URL into a URL class instance.
-export function getUrl(src: string, win: Window): URL {
+export function getUrl(src: string, win: PlatformLocation): URL {
   // Don't use a base URL is the URL is absolute.
-  return isAbsoluteUrl(src) ? new URL(src) : new URL(src, win.location.href);
+  return isAbsoluteUrl(src) ? new URL(src) : new URL(src, win.href);
 }
 
 // Checks whether a URL is absolute (i.e. starts with `http://` or `https://`).

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -11,7 +11,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {isBrowser, isNode, withHead} from '@angular/private/testing';
 import {expect} from '@angular/private/testing/matchers';
-import {CommonModule, DOCUMENT, IMAGE_CONFIG, ImageConfig} from '../../index';
+import {CommonModule, DOCUMENT, IMAGE_CONFIG, ImageConfig, PlatformLocation} from '../../index';
 import {RuntimeErrorCode} from '../../src/errors';
 import {PLATFORM_SERVER_ID} from '../../src/platform_id';
 
@@ -32,6 +32,7 @@ import {
   resetImagePriorityCount,
 } from '../../src/directives/ng_optimized_image/ng_optimized_image';
 import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_image/preconnect_link_checker';
+import {MockPlatformLocation} from '../../testing';
 
 describe('Image directive', () => {
   const PLACEHOLDER_BLUR_AMOUNT = 15;
@@ -1611,6 +1612,29 @@ describe('Image directive', () => {
       'should not log a warning if there is a matching preconnect link for a priority image (with an extra `/` at the end)',
       withHead('<link rel="preconnect" href="https://angular.dev/">', () => {
         setupTestingModule({imageLoader});
+
+        const consoleWarnSpy = spyOn(console, 'warn');
+        const template = '<img ngSrc="a.png" width="100" height="50" priority>';
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        // Expect no warnings in the console.
+        expect(consoleWarnSpy.calls.count()).toBe(0);
+      }),
+    );
+
+    it(
+      'should not log a warning if there is no preconnect link, but the image is loaded from the same origin',
+      withHead('', () => {
+        setupTestingModule({
+          imageLoader,
+          extraProviders: [
+            {
+              provide: PlatformLocation,
+              useValue: new MockPlatformLocation({startUrl: 'https://angular.dev/some-page'}),
+            },
+          ],
+        });
 
         const consoleWarnSpy = spyOn(console, 'warn');
         const template = '<img ngSrc="a.png" width="100" height="50" priority>';


### PR DESCRIPTION
In local development, `PreconnectLinkChecker` checks whether an priority image has a corresponding preconnect hint and warns in the console if it does not.
It should not log a warning if the image location is the same origin as the page, even if there is no preconnect link, since the browser already establishes a connection to the origin of the page and there is no benefit of adding the preconnect hint.

Previously, accessing local development server through a hostname other than `localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]`, it logs a warning in the browser console despite the same-origin image:

```
NG02956: The NgOptimizedImage directive (activated on an <img> element with the `ngSrc="assets/foo.png"`) has detected that there is no preconnect tag present for this image. Preconnecting to the origin(s) that serve priority images ensures that these images are delivered as soon as possible. To fix this, please add the following element into the <head> of the document:
  <link rel="preconnect" href="https://internal.example.com">
```

Developers can manually provide `PRECONNECT_CHECK_BLOCKLIST` to exclude specific origins from the preconnect checks, but IMHO this change gives a sensible default behavior.

Also replace the usage of `inject(DOCUMENT).defaultView.location` with `PlatformLocation` for a test with a mocked location.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

1. Place NgOptimizedImage that points to a relative (same-origin) URL: `<img ngSrc="assets/foo.png" width="100" height="50" priority>`
2. Start a local development server at `http://localhost:4200`
3. Setup a local reverse-proxy that maps `https://internal.example.com` to `http://localhost:4200`
4. Visit `https://internal.example.com`
5. It logs a `NG02956` warning in the browser console

## What is the new behavior?

It doesn't log the warning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
