### PR TITLE
docs: document barrel file caveat for @defer lazy chunks

### DIFF
--- a/adev/src/content/guide/templates/defer.md
+++ b/adev/src/content/guide/templates/defer.md
@@ -382,6 +382,37 @@ By default, when rendering an application on the server (either using SSR or SSG
 
 To render the main content of `@defer` blocks on the server (both SSR and SSG), you can enable [the Incremental Hydration feature](/guide/incremental-hydration) and configure `hydrate` triggers for the necessary blocks.
 
+## Barrel files and lazy chunks
+
+If you're using `@defer` but not seeing a separate lazy chunk in your build output, check how you're importing the deferred component. Importing through a barrel file (`index.ts`) is a common culprit — bundlers see the barrel as a single module and keep all its exports together, so your component ends up in the main bundle regardless of `@defer`.
+
+```typescript
+// index.ts
+export {HeavyComponent} from './heavy.component';
+export {OtherComponent} from './other.component';
+```
+
+```typescript
+// parent.component.ts
+import {HeavyComponent} from './index'; // pulls in OtherComponent too
+
+@Component({
+  imports: [HeavyComponent],
+  template: `@defer {
+    <heavy-component />
+  }`,
+})
+export class ParentComponent {}
+```
+
+The fix is straightforward — import directly from the component's own file:
+
+```typescript
+import {HeavyComponent} from './heavy.component';
+```
+
+That's enough for the bundler to split it into its own chunk and load it lazily when the trigger fires.
+
 ## Best practices for deferring views
 
 ### Avoid cascading loads with nested `@defer` blocks


### PR DESCRIPTION
Users often enable @defer expecting a separate lazy chunk but don't get one, with no obvious error to explain why. The root cause is almost always a barrel file import — the bundler treats the whole barrel as a single module and can't split out individual exports.

Add a section to the defer guide that starts from the symptom (no lazy chunk), shows the barrel import pattern that causes it, and gives the direct-import fix.

Closes #52554