### PR TITLE
refactor(router): remove unused imports

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -27,14 +27,14 @@ import {
   SimpleChanges,
   ViewContainerRef,
 } from '@angular/core';
-import {combineLatest, Observable, of, Subscription} from 'rxjs';
+import {combineLatest, of, Subscription} from 'rxjs';
 import {switchMap} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from '../errors';
 import {Data} from '../models';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute} from '../router_state';
-import {Params, PRIMARY_OUTLET} from '../shared';
+import {PRIMARY_OUTLET} from '../shared';
 import {ComponentInputBindingOptions} from '../router_config';
 
 /**

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {EnvironmentInjector, ProviderToken, runInInjectionContext} from '@angular/core';
+import {ProviderToken, runInInjectionContext} from '@angular/core';
 import {defer, EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, map, mergeMap, takeLast, tap} from 'rxjs/operators';
 

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -17,7 +17,6 @@ import {
 
 import {RuntimeErrorCode} from '../errors';
 import {Route, Routes} from '../models';
-import {ActivatedRouteSnapshot} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
 
 /**

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -10,7 +10,6 @@ import {
   Injector,
   ProviderToken,
   ɵisInjectable as isInjectable,
-  EnvironmentInjector,
   runInInjectionContext,
 } from '@angular/core';
 import {RunGuardsAndResolvers} from '../models';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Four files in `packages/router/src` import names they don't use:

- `directives/router_outlet.ts`: `Observable` from `rxjs` and `Params` from `../shared`
- `operators/resolve_data.ts`: `EnvironmentInjector` from `@angular/core`
- `utils/config.ts`: `ActivatedRouteSnapshot` from `../router_state`
- `utils/preactivation.ts`: `EnvironmentInjector` from `@angular/core`

Each is unreferenced outside its import line.

## What is the new behavior?

The unused imports are removed. No runtime or type-surface changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
