### PR TITLE
docs: Fix accepted Provider type in doc snippet

### DIFF
--- a/adev/src/content/guide/testing/overview.md
+++ b/adev/src/content/guide/testing/overview.md
@@ -53,11 +53,10 @@ The `setupFiles` and `providersFile` options are particularly useful for managin
 For example, you could create a `src/test-providers.ts` file to provide `provideHttpClientTesting` to all your tests:
 
 ```typescript {header: "src/test-providers.ts"}
-import {Provider} from '@angular/core';
-import {provideHttpClient} from '@angular/common/http';
+import {EnvironmentProviders, Provider} from '@angular/core';
 import {provideHttpClientTesting} from '@angular/common/http/testing';
 
-const testProviders: Provider[] = [provideHttpClient(), provideHttpClientTesting()];
+const testProviders: (Provider | EnvironmentProviders)[] = [provideHttpClientTesting()];
 
 export default testProviders;
 ```


### PR DESCRIPTION
out of the box my IDE tells me there an error on

    const testProviders: Provider[] = [provideHttpClient(), provideHttpClientTesting()];

because `provideHttpClient()` returns an `EnvironmentProviders` so I can't put it in a variable of type `Provider[]`.

As I'm pretty much a noob, that leads me to wasting a lot of time, trying to understand how I could turn my `EnvironmentProviders` into a `Provider`, not realizing `EnvironmentProviders` were just fine here. I hope this change will prevent other folks lose time as I did.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The code snippet from the doc does not compile.

## What is the new behavior?

The code snippet from the doc builds just fine

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
