### PR TITLE
fix(compiler): restore audio src URL security context

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -63,9 +63,10 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['a', ['href', 'xlink:href']],
       ['form', ['action']],
 
-      // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
+      // The below items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
       ['img', ['src']],
       ['video', ['src']],
+      ['audio', ['src']],
     ]);
 
     registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -153,6 +153,7 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext('p', 'innerHTML', false)).toBe(SecurityContext.HTML);
     expect(registry.securityContext('a', 'href', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext('a', 'style', false)).toBe(SecurityContext.STYLE);
+    expect(registry.securityContext('audio', 'src', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext('base', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
 
     // SVG animate and set attributes


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [x] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

After #66068, `audio[src]` no longer resolves to `SecurityContext.URL`.

As a result, bindings using `SafeResourceUrl` values may no longer unwrap correctly and can render the XSS error string instead of the actual URL.

Issue Number: #66338

## What is the new behavior?

Restores `SecurityContext.URL` handling for `audio[src]`, matching the existing compatibility handling for `img[src]` and `video[src]`.

Also adds regression coverage to verify that `audio[src]` resolves to `SecurityContext.URL`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This restores the previous behavior prior to #66068 for `audio[src]` bindings.
