### PR TITLE
fix(forms): reflect required validators in compat form fields

### DIFF
--- a/packages/forms/signals/compat/src/compat_field_node.ts
+++ b/packages/forms/signals/compat/src/compat_field_node.ts
@@ -15,6 +15,8 @@ import {FieldNode} from '../../src/field/node';
 import {getInjectorFromOptions} from '../../src/field/util';
 import type {CompatFieldNodeOptions} from './compat_structure';
 
+type AbstractControlWithRequiredSignal = AbstractControl & {_hasRequired: Signal<boolean>};
+
 /**
  * Field node with additional  control property.
  *
@@ -22,10 +24,17 @@ import type {CompatFieldNodeOptions} from './compat_structure';
  */
 export class CompatFieldNode extends FieldNode {
   readonly control: Signal<AbstractControl>;
+  private controlRequired: Signal<boolean> | undefined;
 
   constructor(public readonly options: CompatFieldNodeOptions) {
     super(options);
     this.control = this.options.control;
+  }
+
+  override get required(): Signal<boolean> {
+    return (this.controlRequired ??= computed(() =>
+      (this.control() as AbstractControlWithRequiredSignal)._hasRequired(),
+    ));
   }
 }
 

--- a/packages/forms/signals/test/node/compat/compat.spec.ts
+++ b/packages/forms/signals/test/node/compat/compat.spec.ts
@@ -198,6 +198,48 @@ describe('Forms compat', () => {
       ]);
     });
 
+    it('reflects required validators from a form control', () => {
+      const control = new FormControl('');
+      const cat = signal({
+        name: 'pirojok-the-cat',
+        age: control,
+      });
+
+      const f = compatForm(cat, {
+        injector: TestBed.inject(Injector),
+      });
+
+      expect(f.age().required()).toBeFalse();
+
+      control.setValidators(Validators.required);
+
+      expect(f.age().required()).toBeTrue();
+
+      control.clearValidators();
+
+      expect(f.age().required()).toBeFalse();
+    });
+
+    it('picks up required validators from a new form control', () => {
+      const cat = signal({
+        name: 'pirojok-the-cat',
+        age: new FormControl(5),
+      });
+
+      const f = compatForm(cat, {
+        injector: TestBed.inject(Injector),
+      });
+
+      expect(f.age().required()).toBeFalse();
+
+      f().value.set({
+        age: new FormControl(4, Validators.required),
+        name: 'lol',
+      });
+
+      expect(f.age().required()).toBeTrue();
+    });
+
     it('supports async validation', async () => {
       let resolve: Function = () => {};
       const formControl = new FormControl<number>(5, {


### PR DESCRIPTION
## Summary
- Reflect Reactive Forms `Validators.required` state from `compatForm` field nodes.
- Keep non-compat Signal Forms required metadata behavior unchanged.
- Add regression coverage for setting, clearing, and swapping required reactive controls.

## Validation
- `pnpm install`
- `pnpm ng-dev format changed --check`
- `pnpm test //packages/forms/signals/test/node:test`
- `pnpm test //packages/forms/signals/test/web:test`

Fixes #68905