### PR TITLE
CSS Variable Namespacing

### DIFF
--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -168,7 +168,7 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
-export function provideCssVarNamespacing(namespace: string): EnvironmentProviders;
+export function provideCssVarNamespacing(namespace?: string): EnvironmentProviders;
 
 // @public
 export function provideProtractorTestingSupport(options?: {

--- a/goldens/public-api/platform-browser/index.api.md
+++ b/goldens/public-api/platform-browser/index.api.md
@@ -55,6 +55,15 @@ export class By {
 export function createApplication(options?: ApplicationConfig, context?: BootstrapContext): Promise<ApplicationRef>;
 
 // @public
+export class CssVarNamespacer {
+    namespace(name: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<CssVarNamespacer, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<CssVarNamespacer>;
+}
+
+// @public
 export function disableDebugTools(): void;
 
 // @public
@@ -157,6 +166,9 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 
 // @public
 export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
+
+// @public
+export function provideCssVarNamespacing(namespace: string): EnvironmentProviders;
 
 // @public
 export function provideProtractorTestingSupport(options?: {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_styles/encapsulation_default.js
@@ -1,1 +1,1 @@
-styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --webkit-transition: 1s linear all; }"]
+styles: ["div.foo[_ngcontent-%COMP%] { color: red; }", "[_nghost-%COMP%]   p[_ngcontent-%COMP%]:nth-child(even) { --%NS%webkit-transition: 1s linear all; }"]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/css_custom_properties.js
@@ -3,6 +3,6 @@ hostAttrs: [2, "--camel-case", "foo", "--kebab-case", "foo"],
 …
 hostBindings: function MyDirective_HostBindings(rf, ctx) {
   if (rf & 2) {
-    i0.ɵɵstyleProp("--camelCase", ctx.value)("--kebab-case", ctx.value);
+    i0.ɵɵstyleProp("--%NS%camelCase", ctx.value)("--%NS%kebab-case", ctx.value);
   } 
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/css_custom_properties.js
@@ -4,6 +4,6 @@
   if (rf & 1) {
     i0.ɵɵelement(0, "div", 0);
   } if (rf & 2) {
-    i0.ɵɵstyleProp("--camelCase", ctx.value)("--kebab-case", ctx.value);
+    i0.ɵɵstyleProp("--%NS%camelCase", ctx.value)("--%NS%kebab-case", ctx.value);
   }
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -10,7 +10,7 @@ import {ConstantPool} from '../../constant_pool';
 import * as core from '../../core';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan} from '../../parse_util';
-import {ShadowCss} from '../../shadow_css';
+import {namespaceCssVariables, ShadowCss} from '../../shadow_css';
 import {CompilationJobKind, TemplateCompilationMode} from '../../template/pipeline/src/compilation';
 import {emitHostBindingFunction, emitTemplateFn, transform} from '../../template/pipeline/src/emit';
 import {ingestComponent, ingestHostBinding} from '../../template/pipeline/src/ingest';
@@ -269,10 +269,11 @@ export function compileComponentFromMetadata(
   let hasStyles = !!meta.externalStyles?.length;
   // e.g. `styles: [str1, str2]`
   if (meta.styles && meta.styles.length) {
+    const namespacedStyles = meta.styles.map((s) => namespaceCssVariables(s));
     const styleValues =
       meta.encapsulation == core.ViewEncapsulation.Emulated
-        ? compileStyles(meta.styles, CONTENT_ATTR, HOST_ATTR)
-        : meta.styles;
+        ? compileStyles(namespacedStyles, CONTENT_ATTR, HOST_ATTR)
+        : namespacedStyles;
     const styleNodes = styleValues.reduce((result, style) => {
       if (style.trim().length > 0) {
         result.push(constantPool.getConstLiteral(o.literal(style)));

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -1052,6 +1052,13 @@ export function namespaceCssVariables(cssText: string): string {
       return match;
     }
 
+    if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
+      throw new Error(
+        `CSS variable "${varName}" has a single hyphen after "--global". ` +
+          `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`,
+      );
+    }
+
     let result;
     if (varName.startsWith('--global--')) {
       result = `--${varName.substring('--global--'.length)}`;

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import * as chars from './chars';
+import {getInvalidCssGlobalError} from './util';
 
 /**
  * The following set contains all keywords that can be used in the animation css shorthand
@@ -1053,10 +1054,7 @@ export function namespaceCssVariables(cssText: string): string {
     }
 
     if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
-      throw new Error(
-        `CSS variable "${varName}" has a single hyphen after "--global". ` +
-          `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`,
-      );
+      throw new Error(getInvalidCssGlobalError(varName));
     }
 
     let result;

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -1033,6 +1033,36 @@ const _cssCommaInPlaceholderReGlobal = new RegExp(COMMA_IN_PLACEHOLDER, 'g');
 const _cssSemiInPlaceholderReGlobal = new RegExp(SEMI_IN_PLACEHOLDER, 'g');
 const _cssColonInPlaceholderReGlobal = new RegExp(COLON_IN_PLACEHOLDER, 'g');
 
+// Matches any CSS variable name, defined by a double-hyphen followed by any valid ident.
+// https://www.w3.org/TR/css-syntax-3/#ident-token-diagram
+const _cssVariableRe = /(var\(\s*)?(--(?:[a-zA-Z0-9_-]|[^\x00-\x7F])+)(\s*:)?/g;
+
+/**
+ * Transforms CSS variables within a stylesheet to include a namespace placeholder.
+ *
+ * E.g. `--foo: bar;` becomes `--%NS%foo: bar;`
+ * E.g. `color: var(--foo);` becomes `color: var(--%NS%foo);`
+ *
+ * If a variable is prefixed with `--global--`, it is NOT namespaced and the prefix is removed.
+ * E.g. `--global--mycolor: red;` becomes `--mycolor: red;`
+ */
+export function namespaceCssVariables(cssText: string): string {
+  return cssText.replace(_cssVariableRe, (match, leadingVar, varName, trailingColon) => {
+    if (!leadingVar && !trailingColon) {
+      return match;
+    }
+
+    let result;
+    if (varName.startsWith('--global--')) {
+      result = `--${varName.substring('--global--'.length)}`;
+    } else {
+      result = `--%NS%${varName.substring('--'.length)}`;
+    }
+
+    return (leadingVar || '') + result + (trailingColon || '');
+  });
+}
+
 export class CssRule {
   constructor(
     public selector: string,

--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 import * as chars from './chars';
-import {getInvalidCssGlobalError} from './util';
+import {namespaceCssVariable} from './util';
 
 /**
  * The following set contains all keywords that can be used in the animation css shorthand
@@ -1049,22 +1049,19 @@ const _cssVariableRe = /(var\(\s*)?(--(?:[a-zA-Z0-9_-]|[^\x00-\x7F])+)(\s*:)?/g;
  */
 export function namespaceCssVariables(cssText: string): string {
   return cssText.replace(_cssVariableRe, (match, leadingVar, varName, trailingColon) => {
+    // Check for a leading `var(` or trailing `:` to approximate whether we're operating on a
+    // real CSS variable, not another piece of syntax that resembles it. For example, this
+    // guards against:
+    // - `.foo--bar {}`
+    // - `/* --foo */`
+    // - `p { content: "--foo" }`
+    // - `[data---bar] {}`
+    // - `[data-status=foo--bar] {}`
+    // etc.
     if (!leadingVar && !trailingColon) {
       return match;
     }
-
-    if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
-      throw new Error(getInvalidCssGlobalError(varName));
-    }
-
-    let result;
-    if (varName.startsWith('--global--')) {
-      result = `--${varName.substring('--global--'.length)}`;
-    } else {
-      result = `--%NS%${varName.substring('--'.length)}`;
-    }
-
-    return (leadingVar || '') + result + (trailingColon || '');
+    return (leadingVar ?? '') + namespaceCssVariable(varName) + (trailingColon ?? '');
   });
 }
 

--- a/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
@@ -9,7 +9,7 @@
 import * as ir from '../../ir';
 
 import type {CompilationJob} from '../compilation';
-import {getInvalidCssGlobalError} from '../../../../util';
+import {namespaceCssVariable} from '../../../../util';
 
 const STYLE_DOT = 'style.';
 const CLASS_DOT = 'class.';
@@ -42,14 +42,7 @@ export function parseHostStyleProperties(job: CompilationJob): void {
       if (!isCssCustomProperty(op.name)) {
         op.name = hyphenate(op.name);
       } else {
-        if (op.name.startsWith('--global-') && !op.name.startsWith('--global--')) {
-          throw new Error(getInvalidCssGlobalError(op.name));
-        }
-        if (op.name.startsWith('--global--')) {
-          op.name = '--' + op.name.substring('--global--'.length);
-        } else {
-          op.name = '--%NS%' + op.name.substring('--'.length);
-        }
+        op.name = namespaceCssVariable(op.name);
       }
 
       const {property, suffix} = parseProperty(op.name);

--- a/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
@@ -9,6 +9,7 @@
 import * as ir from '../../ir';
 
 import type {CompilationJob} from '../compilation';
+import {getInvalidCssGlobalError} from '../../../../util';
 
 const STYLE_DOT = 'style.';
 const CLASS_DOT = 'class.';
@@ -40,6 +41,15 @@ export function parseHostStyleProperties(job: CompilationJob): void {
 
       if (!isCssCustomProperty(op.name)) {
         op.name = hyphenate(op.name);
+      } else {
+        if (op.name.startsWith('--global-') && !op.name.startsWith('--global--')) {
+          throw new Error(getInvalidCssGlobalError(op.name));
+        }
+        if (op.name.startsWith('--global--')) {
+          op.name = '--' + op.name.substring('--global--'.length);
+        } else {
+          op.name = '--%NS%' + op.name.substring('--'.length);
+        }
       }
 
       const {property, suffix} = parseProperty(op.name);

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -36,7 +36,7 @@ import {InterpolatedAttributeToken, InterpolatedTextToken} from '../ml_parser/to
 import {ParseError, ParseErrorLevel, ParseSourceSpan} from '../parse_util';
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
 import {CssSelector} from '../directive_matching';
-import {splitAtColon, splitAtPeriod} from '../util';
+import {getInvalidCssGlobalError, splitAtColon, splitAtPeriod} from '../util';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from '../template/pipeline/src/namespaces';
 
 const PROPERTY_PARTS_SEPARATOR = '.';
@@ -594,7 +594,19 @@ export class BindingParser {
         securityContexts = [SecurityContext.NONE];
       } else if (parts[0] == STYLE_PREFIX) {
         unit = parts.length > 2 ? parts[2] : null;
-        boundPropertyName = parts[1];
+        const boundName = parts[1];
+        if (!boundName.startsWith('--')) {
+          boundPropertyName = boundName;
+        } else {
+          if (boundName.startsWith('--global-') && !boundName.startsWith('--global--')) {
+            this._reportError(getInvalidCssGlobalError(boundName), boundProp.sourceSpan);
+          }
+          if (boundName.startsWith('--global--')) {
+            boundPropertyName = '--' + boundName.substring('--global--'.length);
+          } else {
+            boundPropertyName = '--%NS%' + boundName.substring('--'.length);
+          }
+        }
         bindingType = BindingType.Style;
         securityContexts = [SecurityContext.STYLE];
       } else if (parts[0] == ANIMATE_PREFIX) {

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -36,7 +36,7 @@ import {InterpolatedAttributeToken, InterpolatedTextToken} from '../ml_parser/to
 import {ParseError, ParseErrorLevel, ParseSourceSpan} from '../parse_util';
 import {ElementSchemaRegistry} from '../schema/element_schema_registry';
 import {CssSelector} from '../directive_matching';
-import {getInvalidCssGlobalError, splitAtColon, splitAtPeriod} from '../util';
+import {namespaceCssVariable, splitAtColon, splitAtPeriod} from '../util';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from '../template/pipeline/src/namespaces';
 
 const PROPERTY_PARTS_SEPARATOR = '.';
@@ -598,13 +598,10 @@ export class BindingParser {
         if (!boundName.startsWith('--')) {
           boundPropertyName = boundName;
         } else {
-          if (boundName.startsWith('--global-') && !boundName.startsWith('--global--')) {
-            this._reportError(getInvalidCssGlobalError(boundName), boundProp.sourceSpan);
-          }
-          if (boundName.startsWith('--global--')) {
-            boundPropertyName = '--' + boundName.substring('--global--'.length);
-          } else {
-            boundPropertyName = '--%NS%' + boundName.substring('--'.length);
+          try {
+            boundPropertyName = namespaceCssVariable(boundName);
+          } catch (e) {
+            this._reportError((e as Error).message, boundProp.sourceSpan);
           }
         }
         bindingType = BindingType.Style;

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -153,3 +153,14 @@ export function getJitStandaloneDefaultForVersion(version: string): boolean {
   // All other Angular versions (v19+) default to true.
   return true;
 }
+
+/**
+ * Formats the compile-time error message for invalid global CSS variable names
+ * (i.e., those starting with `--global-` with a single hyphen instead of two).
+ */
+export function getInvalidCssGlobalError(varName: string): string {
+  return (
+    `CSS variable "${varName}" has a single hyphen after "--global". ` +
+    `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`
+  );
+}

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -162,12 +162,16 @@ export function getJitStandaloneDefaultForVersion(version: string): boolean {
  * @returns The namespaced CSS variable name.
  */
 export function namespaceCssVariable(varName: string): string {
-  if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
-    throw new Error(
-      `CSS variable "${varName}" has a single hyphen after "--global". ` +
-        `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`,
-    );
-  }
+  // TODO: Enforce this in v23. This is a breaking change.
+  //       Enable tests under platform-browser and compiler matching "has a single hyphen".
+  // g3-only-start
+  // if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
+  //   throw new Error(
+  //     `CSS variable "${varName}" has a single hyphen after "--global". ` +
+  //       `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`,
+  //   );
+  // }
+  // g3-only-end
 
   if (varName.startsWith('--global--')) {
     return '--' + varName.substring('--global--'.length);

--- a/packages/compiler/src/util.ts
+++ b/packages/compiler/src/util.ts
@@ -155,12 +155,23 @@ export function getJitStandaloneDefaultForVersion(version: string): boolean {
 }
 
 /**
- * Formats the compile-time error message for invalid global CSS variable names
- * (i.e., those starting with `--global-` with a single hyphen instead of two).
+ * Namespaces a CSS variable name and validates its syntax.
+ *
+ * @param varName The CSS variable name starting with `--`.
+ * @throws An Error if the CSS variable is invalid (e.g. has a single hyphen after "--global").
+ * @returns The namespaced CSS variable name.
  */
-export function getInvalidCssGlobalError(varName: string): string {
-  return (
-    `CSS variable "${varName}" has a single hyphen after "--global". ` +
-    `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`
-  );
+export function namespaceCssVariable(varName: string): string {
+  if (varName.startsWith('--global-') && !varName.startsWith('--global--')) {
+    throw new Error(
+      `CSS variable "${varName}" has a single hyphen after "--global". ` +
+        `Use two hyphens ("--global--${varName.substring('--global-'.length)}") to opt-out of namespacing.`,
+    );
+  }
+
+  if (varName.startsWith('--global--')) {
+    return '--' + varName.substring('--global--'.length);
+  } else {
+    return '--%NS%' + varName.substring('--'.length);
+  }
 }

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {namespaceCssVariables} from '../../src/shadow_css';
 import {shim} from './utils';
 
 describe('ShadowCss', () => {
@@ -388,6 +389,200 @@ describe('ShadowCss', () => {
 
     it('should handle adjacent comments', () => {
       expect(shim('/* comment 1 */ /* comment 2 */ b {}', 'contenta')).toBe('  b[contenta] {}');
+    });
+  });
+
+  describe('CSS variable namespacing', () => {
+    it('should inject `%NS%` placeholder into CSS variable declarations and usages', () => {
+      const input = `
+.foo {
+  --my-color: red;
+  color: var(--my-color, blue);
+}
+      `.trim();
+
+      const expected = `
+.foo {
+  --%NS%my-color: red;
+  color: var(--%NS%my-color, blue);
+}
+      `.trim();
+
+      expect(namespaceCssVariables(input)).toEqualCss(expected);
+    });
+
+    it('should not inject `%NS%` when `--global--` prefix is present', () => {
+      const input = `
+.foo {
+  --global--my-color: green;
+  background: var(--global--my-color);
+}
+      `.trim();
+
+      const expected = `
+.foo {
+  --my-color: green;
+  background: var(--my-color);
+}
+      `.trim();
+
+      expect(namespaceCssVariables(input)).toEqualCss(expected);
+    });
+
+    it('should handle multiple variables with mixed namespacing', () => {
+      const input = `
+.foo {
+  border: var(--global--border-size) solid var(--border-color);
+  box-shadow: 
+    var(--shadow-1),
+    var(--global--shadow-2),
+    var(--shadow-3);
+}
+      `.trim();
+
+      const expected = `
+.foo {
+  border: var(--border-size) solid var(--%NS%border-color);
+  box-shadow: 
+    var(--%NS%shadow-1),
+    var(--shadow-2),
+    var(--%NS%shadow-3);
+}
+      `.trim();
+
+      expect(namespaceCssVariables(input)).toEqualCss(expected);
+    });
+
+    it('should not namespace or modify -- in comments', () => {
+      expect(namespaceCssVariables('/* --bar */')).toBe('/* --bar */');
+      expect(namespaceCssVariables('/* --global--bar */')).toBe('/* --global--bar */');
+    });
+
+    it('should not namespace or modify -- in strings', () => {
+      expect(namespaceCssVariables('div { content: "--bar"; }')).toBe('div { content: "--bar"; }');
+      expect(namespaceCssVariables('div { content: "--global--bar"; }')).toBe(
+        'div { content: "--global--bar"; }',
+      );
+    });
+
+    it('should not namespace or modify -- in the middle of identifiers', () => {
+      expect(namespaceCssVariables('.foo--bar { color: red; }')).toBe('.foo--bar { color: red; }');
+      expect(namespaceCssVariables('.foo--global--bar { color: red; }')).toBe(
+        '.foo--global--bar { color: red; }',
+      );
+    });
+
+    it('should not namespace or modify -- in attribute names', () => {
+      expect(namespaceCssVariables('[data---bar] { color: red; }')).toBe(
+        '[data---bar] { color: red; }',
+      );
+      expect(namespaceCssVariables('[data---global--bar] { color: red; }')).toBe(
+        '[data---global--bar] { color: red; }',
+      );
+    });
+
+    it('should not namespace or modify -- in unquoted attribute values', () => {
+      expect(namespaceCssVariables('[data-status=foo--bar] { color: red; }')).toBe(
+        '[data-status=foo--bar] { color: red; }',
+      );
+      expect(namespaceCssVariables('[data-status=foo--global--bar] { color: red; }')).toBe(
+        '[data-status=foo--global--bar] { color: red; }',
+      );
+    });
+
+    it('should not namespace or modify CDO and CDC tokens', () => {
+      expect(namespaceCssVariables('<!--foo')).toBe('<!--foo');
+      expect(namespaceCssVariables('--global-->')).toBe('--global-->');
+    });
+
+    it('should not namespace or modify -- in URLs', () => {
+      expect(namespaceCssVariables('div { background: url(--bar); }')).toBe(
+        'div { background: url(--bar); }',
+      );
+      expect(namespaceCssVariables('div { background: url(--global--bar); }')).toBe(
+        'div { background: url(--global--bar); }',
+      );
+    });
+
+    it('should not namespace or modify -- in custom media queries', () => {
+      expect(namespaceCssVariables('@custom-media --bar (max-width: 30em);')).toBe(
+        '@custom-media --bar (max-width: 30em);',
+      );
+      expect(namespaceCssVariables('@custom-media --global--bar (max-width: 30em);')).toBe(
+        '@custom-media --global--bar (max-width: 30em);',
+      );
+    });
+
+    it('should handle whitespace in variable declarations and usages', () => {
+      expect(
+        namespaceCssVariables(`
+p {
+  color: var(
+    --bgc
+  );
+  --bgc
+  : red;
+}
+      `),
+      ).toBe(`
+p {
+  color: var(
+    --%NS%bgc
+  );
+  --%NS%bgc
+  : red;
+}
+      `);
+
+      expect(
+        namespaceCssVariables(`
+p {
+  color: var(
+    --global--bgc
+  );
+  --global--bgc
+  : red;
+}
+      `),
+      ).toBe(`
+p {
+  color: var(
+    --bgc
+  );
+  --bgc
+  : red;
+}
+      `);
+    });
+
+    it('should handle non-ascii characters', () => {
+      expect(
+        namespaceCssVariables(`
+p {
+  --🅰️ngular: red;
+  color: var(--🅰️ngular);
+}
+        `),
+      ).toEqualCss(`
+p {
+  --%NS%🅰️ngular: red;
+  color: var(--%NS%🅰️ngular);
+}
+      `);
+
+      expect(
+        namespaceCssVariables(`
+p {
+  --global--🅰️ngular: red;
+  color: var(--global--🅰️ngular);
+}
+        `),
+      ).toEqualCss(`
+p {
+  --🅰️ngular: red;
+  color: var(--🅰️ngular);
+}
+      `);
     });
   });
 });

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -585,7 +585,8 @@ p {
       `);
     });
 
-    it('should throw an error when a CSS variable has a single hyphen after --global', () => {
+    // TODO: Enforce this in v23.
+    xit('should throw an error when a CSS variable has a single hyphen after --global', () => {
       expect(() => namespaceCssVariables('p { --global-foo: red; }')).toThrowError(
         'CSS variable "--global-foo" has a single hyphen after "--global". Use two hyphens ("--global--foo") to opt-out of namespacing.',
       );

--- a/packages/compiler/test/shadow_css/shadow_css_spec.ts
+++ b/packages/compiler/test/shadow_css/shadow_css_spec.ts
@@ -584,5 +584,17 @@ p {
 }
       `);
     });
+
+    it('should throw an error when a CSS variable has a single hyphen after --global', () => {
+      expect(() => namespaceCssVariables('p { --global-foo: red; }')).toThrowError(
+        'CSS variable "--global-foo" has a single hyphen after "--global". Use two hyphens ("--global--foo") to opt-out of namespacing.',
+      );
+      expect(() => namespaceCssVariables('p { color: var(--global-my-color); }')).toThrowError(
+        'CSS variable "--global-my-color" has a single hyphen after "--global". Use two hyphens ("--global--my-color") to opt-out of namespacing.',
+      );
+      expect(() => namespaceCssVariables('p { --global-: red; }')).toThrowError(
+        'CSS variable "--global-" has a single hyphen after "--global". Use two hyphens ("--global--") to opt-out of namespacing.',
+      );
+    });
   });
 });

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -30,7 +30,7 @@ describe('CSP integration', () => {
     for (let i = 0; i < styles.length; i++) {
       const style = styles[i];
       const nonce = style.getAttribute('nonce');
-      if (nonce && style.textContent?.includes('--csp-test-var')) {
+      if (nonce && style.textContent?.includes('csp-test-var')) {
         nonces.push(nonce);
       }
     }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -54,6 +54,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/create_component/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/create_component/bundle.golden_symbols.json
@@ -31,6 +31,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/defer/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/defer/bundle.golden_symbols.json
@@ -13,6 +13,7 @@
       "COMPONENT_REGEX",
       "COMPONENT_VARIABLE",
       "CONTENT_ATTR",
+      "CSS_VAR_NAMESPACE",
       "DefaultDomRenderer2",
       "DomAdapter",
       "DomEventsPlugin",

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -49,6 +49,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "CachedInjectorService",
       "ChainedInjector",
       "ChangeDetectionScheduler",

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -48,6 +48,7 @@
       "CONTEXT",
       "CREATE_VIEW_TRANSITION",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "CanActivate",
       "CanDeactivate",
       "ChainedInjector",

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -31,6 +31,7 @@
       "CONTENT_ATTR",
       "CONTEXT",
       "CSP_NONCE",
+      "CSS_VAR_NAMESPACE",
       "ChainedInjector",
       "ChangeDetectionScheduler",
       "ChangeDetectionSchedulerImpl",

--- a/packages/platform-browser/src/dom/css_var_namespacer.ts
+++ b/packages/platform-browser/src/dom/css_var_namespacer.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {inject, Service} from '@angular/core';
+import {CSS_VAR_NAMESPACE} from './dom_renderer';
+
+/**
+ * A service that can be used to manually namespace CSS variable names at runtime.
+ * This is useful when reading or setting CSS variables dynamically in JavaScript that
+ * were transformed by the compiler during the build.
+ *
+ * @publicApi 22.1
+ */
+@Service()
+export class CssVarNamespacer {
+  private readonly namespacePrefix = inject(CSS_VAR_NAMESPACE, {optional: true}) ?? '';
+
+  /**
+   * Prepends the namespace prefix to a CSS variable name.
+   *
+   * @param name The CSS variable name to namespace, including the leading `--`.
+   * @returns The namespaced CSS variable name, including the leading `--`. Returns the input
+   *     unchanged if no namespace is configured.
+   */
+  namespace(name: string): string {
+    // Validate that the whole `--foo` variable is passed in.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (!name.startsWith('--')) {
+        throw new Error(
+          `CSS variable names passed to \`CssVarNamespacer\` must start with '--', got: '${name}'`,
+        );
+      }
+    }
+
+    // We want to support libraries which might be used by applications which do and don't
+    // namespace variables. Therefore the library always needs to use `CssVarNamespacer`, even
+    // though the application may not actually be namespacing anything.
+    if (!this.namespacePrefix) return name;
+
+    return `--${this.namespacePrefix}${name.substring('--'.length)}`;
+  }
+}

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -27,6 +27,8 @@ import {
   Optional,
   ɵallLeavingAnimations as allLeavingAnimations,
   ɵSHARED_STYLES_HOST as SHARED_STYLES_HOST,
+  makeEnvironmentProviders,
+  type EnvironmentProviders,
 } from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
@@ -69,6 +71,30 @@ export const REMOVE_STYLES_ON_COMPONENT_DESTROY = new InjectionToken<boolean>(
     factory: () => REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT,
   },
 );
+
+/**
+ * An injection token that allows an application to configure a prefix to be used for all
+ * CSS variables generated compiled with CSS namespacing enabled.
+ *
+ * Typically set via {@link provideCssVarNamespacing}.
+ */
+export const CSS_VAR_NAMESPACE = new InjectionToken<string>('CSS_VAR_NAMESPACE');
+
+/**
+ * Configures the application to use the given namespace for all CSS variables.
+ *
+ * @param namespace The prefix string to use as a namespace. This is typically the `APP_ID`
+ *     followed by a separator, such as 'my-app_'.
+ * @publicApi
+ */
+export function provideCssVarNamespacing(namespace: string): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: CSS_VAR_NAMESPACE,
+      useValue: namespace,
+    },
+  ]);
+}
 
 export function shimContentAttribute(componentShortId: string): string {
   return CONTENT_ATTR.replace(COMPONENT_REGEX, componentShortId);
@@ -135,6 +161,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
     EmulatedEncapsulationDomRenderer2 | NoneEncapsulationDomRenderer
   >();
   private readonly defaultRenderer: Renderer2;
+  private readonly cssVarNamespace: string;
 
   constructor(
     private readonly eventManager: EventManager,
@@ -147,7 +174,9 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
     @Inject(TracingService)
     @Optional()
     private readonly tracingService: TracingService<TracingSnapshot> | null = null,
+    @Inject(CSS_VAR_NAMESPACE) @Optional() cssVarNamespace: string | null = null,
   ) {
+    this.cssVarNamespace = cssVarNamespace ?? '';
     this.defaultRenderer = new DefaultDomRenderer2(eventManager, doc, ngZone, this.tracingService);
   }
 
@@ -201,6 +230,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
             doc,
             ngZone,
             tracingService,
+            this.cssVarNamespace,
           );
           break;
         case ViewEncapsulation.ShadowDom:
@@ -212,6 +242,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
             ngZone,
             this.nonce,
             tracingService,
+            this.cssVarNamespace,
             sharedStylesHost,
           );
         case ViewEncapsulation.ExperimentalIsolatedShadowDom:
@@ -223,6 +254,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
             ngZone,
             this.nonce,
             tracingService,
+            this.cssVarNamespace,
           );
 
         default:
@@ -234,6 +266,7 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
             doc,
             ngZone,
             tracingService,
+            this.cssVarNamespace,
           );
           break;
       }
@@ -502,6 +535,7 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
     ngZone: NgZone,
     nonce: string | null,
     tracingService: TracingService<TracingSnapshot> | null,
+    cssVarNamespace: string,
     private sharedStylesHost?: SharedStylesHost,
   ) {
     super(eventManager, doc, ngZone, tracingService);
@@ -519,7 +553,9 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
       styles = addBaseHrefToCssSourceMap(baseHref, styles);
     }
 
-    styles = shimStylesContent(component.id, styles);
+    styles = shimStylesContent(component.id, styles).map((s) =>
+      s.replace(/%NS%/g, cssVarNamespace),
+    );
 
     for (const style of styles) {
       const styleEl = document.createElement('style');
@@ -589,6 +625,7 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
     doc: Document,
     ngZone: NgZone,
     tracingService: TracingService<TracingSnapshot> | null,
+    cssVarNamespace: string,
     compId?: string,
   ) {
     super(eventManager, doc, ngZone, tracingService);
@@ -599,7 +636,8 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
       styles = addBaseHrefToCssSourceMap(baseHref, styles);
     }
 
-    this.styles = compId ? shimStylesContent(compId, styles) : styles;
+    const shimmed = compId ? shimStylesContent(compId, styles) : styles;
+    this.styles = shimmed.map((s) => s.replace(/%NS%/g, cssVarNamespace));
     this.styleUrls = component.getExternalStyles?.(compId);
   }
 
@@ -630,6 +668,7 @@ class EmulatedEncapsulationDomRenderer2 extends NoneEncapsulationDomRenderer {
     doc: Document,
     ngZone: NgZone,
     tracingService: TracingService<TracingSnapshot> | null,
+    cssVarNamespace: string,
   ) {
     const compId = appId + '-' + component.id;
     super(
@@ -640,6 +679,7 @@ class EmulatedEncapsulationDomRenderer2 extends NoneEncapsulationDomRenderer {
       doc,
       ngZone,
       tracingService,
+      cssVarNamespace,
       compId,
     );
     this.contentAttr = shimContentAttribute(compId);

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -177,7 +177,13 @@ export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
     @Inject(CSS_VAR_NAMESPACE) @Optional() cssVarNamespace: string | null = null,
   ) {
     this.cssVarNamespace = cssVarNamespace ?? '';
-    this.defaultRenderer = new DefaultDomRenderer2(eventManager, doc, ngZone, this.tracingService);
+    this.defaultRenderer = new DefaultDomRenderer2(
+      eventManager,
+      doc,
+      ngZone,
+      this.tracingService,
+      this.cssVarNamespace,
+    );
   }
 
   createRenderer(element: any, type: RendererType2 | null): Renderer2 {
@@ -304,6 +310,7 @@ class DefaultDomRenderer2 implements Renderer2 {
     private readonly doc: Document,
     protected readonly ngZone: NgZone,
     private readonly tracingService: TracingService<TracingSnapshot> | null,
+    private readonly cssVarNamespace: string = '',
   ) {}
 
   destroy(): void {}
@@ -412,7 +419,10 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   setStyle(el: any, style: string, value: any, flags: RendererStyleFlags2): void {
-    if (flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
+    if (style.startsWith('--')) {
+      style = style.replace('%NS%', this.cssVarNamespace);
+      el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
+    } else if (flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
       el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
     } else {
       el.style[style] = value;
@@ -420,7 +430,10 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   removeStyle(el: any, style: string, flags: RendererStyleFlags2): void {
-    if (flags & RendererStyleFlags2.DashCase) {
+    if (style.startsWith('--')) {
+      style = style.replace('%NS%', this.cssVarNamespace);
+      el.style.removeProperty(style);
+    } else if (flags & RendererStyleFlags2.DashCase) {
       // removeProperty has no effect when used on camelCased properties.
       el.style.removeProperty(style);
     } else {
@@ -538,7 +551,7 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
     cssVarNamespace: string,
     private sharedStylesHost?: SharedStylesHost,
   ) {
-    super(eventManager, doc, ngZone, tracingService);
+    super(eventManager, doc, ngZone, tracingService, cssVarNamespace);
     this.shadowRoot = (hostEl as any).attachShadow({mode: 'open'});
 
     // SharedStylesHost is used to add styles to the shadow root by ShadowDom.
@@ -628,7 +641,7 @@ class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
     cssVarNamespace: string,
     compId?: string,
   ) {
-    super(eventManager, doc, ngZone, tracingService);
+    super(eventManager, doc, ngZone, tracingService, cssVarNamespace);
     let styles = component.styles;
     if (ngDevMode) {
       // We only do this in development, as for production users should not add CSS sourcemaps to components.

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -78,20 +78,23 @@ export const REMOVE_STYLES_ON_COMPONENT_DESTROY = new InjectionToken<boolean>(
  *
  * Typically set via {@link provideCssVarNamespacing}.
  */
-export const CSS_VAR_NAMESPACE = new InjectionToken<string>('CSS_VAR_NAMESPACE');
+export const CSS_VAR_NAMESPACE = new InjectionToken<string>(
+  typeof ngDevMode !== 'undefined' && ngDevMode ? 'CSS_VAR_NAMESPACE' : '',
+);
 
 /**
  * Configures the application to use the given namespace for all CSS variables.
  *
- * @param namespace The prefix string to use as a namespace. This is typically the `APP_ID`
- *     followed by a separator, such as 'my-app_'.
+ * @param namespace The prefix string to use as a namespace. If not provided, it defaults
+ *     to the `APP_ID`. An underscore is appended unconditionally.
  * @publicApi
  */
-export function provideCssVarNamespacing(namespace: string): EnvironmentProviders {
+export function provideCssVarNamespacing(namespace?: string): EnvironmentProviders {
   return makeEnvironmentProviders([
     {
       provide: CSS_VAR_NAMESPACE,
-      useValue: namespace,
+      useFactory: (appId: string) => `${namespace ?? appId}_`,
+      deps: [APP_ID],
     },
   ]);
 }
@@ -419,10 +422,11 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   setStyle(el: any, style: string, value: any, flags: RendererStyleFlags2): void {
-    if (style.startsWith('--')) {
+    const isVariable = style.startsWith('--');
+    if (isVariable) {
       style = style.replace('%NS%', this.cssVarNamespace);
-      el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
-    } else if (flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
+    }
+    if (isVariable || flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
       el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
     } else {
       el.style[style] = value;
@@ -430,10 +434,11 @@ class DefaultDomRenderer2 implements Renderer2 {
   }
 
   removeStyle(el: any, style: string, flags: RendererStyleFlags2): void {
-    if (style.startsWith('--')) {
+    const isVariable = style.startsWith('--');
+    if (isVariable) {
       style = style.replace('%NS%', this.cssVarNamespace);
-      el.style.removeProperty(style);
-    } else if (flags & RendererStyleFlags2.DashCase) {
+    }
+    if (isVariable || flags & RendererStyleFlags2.DashCase) {
       // removeProperty has no effect when used on camelCased properties.
       el.style.removeProperty(style);
     } else {

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -18,7 +18,8 @@ export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {By} from './dom/debug/by';
-export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
+export {provideCssVarNamespacing, REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
+export {CssVarNamespacer} from './dom/css_var_namespacer';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {EventManagerPlugin} from './dom/events/event_manager_plugin';
 export {

--- a/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
+++ b/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+
+import {CssVarNamespacer} from '../../src/dom/css_var_namespacer';
+import {provideCssVarNamespacing} from '../../src/dom/dom_renderer';
+
+describe('CssVarNamespacer', () => {
+  it('should namespace variables when `CSS_VAR_NAMESPACE` is provided', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer, provideCssVarNamespacing('test-app_')],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(namespacer.namespace('--my-var')).toBe('--test-app_my-var');
+  });
+
+  it('should not namespace variables when `CSS_VAR_NAMESPACE` is not provided', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(namespacer.namespace('--my-var')).toBe('--my-var');
+  });
+
+  it('throws an error when a variable is passed in without the leading `--`', () => {
+    TestBed.configureTestingModule({
+      providers: [CssVarNamespacer],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(() => namespacer.namespace('my-var')).toThrowError(/must start with '--'/);
+  });
+});

--- a/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
+++ b/packages/platform-browser/test/dom/css_var_namespacer_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {APP_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {CssVarNamespacer} from '../../src/dom/css_var_namespacer';
@@ -14,12 +15,26 @@ import {provideCssVarNamespacing} from '../../src/dom/dom_renderer';
 describe('CssVarNamespacer', () => {
   it('should namespace variables when `CSS_VAR_NAMESPACE` is provided', () => {
     TestBed.configureTestingModule({
-      providers: [CssVarNamespacer, provideCssVarNamespacing('test-app_')],
+      providers: [CssVarNamespacer, provideCssVarNamespacing('test-app')],
     });
 
     const namespacer = TestBed.inject(CssVarNamespacer);
 
     expect(namespacer.namespace('--my-var')).toBe('--test-app_my-var');
+  });
+
+  it('should fallback to `APP_ID` with an underscore when no namespace is provided to `provideCssVarNamespacing`', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        CssVarNamespacer,
+        {provide: APP_ID, useValue: 'custom-app'},
+        provideCssVarNamespacing(),
+      ],
+    });
+
+    const namespacer = TestBed.inject(CssVarNamespacer);
+
+    expect(namespacer.namespace('--my-var')).toBe('--custom-app_my-var');
   });
 
   it('should not namespace variables when `CSS_VAR_NAMESPACE` is not provided', () => {

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -520,7 +520,8 @@ describe('DefaultDomRendererV2', () => {
         expect(div.style.getPropertyValue('--foo')).toBe('');
       });
 
-      it('should throw an error if style property binding starts with `--global-` with a single hyphen', () => {
+      // TODO: Enforce this in v23.
+      xit('should throw an error if style property binding starts with `--global-` with a single hyphen', () => {
         @Component({
           selector: 'cmp-style-prop-error',
           template: `<div [style.--global-foo]="'blue'"></div>`,

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -361,7 +361,7 @@ describe('DefaultDomRendererV2', () => {
 
         TestBed.configureTestingModule({
           imports: [CmpNamespaceEmulated],
-          providers: [provideCssVarNamespacing('my-namespace_')],
+          providers: [provideCssVarNamespacing('my-namespace')],
         });
         const fixture = TestBed.createComponent(CmpNamespaceEmulated);
         fixture.detectChanges();
@@ -384,7 +384,7 @@ describe('DefaultDomRendererV2', () => {
 
         TestBed.configureTestingModule({
           imports: [CmpNamespaceNone],
-          providers: [provideCssVarNamespacing('my-namespace_')],
+          providers: [provideCssVarNamespacing('my-namespace')],
         });
         const fixture = TestBed.createComponent(CmpNamespaceNone);
         fixture.detectChanges();
@@ -407,7 +407,7 @@ describe('DefaultDomRendererV2', () => {
 
         TestBed.configureTestingModule({
           imports: [CmpNamespaceShadow],
-          providers: [provideCssVarNamespacing('my-namespace_')],
+          providers: [provideCssVarNamespacing('my-namespace')],
         });
         const fixture = TestBed.createComponent(CmpNamespaceShadow);
         fixture.detectChanges();
@@ -510,7 +510,7 @@ describe('DefaultDomRendererV2', () => {
 
         TestBed.configureTestingModule({
           imports: [CmpStylePropNamespace],
-          providers: [provideCssVarNamespacing('my-namespace_')],
+          providers: [provideCssVarNamespacing('my-namespace')],
         });
         const fixture = TestBed.createComponent(CmpStylePropNamespace);
         fixture.detectChanges();
@@ -531,7 +531,7 @@ describe('DefaultDomRendererV2', () => {
         expect(() => {
           TestBed.configureTestingModule({
             imports: [CmpStylePropError],
-            providers: [provideCssVarNamespacing('my-namespace_')],
+            providers: [provideCssVarNamespacing('my-namespace')],
           });
         }).toThrowError(/CSS variable "--global-foo" has a single hyphen after "--global"/);
       });
@@ -548,7 +548,7 @@ describe('DefaultDomRendererV2', () => {
 
         TestBed.configureTestingModule({
           imports: [CmpRendererSetStyle],
-          providers: [provideCssVarNamespacing('my-namespace_')],
+          providers: [provideCssVarNamespacing('my-namespace')],
         });
         const fixture = TestBed.createComponent(CmpRendererSetStyle);
         const comp = fixture.componentInstance;

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -498,6 +498,73 @@ describe('DefaultDomRendererV2', () => {
         expect(css).toContain('var(--foo)');
       });
     });
+
+    describe('style property bindings namespacing', () => {
+      it('should namespace style property bindings starting with `--`', () => {
+        @Component({
+          selector: 'cmp-style-prop-namespace',
+          template: `<div [style.--foo]="'blue'"></div>`,
+          standalone: true,
+        })
+        class CmpStylePropNamespace {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpStylePropNamespace],
+          providers: [provideCssVarNamespacing('my-namespace_')],
+        });
+        const fixture = TestBed.createComponent(CmpStylePropNamespace);
+        fixture.detectChanges();
+
+        const div = fixture.nativeElement.querySelector('div');
+        expect(div.style.getPropertyValue('--my-namespace_foo')).toBe('blue');
+        expect(div.style.getPropertyValue('--foo')).toBe('');
+      });
+
+      it('should throw an error if style property binding starts with `--global-` with a single hyphen', () => {
+        @Component({
+          selector: 'cmp-style-prop-error',
+          template: `<div [style.--global-foo]="'blue'"></div>`,
+          standalone: true,
+        })
+        class CmpStylePropError {}
+
+        expect(() => {
+          TestBed.configureTestingModule({
+            imports: [CmpStylePropError],
+            providers: [provideCssVarNamespacing('my-namespace_')],
+          });
+        }).toThrowError(/CSS variable "--global-foo" has a single hyphen after "--global"/);
+      });
+
+      it('should namespace styles set via Renderer2.setStyle/removeStyle', () => {
+        @Component({
+          selector: 'cmp-renderer-set-style',
+          template: '',
+          standalone: true,
+        })
+        class CmpRendererSetStyle {
+          constructor(public renderer: Renderer2) {}
+        }
+
+        TestBed.configureTestingModule({
+          imports: [CmpRendererSetStyle],
+          providers: [provideCssVarNamespacing('my-namespace_')],
+        });
+        const fixture = TestBed.createComponent(CmpRendererSetStyle);
+        const comp = fixture.componentInstance;
+        const div = document.createElement('div');
+
+        comp.renderer.setStyle(div, '--%NS%foo', 'blue');
+        expect(div.style.getPropertyValue('--my-namespace_foo')).toBe('blue');
+
+        comp.renderer.setStyle(div, '--bar', 'red');
+        expect(div.style.getPropertyValue('--bar')).toBe('red');
+        expect(div.style.getPropertyValue('--my-namespace_bar')).toBe('');
+
+        comp.renderer.removeStyle(div, '--%NS%foo');
+        expect(div.style.getPropertyValue('--my-namespace_foo')).toBe('');
+      });
+    });
   });
 });
 

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -14,6 +14,7 @@ import {By} from '../../src/dom/debug/by';
 import {
   addBaseHrefToCssSourceMap,
   NAMESPACE_URIS,
+  provideCssVarNamespacing,
   REMOVE_STYLES_ON_COMPONENT_DESTROY,
 } from '../../src/dom/dom_renderer';
 
@@ -337,6 +338,166 @@ describe('DefaultDomRendererV2', () => {
     );
 
     document.head.innerHTML = '';
+  });
+
+  describe('CSS namespacing', () => {
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+    });
+
+    describe('with provided namespace', () => {
+      it('should replace `%NS%` in styles for `Emulated` encapsulation', async () => {
+        @Component({
+          selector: 'cmp-namespace-emulated',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.Emulated,
+        })
+        class CmpNamespaceEmulated {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceEmulated],
+          providers: [provideCssVarNamespacing('my-namespace_')],
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceEmulated);
+        fixture.detectChanges();
+
+        expect(await styleCount(fixture, 'var(--my-namespace_foo)')).toBe(1);
+      });
+
+      it('should replace `%NS%` in styles for `None` encapsulation', async () => {
+        @Component({
+          selector: 'cmp-namespace-none',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.None,
+        })
+        class CmpNamespaceNone {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceNone],
+          providers: [provideCssVarNamespacing('my-namespace_')],
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceNone);
+        fixture.detectChanges();
+
+        expect(await styleCount(fixture, 'var(--my-namespace_foo)')).toBe(1);
+      });
+
+      it('should replace `%NS%` in styles for `ShadowDom` encapsulation', () => {
+        @Component({
+          selector: 'cmp-namespace-shadow',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.ShadowDom,
+        })
+        class CmpNamespaceShadow {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceShadow],
+          providers: [provideCssVarNamespacing('my-namespace_')],
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceShadow);
+        fixture.detectChanges();
+
+        const styles = fixture.nativeElement.shadowRoot.querySelectorAll(
+          'style',
+        ) as NodeListOf<HTMLStyleElement>;
+        const css = Array.from(styles)
+          .map((s) => s.textContent)
+          .join('\n\n');
+        expect(css).toContain('var(--my-namespace_foo)');
+      });
+    });
+
+    describe('with default (empty) namespace', () => {
+      it('should replace `%NS%` in styles for `Emulated` encapsulation', async () => {
+        @Component({
+          selector: 'cmp-namespace-emulated',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.Emulated,
+        })
+        class CmpNamespaceEmulated {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceEmulated],
+          providers: [], // No `provideCssVarNamespacing`.
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceEmulated);
+        fixture.detectChanges();
+
+        expect(await styleCount(fixture, 'var(--foo)')).toBe(1);
+      });
+
+      it('should replace `%NS%` in styles for `None` encapsulation', async () => {
+        @Component({
+          selector: 'cmp-namespace-none',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.None,
+        })
+        class CmpNamespaceNone {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceNone],
+          providers: [], // No `provideCssVarNamespacing`.
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceNone);
+        fixture.detectChanges();
+
+        expect(await styleCount(fixture, 'var(--foo)')).toBe(1);
+      });
+
+      it('should replace `%NS%` in styles for `ShadowDom` encapsulation', () => {
+        @Component({
+          selector: 'cmp-namespace-shadow',
+          template: '',
+          styles: `
+            :host {
+              color: var(--%NS%foo);
+            }
+          `,
+          encapsulation: ViewEncapsulation.ShadowDom,
+        })
+        class CmpNamespaceShadow {}
+
+        TestBed.configureTestingModule({
+          imports: [CmpNamespaceShadow],
+          providers: [], // No `provideCssVarNamespacing`.
+        });
+        const fixture = TestBed.createComponent(CmpNamespaceShadow);
+        fixture.detectChanges();
+
+        const styles = fixture.nativeElement.shadowRoot.querySelectorAll(
+          'style',
+        ) as NodeListOf<HTMLStyleElement>;
+        const css = Array.from(styles)
+          .map((s) => s.textContent)
+          .join('\n\n');
+        expect(css).toContain('var(--foo)');
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Superseds https://github.com/angular/angular/pull/67362. Primary differences are:
- Opt-out syntax is now a `--global` prefix, e.g. `--global--foo: blue`
- Added support for style properties, e.g. `[style.--foo]="'blue'"`
- Added errors for prefix missing trailing double-hyphen, e.g. `--global-foo`

-----

This adds CSS variable namespacing support to Angular.

This allows multiple apps to coexist on the same page with isolated CSS variables, meaning one can use `color: var(--primary-color);` without worrying about accidentally inheriting the primary color of a different app which happens to set it on an ancestor element.

To enable this feature, call `provideCssVarNamespacing` in your `app.config.ts`. Typically you want to configure this with the same value as [`APP_ID`](https://angular.dev/api/core/APP_ID), but with an additional separator at the end (a `-` or `_`):

```typescript
import {ApplicationConfig, APP_ID} from '@angular/core';
import {provideCssVarNamespacing} from '@angular/platform-browser';

export const appConfig: ApplicationConfig = {
  providers: [
    {
      provide: APP_ID,
      useValue: 'my-app',
    },
    provideCssVarNamespacing('my-app_'),
  ],
};
```

This only namespaces styles in Angular components (the `styles` or `styleUrls` properties in `@Component`). It does not namespace global styles, which are out of scope for this effort.

Namespacing does naturally break any JavaScript references to CSS variables, therefore this PR also introduces `CssVarNamespacer` which allows you to automatically namespace variables based on what is configured in the application.

```typescript
import {CssVarNamespacer} from '@angular/platform-browser';

const namespacer = inject(CssVarNamespacer);
const color = namespacer.namespace('--primary-color');
getComputedStyle(someElement).getPropertyValue(color);
```

Libraries should consider always using the namespacer when referring to CSS variables, as they may be consumed by applications which enable namespacing.

Namespacing works by having the compiler unconditionally prepend `%NS%` to CSS variables (`--foo` -> `--%NS%foo`) and then at runtime replaces `%NS%` with a namespace specified by `provideCssVarNamespacing('my-app_')` (`--%NS%foo` -> `--my-app_foo`).

Internal bug: [b/485672083](http://b/485672083)

-----

Closes https://github.com/angular/angular/pull/67362 via supersession.