### PR TITLE
docs(docs-infra): add Spanish community translation

### DIFF
--- a/adev/src/app/core/layout/footer/footer.component.html
+++ b/adev/src/app/core/layout/footer/footer.component.html
@@ -100,6 +100,9 @@
           <a href="https://angular.az/" title="Azərbaycanca">Azərbaycanca</a>
         </li>
         <li>
+          <a href="https://docs.angular.lat/" title="Español">Español</a>
+        </li>
+        <li>
           <a href="https://angular-docs.tr/" title="Türkçe">Türkçe</a>
         </li>
         <li>


### PR DESCRIPTION
Add https://docs.angular.lat (Español) to the community translations section.