### PR TITLE
fix(common): prevent prototype pollution in formatDateTime

### DIFF
--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -263,7 +263,7 @@ function getNamedFormat(locale: string, format: string): string {
 function formatDateTime(str: string, opt_values: string[]) {
   if (opt_values) {
     str = str.replace(/\{([^}]+)}/g, function (match, key) {
-      return opt_values != null && key in opt_values ? opt_values[key] : match;
+      return Object.hasOwn(opt_values, key) ? opt_values[key] : match;
     });
   }
   return str;


### PR DESCRIPTION
Replace `in` operator with `Object.hasOwn` in
formatDateTime to prevent prototype pollution attacks.

The `in` operator traverses the prototype chain, meaning a polluted
Object.prototype key could be picked up as a valid replacement value.
This is especially critical in SSR environments where a single
prototype pollution attack persists across all subsequent requests in
the shared Node.js process, potentially injecting malicious content
into every user's rendered HTML.

Using `Object.hasOwn` restricts the lookup to
own properties only, blocking prototype chain traversal.