### PR TITLE
docs(docs-infra): simplify code block styles

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -80,25 +80,11 @@ $code-font-size: 0.875rem;
     &:not(pre *) {
       position: relative;
       padding: 0 0.3rem;
-      // Fallback for older browsers
-      background: #e62600;
-      background: var(--red-to-orange-horizontal-gradient);
-      background-clip: text;
-      -webkit-background-clip: text;
-      color: transparent;
+      background: var(--subtle-purple);
+      color: var(--hot-pink);
       max-width: max-content;
-      display: inline;
-
-      &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        width: 100%;
-        height: 100%;
-        background: var(--subtle-purple);
-        border-radius: 0.25rem;
-        z-index: -1;
-      }
+      border-radius: 0.25rem;
+      width: 100%;
 
       a:not(.docs-anchor) > & {
         position: relative;


### PR DESCRIPTION
#68940 introduced a regression that broke style for wrapped `code` blocks. Simplifying the style by droping the unecessary gradient + before workaround fixes the issue.
