### PR TITLE
fix(vscode-extension): disable language server in untrusted workspaces

### DIFF
--- a/vscode-ng-language-service/client/src/extension.ts
+++ b/vscode-ng-language-service/client/src/extension.ts
@@ -14,22 +14,35 @@ import {shouldRestartOnConfigurationChange} from './config_change';
 
 export function activate(context: vscode.ExtensionContext) {
   const client = new AngularLanguageClient(context);
+  context.subscriptions.push(client);
 
-  // Push the disposable to the context's subscriptions so that the
-  // client can be deactivated on extension deactivation
-  registerCommands(client, context);
+  const startServer = async () => {
+    registerCommands(client, context);
 
-  // Restart the server on configuration changes that affect startup/session state.
-  const disposable = vscode.workspace.onDidChangeConfiguration(
-    async (e: vscode.ConfigurationChangeEvent) => {
-      if (!shouldRestartOnConfigurationChange(e)) {
-        return;
-      }
-      await client.stop();
-      await client.start();
-    },
-  );
-  context.subscriptions.push(client, disposable);
+    // Restart the server on configuration changes that affect startup/session state.
+    const disposable = vscode.workspace.onDidChangeConfiguration(
+      async (e: vscode.ConfigurationChangeEvent) => {
+        if (!shouldRestartOnConfigurationChange(e)) {
+          return;
+        }
+        await client.stop();
+        await client.start();
+      },
+    );
+    context.subscriptions.push(disposable);
 
-  client.start();
+    await client.start();
+  };
+
+  // If the workspace is untrusted, operate in limited mode:
+  // Do NOT start the language server or register commands.
+  if (!vscode.workspace.isTrusted) {
+    const trustDisposable = vscode.workspace.onDidGrantWorkspaceTrust(async () => {
+      await startServer();
+    });
+    context.subscriptions.push(trustDisposable);
+    return;
+  }
+
+  startServer();
 }

--- a/vscode-ng-language-service/package.json
+++ b/vscode-ng-language-service/package.json
@@ -16,7 +16,8 @@
   },
   "capabilities": {
     "untrustedWorkspaces": {
-      "supported": true
+      "supported": "limited",
+      "description": "Angular language features are disabled in untrusted workspaces to prevent execution of untrusted local code."
     },
     "virtualWorkspaces": {
       "supported": "limited",


### PR DESCRIPTION
Restrict untrusted workspace support to limited mode. Skip launching the language client and registering commands in restricted mode, and only start them once workspace trust has been explicitly granted.
