### PR TITLE
docs(core): add useFactory example to LOCALE_ID API docs

### DIFF
--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -76,6 +76,30 @@ export function getGlobalLocale(): string {
  * });
  * ```
  *
+ * When the locale must be resolved through an Angular service (for example,
+ * to read it from user preferences, route parameters, or cookies), use
+ * `useFactory` with `inject()`:
+ * ```ts
+ * import { inject, Injectable, LOCALE_ID, ApplicationConfig } from '@angular/core';
+ *
+ * @Injectable({providedIn: 'root'})
+ * export class LangService {
+ *   getLocale(): string {
+ *     // read from user prefs, cookie, navigator, etc.
+ *     return 'en-US';
+ *   }
+ * }
+ *
+ * const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     {
+ *       provide: LOCALE_ID,
+ *       useFactory: () => inject(LangService).getLocale(),
+ *     },
+ *   ],
+ * };
+ * ```
+ *
  * @publicApi
  * @see [Import global variants of the locale data](guide/i18n/import-global-variants)
  */


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Documentation content changes

## What is the current behavior?

The `LOCALE_ID` API documentation at https://angular.dev/api/core/LOCALE_ID shows only `useValue: 'en-US'` in both the standalone and module examples. `useValue` works for a static string or a value computed before the injector exists (for example, reading `navigator.language` at module load), but it can't reach a service that owns the locale logic (user preferences, route params, cookies, etc.) because there is no injection context at that point. A developer landing on the API page after searching "Angular locale" doesn't realize the service case is a one-liner.

Issue Number: #68754

## What is the new behavior?

Adds a third example to the `LOCALE_ID` JSDoc showing the `useFactory` + `inject()` pattern from inside an `ApplicationConfig`. Mirrors the example in the issue body.

```ts
const appConfig: ApplicationConfig = {
  providers: [
    {
      provide: LOCALE_ID,
      useFactory: () => inject(LangService).getLocale(),
    },
  ],
};
```