### PR TITLE
fix(docs-infra): avoid code copy button overlap

### DIFF
--- a/adev/shared-docs/styles/docs/_code.scss
+++ b/adev/shared-docs/styles/docs/_code.scss
@@ -340,6 +340,17 @@ $code-font-size: 0.875rem;
     }
   }
 
+  .docs-code:has(.docs-code-header) {
+    .docs-code-header {
+      padding-inline-end: 3.5rem;
+    }
+
+    > button[docs-copy-source-code] {
+      top: 0.45rem;
+      right: 0.65rem;
+    }
+  }
+
   // Single line docs-code elements, without headers, shell code
   .docs-code:not(:has(.docs-code-header)) {
     button[docs-copy-source-code] {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Headered docs code blocks position the copy-source button over the scrollable code area. On narrow viewports or horizontally scrollable snippets, code can slide underneath the button and become obscured.

Issue Number: Fixes #68534

## What is the new behavior?

For code blocks with a header, the copy button is positioned in the header band instead of over the code content. The header also reserves inline space for the button so long filenames do not run underneath it. Headerless snippets keep their existing button placement.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Tests run:

- `npx --yes prettier@3.8.3 --check adev/shared-docs/styles/docs/_code.scss`
- `npx --yes sass@1.93.3 --no-source-map --style=expanded adev/shared-docs/styles/docs/_code.scss`
- `git diff --check HEAD~1..HEAD`

Local note: the repository `pnpm` wrapper failed before running formatter commands on this Windows checkout because the `pnpm` executable was not available on PATH, so the same Prettier version was run directly with `npx`.