### PR TITLE
refactor(compiler): emit instructions for foreign components

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -254,6 +254,7 @@ export class PartialComponentLinkerVersion1<
       i18nUseExternalIds: false,
       declarations,
       hasDirectiveDependencies: !baseMeta.isStandalone || hasDirectiveDependencies,
+      foreignImports: null,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -2346,7 +2346,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     const context = getSourceFile(node);
 
     return analysis.foreignImports.map((foreignMeta) => {
-      const {ref, rawExpression} = foreignMeta;
+      const {name, ref, rawExpression} = foreignMeta;
 
       const emittedRef = this.refEmitter.emit(ref, context);
       assertSuccessfulReferenceEmit(emittedRef, node.name, 'foreign component');
@@ -2354,7 +2354,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
       ts.setEmitFlags(rawExpression, ts.EmitFlags.NoComments | ts.EmitFlags.NoNestedComments);
 
       return {
-        name: foreignMeta.name,
+        name,
         component: new o.WrappedNodeExpr(rawExpression),
       } satisfies R3ForeignComponentMetadata;
     });

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1024,6 +1024,7 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
           relativeContextFilePath,
           rawImports: rawImports !== null ? new o.WrappedNodeExpr(rawImports) : undefined,
           relativeTemplatePath,
+          foreignImports: null,
         },
         typeCheckMeta: extractDirectiveTypeCheckMeta(node, inputs, this.reflector),
         classMetadata: this.includeClassMetadata

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -39,6 +39,7 @@ import {
   R3TemplateDependency,
   R3TemplateDependencyKind,
   R3TemplateDependencyMetadata,
+  R3ForeignComponentMetadata,
   SchemaMetadata,
   SelectorlessMatcher,
   SelectorMatcher,
@@ -1495,10 +1496,12 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
       ? this.resolveAllDeferredDependencies(resolution)
       : null;
     const defer = this.compileDeferBlocks(resolution);
+    const foreignImports = this.resolveForeignComponentImports(node, analysis);
     const meta: R3ComponentMetadata<R3TemplateDependency> = {
       ...analysis.meta,
       ...resolution,
       defer,
+      foreignImports,
     };
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
 
@@ -1625,10 +1628,12 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     const deferrableTypes = this.canDeferDeps ? analysis.explicitlyDeferredTypes : null;
 
     const defer = this.compileDeferBlocks(resolution);
+    const foreignImports = this.resolveForeignComponentImports(node, analysis);
     const meta = {
       ...analysis.meta,
       ...resolution,
       defer,
+      foreignImports,
     } as R3ComponentMetadata<R3TemplateDependency>;
 
     if (deferrableTypes !== null) {
@@ -1688,10 +1693,12 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     // Create a brand-new constant pool since there shouldn't be any constant sharing.
     const pool = new ConstantPool();
     const defer = this.compileDeferBlocks(resolution);
+    const foreignImports = this.resolveForeignComponentImports(node, analysis);
     const meta: R3ComponentMetadata<R3TemplateDependency> = {
       ...analysis.meta,
       ...resolution,
       defer,
+      foreignImports,
     };
     const fac = compileNgFactoryDefField(toFactoryMetadata(meta, FactoryTarget.Component));
     const def = compileComponentFromMetadata(meta, pool, this.getNewBindingParser());
@@ -2323,6 +2330,33 @@ export class ComponentDecoratorHandler implements DecoratorHandler<
     }
 
     this.cycleAnalyzer.recordSyntheticImport(origin, imported);
+  }
+
+  /**
+   * Resolves imported foreign components for code generation.
+   */
+  private resolveForeignComponentImports(
+    node: ClassDeclaration,
+    analysis: Readonly<ComponentAnalysisData>,
+  ): R3ForeignComponentMetadata[] | null {
+    if (analysis.foreignImports === null || analysis.foreignImports.length === 0) {
+      return null;
+    }
+    const context = getSourceFile(node);
+
+    return analysis.foreignImports.map((foreignMeta) => {
+      const {ref, rawExpression} = foreignMeta;
+
+      const emittedRef = this.refEmitter.emit(ref, context);
+      assertSuccessfulReferenceEmit(emittedRef, node.name, 'foreign component');
+
+      ts.setEmitFlags(rawExpression, ts.EmitFlags.NoComments | ts.EmitFlags.NoNestedComments);
+
+      return {
+        name: foreignMeta.name,
+        component: new o.WrappedNodeExpr(rawExpression),
+      } satisfies R3ForeignComponentMetadata;
+    });
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
@@ -12,13 +12,13 @@ import {
   SchemaMetadata,
   SelectorlessMatcher,
   SelectorMatcher,
-  ForeignComponentMeta,
 } from '@angular/compiler';
 
 import {Reference} from '../../imports';
 import {
   DirectiveMeta,
   flattenInheritedDirectiveMetadata,
+  ForeignComponentMeta,
   HostDirectivesResolver,
   MetadataReader,
   MetaKind,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -375,3 +375,42 @@ export declare class StandaloneComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<StandaloneComponent, "other-standalone", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: foreign_component.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export function FancyButton() { }
+// @angular/core does not expose the `ForeignComponent` type this should return. 
+function frameworkImport(component) {
+    return () => { };
+}
+export class TestCmp {
+    title = 'Submit';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "main", ngImport: i0, template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>', isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'main',
+                    template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>',
+                    // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+                    foreignImports: [
+                        // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+                        frameworkImport(FancyButton)
+                    ],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: foreign_component.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare function FancyButton(): void;
+export declare class TestCmp {
+    title: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "main", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -388,13 +388,27 @@ function frameworkImport(component) {
 export class TestCmp {
     title = 'Submit';
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
-    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "main", ngImport: i0, template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>', isInline: true });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmp, isStandalone: true, selector: "main", ngImport: i0, template: `
+    <FancyButton
+      class="btn-cls"
+      unsafe-attr="value"
+      [label]="title"
+      [unsafe-input]="title"
+    />
+  `, isInline: true });
 }
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmp, decorators: [{
             type: Component,
             args: [{
                     selector: 'main',
-                    template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>',
+                    template: `
+    <FancyButton
+      class="btn-cls"
+      unsafe-attr="value"
+      [label]="title"
+      [unsafe-input]="title"
+    />
+  `,
                     // @ts-ignore: @angular/core does not expose the `foreignImports` property.
                     foreignImports: [
                         // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/TEST_CASES.json
@@ -3,106 +3,85 @@
   "cases": [
     {
       "description": "should properly compile a standalone component",
-      "inputFiles": [
-        "component.ts"
-      ],
+      "inputFiles": ["component.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "component.js"
-          ]
+          "files": ["component.js"]
         }
       ],
-      "compilationModeFilter": [
-        "full compile",
-        "local compile",
-        "declaration-only emit"
-      ]
+      "compilationModeFilter": ["full compile", "local compile", "declaration-only emit"]
     },
     {
       "description": "should properly compile a standalone directive",
-      "inputFiles": [
-        "directive.ts"
-      ],
+      "inputFiles": ["directive.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid directive definition",
-          "files": [
-            "directive.js"
-          ]
+          "files": ["directive.js"]
         }
       ]
     },
     {
       "description": "should properly compile a standalone pipe",
-      "inputFiles": [
-        "pipe.ts"
-      ],
+      "inputFiles": ["pipe.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid pipe definition",
-          "files": [
-            "pipe.js"
-          ]
+          "files": ["pipe.js"]
         }
       ]
     },
     {
       "description": "should generate dependencies array from imports",
-      "inputFiles": [
-        "imports.ts"
-      ],
+      "inputFiles": ["imports.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid standalone component dependencies",
-          "files": [
-            "imports.js"
-          ]
+          "files": ["imports.js"]
         }
       ]
     },
     {
       "description": "should support recursivity in templates",
-      "inputFiles": [
-        "recursive.ts"
-      ],
+      "inputFiles": ["recursive.ts"],
       "expectations": [
         {
           "failureMessage": "Recursive usage not accounted for",
-          "files": [
-            "recursive.js"
-          ]
+          "files": ["recursive.js"]
         }
       ]
     },
     {
       "description": "should optimize injector imports",
-      "inputFiles": [
-        "module_optimization.ts"
-      ],
+      "inputFiles": ["module_optimization.ts"],
       "expectations": [
         {
           "failureMessage": "Injector imports not optimized",
-          "files": [
-            "module_optimization.js"
-          ]
+          "files": ["module_optimization.js"]
         }
       ]
     },
     {
       "description": "should handle a forwardRef in the imports of a standalone component",
-      "inputFiles": [
-        "forward_ref.ts"
-      ],
+      "inputFiles": ["forward_ref.ts"],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": [
-            "forward_ref.js"
-          ]
+          "files": ["forward_ref.js"]
         }
       ]
+    },
+    {
+      "description": "should properly compile foreign component imports in a standalone component",
+      "inputFiles": ["foreign_component.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid foreign component definition",
+          "files": ["foreign_component.js"]
+        }
+      ],
+      "compilationModeFilter": ["full compile", "local compile"]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -1,0 +1,15 @@
+export class TestCmp {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmp,
+    selectors: [["main"]],
+    decls: 1,
+    vars: 0,
+    template: function TestCmp_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", label: ctx.title });
+      }
+    },
+    encapsulation: 2
+  });
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -7,7 +7,7 @@ export class TestCmp {
     vars: 0,
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", label: ctx.title });
+        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -1,0 +1,15 @@
+export class TestCmp {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmp,
+    selectors: [["main"]],
+    decls: 1,
+    vars: 0,
+    template: function TestCmp_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", label: ctx.title });
+      }
+    },
+    encapsulation: 2
+  });
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -7,7 +7,7 @@ export class TestCmp {
     vars: 0,
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", label: ctx.title });
+        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -9,7 +9,14 @@ function frameworkImport(component: {}): Function {
 
 @Component({
   selector: 'main',
-  template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>',
+  template: `
+    <FancyButton
+      class="btn-cls"
+      unsafe-attr="value"
+      [label]="title"
+      [unsafe-input]="title"
+    />
+  `,
   // @ts-ignore: @angular/core does not expose the `foreignImports` property.
   foreignImports: [
     // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -1,0 +1,21 @@
+import {Component} from '@angular/core';
+
+export function FancyButton() {}
+
+// @angular/core does not expose the `ForeignComponent` type this should return. 
+function frameworkImport(component: {}): Function {
+  return () => {};
+}
+
+@Component({
+  selector: 'main',
+  template: '<FancyButton class="btn-cls" [label]="title"></FancyButton>',
+  // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+  foreignImports: [
+    // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+    frameworkImport(FancyButton)
+  ],
+})
+export class TestCmp {
+  title = 'Submit';
+}

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -360,6 +360,7 @@ export class CompilerFacadeImpl implements CompilerFacade {
       relativeContextFilePath: '',
       i18nUseExternalIds: true,
       relativeTemplatePath: null,
+      foreignImports: null,
     };
     const jitExpressionSourceMap = `ng:///${facade.name}.js`;
     return this.compileComponentFromMeta(angularCoreEnv, jitExpressionSourceMap, meta);
@@ -717,6 +718,7 @@ function convertDeclareComponentFacadeToMetadata(
     relativeTemplatePath: null,
     hasDirectiveDependencies,
     legacyOptionalChaining: decl.legacyOptionalChaining ?? LEGACY_OPTIONAL_CHAINING_DEFAULT,
+    foreignImports: null,
   };
 }
 

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -25,6 +25,8 @@ export class Identifiers {
 
   static elementEnd: o.ExternalReference = {name: 'ɵɵelementEnd', moduleName: CORE};
 
+  static foreignComponent: o.ExternalReference = {name: 'ɵɵforeignComponent', moduleName: CORE};
+
   static domElement: o.ExternalReference = {name: 'ɵɵdomElement', moduleName: CORE};
   static domElementStart: o.ExternalReference = {name: 'ɵɵdomElementStart', moduleName: CORE};
   static domElementEnd: o.ExternalReference = {name: 'ɵɵdomElementEnd', moduleName: CORE};

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -305,6 +305,11 @@ export interface R3ComponentMetadata<
    * not be set. If component has empty array imports then this field is not set.
    */
   rawImports?: o.Expression;
+
+  /**
+   * Foreign components imported by the component.
+   */
+  foreignImports?: R3ForeignComponentMetadata[] | null;
 }
 
 /**
@@ -404,6 +409,21 @@ export interface R3PipeDependencyMetadata extends R3TemplateDependency {
 
 export interface R3NgModuleDependencyMetadata extends R3TemplateDependency {
   kind: R3TemplateDependencyKind.NgModule;
+}
+
+/**
+ * Information about a foreign component that is used in a component template.
+ */
+export interface R3ForeignComponentMetadata {
+  /**
+   * The foreign component's name.
+   */
+  name: string;
+
+  /**
+   * The expression used to refer to this foreign component.
+   */
+  component: o.Expression;
 }
 
 /**

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -309,7 +309,7 @@ export interface R3ComponentMetadata<
   /**
    * Foreign components imported by the component.
    */
-  foreignImports?: R3ForeignComponentMetadata[] | null;
+  foreignImports: R3ForeignComponentMetadata[] | null;
 }
 
 /**

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -216,6 +216,7 @@ export function compileComponentFromMetadata(
     meta.relativeTemplatePath,
     getTemplateSourceLocationsEnabled(),
     meta.legacyOptionalChaining,
+    meta.foreignImports,
   );
 
   // Then the IR is transformed to prepare it for code generation.

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -39,6 +39,11 @@ export enum OpKind {
   Element,
 
   /**
+   * An operation to render a foreign component.
+   */
+  ForeignComponent,
+
+  /**
    * An operation which declares an embedded view.
    */
   Template,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -1266,6 +1266,11 @@ export function transformExpressionsInOp(
     case OpKind.StoreLet:
       op.value = transformExpressionsInExpression(op.value, transform, flags);
       break;
+    case OpKind.ForeignComponent:
+      if (op.props !== null) {
+        op.props = transformExpressionsInExpression(op.props, transform, flags);
+      }
+      break;
     case OpKind.Advance:
     case OpKind.Container:
     case OpKind.ContainerEnd:

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -44,6 +44,7 @@ export type CreateOp =
   | ElementOp
   | ElementStartOp
   | ElementEndOp
+  | ForeignComponentOp
   | ContainerOp
   | ContainerStartOp
   | ContainerEndOp
@@ -232,6 +233,51 @@ export function createElementStartOp(
     i18nPlaceholder,
     startSourceSpan,
     wholeSourceSpan,
+    ...TRAIT_CONSUMES_SLOT,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * Logical operation representing a foreign component in the creation IR.
+ */
+export interface ForeignComponentOp extends Op<CreateOp>, ConsumesSlotOpTrait {
+  kind: OpKind.ForeignComponent;
+
+  /**
+   * The `XrefId` allocated for this foreign component.
+   */
+  xref: XrefId;
+
+  /**
+   * Reference to the foreign component class/function itself as an output AST expression.
+   */
+  foreignComponentRef: o.Expression;
+
+  /**
+   * Static attributes and property bindings aggregated as an object literal.
+   */
+  props: o.Expression | null;
+
+  sourceSpan: ParseSourceSpan | null;
+}
+
+/**
+ * Create a `ForeignComponentOp`.
+ */
+export function createForeignComponentOp(
+  xref: XrefId,
+  foreignComponentRef: o.Expression,
+  props: o.Expression | null,
+  sourceSpan: ParseSourceSpan | null,
+): ForeignComponentOp {
+  return {
+    kind: OpKind.ForeignComponent,
+    xref,
+    handle: new SlotHandle(),
+    foreignComponentRef,
+    props,
+    sourceSpan,
     ...TRAIT_CONSUMES_SLOT,
     ...NEW_OP,
   };

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -90,7 +90,7 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly relativeTemplatePath: string | null,
     readonly enableDebugLocations: boolean,
     legacyOptionalChaining: boolean,
-    readonly foreignImports?: R3ForeignComponentMetadata[] | null,
+    readonly foreignImports: R3ForeignComponentMetadata[] | null,
   ) {
     super(componentName, pool, mode, legacyOptionalChaining);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -7,8 +7,10 @@
  */
 
 import {ConstantPool} from '../../../constant_pool';
+import {SelectorlessMatcher} from '../../../directive_matching';
 import * as o from '../../../output/output_ast';
-import {R3ComponentDeferMetadata} from '../../../render3/view/api';
+import {R3ComponentDeferMetadata, R3ForeignComponentMetadata} from '../../../render3/view/api';
+import * as t from '../../../render3/r3_ast';
 import * as ir from '../ir';
 
 export enum CompilationJobKind {
@@ -75,6 +77,8 @@ export abstract class CompilationJob {
  * embedded views or host bindings.
  */
 export class ComponentCompilationJob extends CompilationJob {
+  private foreignMatcher: SelectorlessMatcher<R3ForeignComponentMetadata> | null;
+
   constructor(
     componentName: string,
     pool: ConstantPool,
@@ -86,10 +90,29 @@ export class ComponentCompilationJob extends CompilationJob {
     readonly relativeTemplatePath: string | null,
     readonly enableDebugLocations: boolean,
     legacyOptionalChaining: boolean,
+    readonly foreignImports?: R3ForeignComponentMetadata[] | null,
   ) {
     super(componentName, pool, mode, legacyOptionalChaining);
     this.root = new ViewCompilationUnit(this, this.allocateXrefId(), null);
     this.views.set(this.root.xref, this.root);
+
+    if (foreignImports && foreignImports.length > 0) {
+      const registry = new Map<string, R3ForeignComponentMetadata[]>();
+      for (const meta of foreignImports) {
+        registry.set(meta.name, [meta]);
+      }
+      this.foreignMatcher = new SelectorlessMatcher(registry);
+    } else {
+      this.foreignMatcher = null;
+    }
+  }
+
+  getForeignComponent(element: t.Element): R3ForeignComponentMetadata | null {
+    if (this.foreignMatcher === null) {
+      return null;
+    }
+    const matches = this.foreignMatcher.match(element.name);
+    return matches.length > 0 ? matches[0] : null;
   }
 
   override kind = CompilationJobKind.Tmpl;

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -309,6 +309,9 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
     }
     const props = propEntries.length > 0 ? o.literalMap(propEntries) : null;
 
+    // Foreign components are created in the creation block. Updates are triggered reactively
+    // through directly passed signal properties, alleviating the need for any explicit update
+    // operations.
     unit.create.push(
       ir.createForeignComponentOp(id, foreignComp.component, props, element.startSourceSpan),
     );

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -14,7 +14,11 @@ import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import * as t from '../../../render3/r3_ast';
-import {DeferBlockDepsEmitMode, R3ComponentDeferMetadata} from '../../../render3/view/api';
+import {
+  DeferBlockDepsEmitMode,
+  R3ComponentDeferMetadata,
+  R3ForeignComponentMetadata,
+} from '../../../render3/view/api';
 import {icuFromI18nMessage} from '../../../render3/view/i18n/util';
 import {DomElementSchemaRegistry} from '../../../schema/dom_element_schema_registry';
 import {BindingParser} from '../../../template_parser/binding_parser';
@@ -65,6 +69,7 @@ export function ingestComponent(
   relativeTemplatePath: string | null,
   enableDebugLocations: boolean,
   legacyOptionalChaining: boolean,
+  foreignImports?: R3ForeignComponentMetadata[] | null,
 ): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
     componentName,
@@ -77,6 +82,7 @@ export function ingestComponent(
     relativeTemplatePath,
     enableDebugLocations,
     legacyOptionalChaining,
+    foreignImports,
   );
   ingestNodes(job.root, template);
   return job;
@@ -283,8 +289,32 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
 
   const id = unit.job.allocateXrefId();
 
-  const [namespaceKey, elementName] = splitNsName(element.name);
+  const foreignComp = unit.job.getForeignComponent(element);
+  if (foreignComp) {
+    const propEntries: {key: string; quoted: boolean; value: o.Expression}[] = [];
+    for (const attr of element.attributes) {
+      propEntries.push({
+        key: attr.name,
+        value: o.literal(attr.value),
+        quoted: false,
+      });
+    }
+    for (const input of element.inputs) {
+      propEntries.push({
+        key: input.name,
+        value: convertAst(input.value, unit.job, input.sourceSpan),
+        quoted: false,
+      });
+    }
+    const props = propEntries.length > 0 ? o.literalMap(propEntries) : null;
 
+    unit.create.push(
+      ir.createForeignComponentOp(id, foreignComp.component, props, element.startSourceSpan),
+    );
+    return;
+  }
+
+  const [namespaceKey, elementName] = splitNsName(element.name);
   const startOp = ir.createElementStartOp(
     elementName,
     id,

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -14,6 +14,7 @@ import {splitNsName} from '../../../ml_parser/tags';
 import * as o from '../../../output/output_ast';
 import {ParseSourceSpan} from '../../../parse_util';
 import * as t from '../../../render3/r3_ast';
+import {isUnsafeObjectKey} from '../../../render3/util';
 import {
   DeferBlockDepsEmitMode,
   R3ComponentDeferMetadata,
@@ -296,14 +297,14 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
       propEntries.push({
         key: attr.name,
         value: o.literal(attr.value),
-        quoted: false,
+        quoted: isUnsafeObjectKey(attr.name),
       });
     }
     for (const input of element.inputs) {
       propEntries.push({
         key: input.name,
         value: convertAst(input.value, unit.job, input.sourceSpan),
-        quoted: false,
+        quoted: isUnsafeObjectKey(input.name),
       });
     }
     const props = propEntries.length > 0 ? o.literalMap(propEntries) : null;

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -70,7 +70,7 @@ export function ingestComponent(
   relativeTemplatePath: string | null,
   enableDebugLocations: boolean,
   legacyOptionalChaining: boolean,
-  foreignImports?: R3ForeignComponentMetadata[] | null,
+  foreignImports: R3ForeignComponentMetadata[] | null,
 ): ComponentCompilationJob {
   const job = new ComponentCompilationJob(
     componentName,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -49,6 +49,19 @@ export function elementStart(
   );
 }
 
+export function foreignComponent(
+  slot: number,
+  foreignComponentRef: o.Expression,
+  props: o.Expression | null,
+  sourceSpan: ParseSourceSpan | null,
+): ir.CreateOp {
+  const args = [o.literal(slot), foreignComponentRef];
+  if (props !== null) {
+    args.push(props);
+  }
+  return call(Identifiers.foreignComponent, args, sourceSpan);
+}
+
 function elementOrContainerBase(
   instruction: o.ExternalReference,
   slot: number,

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -142,6 +142,12 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
               ),
         );
         break;
+      case ir.OpKind.ForeignComponent:
+        ir.OpList.replace(
+          op,
+          ng.foreignComponent(op.handle.slot!, op.foreignComponentRef, op.props, op.sourceSpan),
+        );
+        break;
       case ir.OpKind.ElementEnd:
         ir.OpList.replace(
           op,

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -150,6 +150,7 @@ export {
   ɵɵelementContainerStart,
   ɵɵelementEnd,
   ɵɵelementStart,
+  ɵɵforeignComponent,
   ɵɵenableBindings,
   ɵɵExternalStylesFeature,
   ɵɵFactoryDeclaration,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -83,6 +83,7 @@ export {
   ɵɵelementContainerStart,
   ɵɵelementEnd,
   ɵɵelementStart,
+  ɵɵforeignComponent,
   ɵɵgetCurrentView,
   ɵɵdomProperty,
   ɵɵinjectAttribute,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -38,6 +38,7 @@ export * from './di';
 export * from './di_attr';
 export * from './element';
 export * from './element_container';
+export * from './foreign_component';
 export {
   ɵgetUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode,

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ForeignComponent} from '../../interface/foreign_component';
+
+/**
+ * Creation phase instruction to render a foreign component.
+ *
+ * @param index The index of the container in the data array.
+ * @param foreignComponent The matched foreign component.
+ * @param props Aggregate properties and static attributes.
+ * @codeGenApi
+ */
+export function ɵɵforeignComponent<TProps>(
+  index: number,
+  foreignComponent: ForeignComponent,
+  props: TProps,
+): void {
+  // No-op for now!
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -55,6 +55,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵelementStart': r3.ɵɵelementStart,
   'ɵɵelementEnd': r3.ɵɵelementEnd,
   'ɵɵelement': r3.ɵɵelement,
+  'ɵɵforeignComponent': r3.ɵɵforeignComponent,
   'ɵɵelementContainerStart': r3.ɵɵelementContainerStart,
   'ɵɵelementContainerEnd': r3.ɵɵelementContainerEnd,
   'ɵɵdomElement': r3.ɵɵdomElement,

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -17,6 +17,7 @@ import {
   ɵɵproperty,
   ɵɵstyleMap,
   ɵɵstyleProp,
+  ɵɵforeignComponent,
 } from '../../src/render3/index';
 import {AttributeMarker} from '../../src/render3/interfaces/attribute_marker';
 import {


### PR DESCRIPTION
When a template element matches an imported foreign component, the compiler omits standard element instructions (`ɵɵelementStart`/`ɵɵelement`) and instead generates a single `ɵɵforeignComponent` call. The call passes the exact foreign import wrapper expression defined in `@Component.foreignImports` along with an aggregated object literal containing all static attributes and property bindings.

The instruction itself is currently a no-op.