### PR TITLE
docs: fix broken card links on roadmap page

### DIFF
--- a/adev/src/content/reference/roadmap.md
+++ b/adev/src/content/reference/roadmap.md
@@ -70,7 +70,7 @@ As part of this project, we'll explore the requirement space of cross framework 
 
   </docs-card>
 
-  <docs-card title="Signal Forms" href="/guide/forms/signals/overview">
+  <docs-card title="Signal Forms" href="guide/forms/signals/overview">
   In Angular v21, we landed an experimental version of Signal Forms. This new approach allows developers to manage form state using signals, providing an ergonomic forms creation experience. Next, our plans include promoting Signal Forms to stable and enhancing interoperability with reactive forms - enabling teams to progressively migrate large forms at their own pace.
   </docs-card>
   <docs-card title="Reactivity">
@@ -231,7 +231,7 @@ We will work on finding a way to implement stricter type checking for reactive f
 <docs-card title="Improve integration of Angular DevTools with framework" link="Completed Q1 2022" href="tools/devtools">
 To improve the integration of Angular DevTools with the framework, we are working on moving the codebase to the angular/angular monorepository. This includes transitioning Angular DevTools to Bazel and integrating it into the existing processes and CI pipeline.
 </docs-card>
-<docs-card title="Launch advanced compiler diagnostics" link="Completed Q1 2022" href="reference/extended-diagnostics">
+<docs-card title="Launch advanced compiler diagnostics" link="Completed Q1 2022" href="extended-diagnostics">
 Extend the diagnostics of the Angular compiler outside type checking. Introduce other correctness and conformance checks to further guarantee correctness and best practices.
 </docs-card>
 <docs-card title="Update our e2e testing strategy" link="Completed Q3 2021" href="guide/testing">
@@ -270,7 +270,7 @@ As part of the v11 release, we introduced an opt-in preview of webpack 5 in the 
 <docs-card title="Faster apps by inlining critical styles in Universal apps" link="Completed Q1 2021" href="guide/ssr">
 Loading external stylesheets is a blocking operation, which means that the browser cannot start rendering your app until it loads all the referenced CSS. Having render-blocking resources in the header of a page can significantly impact its load performance, for example, its first contentful paint. To make apps faster, we have been collaborating with the Google Chrome team on inlining critical CSS and loading the rest of the styles asynchronously.
 </docs-card>
-<docs-card title="Improve debugging with better Angular error messages" link="Completed Q1 2021" href="reference/errors">
+<docs-card title="Improve debugging with better Angular error messages" link="Completed Q1 2021" href="errors">
 Error messages often bring limited actionable information to help developers resolve them. We have been working on making error messages more discoverable by adding associated codes, developing guides, and other materials to ensure a smoother debugging experience.
 </docs-card>
 <docs-card title="Improved developer onboarding with refreshed introductory documentation" link="Completed Q1 2021" href="tutorials">


### PR DESCRIPTION
The "Improve debugging with better Angular error messages" and "Launch advanced compiler diagnostics" cards on the roadmap page pointed to `reference/errors` and `reference/extended-diagnostics`, which are not routed on angular.dev. The published routes are `/errors` and `/extended-diagnostics`. Also drop an inconsistent leading slash from the Signal Forms card href to match the rest of the file.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Two cards on https://angular.dev/roadmap 404:

- "Improve debugging with better Angular error messages" → `reference/errors`
- "Launch advanced compiler diagnostics" → `reference/extended-diagnostics`

The published routes are `/errors` and `/extended-diagnostics`.

## What is the new behavior?

Cards point to the real routes. Also removes a stray leading slash from one href so all cards in the file use the same format.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No