### PR TITLE
docs: link to ng new reference from installation guide

### DIFF
--- a/adev/src/content/introduction/installation.md
+++ b/adev/src/content/introduction/installation.md
@@ -62,7 +62,7 @@ If you are having issues running this command in Windows or Unix, check out the 
 
 #### Create a new project
 
-In your terminal, run the CLI command `ng new` with the desired project name. In the following examples, we'll be using the example project name of `my-first-angular-app`.
+In your terminal, run the CLI command [`ng new`](cli/new) with the desired project name. In the following examples, we'll be using the example project name of `my-first-angular-app`.
 
 ```shell
 ng new <project-name>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The installation guide (`introduction/installation.md`) walks a developer through `ng new <project-name>` but provides no link to the `ng new` CLI reference. Every option the command supports is therefore undiscoverable from the install flow unless the reader thinks to dig into the `tools/cli` reference on their own.

## What is the new behavior?

The ng new mention in the prose is linked to the ng new reference page so readers can discover the available options with one click.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

