### PR TITLE
refactor(compiler): sync compiler_facade_interface replica with main

### DIFF
--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -222,8 +222,8 @@ export interface R3DirectiveMetadataFacade {
   providers: Provider[] | null;
   viewQueries: R3QueryMetadataFacade[];
   isStandalone: boolean;
-  isSignal: boolean;
   hostDirectives: R3HostDirectiveMetadataFacade[] | null;
+  isSignal: boolean;
   legacyOptionalChaining: boolean;
 }
 
@@ -274,12 +274,11 @@ export interface R3DeclareDirectiveFacade {
   exportAs?: string[];
   usesInheritance?: boolean;
   usesOnChanges?: boolean;
-  controlCreate?: {
-    passThroughInput: string | null;
-  };
+  controlCreate?: {passThroughInput: string | null};
   isStandalone?: boolean;
-  hostDirectives?: R3HostDirectiveMetadataFacade[] | null;
   isSignal?: boolean;
+  hostDirectives?: R3HostDirectiveMetadataFacade[] | null;
+  legacyOptionalChaining?: boolean;
 }
 
 export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
@@ -301,7 +300,6 @@ export interface R3DeclareComponentFacade extends R3DeclareDirectiveFacade {
   changeDetection?: ChangeDetectionStrategy;
   encapsulation?: ViewEncapsulation;
   preserveWhitespaces?: boolean;
-  legacyOptionalChaining?: boolean;
 }
 
 export type R3DeclareTemplateDependencyFacade = {
@@ -422,8 +420,8 @@ export interface R3DeclareNgModuleFacade {
 
 export interface R3DeclarePipeFacade {
   type: Type;
-  name: string;
   version: string;
+  name: string;
   pure?: boolean;
   isStandalone?: boolean;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`packages/compiler/src/compiler_facade_interface.ts` and `packages/core/src/compiler/compiler_facade_interface.ts` are described in the file header as two copies of the same interfaces, with an explicit `cp` command for keeping them in sync. The replica in `core/` has drifted from the main in `compiler/`:

- `R3DirectiveMetadataFacade`: `isSignal` / `hostDirectives` field order is reversed.
- `R3DeclareDirectiveFacade`: `controlCreate` formatted on multiple lines; `isSignal` / `hostDirectives` order reversed; `legacyOptionalChaining?: boolean;` is missing.
- `R3DeclareComponentFacade`: carries a duplicate `legacyOptionalChaining?: boolean;` even though it already extends `R3DeclareDirectiveFacade`.

## What is the new behavior?

The replica is brought back in sync with the main by running the exact `cp` command the file header specifies. The drift items above are all corrected; `legacyOptionalChaining` is removed from the child interface and present on the parent where it inherits naturally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

