### PR TITLE
docs: fix grammar issues in resource guide

### DIFF
--- a/adev/src/content/guide/signals/resource.md
+++ b/adev/src/content/guide/signals/resource.md
@@ -26,7 +26,7 @@ const firstName = computed(() => {
   if (userResource.hasValue()) {
     // `hasValue` serves 2 purposes:
     // - It acts as type guard to strip `undefined` from the type
-    // - If protects against reading a throwing `value` when the resource is in error state
+    // - It protects against reading a throwing `value` when the resource is in error state
     return userResource.value().firstName;
   }
 
@@ -114,11 +114,11 @@ The `status` signal provides a specific `ResourceStatus` that describes the stat
 | `'idle'`      | `undefined`       | The resource has no valid request and the loader has not run.                |
 | `'error'`     | `undefined`       | The loader has encountered an error.                                         |
 | `'loading'`   | `undefined`       | The loader is running as a result of the `params` value changing.            |
-| `'reloading'` | Previous value    | The loader is running as a result calling of the resource's `reload` method. |
+| `'reloading'` | Previous value    | The loader is running as a result of calling the resource's `reload` method. |
 | `'resolved'`  | Resolved value    | The loader has completed.                                                    |
 | `'local'`     | Locally set value | The resource's value has been set locally via `.set()` or `.update()`        |
 
-You can use this status information to conditionally display user interface elements, such loading indicators and error messages.
+You can use this status information to conditionally display user interface elements, such as loading indicators and error messages.
 
 ## Reactive data fetching with `httpResource`
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The Signals Resource guide contains a few minor grammar mistakes and wording issues.

Issue Number: N/A

## What is the new behavior?

Fixed minor grammar issues in the Resource guide documentation:

* “If protects” → “It protects”
* “as a result calling of” → “as a result of calling”
* Added missing “as” in “such as loading indicators”

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This PR only updates documentation text and does not introduce any functional changes.
