### PR TITLE
docs(compiler): add typeCheckHostBindings option to angular compiler options

### DIFF
--- a/adev/src/content/reference/configs/angular-compiler-options.md
+++ b/adev/src/content/reference/configs/angular-compiler-options.md
@@ -213,6 +213,11 @@ When `true`, reports an error if a component, directive, or pipe is not standalo
 When `true`, prints extra information while compiling templates.
 Default is `false`.
 
+### `typeCheckHostBindings`
+
+When `true`, enables type checking of expressions in the `host` object literal and `@HostBinding`/`@HostListener` decorators of components and directives.
+Default is `true`.
+
 ## Command line options
 
 Most of the time, you interact with the Angular Compiler indirectly using [Angular CLI](reference/configs/angular-compiler-options). When debugging certain issues, you might find it useful to invoke the Angular Compiler directly.


### PR DESCRIPTION
## Summary

Adds reference documentation for the `typeCheckHostBindings` Angular compiler option, which is currently missing from `angular-compiler-options.md`.

- The option already exists in the compiler (introduced in #60267, enabled by default in #63654) but was never documented in the public reference.
- Defined at `packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts`.
- Default: `true` (since v21).

## Test plan

- [x] Markdown-only change; no code paths affected.
- [x] Formatting and tone match adjacent entries (`trace`, `strictStandalone`).