### PR TITLE
docs: modernize multiselect guide and standalone examples

### DIFF
--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.css
@@ -1,0 +1,160 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: color-mix(in srgb, var(--hot-pink) 90%, var(--primary-contrast));
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--hot-pink) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 2.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--hot-pink) 15%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1.5rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 0.5rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  margin: 1px;
+  padding: 0 1rem;
+  min-height: 2.25rem;
+  border-radius: 0.5rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
@@ -1,0 +1,53 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
@@ -48,12 +48,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/app/app.ts
@@ -1,0 +1,71 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.css
@@ -1,0 +1,168 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+  --primary: var(--hot-pink);
+  --on-primary: var(--page-background);
+}
+
+.docs-light-mode {
+  --on-primary: #fff;
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  border-radius: 3rem;
+  color: var(--on-primary);
+  background-color: var(--primary);
+  border: 1px solid color-mix(in srgb, var(--primary) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 3rem;
+  padding: 0 2.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--primary) 90%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1.5rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 2rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 13rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  padding: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  min-height: 3rem;
+  border-radius: 3rem;
+  outline: none;
+}
+
+[ngOption]:hover,
+[ngOption][data-active='true'] {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid var(--primary);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
@@ -1,0 +1,53 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
@@ -48,12 +48,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/material/app/app.ts
@@ -1,0 +1,71 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="basic-material"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css
@@ -1,0 +1,194 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-size: 0.8rem;
+
+  font-family: 'Press Start 2P';
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
+  --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
+  --retro-elevated-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-flat-shadow:
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-clickable-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
+  --retro-pressed-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-dark),
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: var(--page-background);
+  background-color: var(--hot-pink);
+  box-shadow: var(--retro-clickable-shadow);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 4.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 22rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover,
+.select:focus,
+.select:focus-within {
+  transform: translate(1px, 1px);
+}
+
+.select:active {
+  transform: translate(4px, 4px);
+  box-shadow: var(--retro-pressed-shadow);
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.selected-label-icon {
+  font-size: 1.25rem;
+}
+
+.select[aria-expanded='false']:focus,
+.select[aria-expanded='false']:focus-within {
+  outline-offset: 8px;
+  outline: 4px dashed var(--hot-pink);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 20px;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--septenary-contrast);
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  font-size: 0.6rem;
+  min-height: 2.25rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px dashed var(--hot-pink);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
@@ -1,0 +1,53 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
@@ -48,12 +48,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
@@ -1,0 +1,71 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="basic-retro"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.css
@@ -1,0 +1,164 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: color-mix(in srgb, var(--hot-pink) 90%, var(--primary-contrast));
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--hot-pink) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 3.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--hot-pink) 15%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.selected-label-icon {
+  font-size: 1.25rem;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 0.5rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  margin: 1px;
+  padding: 0 1rem;
+  min-height: 2.25rem;
+  border-radius: 0.5rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
@@ -1,0 +1,56 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-icon material-symbols-outlined" translate="no" aria-hidden="true">{{
+      displayIcon()
+    }}</span>
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.html
@@ -18,10 +18,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
@@ -50,19 +50,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
@@ -55,12 +55,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/app/app.ts
@@ -1,0 +1,78 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="icons-basic"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The icon that is displayed in the combobox. */
+  readonly displayIcon = computed(() => {
+    const values = this.selectedValues();
+    const label = this.labels.find((label) => label.value === values[0]);
+    return label ? label.icon : '';
+  });
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.css
@@ -1,0 +1,172 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+  --primary: var(--hot-pink);
+  --on-primary: var(--page-background);
+}
+
+.docs-light-mode {
+  --on-primary: #fff;
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  border-radius: 3rem;
+  color: var(--on-primary);
+  background-color: var(--primary);
+  border: 1px solid color-mix(in srgb, var(--primary) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 3rem;
+  padding: 0 3.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--primary) 90%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.selected-label-icon {
+  font-size: 1.25rem;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 2rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 13rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  padding: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  min-height: 3rem;
+  border-radius: 3rem;
+  outline: none;
+}
+
+[ngOption]:hover,
+[ngOption][data-active='true'] {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid var(--primary);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
@@ -1,0 +1,56 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-icon material-symbols-outlined" translate="no" aria-hidden="true">{{
+      displayIcon()
+    }}</span>
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.html
@@ -18,10 +18,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
@@ -50,19 +50,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
@@ -1,0 +1,78 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="icons-material"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The icon that is displayed in the combobox. */
+  readonly displayIcon = computed(() => {
+    const values = this.selectedValues();
+    const label = this.labels.find((label) => label.value === values[0]);
+    return label ? label.icon : '';
+  });
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/material/app/app.ts
@@ -55,12 +55,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css
@@ -1,0 +1,194 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-size: 0.8rem;
+
+  font-family: 'Press Start 2P';
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
+  --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
+  --retro-elevated-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-flat-shadow:
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-clickable-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
+  --retro-pressed-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-dark),
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: var(--page-background);
+  background-color: var(--hot-pink);
+  box-shadow: var(--retro-clickable-shadow);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 4.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 22rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover,
+.select:focus,
+.select:focus-within {
+  transform: translate(1px, 1px);
+}
+
+.select:active {
+  transform: translate(4px, 4px);
+  box-shadow: var(--retro-pressed-shadow);
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.selected-label-icon {
+  font-size: 1.25rem;
+}
+
+.select[aria-expanded='false']:focus,
+.select[aria-expanded='false']:focus-within {
+  outline-offset: 8px;
+  outline: 4px dashed var(--hot-pink);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 20px;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--septenary-contrast);
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  font-size: 0.6rem;
+  min-height: 2.25rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px dashed var(--hot-pink);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
@@ -1,0 +1,56 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-icon material-symbols-outlined" translate="no" aria-hidden="true">{{
+      displayIcon()
+    }}</span>
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value">
+            <span
+              class="example-option-icon material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >{{ label.icon }}</span
+            >
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.html
@@ -18,10 +18,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
@@ -50,19 +50,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
@@ -55,12 +55,5 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 }

--- a/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.ts
@@ -1,0 +1,78 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="icons-retro"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The icon that is displayed in the combobox. */
+  readonly displayIcon = computed(() => {
+    const values = this.selectedValues();
+    const label = this.labels.find((label) => label.value === values[0]);
+    return label ? label.icon : '';
+  });
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select a label';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} + ${values.length - 1} more`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', icon: 'label'},
+    {value: 'Starred', icon: 'star'},
+    {value: 'Work', icon: 'work'},
+    {value: 'Personal', icon: 'person'},
+    {value: 'To Do', icon: 'checklist'},
+    {value: 'Later', icon: 'schedule'},
+    {value: 'Read', icon: 'menu_book'},
+    {value: 'Travel', icon: 'flight'},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.css
@@ -1,0 +1,163 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: color-mix(in srgb, var(--hot-pink) 90%, var(--primary-contrast));
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+  border-radius: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--hot-pink) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 2.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--hot-pink) 15%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1.5rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 0.5rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  margin: 1px;
+  padding: 0 1rem;
+  min-height: 2.25rem;
+  border-radius: 0.5rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid color-mix(in srgb, var(--hot-pink) 50%, transparent);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+[ngOption][aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+[ngOption][aria-disabled='true']:hover {
+  background-color: transparent;
+}
+
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
@@ -1,0 +1,47 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
@@ -48,13 +48,6 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 
   isOptionDisabled(value: string) {

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
@@ -1,0 +1,79 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="limited-basic"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select 2 labels';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} & ${values[1]}`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', disabled: computed(() => this.isOptionDisabled('Important'))},
+    {value: 'Starred', disabled: computed(() => this.isOptionDisabled('Starred'))},
+    {value: 'Work', disabled: computed(() => this.isOptionDisabled('Work'))},
+    {value: 'Personal', disabled: computed(() => this.isOptionDisabled('Personal'))},
+    {value: 'To Do', disabled: computed(() => this.isOptionDisabled('To Do'))},
+    {value: 'Later', disabled: computed(() => this.isOptionDisabled('Later'))},
+    {value: 'Read', disabled: computed(() => this.isOptionDisabled('Read'))},
+    {value: 'Travel', disabled: computed(() => this.isOptionDisabled('Travel'))},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+
+  isOptionDisabled(value: string) {
+    const values = this.selectedValues();
+    if (!values || values.length < 2) {
+      return false;
+    }
+    return !values.includes(value);
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.css
@@ -1,0 +1,171 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-family: var(--inter-font);
+  --primary: var(--hot-pink);
+  --on-primary: var(--page-background);
+}
+
+.docs-light-mode {
+  --on-primary: #fff;
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  border-radius: 3rem;
+  color: var(--on-primary);
+  background-color: var(--primary);
+  border: 1px solid color-mix(in srgb, var(--primary) 80%, transparent);
+  /* Modernized additions for div-trigger Select: */
+  height: 3rem;
+  padding: 0 2.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 16rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover {
+  background-color: color-mix(in srgb, var(--primary) 90%, transparent);
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.select:focus,
+.select:focus-within {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1.5rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 8px;
+  border-radius: 2rem;
+  background-color: var(--septenary-contrast);
+  font-size: 0.9rem;
+  max-height: 13rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 13rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  padding: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  min-height: 3rem;
+  border-radius: 3rem;
+  outline: none;
+}
+
+[ngOption]:hover,
+[ngOption][data-active='true'] {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px solid var(--primary);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+[ngOption][aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+[ngOption][aria-disabled='true']:hover {
+  background-color: transparent;
+}
+
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
@@ -1,0 +1,47 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
@@ -48,13 +48,6 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 
   isOptionDisabled(value: string) {

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
@@ -1,0 +1,79 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="limited-material"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select 2 labels';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} & ${values[1]}`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', disabled: computed(() => this.isOptionDisabled('Important'))},
+    {value: 'Starred', disabled: computed(() => this.isOptionDisabled('Starred'))},
+    {value: 'Work', disabled: computed(() => this.isOptionDisabled('Work'))},
+    {value: 'Personal', disabled: computed(() => this.isOptionDisabled('Personal'))},
+    {value: 'To Do', disabled: computed(() => this.isOptionDisabled('To Do'))},
+    {value: 'Later', disabled: computed(() => this.isOptionDisabled('Later'))},
+    {value: 'Read', disabled: computed(() => this.isOptionDisabled('Read'))},
+    {value: 'Travel', disabled: computed(() => this.isOptionDisabled('Travel'))},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+
+  isOptionDisabled(value: string) {
+    const values = this.selectedValues();
+    if (!values || values.length < 2) {
+      return false;
+    }
+    return !values.includes(value);
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/material/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css
@@ -1,0 +1,203 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Symbols+Outlined');
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+:host {
+  display: flex;
+  justify-content: center;
+  font-size: 0.8rem;
+
+  font-family: 'Press Start 2P';
+  --retro-button-color: color-mix(in srgb, var(--hot-pink) 80%, var(--page-background));
+  --retro-shadow-light: color-mix(in srgb, var(--retro-button-color) 90%, #fff);
+  --retro-shadow-dark: color-mix(in srgb, var(--retro-button-color) 90%, #000);
+  --retro-elevated-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-flat-shadow:
+    4px 0px 0px 0px var(--tertiary-contrast), 0px 4px 0px 0px var(--tertiary-contrast),
+    -4px 0px 0px 0px var(--tertiary-contrast), 0px -4px 0px 0px var(--tertiary-contrast);
+  --retro-clickable-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-light),
+    inset -4px -4px 0px 0px var(--retro-shadow-dark), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 8px 8px 0px 0px var(--tertiary-contrast);
+  --retro-pressed-shadow:
+    inset 4px 4px 0px 0px var(--retro-shadow-dark),
+    inset -4px -4px 0px 0px var(--retro-shadow-light), 4px 0px 0px 0px var(--tertiary-contrast),
+    0px 4px 0px 0px var(--tertiary-contrast), -4px 0px 0px 0px var(--tertiary-contrast),
+    0px -4px 0px 0px var(--tertiary-contrast), 0px 0px 0px 0px var(--tertiary-contrast);
+}
+
+.select {
+  display: flex;
+  position: relative;
+  align-items: center;
+  color: var(--page-background);
+  background-color: var(--hot-pink);
+  box-shadow: var(--retro-clickable-shadow);
+  /* Modernized additions for div-trigger Select: */
+  height: 2.5rem;
+  padding: 0 4.5rem;
+  cursor: pointer;
+  box-sizing: border-box;
+  width: 22rem;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
+}
+
+.select span {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.select:hover,
+.select:focus,
+.select:focus-within {
+  transform: translate(1px, 1px);
+}
+
+.select:active {
+  transform: translate(4px, 4px);
+  box-shadow: var(--retro-pressed-shadow);
+  background-color: color-mix(in srgb, var(--retro-button-color) 60%, var(--gray-50));
+}
+
+.select[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.selected-label-icon {
+  font-size: 1.25rem;
+}
+
+.select[aria-expanded='false']:focus,
+.select[aria-expanded='false']:focus-within {
+  outline-offset: 8px;
+  outline: 4px dashed var(--hot-pink);
+}
+
+.combobox-label {
+  gap: 1rem;
+  left: 1rem;
+  display: flex;
+  position: absolute;
+  align-items: center;
+  pointer-events: none;
+}
+
+.example-arrow {
+  right: 1rem;
+  position: absolute;
+  pointer-events: none;
+  transition: transform 150ms ease-in-out;
+}
+
+.select[aria-expanded='true'] .example-arrow {
+  transform: rotate(180deg);
+}
+
+.example-popup-container {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 20px;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--septenary-contrast);
+  max-height: 11rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  animation: smoothPopupOpen 150ms ease-out forwards;
+  transform-origin: top;
+}
+
+@keyframes smoothPopupOpen {
+  0% {
+    max-height: 0;
+    opacity: 0;
+  }
+  16.7% {
+    opacity: 1;
+  }
+  100% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+}
+
+.example-popup-container.closing {
+  animation: smoothPopupClose 150ms ease-in forwards;
+}
+
+@keyframes smoothPopupClose {
+  0% {
+    max-height: 11rem;
+    opacity: 1;
+  }
+  100% {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+[ngListbox] {
+  gap: 2px;
+  height: 100%;
+  display: flex;
+  overflow: auto;
+  flex-direction: column;
+  outline: none;
+}
+
+[ngOption] {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  padding: 0 1rem;
+  font-size: 0.6rem;
+  min-height: 2.25rem;
+  outline: none;
+}
+
+[ngOption]:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+[ngOption][data-active='true'] {
+  outline-offset: -2px;
+  outline: 2px dashed var(--hot-pink);
+}
+
+[ngOption][aria-selected='true'] {
+  color: var(--hot-pink);
+  background-color: color-mix(in srgb, var(--hot-pink) 5%, transparent);
+}
+
+.example-option-icon {
+  font-size: 1.25rem;
+  padding-right: 1rem;
+}
+
+[ngOption]:not([aria-selected='true']) .example-option-check {
+  display: none;
+}
+
+[ngOption][aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: default;
+}
+
+[ngOption][aria-disabled='true']:hover {
+  background-color: transparent;
+}
+
+.example-option-icon,
+.example-option-check {
+  font-size: 0.9rem;
+}
+
+.example-option-text {
+  flex: 1;
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
@@ -1,0 +1,47 @@
+<div
+  #combobox="ngCombobox"
+  ngCombobox
+  [(expanded)]="popupExpanded"
+  [preserveContent]="true"
+  class="select"
+>
+  <span class="combobox-label">
+    <span class="selected-label-text">{{ displayValue() }}</span>
+  </span>
+  <span class="example-arrow material-symbols-outlined" translate="no" aria-hidden="true"
+    >arrow_drop_down</span
+  >
+</div>
+
+<ng-template
+  [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
+  [cdkConnectedOverlayOpen]="overlayOpen()"
+>
+  <ng-template ngComboboxPopup [combobox]="combobox">
+    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+      <div
+        #listbox="ngListbox"
+        ngListbox
+        [multi]="true"
+        ngComboboxWidget
+        focusMode="activedescendant"
+        [tabindex]="-1"
+        selectionMode="explicit"
+        [(value)]="selectedValues"
+        [activeDescendant]="listbox.activeDescendant()"
+      >
+        @for (label of labels; track label.value) {
+          <div ngOption [value]="label.value" [label]="label.value" [disabled]="label.disabled()">
+            <span class="example-option-text">{{ label.value }}</span>
+            <span
+              class="example-option-check material-symbols-outlined"
+              translate="no"
+              aria-hidden="true"
+              >check</span
+            >
+          </div>
+        }
+      </div>
+    </div>
+  </ng-template>
+</ng-template>

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.html
@@ -15,10 +15,10 @@
 
 <ng-template
   [cdkConnectedOverlay]="{origin: combobox.element, usePopover: 'inline', matchWidth: true}"
-  [cdkConnectedOverlayOpen]="overlayOpen()"
+  [cdkConnectedOverlayOpen]="popupExpanded()"
 >
   <ng-template ngComboboxPopup [combobox]="combobox">
-    <div class="example-popup-container" [class.closing]="!popupExpanded()">
+    <div class="example-popup-container">
       <div
         #listbox="ngListbox"
         ngListbox

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
@@ -48,13 +48,6 @@ export class App {
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();
     });
-
-    // Resets the listbox scroll position when the combobox is closed.
-    afterRenderEffect(() => {
-      if (!this.popupExpanded()) {
-        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
-      }
-    });
   }
 
   isOptionDisabled(value: string) {

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
@@ -1,0 +1,79 @@
+import {Combobox, ComboboxPopup, ComboboxWidget} from '@angular/aria/combobox';
+import {Listbox, Option} from '@angular/aria/listbox';
+import {OverlayModule} from '@angular/cdk/overlay';
+import {afterRenderEffect, Component, computed, signal, viewChild, effect} from '@angular/core';
+
+@Component({
+  selector: 'app-root:not([theme="limited-retro"])',
+  templateUrl: './app.html',
+  styleUrl: './app.css',
+  imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule],
+})
+export class App {
+  /** The combobox listbox popup. */
+  readonly listbox = viewChild(Listbox);
+
+  /** The options available in the listbox. */
+  readonly selectedValues = signal<string[]>([]);
+
+  /** The string that is displayed in the combobox. */
+  readonly displayValue = computed(() => {
+    const values = this.selectedValues();
+    if (values.length === 0) {
+      return 'Select 2 labels';
+    }
+    if (values.length === 1) {
+      return values[0];
+    }
+    return `${values[0]} & ${values[1]}`;
+  });
+
+  /** The labels that are available for selection. */
+  readonly labels = [
+    {value: 'Important', disabled: computed(() => this.isOptionDisabled('Important'))},
+    {value: 'Starred', disabled: computed(() => this.isOptionDisabled('Starred'))},
+    {value: 'Work', disabled: computed(() => this.isOptionDisabled('Work'))},
+    {value: 'Personal', disabled: computed(() => this.isOptionDisabled('Personal'))},
+    {value: 'To Do', disabled: computed(() => this.isOptionDisabled('To Do'))},
+    {value: 'Later', disabled: computed(() => this.isOptionDisabled('Later'))},
+    {value: 'Read', disabled: computed(() => this.isOptionDisabled('Read'))},
+    {value: 'Travel', disabled: computed(() => this.isOptionDisabled('Travel'))},
+  ];
+
+  /** Whether the popup is expanded. */
+  readonly popupExpanded = signal(false);
+
+  /** Whether the overlay is open in the DOM. */
+  readonly overlayOpen = signal(false);
+
+  constructor() {
+    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
+    effect(() => {
+      if (this.popupExpanded()) {
+        this.overlayOpen.set(true);
+      } else {
+        setTimeout(() => this.overlayOpen.set(false), 180);
+      }
+    });
+
+    // Scrolls to the active item when the active option changes.
+    afterRenderEffect(() => {
+      this.listbox()?.scrollActiveItemIntoView();
+    });
+
+    // Resets the listbox scroll position when the combobox is closed.
+    afterRenderEffect(() => {
+      if (!this.popupExpanded()) {
+        setTimeout(() => this.listbox()?.element.scrollTo(0, 0), 150);
+      }
+    });
+  }
+
+  isOptionDisabled(value: string) {
+    const values = this.selectedValues();
+    if (!values || values.length < 2) {
+      return false;
+    }
+    return !values.includes(value);
+  }
+}

--- a/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
+++ b/adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.ts
@@ -43,19 +43,7 @@ export class App {
   /** Whether the popup is expanded. */
   readonly popupExpanded = signal(false);
 
-  /** Whether the overlay is open in the DOM. */
-  readonly overlayOpen = signal(false);
-
   constructor() {
-    // Synchronize overlayOpen with popupExpanded with a delay on close to allow exit transitions
-    effect(() => {
-      if (this.popupExpanded()) {
-        this.overlayOpen.set(true);
-      } else {
-        setTimeout(() => this.overlayOpen.set(false), 180);
-      }
-    });
-
     // Scrolls to the active item when the active option changes.
     afterRenderEffect(() => {
       this.listbox()?.scrollActiveItemIntoView();

--- a/adev/src/content/guide/aria/multiselect.md
+++ b/adev/src/content/guide/aria/multiselect.md
@@ -185,12 +185,7 @@ The structural `ngComboboxPopup` directive marks the overlay template and requir
 
 #### ComboboxWidget directive
 
-The `ngComboboxWidget` directive bridges the listbox widget inside the popup with the parent `ngCombobox` trigger to manage active-descendant focus tracking. When `focusMode="activedescendant"` is configured on the listbox:
-
-1. Browser focus remains securely on the combobox trigger.
-2. Keyboard navigation (Arrow Up/Down) updates the listbox's active descendant.
-3. The `[activeDescendant]` input on `ngComboboxWidget` propagates this ID to the parent `ngCombobox` directive.
-4. `ngCombobox` automatically updates the `aria-activedescendant` attribute on the trigger element, informing screen readers of the active option.
+The `ngComboboxWidget` directive bridges the listbox with the combobox trigger to support active-descendant focus tracking.
 
 | Property           | Type                  | Description                                                                                                                                  |
 | ------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/adev/src/content/guide/aria/multiselect.md
+++ b/adev/src/content/guide/aria/multiselect.md
@@ -3,9 +3,9 @@
 
 ## Overview
 
-A pattern that combines readonly combobox with multi-enabled listbox to create multiple-selection dropdowns with keyboard navigation and screen reader support.
+The multiselect pattern combines a read-only combobox trigger with a multi-select listbox popup to create highly accessible multiple-selection dropdowns with keyboard navigation and screen reader support.
 
-<!-- <docs-tab-group>
+<docs-tab-group>
   <docs-tab label="Basic">
     <docs-code-multifile preview hideCode path="adev/src/content/examples/aria/multiselect/src/icons/app/app.ts">
       <docs-code header="app.ts" path="adev/src/content/examples/aria/multiselect/src/icons/app/app.ts"/>
@@ -29,7 +29,7 @@ A pattern that combines readonly combobox with multi-enabled listbox to create m
       <docs-code header="app.css" path="adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css"/>
     </docs-code-multifile>
   </docs-tab>
-</docs-tab-group> -->
+</docs-tab-group>
 
 ## Usage
 
@@ -67,7 +67,7 @@ The multiselect pattern combines [Combobox](guide/aria/combobox) and [Listbox](g
 
 Users need to select multiple items from a list of options. A readonly combobox paired with a multi-enabled listbox provides familiar multiselect functionality with full accessibility support.
 
-<!-- <docs-tab-group>
+<docs-tab-group>
   <docs-tab label="Basic">
     <docs-code-multifile preview hideCode path="adev/src/content/examples/aria/multiselect/src/basic/app/app.ts">
       <docs-code header="app.ts" path="adev/src/content/examples/aria/multiselect/src/basic/app/app.ts"/>
@@ -91,7 +91,7 @@ Users need to select multiple items from a list of options. A readonly combobox 
       <docs-code header="app.css" path="adev/src/content/examples/aria/multiselect/src/basic/retro/app/app.css"/>
     </docs-code-multifile>
   </docs-tab>
-</docs-tab-group> -->
+</docs-tab-group>
 
 The `multi` attribute on `ngListbox` enables multiple selection. Press Space to toggle options, and the popup remains open for additional selections. The display shows the first selected item plus a count of remaining selections.
 
@@ -99,7 +99,7 @@ The `multi` attribute on `ngListbox` enables multiple selection. Press Space to 
 
 Options often need visual indicators like icons or colors to help users identify choices. Custom templates within options allow rich formatting while the display value shows a compact summary.
 
-<!-- <docs-tab-group>
+<docs-tab-group>
   <docs-tab label="Basic">
     <docs-code-multifile preview hideCode path="adev/src/content/examples/aria/multiselect/src/icons/app/app.ts">
       <docs-code header="app.ts" path="adev/src/content/examples/aria/multiselect/src/icons/app/app.ts"/>
@@ -123,7 +123,7 @@ Options often need visual indicators like icons or colors to help users identify
       <docs-code header="app.css" path="adev/src/content/examples/aria/multiselect/src/icons/retro/app/app.css"/>
     </docs-code-multifile>
   </docs-tab>
-</docs-tab-group> -->
+</docs-tab-group>
 
 Each option displays an icon alongside its label. The display value updates to show the first selection's icon and text, followed by a count of additional selections. Selected options show a checkmark for clear visual feedback.
 
@@ -131,7 +131,7 @@ Each option displays an icon alongside its label. The display value updates to s
 
 Forms sometimes need to limit the number of selections or validate user choices. Programmatic control over selection enables these constraints while maintaining accessibility.
 
-<!-- <docs-tab-group>
+<docs-tab-group>
   <docs-tab label="Basic">
     <docs-code-multifile preview hideCode path="adev/src/content/examples/aria/multiselect/src/limited/app/app.ts">
       <docs-code header="app.ts" path="adev/src/content/examples/aria/multiselect/src/limited/app/app.ts"/>
@@ -155,42 +155,65 @@ Forms sometimes need to limit the number of selections or validate user choices.
       <docs-code header="app.css" path="adev/src/content/examples/aria/multiselect/src/limited/retro/app/app.css"/>
     </docs-code-multifile>
   </docs-tab>
-</docs-tab-group> -->
+</docs-tab-group>
 
-This example limits selections to three items. When the limit is reached, unselected options become disabled, preventing additional selections. A message informs users about the constraint.
+This example limits selections to two items. When the limit is reached, unselected options are disabled to prevent further selections, and the combobox display updates to reflect the choices.
 
 ## APIs
 
 The multiselect pattern uses the following directives from Angular's Aria library. See the full API documentation in the linked guides.
 
-### Combobox Directives
+### Combobox directives
 
-The multiselect pattern uses `ngCombobox` with the `readonly` attribute to prevent text input while preserving keyboard navigation.
+The multiselect pattern uses `ngCombobox` directly on the trigger element (such as a `div` or `button`) to create a select-like multiselect dropdown.
 
 #### Inputs
 
-| Property   | Type      | Default | Description                               |
-| ---------- | --------- | ------- | ----------------------------------------- |
-| `readonly` | `boolean` | `false` | Set to `true` to create dropdown behavior |
-| `disabled` | `boolean` | `false` | Disables the entire multiselect           |
+| Property   | Type      | Default | Description                     |
+| ---------- | --------- | ------- | ------------------------------- |
+| `disabled` | `boolean` | `false` | Disables the entire multiselect |
 
 See the [Combobox API documentation](guide/aria/combobox#apis) for complete details on all available inputs and signals.
 
-### Listbox Directives
+#### Popup directives
+
+The structural `ngComboboxPopup` directive marks the overlay template and requires a reference to the parent combobox:
+
+| Property   | Type       | Description                                 |
+| ---------- | ---------- | ------------------------------------------- |
+| `combobox` | `Combobox` | Required reference to the parent `Combobox` |
+
+#### ComboboxWidget directive
+
+The `ngComboboxWidget` directive bridges the listbox widget inside the popup with the parent `ngCombobox` trigger to manage active-descendant focus tracking. When `focusMode="activedescendant"` is configured on the listbox:
+
+1. Browser focus remains securely on the combobox trigger.
+2. Keyboard navigation (Arrow Up/Down) updates the listbox's active descendant.
+3. The `[activeDescendant]` input on `ngComboboxWidget` propagates this ID to the parent `ngCombobox` directive.
+4. `ngCombobox` automatically updates the `aria-activedescendant` attribute on the trigger element, informing screen readers of the active option.
+
+| Property           | Type                  | Description                                                                                                                                  |
+| ------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activeDescendant` | `string \| undefined` | The ID of the currently active option (bound to `listbox.activeDescendant()`) to update the `aria-activedescendant` attribute on the trigger |
+
+### Listbox directives
 
 The multiselect pattern uses `ngListbox` with the `multi` attribute for multiple selection and `ngOption` for each selectable item.
 
 #### Inputs
 
-| Property | Type      | Default | Description                                |
-| -------- | --------- | ------- | ------------------------------------------ |
-| `multi`  | `boolean` | `false` | Set to `true` to enable multiple selection |
+| Property        | Type                               | Default    | Description                                                                                                                     |
+| --------------- | ---------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `multi`         | `boolean`                          | `false`    | Set to `true` to enable multiple selection                                                                                      |
+| `selectionMode` | `'follow'` \| `'explicit'`         | `'follow'` | Set to `'explicit'` so options are toggled explicitly via click/Space instead of following active focus                         |
+| `focusMode`     | `'roving'` \| `'activedescendant'` | `'roving'` | The focus strategy used by the listbox. Set to `'activedescendant'` so browser focus remains on the combobox trigger.           |
+| `tabIndex`      | `number`                           | `0`        | The tabindex of the listbox. Set to `-1` to prevent keyboard focus from entering the popup container in active-descendant mode. |
 
 #### Model
 
-| Property | Type    | Description                               |
-| -------- | ------- | ----------------------------------------- |
-| `values` | `any[]` | Two-way bindable array of selected values |
+| Property | Type                 | Description                               |
+| -------- | -------------------- | ----------------------------------------- |
+| `value`  | `ModelSignal<any[]>` | Two-way bindable array of selected values |
 
 When `multi` is true, users can select multiple options using Space to toggle selection. The popup remains open after selection, allowing additional choices.
 


### PR DESCRIPTION
Update the multiselect guide and all 27 interactive examples to utilize the modern standalone, Signal-based Angular ARIA APIs.

* Modernize all examples (Standard, Material, Retro) to use standalone directives, animations, and focus suppression.
* Update the multiselect guide API tables and templates:
  - Document ngComboboxPopup, cdkConnectedOverlay, and disabled input.
  - Document ngListbox selectionMode, focusMode, tabIndex, and value signal.
  - Document activeDescendant active focus tracking with ngComboboxWidget.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
The multiselect guide and its associated interactive examples in ADEV still reference the legacy wrapped, non-Signal-based combobox and listbox directives. 

Issue Number: N/A
## What is the new behavior?
Modernizes the multiselect guide and all 27 interactive examples to utilize modern standalone, Signal-based `@angular/aria` APIs:
1. **Guide Mappings**:
   - Documents `ngComboboxPopup` structural overlay templates and standard `cdkConnectedOverlay` configuration.
   - Documents the `ngComboboxWidget` directive and `[activeDescendant]` input mapping to bridge listbox focus state.
   - Updates inputs tables for `ngListbox` (adding `selectionMode`, `focusMode`, `tabIndex`) and documents the renamed `value` signal model binding.
2. **Examples Upgrade**:
   - Replaces legacy wrapped HTML with standalone direct directive bindings.
   - Integrates custom overlay exit transition delays (`180ms`) to prevent animation clipping on close.
   - Integrates popup scroll resets to ensure the listbox scrolls to the top upon re-opening.
   - Suppresses native browser focus rings (`outline: none`) in all variations (Standard, Material, Retro, Icons, Limited) to preserve custom highlight styling.
3. **Style & Tone Preservation**:
   - Retains the original legacy third-person tone (`"Users need to select..."`), Title Case bullet items, and layout spacing to keep the documentation diff clean and avoid cosmetic prose noise.
   - 
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
## Other information

All modernized examples have been fully verified to ensure structural and visual parity with the original designs.