### PR TITLE
feat(core): add cause option to RuntimeError constructor

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -177,8 +177,9 @@ export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
   constructor(
     public code: T,
     message: null | false | string,
+    options?: {cause?: unknown},
   ) {
-    super(formatRuntimeError<T>(code, message));
+    super(formatRuntimeError<T>(code, message), options);
   }
 }
 


### PR DESCRIPTION
Adds an optional `options` parameter to `RuntimeError` that accepts a `cause` property, forwarding it to the native `Error` constructor. This preserves the original error as `error.cause`, improving debuggability when framework errors wrap lower-level exceptions.