### PR TITLE
fix(docs-infra): improve inline code layout

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -87,8 +87,7 @@ $code-font-size: 0.875rem;
       -webkit-background-clip: text;
       color: transparent;
       max-width: max-content;
-      width: 100%;
-      display: inline-block;
+      display: inline;
 
       &::before {
         content: '';


### PR DESCRIPTION
Remove inline-block layout behavior from inline code elements to improve wrapping and spacing in multiline documentation paragraphs.

## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Inline code elements in Angular.dev documentation use `display: inline-block`, which can cause cramped wrapping and visually crowded spacing in multiline paragraphs.

<img width="1030" height="349" alt="image" src="https://github.com/user-attachments/assets/451b246b-f7d3-48aa-b787-1be679ff13f9" />


Issue Number: N/A

## What is the new behavior?

Inline code elements now use natural inline flow, improving spacing and wrapping behavior in multiline documentation paragraphs while preserving the existing visual appearance.

<img width="940" height="325" alt="image" src="https://github.com/user-attachments/assets/23b43059-8444-4167-8324-7cd36233b779" />


## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This change only affects inline code layout styling in Angular.dev documentation pages.
