### PR TITLE
perf(forms): avoid redundant invalidations in parser errors signal

### DIFF
--- a/packages/forms/signals/src/util/parser.ts
+++ b/packages/forms/signals/src/util/parser.ts
@@ -10,6 +10,7 @@ import {type Signal, linkedSignal} from '@angular/core';
 import type {ValidationError} from '../api/rules';
 import {normalizeErrors} from '../api/rules/validation/util';
 import type {ParseResult} from '../api/transformed_value';
+import {shallowArrayEquals} from './array';
 
 /**
  * An object that handles parsing raw UI values into model values.
@@ -45,6 +46,7 @@ export function createParser<TValue, TRaw>(
   const errors = linkedSignal({
     source: getValue,
     computation: () => [] as readonly ValidationError.WithoutFieldTree[],
+    equal: shallowArrayEquals,
   });
 
   const setRawValue = (rawValue: TRaw) => {


### PR DESCRIPTION
The `errors` linkedSignal in `createParser` had no equality check, so every reset or recomputation — even to an identical empty array — would mark downstream dependents as dirty and trigger unnecessary re-renders.

Add `shallowArrayEquals` as the equality function so the signal only notifies dependents when the error list actually changes.

---

<img width="961" height="313" alt="image" src="https://github.com/user-attachments/assets/5b55e895-2d6b-4f8a-aab4-edfd8c89d647" />
