### PR TITLE
fix(zone.js): avoid type error on custom object rejection with reject…

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -34,7 +34,7 @@ export function patchPromise(Zone: ZoneType): void {
     api.onUnhandledError = (e: any) => {
       if (api.showUncaughtError()) {
         const rejection = e && e.rejection;
-        if (rejection) {
+        if (rejection && e.zone && e.task) {
           console.error(
             'Unhandled Promise rejection:',
             rejection instanceof Error ? rejection.message : rejection,

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -1435,10 +1435,13 @@ export function initZone(): ZoneType {
         task.runCount++;
         return task.zone.runTask(task, target, args);
       } finally {
-        if (_numberOfNestedTaskFrames === 1 && !global[enableNativeMicrotaskDraining]) {
-          drainMicroTaskQueueSynchronously();
+        try {
+          if (_numberOfNestedTaskFrames === 1 && !global[enableNativeMicrotaskDraining]) {
+            drainMicroTaskQueueSynchronously();
+          }
+        } finally {
+          _numberOfNestedTaskFrames--;
         }
-        _numberOfNestedTaskFrames--;
       }
     }
 
@@ -1551,26 +1554,31 @@ export function initZone(): ZoneType {
 
     _isDrainingMicrotaskQueue = true;
 
-    while (_microTaskQueue.length) {
-      const queue = _microTaskQueue;
-      _microTaskQueue = [];
+    try {
+      while (_microTaskQueue.length) {
+        const queue = _microTaskQueue;
+        _microTaskQueue = [];
 
-      for (const task of queue) {
-        try {
-          task.zone.runTask(task, null, null);
-        } catch (error) {
-          _api.onUnhandledError(error as Error);
+        for (const task of queue) {
+          try {
+            task.zone.runTask(task, null, null);
+          } catch (error) {
+            _api.onUnhandledError(error as Error);
+          }
         }
       }
-    }
-
-    // The order matters!
-    if (global[enableNativeMicrotaskDraining]) {
-      _isDrainingMicrotaskQueue = false;
-      _api.microtaskDrainDone();
-    } else {
-      _api.microtaskDrainDone();
-      _isDrainingMicrotaskQueue = false;
+    } finally {
+      // The order matters!
+      if (global[enableNativeMicrotaskDraining]) {
+        _isDrainingMicrotaskQueue = false;
+        _api.microtaskDrainDone();
+      } else {
+        try {
+          _api.microtaskDrainDone();
+        } finally {
+          _isDrainingMicrotaskQueue = false;
+        }
+      }
     }
   }
 

--- a/packages/zone.js/test/common/promise-disable-wrap-uncaught-promise-rejection.spec.ts
+++ b/packages/zone.js/test/common/promise-disable-wrap-uncaught-promise-rejection.spec.ts
@@ -110,4 +110,28 @@ describe('disable wrap uncaught promise rejection', () => {
       done();
     });
   });
+
+  it('should handle a custom object rejection with a rejection property without crashing the error logger', async () => {
+    await jasmine.spyOnGlobalErrorsAsync(() => {
+      const originalConsoleError = console.error;
+      console.error = jasmine.createSpy('consoleErr');
+
+      const rejectObj = {
+        rejection: 'custom-inner-rejection',
+        message: 'custom-error-message',
+      };
+
+      Zone.current.fork({name: 'promise-error-zone'}).run(() => {
+        Promise.reject(rejectObj);
+      });
+
+      return new Promise<void>((res) => {
+        setTimeout(() => {
+          expect(console.error).toHaveBeenCalledWith(rejectObj);
+          console.error = originalConsoleError;
+          res();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
…ion property

Ensure that when a custom object with a 'rejection' property is thrown as a raw promise rejection, the unhandled promise rejection error logger does not crash with a TypeError while trying to access undefined zone properties.

Also wrap microtask queue draining and task frame counter updates with defensive try-finally blocks to guarantee internal scheduler states are properly reset under any potential call stack exception unwinding scenarios.
