### PR TITLE
fix(compiler): disallow i18n event attributes

### DIFF
--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -208,7 +208,7 @@ export class I18nMetaVisitor implements html.Visitor {
             isTrustedType = isTrustedTypesSink(node.name, name);
           }
 
-          if (isTrustedType) {
+          if (isTrustedType || name.toLowerCase().startsWith('on')) {
             this._reportError(
               attr,
               `Translating attribute '${name}' is disallowed for security reasons.`,

--- a/packages/core/test/linker/security_integration_spec.ts
+++ b/packages/core/test/linker/security_integration_spec.ts
@@ -376,6 +376,15 @@ describe('security integration tests', function () {
       expect(link.getAttribute('href')).toEqual('unsafe:javascript:alert(1)');
     });
 
+    it('should throw error on translated event attributes', () => {
+      const template = `<img src="/missing-image.png" onerror="void 0" i18n-onerror>`;
+      TestBed.overrideComponent(SecuredComponent, {set: {template}});
+
+      expect(() => TestBed.createComponent(SecuredComponent)).toThrowError(
+        /Translating attribute 'onerror' is disallowed for security reasons./,
+      );
+    });
+
     it('should throw error on security-sensitive attributes with constant values', () => {
       const template = `<iframe srcdoc="foo" i18n-srcdoc></iframe>`;
       TestBed.overrideComponent(SecuredComponent, {set: {template}});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Security hardening

## What is the current behavior?

Angular disallows binding to event-handler attributes such as `onclick` and `onerror` through `validateAttribute()` / `validateProperty()`, but the i18n metadata path still allowed the same attribute names to be marked for translation with `i18n-on*`.

This creates an XSS sink in the i18n pipeline: a lower-trust translation file could replace a benign static handler such as `onerror="void 0"` with executable JavaScript in the localized build.

### Affected versions / verification

I reproduced the vulnerable behavior in localized AOT builds against:

- Angular `21.2.11`
- Angular `21.2.13`
- Angular `22.0.0-rc.0`
- Angular main with the merged i18n schema-hardening changes from #68591 present

The #68591 hardening correctly covers schema-driven i18n security contexts such as URL, ResourceURL, iframe policy attributes, and SVG animation attributes. This event-handler case remained separate because `on*` attributes are rejected by Angular's event-attribute validation path rather than by `SECURITY_SCHEMA`.

## What is the new behavior?

`i18n-on*` attributes are rejected during i18n metadata collection with the same security error shape used for other disallowed translated attributes.

This prevents translated static attributes from bypassing Angular's event-attribute validation invariant.

The implementation intentionally performs the event-attribute check directly in the i18n metadata gate, alongside the existing Trusted Types sink check, so this path rejects translated executable event handlers before they are collected as translatable attribute metadata.

## Does this PR introduce a breaking change?

- [x] Yes

Applications that intentionally translate static event-handler attributes such as `i18n-onerror` will now fail compilation. This is intentional because translated event-handler attributes are executable JavaScript sinks.

## Other information

The change is intentionally limited to translated event-handler attributes. Normal non-security-sensitive translated attributes continue to work, and the existing schema-driven i18n sanitizer/validator paths continue to handle URL, ResourceURL, iframe policy, and SVG animation attributes.

Fix validation run locally:

- `bazelisk test //packages/core/test:test`
- `bazelisk test //packages/compiler/test:test`
- `pnpm ng-dev commit-message validate-range`
