### PR TITLE
fix(core): skip DOM trigger registration in DeferBlockBehavior.Manual…

### DIFF
--- a/packages/core/src/defer/instructions.ts
+++ b/packages/core/src/defer/instructions.ts
@@ -69,6 +69,7 @@ import {
   triggerPrefetching,
   triggerResourceLoading,
   shouldAttachTrigger,
+  shouldTriggerDeferBlock,
   hasHydrateTriggers,
 } from './triggering';
 import {formatRuntimeError, RuntimeErrorCode} from '../errors';
@@ -580,8 +581,8 @@ export function ɵɵdeferOnHover(triggerIndex: number, walkUpTimes?: number) {
 
   renderPlaceholder(lView, tNode);
 
-  // Avoid adding event listeners when this instruction is invoked on the server.
-  if (!(typeof ngServerMode !== 'undefined' && ngServerMode)) {
+  // Avoid adding event listeners on the server or in manual testing mode.
+  if (shouldTriggerDeferBlock(TriggerType.Regular, lView)) {
     registerDomTrigger(
       lView,
       tNode,
@@ -677,8 +678,8 @@ export function ɵɵdeferOnInteraction(triggerIndex: number, walkUpTimes?: numbe
 
   renderPlaceholder(lView, tNode);
 
-  // Avoid adding event listeners when this instruction is invoked on the server.
-  if (!(typeof ngServerMode !== 'undefined' && ngServerMode)) {
+  // Avoid adding event listeners on the server or in manual testing mode.
+  if (shouldTriggerDeferBlock(TriggerType.Regular, lView)) {
     registerDomTrigger(
       lView,
       tNode,
@@ -785,8 +786,8 @@ export function ɵɵdeferOnViewport(
 
   renderPlaceholder(lView, tNode);
 
-  // Avoid adding event listeners when this instruction is invoked on the server.
-  if (!(typeof ngServerMode !== 'undefined' && ngServerMode)) {
+  // Avoid registering IntersectionObserver on the server or in manual testing mode.
+  if (shouldTriggerDeferBlock(TriggerType.Regular, lView)) {
     registerDomTrigger(
       lView,
       tNode,

--- a/packages/core/src/defer/triggering.ts
+++ b/packages/core/src/defer/triggering.ts
@@ -316,7 +316,7 @@ export function triggerResourceLoading(
 /**
  * Defines whether we should proceed with triggering a given defer block.
  */
-function shouldTriggerDeferBlock(triggerType: TriggerType, lView: LView): boolean {
+export function shouldTriggerDeferBlock(triggerType: TriggerType, lView: LView): boolean {
   // prevents triggering regular triggers when on the server.
   if (triggerType === TriggerType.Regular && typeof ngServerMode !== 'undefined' && ngServerMode) {
     return false;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

When using `DeferBlockBehavior.Manual` in tests (e.g. Jest + JSDOM), Angular still
registers DOM observers for `@defer` trigger functions (`on viewport`, `on hover`,
`on interaction`). This causes `ReferenceError: IntersectionObserver is not defined`
and similar errors, because JSDOM does not implement these browser APIs.

Issue Number: #68800

## What is the new behavior?

`ɵɵdeferOnViewport`, `ɵɵdeferOnHover`, and `ɵɵdeferOnInteraction` now call
`shouldTriggerDeferBlock()` before registering DOM triggers. In Manual mode
the check returns `false`, so no observers or event listeners are attached.
The existing SSR guard is replaced by this check, which already covers the
server-side case as well.

## Does this PR introduce a breaking change?

- [x] No

## Other information

`shouldTriggerDeferBlock` was made `export` so it can be reused in
`instructions.ts` alongside the existing `shouldAttachTrigger`.
`ɵɵdeferOnIdle` is unaffected — it delegates to `scheduleDelayedTrigger`
which already gates on `shouldTriggerDeferBlock` internally.