### PR TITLE
fix(core): accept `static` option in ContentChildren and ViewChildren typings

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -418,12 +418,14 @@ export interface ContentChildrenDecorator {
         descendants?: boolean;
         emitDistinctChangesOnly?: boolean;
         read?: any;
+        static?: boolean;
     }): any;
     // (undocumented)
     new (selector: ProviderToken<unknown> | Function | string, opts?: {
         descendants?: boolean;
         emitDistinctChangesOnly?: boolean;
         read?: any;
+        static?: boolean;
     }): Query;
 }
 
@@ -2075,11 +2077,13 @@ export interface ViewChildrenDecorator {
     (selector: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
+        static?: boolean;
     }): any;
     // (undocumented)
     new (selector: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
+        static?: boolean;
     }): ViewChildren;
 }
 

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -126,6 +126,8 @@ export interface ContentChildrenDecorator {
    *   ** Note: *** This config option is **deprecated**, it will be permanently set to `true` and
    *   removed in future versions of Angular.
    * * **read** - Used to read a different token from the queried elements.
+   * * **static** - True to resolve query results before change detection runs,
+   * false to resolve after change detection. Defaults to false.
    *
    * The following selectors are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
@@ -170,11 +172,17 @@ export interface ContentChildrenDecorator {
       descendants?: boolean;
       emitDistinctChangesOnly?: boolean;
       read?: any;
+      static?: boolean;
     },
   ): any;
   new (
     selector: ProviderToken<unknown> | Function | string,
-    opts?: {descendants?: boolean; emitDistinctChangesOnly?: boolean; read?: any},
+    opts?: {
+      descendants?: boolean;
+      emitDistinctChangesOnly?: boolean;
+      read?: any;
+      static?: boolean;
+    },
   ): Query;
 }
 
@@ -337,6 +345,8 @@ export interface ViewChildrenDecorator {
    *   if the QueryList has not changed.
    *   ** Note: *** This config option is **deprecated**, it will be permanently set to `true` and
    * removed in future versions of Angular.
+   * * **static** - True to resolve query results before change detection runs,
+   * false to resolve after change detection. Defaults to false.
    *
    * The following selectors are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
@@ -372,11 +382,11 @@ export interface ViewChildrenDecorator {
    */
   (
     selector: ProviderToken<unknown> | Function | string,
-    opts?: {read?: any; emitDistinctChangesOnly?: boolean},
+    opts?: {read?: any; emitDistinctChangesOnly?: boolean; static?: boolean},
   ): any;
   new (
     selector: ProviderToken<unknown> | Function | string,
-    opts?: {read?: any; emitDistinctChangesOnly?: boolean},
+    opts?: {read?: any; emitDistinctChangesOnly?: boolean; static?: boolean},
   ): ViewChildren;
 }
 

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -676,6 +676,49 @@ describe('query logic', () => {
       expect(secondComponent.setEvents).toEqual(['textDir set', 'foo set']);
     });
 
+    // Regression test for https://github.com/angular/angular/issues/36876.
+    // The `static` option has always been accepted at runtime by the
+    // `ContentChildren` / `ViewChildren` decorator factories, but the
+    // TypeScript decorator typings used to reject it. This test ensures the
+    // option is accepted by the type-checker and still produces a usable
+    // `QueryList` at runtime.
+    it('should accept the `static` option on `ContentChildren` and `ViewChildren`', () => {
+      @Component({
+        selector: 'static-children-host',
+        template: '<ng-content></ng-content>',
+        standalone: false,
+      })
+      class StaticChildrenHost {
+        @ContentChildren('foo', {static: true}) contentFoos!: QueryList<ElementRef>;
+        @ContentChild('foo', {static: true}) contentFoo!: ElementRef;
+      }
+
+      @Component({
+        template: `
+          <static-children-host>
+            <div #foo></div>
+            <div #foo></div>
+          </static-children-host>
+        `,
+        standalone: false,
+      })
+      class App {
+        @ViewChildren(StaticChildrenHost, {static: true})
+        viewHosts!: QueryList<StaticChildrenHost>;
+        @ViewChild(StaticChildrenHost, {static: true}) viewHost!: StaticChildrenHost;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, StaticChildrenHost]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.viewHost).toBeInstanceOf(StaticChildrenHost);
+      expect(fixture.componentInstance.viewHosts.length).toBe(1);
+      expect(fixture.componentInstance.viewHost.contentFoos).toBeInstanceOf(QueryList);
+      expect(fixture.componentInstance.viewHost.contentFoos.length).toBe(2);
+      expect(fixture.componentInstance.viewHost.contentFoo).toBeInstanceOf(ElementRef);
+    });
+
     it('should support ContentChild query inherited from undecorated superclasses', () => {
       class MyComp {
         @ContentChild('foo') foo: any;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`@ContentChildren` and `@ViewChildren` decorator factories accept and forward
`{ static: true }` to the underlying query metadata at runtime (`...opts` is
spread into the metadata object), but the TypeScript decorator option typings
omit `static`. As a result, the following compiles with `ViewChild` /
`ContentChild` but fails type-checking with `ContentChildren` / `ViewChildren`:

```ts
@ContentChildren('foo', { static: true }) foos!: QueryList<ElementRef>;
//                       ^^^^^^^^^^^^^^ rejected by TS even though it works
```

Issue Number: #36876

## What is the new behavior?

`static?: boolean` is added to the option bag of `ContentChildrenDecorator`
and `ViewChildrenDecorator` (both call and `new` signatures), matching the
existing `static?: boolean` on `ContentChild` / `ViewChild`. The JSDoc on
both interfaces gains a `**static**` bullet using the same wording as the
existing entry on `ViewChild`. The public-API golden is updated in lockstep.

A regression test in `packages/core/test/acceptance/query_spec.ts` instantiates
a component using `{ static: true }` on every one of the four decorators and
asserts both that it type-checks and that the query resolves correctly at
runtime.

`ContentChild` already had this option, so its typings are untouched.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`static` was already accepted at runtime — the typing change only relaxes the
type-checker to match runtime behavior. No existing code is invalidated.

## Other information

Public-API golden was updated to reflect the new optional `static` field.