### PR TITLE
fix(service-worker): verify event source before processing INITIALIZE message

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -309,9 +309,19 @@ export class Driver implements Debuggable, UpdateSource {
 
     event.waitUntil(
       (async () => {
-        // Initialization is the only event which is sent directly from the SW to itself, and thus
-        // `event.source` is not a `Client`. Handle it here, before the check for `Client` sources.
+        // INITIALIZE is sent by the SW to itself on activation, so event.source is
+        // the SW registration (not a Client). Only accept it from the SW itself to
+        // prevent arbitrary sources from triggering initialization.
         if (data.action === 'INITIALIZE') {
+          const isOwnSW =
+            event.source === this.scope.registration.active ||
+            event.source === this.scope.registration.installing ||
+            event.source === this.scope.registration.waiting;
+
+          if (!isOwnSW) {
+            return;
+          }
+
           return this.ensureInitialized(event);
         }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -2300,8 +2300,10 @@ import {envIsSupported} from '../testing/utils';
       });
 
       it('should not enter degraded mode if manifest for latest hash is missing upon initialization', async () => {
+        const ownSW = scope.registration.active as unknown as MessageEventSource;
+
         // Initialize the SW.
-        scope.handleMessage({action: 'INITIALIZE'}, null);
+        scope.handleMessage({action: 'INITIALIZE'}, null, ownSW);
         await driver.initialized;
         expect(driver.state).toBe(DriverReadyState.NORMAL);
 
@@ -2316,10 +2318,24 @@ import {envIsSupported} from '../testing/utils';
 
         // Re-initialize the SW and ensure it does not enter a degraded mode.
         driver.initialized = null;
-        scope.handleMessage({action: 'INITIALIZE'}, null);
+        scope.handleMessage({action: 'INITIALIZE'}, null, ownSW);
         await driver.initialized;
         expect(driver.state).toBe(DriverReadyState.NORMAL);
         expect(await getLatestHashFromDb()).toBe(manifestHash);
+      });
+
+      it('should silently drop INITIALIZE from an untrusted source', async () => {
+        await driver.initialized;
+        expect(driver.state).toBe(DriverReadyState.NORMAL);
+
+        // Reset so we can detect whether ensureInitialized is triggered again.
+        driver.initialized = null;
+
+        const untrustedSource = {postMessage: () => {}} as unknown as MessageEventSource;
+        await scope.handleMessage({action: 'INITIALIZE'}, null, untrustedSource);
+
+        // driver.initialized must still be null — ensureInitialized was not called.
+        expect(driver.initialized).toBeNull();
       });
 
       it('ignores invalid `only-if-cached` requests ', async () => {

--- a/packages/service-worker/worker/testing/scope.ts
+++ b/packages/service-worker/worker/testing/scope.ts
@@ -109,7 +109,11 @@ export class SwTestHarnessImpl
       this.selfMessageQueue = [];
       await queue.reduce(async (previous, msg) => {
         await previous;
-        await this.handleMessage(msg, null);
+        await this.handleMessage(
+          msg,
+          null,
+          this.registration.active as unknown as MessageEventSource,
+        );
       }, Promise.resolve());
     }
   }
@@ -218,7 +222,11 @@ export class SwTestHarnessImpl
     return [event.response, event.ready];
   }
 
-  handleMessage(data: Object, clientId: string | null): Promise<void> {
+  handleMessage(
+    data: Object,
+    clientId: string | null,
+    source?: MessageEventSource | null,
+  ): Promise<void> {
     if (!this.eventHandlers.has('message')) {
       throw new Error('No message handler registered');
     }
@@ -227,9 +235,11 @@ export class SwTestHarnessImpl
       this.clients.add(clientId, this.scopeUrl);
     }
 
+    const eventSource =
+      source !== undefined ? source : (clientId && this.clients.getMock(clientId)) || null;
     const event = new MockExtendableMessageEvent(
       data,
-      (clientId && this.clients.getMock(clientId)) || null,
+      eventSource as Client | MessagePort | ServiceWorker | null,
     );
     this.eventHandlers.get('message')!.call(this, event);
 


### PR DESCRIPTION
Previously, the `INITIALIZE` action in `onMessage` was handled before the `isClient()` guard, allowing any source — including cross-origin iframes or unknown `MessagePort` handles — to trigger SW initialization without verification.

The fix explicitly checks that the message source is either the SW's own registration or a legitimate client before proceeding with `ensureInitialized`.

**Example of the previous behavior:**

A cross-origin iframe with a `postMessage` handle to the SW could trigger initialization at an arbitrary time:

```js
// attacker-controlled iframe on https://evil.com
navigator.serviceWorker.getRegistration('/').then(reg => {
  reg.active.postMessage({ action: 'INITIALIZE' });
});
```

This would bypass the `isClient()` check that guards all other actions and invoke `ensureInitialized()` from an untrusted source, racing with cache writes during first-load initialization.

**After the fix**, messages with `action: 'INITIALIZE'` are accepted only from the SW's own registration (`self.registration.active/installing/waiting`) or from a verified client. All other sources are silently dropped, consistent with how all other actions are handled.