### PR TITLE
fix(common): only strip a literal /index.html suffix in AngularJSUrlCodec

### DIFF
--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -235,7 +235,7 @@ export class AngularJSUrlCodec implements UrlCodec {
 }
 
 function _stripIndexHtml(url: string): string {
-  return url.replace(/\/index.html$/, '');
+  return url.replace(/\/index\.html$/, '');
 }
 
 /**

--- a/packages/common/upgrade/test/params.spec.ts
+++ b/packages/common/upgrade/test/params.spec.ts
@@ -76,4 +76,14 @@ describe('AngularJSUrlCodec', () => {
       }).toThrowError('Invalid URL (http://foo.bar) with base (abc)');
     });
   });
+
+  describe('encodePath', () => {
+    it('should only strip a literal /index.html suffix, not arbitrary characters', () => {
+      // The `.` in the strip regex must be escaped; otherwise it would match any
+      // character and turn e.g. `/foo/indexXhtml` into `/foo`.
+      expect(codec.encodePath('/page/indexXhtml')).toBe('/page/indexXhtml');
+      expect(codec.encodePath('/page/index_html')).toBe('/page/index_html');
+      expect(codec.encodePath('/page/index.html')).toBe('/page');
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) - not applicable

## What is the current behavior?

`AngularJSUrlCodec._stripIndexHtml` in `@angular/common/upgrade` (`packages/common/upgrade/src/params.ts:238`) has an unescaped `.` in the strip regex `/\/index.html$/`. The unescaped dot matches any character, so suffixes such as `/indexXhtml`, `/index_html`, `/index!html`, and `/index/html` are all stripped to the empty string instead of being preserved.

This is the same bug class that was fixed by commit d109bf9 ("fix(common): only strip a literal /index.html suffix from URLs") in `Location._stripIndexHtml` (`packages/common/src/location/location.ts:319`), but the sibling copy in the upgrade package's `AngularJSUrlCodec` was not updated.

Repro (Node only, mirrors the buggy regex):

\`\`\`js
function buggy(url)  { return url.replace(/\/index.html$/,  ""); }
function fixed(url)  { return url.replace(/\/index\.html$/, ""); }

console.log(buggy("/page/indexXhtml")); // "/page"            <- bug
console.log(fixed("/page/indexXhtml")); // "/page/indexXhtml" <- intended
\`\`\`

In hybrid AngularJS-Angular apps that wire up `LocationUpgradeModule`, this affects `$location.path()` / `$location.url()` (route resolves to the stripped URL instead of the literal one) and `$location.replace` change detection in `location_shim.ts:198`, which calls `urlCodec.areEqual(oldUrl, newUrl)`. `areEqual('/page', '/page/indexXhtml')` returns `true` and the URL-change event is suppressed.

## Issue Number: N/A

## What is the new behavior?

Escape the dot so the regex only matches the literal `/index.html` suffix, matching the precedent set by `Location._stripIndexHtml`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`AngularJSUrlCodec.encodePath` now preserves trailing segments that happen to match `/index<any>html` (e.g. `/indexXhtml`, `/index_html`). Apps that intentionally relied on the lossy stripping to alias arbitrary `index<x>html` suffixes to the parent path were depending on a regex typo and are extremely unlikely to exist; the parallel `Location._stripIndexHtml` shipped this same change in d109bf9 without being flagged as breaking.

## Other information

Tests added in `packages/common/upgrade/test/params.spec.ts` mirror the cases used in d109bf9's `location_spec.ts` addition.
