### PR TITLE
feat(core): split tracking for `effect` and `afterRenderEffect`

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1870,6 +1870,9 @@ export interface SkipSelfDecorator {
 }
 
 // @public
+export function splitTracking<T, Ret, Args extends any[]>(track: () => T, execute: (tracked: T, ...args: Args) => Ret): (...args: Args) => Ret;
+
+// @public
 export type StateKey<T> = string & {
     __not_a_string: never;
     __value_type?: T;

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -8,23 +8,24 @@
 
 export {SIGNAL as ɵSIGNAL} from '../primitives/signals';
 
+export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
 export {isSignal, isWritableSignal, Signal, ValueEqualityFn} from './render3/reactivity/api';
+export {assertNotInReactiveContext} from './render3/reactivity/asserts';
 export {computed, CreateComputedOptions} from './render3/reactivity/computed';
+export {
+  CreateEffectOptions,
+  effect,
+  EffectCleanupFn,
+  EffectCleanupRegisterFn,
+  EffectRef,
+} from './render3/reactivity/effect';
+export {linkedSignal} from './render3/reactivity/linked_signal';
+export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
 export {
   CreateSignalOptions,
   signal,
   WritableSignal,
   ɵunwrapWritableSignal,
 } from './render3/reactivity/signal';
-export {linkedSignal} from './render3/reactivity/linked_signal';
+export {splitTracking} from './render3/reactivity/split_tracking';
 export {untracked} from './render3/reactivity/untracked';
-export {
-  CreateEffectOptions,
-  effect,
-  EffectRef,
-  EffectCleanupFn,
-  EffectCleanupRegisterFn,
-} from './render3/reactivity/effect';
-export {EffectScheduler as ɵEffectScheduler} from './render3/reactivity/root_effect_scheduler';
-export {afterRenderEffect, ɵFirstAvailableSignal} from './render3/reactivity/after_render_effect';
-export {assertNotInReactiveContext} from './render3/reactivity/asserts';

--- a/packages/core/src/render3/reactivity/split_tracking.ts
+++ b/packages/core/src/render3/reactivity/split_tracking.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {untracked} from './untracked';
+
+/**
+ * Splits a reactive effect's tracking and side-effecting code, ensuring that the
+ * side-effecting code doesn't implicitly track dependencies.
+ *
+ * @param track A function whose reactive reads will be tracked.
+ * @param execute A function which receives the tracked value and the execution context arguments,
+ *                and runs in a non-tracking context.
+ * @returns A function that combines the tracking and execution phases.
+ *
+ * @usageNotes
+ *
+ * ```ts
+ * effect(
+ *   splitTracking(
+ *     () => mySignal(),
+ *     (mySignalValue, onCleanup) => {
+ *       // Execution phase: any signal reads here are untracked
+ *       console.log('Tracked values:', mySignalValue);
+ *       console.log('Untracked read:', untrackedSig());
+ *     }
+ *   )
+ * );
+ * ```
+ *
+ * Using `splitTracking` with `afterRenderEffect` phases:
+ *
+ * ```ts
+ * afterRenderEffect({
+ *   earlyRead: () => {
+ *     return this.element.nativeElement.scrollWidth;
+ *   },
+ *   write: splitTracking(
+ *     // Tracking phase: tracks `isExpanded`
+ *     () => this.isExpanded(),
+ *     (isExpanded, scrollWidth, onCleanup) => {
+ *       // Execution phase: receives `isExpanded` from the track phase,
+ *       // and `scrollWidth` from the `earlyRead` phase.
+ *       // This block runs untracked, avoiding implicit dependencies on any reads.
+ *       if (isExpanded) {
+ *         this.element.nativeElement.style.width = `${scrollWidth}px`;
+ *       }
+ *     }
+ *   )
+ * });
+ * ```
+ *
+ * @publicApi 22.1
+ */
+export function splitTracking<T, Ret, Args extends any[]>(
+  track: () => T,
+  execute: (tracked: T, ...args: Args) => Ret,
+): (...args: Args) => Ret {
+  return (...args: Args) => {
+    const trackedValue = track();
+    return untracked(() => execute(trackedValue, ...args));
+  };
+}

--- a/packages/core/test/acceptance/split_tracking_spec.ts
+++ b/packages/core/test/acceptance/split_tracking_spec.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+import {
+  afterRenderEffect,
+  ApplicationRef,
+  computed,
+  effect,
+  Injector,
+  signal,
+  Signal,
+} from '../../src/core';
+import {EffectCleanupRegisterFn} from '../../src/render3/reactivity/effect';
+import {splitTracking} from '../../src/render3/reactivity/split_tracking';
+
+describe('splitTracking', () => {
+  it('should track only the tracking function (effect)', () => {
+    let effectCount = 0;
+    const trackedValue = signal('tracked');
+    const untrackedValue = signal('untracked');
+
+    effect(
+      splitTracking(
+        () => trackedValue(),
+        (val: string) => {
+          // Read untrackedValue to verify it's not tracked
+          untrackedValue();
+          effectCount++;
+        },
+      ),
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.tick();
+    expect(effectCount).toBe(1);
+
+    untrackedValue.set('changed untracked');
+    appRef.tick();
+    expect(effectCount).toBe(1);
+
+    trackedValue.set('changed tracked');
+    appRef.tick();
+    expect(effectCount).toBe(2);
+  });
+
+  it('should provide cleanup function for effect', () => {
+    let cleanupCount = 0;
+    let effectCount = 0;
+    const trackedValue = signal('tracked');
+
+    effect(
+      splitTracking(
+        () => trackedValue(),
+        (val: string, onCleanup: EffectCleanupRegisterFn) => {
+          effectCount++;
+          onCleanup(() => cleanupCount++);
+        },
+      ),
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.tick();
+    expect(effectCount).toBe(1);
+    expect(cleanupCount).toBe(0);
+
+    trackedValue.set('changed 1');
+    appRef.tick();
+    expect(effectCount).toBe(2);
+    expect(cleanupCount).toBe(1);
+
+    trackedValue.set('changed 2');
+    appRef.tick();
+    expect(effectCount).toBe(3);
+    expect(cleanupCount).toBe(2);
+  });
+
+  it('should track only invoked signals', () => {
+    let effectCount = 0;
+    const sigA = signal('A');
+    const sigB = signal('B');
+    effect(
+      splitTracking(
+        () => [sigA, sigB] as const,
+        ([valA, valB]) => {
+          // Those signals were not invoked before hands.
+          valA();
+          valB();
+          effectCount++;
+        },
+      ),
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.tick();
+    expect(effectCount).toBe(1);
+    sigA.set('changed A');
+    appRef.tick();
+    expect(effectCount).toBe(1);
+    sigB.set('changed B');
+    appRef.tick();
+    expect(effectCount).toBe(1);
+  });
+
+  it('should work with afterRenderEffect without phases', () => {
+    let effectCount = 0;
+    const trackedValue = signal('tracked');
+    const untrackedValue = signal('untracked');
+
+    afterRenderEffect(
+      splitTracking(
+        () => trackedValue(),
+        (val: string) => {
+          untrackedValue();
+          effectCount++;
+        },
+      ),
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.tick();
+    expect(effectCount).toBe(1);
+
+    untrackedValue.set('changed untracked');
+    appRef.tick();
+    expect(effectCount).toBe(1);
+
+    trackedValue.set('changed tracked');
+    appRef.tick();
+    expect(effectCount).toBe(2);
+  });
+
+  it('should work with afterRenderEffect with phases', () => {
+    let earlyReadCount = 0;
+    let writeCount = 0;
+    let cleanupCount = 0;
+    const trackedValue = signal('tracked');
+    const untrackedValue = signal('untracked');
+
+    afterRenderEffect(
+      {
+        earlyRead: () => {
+          // early read is tracked
+          trackedValue();
+          earlyReadCount++;
+          return 42;
+        },
+        write: splitTracking(
+          // tracking fn
+          () => trackedValue(),
+          (val: string, earlyReadVal: Signal<number>, onCleanup: EffectCleanupRegisterFn) => {
+            // non tracking execute fn
+            untrackedValue();
+            writeCount++;
+            expect(earlyReadVal()).toBe(42);
+            onCleanup(() => {
+              cleanupCount++;
+            });
+          },
+        ),
+      },
+      {injector: TestBed.inject(Injector)},
+    );
+
+    const appRef = TestBed.inject(ApplicationRef);
+    appRef.tick();
+    expect(earlyReadCount).toBe(1);
+    expect(writeCount).toBe(1);
+    expect(cleanupCount).toBe(0);
+
+    untrackedValue.set('changed untracked');
+    appRef.tick();
+    expect(earlyReadCount).toBe(1);
+    expect(writeCount).toBe(1);
+    expect(cleanupCount).toBe(0);
+
+    trackedValue.set('changed tracked');
+    appRef.tick();
+    expect(earlyReadCount).toBe(2);
+    expect(writeCount).toBe(2);
+    expect(cleanupCount).toBe(1);
+  });
+
+  it('should work with computed', () => {
+    let executeCount = 0;
+    const trackedValue = signal('tracked');
+    const untrackedValue = signal('untracked');
+
+    const result = computed(
+      splitTracking(
+        () => trackedValue(),
+        (val: string) => {
+          untrackedValue();
+          executeCount++;
+          return val + ' and ' + untrackedValue();
+        },
+      ),
+    );
+
+    expect(result()).toBe('tracked and untracked');
+    expect(executeCount).toBe(1);
+
+    untrackedValue.set('changed untracked');
+    // untracked changing should not trigger recomputation
+    expect(result()).toBe('tracked and untracked');
+    expect(executeCount).toBe(1);
+
+    trackedValue.set('changed tracked');
+    // tracked changing should trigger recomputation, reading the new untracked value
+    expect(result()).toBe('changed tracked and changed untracked');
+    expect(executeCount).toBe(2);
+  });
+});


### PR DESCRIPTION
Mere investigation / WIP:  

Introduce a `splitTracking` helper to separate reactive tracking from non-reactive effect execution by isolating the reactive logic into a dedicated function.

fixes #56155
