### PR TITLE
refactor(docs-infra): correct misspelled `CodeHighlighter` class name

### DIFF
--- a/adev/src/app/features/home/code-highlighting/code-highlighter.ts
+++ b/adev/src/app/features/home/code-highlighting/code-highlighter.ts
@@ -15,8 +15,8 @@ import {CodeToHastOptions, createHighlighterCoreSync, HighlighterCore} from 'shi
 import {createOnigurumaEngine} from 'shiki/engine/oniguruma';
 
 @Service()
-export class CodeHighligher implements OnDestroy {
-  private cachedHighligher: HighlighterCore | undefined;
+export class CodeHighlighter implements OnDestroy {
+  private cachedHighlighter: HighlighterCore | undefined;
 
   async codeToHtml(code: string, options: CodeToHastOptions): Promise<string> {
     const highlighter = await this.getHighlighter();
@@ -24,19 +24,19 @@ export class CodeHighligher implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.cachedHighligher?.dispose();
+    this.cachedHighlighter?.dispose();
   }
 
   private async getHighlighter() {
-    if (!this.cachedHighligher) {
+    if (!this.cachedHighlighter) {
       const engine = await createOnigurumaEngine(import('shiki/wasm'));
-      this.cachedHighligher = createHighlighterCoreSync({
+      this.cachedHighlighter = createHighlighterCoreSync({
         themes: [githubLight, githubDark],
         langs: [angularTs, angularHtml],
         engine,
       });
     }
 
-    return this.cachedHighligher;
+    return this.cachedHighlighter;
   }
 }

--- a/adev/src/app/features/home/components/code-block/code-block.ts
+++ b/adev/src/app/features/home/components/code-block/code-block.ts
@@ -10,7 +10,7 @@ import {AsyncPipe} from '@angular/common';
 import {Component, computed, inject, input} from '@angular/core';
 import {DomSanitizer} from '@angular/platform-browser';
 import {ThemeManager} from '../../../../core/services/theme-manager.service';
-import {CodeHighligher} from '../../code-highlighting/code-highlighter';
+import {CodeHighlighter} from '../../code-highlighting/code-highlighter';
 
 @Component({
   selector: 'adev-code-block',
@@ -23,7 +23,7 @@ import {CodeHighligher} from '../../code-highlighting/code-highlighter';
   `,
 })
 export class CodeBlock {
-  codeHighlighter = inject(CodeHighligher);
+  codeHighlighter = inject(CodeHighlighter);
   code = input.required<string>();
   language = input<'angular-html' | 'angular-ts'>('angular-ts');
   sanitizer = inject(DomSanitizer);


### PR DESCRIPTION
The class exported from `code-highlighter.ts` was named `CodeHighligher` (missing the second `h`) and its private field was `cachedHighligher`, both disagreeing with the filename which spells "highlighter" correctly. Rename the class to `CodeHighlighter` and the field to `cachedHighlighter`, and update the sole consumer (`CodeBlock`). Pure rename, no behavior change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The shiki-backed code highlighter service in adev is exported as `CodeHighligher` (missing the second `h`) and its cached instance field is `cachedHighligher`. The file itself is named `code-highlighter.ts`, so the class name disagrees with the file it's declared in. The sole consumer (`CodeBlock`) imports the misspelled symbol to match.

## What is the new behavior?

The class is renamed to `CodeHighlighter` and the field to `cachedHighlighter`. The import and `inject()` call in `CodeBlock` are updated to match. Pure rename, no behavior change.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
