### PR TITLE
fix(vscode-extension): restrict jsdoc markdown trust and harden docum…

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -27,6 +27,7 @@ import {
 import {NodeModule, resolve, Version} from '../../common/resolver';
 
 import {isInsideStringLiteral, isNotTypescriptOrSupportedDecoratorField} from './embedded_support';
+import {OpenJsDocLinkCommandId} from '../../common/initialize';
 
 interface GetTcbResponse {
   uri: vscode.Uri;
@@ -82,7 +83,9 @@ export class AngularLanguageClient implements vscode.Disposable {
       revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
       outputChannel: this.outputChannel,
       markdown: {
-        isTrusted: true,
+        isTrusted: {
+          enabledCommands: [OpenJsDocLinkCommandId],
+        },
       },
       middleware: {
         provideCodeActions: async (

--- a/vscode-ng-language-service/client/src/commands.ts
+++ b/vscode-ng-language-service/client/src/commands.ts
@@ -189,9 +189,12 @@ function openJsDocLinkCommand(): Command<OpenJsDocLinkCommand_Args> {
     id: OpenJsDocLinkCommandId,
     isTextEditorCommand: false,
     async execute(args) {
-      return await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(args.file), <
-        vscode.TextDocumentShowOptions
-      >{
+      if (!args?.file) {
+        return;
+      }
+      const uri = vscode.Uri.parse(args.file);
+      const document = await vscode.workspace.openTextDocument(uri);
+      return await vscode.window.showTextDocument(document, {
         selection: new vscode.Range(
           new vscode.Position(args.position?.start.line ?? 0, args.position?.start.character ?? 0),
           new vscode.Position(args.position?.end.line ?? 0, args.position?.end.character ?? 0),


### PR DESCRIPTION
…ent opening

Restrict JSDoc hover links to the custom openJSDocLink command and implement document opening using safe workspace APIs.
