### PR TITLE
fix(forms): reflect required validators in compat fields

### DIFF
--- a/packages/forms/signals/compat/src/compat_field_node.ts
+++ b/packages/forms/signals/compat/src/compat_field_node.ts
@@ -8,7 +8,7 @@
 
 import {computed, linkedSignal, runInInjectionContext, Signal, untracked} from '@angular/core';
 import {toSignal} from '@angular/core/rxjs-interop';
-import {AbstractControl} from '@angular/forms';
+import {AbstractControl, Validators} from '@angular/forms';
 import {Observable, ReplaySubject} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
 import {FieldNode} from '../../src/field/node';
@@ -22,10 +22,18 @@ import type {CompatFieldNodeOptions} from './compat_structure';
  */
 export class CompatFieldNode extends FieldNode {
   readonly control: Signal<AbstractControl>;
+  private readonly requiredSignal: Signal<boolean>;
 
   constructor(public readonly options: CompatFieldNodeOptions) {
     super(options);
     this.control = this.options.control;
+    this.requiredSignal = getControlStatusSignal(this.options, (c) =>
+      c.hasValidator(Validators.required),
+    );
+  }
+
+  override get required(): Signal<boolean> {
+    return this.requiredSignal;
   }
 }
 

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -157,6 +157,27 @@ describe('Forms compat', () => {
       expect(f.age().valid()).toBeTrue();
     });
 
+    it('picks up the required state from a reactive form control', () => {
+      const control = new FormControl('pirojok-the-cat', Validators.required);
+      const cat = signal({name: control});
+
+      const f = compatForm(cat, {
+        injector: TestBed.inject(Injector),
+      });
+
+      expect(f.name().required()).toBeTrue();
+
+      control.clearValidators();
+      control.updateValueAndValidity();
+
+      expect(f.name().required()).toBeFalse();
+
+      control.setValidators(Validators.required);
+      control.updateValueAndValidity();
+
+      expect(f.name().required()).toBeTrue();
+    });
+
     it('allows to manually set errors', () => {
       const catControl = new FormControl('meow', Validators.minLength(3));
       const cat = signal(catControl);


### PR DESCRIPTION
﻿## Problem

`compatForm` wraps reactive `FormControl`s, but the signal-forms `required` state does not reflect a wrapped control that has `Validators.required`. This leaves `FieldTree#required` false even when the reactive control reports the required validator.

Fixes #68905.

## Root cause

Compat field nodes inherit `FieldNode.required`, which only reads signal-forms `REQUIRED` metadata. Reactive form validators on the wrapped `AbstractControl` are not included in that metadata.

## Solution

Expose `required` from `CompatFieldNode` by deriving a signal from the wrapped control's `hasValidator(Validators.required)` state, using the existing control-status signal helper so validator updates and control swaps are observed.

## Tests run

- `corepack pnpm bazel test //packages/forms/signals/test/node:test --test_arg=--filter='picks up the required state from a reactive form control' --test_output=errors`
- `corepack pnpm bazel test //packages/forms/signals/test/node:test --test_output=errors`
- `npx --yes prettier@3.8.3 --check packages\forms\signals\compat\src\compat_field_node.ts packages\forms\signals\test\node\compat\compat.spec.ts`
- `git diff --check`
