### PR TITLE
refactor(forms): Allow lazy loading of signal forms when using `provi…

### DIFF
--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -17,6 +17,7 @@ ng_project(
         "//:node_modules/rxjs",
         "//packages/common",
         "//packages/core",
+        "//packages/forms/signals:config",
     ],
 )
 

--- a/packages/forms/signals/BUILD.bazel
+++ b/packages/forms/signals/BUILD.bazel
@@ -3,14 +3,29 @@ load("//tools:defaults.bzl", "generate_api_docs", "ng_project")
 package(default_visibility = ["//visibility:public"])
 
 ng_project(
+    name = "config",
+    srcs = [
+        "src/config/api.ts",
+        "src/config/di.ts",
+    ],
+    deps = [
+        "//packages/core",
+    ],
+)
+
+ng_project(
     name = "signals",
     srcs = glob(
         [
             "*.ts",
             "src/**/*.ts",
         ],
+        exclude = [
+            "src/config/**/*.ts",
+        ],
     ),
     deps = [
+        ":config",
         "//packages/common/http",
         "//packages/core",
         "//packages/forms",

--- a/packages/forms/signals/compat/BUILD.bazel
+++ b/packages/forms/signals/compat/BUILD.bazel
@@ -16,6 +16,7 @@ ng_project(
         "//packages/core/rxjs-interop",
         "//packages/forms",
         "//packages/forms/signals",
+        "//packages/forms/signals:config",
     ],
 )
 

--- a/packages/forms/signals/compat/src/api/di.ts
+++ b/packages/forms/signals/compat/src/api/di.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type {SignalFormsConfig} from '../../../src/api/di';
+import type {SignalFormsConfig} from '../../../src/config/api';
 
 /**
  * A value that can be used for `SignalFormsConfig.classes` to automatically add

--- a/packages/forms/signals/public_api.ts
+++ b/packages/forms/signals/public_api.ts
@@ -12,7 +12,7 @@
  * Entry point for all public APIs of this package.
  */
 export * from './src/api/control';
-export * from './src/api/di';
+export * from './src/config/api';
 export * from './src/api/rules';
 export * from './src/api/rules/debounce';
 export * from './src/api/rules/metadata';

--- a/packages/forms/signals/src/config/api.ts
+++ b/packages/forms/signals/src/config/api.ts
@@ -8,7 +8,7 @@
 
 import {type Provider} from '@angular/core';
 import type {FormFieldBinding} from '../api/types';
-import {SIGNAL_FORMS_CONFIG} from '../field/di';
+import {SIGNAL_FORMS_CONFIG} from './di';
 
 /**
  * Configuration options for signal forms.

--- a/packages/forms/signals/src/config/di.ts
+++ b/packages/forms/signals/src/config/di.ts
@@ -7,7 +7,7 @@
  */
 
 import {InjectionToken} from '@angular/core';
-import type {SignalFormsConfig} from '../api/di';
+import type {SignalFormsConfig} from './api';
 
 /** Injection token for the signal forms configuration. */
 export const SIGNAL_FORMS_CONFIG = new InjectionToken<SignalFormsConfig>(

--- a/packages/forms/signals/src/directive/form_field.ts
+++ b/packages/forms/signals/src/directive/form_field.ts
@@ -36,7 +36,7 @@ import {type ValidationError} from '../api/rules';
 import type {Field, FieldState} from '../api/types';
 import {InteropNgControl} from '../controls/interop_ng_control';
 import {RuntimeErrorCode} from '../errors';
-import {SIGNAL_FORMS_CONFIG} from '../field/di';
+import {SIGNAL_FORMS_CONFIG} from '../config/di';
 import type {FieldNode} from '../field/node';
 import type {FormUiControl} from '../api/control';
 import {shallowArrayEquals} from '../util/array';


### PR DESCRIPTION
…deSignalFormsConfig`

`provideSignalFormsConfig` is moved into its own chunk to prevent its usage from pulling the whole signal form code base.

fixes #67909
