### PR TITLE
docs: mention `parse` of `validateHttp`

### DIFF
--- a/adev/src/content/guide/forms/signals/async-operations.md
+++ b/adev/src/content/guide/forms/signals/async-operations.md
@@ -180,6 +180,23 @@ onSuccess: (response: { usernameTaken: boolean; profanity: boolean }) => {
 } // prettier-ignore
 ```
 
+The type for `onSuccess` can be specified either directly in the parameter, or with the `parse` property of `validateHttp`'s `options`
+
+```ts
+onSuccess: (response: { usernameTaken: boolean; profanity: boolean }) => {
+  // ...
+} // prettier-ignore
+
+// or
+
+options: {
+  parse: (response) => response as {usernameTaken: boolean; profanity: boolean};
+}
+onSuccess: (response) => {
+  // ...
+} // prettier-ignore
+```
+
 The `onError` function handles request failures like network errors or HTTP errors:
 
 ```ts


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Does not mention `parse`, as suggested in previous change: https://github.com/angular/angular/pull/68528#issuecomment-4384118300

Issue Number: N/A

## What is the new behavior?

Mentions `parse`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
