### PR TITLE
refactor(devtools): remove unnecessary async from serializeTransferState

### DIFF
--- a/devtools/src/app/app.config.ts
+++ b/devtools/src/app/app.config.ts
@@ -41,7 +41,7 @@ export const appConfig: ApplicationConfig = {
       useClass: DemoApplicationEnvironment,
     },
     // We simulate a transfer state created by the server-side rendering.
-    provideAppInitializer(async () => serializeTransferState()),
+    provideAppInitializer(() => serializeTransferState()),
     provideSettings(),
   ],
 };

--- a/devtools/src/app/transfer-state.ts
+++ b/devtools/src/app/transfer-state.ts
@@ -12,7 +12,7 @@ import {APP_ID, DOCUMENT, inject, makeStateKey, TransferState} from '@angular/co
 /**
  * This function serializes the transfer state into the DOM.
  */
-export async function serializeTransferState(): Promise<void> {
+export function serializeTransferState(): void {
   const doc = inject(DOCUMENT);
   const appId = inject(APP_ID);
   const transferState = inject(TransferState);


### PR DESCRIPTION
Remove unnecessary `async`/`Promise<void>` from `serializeTransferState` and the redundant `async () =>` wrapper in `provideAppInitializer`  the function contains no async operations, so this is a zero behavior change cleanup.