### PR TITLE
fix(forms): harden FormGroup control lookups against prototype shadowing

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -674,6 +674,7 @@
       "hasModelInput",
       "hasOnDestroy",
       "hasOutput",
+      "hasOwnControl",
       "hasParentInjector",
       "hasStyleInput",
       "hasStylingInputShadow",

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -669,6 +669,7 @@
       "hasModelInput",
       "hasOnDestroy",
       "hasOutput",
+      "hasOwnControl",
       "hasParentInjector",
       "hasStyleInput",
       "hasStylingInputShadow",

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -7,12 +7,12 @@
  */
 
 import {
-  EventEmitter,
-  signal,
-  ɵRuntimeError as RuntimeError,
-  ɵWritable as Writable,
-  untracked,
   computed,
+  EventEmitter,
+  ɵRuntimeError as RuntimeError,
+  signal,
+  untracked,
+  ɵWritable as Writable,
 } from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 
@@ -265,7 +265,7 @@ export function isOptionsObj(
 }
 
 export function assertControlPresent(parent: any, isGroup: boolean, key: string | number): void {
-  const controls = parent.controls as {[key: string | number]: unknown};
+  const controls = parent.controls as {[key: string | number]: AbstractControl<any>};
   const collection = isGroup ? Object.keys(controls) : controls;
   if (!collection.length) {
     throw new RuntimeError(
@@ -273,7 +273,7 @@ export function assertControlPresent(parent: any, isGroup: boolean, key: string 
       typeof ngDevMode === 'undefined' || ngDevMode ? noControlsError(isGroup) : '',
     );
   }
-  if (!controls[key]) {
+  if (!hasOwnControl(controls, key)) {
     throw new RuntimeError(
       RuntimeErrorCode.MISSING_CONTROL,
       typeof ngDevMode === 'undefined' || ngDevMode ? missingControlError(isGroup, key) : '',
@@ -1806,4 +1806,11 @@ export abstract class AbstractControl<
   private _updateHasRequiredValidator(): void {
     untracked(() => this._hasRequired.set(this.hasValidator(Validators.required)));
   }
+}
+
+export function hasOwnControl(
+  controls: {[key: string]: AbstractControl<any>},
+  name: string | number | symbol,
+): boolean {
+  return Object.hasOwn(controls, name);
 }

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -16,6 +16,7 @@ import {
   assertAllValuesPresent,
   assertControlPresent,
   FormResetEvent,
+  hasOwnControl,
   pickAsyncValidators,
   pickValidators,
   ɵRawValue,
@@ -245,7 +246,8 @@ export class FormGroup<
   ): AbstractControl<any>;
 
   registerControl<K extends string & keyof TControl>(name: K, control: TControl[K]): TControl[K] {
-    if (this.controls[name]) return (this.controls as any)[name];
+    const existingControl = this._find(name as string);
+    if (existingControl) return existingControl as TControl[K];
     this.controls[name] = control;
     control.setParent(this as FormGroup);
     control._registerOnCollectionChange(this._onCollectionChange);
@@ -322,8 +324,8 @@ export class FormGroup<
    * removed. When false, no events are emitted.
    */
   removeControl(name: string, options: {emitEvent?: boolean} = {}): void {
-    if ((this.controls as any)[name])
-      (this.controls as any)[name]._registerOnCollectionChange(() => {});
+    const existingControl = this._find(name);
+    if (existingControl) existingControl._registerOnCollectionChange(() => {});
     delete (this.controls as any)[name];
     this.updateValueAndValidity({emitEvent: options.emitEvent});
     this._onCollectionChange();
@@ -364,7 +366,8 @@ export class FormGroup<
       emitEvent?: boolean;
     } = {},
   ): void {
-    if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
+    const existingControl = this._find(name as string);
+    if (existingControl) existingControl._registerOnCollectionChange(() => {});
     delete this.controls[name];
     if (control) this.registerControl(name, control);
     this.updateValueAndValidity({emitEvent: options.emitEvent});
@@ -385,7 +388,7 @@ export class FormGroup<
   contains(this: FormGroup<{[key: string]: AbstractControl<any>}>, controlName: string): boolean;
 
   contains<K extends string & keyof TControl>(controlName: K): boolean {
-    return this.controls.hasOwnProperty(controlName) && this.controls[controlName].enabled;
+    return this._find(controlName)?.enabled === true;
   }
 
   /**
@@ -487,11 +490,9 @@ export class FormGroup<
     // `undefined` as a value.
     if (value == null /* both `null` and `undefined` */) return;
     (Object.keys(value) as Array<keyof TControl>).forEach((name) => {
-      // The compiler cannot see through the uninstantiated conditional type of `this.controls`, so
-      // `as any` is required.
-      const control = (this.controls as any)[name];
-      if (control) {
-        control.patchValue(
+      const existingControl = this._find(name as string);
+      if (existingControl) {
+        existingControl.patchValue(
           /* Guaranteed to be present, due to the outer forEach. */ value[
             name as keyof ɵFormGroupValue<TControl>
           ]!,
@@ -664,7 +665,7 @@ export class FormGroup<
 
   /** @internal */
   override _find(name: string | number): AbstractControl | null {
-    return this.controls.hasOwnProperty(name as string)
+    return hasOwnControl(this.controls, name as string)
       ? (this.controls as any)[name as keyof TControl]
       : null;
   }

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -17,6 +17,7 @@ import {
   FormArray,
   FormControl,
   FormGroup,
+  FormRecord,
   NG_VALUE_ACCESSOR,
   ReactiveFormsModule,
   ValidationErrors,
@@ -947,6 +948,65 @@ import {
 
       it('should not get inherited properties', () => {
         expect(group.get('constructor')).toBe(null);
+      });
+    });
+
+    describe('prototype-shadowed control names', () => {
+      it('should register a control named toString', () => {
+        const group: FormGroup = new FormGroup({});
+
+        group.addControl('toString', new FormControl('', Validators.required));
+
+        expect(group.contains('toString')).toBe(true);
+        expect(group.get('toString')).toBe(group.controls['toString']);
+        expect(group.valid).toBe(false);
+      });
+
+      it('should support contains and get for hasOwnProperty controls', () => {
+        const group = new FormGroup({'hasOwnProperty': new FormControl('value')});
+
+        expect(group.contains('hasOwnProperty')).toBe(true);
+        expect(group.get('hasOwnProperty')).toBe(group.controls['hasOwnProperty']);
+      });
+
+      it('should support setControl and removeControl for toString', () => {
+        const group: FormGroup = new FormGroup({});
+
+        group.setControl('toString', new FormControl('value'));
+        expect((group.get('toString') as FormControl).value).toBe('value');
+
+        group.removeControl('toString');
+        expect(group.get('toString')).toBe(null);
+      });
+
+      it('should support hasOwnProperty controls in FormRecord', () => {
+        const record = new FormRecord<FormControl<string | null>>({});
+
+        record.addControl('hasOwnProperty', new FormControl('value'));
+
+        expect(record.contains('hasOwnProperty')).toBe(true);
+        expect(record.get('hasOwnProperty')?.value).toBe('value');
+      });
+
+      it('should not crash when patching a shadowed control name', () => {
+        const group = new FormGroup({});
+        expect(() => group.patchValue({toString: 'value'})).not.toThrow();
+        expect(group.get('toString')).toBe(null);
+      });
+
+      it('should throw no-controls error when setting value on an empty group with a shadowed key', () => {
+        const group = new FormGroup({});
+        expect(() => group.setValue({toString: 'value'})).toThrowError(
+          new RegExp(`no form controls registered with this group`),
+        );
+      });
+
+      it('should throw missing-control error (not crash) for shadowed key in setValue', () => {
+        const group = new FormGroup({'one': new FormControl('')});
+
+        expect(() => group.setValue({one: 'v', toString: 'value'} as any)).toThrowError(
+          new RegExp(`NG01001: Cannot find form control with name: 'toString'`),
+        );
       });
     });
 


### PR DESCRIPTION
Guard FormGroup control-map presence checks with safe own-property checks to avoid inherited/prototype collisions from reserved keys (for example hasOwnProperty, toString).

This prevents:
- crashes from shadowed hasOwnProperty access paths
- incorrect early-return and existence behavior for prototype-named controls

Adds regression tests for prototype-shadowed keys covering:
- register/add with toString
- contains/get with hasOwnProperty
- setControl/removeControl with toString
- FormRecord behavior with hasOwnProperty