### PR TITLE
[19.2.x] fix(common): add upper bounds for digitsInfo

### DIFF
--- a/goldens/public-api/common/errors.api.md
+++ b/goldens/public-api/common/errors.api.md
@@ -9,6 +9,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     EQUALITY_NG_SWITCH_DIFFERENCE = 2001,
     // (undocumented)
+    INVALID_DIGIT_INFO = 2306,
+    // (undocumented)
     INVALID_INPUT = 2952,
     // (undocumented)
     INVALID_LOADER_ARGUMENTS = 2959,

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -21,6 +21,9 @@ export const enum RuntimeErrorCode {
   // Pipe errors
   INVALID_PIPE_ARGUMENT = 2100,
 
+  // I18n errors
+  INVALID_DIGIT_INFO = 2306,
+
   // NgForOf errors
   NG_FOR_MISSING_DIFFER = -2200,
 

--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 import {
   getLocaleNumberFormat,
   getLocaleNumberSymbol,
@@ -70,6 +73,20 @@ function formatNumberToLocaleString(
         maxFraction = parseIntAutoRadix(maxFractionPart);
       } else if (minFractionPart != null && minFraction > maxFraction) {
         maxFraction = minFraction;
+      }
+
+      // Prevent DoS via resource exhaustion by capping the maximum padding iterations
+      const MAX_ALLOWED_DIGITS = 100;
+      if (
+        minInt > MAX_ALLOWED_DIGITS ||
+        minFraction > MAX_ALLOWED_DIGITS ||
+        maxFraction > MAX_ALLOWED_DIGITS
+      ) {
+        throw new RuntimeError(
+          RuntimeErrorCode.INVALID_DIGIT_INFO,
+          ngDevMode &&
+            `${digitsInfo} is not a valid digit info. Exceeded maximum limits of ${MAX_ALLOWED_DIGITS} digits.`,
+        );
       }
     }
 

--- a/packages/common/test/i18n/format_number_spec.ts
+++ b/packages/common/test/i18n/format_number_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ɵDEFAULT_LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {formatCurrency, formatNumber, formatPercent} from '../../index';
 import localeAr from '../../locales/ar';
 import localeEn from '../../locales/en';
 import localeEsUS from '../../locales/es-US';
 import localeFr from '../../locales/fr';
-import {ɵDEFAULT_LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 
 describe('Format number', () => {
   beforeAll(() => {
@@ -41,6 +41,18 @@ describe('Format number', () => {
       it('should throw if minFractionDigits is explicitly higher than maxFractionDigits', () => {
         expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '3.4-2')).toThrowError(
           /is higher than the maximum/,
+        );
+      });
+
+      it('should throw if minInt, minFraction, or maxFraction exceeds 100 to prevent DoS', () => {
+        const expectedError = /Exceeded maximum limits of 100 digits/;
+        expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '101.4-5')).toThrowError(expectedError);
+        expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '3.101-105')).toThrowError(
+          expectedError,
+        );
+        expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '3.4-101')).toThrowError(expectedError);
+        expect(() => formatNumber(1.1, ɵDEFAULT_LOCALE_ID, '1.2000000000-20000000')).toThrowError(
+          expectedError,
         );
       });
     });


### PR DESCRIPTION
The prevents the `roundNumber` function from allocating a large array.

Backport of #68840