### PR TITLE
fix: correct typos in source code comments

### DIFF
--- a/packages/compiler-cli/src/ngtsc/docs/src/decorator_extractor.ts
+++ b/packages/compiler-cli/src/ngtsc/docs/src/decorator_extractor.ts
@@ -168,7 +168,7 @@ function extractParams(
 }
 
 /**
- * Find the the interface usually suffixed with "Decorator" that describes the decorator.
+ * Find the interface usually suffixed with "Decorator" that describes the decorator.
  */
 function getDecoratorInterface(declaration: ts.VariableDeclaration, typeChecker: ts.TypeChecker) {
   const name = declaration.name.getText();

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -160,7 +160,7 @@ class _I18nVisitor implements html.Visitor {
     }
 
     // Else returns a placeholder
-    // ICU placeholders should not be replaced with their original content but with the their
+    // ICU placeholders should not be replaced with their original content but with their
     // translations.
     // TODO(vicb): add a html.Node -> i18n.Message cache to avoid having to re-create the msg
     const phName = context.placeholderRegistry.getPlaceholderName('ICU', icu.sourceSpan.toString());

--- a/packages/core/src/render3/hmr.ts
+++ b/packages/core/src/render3/hmr.ts
@@ -70,7 +70,7 @@ export function ɵɵgetReplaceMetadataURL(id: string, timestamp: string, base: s
  * Replaces the metadata of a component type and re-renders all live instances of the component.
  * @param type Class whose metadata will be replaced.
  * @param applyMetadata Callback that will apply a new set of metadata on the `type` when invoked.
- * @param environment Syntehtic namespace imports that need to be passed along to the callback.
+ * @param environment Synthetic namespace imports that need to be passed along to the callback.
  * @param locals Local symbols from the source location that have to be exposed to the callback.
  * @param importMeta `import.meta` from the call site of the replacement function. Optional since
  *   it isn't used internally.

--- a/packages/core/src/render3/view/construction.ts
+++ b/packages/core/src/render3/view/construction.ts
@@ -323,7 +323,7 @@ export function addToEndOfViewTree<T extends LView | LContainer>(
 ): T {
   // TODO(benlesh/misko): This implementation is incorrect, because it always adds the LContainer
   // to the end of the queue, which means if the developer retrieves the LContainers from RNodes out
-  // of order, the change detection will run out of order, as the act of retrieving the the
+  // of order, the change detection will run out of order, as the act of retrieving the
   // LContainer from the RNode is what adds it to the queue.
   if (lView[CHILD_HEAD]) {
     lView[CHILD_TAIL]![NEXT] = lViewOrLContainer;

--- a/packages/platform-browser/animations/async/src/async_animation_renderer.ts
+++ b/packages/platform-browser/animations/async/src/async_animation_renderer.ts
@@ -44,7 +44,7 @@ export class AsyncAnimationRendererFactory implements OnDestroy, RendererFactory
 
   /**
    *
-   * @param moduleImpl allows to provide a mock implmentation (or will load the animation module)
+   * @param moduleImpl allows to provide a mock implementation (or will load the animation module)
    */
   constructor(
     private doc: Document,


### PR DESCRIPTION
## Description

Fixes several spelling errors and duplicate words in JSDoc and inline comments across multiple packages. These are comment-only changes with no impact on runtime behavior.

**Changes:**
- `packages/core/src/render3/hmr.ts`: "Syntehtic" → "Synthetic"
- `packages/platform-browser/animations/async/src/async_animation_renderer.ts`: "implmentation" → "implementation"
- `packages/core/src/render3/view/construction.ts`: removed duplicate word "the the" → "the"
- `packages/compiler-cli/src/ngtsc/docs/src/decorator_extractor.ts`: removed duplicate word "the the" → "the"
- `packages/compiler/src/i18n/i18n_parser.ts`: removed duplicate word "the their" → "their"

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / comment fix
- [ ] Refactoring

## Testing

No functional code was changed. All existing tests remain valid.