### PR TITLE
docs: document FormBuilder.group() controlsConfig value shapes

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -194,7 +194,15 @@ export class FormBuilder {
    * containing all the keys and corresponding inner control types.
    *
    * @param controls A collection of child controls. The key for each child is the name
-   * under which it is registered.
+   * under which it is registered. Each value can be one of:
+   * * An `AbstractControl` instance — passed through as-is.
+   * * A raw value — shorthand for `fb.control(value)`.
+   * * A `FormControlState` object (`{value, disabled}`) — initializes the control with a value
+   *   and disabled status.
+   * * A `ControlConfig` tuple — `[value | FormControlState, validatorOrOpts?, asyncValidator?]`.
+   *   The second element accepts a `ValidatorFn`, an array of `ValidatorFn`, or an
+   *   `AbstractControlOptions` object (use this to set `updateOn`). The optional third element
+   *   accepts an `AsyncValidatorFn` or an array of `AsyncValidatorFn`.
    *
    * @param options Configuration options object for the `FormGroup`. The object should have the
    * `AbstractControlOptions` type and might contain the following fields:
@@ -202,6 +210,34 @@ export class FormBuilder {
    * * `asyncValidators`: A single async validator or array of async validator functions.
    * * `updateOn`: The event upon which the control should be updated (options: 'change' | 'blur'
    * | submit').
+   *
+   * @usageNotes
+   *
+   * ### Different ways to specify a control value
+   *
+   * ```ts
+   * const fb = new FormBuilder();
+   *
+   * fb.group({
+   *   // Raw value — equivalent to fb.control('Ada')
+   *   name: 'Ada',
+   *
+   *   // FormControlState — sets initial value and disabled status
+   *   city: {value: 'London', disabled: true},
+   *
+   *   // ControlConfig tuple — value with a sync validator
+   *   email: ['ada@example.com', Validators.email],
+   *
+   *   // ControlConfig tuple — value, sync validator, and async validator
+   *   username: ['ada', Validators.required, checkUsernameAvailable],
+   *
+   *   // ControlConfig tuple — disabled value with updateOn option
+   *   role: [{value: 'admin', disabled: true}, {updateOn: 'blur'}],
+   *
+   *   // Pre-built control — passed through unchanged
+   *   address: new FormControl('', Validators.required),
+   * });
+   * ```
    */
   group<T extends {}>(
     controls: T,


### PR DESCRIPTION
The `@param` JSDoc for `FormBuilder.group()` previously described the argument only as “a collection of child controls”, without explaining the four supported value shapes:

* a raw value
* a `FormControlState`
* a `ControlConfig` tuple
* a pre-built `AbstractControl`

The fact that the second element of a `ControlConfig` tuple can accept `AbstractControlOptions` (for example to configure per-control `updateOn`) was especially non-obvious and undocumented.

This change adds a `@usageNotes` section with concrete examples covering each supported shape.

Closes #43984