### PR TITLE
fix(docs-infra): readable contrast for DEV/EXP api badges in light mode

### DIFF
--- a/adev/src/app/features/references/api-items-section/api-items-section.component.scss
+++ b/adev/src/app/features/references/api-items-section/api-items-section.component.scss
@@ -79,12 +79,15 @@
 
 :host {
   --item-attr-base-mix: 80%;
+  --item-attr-text: var(--page-background);
 
   .docs-light-mode & {
     --item-attr-base-mix: 20%;
+    --item-attr-text: var(--primary-contrast);
   }
   @media screen and (prefers-color-scheme: light) {
     --item-attr-base-mix: 20%;
+    --item-attr-text: var(--primary-contrast);
   }
 }
 
@@ -110,7 +113,7 @@
       var(--symbolic-yellow) var(--item-attr-base-mix),
       var(--octonary-contrast)
     );
-    color: var(--page-background);
+    color: var(--item-attr-text);
   }
 
   &.adev-experimental {
@@ -119,7 +122,7 @@
       var(--symbolic-green) var(--item-attr-base-mix),
       var(--octonary-contrast)
     );
-    color: var(--page-background);
+    color: var(--item-attr-text);
   }
 
   &.adev-deprecated {


### PR DESCRIPTION
The DEV (developer preview) and EXP (experimental) badges in the API reference list used `--page-background` for text, which is dark in dark mode (working as intended on the pale colored bg) but white in light mode, making the labels invisible against the near-white badge bg. Introduce an `--item-attr-text` CSS variable defaulting to `--page-background` and overridden to `--primary-contrast` in light mode, following the per-mode pattern the file already uses for `--item-attr-base-mix`.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On the API reference list pages on angular.dev (e.g. `/api/aria/accordion`), the `DEV` (developer preview) and `EXP` (experimental) badges next to symbol names are unreadable in light mode. The text is `var(--page-background)`, which is white in light mode, rendered on a pale yellow/green badge background, so the label disappears into the badge.

<img width="976" height="193" alt="image" src="https://github.com/user-attachments/assets/6bc507b4-e6ff-4ce3-aafd-f0d669ed8e60" />

## What is the new behavior?

The badge text color is now driven by a new `--item-attr-text` CSS variable on the host, mirroring the per-mode override pattern already used for `--item-attr-base-mix`. It defaults to `--page-background` (dark in dark mode, where the existing behavior was already correct) and overrides to `--primary-contrast` in light mode, so the text is dark in both themes and the labels remain readable.

<img width="1076" height="202" alt="image" src="https://github.com/user-attachments/assets/d7e7c47c-73cd-4986-8857-3b80da79f9a2" />


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
