### PR TITLE
docs(forms): remove hasMetadata references from v21 guide

### DIFF
--- a/adev/src/content/guide/forms/signals/field-metadata.md
+++ b/adev/src/content/guide/forms/signals/field-metadata.md
@@ -2,7 +2,7 @@
 
 Field metadata is reactive data you can attach to an individual field. Angular's built-in constraint validators like `required()` and `min()` use this system internally. In other words, every time you call a validator, you're contributing to a metadata key for that particular field.
 
-This guide covers the metadata system in depth: how reducers combine contributions from multiple schema rules, how to write custom reducers, how reading composes with `hasMetadata()`, and how managed metadata ties lifecycle-aware objects to individual fields.
+This guide covers the metadata system in depth: how reducers combine contributions from multiple schema rules, how to write custom reducers, how to read metadata values from fields, and how managed metadata ties lifecycle-aware objects to individual fields.
 
 ## You have already been using metadata
 
@@ -126,23 +126,15 @@ The logic function receives the field's context, which exposes `value` as a sign
 
 ## Reading metadata from a field
 
-`hasMetadata(key)` returns `true` if any schema rule registered the key on this field. `state.metadata(key)` returns `undefined` when no rule has registered the key, and a signal of the current reduced value otherwise.
+`state.metadata(key)` returns `undefined` when no rule has registered the key, and a signal of the current reduced value otherwise.
 
 ```ts
-registrationForm.username().hasMetadata(USERNAME_HELP); // true if any metadata() rule registered this key
+const usernameHelp = registrationForm.username().metadata(USERNAME_HELP);
 ```
 
 The shape of that inner value (whether it can itself be `undefined`, what type it holds) depends on the key's reducer. Reducers are covered in the next section.
 
-When the key may not be registered, gate the read with `hasMetadata()`:
-
-```angular-html
-@if (registrationForm.username().hasMetadata(USERNAME_HELP)) {
-  <p class="help">{{ registrationForm.username().metadata(USERNAME_HELP)!() }}</p>
-}
-```
-
-When you know a rule always registers the key (because the schema in the same file does so), you can skip the `hasMetadata()` check and use optional chaining as a compact alternative:
+When the key may not be registered, use optional chaining:
 
 ```ts
 const message = registrationForm.username().metadata(USERNAME_HELP)?.();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

The Angular 21 Signal Forms metadata guide references `hasMetadata()`, but this API is not available in Angular 21.2.x. This can cause confusion when following the documentation.

Issue Number: #69001

## What is the new behavior?

Removes references and examples using `hasMetadata()` from the Angular 21 metadata guide and updates the wording to describe reading metadata through `metadata()`.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

This aligns the Angular 21 documentation with the APIs available in the 21.x release line.
