### PR TITLE
fix(router): preserve error names in minified bundles

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -18,6 +18,8 @@ import {wrapIntoObservable} from './utils/collection';
 import {firstValueFrom} from './utils/first_value_from';
 
 export class NoMatch extends Error {
+  override readonly name = 'NoMatch';
+
   public segmentGroup: UrlSegmentGroup | null;
 
   constructor(segmentGroup?: UrlSegmentGroup) {
@@ -32,6 +34,8 @@ export class NoMatch extends Error {
 }
 
 export class AbsoluteRedirect extends Error {
+  override readonly name = 'AbsoluteRedirect';
+
   constructor(public urlTree: UrlTree) {
     super();
 


### PR DESCRIPTION
`NoMatch` and `AbsoluteRedirect` are thrown from asynchronous contexts, which means error tracking tools often report only the minified constructor name instead of the original class name (for example Rollbar showing just `"t"` as the error type).

This change sets an explicit `name` property on both classes so their readable names are preserved at runtime, even after minification. This is also important for applications that intentionally filter these errors from logging using checks like:

```ts
if (error instanceof Error && error.name === 'NoMatch') return;
```

Without a stable `name`, those checks can fail after minification.
