### PR TITLE
fix(common): only strip a literal /index.html suffix from URLs

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -319,7 +319,7 @@ function _stripBasePath(basePath: string, url: string): string {
 }
 
 function _stripIndexHtml(url: string): string {
-  return url.replace(/\/index.html$/, '');
+  return url.replace(/\/index\.html$/, '');
 }
 
 function _stripOrigin(baseHref: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -304,5 +304,19 @@ describe('Location Class', () => {
       expect(location.normalize(baseHref)).toBe('');
       expect(location.normalize(baseHref + path)).toBe(path);
     });
+
+    it('should only strip a literal /index.html suffix, not arbitrary characters', () => {
+      const baseHref = '/en';
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      // The `.` in the strip regex must be escaped; otherwise it would match any
+      // character and turn e.g. `/foo/indexXhtml` into `/foo`.
+      expect(location.normalize('/en/page/indexXhtml')).toBe('/page/indexXhtml');
+      expect(location.normalize('/en/page/index_html')).toBe('/page/index_html');
+      expect(location.normalize('/en/page/index.html')).toBe('/page');
+    });
   });
 });


### PR DESCRIPTION
Hit this while exercising `Location.normalize` with route paths that end in
non-`.html` suffixes. The unescaped `.` in the strip regex inside
`_stripIndexHtml` matches any character, so e.g. `/foo/indexXhtml` and
`/foo/index_html` both collapse to `/foo` before the base-path strip and end
up resolving to the wrong route. Escape the dot so only the literal
`/index.html` suffix is stripped.