### PR TITLE
fix(devtools): handle null-prototype object previews

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
@@ -45,4 +45,4 @@ export function getKeys(obj: {}): string[] {
  */
 export const getDescriptor = (instance: any, propName: string): PropertyDescriptor | undefined =>
   Object.getOwnPropertyDescriptor(instance, propName) ||
-  Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), propName);
+  Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance) ?? {}, propName);

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -50,6 +50,14 @@ const serializable: Set<PropType> = new Set([
   PropType.Unknown,
 ]);
 
+const getConstructorName = (prop: object, fallback: string): string => {
+  const constructorName = (prop as {constructor?: {name?: unknown}}).constructor?.name;
+
+  return typeof constructorName === 'string' && constructorName.length > 0
+    ? constructorName
+    : fallback;
+};
+
 const typeToDescriptorPreview: Formatter<string> = {
   [PropType.Array]: (prop: Array<unknown>) => `Array(${prop.length})`,
   [PropType.Set]: (prop: Set<unknown>) => `Set(${prop.size})`,
@@ -58,12 +66,16 @@ const typeToDescriptorPreview: Formatter<string> = {
   [PropType.Boolean]: (prop: boolean) => truncate(prop.toString()),
   [PropType.String]: (prop: string) => `"${prop}"`,
   [PropType.Function]: (prop: Function) => `${prop.name ? 'ƒ ' : ''}(...)`,
-  [PropType.HTMLNode]: (prop: Node) => prop.constructor.name,
+  [PropType.HTMLNode]: (prop: Node) => getConstructorName(prop, 'Node'),
   [PropType.Null]: (_: null) => 'null',
   [PropType.Number]: (prop: any) => prop.toString(),
-  [PropType.Object]: (prop: Object) =>
-    (prop.constructor.name !== 'Object' ? `${prop.constructor.name} ` : '') +
-    (getKeys(prop).length > 0 ? '{...}' : '{}'),
+  [PropType.Object]: (prop: object) => {
+    const constructorName = getConstructorName(prop, 'Object');
+    return (
+      (constructorName !== 'Object' ? `${constructorName} ` : '') +
+      (getKeys(prop).length > 0 ? '{...}' : '{}')
+    );
+  },
   [PropType.Symbol]: (symbol: symbol) => `Symbol(${symbol.description})`,
   [PropType.Undefined]: (_: undefined) => 'undefined',
   [PropType.Date]: (prop: unknown) => {
@@ -308,7 +320,10 @@ function getNestedDescriptorValue(
     case PropType.Object:
       return nodes.reduce(
         (accumulator, nestedProp) => {
-          if (prop.hasOwnProperty(nestedProp.name) && !ignoreList.has(nestedProp.name)) {
+          if (
+            Object.prototype.hasOwnProperty.call(value, nestedProp.name) &&
+            !ignoreList.has(nestedProp.name)
+          ) {
             accumulator[nestedProp.name] = nestedSerializer(
               value,
               nestedProp.name,

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -9,7 +9,7 @@
 import {PropType} from '../../../../protocol';
 
 import {getDescriptor, getKeys} from './object-utils';
-import {deeplySerializeSelectedProperties} from './state-serializer';
+import {deeplySerializeSelectedProperties, serializeDirectiveState} from './state-serializer';
 
 const QUERY_1_1: any[] = [];
 
@@ -494,6 +494,50 @@ describe('deeplySerializeSelectedProperties', () => {
     });
   });
 
+  it('should preview objects without prototypes as plain objects', () => {
+    const grouped = Object.create(null);
+    grouped.foo = 1;
+
+    const result = serializeDirectiveState({grouped});
+
+    expect(result['grouped']).toEqual({
+      type: PropType.Object,
+      editable: false,
+      expandable: true,
+      preview: '{...}',
+      containerType: null,
+    });
+  });
+
+  it('should deeply serialize selected properties from objects without prototypes', () => {
+    const grouped = Object.create(null);
+    grouped.foo = 1;
+
+    const result = deeplySerializeSelectedProperties({grouped}, [
+      {name: 'grouped', children: [{name: 'foo', children: []}]},
+    ]);
+
+    expect(result).toEqual({
+      grouped: {
+        type: PropType.Object,
+        editable: false,
+        expandable: true,
+        preview: '{...}',
+        value: {
+          foo: {
+            type: PropType.Number,
+            expandable: false,
+            editable: true,
+            preview: '1',
+            value: 1,
+            containerType: null,
+          },
+        },
+        containerType: null,
+      },
+    });
+  });
+
   it('getDescriptor should get the descriptors for both getters and setters correctly from the prototype', () => {
     const instance = {
       __proto__: {
@@ -553,6 +597,12 @@ describe('deeplySerializeSelectedProperties', () => {
     const instance = Object.create(null);
 
     expect(getKeys(instance)).toEqual([]);
+  });
+
+  it('getDescriptor should not throw on object without prototype', () => {
+    const instance = Object.create(null);
+
+    expect(getDescriptor(instance, 'foo')).toBeUndefined();
   });
 
   it('getKeys would ignore getters and setters for "__proto__"', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] N/A - Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #68798

Angular DevTools can throw while previewing component state values created with `Object.create(null)` or `Object.groupBy()`, because the serializer assumes object values always have a constructor. Expanding selected nested properties also assumes `hasOwnProperty` exists on the object itself.

## What is the new behavior?

Null-prototype objects are previewed as plain objects, and selected nested properties are checked with `Object.prototype.hasOwnProperty.call`. The DevTools state serializer can inspect those values without throwing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Local checks:

- `./node_modules/.bin/prettier --check devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts`
- `git diff --check`
- `./node_modules/.bin/bazelisk --output_user_root="$PWD/.bazel-user-root" test -- //devtools/projects/ng-devtools-backend/src/lib/state-serializer:test`
