### PR TITLE
docs(di): fix typos and grammar in dependency injection guides

### DIFF
--- a/adev/src/content/guide/di/defining-dependency-providers.md
+++ b/adev/src/content/guide/di/defining-dependency-providers.md
@@ -36,7 +36,7 @@ NOTE: The string parameter (e.g., `'api.url'`) is a description purely for debug
 
 ### InjectionToken with `providedIn: 'root'`
 
-An `InjectionToken` that has a `factory` results in `providedIn: 'root'` by default (but can be overidden via the `providedIn` prop).
+An `InjectionToken` that has a `factory` results in `providedIn: 'root'` by default (but can be overridden via the `providedIn` prop).
 
 ```ts
 // 📁 /app/config.token.ts
@@ -279,7 +279,7 @@ Provider identifiers allow Angular's dependency injection (DI) system to retriev
 
 #### Class names
 
-Class name use the imported class directly as the identifier:
+Class names use the imported class directly as the identifier:
 
 ```angular-ts
 import {Component} from '@angular/core';

--- a/adev/src/content/guide/di/dependency-injection-context.md
+++ b/adev/src/content/guide/di/dependency-injection-context.md
@@ -36,7 +36,7 @@ const canActivateTeam: CanActivateFn = (
 If you need to run a function within an injection context without already being in one, you can use `runInInjectionContext`.
 This requires access to an injector, such as the `EnvironmentInjector`:
 
-```ts {highlight: [9], header"hero.service.ts"}
+```ts {highlight: [9], header:"hero.service.ts"}
 @Injectable({
   providedIn: 'root',
 })

--- a/adev/src/content/guide/di/hierarchical-dependency-injection.md
+++ b/adev/src/content/guide/di/hierarchical-dependency-injection.md
@@ -364,7 +364,7 @@ A component class can provide services in two ways:
 
 In the examples below, you will see the logical tree of an Angular application.
 To illustrate how the injector works in the context of templates, the logical tree will represent the HTML structure of the application.
-For example, the logical tree will show that `<child-component>` is a direct children of `<parent-component>`.
+For example, the logical tree will show that `<child-component>` is a direct child of `<parent-component>`.
 
 In the logical tree, you will see special attributes: `@Provide`, `@Inject`, and `@ApplicationConfig`.
 These aren't real attributes but are here to demonstrate what is going on under the hood.
@@ -379,7 +379,7 @@ These aren't real attributes but are here to demonstrate what is going on under 
 
 The example application has a `FlowerService` provided in `root` with an `emoji` value of red hibiscus <code>🌺</code>.
 
-```ts {header:"lower.service.ts"}
+```ts {header:"flower.service.ts"}
 @Service()
 export class FlowerService {
   emoji = '🌺';
@@ -751,7 +751,7 @@ Visibility decorators influence where the search for the injection token begins 
 To do this, place visibility configuration at the point of injection, that is, when invoking `inject()`, rather than at a point of declaration.
 
 To alter where the injector starts looking for `FlowerService`, add `skipSelf` to the `<app-child>` `inject()` invocation where `FlowerService` is injected.
-This invocation is a property initializer the `<app-child>` as shown in `child.ts`:
+This invocation is a property initializer in `<app-child>` as shown in `child.ts`:
 
 ```typescript
 flower = inject(FlowerService, {skipSelf: true});
@@ -944,7 +944,7 @@ For example, consider we build a `VillainsList` that displays a list of villains
 It gets those villains from a `VillainsService`.
 
 If you provide `VillainsService` in the root `AppModule`, it will make `VillainsService` visible everywhere in the application.
-If you later modify the `VillainsService`, you could break something in other components that started depending this service by accident.
+If you later modify the `VillainsService`, you could break something in other components that started depending on this service by accident.
 
 Instead, you should provide the `VillainsService` in the `providers` metadata of the `VillainsList` like this:
 

--- a/adev/src/content/guide/di/lightweight-injection-tokens.md
+++ b/adev/src/content/guide/di/lightweight-injection-tokens.md
@@ -56,7 +56,7 @@ This is because `LibCard` actually contains two references to the `LibHeader`:
 readonly header = contentChild(LibHeader);
 ```
 
-- One of these reference is in the _type position_-- that is, it specifies `LibHeader` as a type: `readonly header: Signal<LibHeader|undefined>`.
+- One of these references is in the _type position_-- that is, it specifies `LibHeader` as a type: `readonly header: Signal<LibHeader|undefined>`.
 - The other reference is in the _value position_-- that is, `LibHeader` is the value passed into the `contentChild` function: `contentChild(LibHeader)`.
 
 The compiler handles token references in these positions differently:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

* [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [ ] angular.dev application / infrastructure changes
* [ ] Other... Please describe:

## What is the current behavior?

Several dependency injection guides contain minor typos, grammar issues, and documentation metadata inconsistencies. These include spelling mistakes, incorrect singular/plural usage, missing words, and a malformed code block header.

Issue Number: N/A

## What is the new behavior?

This PR corrects documentation issues across several dependency injection guides, including:

* Fixing spelling and grammar mistakes.
* Correcting singular/plural agreement issues.
* Fixing a malformed code block header attribute.
* Correcting an example filename to match the referenced `FlowerService`.
* Improving sentence clarity without changing the meaning of the documentation.

These changes are documentation-only and do not affect Angular runtime behavior.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Other information

The changes are limited to documentation content and do not modify application code, APIs, or behavior.
