### PR TITLE
fix(docs-infra): secure update-assets script against RCE and SSRF

### DIFF
--- a/adev/scripts/update-cross-repo-docs/github-client.mjs
+++ b/adev/scripts/update-cross-repo-docs/github-client.mjs
@@ -10,6 +10,8 @@ import {get} from 'node:https';
 import {posix} from 'node:path';
 
 const GITHUB_API = 'https://api.github.com/repos/';
+const SHA_REGEX = /^[0-9a-f]{40}$/i;
+const BRANCH_REGEX = /^(?!.*\.\.)[a-zA-Z0-9/_.-]+$/;
 
 export class GithubClient {
   #token;
@@ -30,6 +32,12 @@ export class GithubClient {
    * @returns Promise<string[]>
    */
   async getAffectedFiles(baseSha, headSha) {
+    if (!SHA_REGEX.test(baseSha)) {
+      throw new Error(`Invalid base SHA: ${baseSha}`);
+    }
+    if (!SHA_REGEX.test(headSha)) {
+      throw new Error(`Invalid head SHA: ${headSha}`);
+    }
     const {files} = JSON.parse(await this.#httpGet(`${this.#api}/compare/${baseSha}...${headSha}`));
     return files.map((f) => f.filename);
   }
@@ -41,6 +49,9 @@ export class GithubClient {
    * @returns Promise<string>
    */
   async getShaForBranch(branch) {
+    if (!BRANCH_REGEX.test(branch)) {
+      throw new Error(`Invalid branch name: ${branch}`);
+    }
     const sha = await this.#httpGet(`${this.#api}/commits/${branch}`, {
       headers: {Accept: 'application/vnd.github.VERSION.sha'},
     });
@@ -49,7 +60,7 @@ export class GithubClient {
       throw new Error(`Unable to extract the SHA for '${branch}'.`);
     }
 
-    return sha;
+    return sha.trim();
   }
 
   #httpGet(url, options = {}) {

--- a/adev/scripts/update-cross-repo-docs/update-assets.mjs
+++ b/adev/scripts/update-cross-repo-docs/update-assets.mjs
@@ -8,7 +8,7 @@
 
 //tslint:disable:no-console
 import assert from 'node:assert';
-import {execSync} from 'node:child_process';
+import {execFileSync} from 'node:child_process';
 import {existsSync, constants as fsConstants} from 'node:fs';
 import {
   copyFile,
@@ -41,6 +41,16 @@ export async function updateAssets({repo, assetsPath, destPath}) {
     await readFile(buildInfoPath, 'utf-8'),
   );
 
+  const shaRegex = /^[0-9a-f]{40}$/i;
+  const branchRegex = /^(?!.*\.\.)[a-zA-Z0-9/_.-]+$/;
+
+  if (!shaRegex.test(storedSha)) {
+    throw new Error(`Invalid SHA in build info: ${storedSha}`);
+  }
+  if (!branchRegex.test(storedBranch)) {
+    throw new Error(`Invalid branch name in build info: ${storedBranch}`);
+  }
+
   assert(process.env.ANGULAR_READONLY_GITHUB_TOKEN);
   const githubApi = new GithubClient(
     repo,
@@ -63,6 +73,10 @@ export async function updateAssets({repo, assetsPath, destPath}) {
     downstreamBranch = storedBranch;
   }
 
+  if (!shaRegex.test(latestSha)) {
+    throw new Error(`Invalid SHA resolved: ${latestSha}`);
+  }
+
   console.log(`Comparing ${storedSha}...${latestSha}.`);
   const affectedFiles = await githubApi.getAffectedFiles(storedSha, latestSha);
   const changedFiles = affectedFiles.filter((file) => file.startsWith(`${assetsPath}/`));
@@ -78,14 +92,18 @@ export async function updateAssets({repo, assetsPath, destPath}) {
 
     try {
       const execOptions = {cwd: temporaryDir, stdio: 'inherit'};
-      execSync('git init', execOptions);
-      execSync(`git remote add origin https://github.com/${repo}.git`, execOptions);
+      execFileSync('git', ['init'], execOptions);
+      execFileSync(
+        'git',
+        ['remote', 'add', 'origin', `https://github.com/${repo}.git`],
+        execOptions,
+      );
       // fetch a commit
-      execSync(`git fetch origin ${latestSha}`, execOptions);
+      execFileSync('git', ['fetch', 'origin', latestSha], execOptions);
       // reset this repository's main branch to the commit of interest
-      execSync('git reset --hard FETCH_HEAD', execOptions);
+      execFileSync('git', ['reset', '--hard', 'FETCH_HEAD'], execOptions);
       // get sha when files where changed
-      shaWhenFilesChanged = execSync(`git rev-list -1 ${latestSha} "${assetsPath}/"`, {
+      shaWhenFilesChanged = execFileSync('git', ['rev-list', '-1', latestSha, `${assetsPath}/`], {
         encoding: 'utf8',
         cwd: temporaryDir,
         stdio: ['ignore', 'pipe', 'ignore'],


### PR DESCRIPTION
This PR fixes a critical Remote Code Execution (RCE) vulnerability in the `update-assets.mjs` script.

### Changes
- Added validation for SHA and branch names in `GithubClient` (`github-client.mjs`) and `updateAssets` (`update-assets.mjs`).
- Replaced `execSync` with `execFileSync` in `update-assets.mjs` to avoid shell command interpolation of untrusted input.