### PR TITLE
fix(compiler): move projection attributes into constants

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/ng_content_fallback.js
@@ -1,5 +1,6 @@
 const $_c0$ = [[["basic"]], "*", [["footer"]], [["structural"]]];
 const $_c1$ = ["basic", "*", "footer", "structural"];
+const $_c2$ = ["*ngIf", "hasStructural"];
 
 function TestComponent_ProjectionFallback_0_Template(rf, ctx) {
   if (rf & 1) {
@@ -46,7 +47,7 @@ function TestComponent_ng_content_6_ProjectionFallback_0_Template(rf, ctx) {
 
 function TestComponent_ng_content_6_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵprojection(0, 3, ["*ngIf", "hasStructural"], TestComponent_ng_content_6_ProjectionFallback_0_Template, 2, 0);
+    $r3$.ɵɵprojection(0, 3, $_c2$, TestComponent_ng_content_6_ProjectionFallback_0_Template, 2, 0);
   }
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/project_as_ng_content.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/project_as_ng_content.js
@@ -1,16 +1,17 @@
 
-const _c0 = [[["", "card-title", ""]], [["", "card-content", ""]]];
-const _c1 = ["[card-title]", "[card-content]"];
-const _c2 = ["*"];
+const $_c0$ = [[["", "card-title", ""]], [["", "card-content", ""]]];
+const $_c1$ = ["[card-title]", "[card-content]"];
+const $_c2$ = ["*"];
+const $_c3$ = ["ngProjectAs", "[card-content]", 5, ["", "card-content", ""]];
 // ...
 selectors: [["card"]],
 standalone: false,
-ngContentSelectors: _c1,
+ngContentSelectors: $_c1$,
 decls: 3,
 vars: 0,
 template: function Card_Template(rf, ctx) {
 	if (rf & 1) {
-		i0.ɵɵprojectionDef(_c0);
+		i0.ɵɵprojectionDef($_c0$);
 		i0.ɵɵprojection(0);
 		i0.ɵɵtext(1, " --- ");
 		i0.ɵɵprojection(2, 1);
@@ -19,7 +20,7 @@ template: function Card_Template(rf, ctx) {
 // ...
 selectors: [["card-with-title"]],
 standalone: false,
-ngContentSelectors: _c2,
+ngContentSelectors: $_c2$,
 decls: 4,
 vars: 0,
 consts: [["ngProjectAs", "[card-title]", 5, ["", "card-title", ""]]],
@@ -29,7 +30,7 @@ template: function CardWithTitle_Template(rf, ctx) {
 		i0.ɵɵelementStart(0, "card")(1, "h1", 0);
 		i0.ɵɵtext(2, "Title");
 		i0.ɵɵelementEnd();
-		i0.ɵɵprojection(3, 0, ["ngProjectAs", "[card-content]", 5, ["", "card-content", ""]]);
+		i0.ɵɵprojection(3, 0, $_c3$);
 		i0.ɵɵelementEnd();
 	}
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_structural_directives.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_structural_directives.js
@@ -1,3 +1,5 @@
+const $_c1$ = ["*ngIf", "flag"];
+
 function MyComponent_img_2_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵi18nStart(0, 0, 1);
@@ -34,7 +36,7 @@ function MyComponent_ng_container_5_Template(rf, ctx) {
 function MyComponent_ng_content_6_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵi18nStart(0, 0, 6);
-    i0.ɵɵprojection(1, 0, ["*ngIf", "flag"]);
+    i0.ɵɵprojection(1, 0, $_c1$);
     i0.ɵɵi18nEnd();
   }
 }

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -1205,7 +1205,7 @@ export interface ProjectionOp extends Op<CreateOp>, ConsumesSlotOpTrait {
 
   projectionSlotIndex: number;
 
-  attributes: null | o.LiteralArrayExpr;
+  attributes: null | o.Expression;
 
   localRefs: string[];
 

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -410,7 +410,7 @@ export function projectionDef(def: o.Expression | null): ir.CreateOp {
 export function projection(
   slot: number,
   projectionSlotIndex: number,
-  attributes: o.LiteralArrayExpr | null,
+  attributes: o.Expression | null,
   fallbackFnName: string | null,
   fallbackDecls: number | null,
   fallbackVars: number | null,

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -45,7 +45,7 @@ export function collectElementConsts(job: CompilationJob): void {
           if (attributes !== undefined) {
             const attrArray = serializeAttributes(attributes);
             if (attrArray.entries.length > 0) {
-              op.attributes = attrArray;
+              op.attributes = job.pool.getConstLiteral(attrArray, true);
             }
           }
         } else if (ir.isElementOrContainerOp(op)) {


### PR DESCRIPTION
We can save some memory by moving the `attrs` passed into the `projection` instruction into the constant pool.
