### PR TITLE
fix(platform-server): extract single-pass URL parser and reject malfo…

### DIFF
--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -13,31 +13,92 @@ import {
   PlatformLocation,
   ɵgetDOM as getDOM,
 } from '@angular/common';
-import {Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
+import {inject, Injectable, Injector, ɵWritable as Writable} from '@angular/core';
 import {Subject} from 'rxjs';
 
-import {INITIAL_CONFIG, PlatformConfig} from './tokens';
+import {INITIAL_CONFIG} from './tokens';
+import {getSafeUrl, parseAndValidateAbsoluteUrl} from './url';
+
+const LEADING_SLASHES_REGEX = /^[/\\]+/;
 
 /**
- * Parses a URL string and returns a URL object.
+ * Parses a URL string and returns a URL components object.
  * @param urlStr The string to parse.
- * @param origin The origin to use for resolving the URL.
- * @returns The parsed URL.
+ * @param origin The origin to use for resolving the URL (optional).
+ * @returns The parsed URL components.
  */
-export function parseUrl(urlStr: string, origin: string): URL {
-  if (URL.canParse(urlStr)) {
-    return new URL(urlStr);
+export function parseUrl(
+  urlStr: string,
+  origin?: string,
+): {
+  protocol: string;
+  hostname: string;
+  port: string;
+  pathname: string;
+  search: string;
+  hash: string;
+  href: string;
+  origin: string;
+} {
+  const parsedUrl = parseAndValidateAbsoluteUrl(urlStr);
+  if (parsedUrl !== null) {
+    return {
+      protocol: parsedUrl.protocol,
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port,
+      pathname: parsedUrl.pathname,
+      search: parsedUrl.search,
+      hash: parsedUrl.hash,
+      href: parsedUrl.href,
+      origin: parsedUrl.origin,
+    };
   }
 
-  if (urlStr && urlStr[0] !== '/') {
-    urlStr = `/${urlStr}`;
+  if (urlStr) {
+    urlStr = '/' + urlStr.replace(LEADING_SLASHES_REGEX, '');
   }
 
-  return new URL(origin + urlStr);
+  if (origin) {
+    try {
+      const url = new URL(urlStr, origin);
+      return {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port,
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+        href: url.href,
+        origin: url.origin,
+      };
+    } catch {
+      // Fallback to simple parser if origin is not a valid base (e.g. 'null')
+    }
+  }
+
+  const hashIdx = urlStr.indexOf('#');
+  const hash = hashIdx !== -1 ? urlStr.substring(hashIdx) : '';
+  const withoutHash = hashIdx !== -1 ? urlStr.substring(0, hashIdx) : urlStr;
+
+  const queryIdx = withoutHash.indexOf('?');
+  const search = queryIdx !== -1 ? withoutHash.substring(queryIdx) : '';
+  const pathname = queryIdx !== -1 ? withoutHash.substring(0, queryIdx) : withoutHash;
+
+  return {
+    protocol: '',
+    hostname: '',
+    port: '',
+    pathname,
+    search,
+    hash,
+    href: urlStr,
+    origin: '',
+  };
 }
 
 /**
- * Server-side implementation of URL state. Implements `pathname`, `search`, and `hash`
+ * Server-side implementation of URL state. Implements `pathname`, `search`, and
+ * `hash`
  * but not the state stack.
  */
 @Injectable()
@@ -50,27 +111,28 @@ export class ServerPlatformLocation implements PlatformLocation {
   public readonly search: string = '';
   public readonly hash: string = '';
   private _hashUpdate = new Subject<LocationChangeEvent>();
+  private injector = inject(Injector);
+  private get _doc(): any {
+    return this.injector.get(DOCUMENT);
+  }
 
-  constructor(
-    @Inject(DOCUMENT) private _doc: any,
-    @Optional() @Inject(INITIAL_CONFIG) _config: any,
-  ) {
-    const config = _config as PlatformConfig | null;
+  constructor() {
+    const config = inject(INITIAL_CONFIG, {optional: true});
     if (!config) {
       return;
     }
     if (config.url) {
-      const {protocol, hostname, port, pathname, search, hash, href} = parseUrl(
-        config.url,
-        this._doc.location.origin,
-      );
-      this.protocol = protocol;
-      this.hostname = hostname;
-      this.port = port;
-      this.pathname = pathname;
-      this.search = search;
-      this.hash = hash;
-      this.href = href;
+      const safeUrl = getSafeUrl(config.url);
+      if (safeUrl) {
+        const {protocol, hostname, port, pathname, search, hash, href} = parseUrl(safeUrl);
+        this.protocol = protocol;
+        this.hostname = hostname;
+        this.port = port;
+        this.pathname = pathname;
+        this.search = search;
+        this.hash = hash;
+        this.href = href;
+      }
     }
   }
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -18,16 +18,16 @@ import {
   createPlatformFactory,
   Injector,
   NgModule,
-  Optional,
   PLATFORM_ID,
   PLATFORM_INITIALIZER,
   platformCore,
   PlatformRef,
   Provider,
-  StaticProvider,
   Testability,
   ɵsetDocument,
   ɵTESTABILITY as TESTABILITY,
+  inject,
+  StaticProvider,
 } from '@angular/core';
 import {
   BrowserModule,
@@ -41,21 +41,23 @@ import {ServerPlatformLocation} from './location';
 import {enableDomEmulation, PlatformState} from './platform_state';
 import {ServerEventManagerPlugin} from './server_events';
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
+import {getSafeUrl} from './url';
 import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
-  {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
+  {provide: DOCUMENT, useFactory: _document},
   {provide: PLATFORM_ID, useValue: PLATFORM_SERVER_ID},
-  {provide: PLATFORM_INITIALIZER, useFactory: initDominoAdapter, multi: true, deps: [Injector]},
+  {provide: PLATFORM_INITIALIZER, useFactory: initDominoAdapter, multi: true},
   {
     provide: PlatformLocation,
     useClass: ServerPlatformLocation,
-    deps: [DOCUMENT, [Optional, INITIAL_CONFIG]],
+    deps: [],
   },
   {provide: PlatformState, deps: [DOCUMENT]},
 ];
 
-function initDominoAdapter(injector: Injector) {
+function initDominoAdapter() {
+  const injector = inject(Injector);
   const _enableDomEmulation = enableDomEmulation(injector);
   return () => {
     if (_enableDomEmulation) {
@@ -90,15 +92,17 @@ export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
 })
 export class ServerModule {}
 
-function _document(injector: Injector) {
+function _document() {
+  const injector = inject(Injector);
   const config: PlatformConfig | null = injector.get(INITIAL_CONFIG, null);
   const _enableDomEmulation = enableDomEmulation(injector);
   let document: Document;
   if (config && config.document) {
+    const safeUrl = config.url !== undefined ? getSafeUrl(config.url) : undefined;
     document =
       typeof config.document === 'string'
         ? _enableDomEmulation
-          ? parseDocument(config.document, config.url)
+          ? parseDocument(config.document, safeUrl)
           : window.document
         : config.document;
   } else {

--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const LEADING_SLASHES_REGEX = /^[/\\]+/;
+
+/**
+ * Regular expression to check if a URL is absolute or protocol-relative.
+ * It matches URLs that start with a scheme (e.g., https:) followed by
+ * either double forward slashes (//) or double backward slashes (\\).
+ * See: https://url.spec.whatwg.org/#absolute-url
+ */
+const ABSOLUTE_OR_PROTOCOL_RELATIVE_REGEX = /^[a-zA-Z][a-zA-Z0-9+.\-]*:(\/\/|\\\\)/;
+
+/**
+ * Parses and validates a URL if it is absolute or protocol-relative.
+ * @returns The parsed WHATWG URL object if it is a valid absolute URL, or `null` if it is relative/non-absolute.
+ * @throws An Error if the URL is structured as absolute but cannot be parsed by the WHATWG standard.
+ */
+export function parseAndValidateAbsoluteUrl(url: string): URL | null {
+  if (!ABSOLUTE_OR_PROTOCOL_RELATIVE_REGEX.test(url)) {
+    return null;
+  }
+
+  try {
+    return new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+}
+
+/**
+ * Validates the URL string and returns a standardized WHATWG absolute URL string
+ * or a normalized relative path.
+ */
+export function getSafeUrl(url: string | undefined): string | undefined {
+  if (typeof url !== 'string') {
+    return undefined;
+  }
+
+  const parsedUrl = parseAndValidateAbsoluteUrl(url);
+  if (parsedUrl !== null) {
+    return parsedUrl.href;
+  }
+
+  return '/' + url.replace(LEADING_SLASHES_REGEX, '');
+}

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -28,6 +28,7 @@ import {platformServer} from './server';
 import {PlatformState} from './platform_state';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 import {createScript} from './transfer_state';
+import {parseAndValidateAbsoluteUrl} from './url';
 
 /**
  * Event dispatch (JSAction) script is inlined into the HTML by the build
@@ -374,11 +375,14 @@ export async function renderApplication(
 }
 
 function validateAllowedHosts(url: string | undefined, allowedHosts: string[] | undefined) {
-  if (typeof url === 'string' && URL.canParse(url)) {
-    const hostname = new URL(url).hostname;
-    const allowedHostsSet: ReadonlySet<string> = new Set(allowedHosts);
-    if (!isHostAllowed(hostname, allowedHostsSet)) {
-      throw new Error(`Host ${url} is not allowed. You can configure \`allowedHosts\` option.`);
+  if (typeof url === 'string') {
+    const parsedUrl = parseAndValidateAbsoluteUrl(url);
+    if (parsedUrl !== null) {
+      const hostname = parsedUrl.hostname;
+      const allowedHostsSet: ReadonlySet<string> = new Set(allowedHosts);
+      if (!isHostAllowed(hostname, allowedHostsSet)) {
+        throw new Error(`Host ${url} is not allowed. You can configure \`allowedHosts\` option.`);
+      }
     }
   }
 }

--- a/packages/platform-server/test/platform_location_spec.ts
+++ b/packages/platform-server/test/platform_location_spec.ts
@@ -7,7 +7,7 @@
  */
 import '@angular/compiler';
 
-import {PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {destroyPlatform} from '@angular/core';
 import {INITIAL_CONFIG, platformServer} from '@angular/platform-server';
 
@@ -28,6 +28,22 @@ import {parseUrl} from '../src/location';
       const url = parseUrl('http://other.com/deep/path', 'http://test.com');
       expect(url.href).toBe('http://other.com/deep/path');
       expect(url.origin).toBe('http://other.com');
+    });
+
+    it('should throw an error for malformed absolute URLs', () => {
+      const malformedUrls = [
+        'http://evil.com:80:80/path',
+        'https://evil.com:80:80/path',
+        'http://[google.com]/path',
+        'http://google.com:port/path',
+        'http://google.com:80a/path',
+      ];
+
+      for (const url of malformedUrls) {
+        expect(() => parseUrl(url, 'http://test.com')).toThrowError(
+          new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+        );
+      }
     });
   });
 
@@ -173,7 +189,50 @@ import {parseUrl} from '../src/location';
         platform.destroy();
 
         expect(location.hostname).withContext(`hostname for URL: "${url}"`).toBe('');
-        expect(location.pathname).withContext(`pathname for URL: "${url}"`).toBe(url);
+        expect(location.pathname)
+          .withContext(`pathname for URL: "${url}"`)
+          .toBe('/attacker.com/deep/path');
+      }
+    });
+
+    it('should not expose protocol-relative URLs on the location to prevent open redirect and SSRF bypasses', async () => {
+      const urls = ['/\\attacker.com/deep/path', '//attacker.com/deep/path'];
+      const origins = [undefined, 'http://localhost:4200'];
+
+      for (const url of urls) {
+        for (const origin of origins) {
+          const providers: any[] = [
+            {
+              provide: INITIAL_CONFIG,
+              useValue: {
+                document: '',
+                url,
+              },
+            },
+          ];
+
+          if (origin) {
+            providers.push({
+              provide: DOCUMENT,
+              useValue: {
+                location: {
+                  origin,
+                },
+              },
+            });
+          }
+
+          const platform = platformServer(providers);
+          const location = platform.injector.get(PlatformLocation) as any;
+          platform.destroy();
+
+          // A relative redirect URL starting with // or /\ is normalized by browsers to a protocol-relative URL.
+          // The PlatformLocation.url property MUST NOT expose these unsafe patterns.
+          const isVulnerable = location.url.startsWith('//') || location.url.startsWith('/\\');
+          expect(isVulnerable)
+            .withContext(`URL: "${url}", origin: "${origin}", location.url: "${location.url}"`)
+            .toBeFalse();
+        }
       }
     });
   });

--- a/packages/platform-server/test/utils_spec.ts
+++ b/packages/platform-server/test/utils_spec.ts
@@ -60,6 +60,28 @@ describe('allowedHosts validation in renderApplication', () => {
       expect(error.message).not.toContain('is not allowed');
     }
   });
+
+  it('should throw an error for malformed absolute URLs (SSRF bypass attempt)', async () => {
+    const malformedUrls = [
+      'http://evil.com:80:80/path',
+      'https://evil.com:80:80/path',
+      'http://[google.com]/path',
+      'http://google.com:port/path',
+      'http://google.com:80a/path',
+    ];
+
+    for (const url of malformedUrls) {
+      await expectAsync(
+        renderApplication(bootstrap, {
+          document: '<app></app>',
+          url,
+          allowedHosts: ['test.com'],
+        }),
+      ).toBeRejectedWithError(
+        new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+      );
+    }
+  });
 });
 
 describe('allowedHosts validation in renderModule', () => {
@@ -92,6 +114,28 @@ describe('allowedHosts validation in renderModule', () => {
       });
     } catch (error: any) {
       expect(error.message).not.toContain('is not allowed');
+    }
+  });
+
+  it('should throw an error for malformed absolute URLs (SSRF bypass attempt)', async () => {
+    const malformedUrls = [
+      'http://evil.com:80:80/path',
+      'https://evil.com:80:80/path',
+      'http://[google.com]/path',
+      'http://google.com:port/path',
+      'http://google.com:80a/path',
+    ];
+
+    for (const url of malformedUrls) {
+      await expectAsync(
+        renderModule(MockModule, {
+          document: '<app></app>',
+          url,
+          allowedHosts: ['test.com'],
+        }),
+      ).toBeRejectedWithError(
+        new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+      );
     }
   });
 });


### PR DESCRIPTION
…rmed absolute URLs

A parser differential exists between Node's WHATWG URL parser (strict) and Domino's URL parser (lenient). Malformed absolute URLs (such as those containing double ports, invalid square brackets, or non-numeric port names) return false for URL.canParse(), bypassing the host allowlist validation but still getting parsed with an origin by Domino, leading to hostname adoption SSRF.

This commit introduces a standalone `url.ts` utility to check and parse absolute/protocol-relative URLs exactly once. It raises an error if the URL starts with a scheme-based authority structure but is not valid WHATWG-wise, and uses this helper in both initial host check and location state routing paths to prevent SSRF bypass.

Also backports path parsing normalization to collapse multiple consecutive leading slashes and backslashes (e.g. // or /\) down to a single forward slash.
