### PR TITLE
docs(forms): add applyWhenValue example for union validation

### DIFF
--- a/adev/src/content/guide/forms/signals/validation.md
+++ b/adev/src/content/guide/forms/signals/validation.md
@@ -332,6 +332,46 @@ export class OrderComponent {
 }
 ```
 
+## Validation for unions and variants
+
+Some forms use union types where validation rules depend on the current variant. Use `applyWhenValue()` to conditionally apply validation rules based on another field's value.
+
+This pattern is useful for discriminated unions where different variants require different validation rules.
+
+```ts
+import {applyWhenValue, form, minLength, required} from '@angular/forms/signals';
+
+type Login =
+  | {
+      type: 'email';
+      email: string;
+      password: string;
+    }
+  | {
+      type: 'guest';
+      nickname: string;
+    };
+
+loginForm = form(this.loginModel, (schemaPath) => {
+  applyWhenValue(schemaPath, {
+    when: ({valueOf}) => valueOf(schemaPath.type) === 'email',
+    apply: (path) => {
+      required(path.email);
+      minLength(path.password, 8);
+    },
+  });
+
+  applyWhenValue(schemaPath, {
+    when: ({valueOf}) => valueOf(schemaPath.type) === 'guest',
+    apply: (path) => {
+      required(path.nickname);
+    },
+  });
+});
+```
+
+`applyWhenValue()` only applies validation rules when the `when` condition returns `true`. This lets each variant define its own validation requirements while keeping validation logic inside the schema function.
+
 ## Validation errors
 
 When validation rules fail, they produce error objects that describe what went wrong. Understanding error structure helps you provide clear feedback to users.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The Signal Forms validation guide documents validation helpers such as `applyEach()`, but it does not explain how to apply validation conditionally for union or variant-based forms using `applyWhenValue()`.

Issue Number: #66906

## What is the new behavior?

Adds a new section to the Signal Forms validation guide showing how to use `applyWhenValue()` with discriminated unions.

The example demonstrates how different validation rules can be applied depending on the active variant.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

Inspired by the discussion and examples linked in the issue and StackOverflow references.
