### PR TITLE
refactor(forms): mark date and limit signal forms APIs public

### DIFF
--- a/packages/forms/signals/src/api/rules/metadata.ts
+++ b/packages/forms/signals/src/api/rules/metadata.ts
@@ -164,7 +164,7 @@ export class MetadataKey<TRead, TWrite, TAcc> {
  * Represents metadata that is used to define a valid limit for a field.
  *
  * @template TLimit The type the limit value.
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export type LimitKey<TLimit> = MetadataKey<
   Signal<NonNullable<TLimit> | undefined>,
@@ -183,7 +183,7 @@ declare const LIMIT_SELECTION_KEY: unique symbol;
  * This indirection allows rules to bind a {@link LimitKey} of a specific limit type (e.g. `number`
  * or `Date`) matching the field's type to a generic {@link MetadataKey}.
  *
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export type LimitSelectionKey = MetadataKey<
   Signal<LimitKey<unknown> | undefined>,
@@ -284,7 +284,7 @@ export function createManagedMetadataKey<TRead, TWrite, TAcc>(
 /**
  * Creates a {@link LimitSelectionKey}.
  *
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function createLimitSelectionKey(): LimitSelectionKey {
   return createMetadataKey() as LimitSelectionKey;
@@ -315,7 +315,7 @@ export const MIN: LimitSelectionKey = createLimitSelectionKey();
  * A {@link MetadataKey} representing the minimum valid value of a date field.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export const MIN_DATE: LimitKey<Date> = createMetadataKey(MetadataReducer.max());
 
@@ -323,7 +323,7 @@ export const MIN_DATE: LimitKey<Date> = createMetadataKey(MetadataReducer.max())
  * A {@link MetadataKey} representing the minimum valid value of a number field.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export const MIN_NUMBER: LimitKey<number> = createMetadataKey(MetadataReducer.max());
 
@@ -342,7 +342,7 @@ export const MAX: LimitSelectionKey = createLimitSelectionKey();
  * A {@link MetadataKey} representing the maximum valid value of a date field.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export const MAX_DATE: LimitKey<Date> = createMetadataKey(MetadataReducer.min());
 
@@ -350,7 +350,7 @@ export const MAX_DATE: LimitKey<Date> = createMetadataKey(MetadataReducer.min())
  * A {@link MetadataKey} representing the maximum valid value of a number field.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export const MAX_NUMBER: LimitKey<number> = createMetadataKey(MetadataReducer.min());
 

--- a/packages/forms/signals/src/api/rules/validation/max_date.ts
+++ b/packages/forms/signals/src/api/rules/validation/max_date.ts
@@ -27,7 +27,7 @@ import {maxDateError} from './validation_errors';
  *
  * @see [Signal Form Max Validation](guide/forms/signals/validation#min-and-max)
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function maxDate<TValue extends Date | null, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/min_date.ts
+++ b/packages/forms/signals/src/api/rules/validation/min_date.ts
@@ -27,7 +27,7 @@ import {minDateError} from './validation_errors';
  *
  * @see [Signal Form Min Validation](guide/forms/signals/validation#min-and-max)
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function minDate<TValue extends Date | null, TPathKind extends PathKind = PathKind.Root>(
   path: SchemaPath<TValue, SchemaPathRules.Supported, TPathKind>,

--- a/packages/forms/signals/src/api/rules/validation/validation_errors.ts
+++ b/packages/forms/signals/src/api/rules/validation/validation_errors.ts
@@ -106,7 +106,7 @@ export function minError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function minDateError(
   minDate: Date,
@@ -118,7 +118,7 @@ export function minDateError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function minDateError(
   minDate: Date,
@@ -168,7 +168,7 @@ export function maxError(
  * @param options The validation error options
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function maxDateError(
   maxDate: Date,
@@ -180,7 +180,7 @@ export function maxDateError(
  * @param options The optional validation error options
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export function maxDateError(
   maxDate: Date,
@@ -436,7 +436,7 @@ export class MinValidationError extends BaseNgValidationError {
  * An error used to indicate that a date value is earlier than the minimum allowed.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export class MinDateValidationError extends BaseNgValidationError {
   override readonly kind = 'minDate';
@@ -470,7 +470,7 @@ export class MaxValidationError extends BaseNgValidationError {
  * An error used to indicate that a date value is later than the maximum allowed.
  *
  * @category validation
- * @experimental 22.0.0
+ * @publicApi 22.0
  */
 export class MaxDateValidationError extends BaseNgValidationError {
   override readonly kind = 'maxDate';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

monDate/maxDate are marked as experimental (probably as they were merged after the stabilization of signal forms).

## What is the new behavior?

Promotes the signal forms date validator and limit metadata APIs from experimental to public API.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
