### PR TITLE
docs: mention Angular Aria in accessibility guide

### DIFF
--- a/adev/src/content/best-practices/a11y.md
+++ b/adev/src/content/best-practices/a11y.md
@@ -63,6 +63,9 @@ For example:
 
 For full details of these and other tools, see the [Angular CDK accessibility overview](https://material.angular.dev/cdk/a11y/overview).
 
+For custom-styled components that need reusable WAI-ARIA interaction patterns, [Angular Aria](guide/aria/overview) provides headless directives for patterns such as accordion, combobox, listbox, menu, tabs, and toolbar.
+These directives handle keyboard interaction, ARIA attributes, focus management, and screen reader support while letting you provide the HTML structure and styling for your application.
+
 ### Augmenting native elements
 
 Native HTML elements capture several standard interaction patterns that are important to accessibility.


### PR DESCRIPTION
Problem
- The accessibility best practices guide links to CDK a11y utilities but does not mention Angular Aria, leaving readers without a path to the newer headless ARIA interaction patterns.

Root cause
- The guide predates the Angular Aria documentation and was never updated with a cross-reference.

Solution
- Add a short note linking to Angular Aria and summarizing the reusable patterns and accessibility behavior it provides.

Tests run
- npx --yes prettier@3.8.0 --check adev/src/content/best-practices/a11y.md
- git diff --check

Closes #68919