### PR TITLE
fix(core): synchronize core sanitization schema with compiler

### DIFF
--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -115,12 +115,6 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['object', ['codebase', 'data']],
     ]);
 
-    // The below are for Script SVG
-    // See: https://developer.mozilla.org/en-US/docs/Web/API/SVGScriptElement/href
-    registerContext(SecurityContext.RESOURCE_URL, SVG_NAMESPACE, [
-      ['script', ['src', 'href', 'xlink:href']],
-    ]);
-
     // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
     // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)
     // and the directive can be applied to multiple different elements (with different tag names). In this case we generate

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -288,19 +288,6 @@ describe('security integration tests', function () {
       clearTranslations();
     });
 
-    it('should throw error on translated SVG script ResourceURL attributes', () => {
-      const template = `
-        <svg>
-          <script href="/safe-svg-script.js" i18n-href></script>
-        </svg>
-      `;
-      TestBed.overrideComponent(SecuredComponent, {set: {template}});
-
-      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
-        /unsafe value used in a resource URL context/i,
-      );
-    });
-
     it('should throw error on SVG animation retargeting attributes', () => {
       const template = `
         <svg>


### PR DESCRIPTION
https://github.com/angular/angular/pull/68689 recently updated the compiler schema which should be kept in sync with the core schema. Fix applied by running `pnpm bazel run //packages/core:dom_security_schema`.