### PR TITLE
docs: standardize padding and margin for insert-container in animation example

### DIFF
--- a/adev/src/content/examples/animations/src/app/native-css/insert.css
+++ b/adev/src/content/examples/animations/src/app/native-css/insert.css
@@ -5,9 +5,13 @@
 .insert-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
+}
+
+.insert-container p {
+  margin: 0;
 }
 
 .enter-animation {

--- a/adev/src/content/examples/animations/src/app/native-css/remove.css
+++ b/adev/src/content/examples/animations/src/app/native-css/remove.css
@@ -5,7 +5,7 @@
 .insert-container {
   border: 1px solid #dddddd;
   margin-top: 1em;
-  padding: 20px 20px 0px 20px;
+  padding: 20px;
   font-weight: bold;
   font-size: 20px;
   opacity: 1;
@@ -14,6 +14,10 @@
   @starting-style {
     opacity: 0;
   }
+}
+
+.insert-container p {
+  margin: 0;
 }
 
 .deleting {


### PR DESCRIPTION
## What is the current behavior?
<img width="1530" height="516" alt="image" src="https://github.com/user-attachments/assets/a302ff51-7cbc-434e-a5bf-346b9e0adfd4" />
<img width="1526" height="472" alt="image" src="https://github.com/user-attachments/assets/cee814c8-d854-470f-b9fc-987efcbfc0a9" />



## What is the new behavior?
<img width="1542" height="490" alt="image" src="https://github.com/user-attachments/assets/da760dc1-1105-4477-8d4b-ffdec7d9e541" />
<img width="1576" height="462" alt="image" src="https://github.com/user-attachments/assets/d1451e81-7584-4db1-b202-b1a9d5fe6e9e" />
