### PR TITLE
docs: update reactive forms reference

### DIFF
--- a/skills/dev-skills/angular-developer/references/reactive-forms.md
+++ b/skills/dev-skills/angular-developer/references/reactive-forms.md
@@ -9,7 +9,7 @@ Reactive forms are built using these fundamental classes from `@angular/forms`:
 - `FormControl`: Manages the value and validity of an individual input.
 - `FormGroup`: Manages a group of controls (an object-like structure).
 - `FormArray`: Manages a numerically indexed array of controls.
-- `FormBuilder`: A service that provides factory methods for creating control instances.
+- `FormBuilder`/`NonNullableFormBuilder`: A service that provides factory methods for creating control instances.
 
 ## Setup
 
@@ -17,7 +17,7 @@ Import `ReactiveFormsModule` into your component.
 
 ```ts
 import {Component, inject} from '@angular/core';
-import {ReactiveFormsModule, FormGroup, FormControl, Validators, FormBuilder} from '@angular/forms';
+import {ReactiveFormsModule, NonNullableFormBuilder, Validators} from '@angular/forms';
 
 @Component({
   selector: 'app-profile-editor',
@@ -25,20 +25,20 @@ import {ReactiveFormsModule, FormGroup, FormControl, Validators, FormBuilder} fr
   templateUrl: './profile-editor.component.html',
 })
 export class ProfileEditor {
-  private fb = inject(FormBuilder);
+  private readonly fb = inject(NonNullableFormBuilder);
 
   // Using FormBuilder for concise definition
-  profileForm = this.fb.group({
+  protected readonly profileForm = this.fb.group({
     firstName: ['', Validators.required],
-    lastName: [''],
+    lastName: '',
     address: this.fb.group({
-      street: [''],
-      city: [''],
+      street: '',
+      city: '',
     }),
     aliases: this.fb.array([this.fb.control('')]),
   });
 
-  onSubmit() {
+  protected onSubmit() {
     console.warn(this.profileForm.value);
   }
 }
@@ -63,7 +63,7 @@ Use directives to bind the model to the view:
   </div>
 
   <div formArrayName="aliases">
-    @for (alias of aliases.controls; track $index) {
+    @for (alias of profileForm.controls.aliases.controls; track alias) {
     <input type="text" [formControlName]="$index" />
     }
   </div>
@@ -74,15 +74,11 @@ Use directives to bind the model to the view:
 
 ## Accessing Controls
 
-Use getters for easy access to controls, especially for `FormArray`.
+Use `.controls` for easy access to controls.
 
 ```ts
-get aliases() {
-  return this.profileForm.get('aliases') as FormArray;
-}
-
 addAlias() {
-  this.aliases.push(this.fb.control(''));
+  this.profileForm.controls.aliases.push(this.fb.control(''));
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The reactive forms skills recommends  using `get` to access a field, and getters with casts `as FormArray` which loses the type-safety with have since v14. 

## What is the new behavior?

This is a slightly more opinionated change but I believe this matches the "modern" way to write reactive forms, whereas the skills document what we used to do pre-v14.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
