### PR TITLE
fix(core): Handle synchronous errors in PendingTasks.run function

### DIFF
--- a/packages/core/src/pending_tasks.ts
+++ b/packages/core/src/pending_tasks.ts
@@ -75,7 +75,12 @@ export class PendingTasks {
    */
   run(fn: () => Promise<unknown>): void {
     const removeTask = this.add();
-    fn().catch(this.errorHandler).finally(removeTask);
+    try {
+      fn().catch(this.errorHandler).finally(removeTask);
+    } catch (err) {
+      this.errorHandler(err);
+      removeTask();
+    }
   }
 
   /** @nocollapse */

--- a/packages/core/test/acceptance/pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/pending_tasks_spec.ts
@@ -116,6 +116,24 @@ describe('public PendingTasks', () => {
     await expectAsync(appRef.whenStable()).toBeResolved();
     expect(spy).toHaveBeenCalled();
   });
+
+  it('should stop blocking stability if run function throws synchronously', async () => {
+    TestBed.configureTestingModule({
+      rethrowApplicationErrors: false,
+    });
+
+    const appRef = TestBed.inject(ApplicationRef);
+    const pendingTasks = TestBed.inject(PendingTasks);
+    const errorHandler = TestBed.inject(ErrorHandler);
+    const spy = spyOn(errorHandler, 'handleError');
+
+    pendingTasks.run(() => {
+      throw new Error('Sync error');
+    });
+    await expectAsync(appRef.whenStable()).toBeResolved();
+    expect(spy).toHaveBeenCalled();
+    expect(spy.calls.mostRecent().args[0].message).toContain('Sync error');
+  });
 });
 
 function applicationRefIsStable(applicationRef: ApplicationRef) {


### PR DESCRIPTION
catches synchronous errors coming out of the function passed to PendingTasks.run
