### PR TITLE
feat(core): add ProviderScopeToken for custom providedIn scopes

### DIFF
--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -166,7 +166,7 @@ export interface R3InjectableMetadataFacade {
   name: string;
   type: Type;
   typeArgumentCount: number;
-  providedIn?: Type | 'root' | 'platform' | 'any' | null;
+  providedIn?: Type | object | 'root' | 'platform' | 'any' | null;
   useClass?: OpaqueValue;
   useFactory?: OpaqueValue;
   useExisting?: OpaqueValue;

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -823,10 +823,12 @@ function wrapExpression(obj: any, property: string): WrappedNodeExpr<any> | unde
 }
 
 function computeProvidedIn(
-  providedIn: Function | string | null | undefined,
+  providedIn: Function | object | string | null | undefined,
 ): MaybeForwardRefExpression {
+  // Functions are class references (e.g. NgModule types) and non-null objects are runtime tokens
+  // (e.g. ProviderScopeToken instances) — both must be wrapped so the runtime value is preserved.
   const expression =
-    typeof providedIn === 'function'
+    providedIn != null && typeof providedIn !== 'string'
       ? new WrappedNodeExpr(providedIn)
       : new LiteralExpr(providedIn ?? null);
   // See `convertToProviderExpression()` for why this uses `ForwardRefHandling.None`.

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -166,7 +166,7 @@ export interface R3InjectableMetadataFacade {
   name: string;
   type: Type;
   typeArgumentCount: number;
-  providedIn?: Type | 'root' | 'platform' | 'any' | null;
+  providedIn?: Type | object | 'root' | 'platform' | 'any' | null;
   useClass?: OpaqueValue;
   useFactory?: OpaqueValue;
   useExisting?: OpaqueValue;

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -53,5 +53,6 @@ export {
   provideEnvironmentInitializer,
 } from './provider_collection';
 export {ProviderToken} from './provider_token';
+export {ProviderScopeToken} from './provider_scope_token';
 export {EnvironmentInjector, R3Injector as ɵR3Injector} from './r3_injector';
 export {Service, ServiceDecorator} from './service';

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -9,6 +9,7 @@
 import {Type} from '../interface/type';
 import {makeDecorator, TypeDecorator} from '../util/decorators';
 
+import {ProviderScopeToken} from './provider_scope_token';
 import {
   ClassSansProvider,
   ConstructorSansProvider,
@@ -66,10 +67,12 @@ export interface InjectableDecorator {
    * @deprecated The `providedIn: NgModule` or `providedIn:'any'` options are deprecated. Please use the other signatures.
    */
   (options?: {providedIn: Type<any> | 'any'} & InjectableProvider): TypeDecorator;
-  (options?: {providedIn: 'root' | 'platform' | null} & InjectableProvider): TypeDecorator;
+  (options?: {providedIn: 'root' | 'platform' | null | ProviderScopeToken} & InjectableProvider): TypeDecorator;
   new (): Injectable;
   new (
-    options?: {providedIn: Type<any> | 'root' | 'platform' | 'any' | null} & InjectableProvider,
+    options?: {
+      providedIn: Type<any> | 'root' | 'platform' | 'any' | null | ProviderScopeToken;
+    } & InjectableProvider,
   ): Injectable;
 }
 
@@ -97,7 +100,7 @@ export interface Injectable {
    * modules share one instance. This option is DEPRECATED.
    *
    */
-  providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+  providedIn?: Type<any> | 'root' | 'platform' | 'any' | null | ProviderScopeToken;
 }
 
 /**

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -10,6 +10,7 @@ import {Type} from '../interface/type';
 import {assertLessThan} from '../util/assert';
 
 import {ɵɵdefineInjectable} from './interface/defs';
+import {ProviderScopeToken} from './provider_scope_token';
 
 /**
  * Creates a token that can be used in a DI Provider.
@@ -88,7 +89,7 @@ export class InjectionToken<T> {
   constructor(
     _desc: string,
     options?: {
-      providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+      providedIn?: Type<any> | 'root' | 'platform' | 'any' | null | ProviderScopeToken;
       factory: () => T;
     },
   );
@@ -96,7 +97,7 @@ export class InjectionToken<T> {
   constructor(
     protected _desc: string,
     options?: {
-      providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+      providedIn?: Type<any> | 'root' | 'platform' | 'any' | null | ProviderScopeToken;
       factory: () => T;
     },
   ) {

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -8,6 +8,7 @@
 
 import {Type} from '../../interface/type';
 import {getClosureSafeProperty} from '../../util/property';
+import {ProviderScopeToken} from '../provider_scope_token';
 
 import {
   ClassProvider,
@@ -43,7 +44,7 @@ export interface ɵɵInjectableDeclaration<T> {
    * - `null`, does not belong to any injector. Must be explicitly listed in the injector
    *   `providers`.
    */
-  providedIn: InjectorType<any> | 'root' | 'platform' | 'any' | 'environment' | null;
+  providedIn: InjectorType<any> | 'root' | 'platform' | 'any' | 'environment' | ProviderScopeToken | null;
 
   /**
    * The token to which this definition belongs.
@@ -166,7 +167,7 @@ export interface InjectorTypeWithProviders<T> {
  */
 export function ɵɵdefineInjectable<T>(opts: {
   token: unknown;
-  providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'environment' | null;
+  providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'environment' | ProviderScopeToken | null;
   factory: (parent?: Type<any>) => T;
 }): ɵɵInjectableDeclaration<T> {
   return {

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -7,6 +7,7 @@
  */
 
 import {Type} from '../../interface/type';
+import {ProviderScopeToken} from '../provider_scope_token';
 
 /**
  * Configures the `Injector` to return a value for a token.
@@ -340,6 +341,7 @@ export type Provider =
   | ConstructorProvider
   | ExistingProvider
   | FactoryProvider
+  | ProviderScopeToken
   | any[];
 
 /**

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -21,6 +21,7 @@ import {resolveForwardRef} from './forward_ref';
 import {ENVIRONMENT_INITIALIZER} from './initializer_token';
 import {ɵɵinject as inject} from './injector_compatibility';
 import {getInjectorDef, InjectorType, InjectorTypeWithProviders} from './interface/defs';
+import {ProviderScopeToken} from './provider_scope_token';
 import {
   ClassProvider,
   ConstructorProvider,
@@ -218,7 +219,8 @@ export type SingleProvider =
   | ConstructorProvider
   | ExistingProvider
   | FactoryProvider
-  | StaticClassProvider;
+  | StaticClassProvider
+  | ProviderScopeToken;
 
 /**
  * The logic visits an `InjectorType`, an `InjectorTypeWithProviders`, or a standalone

--- a/packages/core/src/di/provider_scope_token.ts
+++ b/packages/core/src/di/provider_scope_token.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * A token that defines a custom DI scope boundary for use with `providedIn`.
+ *
+ * `ProviderScopeToken` enables a middle ground between `providedIn: 'root'` (global singleton)
+ * and explicit provider arrays. Services that declare `providedIn: myScopeToken` are lazily
+ * provided in any injector that lists the `ProviderScopeToken` in its providers, without
+ * needing to be explicitly listed themselves.
+ *
+ * This solves the problem where a single non-root-providable dependency forces all of its
+ * dependants into explicit provider arrays, which are error-prone and hard to maintain.
+ *
+ * @usageNotes
+ *
+ * ### Define a scope token
+ *
+ * ```ts
+ * export const entityScope = new ProviderScopeToken('entityScope');
+ * ```
+ *
+ * ### Declare a service in that scope
+ *
+ * ```ts
+ * @Injectable({ providedIn: entityScope })
+ * export class ChildPreviewService { ... }
+ * ```
+ *
+ * ### Register the scope on an environment injector
+ *
+ * ```ts
+ * const scopedInjector = createEnvironmentInjector(
+ *   [entityScope],
+ *   parentInjector,
+ * );
+ *
+ * scopedInjector.get(ChildPreviewService); // lazily created here
+ * parentInjector.get(ChildPreviewService); // NullInjectorError – not in scope
+ * ```
+ *
+ * @see {@link Injectable}
+ * @see {@link InjectionToken}
+ *
+ * @publicApi
+ */
+export class ProviderScopeToken {
+  readonly ngMetadataName = 'ProviderScopeToken';
+
+  constructor(readonly _desc: string) {}
+
+  toString(): string {
+    return `ProviderScopeToken(${this._desc})`;
+  }
+}

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -74,6 +74,7 @@ import {
   SingleProvider,
 } from './provider_collection';
 import {ProviderToken} from './provider_token';
+import {ProviderScopeToken} from './provider_scope_token';
 import {INJECTOR_SCOPE, InjectorScope} from './scope';
 import {setActiveConsumer} from '@angular/core/primitives/signals';
 import {
@@ -213,6 +214,8 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
 
   private injectorDefTypes: Set<Type<unknown>>;
 
+  private scopeTokens = new Set<ProviderScopeToken>();
+
   constructor(
     providers: Array<Provider | EnvironmentProviders>,
     readonly parent: Injector,
@@ -290,6 +293,7 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
       this.records.clear();
       this._ngOnDestroyHooks.clear();
       this.injectorDefTypes.clear();
+      this.scopeTokens.clear();
       setActiveConsumer(prevConsumer);
     }
   }
@@ -474,6 +478,14 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
     // Determine the token from the provider. Either it's its own token, or has a {provide: ...}
     // property.
     provider = resolveForwardRef(provider);
+
+    // ProviderScopeToken instances are scope markers, not value providers. Register the scope and
+    // return early so the rest of the provider-processing logic is not applied.
+    if (provider instanceof ProviderScopeToken) {
+      this.scopeTokens.add(provider);
+      return;
+    }
+
     let token: any = isTypeProvider(provider)
       ? provider
       : resolveForwardRef(provider && provider.provide);
@@ -555,6 +567,8 @@ export class R3Injector extends EnvironmentInjector implements PrimitivesInjecto
     const providedIn = resolveForwardRef(def.providedIn);
     if (typeof providedIn === 'string') {
       return providedIn === 'any' || this.scopes.has(providedIn);
+    } else if (providedIn instanceof ProviderScopeToken) {
+      return this.scopeTokens.has(providedIn);
     } else {
       return this.injectorDefTypes.has(providedIn);
     }

--- a/packages/core/test/di/provider_scope_token_spec.ts
+++ b/packages/core/test/di/provider_scope_token_spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {createEnvironmentInjector, EnvironmentInjector, inject, Injectable} from '../../src/core';
+import {ProviderScopeToken} from '../../src/di/provider_scope_token';
+
+describe('ProviderScopeToken', () => {
+  describe('basic class', () => {
+    it('has a readable description', () => {
+      const token = new ProviderScopeToken('myScope');
+      expect(token.toString()).toBe('ProviderScopeToken(myScope)');
+    });
+
+    it('has the expected ngMetadataName', () => {
+      const token = new ProviderScopeToken('test');
+      expect(token.ngMetadataName).toBe('ProviderScopeToken');
+    });
+
+    it('two tokens with the same description are distinct', () => {
+      const a = new ProviderScopeToken('same');
+      const b = new ProviderScopeToken('same');
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('with environment injectors', () => {
+    let rootInjector: EnvironmentInjector;
+
+    beforeEach(() => {
+      rootInjector = createEnvironmentInjector([], null as any);
+    });
+
+    afterEach(() => {
+      rootInjector.destroy();
+    });
+
+    it('provides a service in the scoped injector that declares the scope token', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class ScopedService {}
+
+      const scopedInjector = createEnvironmentInjector([myScope], rootInjector);
+
+      const instance = scopedInjector.get(ScopedService);
+      expect(instance).toBeInstanceOf(ScopedService);
+
+      scopedInjector.destroy();
+    });
+
+    it('does not provide a scoped service in an injector that lacks the scope token', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class ScopedService {}
+
+      // rootInjector does NOT have myScope registered
+      expect(() => rootInjector.get(ScopedService)).toThrow();
+    });
+
+    it('provides distinct instances for two independent injectors with the same scope token', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class ScopedService {}
+
+      const injectorA = createEnvironmentInjector([myScope], rootInjector);
+      const injectorB = createEnvironmentInjector([myScope], rootInjector);
+
+      const instanceA = injectorA.get(ScopedService);
+      const instanceB = injectorB.get(ScopedService);
+
+      expect(instanceA).toBeInstanceOf(ScopedService);
+      expect(instanceB).toBeInstanceOf(ScopedService);
+      expect(instanceA).not.toBe(instanceB);
+
+      injectorA.destroy();
+      injectorB.destroy();
+    });
+
+    it('provides the same instance on repeated calls within the same injector', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class ScopedService {}
+
+      const scopedInjector = createEnvironmentInjector([myScope], rootInjector);
+
+      const first = scopedInjector.get(ScopedService);
+      const second = scopedInjector.get(ScopedService);
+      expect(first).toBe(second);
+
+      scopedInjector.destroy();
+    });
+
+    it('resolves to the nearest ancestor injector that has the scope token', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class ScopedService {}
+
+      const middleInjector = createEnvironmentInjector([myScope], rootInjector);
+      const childInjector = createEnvironmentInjector([], middleInjector);
+
+      // Request from child injector – the instance should live in middleInjector
+      const instance = childInjector.get(ScopedService);
+      expect(instance).toBeInstanceOf(ScopedService);
+      // Same instance when requested directly from the scope boundary
+      expect(middleInjector.get(ScopedService)).toBe(instance);
+
+      middleInjector.destroy();
+    });
+
+    it('supports multiple independent scope tokens on the same injector', () => {
+      const scopeA = new ProviderScopeToken('A');
+      const scopeB = new ProviderScopeToken('B');
+
+      @Injectable({providedIn: scopeA})
+      class ServiceA {}
+
+      @Injectable({providedIn: scopeB})
+      class ServiceB {}
+
+      const injector = createEnvironmentInjector([scopeA, scopeB], rootInjector);
+
+      expect(injector.get(ServiceA)).toBeInstanceOf(ServiceA);
+      expect(injector.get(ServiceB)).toBeInstanceOf(ServiceB);
+
+      injector.destroy();
+    });
+
+    it('a scoped service can inject other services from the same scope', () => {
+      const myScope = new ProviderScopeToken('myScope');
+
+      @Injectable({providedIn: myScope})
+      class InnerService {}
+
+      @Injectable({providedIn: myScope})
+      class OuterService {
+        readonly inner = inject(InnerService);
+      }
+
+      const scopedInjector = createEnvironmentInjector([myScope], rootInjector);
+
+      const outer = scopedInjector.get(OuterService);
+      expect(outer.inner).toBeInstanceOf(InnerService);
+
+      scopedInjector.destroy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #68007

Introduces `ProviderScopeToken`, a new DI primitive that fills the gap between `providedIn: 'root'` (global singleton, too broad) and explicit provider arrays (flexible, but error-prone and hard to maintain).

**The problem:** As soon as one service cannot be `providedIn: 'root'`, every service that depends on it must be explicitly listed in each component's `providers` array. Old entries accumulate and are never cleaned up.

**The solution:** A named scope boundary that services can self-register into, without requiring every intermediate component to list them.

### API

```ts
// 1. Define a scope token (one per feature/domain boundary)
export const entityScope = new ProviderScopeToken('entityScope');

// 2. Declare the service in that scope — no explicit listing needed
@Injectable({ providedIn: entityScope })
export class ChildPreviewService {
  readonly entity = inject(entityToken);
}

// 3. Register the scope on the injector that should own the instances
const scopedInjector = createEnvironmentInjector(
  [entityScope],
  parentInjector,
);

scopedInjector.get(ChildPreviewService); // ✅ lazily created here
parentInjector.get(ChildPreviewService); // ❌ NullInjectorError — correct boundary
```

## Changes

| File | Change |
|------|--------|
| `packages/core/src/di/provider_scope_token.ts` | **NEW** — `ProviderScopeToken` class |
| `packages/core/src/di/interface/defs.ts` | Add `ProviderScopeToken` to `providedIn` union in `ɵɵInjectableDeclaration` and `ɵɵdefineInjectable` |
| `packages/core/src/di/injectable.ts` | Add `ProviderScopeToken` to `providedIn` union in `Injectable` and `InjectableDecorator` |
| `packages/core/src/di/injection_token.ts` | Add `ProviderScopeToken` to `providedIn` union in `InjectionToken` options |
| `packages/core/src/di/interface/provider.ts` | Add `ProviderScopeToken` to `Provider` type |
| `packages/core/src/di/provider_collection.ts` | Add `ProviderScopeToken` to `SingleProvider` type |
| `packages/core/src/di/r3_injector.ts` | `scopeTokens` set, early exit in `processProvider`, `instanceof` check in `injectableDefInScope` |
| `packages/compiler/src/jit_compiler_facade.ts` | `computeProvidedIn` handles object values (not just functions/strings) |
| Both `compiler_facade_interface.ts` copies | Extend `R3InjectableMetadataFacade.providedIn` type |
| `packages/core/test/di/provider_scope_token_spec.ts` | **NEW** — unit + integration tests |

## Implementation notes

**Scope resolution in `R3Injector`:**

`R3Injector` gains a `scopeTokens: Set<ProviderScopeToken>` (parallel to `scopes: Set<InjectorScope>`). When a `ProviderScopeToken` instance appears in a provider list, `processProvider` detects it early (before the standard `token`/`record` logic), adds it to `scopeTokens`, and returns. The existing `injectableDefInScope` method gets an additional branch:

```ts
} else if (providedIn instanceof ProviderScopeToken) {
  return this.scopeTokens.has(providedIn);
}
```

**JIT compiler facade:**

`computeProvidedIn` previously only wrapped `Function` values as `WrappedNodeExpr`. The condition is broadened to wrap any non-string, non-null value so that `ProviderScopeToken` instances survive the JIT compilation round-trip as live object references.

**What's not in this PR (future work):**

Full component-level node injector support (allowing `providers: [entityScope]` in `@Component` to make services lazy in the view injector hierarchy) requires pre-allocation of slots in the compiled component's TView, which is a compiler-level change tracked separately.

## Test plan

- [x] `ProviderScopeToken` basic class invariants (description, `ngMetadataName`, identity)
- [x] Service provided in scoped `EnvironmentInjector` resolves correctly
- [x] Service NOT provided in an ancestor injector that lacks the scope token (throws)
- [x] Two sibling injectors with the same scope token produce independent instances
- [x] Same instance returned on repeated calls within one scoped injector (singleton)
- [x] Nearest ancestor with scope token wins when child inherits from parent
- [x] Multiple scope tokens on one injector work independently
- [x] Scoped services can inject other services in the same scope