### PR TITLE
fix(core): harden inherit definition feature against polluted prototypes

### DIFF
--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -10,6 +10,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Type, Writable} from '../../interface/type';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../../util/empty';
 import {fillProperties} from '../../util/property';
+import {NG_COMP_DEF, NG_DIR_DEF} from '../fields';
 import {
   ComponentDef,
   ContentQueriesFunction,
@@ -45,13 +46,20 @@ export function ɵɵInheritDefinitionFeature(
   let shouldInheritFields = true;
   const inheritanceChain: WritableDef[] = [definition];
 
-  while (superType) {
+  // Only accept defs declared on the current type to avoid polluted prototype members.
+  // Don't use getComponentDef/getDirectiveDef. This logic relies on inheritance.
+  while (superType && superType !== Function.prototype && superType !== Object.prototype) {
     let superDef: DirectiveDef<any> | ComponentDef<any> | undefined = undefined;
+    const cmpDef = Object.hasOwn(superType, NG_COMP_DEF)
+      ? ((superType as any)[NG_COMP_DEF] as ComponentDef<any>)
+      : undefined;
+    const dirDef = Object.hasOwn(superType, NG_DIR_DEF)
+      ? ((superType as any)[NG_DIR_DEF] as DirectiveDef<any>)
+      : undefined;
     if (isComponentDef(definition)) {
-      // Don't use getComponentDef/getDirectiveDef. This logic relies on inheritance.
-      superDef = superType.ɵcmp || superType.ɵdir;
+      superDef = cmpDef ?? dirDef;
     } else {
-      if (superType.ɵcmp) {
+      if (cmpDef) {
         throw new RuntimeError(
           RuntimeErrorCode.INVALID_INHERITANCE,
           ngDevMode &&
@@ -60,8 +68,7 @@ export function ɵɵInheritDefinitionFeature(
             )} is attempting to extend component ${stringifyForError(superType)}`,
         );
       }
-      // Don't use getComponentDef/getDirectiveDef. This logic relies on inheritance.
-      superDef = superType.ɵdir;
+      superDef = dirDef;
     }
 
     if (superDef) {

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -24,7 +24,7 @@ import {
   QueryList,
   ViewChildren,
 } from '../../src/core';
-import {getDirectiveDef} from '../../src/render3/def_getters';
+import {getComponentDef, getDirectiveDef} from '../../src/render3/def_getters';
 import {TestBed} from '../../testing';
 
 describe('inheritance', () => {
@@ -66,6 +66,67 @@ describe('inheritance', () => {
     }).toThrowError(
       'NG0903: Directives cannot inherit Components. Directive MyDirective is attempting to extend component MyComponent',
     );
+  });
+
+  it('should ignore inherited ɵdir from polluted Object.prototype', () => {
+    const originalDir = (Object.prototype as any).ɵdir;
+    let hadOwnDir = false;
+
+    try {
+      hadOwnDir = Object.hasOwn(Object.prototype, 'ɵdir');
+      (Object.prototype as any).ɵdir = {
+        hostAttrs: ['data-pwned', 'yes'],
+      };
+
+      class BareBase {}
+
+      @Directive({
+        selector: '[childDir]',
+        standalone: false,
+      })
+      class ChildDirective extends BareBase {}
+
+      const dirDef = getDirectiveDef(ChildDirective)!;
+      expect(dirDef.hostAttrs).toBe(null);
+    } finally {
+      if (hadOwnDir) {
+        (Object.prototype as any).ɵdir = originalDir;
+      } else {
+        delete (Object.prototype as any).ɵdir;
+      }
+    }
+  });
+
+  it('should ignore inherited ɵcmp from polluted Object.prototype', () => {
+    const originalCmp = (Object.prototype as any).ɵcmp;
+    let hadOwnCmp = false;
+
+    try {
+      hadOwnCmp = Object.hasOwn(Object.prototype, 'ɵcmp');
+      (Object.prototype as any).ɵcmp = {
+        hostAttrs: ['data-pwned', 'yes'],
+      };
+
+      class BareBase {}
+
+      @Component({
+        selector: 'child-cmp',
+        template: `child`,
+        standalone: false,
+
+        changeDetection: ChangeDetectionStrategy.Eager,
+      })
+      class ChildComponent extends BareBase {}
+
+      const cmpDef = getComponentDef(ChildComponent)!;
+      expect(cmpDef.hostAttrs).toBe(null);
+    } finally {
+      if (hadOwnCmp) {
+        (Object.prototype as any).ɵcmp = originalCmp;
+      } else {
+        delete (Object.prototype as any).ɵcmp;
+      }
+    }
   });
 
   describe('multiple children', () => {


### PR DESCRIPTION
Stop inheritance traversal before built-in prototype objects and only read `ɵcmp`/`ɵdir` when they are own properties of a super type. This prevents polluted inherited properties from being treated as Angular defs during inheritance merging.

Also adds regression tests covering polluted `Object.prototype.ɵdir` and `Object.prototype.ɵcmp` to ensure polluted host metadata is not inherited.
