### PR TITLE
docs: fix roadmap error link

### DIFF
--- a/adev/src/content/reference/roadmap.md
+++ b/adev/src/content/reference/roadmap.md
@@ -270,7 +270,7 @@ As part of the v11 release, we introduced an opt-in preview of webpack 5 in the 
 <docs-card title="Faster apps by inlining critical styles in Universal apps" link="Completed Q1 2021" href="guide/ssr">
 Loading external stylesheets is a blocking operation, which means that the browser cannot start rendering your app until it loads all the referenced CSS. Having render-blocking resources in the header of a page can significantly impact its load performance, for example, its first contentful paint. To make apps faster, we have been collaborating with the Google Chrome team on inlining critical CSS and loading the rest of the styles asynchronously.
 </docs-card>
-<docs-card title="Improve debugging with better Angular error messages" link="Completed Q1 2021" href="reference/errors">
+<docs-card title="Improve debugging with better Angular error messages" link="Completed Q1 2021" href="errors">
 Error messages often bring limited actionable information to help developers resolve them. We have been working on making error messages more discoverable by adding associated codes, developing guides, and other materials to ensure a smoother debugging experience.
 </docs-card>
 <docs-card title="Improved developer onboarding with refreshed introductory documentation" link="Completed Q1 2021" href="tutorials">


### PR DESCRIPTION
## Problem
The roadmap card for “Improve debugging with better Angular error messages” links to `reference/errors`, which does not resolve on angular.dev.

## Root cause
The errors reference content lives under `reference/errors/overview`, but the public route is `errors`.

## Solution
Update the roadmap card to link to `errors`.

## Tests
- `git diff --check -- adev/src/content/reference/roadmap.md`
- `rg -n "path: 'errors'" adev/src/app/routing/navigation-entries/index.ts`
- `rg -n "contentPath: 'reference/errors/overview'" adev/src/app/routing/navigation-entries/index.ts`
- `rg -n 'href="errors"' adev/src/content/reference/roadmap.md`

Closes #69010
