### PR TITLE
fix(core): verify property ownership on global Zone object before lookup

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -170,11 +170,11 @@ export class NgZone {
       self._inner = self._inner.fork(new AsyncStackTaggingZoneSpec('Angular'));
     }
 
-    if ((Zone as any)['TaskTrackingZoneSpec']) {
+    if (Object.prototype.hasOwnProperty.call(Zone, 'TaskTrackingZoneSpec')) {
       self._inner = self._inner.fork(new ((Zone as any)['TaskTrackingZoneSpec'] as any)());
     }
 
-    if (enableLongStackTrace && (Zone as any)['longStackTraceZoneSpec']) {
+    if (enableLongStackTrace && Object.prototype.hasOwnProperty.call(Zone, 'longStackTraceZoneSpec')) {
       self._inner = self._inner.fork((Zone as any)['longStackTraceZoneSpec']);
     }
     // if shouldCoalesceRunChangeDetection is true, all tasks including event tasks will be

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -36,8 +36,14 @@ export function patchJasmine(Zone: ZoneType): void {
     }
     (jasmine as any)['__zone_patch__'] = true;
 
-    const SyncTestZoneSpec: {new (name: string): ZoneSpec} = (Zone as any)['SyncTestZoneSpec'];
-    const ProxyZoneSpec: {new (): ZoneSpec} = (Zone as any)['ProxyZoneSpec'];
+    const SyncTestZoneSpec: {new (name: string): ZoneSpec} =
+        Object.prototype.hasOwnProperty.call(Zone, 'SyncTestZoneSpec')
+            ? (Zone as any)['SyncTestZoneSpec']
+            : undefined;
+    const ProxyZoneSpec: {new (): ZoneSpec} =
+        Object.prototype.hasOwnProperty.call(Zone, 'ProxyZoneSpec')
+            ? (Zone as any)['ProxyZoneSpec']
+            : undefined;
     if (!SyncTestZoneSpec) throw new Error('Missing: SyncTestZoneSpec');
     if (!ProxyZoneSpec) throw new Error('Missing: ProxyZoneSpec');
 
@@ -123,7 +129,10 @@ export function patchJasmine(Zone: ZoneType): void {
             ['install', 'uninstall'].forEach((methodName) => {
               const originalClockFn: Function = (clock[symbol(methodName)] = clock[methodName]);
               clock[methodName] = function () {
-                const FakeAsyncTestZoneSpec = (Zone as any)['FakeAsyncTestZoneSpec'];
+                const FakeAsyncTestZoneSpec =
+                    Object.prototype.hasOwnProperty.call(Zone, 'FakeAsyncTestZoneSpec')
+                        ? (Zone as any)['FakeAsyncTestZoneSpec']
+                        : undefined;
                 if (FakeAsyncTestZoneSpec) {
                   (jasmine as any)[symbol('clockInstalled')] = 'install' === methodName;
                   return;

--- a/packages/zone.js/lib/jest/jest.ts
+++ b/packages/zone.js/lib/jest/jest.ts
@@ -28,8 +28,12 @@ export function patchJest(Zone: ZoneType): void {
     (Zone as any)[api.symbol('ignoreConsoleErrorUncaughtError')] = true;
     jest['__zone_patch__'] = true;
 
-    const ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'];
-    const SyncTestZoneSpec = (Zone as any)['SyncTestZoneSpec'];
+    const ProxyZoneSpec = Object.prototype.hasOwnProperty.call(Zone, 'ProxyZoneSpec')
+        ? (Zone as any)['ProxyZoneSpec']
+        : undefined;
+    const SyncTestZoneSpec = Object.prototype.hasOwnProperty.call(Zone, 'SyncTestZoneSpec')
+        ? (Zone as any)['SyncTestZoneSpec']
+        : undefined;
 
     if (!ProxyZoneSpec) {
       throw new Error('Missing ProxyZoneSpec');
@@ -85,7 +89,9 @@ export function patchJest(Zone: ZoneType): void {
           !(testBody as any).isFakeAsync
         ) {
           // jest.useFakeTimers is called, run into fakeAsyncTest automatically.
-          const fakeAsyncModule = (Zone as any)[Zone.__symbol__('fakeAsyncTest')];
+          const fakeAsyncModule = Object.prototype.hasOwnProperty.call(Zone, Zone.__symbol__('fakeAsyncTest'))
+              ? (Zone as any)[Zone.__symbol__('fakeAsyncTest')]
+              : undefined;
           if (fakeAsyncModule && typeof fakeAsyncModule.fakeAsync === 'function') {
             testBody = fakeAsyncModule.fakeAsync(testBody);
           }

--- a/packages/zone.js/lib/mocha/mocha.ts
+++ b/packages/zone.js/lib/mocha/mocha.ts
@@ -24,8 +24,12 @@ export function patchMocha(Zone: ZoneType): void {
       throw new Error('Missing Zone.js');
     }
 
-    const ProxyZoneSpec = (Zone as any)['ProxyZoneSpec'];
-    const SyncTestZoneSpec = (Zone as any)['SyncTestZoneSpec'];
+    const ProxyZoneSpec = Object.prototype.hasOwnProperty.call(Zone, 'ProxyZoneSpec')
+        ? (Zone as any)['ProxyZoneSpec']
+        : undefined;
+    const SyncTestZoneSpec = Object.prototype.hasOwnProperty.call(Zone, 'SyncTestZoneSpec')
+        ? (Zone as any)['SyncTestZoneSpec']
+        : undefined;
 
     if (!ProxyZoneSpec) {
       throw new Error('Missing ProxyZoneSpec');

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -906,7 +906,9 @@ class FakeAsyncTestZoneSpec implements ZoneSpec {
 let _fakeAsyncTestZoneSpec: FakeAsyncTestZoneSpec | null = null;
 
 function getProxyZoneSpec(): typeof ProxyZoneSpec | undefined {
-  return Zone && (Zone as any)['ProxyZoneSpec'];
+  return Zone && Object.prototype.hasOwnProperty.call(Zone, 'ProxyZoneSpec')
+    ? (Zone as any)['ProxyZoneSpec']
+    : undefined;
 }
 
 let _sharedProxyZoneSpec: ProxyZoneSpec | null = null;
@@ -963,7 +965,9 @@ export function fakeAsync(fn: Function, options: {flush?: boolean} = {}): (...ar
     try {
       // in case jasmine.clock init a fakeAsyncTestZoneSpec
       if (!_fakeAsyncTestZoneSpec) {
-        const FakeAsyncTestZoneSpec = Zone && (Zone as any)['FakeAsyncTestZoneSpec'];
+        const FakeAsyncTestZoneSpec = Zone && Object.prototype.hasOwnProperty.call(Zone, 'FakeAsyncTestZoneSpec')
+            ? (Zone as any)['FakeAsyncTestZoneSpec']
+            : undefined;
         if (proxyZoneSpec.getDelegate() instanceof FakeAsyncTestZoneSpec) {
           throw new Error('fakeAsync() calls can not be nested');
         }


### PR DESCRIPTION
Ensure that lookups for optional runtime specifications (such as TaskTrackingZoneSpec
and longStackTraceZoneSpec) on the global Zone object verify own property ownership
rather than traversing up the prototype chain. This aligns with modern best practices
for environment configuration resolution and avoids unexpected default prototype fallbacks.