### PR TITLE
fix(forms): support nullable string in email and pattern validators

### DIFF
--- a/packages/forms/signals/src/api/rules/validation/email.ts
+++ b/packages/forms/signals/src/api/rules/validation/email.ts
@@ -58,18 +58,19 @@ const EMAIL_REGEXP =
  * @category validation
  * @publicApi 22.0
  */
-export function email<TPathKind extends PathKind = PathKind.Root>(
-  path: SchemaPath<string, SchemaPathRules.Supported, TPathKind>,
-  config?: BaseValidatorConfig<string, TPathKind>,
+export function email<TValue extends string | null, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  config?: BaseValidatorConfig<TValue, TPathKind>,
 ) {
   validate(path, (ctx) => {
     if (config?.when && !config.when(ctx)) {
       return undefined;
     }
-    if (isEmpty(ctx.value())) {
+    const value = ctx.value();
+    if (value == null || isEmpty(value)) {
       return undefined;
     }
-    if (!EMAIL_REGEXP.test(ctx.value())) {
+    if (!EMAIL_REGEXP.test(value)) {
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {

--- a/packages/forms/signals/src/api/rules/validation/pattern.ts
+++ b/packages/forms/signals/src/api/rules/validation/pattern.ts
@@ -28,10 +28,10 @@ import {patternError} from './validation_errors';
  * @category validation
  * @publicApi 22.0
  */
-export function pattern<TPathKind extends PathKind = PathKind.Root>(
-  path: SchemaPath<string, SchemaPathRules.Supported, TPathKind>,
-  pattern: RegExp | LogicFn<string | undefined, RegExp | undefined, TPathKind>,
-  config?: BaseValidatorConfig<string, TPathKind>,
+export function pattern<TValue extends string | null, TPathKind extends PathKind = PathKind.Root>(
+  path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,
+  pattern: RegExp | LogicFn<TValue | undefined, RegExp | undefined, TPathKind>,
+  config?: BaseValidatorConfig<TValue, TPathKind>,
 ) {
   const PATTERN_MEMO = metadata(path, createMetadataKey<RegExp | undefined>(), (ctx) => {
     if (config?.when && !config.when(ctx)) {
@@ -41,14 +41,15 @@ export function pattern<TPathKind extends PathKind = PathKind.Root>(
   });
   metadata(path, PATTERN, ({state}) => state.metadata(PATTERN_MEMO)!());
   validate(path, (ctx) => {
-    if (isEmpty(ctx.value())) {
+    const value = ctx.value();
+    if (value == null || isEmpty(value)) {
       return undefined;
     }
     const pattern = ctx.state.metadata(PATTERN_MEMO)!();
     if (pattern === undefined) {
       return undefined;
     }
-    if (!pattern.test(ctx.value())) {
+    if (!pattern.test(value)) {
       if (config?.error) {
         return getOption(config.error, ctx);
       } else {

--- a/packages/forms/signals/test/node/types.spec.ts
+++ b/packages/forms/signals/test/node/types.spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-
+import {email, pattern} from '../../src/api/rules/validation';
 import {signal, WritableSignal} from '@angular/core';
 import {
   createMetadataKey,
@@ -26,7 +26,6 @@ import {
   SchemaFn,
   validate,
 } from '../../public_api';
-
 interface Order {
   id: string;
   details: {
@@ -229,3 +228,11 @@ function typeVerificationOnlyDoNotRunMe() {
     });
   });
 }
+
+// Type test for nullable string validators
+const nullableEmailModel: WritableSignal<{email: string | null}> = null!;
+
+form(nullableEmailModel, (p) => {
+  email(p.email);
+  pattern(p.email, /^[a-z]+$/);
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added
* [ ] Docs have been added / updated

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

`email()` and `pattern()` only accept `SchemaPath<string, ...>` types, which causes TypeScript errors when optional fields are represented as `string | null`.

Issue Number: #66539

## What is the new behavior?

Updates `email()` and `pattern()` validators to support nullable string paths.

A type test was also added to verify usage with `string | null`.

Runtime behavior is unchanged because nullable values were already treated as empty values.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

None.
