### PR TITLE
fix(core): do not insert todo when migrating void @Output

### DIFF
--- a/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.spec.ts
@@ -198,6 +198,35 @@ describe('outputs', () => {
         });
       });
 
+      it('should not insert a TODO comment for emit function with void type', async () => {
+        await verify({
+          before: `
+              import {Directive, Output, EventEmitter} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                @Output() someChange = new EventEmitter<void>();
+
+                someMethod(): void {
+                  this.someChange.emit();
+                }
+              }
+            `,
+          after: `
+              import {Directive, output} from '@angular/core';
+
+              @Directive()
+              export class TestDir {
+                readonly someChange = output<void>();
+
+                someMethod(): void {
+                  this.someChange.emit();
+                }
+              }
+            `,
+        });
+      });
+
       it('should insert a TODO comment for emit function with type', async () => {
         await verify({
           before: `

--- a/packages/core/schematics/migrations/output-migration/output-migration.ts
+++ b/packages/core/schematics/migrations/output-migration/output-migration.ts
@@ -477,7 +477,7 @@ function addCommentForEmptyEmit(
   if (!propertyDeclaration) return;
 
   const eventEmitterType = getEventEmitterArgumentType(propertyDeclaration);
-  if (!eventEmitterType) return;
+  if (!eventEmitterType || eventEmitterType === 'void') return;
 
   const id = getUniqueIdForProperty(info, propertyDeclaration);
   const file = projectFile(node.getSourceFile(), info);


### PR DESCRIPTION
The following:

`@Output() someChange = new EventEmitter<void>();`

is correctly migrated to:

`readonly someChange = output<void>();`

However, a TODO is incorrectly inserted for subsequent emissions from `someChange`, stating that an argument is expected.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Void-emitting outputs get spurious TODO messages during migration to output function.

Issue Number: N/A

## What is the new behavior?

No spurious TODO messages are inserted during migration of void outputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A
