### PR TITLE
fix(compiler,core): add SVG namespace URL security context for <a> elements

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -106,6 +106,12 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['none', ['href', 'xlink:href']],
     ]);
 
+    registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+      // SVG namespace - SVG <a> elements can also carry href attributes
+      // that must be sanitized. See angular/angular#68920.
+      ['a', ['href', 'xlink:href']],
+    ]);
+
     registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
       ['base', ['href']],
       ['embed', ['src']],

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -106,6 +106,12 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['none', ['href', 'xlink:href']],
     ]);
 
+    registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+      // SVG namespace - SVG <a> elements can also carry href attributes
+      // that must be sanitized. See angular/angular#68920.
+      ['a', ['href', 'xlink:href']],
+    ]);
+
     registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
       ['base', ['href']],
       ['embed', ['src']],


### PR DESCRIPTION
Fixes #68920

## Summary

The namespace-aware schema refactor (commits `cef4a095`, `61a97f22`, `933608c0`) added `:math:` prefixed entries for MathML elements in `dom_security_schema.ts` but **omitted the equivalent `:svg:` prefixed entries** for SVG `<a>` elements.

This causes `calcPossibleSecurityContexts` to return `SecurityContext.NONE` for `<svg><a [attr.href]>`, making the compiler emit `ɵɵattribute("href", value)` **without** the `ɵɵsanitizeUrl` wrapper. A `javascript:` URL bound to `<svg><a [attr.href]>` reaches the DOM unsanitized → **XSS**.

## Root Cause

The `registerContext` function (line 162) prepends `:${namespace}:` to element names when a namespace is specified. After the refactor, lookups for SVG elements use the key `:svg:a|href`, but only `a|href` (HTML namespace) was registered. The MathML block correctly added entries like `:math:mi|href`, but no SVG block existed.

## Fix

Added `registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]])` in both:
- `packages/compiler/src/schema/dom_security_schema.ts`
- `packages/core/src/sanitization/dom_security_schema.ts` (the synchronized copy)

This ensures the schema lookup for `:svg:a|href` and `:svg:a|xlink:href` returns `SecurityContext.URL`, causing the compiler to wrap the binding with `ɵɵsanitizeUrl`.

## Impact

- **Severity:** HIGH — XSS via SVG `<a>` href in Angular applications
- **Regression:** Introduced in `22.0.0-rc.1` (`@next` dist-tag on npm)
- **Same class as:** CVE-2025-66412 (MathML `<mi href>` sanitizer bypass)
- **Affected:** Any Angular app using `<svg><a [attr.href]="userInput">`
