### PR TITLE
fix(router): Add strict typing on 'getResolvedTitleForRoute'

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -1021,7 +1021,7 @@ export class Scroll {
 export abstract class TitleStrategy {
     // (undocumented)
     buildTitle(snapshot: RouterStateSnapshot): string | undefined;
-    getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): any;
+    getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): string | undefined;
     abstract updateTitle(snapshot: RouterStateSnapshot): void;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<TitleStrategy, never>;

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -57,7 +57,7 @@ export abstract class TitleStrategy {
    * Given an `ActivatedRouteSnapshot`, returns the final value of the
    * `Route.title` property, which can either be a static string or a resolved value.
    */
-  getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot) {
+  getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): string | undefined {
     return snapshot.data[RouteTitleKey];
   }
 }


### PR DESCRIPTION
The title property in Router type already requires that the return type of a resolved title is a string. The type was looser here only because 'data' values are typed as 'any'.


(technically could be considered breaking. If we have a green TGP I'm going to consider this not)