### PR TITLE
fix(common): handle invalid percent-encoding in parseCookieValue

### DIFF
--- a/packages/common/src/cookie.ts
+++ b/packages/common/src/cookie.ts
@@ -13,7 +13,14 @@ export function parseCookieValue(cookieStr: string, name: string): string | null
     const [cookieName, cookieValue]: string[] =
       eqIndex == -1 ? [cookie, ''] : [cookie.slice(0, eqIndex), cookie.slice(eqIndex + 1)];
     if (cookieName.trim() === name) {
-      return decodeURIComponent(cookieValue);
+      try {
+        return decodeURIComponent(cookieValue);
+      } catch {
+        // A bare `%` is a valid cookie-octet per RFC 6265, but is not a valid
+        // percent-encoding sequence, so `decodeURIComponent` throws on it. Fall
+        // back to the raw value rather than letting the error escape to callers.
+        return cookieValue;
+      }
     }
   }
   return null;

--- a/packages/common/test/cookie_spec.ts
+++ b/packages/common/test/cookie_spec.ts
@@ -30,4 +30,8 @@ describe('cookies', () => {
     expect(parseCookieValue('token=whitespace%20', 'token')).toBe('whitespace ');
     expect(parseCookieValue('token=whitespace%0A', 'token')).toBe('whitespace\n');
   });
+  it('returns the raw value when it is not a valid percent-encoding', () => {
+    expect(parseCookieValue('token=100%done', 'token')).toBe('100%done');
+    expect(parseCookieValue('token=%', 'token')).toBe('%');
+  });
 });


### PR DESCRIPTION
`parseCookieValue` runs `decodeURIComponent` on the matched value:

    Uncaught URIError: URI malformed

A bare `%` is a valid cookie-octet under RFC 6265 but not a valid escape sequence, so reading such a cookie (via `getCookie` or the XSRF extractor) throws instead of returning a value. Fall back to the raw value when decoding fails.