### PR TITLE
fix(vscode-extension): respect workspace trust when resolving backend…

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -713,6 +713,9 @@ function getProbeLocations(bundled: string): string[] {
   const locations = [];
   // Prioritize the bundled version
   locations.push(bundled);
+  if (!vscode.workspace.isTrusted) {
+    return locations;
+  }
   // Look in workspaces currently open
   const workspaceFolders = vscode.workspace.workspaceFolders || [];
   for (const folder of workspaceFolders) {
@@ -726,7 +729,7 @@ function extensionVersionCompatibleWithAllProjects(serverModuleLocation: string)
     '@angular/language-service',
     serverModuleLocation,
   )?.version;
-  if (languageServiceVersion === undefined) {
+  if (languageServiceVersion === undefined || !vscode.workspace.isTrusted) {
     return true;
   }
 
@@ -750,6 +753,10 @@ function extensionVersionCompatibleWithAllProjects(serverModuleLocation: string)
 async function getAngularVersionsInWorkspace(
   outputChannel: vscode.OutputChannel,
 ): Promise<NodeModule[]> {
+  if (!vscode.workspace.isTrusted) {
+    return [];
+  }
+
   const packageJsonFiles = await vscode.workspace.findFiles(
     '**/package.json',
     // Skip looking inside `node_module` folders as those contain irrelevant files.


### PR DESCRIPTION
fix(vscode-extension): respect workspace trust when resolving backend modules

Only resolve and load `@angular/language-service` and `typescript` compiler
modules from workspace folders when the workspace is trusted. In untrusted
workspaces (Restricted Mode), default strictly to the bundled extension modules.

This change implements this by:
1. Returning early in getProbeLocations with only the bundled extension paths
   when vscode.workspace.isTrusted is false.
2. Bypassing workspace-local `@angular/core` compatibility checks in untrusted
   workspaces by checking the trust status inside
   extensionVersionCompatibleWithAllProjects.
3. Bypassing the workspace package.json search and returning an empty array
   directly in getAngularVersionsInWorkspace when the workspace is untrusted.