### PR TITLE
refactor(vscode-extension): remove duplicated getTokenAtPosition in c…

### DIFF
--- a/vscode-ng-language-service/server/src/handlers/completions.ts
+++ b/vscode-ng-language-service/server/src/handlers/completions.ts
@@ -13,6 +13,7 @@ import {TextDocument} from 'vscode-languageserver-textdocument';
 import {Session} from '../session';
 import {getSCSSVirtualContent, isInlineStyleNode} from '../embedded_support';
 import {
+  getTokenAtPosition,
   lspPositionToTsPosition,
   tsFileTextChangesToLspWorkspaceEdit,
   tsTextSpanToLspRange,
@@ -20,11 +21,6 @@ import {
 import {documentationToMarkdown} from '../text_render';
 
 const scssLS = getSCSSLanguageService();
-// TODO: Share this or import it if possible, but it's local in session.ts usually.
-// For now, duplicating the simple helper or need to find a way to share `defaultPreferences`.
-
-// We need to access private/internal methods of Session if possible, or move them.
-// getTokenAtPosition was added to session.ts recently. We should move it to utils or export it.
 
 export function onCompletion(
   session: Session,
@@ -69,9 +65,6 @@ export function onCompletion(
     if (!sf) {
       return null;
     }
-    // We need getTokenAtPosition. It is currently in session.ts.
-    // I should move it to utils.ts first or duplicate it (bad).
-    // Let's assume I will move it to utils.ts in the next step.
     const node = getTokenAtPosition(sf, offset);
     if (!isInlineStyleNode(node)) {
       return null;
@@ -148,18 +141,6 @@ export function onCompletionResolve(
   return item;
 }
 
-function getTokenAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node {
-  let current: ts.Node = sourceFile;
-  while (true) {
-    const child = current
-      .getChildren(sourceFile)
-      .find((c) => c.getStart(sourceFile) <= position && c.getEnd() > position);
-    if (!child || child.kind === ts.SyntaxKind.EndOfFileToken) {
-      return current;
-    }
-    current = child;
-  }
-}
 // TODO: Move this to `@angular/language-service`.
 enum CompletionKind {
   attribute = 'attribute',


### PR DESCRIPTION
The completions handler kept a local copy of getTokenAtPosition plus three stale TODO comments noting the duplication, but the function is already exported from server/src/utils.ts (hover.ts and others import it from there). Drop the local copy, import the canonical one, and remove the now-meaningless comments.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`completions.ts` keeps a local copy of `getTokenAtPosition` plus three stale TODO comments asking for the duplication to be cleaned up. The canonical version already lives in `server/src/utils.ts` and is consumed by `hover.ts` and other handlers, completions is the last duplicate.

## What is the new behavior?

- Import `getTokenAtPosition` from `../utils` in `completions.ts` (extending the existing import block).
- Delete the duplicated local function.
- Delete the three stale TODO/notes-to-self comments.

No behavioral change. 21 lines removed, 1 line added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No