### PR TITLE
test(upgrade): exclude unit test files from E2E application sources

### DIFF
--- a/packages/examples/upgrade/static/ts/full/BUILD.bazel
+++ b/packages/examples/upgrade/static/ts/full/BUILD.bazel
@@ -6,7 +6,10 @@ create_upgrade_example_targets(
     name = "full",
     srcs = glob(
         ["**/*.ts"],
-        exclude = ["**/*_spec.ts"],
+        exclude = [
+            "**/*_spec.ts",
+            "**/*.spec.ts",
+        ],
     ),
     assets = ["styles.css"],
     e2e_srcs = glob(["e2e_test/*_spec.ts"]),


### PR DESCRIPTION
Exclude `**/*.spec.ts` files from the `srcs` glob of the `full_sources` target.

Previously, `module.spec.ts` was compiled as part of the application's main sources because the glob pattern only excluded `**/*_spec.ts` (E2E specs). Consequently, `module.spec.js` was generated and included in the runfiles of the E2E test target, causing the Protractor runner to load and execute it. This failed since the E2E testing runner does not have access to unit testing imports like `@angular/core/testing`.
