### PR TITLE
feat(core): support applying directives via TestBed.createComponent

### DIFF
--- a/adev/src/content/guide/testing/components-scenarios.md
+++ b/adev/src/content/guide/testing/components-scenarios.md
@@ -110,6 +110,21 @@ const fixture = TestBed.createComponent(ValueDisplay, {
 });
 ```
 
+### Applying host directives
+
+To apply host directives to a component created via `TestBed.createComponent()`, use the `directives` option. You can pass directive types directly, or provide bindings for their inputs.
+
+```ts
+import {inputBinding} from '@angular/core';
+
+const fixture = TestBed.createComponent(MyComponent, {
+  directives: [
+    HighlightDirective,
+    {type: TooltipDirective, bindings: [inputBinding('tooltipText', tooltipSignal)]},
+  ],
+});
+```
+
 ### Change an input value with `dispatchEvent()`
 
 To simulate user input, find the input element and set its `value` property.

--- a/goldens/public-api/core/testing/index.api.md
+++ b/goldens/public-api/core/testing/index.api.md
@@ -182,6 +182,7 @@ export interface TestBedStatic extends TestBed {
 // @public
 export interface TestComponentOptions {
     bindings?: Binding[];
+    directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
     inferTagName?: boolean;
 }
 

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -1293,6 +1293,65 @@ describe('TestBed', () => {
     });
   });
 
+  describe('directives', () => {
+    it('should be able to apply directives to the component', () => {
+      const logs: string[] = [];
+
+      @Directive({
+        host: {'class': 'dir-class', 'attr-one': 'one'},
+      })
+      class Dir {
+        constructor() {
+          logs.push('Dir');
+        }
+      }
+
+      @Component({template: '', host: {'class': 'host-class'}})
+      class TestComp {
+        constructor() {
+          logs.push('TestComp');
+        }
+      }
+
+      const fixture = TestBed.createComponent(TestComp, {
+        directives: [Dir],
+      });
+      fixture.detectChanges();
+
+      expect(logs).toEqual(['TestComp', 'Dir']);
+      expect(fixture.nativeElement.classList.contains('host-class')).toBe(true);
+      expect(fixture.nativeElement.classList.contains('dir-class')).toBe(true);
+      expect(fixture.nativeElement.getAttribute('attr-one')).toBe('one');
+    });
+
+    it('should be able to apply directives with bindings', () => {
+      @Directive({})
+      class Dir {
+        @Input() dirInput = '';
+      }
+
+      @Component({template: 'Value: {{value}}'})
+      class TestComp {
+        @Input() value = '';
+      }
+
+      const dirValue = signal('dir-initial');
+      const fixture = TestBed.createComponent(TestComp, {
+        bindings: [inputBinding('value', () => 'host-value')],
+        directives: [{type: Dir, bindings: [inputBinding('dirInput', dirValue)]}],
+      });
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toBe('Value: host-value');
+      const dirInstance = fixture.debugElement.injector.get(Dir);
+      expect(dirInstance.dirInput).toBe('dir-initial');
+
+      dirValue.set('dir-updated');
+      fixture.detectChanges();
+      expect(dirInstance.dirInput).toBe('dir-updated');
+    });
+  });
+
   it('should allow overriding a provider defined via ModuleWithProviders (using TestBed.overrideProvider)', () => {
     const serviceOverride = {
       get() {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -18,6 +18,7 @@ import {
   ComponentRef,
   ɵDeferBlockBehavior as DeferBlockBehavior,
   Directive,
+  DirectiveWithBindings,
   EnvironmentInjector,
   ɵflushModuleScopingQueueAsMuchAsPossible as flushModuleScopingQueueAsMuchAsPossible,
   ɵgetAsyncClassMetadataFn as getAsyncClassMetadataFn,
@@ -75,6 +76,9 @@ export interface TestBedStatic extends TestBed {
 export interface TestComponentOptions {
   /** Bindings to apply to the test component. */
   bindings?: Binding[];
+
+  /** Directives to apply to the test component. */
+  directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
 
   /**
    * Whether to infer the tag name of the test component from its selector.
@@ -711,7 +715,7 @@ export class TestBedImpl implements TestBed {
         [],
         `#${rootElId}`,
         this.testModuleRef,
-        undefined,
+        options?.directives,
         options?.bindings,
       ) as ComponentRef<T>;
       return this.runInInjectionContext(() => new ComponentFixture(componentRef));


### PR DESCRIPTION
Add a `directives` option to `TestComponentOptions` that allows applying host directives to a component created via `TestBed.createComponent()`. This enables testing scenarios where directives need to be dynamically applied to the test component, including directives with bindings.

Closes https://github.com/angular/angular/issues/68779

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
