### PR TITLE
refactor(core): Update webmcp support to use `document.modelContext`

### DIFF
--- a/packages/core/src/webmcp/declare_tool.ts
+++ b/packages/core/src/webmcp/declare_tool.ts
@@ -9,8 +9,8 @@
 // g3-only import type {JsonSchemaForInference} from '@mcp-b/webmcp-types';
 import type {JsonSchemaForInference} from '../../third_party/@mcp-b/webmcp-types'; // 3p-only
 import {assertInInjectionContext, inject, Injector, runInInjectionContext} from '../di';
-import type {ModelContext, ToolDescriptor} from './types';
 import {DestroyRef} from '../linker';
+import type {ModelContext, ToolDescriptor} from './types';
 
 /**
  * Declares a WebMCP tool.
@@ -33,9 +33,10 @@ export function declareExperimentalWebMcpTool<const InputSchema extends JsonSche
   tool: ToolDescriptor<InputSchema>,
   injector?: Injector,
 ): void {
-  const {modelContext} = globalThis.navigator as typeof globalThis.navigator & {
-    modelContext?: ModelContext;
-  };
+  // modelContext was moved from `navigator` to `document` in the spec, but we check both for compatibility with different environments.
+  const modelContext =
+    (globalThis.document as {modelContext?: ModelContext}).modelContext ??
+    (globalThis.navigator as unknown as {modelContext?: ModelContext}).modelContext;
 
   // Verify WebMCP is supported in this client.
   if (!modelContext) return;
@@ -66,11 +67,5 @@ export function declareExperimentalWebMcpTool<const InputSchema extends JsonSche
   modelContext.registerTool(wrappedTool, {signal: abortCtrl.signal});
 
   // Unregister when the associated `Injector` is destroyed.
-  destroyRef.onDestroy(() => {
-    abortCtrl.abort();
-
-    // `unregisterTool` has been removed from the spec, but we continue to
-    // call it because `@mcp-b/webmcp-polyfill` still relies on it for tests.
-    modelContext.unregisterTool?.({name: tool.name});
-  });
+  destroyRef.onDestroy(() => void abortCtrl.abort());
 }

--- a/packages/core/src/webmcp/types.ts
+++ b/packages/core/src/webmcp/types.ts
@@ -78,7 +78,7 @@ export interface ToolDescriptor<InputSchema extends JsonSchemaForInference> {
   execute: Execute<InputSchema>;
 }
 
-/** The `window.navigator.modelContext` object for imperatively registering WebMCP tools. */
+/** The `window.document.modelContext` object for imperatively registering WebMCP tools. */
 export interface ModelContext {
   /**
    * Register a WebMCP tool for the agent to invoke.


### PR DESCRIPTION
The implementation in Chrome 150 moved `modelContext` from the navigator to the document (see webmachinelearning/webmcp/pull/184)

We're also removing the calls to the deprecated `unregisterTool` method.

fixes #68947
