### PR TITLE
feat(core): allow signal() to be called without an initial value

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1830,6 +1830,9 @@ export type Signal<T> = (() => T) & {
 };
 
 // @public
+export function signal<T = undefined>(): WritableSignal<T | undefined>;
+
+// @public (undocumented)
 export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
 
 // @public

--- a/packages/core/src/render3/reactivity/signal.ts
+++ b/packages/core/src/render3/reactivity/signal.ts
@@ -69,15 +69,23 @@ export interface CreateSignalOptions<T> {
  * Create a `Signal` that can be set or updated directly.
  * @see [Angular Signals](guide/signals)
  */
-export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T> {
-  const [get, set, update] = createSignal(initialValue, options?.equal);
+export function signal<T = undefined>(): WritableSignal<T | undefined>;
+export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): WritableSignal<T>;
+export function signal<T>(
+  initialValue?: T,
+  options?: CreateSignalOptions<T>,
+): WritableSignal<T | undefined> {
+  const [get, set, update] = createSignal<T | undefined>(
+    initialValue,
+    options?.equal as ValueEqualityFn<T | undefined>,
+  );
 
-  const signalFn = get as SignalGetter<T> & WritableSignal<T>;
+  const signalFn = get as SignalGetter<T | undefined> & WritableSignal<T | undefined>;
   const node = signalFn[SIGNAL];
 
   signalFn.set = set;
   signalFn.update = update;
-  signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T>;
+  signalFn.asReadonly = signalAsReadonlyFn.bind(signalFn as any) as () => Signal<T | undefined>;
 
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     const debugName = options?.debugName;
@@ -85,7 +93,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
     signalFn.toString = () => `[Signal${debugName ? ' (' + debugName + ')' : ''}: ${signalFn()}]`;
   }
 
-  return signalFn as WritableSignal<T>;
+  return signalFn as WritableSignal<T | undefined>;
 }
 
 export function signalAsReadonlyFn<T>(this: SignalGetter<T>): Signal<T> {

--- a/packages/core/test/authoring/BUILD.bazel
+++ b/packages/core/test/authoring/BUILD.bazel
@@ -8,6 +8,7 @@ ts_project(
         "signal_input_signature_test.ts",
         "signal_model_signature_test.ts",
         "signal_queries_signature_test.ts",
+        "signal_signature_test.ts",
         "simple_changes_signature_test.ts",
         "unwrap_writable_signal_signature_test.ts",
     ],

--- a/packages/core/test/authoring/signal_signature_test.ts
+++ b/packages/core/test/authoring/signal_signature_test.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * @fileoverview
+ * This file contains various `signal()` patterns and ensures
+ * the resulting types match our expectations (via comments asserting the `.d.ts`).
+ */
+
+import {signal} from '@angular/core';
+// import preserved to simplify `.d.ts` emit and simplify the `type_tester` logic.
+// tslint:disable-next-line no-duplicate-imports
+import {WritableSignal} from '@angular/core';
+
+export class SignalSignatureTest {
+  /** boolean */
+  inferredBoolean = signal(false);
+
+  /** string */
+  inferredString = signal('hello');
+
+  /** number */
+  inferredNumber = signal(0);
+
+  /** undefined */
+  explicitUndefinedValue = signal(undefined);
+
+  /** undefined */
+  noArgNoType = signal();
+
+  /** string | undefined */
+  noArgExplicitType = signal<string>();
+
+  /** string | undefined */
+  noArgExplicitUnionType = signal<string | undefined>();
+
+  /** string */
+  explicitTypeWithValue = signal<string>('hello');
+
+  /** string */
+  withEqualOption = signal('hello', {equal: (a, b) => a === b});
+
+  /** #ignore */
+  // @ts-expect-error type mismatch between explicit type and value
+  invalidExplicitType = signal<number>('1');
+}

--- a/packages/core/test/authoring/type_tester.ts
+++ b/packages/core/test/authoring/type_tester.ts
@@ -13,6 +13,7 @@ import url from 'url';
 
 /** Currently-configured tests. */
 const TESTS = new Map<string, (value: string) => string>([
+  ['signal_signature_test', (v) => `WritableSignal<${v}>`],
   ['linked_signal_signature_test', (v) => `WritableSignal<${v}>`],
   [
     'signal_input_signature_test',

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -16,6 +16,13 @@ import {
 } from '../../primitives/signals';
 
 describe('signals', () => {
+  it('should default to undefined when called with no argument', () => {
+    const s = signal<string>();
+    expect(s()).toBeUndefined();
+    s.set('hello');
+    expect(s()).toBe('hello');
+  });
+
   it('should be a getter which reflects the set value', () => {
     const state = signal(false);
     expect(state()).toBeFalse();


### PR DESCRIPTION
Adds a no-argument overload to `signal()` so `undefined` is inferred when no initial value is provided, matching the behavior of the `input()` API.

```ts
// before
name = signal<string | undefined>(undefined);

// after — `undefined` is inferred automatically
name = signal<string>();
```

Closes #64118