### PR TITLE
fix(zone.js): handle punctuation event names in node cleanup

### DIFF
--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -88,7 +88,7 @@ const OPTIMIZED_ZONE_EVENT_TASK_DATA: EventTaskData = {
 export const zoneSymbolEventNames: any = {};
 export const globalSources: any = {};
 
-const EVENT_NAME_SYMBOL_REGX = new RegExp('^' + ZONE_SYMBOL_PREFIX + '(\\w+)(true|false)$');
+const EVENT_NAME_SYMBOL_REGX = new RegExp('^' + ZONE_SYMBOL_PREFIX + '([\\s\\S]+)(true|false)$');
 const IMMEDIATE_PROPAGATION_SYMBOL = zoneSymbol('propagationStopped');
 
 function prepareEventNames(eventName: string, eventNameToString?: (eventName: string) => string) {

--- a/packages/zone.js/test/node/events.spec.ts
+++ b/packages/zone.js/test/node/events.spec.ts
@@ -146,6 +146,26 @@ describe('nodejs EventEmitter', () => {
       expect(emitter.listeners('test1').length).toEqual(0);
     });
   });
+  it('should remove all listeners for non-word event names without a type parameter', () => {
+    zoneA.run(() => {
+      const eventNames = [
+        'tenant:notification',
+        'tenant.notification',
+        'tenant-notification',
+        'tenant\u2603notification',
+      ];
+      for (const eventName of eventNames) {
+        emitter.on(eventName, shouldNotRun);
+      }
+
+      emitter.removeAllListeners();
+
+      for (const eventName of eventNames) {
+        expect(emitter.listeners(eventName).length).toEqual(0);
+        emitter.emit(eventName);
+      }
+    });
+  });
   it('should remove once listener after emit', () => {
     zoneA.run(() => {
       emitter.once('test', expectZoneA);


### PR DESCRIPTION
Widen the EventEmitter cleanup key matcher so event names are not limited to word characters before the trailing true/false marker.

This keeps the existing removeAllListeners() cleanup flow while allowing string event names that contain punctuation or Unicode characters to be matched correctly.

More context: https://issuetracker.google.com/u/1/issues/515882352