### PR TITLE
docs: clarify signals effect import source

### DIFF
--- a/adev/src/content/guide/signals/effect.md
+++ b/adev/src/content/guide/signals/effect.md
@@ -3,6 +3,8 @@
 Signals are useful because they notify interested consumers when they change. An **effect** is an operation that runs whenever one or more signal values change. You can create an effect with the `effect` function:
 
 ```ts
+import {effect} from '@angular/core';
+
 effect(() => {
   console.log(`The current count is: ${count()}`);
 });


### PR DESCRIPTION
## Summary
Adds an explicit @angular/core import to the first effect() example in the Signals effect guide.

## Why
Issue #68883 points out that the first effect() example omits the import source, which makes the page slightly harder to use as a search landing page for developers new to Signals.

The final fix keeps the scope to the reported page and makes the import source visible directly in the snippet.

## Testing
- Verified the updated Markdown in source
- Ran git diff --check

Fixes #68883 