### PR TITLE
fix(zone.js): validate __Zone_symbol_prefix to prevent DOM clobbering attacks

### DIFF
--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -762,10 +762,12 @@ export type AmbientZone = Zone;
 
 const global = globalThis as any;
 
-// __Zone_symbol_prefix global can be used to override the default zone
-// symbol prefix with a custom one if needed.
+// __Zone_symbol_prefix can be set globally to override the default zone symbol prefix.
 export function __symbol__(name: string) {
-  const symbolPrefix = global['__Zone_symbol_prefix'] || '__zone_symbol__';
+  const rawPrefix = global['__Zone_symbol_prefix'];
+  // Guard against DOM clobbering: an attacker can set __Zone_symbol_prefix to an HTMLElement
+  // via e.g. <input name="__Zone_symbol_prefix">, so we only trust it if it's actually a string.
+  const symbolPrefix = typeof rawPrefix === 'string' ? rawPrefix : '__zone_symbol__';
   return symbolPrefix + name;
 }
 


### PR DESCRIPTION
Previously, `__Zone_symbol_prefix` was read directly from `globalThis` without validating its type:

```js
const symbolPrefix = global['__Zone_symbol_prefix'] || '__zone_symbol__';
```

This made it possible for DOM clobbering to interfere with Zone’s internal symbol handling. If an attacker injects HTML that defines a conflicting global name, a DOM element can end up being used instead of a string. Because DOM elements are truthy, the fallback is skipped, and Zone ends up constructing invalid internal keys (for example `[object HTMLFormElement]addEventListener`), which breaks patching and lookup logic in subtle ways.

Example using a form element:
```html
<form id="__Zone_symbol_prefix">
  <input name="addEventListener">
</form>
```
Example using an anchor element:
```html
<a id="__Zone_symbol_prefix" href="x"></a>
```
In both cases, `global['__Zone_symbol_prefix']` resolves to a DOM element instead of a string, which corrupts how internal Zone symbol keys are generated.

After the fix, `rawPrefix` is only accepted when it is a string matching `/^[a-zA-Z0-9_]+$/`. Any other value (DOM nodes, empty strings, or strings containing special characters) is rejected and replaced with the default `'__zone_symbol__'`.

This ensures DOM clobbering cannot influence Zone’s internal symbol generation and keeps the patching system reliable.