### PR TITLE
fix(common): tolerate invalid percent-encoding in HttpUrlEncodingCodec

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -62,7 +62,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The decoded key name.
    */
   decodeKey(key: string): string {
-    return decodeURIComponent(key);
+    return tryDecodeURIComponent(key);
   }
 
   /**
@@ -71,7 +71,19 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The decoded value.
    */
   decodeValue(value: string) {
+    return tryDecodeURIComponent(value);
+  }
+}
+
+// A bare `%` (or any other malformed percent-escape) is a legal character in a
+// query string but makes `decodeURIComponent` throw a `URIError`. Since the
+// raw string can come straight from `window.location.search`, fall back to the
+// undecoded value instead of letting the error escape `HttpParams`.
+function tryDecodeURIComponent(value: string): string {
+  try {
     return decodeURIComponent(value);
+  } catch {
+    return value;
   }
 }
 

--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵRuntimeError as RuntimeError} from '@angular/core';
+import {
+  ɵRuntimeError as RuntimeError,
+  ɵdecodeURIComponentSafe as decodeURIComponentSafe,
+} from '@angular/core';
 
 import {RuntimeErrorCode} from './errors';
 
@@ -62,7 +65,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The decoded key name.
    */
   decodeKey(key: string): string {
-    return tryDecodeURIComponent(key);
+    return decodeURIComponentSafe(key);
   }
 
   /**
@@ -71,19 +74,7 @@ export class HttpUrlEncodingCodec implements HttpParameterCodec {
    * @returns The decoded value.
    */
   decodeValue(value: string) {
-    return tryDecodeURIComponent(value);
-  }
-}
-
-// A bare `%` (or any other malformed percent-escape) is a legal character in a
-// query string but makes `decodeURIComponent` throw a `URIError`. Since the
-// raw string can come straight from `window.location.search`, fall back to the
-// undecoded value instead of letting the error escape `HttpParams`.
-function tryDecodeURIComponent(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
+    return decodeURIComponentSafe(value);
   }
 }
 

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -33,6 +33,23 @@ describe('HttpUrlEncodedParams', () => {
       expect(body.getAll('c')).toEqual(['d']);
       expect(body.getAll('?e')).toEqual(['f']);
     });
+
+    it('should keep malformed percent-encoding in values undecoded', () => {
+      const body = new HttpParams({fromString: 'a=100%done&b=ok'});
+      expect(body.getAll('a')).toEqual(['100%done']);
+      expect(body.getAll('b')).toEqual(['ok']);
+    });
+
+    it('should keep malformed percent-encoding in keys undecoded', () => {
+      const body = new HttpParams({fromString: 'a%=b'});
+      expect(body.getAll('a%')).toEqual(['b']);
+    });
+
+    it('should still decode valid percent-encoding', () => {
+      const body = new HttpParams({fromString: 'a=1%202&b%5Bx%5D=c'});
+      expect(body.getAll('a')).toEqual(['1 2']);
+      expect(body.getAll('b[x]')).toEqual(['c']);
+    });
   });
 
   describe('lazy mutation', () => {

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -21,6 +21,7 @@ export {
   type NavigationUpdateCurrentEntryOptions as ɵNavigationUpdateCurrentEntryOptions,
 } from '../primitives/dom-navigation';
 export {maybeUnwrapDefaultExport as ɵmaybeUnwrapDefaultExport} from './util/default_export';
+export {decodeURIComponentSafe as ɵdecodeURIComponentSafe} from './util/decode_uri';
 
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {ANIMATIONS_DISABLED as ɵANIMATIONS_DISABLED} from './animation/interfaces';

--- a/packages/core/src/util/decode_uri.ts
+++ b/packages/core/src/util/decode_uri.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Decodes a URI component, falling back to the raw value if it cannot be decoded.
+ *
+ * A bare `%` or any other malformed percent-escape is a legal character in a
+ * URL but makes `decodeURIComponent` throw a `URIError`. Callers that decode
+ * attacker-influenced strings (e.g. `window.location`) can use this to fall
+ * back to the raw value instead of letting the error escape.
+ *
+ * @param value potential URI component to decode.
+ * @returns the decoded URI if it can be decoded, otherwise the original value.
+ */
+export function decodeURIComponentSafe(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    // Ignore any invalid uri component.
+    return value;
+  }
+}


### PR DESCRIPTION
Noticed `HttpUrlEncodingCodec.decodeKey`/`decodeValue` call `decodeURIComponent` directly, and `HttpParams` feeds them straight from its `fromString` option (the class docs suggest passing `window.location.search`). A stray `%` in the query, e.g. `?a=100%done`, is a valid query character but makes `decodeURIComponent` throw a `URIError` that escapes the `HttpParams` constructor. Decode in a try/catch and fall back to the raw value, leaving valid escapes decoded as before.