### PR TITLE
fix(core): use Object.hasOwn to handle null-prototype objects in toStylingKeyValueArray

### DIFF
--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -701,7 +701,7 @@ export function toStylingKeyValueArray(
     }
   } else if (typeof unwrappedValue === 'object') {
     for (const key in unwrappedValue) {
-      if (unwrappedValue.hasOwnProperty(key)) {
+      if (Object.hasOwn(unwrappedValue, key)) {
         keyValueArraySet(styleKeyValueArray, key, unwrappedValue[key]);
       }
     }

--- a/packages/core/test/render3/instructions/styling_spec.ts
+++ b/packages/core/test/render3/instructions/styling_spec.ts
@@ -423,6 +423,15 @@ describe('styling', () => {
             'x',
           ] as any);
         });
+        it('should parse objects with null prototype', () => {
+          const nullProtoObj = Object.assign(Object.create(null), {X: 'x', A: 'a'});
+          expect(toStylingKeyValueArray(keyValueArraySet, null!, nullProtoObj)).toEqual([
+            'A',
+            'a',
+            'X',
+            'x',
+          ] as any);
+        });
       });
     });
   });


### PR DESCRIPTION
Calling `.hasOwnProperty()` on an object created with `Object.create(null)` throws a TypeError because such objects have no prototype and therefore no inherited `hasOwnProperty` method. Replace it with `Object.hasOwn()`, which is a static method immune to prototype chain issues.

Adds a regression test covering null-prototype objects passed to `toStylingKeyValueArray`.