### PR TITLE
feat(compiler-cli): add extended diagnostic for template reference shadowing component member

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -664,6 +664,23 @@ export enum ErrorCode {
   FORBIDDEN_REQUIRED_INITIALIZER_INVOCATION = 8118,
 
   /**
+   * A template reference variable uses the same name as a component class member,
+   * which causes the class member to be shadowed within the template scope.
+   *
+   * For example:
+   * ```ts
+   * class MyComponent {
+   *   name = 'Alice';
+   * }
+   * ```
+   * ```angular-html
+   * <!-- `name` refers to the reference, not `MyComponent.name` -->
+   * <input #name />
+   * ```
+   */
+  TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE = 8119,
+
+  /**
    * The template type-checking engine would need to generate an inline type check block for a
    * component, but the current type-checking environment doesn't support it.
    */

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/extended_template_diagnostic_name.ts
@@ -34,4 +34,5 @@ export enum ExtendedTemplateDiagnosticName {
   UNPARENTHESIZED_NULLISH_COALESCING = 'unparenthesizedNullishCoalescing',
   UNINVOKED_FUNCTION_IN_TEXT_INTERPOLATION = 'uninvokedFunctionInTextInterpolation',
   DEFER_TRIGGER_MISCONFIGURATION = 'deferTriggerMisconfiguration',
+  TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE = 'templateReferenceShadowsComponentVariable',
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/BUILD.bazel
@@ -23,6 +23,7 @@ ts_project(
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/optional_chain_not_nullable",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/skip_hydration_not_static",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/suffix_not_supported",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/text_attribute_not_binding",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uninvoked_function_in_event_binding",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/uninvoked_function_in_text_interpolation",

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//tools:defaults.bzl", "ts_project")
+
+ts_project(
+    name = "template_reference_shadows_variable",
+    srcs = ["index.ts"],
+    visibility = [
+        "//packages/compiler-cli/src/ngtsc:__subpackages__",
+        "//packages/compiler-cli/test/ngtsc:__pkg__",
+    ],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/api",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable/index.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {AST, TmplAstNode, TmplAstReference} from '@angular/compiler';
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName} from '../../../../diagnostics';
+import {NgTemplateDiagnostic} from '../../../api';
+import {
+  TemplateCheckFactory,
+  TemplateCheckWithVisitor,
+  TemplateContext,
+  formatExtendedError,
+} from '../../api';
+
+/**
+ * Warns when a template reference variable (`#ref`) uses the same name as a public member
+ * on the component class, since the template reference silently shadows the class member
+ * within the template scope.
+ */
+class TemplateReferenceShadowsVariableCheck extends TemplateCheckWithVisitor<ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE> {
+  override code = ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE as const;
+
+  private memberNames = new Set<string>();
+
+  override run(
+    ctx: TemplateContext<ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE>,
+    component: ts.ClassDeclaration,
+    template: TmplAstNode[],
+  ): NgTemplateDiagnostic<ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE>[] {
+    // Collect once per component so `visitNode` doesn't repeat the work for every node.
+    this.memberNames = collectPublicMemberNames(component);
+    const diagnostics = super.run(ctx, component, template);
+    // Clear after the visit so the instance doesn't hold references between components.
+    this.memberNames = new Set();
+    return diagnostics;
+  }
+
+  override visitNode(
+    ctx: TemplateContext<ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE>,
+    component: ts.ClassDeclaration,
+    node: TmplAstNode | AST,
+  ): NgTemplateDiagnostic<ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE>[] {
+    // Only template reference variables (`#ref`) can shadow class members.
+    if (!(node instanceof TmplAstReference)) return [];
+    // No class member with this name — nothing is shadowed.
+    if (!this.memberNames.has(node.name)) return [];
+
+    return [
+      ctx.makeTemplateDiagnostic(
+        node.keySpan,
+        formatExtendedError(
+          ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+          `The template reference #${node.name} shadows the component member '${node.name}'.`,
+        ),
+      ),
+    ];
+  }
+}
+
+/** Collects names of public, non-static class members accessible in a template. */
+function collectPublicMemberNames(component: ts.ClassDeclaration): Set<string> {
+  const names = new Set<string>();
+  for (const member of component.members) {
+    // Constructors and index signatures don't have a usable name, so they can be skipped.
+    // Computed property names (for example `[Symbol.iterator]()`) also can't be referenced
+    // from a template using a plain identifier, so only simple `ts.Identifier` names are relevant here.
+    if (!member.name || !ts.isIdentifier(member.name)) continue;
+
+    const modifiers = ts.canHaveModifiers(member) ? (ts.getModifiers(member) ?? []) : [];
+    const isPrivate = modifiers.some((m) => m.kind === ts.SyntaxKind.PrivateKeyword);
+    const isStatic = modifiers.some((m) => m.kind === ts.SyntaxKind.StaticKeyword);
+    if (!isPrivate && !isStatic) {
+      names.add(member.name.text);
+    }
+  }
+  return names;
+}
+
+export const factory: TemplateCheckFactory<
+  ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+  ExtendedTemplateDiagnosticName.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE
+> = {
+  code: ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+  name: ExtendedTemplateDiagnosticName.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+  create: () => new TemplateReferenceShadowsVariableCheck(),
+};

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/index.ts
@@ -25,6 +25,7 @@ import {factory as unusedLetDeclarationFactory} from './checks/unused_let_declar
 import {factory as uninvokedTrackFunctionFactory} from './checks/uninvoked_track_function';
 import {factory as uninvokedFunctionInTextInterpolationFactory} from './checks/uninvoked_function_in_text_interpolation';
 import {factory as deferTriggerMisconfigurationFactory} from './checks/defer_trigger_misconfiguration';
+import {factory as templateReferenceShadowsVariableFactory} from './checks/template_reference_shadows_variable';
 
 export {ExtendedTemplateCheckerImpl} from './src/extended_template_checker';
 
@@ -48,6 +49,7 @@ export const ALL_DIAGNOSTIC_FACTORIES: readonly TemplateCheckFactory<
   uninvokedTrackFunctionFactory,
   uninvokedFunctionInTextInterpolationFactory,
   deferTriggerMisconfigurationFactory,
+  templateReferenceShadowsVariableFactory,
 ];
 
 export const SUPPORTED_DIAGNOSTIC_NAMES = new Set<string>([

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/template_reference_shadows_variable/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/template_reference_shadows_variable/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["template_reference_shadows_variable_spec.ts"],
+    deps = [
+        "//:node_modules/typescript",
+        "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/core:api",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
+        "//packages/compiler-cli/src/ngtsc/file_system",
+        "//packages/compiler-cli/src/ngtsc/file_system/testing",
+        "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended",
+        "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/template_reference_shadows_variable",
+        "//packages/compiler-cli/src/ngtsc/typecheck/testing",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [
+        ":test_lib",
+        "//packages/core:npm_package",
+    ],
+)

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/template_reference_shadows_variable/template_reference_shadows_variable_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/template_reference_shadows_variable/template_reference_shadows_variable_spec.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from 'typescript';
+
+import {ErrorCode, ExtendedTemplateDiagnosticName, ngErrorCode} from '../../../../../diagnostics';
+import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
+import {runInEachFileSystem} from '../../../../../file_system/testing';
+import {getSourceCodeForDiagnostic} from '../../../../../testing';
+import {getClass, setup} from '../../../../testing';
+import {factory as templateReferenceShadowsVariableFactory} from '../../../checks/template_reference_shadows_variable/index';
+import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checker';
+
+runInEachFileSystem(() => {
+  describe('TemplateReferenceShadowsVariableCheck', () => {
+    function diagnose(template: string, source: string) {
+      const fileName = absoluteFrom('/main.ts');
+      const {program, templateTypeChecker} = setup([
+        {
+          fileName,
+          templates: {'TestCmp': template},
+          source,
+        },
+      ]);
+      const sf = getSourceFileOrError(program, fileName);
+      const component = getClass(sf, 'TestCmp');
+      const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+        templateTypeChecker,
+        program.getTypeChecker(),
+        [templateReferenceShadowsVariableFactory],
+        {},
+      );
+      return extendedTemplateChecker.getDiagnosticsForComponent(component);
+    }
+
+    it('binds the error code to its extended template diagnostic name', () => {
+      expect(templateReferenceShadowsVariableFactory.code).toBe(
+        ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+      );
+      expect(templateReferenceShadowsVariableFactory.name).toBe(
+        ExtendedTemplateDiagnosticName.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE,
+      );
+    });
+
+    it('should warn when a template reference shadows a public property', () => {
+      const diags = diagnose(`<input #name />`, `export class TestCmp { name = 'Alice'; }`);
+
+      expect(diags.length).toBe(1);
+      expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
+      expect(diags[0].code).toBe(
+        ngErrorCode(ErrorCode.TEMPLATE_REFERENCE_SHADOWS_COMPONENT_VARIABLE),
+      );
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('name');
+    });
+
+    it('should warn when a template reference shadows a public method', () => {
+      const diags = diagnose(`<input #submit />`, `export class TestCmp { submit() {} }`);
+
+      expect(diags.length).toBe(1);
+      expect(getSourceCodeForDiagnostic(diags[0])).toBe('submit');
+    });
+
+    it('should not warn when the reference name does not match any class member', () => {
+      const diags = diagnose(`<input #myInput />`, `export class TestCmp { name = 'Alice'; }`);
+
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not warn when the matching member is private', () => {
+      const diags = diagnose(`<input #name />`, `export class TestCmp { private name = 'Alice'; }`);
+
+      expect(diags.length).toBe(0);
+    });
+
+    it('should not warn when the matching member is static', () => {
+      const diags = diagnose(
+        `<input #name />`,
+        `export class TestCmp { static name = 'TestCmp'; }`,
+      );
+
+      expect(diags.length).toBe(0);
+    });
+
+    it('should warn for multiple shadowing references in the same template', () => {
+      const diags = diagnose(
+        `<input #name /><form #submit></form>`,
+        `export class TestCmp { name = 'Alice'; submit() {} }`,
+      );
+
+      expect(diags.length).toBe(2);
+    });
+
+    it('should warn when a template reference on ng-template shadows a class member', () => {
+      const diags = diagnose(
+        `<ng-template #name></ng-template>`,
+        `export class TestCmp { name = 'Alice'; }`,
+      );
+
+      expect(diags.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Adds a new extended template diagnostic (`NG8119`) that warns when a template reference variable (`#ref`) uses the same name as a public, non-static member of the component class. In those cases, the template reference silently shadows the class member within the template scope, which is usually unintended.

The diagnostic can be configured through `extendedDiagnostics.checks.templateReferenceShadowsComponentVariable` in the Angular compiler options.

Closes #45227