### PR TITLE
fix(compiler-cli): bind switch exhaustive check expressions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -1487,6 +1487,27 @@ class TestComponent {
 
       expect(messages).toEqual([]);
     });
+
+    it('should narrow a let declaration with the same name as a component property', () => {
+      const messages = diagnose(
+        `
+          @let state = this.state();
+          @switch (state.mode) {
+            @case ('show') { {{ state.menu }}; }
+            @case ('hide') {}
+            @default never(state);
+          }
+        `,
+        `
+          import {InputSignal} from '@angular/core';
+          export class TestComponent {
+            state: InputSignal<{ mode: 'hide' } | { mode: 'show'; menu: number }>;
+          }
+        `,
+      );
+
+      expect(messages).toEqual([]);
+    });
   });
 
   // https://github.com/angular/angular/issues/43970

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -90,6 +90,7 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
   visitSwitchBlock(block: t.SwitchBlock): void {
     this.visit(block.expression);
     this.visitAllTemplateNodes(block.groups);
+    block.exhaustiveCheck?.visit(this);
   }
 
   visitSwitchBlockCase(block: t.SwitchBlockCase): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

This template:

```html
@let state = this.state();
@switch (state.mode) {
  @case ('show') { {{ state.menu }}; }
  @case ('hide') {}
  @default never(state);
}
```

currently throws:

```
TestComponent.html(6, 28): Type 'InputSignal<{ mode: "hide"; } | { mode: "show"; menu: number; }>' is not assignable to type 'never'.
```

## What is the new behavior?

Ensure switch exhaustive check parameters are visited during template binding so local template symbols are resolved correctly.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
