### PR TITLE
feat(core): support Explicit Resource Management on PendingTasks

### DIFF
--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -34,6 +34,16 @@ import {PendingTasksInternal} from './pending_tasks_internal';
  * taskCleanup();
  * ```
  *
+ * The returned cleanup function also implements `Disposable`, allowing use
+ * with the `using` keyword for automatic cleanup:
+ * ```ts
+ * const pendingTasks = inject(PendingTasks);
+ * function foo() {
+ *   using _ = pendingTasks.add();
+ *   // _ is automatically disposed when the block exits
+ * }
+ * ```
+ *
  *
  * @see [PendingTasks for Server Side Rendering (SSR)](guide/zoneless#pendingtasks-for-server-side-rendering-ssr)
  *
@@ -45,11 +55,12 @@ export class PendingTasks {
   private readonly errorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
   /**
    * Adds a new task that should block application's stability.
-   * @returns A cleanup function that removes a task when called.
+   * @returns A cleanup function that removes a task when called. The function also
+   *   implements `Disposable` to support the `using` keyword.
    */
-  add(): () => void {
+  add(): (() => void) & Disposable {
     const taskId = this.internalPendingTasks.add();
-    return () => {
+    const cleanup = () => {
       if (!this.internalPendingTasks.has(taskId)) {
         // This pending task has already been cleared.
         return;
@@ -58,6 +69,11 @@ export class PendingTasks {
       this.scheduler.notify(NotificationSource.PendingTaskRemoved);
       this.internalPendingTasks.remove(taskId);
     };
+    // Symbol.dispose may not be defined in all environments (e.g. Safari < 17.4).
+    if (typeof (Symbol as {dispose?: symbol}).dispose === 'symbol') {
+      (cleanup as unknown as Record<symbol, unknown>)[Symbol.dispose] = cleanup;
+    }
+    return cleanup as unknown as (() => void) & Disposable;
   }
 
   /**

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -84,6 +84,26 @@ describe('public PendingTasks', () => {
     await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(true);
   });
 
+  it('cleanup function returned by add() should implement Disposable', () => {
+    const pendingTasks = TestBed.inject(PendingTasks);
+    const cleanup = pendingTasks.add();
+    expect(cleanup[Symbol.dispose]).toBe(cleanup);
+    cleanup();
+  });
+
+  it('should support using keyword for automatic cleanup', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    const pendingTasks = TestBed.inject(PendingTasks);
+
+    {
+      using _ = pendingTasks.add();
+      await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(false);
+    }
+    TestBed.inject(ApplicationRef).tick();
+    await Promise.resolve();
+    await expectAsync(applicationRefIsStable(appRef)).toBeResolvedTo(true);
+  });
+
   it('should allow blocking stability with run', async () => {
     const appRef = TestBed.inject(ApplicationRef);
     const pendingTasks = TestBed.inject(PendingTasks);

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -19,7 +19,7 @@
     "moduleResolution": "bundler",
     "module": "esnext",
     "target": "es2022",
-    "lib": ["es2020", "es2022", "dom", "dom.iterable"],
+    "lib": ["es2020", "es2022", "esnext.disposable", "dom", "dom.iterable"],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],
@@ -36,9 +36,9 @@
       "@angular/common/locales/*": ["./common/locales/*"],
       "@angular/compiler-cli": ["./compiler-cli"],
       "@angular/compiler-cli/*": ["./compiler-cli/*"],
-      "@angular/compiler-cli/src/ngtsc/reflection":  ["./compiler-cli/src/ngtsc/reflection/index"],
-      "@angular/compiler-cli/src/ngtsc/metadata":  ["./compiler-cli/src/ngtsc/metadata/index"],
-      "@angular/compiler-cli/private/migrations":  ["./compiler-cli/private/migrations"],
+      "@angular/compiler-cli/src/ngtsc/reflection": ["./compiler-cli/src/ngtsc/reflection/index"],
+      "@angular/compiler-cli/src/ngtsc/metadata": ["./compiler-cli/src/ngtsc/metadata/index"],
+      "@angular/compiler-cli/private/migrations": ["./compiler-cli/private/migrations"],
       "@angular/core/schematics/utils/tsurge/*": ["./core/schematics/utils/tsurge/*"]
     }
   },


### PR DESCRIPTION
This change makes the cleanup function returned by `PendingTasks.prototype.add()` implement the `Disposable` interface, so it can be used with the `using` keyword for automatic cleanup.

Since some environments still don’t support `Symbol.dispose` natively (for example Safari versions before 17.4), the assignment is guarded behind a runtime check. In those environments, using the `using` keyword will still require a `Symbol.dispose` polyfill.

Closes #64742