### PR TITLE
fix(common): tolerate malformed percent-encoding in AngularJSUrlCodec

### DIFF
--- a/packages/common/upgrade/src/params.ts
+++ b/packages/common/upgrade/src/params.ts
@@ -147,7 +147,7 @@ export class AngularJSUrlCodec implements UrlCodec {
     let i = segments.length;
 
     while (i--) {
-      segments[i] = decodeURIComponent(segments[i]);
+      segments[i] = tryDecodeURIComponent(segments[i]) ?? segments[i];
       if (html5Mode) {
         // encode forward slashes to prevent them from being mistaken for path separators
         segments[i] = segments[i].replace(/\//g, '%2F');
@@ -164,7 +164,7 @@ export class AngularJSUrlCodec implements UrlCodec {
 
   // https://github.com/angular/angular.js/blob/864c7f0/src/ng/location.js#L73
   decodeHash(hash: string) {
-    hash = decodeURIComponent(hash);
+    hash = tryDecodeURIComponent(hash) ?? hash;
     return hash[0] === '#' ? hash.substring(1) : hash;
   }
 

--- a/packages/common/upgrade/test/params.spec.ts
+++ b/packages/common/upgrade/test/params.spec.ts
@@ -76,4 +76,27 @@ describe('AngularJSUrlCodec', () => {
       }).toThrowError('Invalid URL (http://foo.bar) with base (abc)');
     });
   });
+
+  describe('decodePath', () => {
+    it('should decode valid percent escapes', () => {
+      expect(codec.decodePath('/a/100%2Fb')).toBe('/a/100%2Fb');
+      expect(codec.decodePath('/a%20b')).toBe('/a b');
+    });
+
+    it('should fall back to the raw segment for malformed escapes', () => {
+      expect(codec.decodePath('/a/100%done')).toBe('/a/100%done');
+      expect(codec.decodePath('/p%2')).toBe('/p%2');
+    });
+  });
+
+  describe('decodeHash', () => {
+    it('should decode valid percent escapes', () => {
+      expect(codec.decodeHash('a%20b')).toBe('a b');
+    });
+
+    it('should fall back to the raw hash for malformed escapes', () => {
+      expect(codec.decodeHash('sec%')).toBe('sec%');
+      expect(codec.decodeHash('frag%zz')).toBe('frag%zz');
+    });
+  });
 });


### PR DESCRIPTION
`decodePath`/`decodeHash` in `AngularJSUrlCodec` decode browser URL parts through `$locationShim`. A stray percent in a crafted path or hash is a legal URL character but throws:

    URIError: URI malformed

`parseKeyValue` already guards with `tryDecodeURIComponent`; route these two through it as well, falling back to the raw value while valid escapes still decode.