### PR TITLE
refactor(language-server): drop duplicate isAngularCore helpers in se…

### DIFF
--- a/vscode-ng-language-service/server/src/session.ts
+++ b/vscode-ng-language-service/server/src/session.ts
@@ -34,6 +34,7 @@ import {tsDiagnosticToLspDiagnostic} from './diagnostic';
 import {ServerHost} from './server_host';
 import {
   filePathToUri,
+  isAngularCore,
   isConfiguredProject,
   isDebugMode,
   lspRangeToTsPositions,
@@ -780,23 +781,6 @@ export class Session {
     }
     return angularCore ?? null;
   }
-}
-
-function isAngularCore(path: string): boolean {
-  return isExternalAngularCore(path) || isInternalAngularCore(path);
-}
-
-function isExternalAngularCore(path: string): boolean {
-  return /@angular\/core\/.+\.d\.ts$/.test(path);
-}
-
-function isInternalAngularCore(path: string): boolean {
-  // path in g3
-  return (
-    path.endsWith('angular2/rc/packages/core/index.d.ts') ||
-    // angular/angular repository direct sources
-    path.includes('angular/packages/core/src')
-  );
 }
 
 function isTypeScriptFile(path: string): boolean {


### PR DESCRIPTION
session.ts defined isAngularCore, isExternalAngularCore, and isInternalAngularCore as byte-identical copies of the already-exported versions in utils.ts. Only isAngularCore was used locally; the other two were dead. handlers/template_info.ts already imports the utils version. Remove the duplicates and import isAngularCore from utils.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

`vscode-ng-language-service/server/src/session.ts` declares three local helpers (`isAngularCore`, `isExternalAngularCore`, `isInternalAngularCore`) that are byte-for-byte identical to the exported versions in `vscode-ng-language-service/server/src/utils.ts`. Only `isAngularCore` is referenced inside `session.ts`; the other two exist solely to support that local copy. `handlers/template_info.ts` already consumes the utils version, so the project ships two copies of the same logic.

## What is the new behavior?

`session.ts` imports `isAngularCore` from `./utils` and the three local helpers are removed. Behavior is unchanged. The server unit tests (`//vscode-ng-language-service/server/src/tests:test`) and the LSP integration suite (`//vscode-ng-language-service/integration/lsp:test`) both pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No