### PR TITLE
fix(docs-infra): avoid copy button overlap in code blocks

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -242,11 +242,14 @@ $code-font-size: 0.875rem;
     border-radius: 0.25rem;
     cursor: pointer;
     z-index: var(--z-index-icon);
+    opacity: 0;
+    pointer-events: none;
     background-color: var(--octonary-contrast);
     border: 1px solid var(--senary-contrast);
     transition:
       background-color 0.3s ease,
-      border-color 0.3s ease;
+      border-color 0.3s ease,
+      opacity 0.3s ease;
 
     .docs-icon {
       transition: opacity 0.3s ease-out;
@@ -270,6 +273,9 @@ $code-font-size: 0.875rem;
     }
 
     &.docs-copy-source-code-button-success {
+      opacity: 1;
+      pointer-events: auto;
+
       .docs-copy {
         opacity: 0;
       }
@@ -284,6 +290,32 @@ $code-font-size: 0.875rem;
           fill: var(--primary-contrast);
         }
       }
+    }
+  }
+
+  .docs-code:hover,
+  .docs-code:focus-within,
+  .docs-example-viewer-code-wrapper:hover,
+  .docs-example-viewer-code-wrapper:focus-within {
+    > button[docs-copy-source-code] {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  button[docs-copy-source-code]:focus-visible,
+  button[docs-copy-source-code].docs-copy-source-code-button-failed {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .docs-code:has(.docs-code-header) {
+    button[docs-copy-source-code] {
+      top: 0.45rem;
+    }
+
+    .docs-code-header {
+      padding-inline-end: 3rem;
     }
   }
 


### PR DESCRIPTION
## Problem
Code-block copy buttons on angular.dev are absolutely positioned over the scrollable code area. On narrow screens or horizontally scrollable examples, the button can cover source text.

## Root cause
For code blocks with headers, the button is still positioned below the header, inside the code body, so horizontal scrolling can move code underneath the fixed button.

## Solution
Move copy buttons for headered code blocks into the header area and reserve inline space in the header so the button does not overlap header text or code content.

Fixes #68534.

## Tests
- `npx --yes prettier@3.8.0 --check adev/shared-docs/styles/docs/_code.scss`
- `npx --yes sass@1.94.2 --no-source-map adev/shared-docs/styles/docs/_code.scss`
- `git diff --check`