### PR TITLE
fix(service-worker): prevent LruList corruption when URL matches Object.prototype key

### DIFF
--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -73,16 +73,29 @@ interface LruState {
  * Manages an instance of `LruState` and moves URLs to the head of the
  * chain when requested.
  */
-class LruList {
+export class LruList {
   state: LruState;
   constructor(state?: LruState) {
     if (state === undefined) {
       state = {
         head: null,
         tail: null,
-        map: {},
+        map: Object.create(null) as LruState['map'],
         count: 0,
       };
+    } else {
+      // Re-create the map with a null prototype so that keys that are also
+      // property names on Object.prototype (e.g. "__proto__", "constructor")
+      // are treated as plain string keys rather than triggering inherited
+      // accessors. Object.getOwnPropertyDescriptor is used to read the stored
+      // value for "__proto__" because bracket-notation access for that key
+      // invokes the inherited getter and returns the object's prototype chain
+      // instead of the cached LruNode.
+      const safeMap: LruState['map'] = Object.create(null);
+      for (const key of Object.getOwnPropertyNames(state.map)) {
+        safeMap[key] = Object.getOwnPropertyDescriptor(state.map, key)!.value as LruNode;
+      }
+      state = {...state, map: safeMap};
     }
     this.state = state;
   }
@@ -123,7 +136,7 @@ class LruList {
         // This is the only node. Reset the cache to be empty.
         this.state.head = null;
         this.state.tail = null;
-        this.state.map = {};
+        this.state.map = Object.create(null) as LruState['map'];
         this.state.count = 0;
         return true;
       }

--- a/packages/service-worker/worker/test/lru_spec.ts
+++ b/packages/service-worker/worker/test/lru_spec.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {LruList} from '../src/data';
+
+/**
+ * These tests cover prototype-key safety in LruList. The root cause is that
+ * state.map is a plain `{}`, so `map['__proto__']` returns `Object.prototype`
+ * (truthy, not undefined) and `map['constructor']` returns `Object`. The LruList
+ * logic reads map[url] !== undefined to decide whether a node already exists;
+ * when the key is inherited from Object.prototype that check produces false
+ * positives, causing TypeError on the subsequent remove() path.
+ *
+ * Fix: use Object.create(null) for every map allocation so no inherited keys exist.
+ */
+describe('LruList - prototype-safe key handling', () => {
+  // -------------------------------------------------------------------------
+  // Failing tests: reproduce each corruption mode
+  // -------------------------------------------------------------------------
+
+  it('accessed(__proto__) on a fresh LruList should not throw', () => {
+    // map['__proto__'] on a plain {} returns Object.prototype (truthy, not
+    // undefined), so the code enters the remove() path with Object.prototype
+    // as the node. node.previous is undefined, map[undefined] is undefined,
+    // and previous.next = … throws TypeError.
+    const lru = new LruList();
+    expect(() => lru.accessed('__proto__')).not.toThrow();
+    expect(lru.size).toBe(1);
+  });
+
+  it('accessed(__proto__) should store __proto__ as a real entry', () => {
+    const lru = new LruList();
+    lru.accessed('__proto__');
+    // Without the fix, accessed() throws before reaching this line.
+    expect(lru.size).toBe(1);
+    expect(lru.remove('__proto__')).toBeTrue();
+    expect(lru.size).toBe(0);
+  });
+
+  it('accessed(constructor) on a fresh LruList should not throw', () => {
+    // map['constructor'] on a plain {} returns the Object constructor
+    // (truthy, not undefined), triggering the same false-positive remove() path.
+    const lru = new LruList();
+    expect(() => lru.accessed('constructor')).not.toThrow();
+    expect(lru.size).toBe(1);
+  });
+
+  it('re-adding __proto__ after it was the sole entry and was removed should not throw', () => {
+    // When the last node is removed, remove() resets: this.state.map = {}
+    // The fresh {} has the same __proto__ accessor issue, so a second
+    // accessed('__proto__') call throws even though the first worked.
+    const lru = new LruList();
+    lru.accessed('/safe');
+    lru.accessed('__proto__');
+    lru.remove('__proto__'); // removes __proto__; when it is the only node,
+    lru.remove('/safe'); // this triggers map = {} reset inside remove()
+    expect(lru.size).toBe(0);
+
+    // Re-add after the map was reset
+    expect(() => lru.accessed('__proto__')).not.toThrow();
+    expect(lru.size).toBe(1);
+  });
+
+  it('loading a deserialized LruState where map has __proto__ key should not throw', () => {
+    // Simulates the service worker loading LruState from Cache Storage
+    // via JSON.parse. JSON.parse stores "__proto__" as an own data property
+    // (bypassing the setter), so the first remove() works in modern V8.
+    // The corruption appears on the next write cycle after remove() resets
+    // this.state.map back to a plain {}.
+    const rawJson =
+      '{"head":"__proto__","tail":"__proto__",' +
+      '"map":{"__proto__":{"url":"__proto__","next":null,"previous":null}},' +
+      '"count":1}';
+    const state = JSON.parse(rawJson) as Parameters<
+      typeof LruList.prototype.accessed
+    >[0] extends string
+      ? never
+      : any;
+
+    const lru = new LruList(state);
+    expect(lru.size).toBe(1);
+
+    // Remove the single entry – triggers the map = {} reset path
+    expect(() => lru.remove('__proto__')).not.toThrow();
+    expect(lru.size).toBe(0);
+
+    // After the reset, adding __proto__ back must not throw
+    expect(() => lru.accessed('__proto__')).not.toThrow();
+    expect(lru.size).toBe(1);
+  });
+});


### PR DESCRIPTION
`LruList.state.map` was previously implemented as a plain object (`{}`). As a result, lookups using keys inherited from `Object.prototype`—most notably `__proto__` and `constructor`—did not return `undefined` as expected.

The `accessed()` method determines whether an entry already exists using `map[url] !== undefined`. For inherited property names, this check produced a false positive, causing `remove()` to be called with `Object.prototype` instead of an actual `LruNode`, ultimately resulting in:

```text id="4ndq9m"
TypeError: Cannot set properties of undefined (setting 'next')
```

This could occur in two situations:

1. When `accessed()` is called with a URL matching an inherited `Object.prototype` property such as `__proto__` or `constructor`.

2. When restoring an `LruState` from Cache Storage containing a `__proto__` entry. The single-entry removal path resets `this.state.map` back to `{}`, allowing the same issue to reoccur on a subsequent lookup.

This change replaces all map allocations with `Object.create(null)`, including both newly created state and maps recreated after removal. For deserialized state, the map is rebuilt using `Object.getOwnPropertyNames()` and `Object.getOwnPropertyDescriptor()` rather than bracket notation, since accessing `__proto__` via property lookup invokes the inherited accessor and returns the prototype chain instead of the stored `LruNode`.

Before:

```ts id="1d6p4v"
const lru = new LruList();

lru.accessed('__proto__');
// TypeError: Cannot set properties of undefined (setting 'next')

lru.accessed('constructor');
// TypeError: Cannot set properties of undefined (setting 'next')
```

After:

```ts id="6m2wqj"
const lru = new LruList();

lru.accessed('__proto__');   // size === 1
lru.remove('__proto__');     // size === 0, returns true

lru.accessed('constructor'); // size === 1
```

Using a null-prototype map ensures these keys behave like ordinary entries rather than interacting with JavaScript's object prototype machinery.