### PR TITLE
docs(forms): remove unavailable metadata API from v21 guide

### DIFF
--- a/adev/src/content/guide/forms/signals/field-metadata.md
+++ b/adev/src/content/guide/forms/signals/field-metadata.md
@@ -2,7 +2,7 @@
 
 Field metadata is reactive data you can attach to an individual field. Angular's built-in constraint validators like `required()` and `min()` use this system internally. In other words, every time you call a validator, you're contributing to a metadata key for that particular field.
 
-This guide covers the metadata system in depth: how reducers combine contributions from multiple schema rules, how to write custom reducers, how reading composes with `hasMetadata()`, and how managed metadata ties lifecycle-aware objects to individual fields.
+This guide covers the metadata system in depth: how reducers combine contributions from multiple schema rules, how to write custom reducers, how to read metadata safely, and how managed metadata ties lifecycle-aware objects to individual fields.
 
 ## You have already been using metadata
 
@@ -126,23 +126,19 @@ The logic function receives the field's context, which exposes `value` as a sign
 
 ## Reading metadata from a field
 
-`hasMetadata(key)` returns `true` if any schema rule registered the key on this field. `state.metadata(key)` returns `undefined` when no rule has registered the key, and a signal of the current reduced value otherwise.
-
-```ts
-registrationForm.username().hasMetadata(USERNAME_HELP); // true if any metadata() rule registered this key
-```
+`state.metadata(key)` returns `undefined` when no rule has registered the key, and a signal of the current reduced value otherwise.
 
 The shape of that inner value (whether it can itself be `undefined`, what type it holds) depends on the key's reducer. Reducers are covered in the next section.
 
-When the key may not be registered, gate the read with `hasMetadata()`:
+When the key may not be registered, check the result of `metadata()` before calling the returned signal:
 
 ```angular-html
-@if (registrationForm.username().hasMetadata(USERNAME_HELP)) {
-  <p class="help">{{ registrationForm.username().metadata(USERNAME_HELP)!() }}</p>
+@if (registrationForm.username().metadata(USERNAME_HELP); as usernameHelp) {
+  <p class="help">{{ usernameHelp() }}</p>
 }
 ```
 
-When you know a rule always registers the key (because the schema in the same file does so), you can skip the `hasMetadata()` check and use optional chaining as a compact alternative:
+Optional chaining is a compact alternative when the key may not be registered:
 
 ```ts
 const message = registrationForm.username().metadata(USERNAME_HELP)?.();


### PR DESCRIPTION
## Problem

Fixes #69001.

The v21 Signal Forms metadata guide references `FieldState.hasMetadata()`, but that method is not part of the public v21 `FieldState` type. This makes the v21 guide recommend code that users cannot type-check on the stable v21 packages.

## Root cause

The metadata guide was merged into the v21 docs with examples for an API that is available on the v22 branch, not the v21 public API surface.

## Solution

Update the v21 metadata guide to describe the supported `metadata()` return value instead:

- remove the `hasMetadata()` references from the v21 guide copy
- show guarding the returned metadata signal directly in template control flow
- keep optional chaining as the compact TypeScript pattern

## Tests

- `git diff --check`
- `npm exec --yes prettier@3.8.0 -- --check adev/src/content/guide/forms/signals/field-metadata.md`
- `rg -n "hasMetadata" adev/src/content/guide/forms/signals/field-metadata.md`
- `node -e "const fs=require('fs'); const p='adev/src/content/guide/forms/signals/field-metadata.md'; const s=fs.readFileSync(p,'utf8'); const fence=(s.match(/```/g)||[]).length; if(fence%2) process.exit(3); if(s.includes('hasMetadata')) process.exit(4); console.log('markdown checks passed; fences balanced:', fence);"`
