### PR TITLE
refactor(common): narrow invalidPipeArgumentError value parameter to string

### DIFF
--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -220,7 +220,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
       return _subscribableStrategy;
     }
 
-    throw invalidPipeArgumentError(AsyncPipe, obj);
+    throw invalidPipeArgumentError(AsyncPipe, typeof obj);
   }
 
   private _dispose(): void {

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -124,6 +124,6 @@ export class UpperCasePipe implements PipeTransform {
 
 function assertPipeArgument(pipe: Type<any>, value: Object): void {
   if (typeof value !== 'string') {
-    throw invalidPipeArgumentError(pipe, value);
+    throw invalidPipeArgumentError(pipe, typeof value);
   }
 }

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -274,6 +274,7 @@ export class DatePipe implements PipeTransform {
         timezone ?? this.defaultOptions?.timezone ?? this.defaultTimezone ?? undefined;
       return formatDate(value, _format, locale || this.locale, _timezone);
     } catch (error) {
+      // TODO: RuntimeError doesn't support `cause`, so the original error and its stack are lost.
       throw invalidPipeArgumentError(DatePipe, (error as Error).message);
     }
   }

--- a/packages/common/src/pipes/i18n_plural_pipe.ts
+++ b/packages/common/src/pipes/i18n_plural_pipe.ts
@@ -51,7 +51,7 @@ export class I18nPluralPipe implements PipeTransform {
     if (value == null) return '';
 
     if (typeof pluralMap !== 'object' || pluralMap === null) {
-      throw invalidPipeArgumentError(I18nPluralPipe, pluralMap);
+      throw invalidPipeArgumentError(I18nPluralPipe, String(pluralMap));
     }
 
     const key = getPluralCategory(value, Object.keys(pluralMap), this._localization, locale);

--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -42,7 +42,7 @@ export class I18nSelectPipe implements PipeTransform {
     if (value == null) return '';
 
     if (typeof mapping !== 'object' || typeof value !== 'string') {
-      throw invalidPipeArgumentError(I18nSelectPipe, mapping);
+      throw invalidPipeArgumentError(I18nSelectPipe, typeof mapping);
     }
 
     if (mapping.hasOwnProperty(value)) {

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -119,6 +119,7 @@ export class DecimalPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatNumber(num, locale, digitsInfo);
     } catch (error) {
+      // TODO: RuntimeError doesn't support `cause`, so the original error and its stack are lost.
       throw invalidPipeArgumentError(DecimalPipe, (error as Error).message);
     }
   }
@@ -186,6 +187,7 @@ export class PercentPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatPercent(num, locale, digitsInfo);
     } catch (error) {
+      // TODO: RuntimeError doesn't support `cause`, so the original error and its stack are lost.
       throw invalidPipeArgumentError(PercentPipe, (error as Error).message);
     }
   }
@@ -309,6 +311,7 @@ export class CurrencyPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatCurrency(num, locale, currency, currencyCode, digitsInfo);
     } catch (error) {
+      // TODO: RuntimeError doesn't support `cause`, so the original error and its stack are lost.
       throw invalidPipeArgumentError(CurrencyPipe, (error as Error).message);
     }
   }

--- a/packages/common/src/pipes/slice_pipe.ts
+++ b/packages/common/src/pipes/slice_pipe.ts
@@ -86,7 +86,7 @@ export class SlicePipe implements PipeTransform {
     const supports = typeof value === 'string' || Array.isArray(value);
 
     if (!supports) {
-      throw invalidPipeArgumentError(SlicePipe, value);
+      throw invalidPipeArgumentError(SlicePipe, typeof value);
     }
 
     return value.slice(start, end);

--- a/packages/common/src/pipes/utils.ts
+++ b/packages/common/src/pipes/utils.ts
@@ -15,10 +15,10 @@ import {
 
 import {RuntimeErrorCode} from '../errors';
 
-export function invalidPipeArgumentError(type: Type<any>, value: Object) {
+export function invalidPipeArgumentError(type: Type<any>, value: string) {
   return new RuntimeError(
     RuntimeErrorCode.INVALID_PIPE_ARGUMENT,
-    ngDevMode && `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'`,
+    ngDevMode ? `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'` : value,
   );
 }
 


### PR DESCRIPTION
Previously, `value` was typed as `Object` and the production error path
called `String(value)`, which throws for null-prototype objects
(e.g. `Object.create(null)`).

Narrowing the parameter to `string` makes both dev and prod paths safe and
forces each caller to decide what to surface. `DatePipe` and number pipes
already passed `(error as Error).message`; the remaining callers now pass
`typeof value` (safe for any object) or `String(value)` where the guard
at the call site ensures a primitive.