### PR TITLE
fix(platform-server): reject scheme-obfuscated URLs in parseUrl

### DIFF
--- a/packages/platform-server/src/url.ts
+++ b/packages/platform-server/src/url.ts
@@ -7,6 +7,9 @@
  */
 
 const LEADING_SLASHES_REGEX = /^[/\\]+/;
+// Characters silently stripped by the WHATWG URL parser, so they can be used to
+// hide a scheme from the malformed-URL guard below.
+const URL_STRIPPED_CHARS_REGEX = /[\t\n\r]/g;
 
 /**
  * Parses a URL string and returns a resolved WHATWG URL object.
@@ -25,7 +28,7 @@ export function parseUrl(urlStr: string | undefined, origin?: string): URL | nul
     return new URL(urlStr);
   }
 
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\\\\)/.test(urlStr)) {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/|\\\\)/.test(urlStr.replace(URL_STRIPPED_CHARS_REGEX, ''))) {
     throw new Error(`Invalid URL: ${urlStr}`);
   }
 

--- a/packages/platform-server/test/url_spec.ts
+++ b/packages/platform-server/test/url_spec.ts
@@ -38,6 +38,18 @@ describe('parseUrl', () => {
         );
       }
     });
+
+    it('should throw an error for malformed absolute URLs with scheme-obfuscating control chars', () => {
+      const obfuscatedUrls = [
+        'ht\ttp://evil.com:80:80/path',
+        'ht\ntp://evil.com:80:80/path',
+        'ht\rtp://[google.com]/path',
+      ];
+
+      for (const url of obfuscatedUrls) {
+        expect(() => parseUrl(url, 'http://test.com')).toThrowError(/^Invalid URL: /);
+      }
+    });
   });
 
   describe('without origin', () => {
@@ -66,6 +78,18 @@ describe('parseUrl', () => {
         expect(() => parseUrl(url)).toThrowError(
           new RegExp(`Invalid URL: ${url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
         );
+      }
+    });
+
+    it('should throw an error for malformed absolute URLs with scheme-obfuscating control chars', () => {
+      const obfuscatedUrls = [
+        'ht\ttp://evil.com:80:80/path',
+        'ht\ntp://evil.com:80:80/path',
+        'ht\rtp://[google.com]/path',
+      ];
+
+      for (const url of obfuscatedUrls) {
+        expect(() => parseUrl(url)).toThrowError(/^Invalid URL: /);
       }
     });
   });


### PR DESCRIPTION
parseUrl()'s malformed-URL guard runs its scheme regex against the raw input, but the WHATWG URL parser silently strips embedded tab/CR/LF. A scheme obfuscated with those characters (e.g. `ht\ttp://evil.com:80:80/path`) misses the regex, returns `null`, and slips past the `validateAllowedHosts` SSRF-bypass guard that the existing test in `test/utils_spec.ts` relies on. Run the regex against the stripped form so the obfuscated variants land in the same `Invalid URL:` branch as the plain ones.