### PR TITLE
fix(platform-server): reject malformed absolute URLs to prevent SSRF bypass

### DIFF
--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -17,6 +17,7 @@ import {inject, Injectable, ɵWritable as Writable} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {INITIAL_CONFIG} from './tokens';
+import {parseAndValidateAbsoluteUrl} from './utils';
 
 /**
  * Parses a URL string and returns a URL object.
@@ -25,8 +26,9 @@ import {INITIAL_CONFIG} from './tokens';
  * @returns The parsed URL.
  */
 export function parseUrl(urlStr: string, origin: string): URL {
-  if (URL.canParse(urlStr)) {
-    return new URL(urlStr);
+  const parsedUrl = parseAndValidateAbsoluteUrl(urlStr);
+  if (parsedUrl !== null) {
+    return parsedUrl;
   }
 
   if (urlStr && urlStr[0] !== '/') {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -376,12 +376,32 @@ export async function renderApplication(
   }
 }
 
+export function parseAndValidateAbsoluteUrl(url: string): URL | null {
+  const isAbsoluteOrProtocolRelative = /^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\\\\)/.test(url);
+  if (isAbsoluteOrProtocolRelative) {
+    try {
+      return new URL(url);
+    } catch {
+      throw new Error(`Invalid URL: ${url}`);
+    }
+  }
+
+  if (URL.canParse(url)) {
+    return new URL(url);
+  }
+
+  return null;
+}
+
 function validateAllowedHosts(url: string | undefined, allowedHosts: string[] | undefined) {
-  if (typeof url === 'string' && URL.canParse(url)) {
-    const hostname = new URL(url).hostname;
-    const allowedHostsSet: ReadonlySet<string> = new Set(allowedHosts);
-    if (!isHostAllowed(hostname, allowedHostsSet)) {
-      throw new Error(`Host ${url} is not allowed. You can configure \`allowedHosts\` option.`);
+  if (typeof url === 'string') {
+    const parsedUrl = parseAndValidateAbsoluteUrl(url);
+    if (parsedUrl !== null) {
+      const hostname = parsedUrl.hostname;
+      const allowedHostsSet: ReadonlySet<string> = new Set(allowedHosts);
+      if (!isHostAllowed(hostname, allowedHostsSet)) {
+        throw new Error(`Host ${url} is not allowed. You can configure \`allowedHosts\` option.`);
+      }
     }
   }
 }

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -29,6 +29,22 @@ import {parseUrl} from '../src/location';
       expect(url.href).toBe('http://other.com/deep/path');
       expect(url.origin).toBe('http://other.com');
     });
+
+    it('should throw an error for malformed absolute URLs', () => {
+      const malformedUrls = [
+        'http://evil.com:80:80/path',
+        'https://evil.com:80:80/path',
+        'http://[google.com]/path',
+        'http://google.com:port/path',
+        'http://google.com:80a/path',
+      ];
+
+      for (const url of malformedUrls) {
+        expect(() => parseUrl(url, 'http://test.com')).toThrowError(
+          new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+        );
+      }
+    });
   });
 
   describe('PlatformLocation', () => {

--- a/packages/platform-server/test/utils_spec.ts
+++ b/packages/platform-server/test/utils_spec.ts
@@ -60,6 +60,28 @@ describe('allowedHosts validation in renderApplication', () => {
       expect(error.message).not.toContain('is not allowed');
     }
   });
+
+  it('should throw an error for malformed absolute URLs (SSRF bypass attempt)', async () => {
+    const malformedUrls = [
+      'http://evil.com:80:80/path',
+      'https://evil.com:80:80/path',
+      'http://[google.com]/path',
+      'http://google.com:port/path',
+      'http://google.com:80a/path',
+    ];
+
+    for (const url of malformedUrls) {
+      await expectAsync(
+        renderApplication(bootstrap, {
+          document: '<app></app>',
+          url,
+          allowedHosts: ['test.com'],
+        }),
+      ).toBeRejectedWithError(
+        new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+      );
+    }
+  });
 });
 
 describe('allowedHosts validation in renderModule', () => {
@@ -92,6 +114,28 @@ describe('allowedHosts validation in renderModule', () => {
       });
     } catch (error: any) {
       expect(error.message).not.toContain('is not allowed');
+    }
+  });
+
+  it('should throw an error for malformed absolute URLs (SSRF bypass attempt)', async () => {
+    const malformedUrls = [
+      'http://evil.com:80:80/path',
+      'https://evil.com:80:80/path',
+      'http://[google.com]/path',
+      'http://google.com:port/path',
+      'http://google.com:80a/path',
+    ];
+
+    for (const url of malformedUrls) {
+      await expectAsync(
+        renderModule(MockModule, {
+          document: '<app></app>',
+          url,
+          allowedHosts: ['test.com'],
+        }),
+      ).toBeRejectedWithError(
+        new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+      );
     }
   });
 });


### PR DESCRIPTION
Addresses the parser differential SSRF bypass where malformed URLs bypass initial WHATWG validation but are parsed leniently by Domino, leading to location hijacking.

Introduces a robust scheme check to throw on any malformed absolute/protocol-relative URLs that fail standard parsing.