### PR TITLE
docs: fix esbuild and TensorFlow branding on overview page

### DIFF
--- a/adev/src/content/introduction/what-is-angular.md
+++ b/adev/src/content/introduction/what-is-angular.md
@@ -76,8 +76,8 @@
     trusted type support, help protect your users from common vulnerabilities like
     cross-site scripting and cross-site request forgery.
   </docs-card>
-  <docs-card title="Keep large teams productive with Vite and esbuild" href="tools/cli/build-system-migration" link="ESBuild and Vite" titleIconName="sensors">
-    Angular CLI includes a fast, modern build pipeline using Vite and ESBuild. Developers report
+  <docs-card title="Keep large teams productive with Vite and esbuild" href="tools/cli/build-system-migration" link="Vite and esbuild" titleIconName="sensors">
+    Angular CLI includes a fast, modern build pipeline using Vite and esbuild. Developers report
     building projects with hundreds of thousands of lines of code in less than a minute.
   </docs-card>
   <docs-card title="Proven in some of Google's largest web apps" titleIconName="sensors">
@@ -108,7 +108,7 @@
   <docs-card title="Partnering with other Google technologies" titleIconName="sensors">
     <p>Angular partners closely with other Google technologies and teams to improve the web.</p>
     <p>Our ongoing partnership with Chrome’s Aurora actively explores improvements to user experience across the web, developing built-in performance optimizations like <code>NgOptimizedImage</code> and improvements to Angular’s Core Web Vitals.</p>
-    <p>We are also working with <a href="https://firebase.google.com/" target="_blank">Firebase</a>, <a href="https://www.tensorflow.org/" target="_blank">Tensorflow</a>, <a href="https://flutter.dev/" target="_blank">Flutter</a>, <a href="https://m3.material.io/" target="_blank">Material Design</a>, and <a href="https://cloud.google.com/" target="_blank">Google Cloud</a> to ensure we provide meaningful integrations across the developer workflow.</p>
+    <p>We are also working with <a href="https://firebase.google.com/" target="_blank">Firebase</a>, <a href="https://www.tensorflow.org/" target="_blank">TensorFlow</a>, <a href="https://flutter.dev/" target="_blank">Flutter</a>, <a href="https://m3.material.io/" target="_blank">Material Design</a>, and <a href="https://cloud.google.com/" target="_blank">Google Cloud</a> to ensure we provide meaningful integrations across the developer workflow.</p>
   </docs-card>
 </docs-card-container>
 


### PR DESCRIPTION
The esbuild card on the "What is Angular?" page rendered the bundler name three different ways (title "esbuild", link "ESBuild and Vite", body "Vite and ESBuild") so this unifies on the official lowercase "esbuild"; also corrects "Tensorflow" to "TensorFlow" to match the other brands on its line (Firebase, Material Design, Flutter, Google Cloud) which were already cased correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

On https://angular.dev/overview:

- The "Vite and esbuild" card renders the bundler name three different ways across the title, link text, and body ("esbuild" / "ESBuild and Vite" / "Vite and ESBuild"). Official branding is lowercase.
- "Tensorflow" is the only brand on its line that is mis-cased; Firebase, Material Design, Flutter, and Google Cloud are already correct.

## What is the new behavior?

- esbuild is rendered consistently across the title, link, and body and matches the project's official lowercase branding.
- TensorFlow uses its official capital-F branding.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

