### PR TITLE
refactor(platform-server): extract parseUrl regex and add comments for URL parsing behavior

### DIFF
--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -103,7 +103,12 @@ function _document() {
         ? _enableDomEmulation
           ? parseDocument(
               config.document,
-              config.url !== undefined ? parseUrl(config.url, 'http://localhost').href : undefined,
+              config.url !== undefined
+                ? // A fallback same-origin base ('http://localhost') is provided so that relative
+                  // page URLs are parsed and resolved as same-origin paths, preventing empty
+                  // or invalid location values in the parsed virtual DOM document.
+                  parseUrl(config.url, 'http://localhost').href
+                : undefined,
             )
           : window.document
         : config.document;

--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -7,6 +7,7 @@
  */
 
 const LEADING_SLASHES_REGEX = /^[/\\]+/;
+const MALFORMED_ABSOLUTE_URL_REGEX = /^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\\\\)/;
 
 /**
  * Parses a URL string and returns a resolved WHATWG URL object.
@@ -25,7 +26,7 @@ export function parseUrl(urlStr: string | undefined, origin?: string): URL | nul
     return new URL(urlStr);
   }
 
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\\\\)/.test(urlStr)) {
+  if (MALFORMED_ABSOLUTE_URL_REGEX.test(urlStr)) {
     throw new Error(`Invalid URL: ${urlStr}`);
   }
 
@@ -33,6 +34,10 @@ export function parseUrl(urlStr: string | undefined, origin?: string): URL | nul
     return null;
   }
 
+  // Normalizes request path parsing by collapsing multiple consecutive leading slashes
+  // and backslashes (e.g. // or /\) down to a single forward slash. This ensures consistent
+  // resolution of relative path segments and prevents unexpected absolute path overrides
+  // during URL parsing.
   let normalizedPath = urlStr.replace(LEADING_SLASHES_REGEX, '/');
   if (normalizedPath[0] !== '/') {
     normalizedPath = `/${normalizedPath}`;


### PR DESCRIPTION

Extracts the regular expression for matching malformed absolute URLs to a module-scoped constant in url.ts.

Additionally, adds comprehensive inline documentation to clarify:
- The path normalization behavior of LEADING_SLASHES_REGEX which collapses consecutive slashes and backslashes.
- The rationale for using 'http://localhost' as the fallback base URL for virtual document initialization in server.ts.
