### PR TITLE
refactor(devtools): use ng-filter in the router tree search

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/BUILD.bazel
@@ -36,9 +36,9 @@ ng_project(
         "//devtools/projects/ng-devtools/src/lib/application-services:frame_manager",
         "//devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row",
         "//devtools/projects/ng-devtools/src/lib/shared/button",
+        "//devtools/projects/ng-devtools/src/lib/shared/filter",
         "//devtools/projects/ng-devtools/src/lib/shared/split",
         "//devtools/projects/ng-devtools/src/lib/shared/tree-visualizer",
-        "//devtools/projects/ng-devtools/src/lib/shared/utils",
         "//devtools/projects/protocol",
     ],
 )

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-fns.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-fns.spec.ts
@@ -8,7 +8,6 @@
 
 import {Route} from '../../../../../protocol';
 import {
-  findNodesByLabel,
   getRouteLabel,
   mapRoute,
   RouterTreeNode,
@@ -96,42 +95,6 @@ describe('router-tree-fns', () => {
           },
         ],
       } as RouterTreeNode);
-    });
-  });
-
-  describe('findNodesByLabel', () => {
-    const home = {
-      label: '/home',
-    };
-    const contacts = {
-      label: '/contacts',
-    };
-    const about = {
-      label: '/about',
-      children: [contacts],
-    };
-    const aboutProduct = {
-      label: '/about-product',
-    };
-    const root = {
-      label: '/',
-      children: [home, about, aboutProduct],
-    } as RouterTreeNode;
-
-    it('should return no results if an empty search string is provided', () => {
-      const result = findNodesByLabel(root, '');
-      expect(result).toEqual(new Set([]));
-    });
-
-    it('should find nodes by label', () => {
-      const result1 = findNodesByLabel(root, 'cont');
-      expect(result1).toEqual(new Set([contacts]));
-
-      const result2 = findNodesByLabel(root, 'about');
-      expect(result2).toEqual(new Set([about, aboutProduct]));
-
-      const result3 = findNodesByLabel(root, 'products');
-      expect(result3).toEqual(new Set([]));
     });
   });
 });

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-fns.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree-fns.ts
@@ -62,26 +62,3 @@ export function transformRoutesIntoVisTree(root: Route, showFullPath: boolean): 
 
   return rootNode!;
 }
-
-export function findNodesByLabel(root: RouterTreeNode, searchString: string): Set<RouterTreeNode> {
-  let matches: Set<RouterTreeNode> = new Set();
-
-  if (!searchString) {
-    return matches;
-  }
-
-  const traverse = (node: RouterTreeNode) => {
-    if (node.label.toLowerCase().includes(searchString)) {
-      matches.add(node);
-    }
-
-    if (node.children) {
-      for (const child of node.children) {
-        traverse(child);
-      }
-    }
-  };
-  traverse(root);
-
-  return matches;
-}

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -1,10 +1,14 @@
 @if (routerDebugApiSupport()) {
   <div class="filter">
-    <input
-      #searchInput
-      (input)="searchRoutes($event.target.value)"
+    <ng-filter
+      #filter
+      (filter)="handleFilter($event)"
+      (nextMatched)="navigateMatchedRoute('next')"
+      (prevMatched)="navigateMatchedRoute('prev')"
+      [matchesCount]="searchMatches().length"
+      [currentMatch]="currentSearchMatchIdx() + 1"
       placeholder="Search routes"
-      class="ng-input filter-input"
+      [debounce]="250"
     />
     <div class="show-full-path">
       <input id="show-full-path" type="checkbox" (change)="togglePathSettings()" />

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.scss
@@ -8,11 +8,13 @@
   .filter {
     border-bottom: 1px solid var(--color-separator);
     display: flex;
+    justify-content: space-between;
     gap: 1.25rem;
     padding: 0.5rem;
 
-    .filter-input {
-      width: 12rem;
+    ng-filter {
+      --ng-filter-width: 8rem;
+      --ng-filter-height: 24px;
     }
 
     .show-full-path {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.ts
@@ -6,17 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {
-  Component,
-  computed,
-  DestroyRef,
-  ElementRef,
-  inject,
-  input,
-  linkedSignal,
-  signal,
-  viewChild,
-} from '@angular/core';
+import {Component, computed, inject, input, linkedSignal, signal, viewChild} from '@angular/core';
 import {TreeVisualizerComponent} from '../../shared/tree-visualizer/tree-visualizer.component';
 import {MatIconModule} from '@angular/material/icon';
 import {MatSnackBar, MatSnackBarModule} from '@angular/material/snack-bar';
@@ -29,15 +19,14 @@ import {
   RouterTreeD3Node,
   transformRoutesIntoVisTree,
   RouterTreeNode,
-  findNodesByLabel,
   RouterTreeVisualizer,
 } from './router-tree-fns';
 import {ButtonComponent} from '../../shared/button/button.component';
 import {SplitComponent} from '../../shared/split/split.component';
 import {SplitAreaDirective} from '../../shared/split/splitArea.directive';
-import {Debouncer} from '../../shared/utils/debouncer';
+import {FilterComponent, FilterFn} from '../../shared/filter/filter.component';
 
-const SEARCH_DEBOUNCE = 250;
+const NODE_SNAP_SCALE = 0.6;
 const RUN_GUARDS_AND_RESOLVERS_OPTIONS: RunGuardsAndResolvers[] = [
   'pathParamsChange',
   'pathParamsOrQueryParamsChange',
@@ -58,10 +47,11 @@ const RUN_GUARDS_AND_RESOLVERS_OPTIONS: RunGuardsAndResolvers[] = [
     MatSnackBarModule,
     RouteDetailsRowComponent,
     ButtonComponent,
+    FilterComponent,
   ],
 })
 export class RouterTreeComponent {
-  private readonly searchInput = viewChild.required<ElementRef>('searchInput');
+  private readonly filter = viewChild.required<FilterComponent>('filter');
   private readonly routerTree = viewChild.required<RouterTreeVisualizer>('routerTree');
 
   private readonly messageBus = inject(MessageBus) as MessageBus<Events>;
@@ -80,6 +70,9 @@ export class RouterTreeComponent {
     ),
   );
 
+  protected readonly currentSearchMatchIdx = signal<number>(-1);
+  protected readonly searchMatches = signal<RouterTreeNode[]>([]);
+
   routes = input.required<Route[]>();
   routerDebugApiSupport = input<boolean>(false);
 
@@ -92,36 +85,13 @@ export class RouterTreeComponent {
     return null;
   });
 
-  private searchMatches: Set<RouterTreeNode> = new Set();
-
-  private readonly searchDebouncer = new Debouncer();
-
-  protected readonly searchRoutes = this.searchDebouncer.debounce((inputValue: string) => {
-    const d3RootNode = this.d3RootNode();
-    if (!d3RootNode) {
-      return;
-    }
-    this.searchMatches = findNodesByLabel(d3RootNode, inputValue.toLowerCase());
-    // Since `searchMatches` is used in the D3 node modifier, reset the root to trigger a re-render.
-    // Consider: Ideally, we could perform the search visual changes via direct DOM manipulations
-    // that won't require re-rendering the whole tree.
-    this.d3RootNode.set({...d3RootNode});
-  }, SEARCH_DEBOUNCE);
-
   protected readonly routerTreeConfig: Partial<TreeVisualizerConfig<RouterTreeNode>> = {
     nodeSeparation: () => 1,
     d3NodeModifier: (n) => this.d3NodeModifier(n),
   };
 
-  constructor() {
-    inject(DestroyRef).onDestroy(() => {
-      this.searchDebouncer.cancel();
-    });
-  }
-
   togglePathSettings(): void {
-    this.searchInput().nativeElement.value = '';
-    this.searchMatches = new Set();
+    this.filter().clearFilter();
     this.showFullPath.update((v) => !v);
   }
 
@@ -181,13 +151,57 @@ export class RouterTreeComponent {
 
   onRouterTreeRender({initial}: {initial: boolean}) {
     if (initial) {
-      this.routerTree().snapToRoot(0.6);
+      this.routerTree().snapToRoot(NODE_SNAP_SCALE);
     }
   }
 
   nodeClick(node: RouterTreeD3Node) {
     this.selectedRoute.set(node);
     this.routerTree().snapToNode(node.data, 0.7);
+  }
+
+  navigateMatchedRoute(dir: 'prev' | 'next') {
+    const dirIdx = dir === 'next' ? 1 : -1;
+    const matches = Array.from(this.searchMatches());
+
+    const newMatchedIdx = (this.currentSearchMatchIdx() + dirIdx + matches.length) % matches.length;
+    const newMatchedNode = matches[newMatchedIdx];
+
+    this.routerTree().snapToNode(newMatchedNode, NODE_SNAP_SCALE);
+    this.routerTree().highlightNode(newMatchedNode);
+    this.currentSearchMatchIdx.set(newMatchedIdx);
+  }
+
+  handleFilter(filterFn: FilterFn): void {
+    this.currentSearchMatchIdx.set(-1);
+    this.searchMatches.set([]);
+    const d3RootNode = this.d3RootNode();
+
+    if (!d3RootNode) {
+      return;
+    }
+    const matches: RouterTreeNode[] = [];
+    const traverse = (node: RouterTreeNode) => {
+      if (filterFn(node.label.toLowerCase()).length) {
+        matches.push(node);
+      }
+
+      if (node.children) {
+        for (const child of node.children) {
+          traverse(child);
+        }
+      }
+    };
+    traverse(d3RootNode);
+
+    this.searchMatches.update((curr) => curr.concat(matches));
+
+    // Select the first match, if there are any.
+    if (this.searchMatches().length) {
+      this.navigateMatchedRoute('next');
+    } else {
+      this.routerTree().highlightNode(null);
+    }
   }
 
   private d3NodeModifier(d3Node: SvgD3Node<RouterTreeNode>) {
@@ -208,12 +222,6 @@ export class RouterTreeComponent {
 
       if (node.data.isActive) {
         nodeClasses.push('node-element');
-      }
-
-      if (this.searchMatches.has(node.data)) {
-        nodeClasses.push('node-search');
-      } else if (this.searchMatches.size) {
-        nodeClasses.push('node-faded');
       }
 
       return nodeClasses.join(' ');

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/graph-renderer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/graph-renderer.ts
@@ -11,6 +11,7 @@ export abstract class GraphRenderer<T, U> {
   abstract getInternalNodeById(id: string): U | null;
   abstract snapToNode(node: T): void;
   abstract snapToRoot(): void;
+  abstract highlightNode(node: T | null): void;
   abstract zoomScale(scale: number): void;
   abstract root: U | null;
 

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.scss
@@ -68,6 +68,12 @@
         border-width: 2px;
         font-weight: 300;
 
+        &.node-highlighted {
+          outline: 4px solid var(--blue-03);
+        }
+
+        /* Instance-specific styles below. */
+
         &.node-environment {
           border: 1px solid var(--red-05);
           background: var(--red-06);
@@ -113,15 +119,7 @@
           }
         }
 
-        &.node-search {
-          outline: 4px solid
-            color-mix(in srgb, var(--quaternary-contrast) 80%, var(--full-contrast) 20%);
-        }
-
-        &.node-faded {
-          opacity: 0.3;
-        }
-
+        /* TODO(hawkgs): Rename to something more context-specific. */
         &.highlighted,
         &.highlighted:hover {
           background: var(--blue-02);
@@ -129,6 +127,7 @@
           color: white;
         }
 
+        /* TODO(hawkgs): Rename to something more context-specific. */
         &.selected,
         &.selected:hover {
           color: var(--blue-02);

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.component.ts
@@ -102,6 +102,10 @@ export class TreeVisualizerComponent<T extends TreeNode = TreeNode> {
     this.visualizer()?.snapToNode(node, scale);
   }
 
+  highlightNode(node: T | null) {
+    this.visualizer()?.highlightNode(node);
+  }
+
   getNodeById(id: string) {
     return this.visualizer()?.getInternalNodeById(id);
   }

--- a/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/tree-visualizer/tree-visualizer.ts
@@ -64,6 +64,7 @@ function wrapEvent<E, V>(fn: (e: E, node: V) => void): (e: E, node: V) => void {
 export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer<T, TreeD3Node<T>> {
   private zoomController: d3.ZoomBehavior<HTMLElement, unknown> | null = null;
   private snappedNode: {node: TreeD3Node<T>; scale: number} | null = null;
+  private highlightedNode: T | null = null;
   private snappedNodeListenersDisposeFn?: () => void;
   private readonly config: TreeVisualizerConfig<T>;
   private readonly defaultConfig: TreeVisualizerConfig<T> = {
@@ -115,6 +116,14 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
     if (d3Node) {
       this.snapToD3Node(d3Node, scale);
     }
+  }
+
+  /** Adds an outline to the provided node. Using `null`, clear the highlighted node. */
+  override highlightNode(node: T | null) {
+    this.highlightedNode = node;
+    d3.select(this.containerElement)
+      .selectAll<HTMLElement, TreeD3Node<T>>('.node-wrapper .node')
+      .classed('node-highlighted', (n) => (node ? n.data === node : false));
   }
 
   override getInternalNodeById(id: string): TreeD3Node<T> | null {
@@ -301,6 +310,7 @@ export class TreeVisualizer<T extends TreeNode = TreeNode> extends GraphRenderer
       .attr('y', -halfLabelHeight)
       .append('xhtml:div')
       .attr('class', 'node')
+      .classed('highlighted', (n) => n.data === this.highlightedNode)
       .style('position', 'relative')
       .text((node: TreeD3Node<T>) => {
         const label = node.data.label;


### PR DESCRIPTION
Use the reusable `ng-filter` for the router tree search.