### PR TITLE
refactor(devtools): Prevent cross-tab privilege escalation

### DIFF
--- a/devtools/projects/shell-browser/src/app/tab_manager.ts
+++ b/devtools/projects/shell-browser/src/app/tab_manager.ts
@@ -38,13 +38,16 @@ export class TabManager {
 
   static initialize(tabs: Tabs, runtime: typeof chrome.runtime = chrome.runtime): TabManager {
     const manager = new TabManager(tabs, runtime);
-    manager.initialize();
+    manager.initialize(runtime);
     return manager;
   }
 
-  private initialize(): void {
+  private initialize(runtime: typeof chrome.runtime): void {
     this.runtime.onConnect.addListener((port) => {
-      if (isNumeric(port.name)) {
+      // Verify that the connection is actually from the extension's DevTools page
+      const isFromExtension = port.sender?.url?.startsWith(runtime.getURL(''));
+
+      if (isNumeric(port.name) && isFromExtension) {
         this.registerDevToolsForTab(port);
         return;
       }

--- a/devtools/projects/shell-browser/src/app/tab_manager_spec.ts
+++ b/devtools/projects/shell-browser/src/app/tab_manager_spec.ts
@@ -20,6 +20,7 @@ interface MockSender {
 
 const TEST_MESSAGE_ONE = {topic: 'test', args: ['test1']};
 const TEST_MESSAGE_TWO = {topic: 'test', args: ['test2']};
+const EXTENSION_URL_PREFIX = 'chrome-extension://test-extension-id/';
 
 class MockPort {
   onMessageListeners: Function[] = [];
@@ -67,7 +68,7 @@ function assertArrayDoesNotHaveObj<T extends object>(array: T[], obj: T) {
 }
 
 function mockSpyFunction(obj: any, property: string, returnValue: any) {
-  (obj[property] as any).and.returnValue(() => returnValue);
+  (obj[property] as any).and.returnValue(returnValue);
 }
 
 function mockSpyProperty(obj: any, property: string, value: any) {
@@ -107,6 +108,13 @@ describe('Tab Manager - ', () => {
   function createDevToolsPort() {
     const port = new MockPort({
       name: tabId.toString(),
+      sender: {
+        url: `${EXTENSION_URL_PREFIX}devtools.html`,
+        tab: {
+          id: tabId,
+        },
+        frameId: 0,
+      },
     });
     connectToChromeRuntime(port);
     return port;
@@ -120,7 +128,7 @@ describe('Tab Manager - ', () => {
       ['onConnect', 'onDisconnect'],
     );
     mockSpyFunction(chromeRuntime, 'getManifest', {manifest_version: 3});
-    mockSpyFunction(chromeRuntime, 'getURL', (path: string) => path);
+    mockSpyFunction(chromeRuntime, 'getURL', EXTENSION_URL_PREFIX);
     mockSpyProperty(chromeRuntime, 'onConnect', {
       addListener: (listener: (port: MockPort) => void) => {
         chromeRuntimeOnConnectListeners.push(listener);


### PR DESCRIPTION
The background script must not rely on the user-controllable `port.name` to authenticate DevTools panel connections.
