### PR TITLE
fix(core): disable WebMCP during SSR

### DIFF
--- a/packages/core/src/webmcp/declare_tool.ts
+++ b/packages/core/src/webmcp/declare_tool.ts
@@ -33,6 +33,9 @@ export function declareExperimentalWebMcpTool<const InputSchema extends JsonSche
   tool: ToolDescriptor<InputSchema>,
   injector?: Injector,
 ): void {
+  // SSR may not have a document yet, so we abort before checking it.
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) return;
+
   // modelContext was moved from `navigator` to `document` in the spec, but we check both for compatibility with different environments.
   const modelContext =
     (globalThis.document as {modelContext?: ModelContext}).modelContext ??


### PR DESCRIPTION
In certain scenarios like `provideExperimentalWebMcpTools` in `app.config.ts`, a WebMCP tool may be declared before SSR has a chance to polyfill Domino and trigger an error due to an `undefined` `document` value. This aborts from the process before WebMCP has a chance to crash.

CARETAKER NOTE: g3 test failure appears to be a flake.