### PR TITLE
fix(forms): set `additionalProperties: false` on generated WebMCP form

### DIFF
--- a/packages/forms/signals/src/webmcp/registration.ts
+++ b/packages/forms/signals/src/webmcp/registration.ts
@@ -105,6 +105,7 @@ function inferSchemaFromFieldNode(node: FieldNode): JsonSchemaForInference | und
       type: 'object',
       properties,
       required,
+      additionalProperties: false,
     };
   }
 

--- a/packages/forms/signals/test/web/webmcp.spec.ts
+++ b/packages/forms/signals/test/web/webmcp.spec.ts
@@ -68,9 +68,11 @@ describe('Signal Forms WebMCP Integration', () => {
               zip: {type: 'number'},
             },
             required: [],
+            additionalProperties: false,
           },
         },
         required: [],
+        additionalProperties: false,
       });
     });
 
@@ -114,9 +116,11 @@ describe('Signal Forms WebMCP Integration', () => {
               zip: {type: 'number'},
             },
             required: ['city'],
+            additionalProperties: false,
           },
         },
         required: ['name'],
+        additionalProperties: false,
       });
     });
 


### PR DESCRIPTION
This tells the agent that all input properties have been explicitly declared and that it should not attempt to specify additional arguments with unknown names. This provides a little more safety and gives the AI a little more information about the allowed set of inputs for this tool.