### PR TITLE
fix(router): tolerate malformed percent-encoding in UrlParser

### DIFF
--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -550,7 +550,13 @@ export function encodeUriSegment(s: string): string {
 }
 
 export function decode(s: string): string {
-  return decodeURIComponent(s);
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    // A malformed percent-escape (e.g. a stray `%`) is a legal URL character but makes
+    // decodeURIComponent throw. Fall back to the raw value so a crafted URL cannot break parsing.
+    return s;
+  }
 }
 
 // Query keys/values should have the "+" replaced first, as "+" in a query string is " ".
@@ -640,7 +646,7 @@ class UrlParser {
   }
 
   parseFragment(): string | null {
-    return this.consumeOptional('#') ? decodeURIComponent(this.remaining) : null;
+    return this.consumeOptional('#') ? decode(this.remaining) : null;
   }
 
   private parseChildren(depth = 0): {[outlet: string]: UrlSegmentGroup} {

--- a/packages/router/test/url_tree.spec.ts
+++ b/packages/router/test/url_tree.spec.ts
@@ -39,6 +39,20 @@ describe('UrlTree', () => {
       expect(tree.queryParams).toEqual({'first': 'http://foo/bar?baz=true', 'second': '123'});
     });
 
+    it('should keep malformed percent-encoding as-is instead of throwing', () => {
+      const tree = serializer.parse('/100%done?a=50%off#frag%');
+      expect(tree.root.children['primary'].segments[0].path).toEqual('100%done');
+      expect(tree.queryParams).toEqual({'a': '50%off'});
+      expect(tree.fragment).toEqual('frag%');
+    });
+
+    it('should still decode valid percent-encoding', () => {
+      const tree = serializer.parse('/a%20b?k=a%20b#a%20b');
+      expect(tree.root.children['primary'].segments[0].path).toEqual('a b');
+      expect(tree.queryParams).toEqual({'k': 'a b'});
+      expect(tree.fragment).toEqual('a b');
+    });
+
     it('create, serialize, parse, serialize results in same serialized tree with outlet and no primary children', () => {
       const router = TestBed.inject(Router);
       const th = router.createUrlTree(['/', {outlets: {a: ['a'], b: [{outlets: {a: ['b1']}}]}}]);


### PR DESCRIPTION
The default `UrlSerializer` parses URLs straight from the address bar, so a crafted link decides the input. `UrlParser.decode` and `parseFragment` call `decodeURIComponent` unconditionally, but a stray percent like `/100%done`, `?a=50%off` or `#frag%` is a legal URL character that makes it throw a `URIError`, escaping `parse` and breaking navigation.

Decode inside try/catch and fall back to the raw value, matching the behaviour already used for cookie and HttpParams decoding. Valid escapes still decode.