### PR TITLE
docs: add clear buttons inside autocomplete examples

### DIFF
--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.css
@@ -33,7 +33,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 0.25rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -110,4 +110,36 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition: background-color 0.15s ease;
+}
+
+.clear-button:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+.clear-button:focus-visible {
+  outline: 2px solid var(--hot-pink);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
@@ -13,6 +13,18 @@
       (click)="popupExpanded.set(true)"
       (focusout)="onBlur()"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.html
@@ -19,7 +19,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/basic/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -37,6 +50,7 @@ export class App {
   onCommit() {
     this.commitSelection();
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 
   private commitSelection() {

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.css
@@ -34,7 +34,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 3rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -111,4 +111,41 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.clear-button:hover {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.clear-button:focus-visible {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
@@ -13,6 +13,18 @@
       (click)="popupExpanded.set(true)"
       (focusout)="onBlur()"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.html
@@ -19,7 +19,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/material/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -37,6 +50,7 @@ export class App {
   onCommit() {
     this.commitSelection();
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 
   private commitSelection() {

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.css
@@ -35,6 +35,12 @@
   display: flex;
   position: relative;
   align-items: center;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--retro-button-color);
+}
+
+.retro-autocomplete:focus-within {
+  box-shadow: var(--retro-pressed-shadow);
 }
 
 .material-symbols-outlined {
@@ -55,18 +61,12 @@
   border-radius: 0;
   font-family: 'Press Start 2P';
   word-spacing: -5px;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: #000;
   border: none;
-  box-shadow: var(--retro-flat-shadow);
-  background-color: var(--retro-button-color);
+  background-color: transparent;
+  box-shadow: none;
   outline: none;
-}
-
-.autocomplete-input:focus-visible {
-  outline: none;
-  transform: translate(1px, 1px);
-  box-shadow: var(--retro-pressed-shadow);
 }
 
 .autocomplete-input::placeholder {
@@ -132,4 +132,49 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--win95-gray);
+  color: var(--win95-shadow);
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--win95-light) var(--win95-dark-gray) var(--win95-dark-gray) var(--win95-light);
+  box-shadow: 1px 1px 0 var(--win95-shadow);
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  outline: none;
+  font-family: 'Press Start 2P';
+  font-size: 0.6rem;
+  user-select: none;
+}
+
+.clear-button:hover {
+  background: #e0e0e0;
+  outline: 1px dashed var(--win95-dark-gray);
+  outline-offset: 1px;
+}
+
+.clear-button:active {
+  border-color: var(--win95-dark-gray) var(--win95-light) var(--win95-light) var(--win95-dark-gray);
+  box-shadow: 1px 1px 0 var(--win95-shadow) inset;
+}
+
+.clear-button:focus-visible {
+  outline: 2px dashed var(--hot-pink);
+  outline-offset: 4px;
+}
+
+.clear-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
@@ -19,7 +19,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon" aria-hidden="true">X</span>
     </button>

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.html
@@ -13,6 +13,16 @@
       (click)="popupExpanded.set(true)"
       (focusout)="onBlur()"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon" aria-hidden="true">X</span>
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/basic/retro/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -37,6 +50,7 @@ export class App {
   onCommit() {
     this.commitSelection();
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 
   private commitSelection() {

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.css
@@ -33,7 +33,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 0.25rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -110,4 +110,36 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition: background-color 0.15s ease;
+}
+
+.clear-button:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+.clear-button:focus-visible {
+  outline: 2px solid var(--hot-pink);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
@@ -21,7 +21,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.html
@@ -15,6 +15,18 @@
       (keydown.arrowup)="navigated.set(true)"
       [inlineSuggestion]="query() || navigated() ? selectedOption()[0] : undefined"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.ts
@@ -18,13 +18,6 @@ export class App {
     this.navigated.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/app/app.ts
@@ -11,6 +11,20 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+    this.navigated.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -45,6 +59,7 @@ export class App {
       this.query.set('');
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.css
@@ -34,7 +34,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 3rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -111,4 +111,41 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.clear-button:hover {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.clear-button:focus-visible {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
@@ -21,7 +21,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.html
@@ -15,6 +15,18 @@
       (keydown.arrowup)="navigated.set(true)"
       [inlineSuggestion]="query() || navigated() ? selectedOption()[0] : undefined"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.ts
@@ -18,13 +18,6 @@ export class App {
     this.navigated.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/material/app/app.ts
@@ -11,6 +11,20 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+    this.navigated.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -45,6 +59,7 @@ export class App {
       this.query.set('');
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.css
@@ -35,6 +35,12 @@
   display: flex;
   position: relative;
   align-items: center;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--retro-button-color);
+}
+
+.retro-autocomplete:focus-within {
+  box-shadow: var(--retro-pressed-shadow);
 }
 
 .material-symbols-outlined {
@@ -55,18 +61,12 @@
   border-radius: 0;
   font-family: 'Press Start 2P';
   word-spacing: -5px;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: #000;
   border: none;
-  box-shadow: var(--retro-flat-shadow);
-  background-color: var(--retro-button-color);
+  background-color: transparent;
+  box-shadow: none;
   outline: none;
-}
-
-.autocomplete-input:focus-visible {
-  outline: none;
-  transform: translate(1px, 1px);
-  box-shadow: var(--retro-pressed-shadow);
 }
 
 .autocomplete-input::placeholder {
@@ -132,4 +132,49 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--win95-gray);
+  color: var(--win95-shadow);
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--win95-light) var(--win95-dark-gray) var(--win95-dark-gray) var(--win95-light);
+  box-shadow: 1px 1px 0 var(--win95-shadow);
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  outline: none;
+  font-family: 'Press Start 2P';
+  font-size: 0.6rem;
+  user-select: none;
+}
+
+.clear-button:hover {
+  background: #e0e0e0;
+  outline: 1px dashed var(--win95-dark-gray);
+  outline-offset: 1px;
+}
+
+.clear-button:active {
+  border-color: var(--win95-dark-gray) var(--win95-light) var(--win95-light) var(--win95-dark-gray);
+  box-shadow: 1px 1px 0 var(--win95-shadow) inset;
+}
+
+.clear-button:focus-visible {
+  outline: 2px dashed var(--hot-pink);
+  outline-offset: 4px;
+}
+
+.clear-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
@@ -15,6 +15,16 @@
       (keydown.arrowup)="navigated.set(true)"
       [inlineSuggestion]="query() || navigated() ? selectedOption()[0] : undefined"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon" aria-hidden="true">X</span>
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.html
@@ -21,7 +21,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon" aria-hidden="true">X</span>
     </button>

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.ts
@@ -18,13 +18,6 @@ export class App {
     this.navigated.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/highlight/retro/app/app.ts
@@ -11,6 +11,20 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+    this.navigated.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -45,6 +59,7 @@ export class App {
       this.query.set('');
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.css
@@ -33,7 +33,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 0.25rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -110,4 +110,36 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition: background-color 0.15s ease;
+}
+
+.clear-button:hover {
+  background-color: color-mix(in srgb, var(--primary-contrast) 5%, transparent);
+}
+
+.clear-button:focus-visible {
+  outline: 2px solid var(--hot-pink);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
@@ -12,6 +12,18 @@
       [(expanded)]="popupExpanded"
       (click)="popupExpanded.set(true)"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.html
@@ -18,7 +18,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -36,6 +49,7 @@ export class App {
       this.query.set(selected[0]);
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.css
@@ -34,7 +34,7 @@
   width: 13rem;
   font-size: 1rem;
   border-radius: 3rem;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: var(--primary-contrast);
   outline: none;
   border: 1px solid var(--quinary-contrast);
@@ -111,4 +111,41 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  color: var(--quaternary-contrast);
+  padding: 0;
+  margin: 0;
+  outline: none;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.clear-button:hover {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+
+.clear-button:focus-visible {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+}
+
+.clear-icon {
+  font-size: 1.25rem;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
@@ -12,6 +12,18 @@
       [(expanded)]="popupExpanded"
       (click)="popupExpanded.set(true)"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
+        >close</span
+      >
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.html
@@ -18,7 +18,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon material-symbols-outlined" translate="no" aria-hidden="true"
         >close</span

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/material/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -36,6 +49,7 @@ export class App {
       this.query.set(selected[0]);
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.css
@@ -35,6 +35,12 @@
   display: flex;
   position: relative;
   align-items: center;
+  box-shadow: var(--retro-flat-shadow);
+  background-color: var(--retro-button-color);
+}
+
+.retro-autocomplete:focus-within {
+  box-shadow: var(--retro-pressed-shadow);
 }
 
 .material-symbols-outlined {
@@ -55,18 +61,12 @@
   border-radius: 0;
   font-family: 'Press Start 2P';
   word-spacing: -5px;
-  padding: 0.75rem 0.5rem 0.75rem 2.5rem;
+  padding: 0.75rem 2.5rem 0.75rem 2.5rem;
   color: #000;
   border: none;
-  box-shadow: var(--retro-flat-shadow);
-  background-color: var(--retro-button-color);
+  background-color: transparent;
+  box-shadow: none;
   outline: none;
-}
-
-.autocomplete-input:focus-visible {
-  outline: none;
-  transform: translate(1px, 1px);
-  box-shadow: var(--retro-pressed-shadow);
 }
 
 .autocomplete-input::placeholder {
@@ -132,4 +132,49 @@
 
 .check-icon {
   font-size: 0.9rem;
+}
+
+.clear-button {
+  position: absolute;
+  right: 0.75rem;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--win95-gray);
+  color: var(--win95-shadow);
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--win95-light) var(--win95-dark-gray) var(--win95-dark-gray) var(--win95-light);
+  box-shadow: 1px 1px 0 var(--win95-shadow);
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+  outline: none;
+  font-family: 'Press Start 2P';
+  font-size: 0.6rem;
+  user-select: none;
+}
+
+.clear-button:hover {
+  background: #e0e0e0;
+  outline: 1px dashed var(--win95-dark-gray);
+  outline-offset: 1px;
+}
+
+.clear-button:active {
+  border-color: var(--win95-dark-gray) var(--win95-light) var(--win95-light) var(--win95-dark-gray);
+  box-shadow: 1px 1px 0 var(--win95-shadow) inset;
+}
+
+.clear-button:focus-visible {
+  outline: 2px dashed var(--hot-pink);
+  outline-offset: 4px;
+}
+
+.clear-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
@@ -18,7 +18,6 @@
       aria-label="Clear"
       (mousedown)="$event.preventDefault()"
       (click)="clear()"
-      (keydown)="onKeydown($event)"
     >
       <span class="clear-icon" aria-hidden="true">X</span>
     </button>

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.html
@@ -12,6 +12,16 @@
       [(expanded)]="popupExpanded"
       (click)="popupExpanded.set(true)"
     />
+    <button
+      type="button"
+      class="clear-button"
+      aria-label="Clear"
+      (mousedown)="$event.preventDefault()"
+      (click)="clear()"
+      (keydown)="onKeydown($event)"
+    >
+      <span class="clear-icon" aria-hidden="true">X</span>
+    </button>
   </div>
 
   <div aria-live="polite" class="cdk-visually-hidden">

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.ts
@@ -17,13 +17,6 @@ export class App {
     this.popupExpanded.set(false);
   }
 
-  onKeydown(event: KeyboardEvent) {
-    if (event.key === 'Enter') {
-      this.clear();
-      event.stopPropagation();
-    }
-  }
-
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 

--- a/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.ts
+++ b/adev/src/content/examples/aria/autocomplete/src/manual/retro/app/app.ts
@@ -11,6 +11,19 @@ import {FormsModule} from '@angular/forms';
   imports: [Combobox, ComboboxPopup, ComboboxWidget, Listbox, Option, OverlayModule, FormsModule],
 })
 export class App {
+  clear() {
+    this.query.set('');
+    this.selectedOption.set([]);
+    this.popupExpanded.set(false);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      this.clear();
+      event.stopPropagation();
+    }
+  }
+
   readonly listbox = viewChild(Listbox);
   readonly combobox = viewChild(Combobox);
 
@@ -36,6 +49,7 @@ export class App {
       this.query.set(selected[0]);
     }
     this.popupExpanded.set(false);
+    this.combobox()?.element.focus();
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

Updates autocomplete examples to have a clear button so that we can clear auto-select examples. 

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Missing clear button

Issue Number: N/A

## What is the new behavior?

Adds clear button feature to autocomplete examples

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
