### PR TITLE
fix(compiler): allow slashes inside unquoted attribute values

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -1051,7 +1051,12 @@ class _Tokenizer {
       );
       this._consumeQuote(quoteChar);
     } else {
-      const endPredicate = () => isNameEnd(this._cursor.peek());
+      // Per the HTML spec, an unquoted attribute value is terminated by ASCII
+      // whitespace, `"`, `'`, `=`, `<`, `>` or EOF. Notably, `/` is _not_ a
+      // terminator: e.g. `<a href=https://example.com>` and
+      // `<img src=path/to/foo.png>` are both valid (see
+      // https://html.spec.whatwg.org/#unquoted).
+      const endPredicate = () => isUnquotedAttrValueEnd(this._cursor.peek());
       this._consumeWithInterpolation(
         TokenType.ATTR_VALUE_TEXT,
         TokenType.ATTR_VALUE_INTERPOLATION,
@@ -1447,6 +1452,24 @@ function isNameEnd(code: number): boolean {
     code === chars.$GT ||
     code === chars.$LT ||
     code === chars.$SLASH ||
+    code === chars.$SQ ||
+    code === chars.$DQ ||
+    code === chars.$EQ ||
+    code === chars.$EOF
+  );
+}
+
+/**
+ * Predicate for the end of an unquoted attribute value. Mirrors `isNameEnd` but
+ * does _not_ include `/`, since the HTML spec allows `/` inside unquoted
+ * attribute values (e.g. `href=https://example.com` or `src=path/to/foo.png`).
+ * See https://html.spec.whatwg.org/#unquoted.
+ */
+function isUnquotedAttrValueEnd(code: number): boolean {
+  return (
+    chars.isWhitespace(code) ||
+    code === chars.$GT ||
+    code === chars.$LT ||
     code === chars.$SQ ||
     code === chars.$DQ ||
     code === chars.$EQ ||

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -324,6 +324,22 @@ describe('HtmlParser', () => {
         ]);
       });
 
+      it('should parse unquoted attribute values containing slashes', () => {
+        // Regression test for https://github.com/angular/angular/issues/36932.
+        // Per the HTML spec, `/` is allowed inside unquoted attribute values.
+        expect(
+          humanizeDom(parser.parse('<a href=https://example.com>Link</a>', 'TestComp')),
+        ).toEqual([
+          [html.Element, 'a', 0],
+          [html.Attribute, 'href', 'https://example.com', ['https://example.com']],
+          [html.Text, 'Link', 1, ['Link']],
+        ]);
+        expect(humanizeDom(parser.parse('<img src=path/to/foo.png>', 'TestComp'))).toEqual([
+          [html.Element, 'img', 0],
+          [html.Attribute, 'src', 'path/to/foo.png', ['path/to/foo.png']],
+        ]);
+      });
+
       it('should parse bound inputs with expressions containing newlines', () => {
         expect(
           humanizeDom(

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -1822,6 +1822,55 @@ describe('HtmlLexer', () => {
       ]);
     });
 
+    it('should parse attributes with unquoted value containing slashes (URL)', () => {
+      // Regression test for https://github.com/angular/angular/issues/36932.
+      // Per the HTML spec, `/` is allowed inside unquoted attribute values.
+      expect(tokenizeAndHumanizeParts('<a href=https://example.com>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'a'],
+        [TokenType.ATTR_NAME, '', 'href'],
+        [TokenType.ATTR_VALUE_TEXT, 'https://example.com'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should parse attributes with unquoted value containing slashes (path)', () => {
+      // Regression test for https://github.com/angular/angular/issues/36932.
+      expect(tokenizeAndHumanizeParts('<img src=path/to/foo.png>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'img'],
+        [TokenType.ATTR_NAME, '', 'src'],
+        [TokenType.ATTR_VALUE_TEXT, 'path/to/foo.png'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should still treat `<br/>` as a self-closing tag', () => {
+      // Regression-of-regression: ensure the self-closing slash is still
+      // handled at the tag-end state for tags without attributes.
+      expect(tokenizeAndHumanizeParts('<br/>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'br'],
+        [TokenType.TAG_OPEN_END_VOID],
+        [TokenType.EOF],
+      ]);
+    });
+
+    it('should consume trailing `/` as part of an unquoted attribute value per the HTML spec', () => {
+      // Regression test for https://github.com/angular/angular/issues/36932.
+      // Per https://html.spec.whatwg.org/#unquoted, the only characters that
+      // terminate an unquoted attribute value are whitespace, `"`, `'`, `=`,
+      // `<`, `>` and `` ` ``. A trailing `/` is therefore part of the value,
+      // so `<input type=text/>` has attribute `type="text/"` and is not a
+      // self-closing tag.
+      expect(tokenizeAndHumanizeParts('<input type=text/>')).toEqual([
+        [TokenType.TAG_OPEN_START, '', 'input'],
+        [TokenType.ATTR_NAME, '', 'type'],
+        [TokenType.ATTR_VALUE_TEXT, 'text/'],
+        [TokenType.TAG_OPEN_END],
+        [TokenType.EOF],
+      ]);
+    });
+
     it('should parse bound inputs with expressions containing newlines', () => {
       expect(
         tokenizeAndHumanizeParts(`<app-component


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Angular's HTML lexer rejects unquoted attribute values that contain a `/`,
even though the HTML spec allows them. For example:

```html
<a href=https://example.com>...</a>
<img src=path/to/foo.png>
```

both fail with an "unexpected character" / "tag opening" parse error,
because the lexer reuses the attribute-name terminator predicate
(`isNameEnd`) for the unquoted attribute-value state, and that predicate
treats `/` as a terminator so that `<br/>` is correctly tokenised.

Issue Number: #36932

## What is the new behavior?

A new predicate `isUnquotedAttrValueEnd` is introduced — identical to
`isNameEnd` minus `$SLASH` — and is used only in the unquoted
attribute-value branch of `_consumeAttribute`. The attribute-name state
still uses the original `isNameEnd`, so self-closing tags like `<br/>`,
`<my-comp/>`, and `<input checked/>` continue to lex as self-closing.

Spec-compliant cases now lex correctly:

```html
<a href=https://example.com>...</a>   <!-- href = "https://example.com" -->
<img src=path/to/foo.png>             <!-- src  = "path/to/foo.png"     -->
```

### Behaviour change to call out

Because `/` is no longer a terminator in the unquoted attribute-value
state, an unquoted value immediately followed by `/>` is now consumed
into the value (matching the HTML spec):

| Input | Before | After |
| --- | --- | --- |
| `<input type=text/>` | attribute `type="text"` + self-closing tag | attribute `type="text/"` + non-self-closing tag |

Authors who relied on the old behaviour should switch to a quoted value
or insert a space:

```html
<input type="text"/>   <!-- unchanged -->
<input type=text />    <!-- unchanged -->
```

Self-closing forms that don't have an immediately-preceding unquoted
attribute value are not affected (`<br/>`, `<my-comp/>`,
`<my-comp prop="x"/>`, `<my-comp prop='x'/>`).

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

`<tag attr=value/>` (unquoted value followed by `/>`) now parses the `/`
as part of the value, where it previously closed the tag. The fix is
mandated by [the HTML spec](https://html.spec.whatwg.org/#unquoted) and
unblocks the bug reported in #36932. Users can migrate by quoting the
value or inserting a space before `/>`.

## Other information

Tests:

- 4 lexer regression tests in `packages/compiler/test/ml_parser/lexer_spec.ts`:
  URL value, path value, `<br/>` regression-of-regression, and the
  spec-conformant `<input type=text/>` → `type="text/"` case.
- 1 integration test in `packages/compiler/test/ml_parser/html_parser_spec.ts`
  verifying both the URL and path examples round-trip through the full
  HTML parser.