### PR TITLE
fix(compiler): support foreign components defined outside top-level scope

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/interpolated_signal_not_invoked/index.ts
@@ -61,6 +61,10 @@ class InterpolatedSignalCheck extends TemplateCheckWithVisitor<ErrorCode.INTERPO
     }
     // check bound inputs like `[prop]="mySignal"` on an element or inline template
     else if (node instanceof TmplAstElement && node.inputs.length > 0) {
+      // Allow signals to be passed directly to foreign components, without invocation.
+      if (ctx.templateTypeChecker.getForeignComponent(component, node) !== null) {
+        return [];
+      }
       const directivesOfElement = ctx.templateTypeChecker.getDirectivesOfNode(component, node);
       return node.inputs.flatMap((input) =>
         checkBoundAttribute(ctx, component, directivesOfElement, input),

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/interpolated_signal_not_invoked/interpolated_signal_not_invoked_spec.ts
@@ -353,6 +353,38 @@ runInEachFileSystem(() => {
     expect(diags.length).toBe(0);
   });
 
+  it('should not produce a warning when a signal is not invoked in a property binding on a foreign component', () => {
+    const fileName = absoluteFrom('/main.ts');
+    const {program, templateTypeChecker} = setup([
+      {
+        fileName,
+        templates: {
+          'TestCmp': `<FancyButton [disabled]="mySignal"></FancyButton>`,
+        },
+        source: `
+          import {signal} from '@angular/core';
+
+          export function FancyButton() {}
+
+          export class TestCmp {
+            mySignal = signal(false);
+          }`,
+        foreignComponents: ['FancyButton'],
+      },
+    ]);
+    const sf = getSourceFileOrError(program, fileName);
+    const component = getClass(sf, 'TestCmp');
+    const extendedTemplateChecker = new ExtendedTemplateCheckerImpl(
+      templateTypeChecker,
+      program.getTypeChecker(),
+      [interpolatedSignalFactory],
+      {},
+      /* options */
+    );
+    const diags = extendedTemplateChecker.getDiagnosticsForComponent(component);
+    expect(diags.length).toBe(0);
+  });
+
   it('should produce a warning when a signal in a nested property read is not invoked', () => {
     const fileName = absoluteFrom('/main.ts');
     const {program, templateTypeChecker} = setup([

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -12,6 +12,7 @@ import {
   ClassPropertyMapping,
   CssSelector,
   DomSchemaChecker,
+  ForeignComponentMeta,
   MatchSource,
   OutOfBandDiagnosticRecorder,
   ParseSourceFile,
@@ -78,6 +79,7 @@ import {
   AmbientImport,
   ClassDeclaration,
   isNamedClassDeclaration,
+  isNamedFunctionDeclaration,
   TypeScriptReflectionHost,
 } from '../../reflection';
 import {
@@ -362,6 +364,7 @@ export function tcb(
   config?: Partial<TypeCheckingConfig>,
   options?: {emitSpans?: boolean},
   templateParserOptions?: ParseTemplateOptions,
+  foreignComponents: string[] = [],
 ): string {
   const codeLines = [
     'declare const ɵNgFieldDirective: unique symbol;',
@@ -398,13 +401,15 @@ export function tcb(
     throw new Error('Template parse errors: \n' + errors.join('\n'));
   }
 
-  const {matcher, pipes} = prepareDeclarations(
+  const {matcher, pipes, foreignMatcher} = prepareDeclarations(
     declarations,
     (decl) => getClass(sf, decl.name),
     new Map(),
     selectorlessEnabled,
+    foreignComponents,
+    (name) => getFunction(sf, name),
   );
-  const binder = new R3TargetBinder<DirectiveMeta>(matcher);
+  const binder = new R3TargetBinder<DirectiveMeta>(matcher, foreignMatcher);
   const boundTarget = binder.bind({template: nodes});
 
   const id = 'tcb' as TypeCheckId;
@@ -503,6 +508,11 @@ export interface TypeCheckingTarget {
    * components in this file.
    */
   declarations?: TestDeclaration[];
+
+  /**
+   * Names of foreign components that are available in the template scope.
+   */
+  foreignComponents?: string[];
 }
 
 /**
@@ -622,6 +632,7 @@ export function setup(
       }
 
       const declarations = target.declarations ?? [];
+      const foreignComponents = target.foreignComponents ?? [];
 
       for (const className of Object.keys(target.templates)) {
         const classDecl = getClass(sf, className);
@@ -633,7 +644,7 @@ export function setup(
           throw new Error('Template parse errors: \n' + errors.join('\n'));
         }
 
-        const {matcher, pipes} = prepareDeclarations(
+        const {matcher, pipes, foreignMatcher} = prepareDeclarations(
           declarations,
           (decl) => {
             let declFile = sf;
@@ -647,8 +658,10 @@ export function setup(
           },
           fakeMetadataRegistry,
           overrides.parseOptions?.enableSelectorless ?? false,
+          foreignComponents,
+          (name) => getFunction(sf, name),
         );
-        const binder = new R3TargetBinder<DirectiveMeta>(matcher);
+        const binder = new R3TargetBinder<DirectiveMeta>(matcher, foreignMatcher);
         const classRef = new Reference(classDecl);
         const templateContext: TemplateContext = {
           nodes,
@@ -820,6 +833,8 @@ function prepareDeclarations(
   resolveDeclaration: DeclarationResolver,
   metadataRegistry: Map<string, TypeCheckableDirectiveMeta>,
   selectorlessEnabled: boolean,
+  foreignComponentNames: string[] = [],
+  resolveForeignComponent: (name: string) => ClassDeclaration,
 ) {
   const pipes = new Map<string, PipeMeta>();
   const hostDirectiveResolder = new HostDirectivesResolver(
@@ -850,6 +865,17 @@ function prepareDeclarations(
     }
   }
 
+  const foreignRegistry = new Map<string, ForeignComponentMeta[]>();
+  for (const name of foreignComponentNames) {
+    foreignRegistry.set(name, [
+      {
+        name,
+        ref: new Reference(resolveForeignComponent(name)),
+      },
+    ]);
+  }
+  const foreignMatcher = new SelectorlessMatcher<ForeignComponentMeta>(foreignRegistry);
+
   // We need to make two passes over the directives so that all declarations
   // have been registered by the time we resolve the host directives.
 
@@ -858,7 +884,7 @@ function prepareDeclarations(
     for (const meta of directives) {
       registry.set(meta.name, [meta, ...hostDirectiveResolder.resolve(meta)]);
     }
-    return {matcher: new SelectorlessMatcher<DirectiveMeta>(registry), pipes};
+    return {matcher: new SelectorlessMatcher<DirectiveMeta>(registry), pipes, foreignMatcher};
   } else {
     const matcher = new SelectorMatcher<DirectiveMeta[]>();
     for (const meta of directives) {
@@ -867,7 +893,7 @@ function prepareDeclarations(
       matcher.addSelectables(selector, matches);
     }
 
-    return {matcher, pipes};
+    return {matcher, pipes, foreignMatcher};
   }
 }
 
@@ -878,6 +904,18 @@ export function getClass(sf: ts.SourceFile, name: string): ClassDeclaration<ts.C
     }
   }
   throw new Error(`Class ${name} not found in file: ${sf.fileName}: ${sf.text}`);
+}
+
+export function getFunction(
+  sf: ts.SourceFile,
+  name: string,
+): ClassDeclaration<ts.FunctionDeclaration> {
+  for (const stmt of sf.statements) {
+    if (isNamedFunctionDeclaration(stmt) && stmt.name.text === name) {
+      return stmt;
+    }
+  }
+  throw new Error(`Function ${name} not found in file: ${sf.fileName}`);
 }
 
 function getDirectiveMetaFromDeclaration(

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -453,6 +453,35 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     ],
                 }]
         }] });
+export class TestCmpRenderProps {
+    title = 'Submit';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpRenderProps, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmpRenderProps, isStandalone: true, selector: "main-render-props", ngImport: i0, template: `
+    <FancyButton [label]="title">
+      @content(items; let item, index) {
+        <span>#{{index}}: {{item}}</span>
+      }
+    </FancyButton>
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpRenderProps, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'main-render-props',
+                    template: `
+    <FancyButton [label]="title">
+      @content(items; let item, index) {
+        <span>#{{index}}: {{item}}</span>
+      }
+    </FancyButton>
+  `,
+                    // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+                    foreignImports: [
+                        // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+                        frameworkImport(FancyButton)
+                    ],
+                }]
+        }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: foreign_component.d.ts
@@ -468,5 +497,10 @@ export declare class TestCmpChildren {
     title: string;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestCmpChildren, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<TestCmpChildren, "main-children", never, {}, {}, never, never, true, never>;
+}
+export declare class TestCmpRenderProps {
+    title: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmpRenderProps, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmpRenderProps, "main-render-props", never, {}, {}, never, never, true, never>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -416,6 +416,31 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     ],
                 }]
         }] });
+export class TestCmpChildren {
+    title = 'Submit';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpChildren, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmpChildren, isStandalone: true, selector: "main-children", ngImport: i0, template: `
+    <FancyButton [label]="title">
+      <span>Click me!</span>
+    </FancyButton>
+  `, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpChildren, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'main-children',
+                    template: `
+    <FancyButton [label]="title">
+      <span>Click me!</span>
+    </FancyButton>
+  `,
+                    // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+                    foreignImports: [
+                        // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+                        frameworkImport(FancyButton)
+                    ],
+                }]
+        }] });
 
 /****************************************************************************************************
  * PARTIAL FILE: foreign_component.d.ts
@@ -426,5 +451,10 @@ export declare class TestCmp {
     title: string;
     static ɵfac: i0.ɵɵFactoryDeclaration<TestCmp, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<TestCmp, "main", never, {}, {}, never, never, true, never>;
+}
+export declare class TestCmpChildren {
+    title: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestCmpChildren, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestCmpChildren, "main-children", never, {}, {}, never, never, true, never>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -421,7 +421,13 @@ export class TestCmpChildren {
     static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestCmpChildren, deps: [], target: i0.ɵɵFactoryTarget.Component });
     static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestCmpChildren, isStandalone: true, selector: "main-children", ngImport: i0, template: `
     <FancyButton [label]="title">
-      <span>Click me!</span>
+      @content(icon) {
+        <span>Icon!</span>
+      }
+      @content(description) {
+        <span>Description text</span>
+      }
+      <span>Other children</span>
     </FancyButton>
   `, isInline: true });
 }
@@ -431,7 +437,13 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     selector: 'main-children',
                     template: `
     <FancyButton [label]="title">
-      <span>Click me!</span>
+      @content(icon) {
+        <span>Icon!</span>
+      }
+      @content(description) {
+        <span>Description text</span>
+      }
+      <span>Other children</span>
     </FancyButton>
   `,
                     // @ts-ignore: @angular/core does not expose the `foreignImports` property.

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -45,9 +45,10 @@ export class TestCmp {
     selectors: [["main"]],
     decls: 1,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
+        i0.ɵɵforeignComponent(0, 0, { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
       }
     },
     encapsulation: 2
@@ -63,10 +64,11 @@ export class TestCmpChildren {
     selectors: [["main-children"]],
     decls: 4,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵdomTemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
-        i0.ɵɵforeignComponent(3, frameworkImport(FancyButton), { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
+        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
       }
     },
     encapsulation: 2
@@ -82,10 +84,11 @@ export class TestCmpRenderProps {
     selectors: [["main-render-props"]],
     decls: 2,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmpRenderProps_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵdomTemplate(0, TestCmpRenderProps_Items_0_Template, 2, 2);
-        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
+        i0.ɵɵforeignComponent(1, 0, { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -1,7 +1,23 @@
-function TestCmpChildren_Children_0_Template(rf, ctx) {
+function TestCmpChildren_Icon_0_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵdomElementStart(0, "span");
-    i0.ɵɵtext(1, "Click me!");
+    i0.ɵɵtext(1, "Icon!");
+    i0.ɵɵdomElementEnd();
+  }
+}
+
+function TestCmpChildren_Description_1_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵdomElementStart(0, "span");
+    i0.ɵɵtext(1, "Description text");
+    i0.ɵɵdomElementEnd();
+  }
+}
+
+function TestCmpChildren_Children_2_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵdomElementStart(0, "span");
+    i0.ɵɵtext(1, "Other children");
     i0.ɵɵdomElementEnd();
   }
 }
@@ -31,12 +47,12 @@ export class TestCmpChildren {
   static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
     type: TestCmpChildren,
     selectors: [["main-children"]],
-    decls: 2,
+    decls: 4,
     vars: 0,
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵdomTemplate(0, TestCmpChildren_Children_0_Template, 2, 0);
-        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, children: i0.ɵɵforeignContent(0) });
+        i0.ɵɵdomTemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
+        i0.ɵɵforeignComponent(3, frameworkImport(FancyButton), { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -1,3 +1,13 @@
+function TestCmpChildren_Children_0_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵdomElementStart(0, "span");
+    i0.ɵɵtext(1, "Click me!");
+    i0.ɵɵdomElementEnd();
+  }
+}
+
+…
+
 export class TestCmp {
   // ...
   static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
@@ -8,6 +18,25 @@ export class TestCmp {
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
+      }
+    },
+    encapsulation: 2
+  });
+}
+
+…
+
+export class TestCmpChildren {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmpChildren,
+    selectors: [["main-children"]],
+    decls: 2,
+    vars: 0,
+    template: function TestCmpChildren_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵdomTemplate(0, TestCmpChildren_Children_0_Template, 2, 0);
+        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, children: i0.ɵɵforeignContent(0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.js
@@ -22,6 +22,20 @@ function TestCmpChildren_Children_2_Template(rf, ctx) {
   }
 }
 
+function TestCmpRenderProps_Items_0_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵdomElementStart(0, "span");
+    i0.ɵɵtext(1);
+    i0.ɵɵdomElementEnd();
+  }
+  if (rf & 2) {
+    const item_r1 = ctx[0];
+    const index_r2 = ctx[1];
+    i0.ɵɵadvance();
+    i0.ɵɵtextInterpolate2("#", index_r2, ": ", item_r1);
+  }
+}
+
 …
 
 export class TestCmp {
@@ -58,3 +72,23 @@ export class TestCmpChildren {
     encapsulation: 2
   });
 }
+
+…
+
+export class TestCmpRenderProps {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmpRenderProps,
+    selectors: [["main-render-props"]],
+    decls: 2,
+    vars: 0,
+    template: function TestCmpRenderProps_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵdomTemplate(0, TestCmpRenderProps_Items_0_Template, 2, 2);
+        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
+      }
+    },
+    encapsulation: 2
+  });
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -22,6 +22,20 @@ function TestCmpChildren_Children_2_Template(rf, ctx) {
   }
 }
 
+function TestCmpRenderProps_Items_0_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "span");
+    i0.ɵɵtext(1);
+    i0.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    const item_r1 = ctx[0];
+    const index_r2 = ctx[1];
+    i0.ɵɵadvance();
+    i0.ɵɵtextInterpolate2("#", index_r2, ": ", item_r1);
+  }
+}
+
 …
 
 export class TestCmp {
@@ -53,6 +67,25 @@ export class TestCmpChildren {
       if (rf & 1) {
         i0.ɵɵtemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
         i0.ɵɵforeignComponent(3, frameworkImport(FancyButton), { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
+      }
+    },
+    encapsulation: 2
+  });
+}
+
+…
+
+export class TestCmpRenderProps {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmpRenderProps,
+    selectors: [["main-render-props"]],
+    decls: 2,
+    vars: 0,
+    template: function TestCmpRenderProps_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵtemplate(0, TestCmpRenderProps_Items_0_Template, 2, 2);
+        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -1,7 +1,23 @@
-function TestCmpChildren_Children_0_Template(rf, ctx) {
+function TestCmpChildren_Icon_0_Template(rf, ctx) {
   if (rf & 1) {
     i0.ɵɵelementStart(0, "span");
-    i0.ɵɵtext(1, "Click me!");
+    i0.ɵɵtext(1, "Icon!");
+    i0.ɵɵelementEnd();
+  }
+}
+
+function TestCmpChildren_Description_1_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "span");
+    i0.ɵɵtext(1, "Description text");
+    i0.ɵɵelementEnd();
+  }
+}
+
+function TestCmpChildren_Children_2_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "span");
+    i0.ɵɵtext(1, "Other children");
     i0.ɵɵelementEnd();
   }
 }
@@ -31,12 +47,12 @@ export class TestCmpChildren {
   static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
     type: TestCmpChildren,
     selectors: [["main-children"]],
-    decls: 2,
+    decls: 4,
     vars: 0,
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵtemplate(0, TestCmpChildren_Children_0_Template, 2, 0);
-        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, children: i0.ɵɵforeignContent(0) });
+        i0.ɵɵtemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
+        i0.ɵɵforeignComponent(3, frameworkImport(FancyButton), { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -1,3 +1,13 @@
+function TestCmpChildren_Children_0_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "span");
+    i0.ɵɵtext(1, "Click me!");
+    i0.ɵɵelementEnd();
+  }
+}
+
+…
+
 export class TestCmp {
   // ...
   static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
@@ -8,6 +18,25 @@ export class TestCmp {
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
+      }
+    },
+    encapsulation: 2
+  });
+}
+
+…
+
+export class TestCmpChildren {
+  // ...
+  static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({
+    type: TestCmpChildren,
+    selectors: [["main-children"]],
+    decls: 2,
+    vars: 0,
+    template: function TestCmpChildren_Template(rf, ctx) {
+      if (rf & 1) {
+        i0.ɵɵtemplate(0, TestCmpChildren_Children_0_Template, 2, 0);
+        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, children: i0.ɵɵforeignContent(0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.local.js
@@ -45,9 +45,10 @@ export class TestCmp {
     selectors: [["main"]],
     decls: 1,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmp_Template(rf, ctx) {
       if (rf & 1) {
-        i0.ɵɵforeignComponent(0, frameworkImport(FancyButton), { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
+        i0.ɵɵforeignComponent(0, 0, { class: "btn-cls", "unsafe-attr": "value", label: ctx.title, "unsafe-input": ctx.title });
       }
     },
     encapsulation: 2
@@ -63,10 +64,11 @@ export class TestCmpChildren {
     selectors: [["main-children"]],
     decls: 4,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmpChildren_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵtemplate(0, TestCmpChildren_Icon_0_Template, 2, 0)(1, TestCmpChildren_Description_1_Template, 2, 0)(2, TestCmpChildren_Children_2_Template, 2, 0);
-        i0.ɵɵforeignComponent(3, frameworkImport(FancyButton), { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
+        i0.ɵɵforeignComponent(3, 0, { label: ctx.title, icon: i0.ɵɵforeignContent(0), description: i0.ɵɵforeignContent(1), children: i0.ɵɵforeignContent(2) });
       }
     },
     encapsulation: 2
@@ -82,10 +84,11 @@ export class TestCmpRenderProps {
     selectors: [["main-render-props"]],
     decls: 2,
     vars: 0,
+    consts: [frameworkImport(FancyButton)],
     template: function TestCmpRenderProps_Template(rf, ctx) {
       if (rf & 1) {
         i0.ɵɵtemplate(0, TestCmpRenderProps_Items_0_Template, 2, 2);
-        i0.ɵɵforeignComponent(1, frameworkImport(FancyButton), { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
+        i0.ɵɵforeignComponent(1, 0, { label: ctx.title, items: i0.ɵɵforeignContentFn(0) });
       }
     },
     encapsulation: 2

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -31,7 +31,13 @@ export class TestCmp {
   selector: 'main-children',
   template: `
     <FancyButton [label]="title">
-      <span>Click me!</span>
+      @content(icon) {
+        <span>Icon!</span>
+      }
+      @content(description) {
+        <span>Description text</span>
+      }
+      <span>Other children</span>
     </FancyButton>
   `,
   // @ts-ignore: @angular/core does not expose the `foreignImports` property.

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -26,3 +26,21 @@ function frameworkImport(component: {}): Function {
 export class TestCmp {
   title = 'Submit';
 }
+
+@Component({
+  selector: 'main-children',
+  template: `
+    <FancyButton [label]="title">
+      <span>Click me!</span>
+    </FancyButton>
+  `,
+  // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+  foreignImports: [
+    // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+    frameworkImport(FancyButton)
+  ],
+})
+export class TestCmpChildren {
+  title = 'Submit';
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/foreign_component.ts
@@ -50,3 +50,22 @@ export class TestCmpChildren {
   title = 'Submit';
 }
 
+@Component({
+  selector: 'main-render-props',
+  template: `
+    <FancyButton [label]="title">
+      @content(items; let item, index) {
+        <span>#{{index}}: {{item}}</span>
+      }
+    </FancyButton>
+  `,
+  // @ts-ignore: @angular/core does not expose the `foreignImports` property.
+  foreignImports: [
+    // @ts-ignore: @angular/core does not expose the `ForeignComponent` type this expects.
+    frameworkImport(FancyButton)
+  ],
+})
+export class TestCmpRenderProps {
+  title = 'Submit';
+}
+

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2190,11 +2190,11 @@ runInEachFileSystem(() => {
       const foreignSetupCode = `
         // We must redeclare foreignImports and ForeignComponent to test them since they are marked @internal.
         declare module '@angular/core' {
-          export interface ForeignComponent {}
-          export function foreignImport(render: Function): ForeignComponent;
+          export interface ForeignComponent<TProps> {}
+          export function foreignImport<TProps>(render: (props: TProps) => any): ForeignComponent<TProps>;
 
           interface Component {
-            foreignImports?: ForeignComponent[];
+            foreignImports?: ForeignComponent<any>[];
           }
         }
 
@@ -2203,7 +2203,7 @@ runInEachFileSystem(() => {
 
         function FancyButton() {}
 
-        function frameworkImport(component: unknown): ForeignComponent {
+        function frameworkImport(component: unknown): ForeignComponent<any> {
           return foreignImport(() => {});
         }
       `;

--- a/packages/compiler/src/combined_visitor.ts
+++ b/packages/compiler/src/combined_visitor.ts
@@ -46,6 +46,10 @@ export class CombinedRecursiveAstVisitor extends RecursiveAstVisitor implements 
     this.visitAllTemplateNodes(content.children);
   }
 
+  visitContentBlock(block: t.ContentBlock): void {
+    this.visitAllTemplateNodes(block.children);
+  }
+
   visitBoundAttribute(attribute: t.BoundAttribute): void {
     this.visit(attribute.value);
   }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -188,6 +188,7 @@ export {
   HostElement as TmplAstHostElement,
   Component as TmplAstComponent,
   Directive as TmplAstDirective,
+  ContentBlock as TmplAstContentBlock,
   visitAll as tmplAstVisitAll,
   Visitor as TmplAstVisitor,
 } from './render3/r3_ast';

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -153,6 +153,7 @@ const SUPPORTED_BLOCKS = [
   '@placeholder',
   '@loading',
   '@error',
+  '@content',
 ] as const;
 
 const INTERPOLATION = {start: '{{', end: '}}'} as const;

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -342,6 +342,7 @@ export class DeferredBlockError extends BlockNode implements Node {
 export class ContentBlock extends BlockNode implements Node {
   constructor(
     public name: string,
+    public variables: Variable[],
     public children: Node[],
     nameSpan: ParseSourceSpan,
     sourceSpan: ParseSourceSpan,

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -339,6 +339,24 @@ export class DeferredBlockError extends BlockNode implements Node {
   }
 }
 
+export class ContentBlock extends BlockNode implements Node {
+  constructor(
+    public name: string,
+    public children: Node[],
+    nameSpan: ParseSourceSpan,
+    sourceSpan: ParseSourceSpan,
+    startSourceSpan: ParseSourceSpan,
+    endSourceSpan: ParseSourceSpan | null,
+    public i18n?: I18nMeta,
+  ) {
+    super(nameSpan, sourceSpan, startSourceSpan, endSourceSpan);
+  }
+
+  visit<Result>(visitor: Visitor<Result>): Result {
+    return visitor.visitContentBlock(this);
+  }
+}
+
 export interface DeferredBlockTriggers {
   when?: BoundDeferredTrigger;
   idle?: IdleDeferredTrigger;
@@ -762,6 +780,7 @@ export interface Visitor<Result = any> {
   visitLetDeclaration(decl: LetDeclaration): Result;
   visitComponent(component: Component): Result;
   visitDirective(directive: Directive): Result;
+  visitContentBlock(block: ContentBlock): Result;
 }
 
 export class RecursiveVisitor implements Visitor<void> {
@@ -846,6 +865,9 @@ export class RecursiveVisitor implements Visitor<void> {
   visitDeferredTrigger(trigger: DeferredTrigger): void {}
   visitUnknownBlock(block: UnknownBlock): void {}
   visitLetDeclaration(decl: LetDeclaration): void {}
+  visitContentBlock(block: ContentBlock): void {
+    visitAll(this, block.children);
+  }
 }
 
 export function visitAll<Result>(visitor: Visitor<Result>, nodes: Node[]): Result[] {

--- a/packages/compiler/src/render3/r3_content_blocks.ts
+++ b/packages/compiler/src/render3/r3_content_blocks.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import * as html from '../ml_parser/ast';
+import {ParseError} from '../parse_util';
+
+import * as t from './r3_ast';
+import {IDENTIFIER_PATTERN} from './util';
+
+/** Creates a content block from an HTML AST node. */
+export function createContentBlock(
+  ast: html.Block,
+  visitor: html.Visitor,
+): {node: t.ContentBlock | null; errors: ParseError[]} {
+  const errors: ParseError[] = [];
+  if (ast.parameters.length !== 1) {
+    errors.push(
+      new ParseError(ast.startSourceSpan, '@content block must have exactly one parameter'),
+    );
+    return {node: null, errors};
+  }
+
+  const param = ast.parameters[0];
+  let expr = param.expression.trim();
+  if (expr.startsWith('(') && expr.endsWith(')')) {
+    expr = expr.slice(1, -1).trim();
+  }
+
+  const parts = expr.split(',').map((p) => p.trim());
+  if (parts.length !== 1 || parts[0] === '') {
+    errors.push(
+      new ParseError(ast.startSourceSpan, '@content block must have exactly one parameter'),
+    );
+    return {node: null, errors};
+  }
+
+  const name = parts[0];
+  if (!IDENTIFIER_PATTERN.test(name)) {
+    errors.push(
+      new ParseError(param.sourceSpan, '@content name must be a valid JavaScript identifier'),
+    );
+    return {node: null, errors};
+  }
+
+  const node = new t.ContentBlock(
+    name,
+    html.visitAll(visitor, ast.children, ast.children),
+    ast.nameSpan,
+    ast.sourceSpan,
+    ast.startSourceSpan,
+    ast.endSourceSpan,
+    ast.i18n,
+  );
+  return {node, errors};
+}

--- a/packages/compiler/src/render3/r3_content_blocks.ts
+++ b/packages/compiler/src/render3/r3_content_blocks.ts
@@ -7,10 +7,10 @@
  */
 
 import * as html from '../ml_parser/ast';
-import {ParseError} from '../parse_util';
+import {ParseError, ParseSourceSpan} from '../parse_util';
 
 import * as t from './r3_ast';
-import {IDENTIFIER_PATTERN} from './util';
+import {IDENTIFIER_PATTERN, LET_PATTERN} from './util';
 
 /** Creates a content block from an HTML AST node. */
 export function createContentBlock(
@@ -18,37 +18,41 @@ export function createContentBlock(
   visitor: html.Visitor,
 ): {node: t.ContentBlock | null; errors: ParseError[]} {
   const errors: ParseError[] = [];
-  if (ast.parameters.length !== 1) {
+  if (ast.parameters.length < 1 || ast.parameters.length > 2) {
     errors.push(
-      new ParseError(ast.startSourceSpan, '@content block must have exactly one parameter'),
+      new ParseError(
+        ast.startSourceSpan,
+        '@content block must have one or two parameters, e.g. ' +
+          '"@content(header)" or "@content(items; let item, index)"',
+      ),
     );
     return {node: null, errors};
   }
 
-  const param = ast.parameters[0];
-  let expr = param.expression.trim();
-  if (expr.startsWith('(') && expr.endsWith(')')) {
-    expr = expr.slice(1, -1).trim();
-  }
-
-  const parts = expr.split(',').map((p) => p.trim());
-  if (parts.length !== 1 || parts[0] === '') {
+  const nameParam = ast.parameters[0];
+  const name = nameParam.expression.trim();
+  if (name.includes(',')) {
     errors.push(
-      new ParseError(ast.startSourceSpan, '@content block must have exactly one parameter'),
+      new ParseError(ast.startSourceSpan, '@content block must have exactly one name parameter'),
     );
     return {node: null, errors};
   }
 
-  const name = parts[0];
   if (!IDENTIFIER_PATTERN.test(name)) {
     errors.push(
-      new ParseError(param.sourceSpan, '@content name must be a valid JavaScript identifier'),
+      new ParseError(nameParam.sourceSpan, '@content name must be a valid JavaScript identifier'),
     );
+    return {node: null, errors};
+  }
+
+  const variables = parseContentBlockVariables(ast, errors);
+  if (variables === null) {
     return {node: null, errors};
   }
 
   const node = new t.ContentBlock(
     name,
+    variables,
     html.visitAll(visitor, ast.children, ast.children),
     ast.nameSpan,
     ast.sourceSpan,
@@ -57,4 +61,82 @@ export function createContentBlock(
     ast.i18n,
   );
   return {node, errors};
+}
+
+/** Parses the variables of a content block. */
+function parseContentBlockVariables(ast: html.Block, errors: ParseError[]): t.Variable[] | null {
+  const variables: t.Variable[] = [];
+  if (ast.parameters.length < 2) {
+    return variables;
+  }
+
+  const varsParam = ast.parameters[1];
+  const varsExpr = varsParam.expression.trim();
+  const letMatch = varsExpr.match(LET_PATTERN);
+  if (!letMatch) {
+    errors.push(
+      new ParseError(
+        varsParam.sourceSpan,
+        '@content block variables must start with "let", e.g. "let item, index"',
+      ),
+    );
+    return null;
+  }
+
+  const varNames = letMatch[1].split(',').map((v) => v.trim());
+  const variablesRawString = letMatch[1];
+  const variablesStartOffset = varsParam.expression.indexOf(variablesRawString);
+  const variablesStartLocation = varsParam.sourceSpan.start.moveBy(variablesStartOffset);
+
+  let searchIndex = 0;
+  for (let varName of varNames) {
+    if (varName === '') {
+      errors.push(new ParseError(varsParam.sourceSpan, 'Invalid variable name in @content block'));
+      continue;
+    }
+
+    let varSpan: ParseSourceSpan;
+    const index = variablesRawString.indexOf(varName, searchIndex);
+    const varStart = variablesStartLocation.moveBy(index);
+
+    if (varName.includes('=')) {
+      const eqIndex = varName.indexOf('=');
+      const namePart = varName.substring(0, eqIndex).trim();
+      const fullVarSpan = new ParseSourceSpan(varStart, varStart.moveBy(varName.length));
+
+      errors.push(
+        new ParseError(fullVarSpan, `@content block variables cannot be assigned a value`),
+      );
+
+      varName = namePart;
+      varSpan = new ParseSourceSpan(varStart, varStart.moveBy(varName.length));
+    } else {
+      varSpan = new ParseSourceSpan(varStart, varStart.moveBy(varName.length));
+    }
+
+    if (!IDENTIFIER_PATTERN.test(varName)) {
+      errors.push(
+        new ParseError(varSpan, `Variable name "${varName}" must be a valid JavaScript identifier`),
+      );
+      searchIndex = index + varName.length;
+      continue;
+    }
+
+    if (variables.some((v) => v.name === varName)) {
+      errors.push(
+        new ParseError(varSpan, `Duplicate variable name "${varName}" in @content block`),
+      );
+      searchIndex = index + varName.length;
+      continue;
+    }
+
+    // @content block variables cannot be assigned an explicit value in the template
+    // (e.g. "let item = value"). Instead, they are assigned an argument of the calling render function
+    // based on their positional index. For example if we have a @content block like
+    // "@content(items; let item, index)" the render function for that block will be called like
+    // "render(items, ctx[0], ctx[1])".
+    variables.push(new t.Variable(varName, '', varSpan, varSpan));
+    searchIndex = index + varName.length;
+  }
+  return variables;
 }

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -12,7 +12,7 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
 
 import * as t from './r3_ast';
-import {IDENTIFIER_PATTERN} from './util';
+import {IDENTIFIER_PATTERN, LET_PATTERN} from './util';
 
 /** Pattern for the expression in a for loop block. */
 const FOR_LOOP_EXPRESSION_PATTERN = /^\s*([0-9A-Za-z_$]*)\s+of\s+([\S\s]*)/;
@@ -25,9 +25,6 @@ const CONDITIONAL_ALIAS_PATTERN = /^(as\s+)(.*)/;
 
 /** Pattern used to identify an `else if` block. */
 const ELSE_IF_PATTERN = /^else[^\S\r\n]+if/;
-
-/** Pattern used to identify a `let` parameter. */
-const FOR_LOOP_LET_PATTERN = /^let\s+([\S\s]*)/;
 
 /**
  * Pattern to group a string into leading whitespace, non whitespace, and trailing whitespace.
@@ -429,7 +426,7 @@ function parseForLoopParameters(
   };
 
   for (const param of secondaryParams) {
-    const letMatch = param.expression.match(FOR_LOOP_LET_PATTERN);
+    const letMatch = param.expression.match(LET_PATTERN);
 
     if (letMatch !== null) {
       const variablesSpan = new ParseSourceSpan(

--- a/packages/compiler/src/render3/r3_control_flow.ts
+++ b/packages/compiler/src/render3/r3_control_flow.ts
@@ -12,6 +12,7 @@ import {ParseError, ParseSourceSpan} from '../parse_util';
 import {BindingParser} from '../template_parser/binding_parser';
 
 import * as t from './r3_ast';
+import {IDENTIFIER_PATTERN} from './util';
 
 /** Pattern for the expression in a for loop block. */
 const FOR_LOOP_EXPRESSION_PATTERN = /^\s*([0-9A-Za-z_$]*)\s+of\s+([\S\s]*)/;
@@ -27,9 +28,6 @@ const ELSE_IF_PATTERN = /^else[^\S\r\n]+if/;
 
 /** Pattern used to identify a `let` parameter. */
 const FOR_LOOP_LET_PATTERN = /^let\s+([\S\s]*)/;
-
-/** Pattern used to validate a JavaScript identifier. */
-const IDENTIFIER_PATTERN = /^[$A-Z_][0-9A-Z_$]*$/i;
 
 /**
  * Pattern to group a string into leading whitespace, non whitespace, and trailing whitespace.

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -26,6 +26,7 @@ export class Identifiers {
   static elementEnd: o.ExternalReference = {name: 'ɵɵelementEnd', moduleName: CORE};
 
   static foreignComponent: o.ExternalReference = {name: 'ɵɵforeignComponent', moduleName: CORE};
+  static foreignContent: o.ExternalReference = {name: 'ɵɵforeignContent', moduleName: CORE};
 
   static domElement: o.ExternalReference = {name: 'ɵɵdomElement', moduleName: CORE};
   static domElementStart: o.ExternalReference = {name: 'ɵɵdomElementStart', moduleName: CORE};

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -27,6 +27,7 @@ export class Identifiers {
 
   static foreignComponent: o.ExternalReference = {name: 'ɵɵforeignComponent', moduleName: CORE};
   static foreignContent: o.ExternalReference = {name: 'ɵɵforeignContent', moduleName: CORE};
+  static foreignContentFn: o.ExternalReference = {name: 'ɵɵforeignContentFn', moduleName: CORE};
 
   static domElement: o.ExternalReference = {name: 'ɵɵdomElement', moduleName: CORE};
   static domElementStart: o.ExternalReference = {name: 'ɵɵdomElementStart', moduleName: CORE};

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -33,6 +33,7 @@ import {
   isConnectedIfLoopBlock,
 } from './r3_control_flow';
 import {createDeferredBlock, isConnectedDeferLoopBlock} from './r3_deferred_blocks';
+import {createContentBlock} from './r3_content_blocks';
 import {I18N_ICU_VAR_PREFIX} from './view/i18n/util';
 
 const BIND_NAME_REGEXP = /^(?:(bind-)|(let-)|(ref-|#)|(on-)|(bindon-)|(@))(.*)$/;
@@ -483,6 +484,10 @@ class HtmlAstToIvyAst implements html.Visitor {
 
       case 'switch':
         result = createSwitchBlock(block, this, this.bindingParser);
+        break;
+
+      case 'content':
+        result = createContentBlock(block, this);
         break;
 
       case 'for':

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -14,6 +14,9 @@ import {Identifiers} from './r3_identifiers';
 /** Regex that includes unsafe characters in an object literal property name. */
 const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
 
+/** Pattern used to validate a JavaScript identifier. */
+export const IDENTIFIER_PATTERN = /^[$A-Z_][0-9A-Z_$]*$/i;
+
 export function typeWithParameters(type: o.Expression, numParams: number): o.ExpressionType {
   if (numParams === 0) {
     return o.expressionType(type);

--- a/packages/compiler/src/render3/util.ts
+++ b/packages/compiler/src/render3/util.ts
@@ -17,6 +17,9 @@ const UNSAFE_OBJECT_KEY_NAME_REGEXP = /[-.]/;
 /** Pattern used to validate a JavaScript identifier. */
 export const IDENTIFIER_PATTERN = /^[$A-Z_][0-9A-Z_$]*$/i;
 
+/** Pattern used to identify a `let` parameter. */
+export const LET_PATTERN = /^let\s+([\S\s]*)/;
+
 export function typeWithParameters(type: o.Expression, numParams: number): o.ExpressionType {
   if (numParams === 0) {
     return o.expressionType(type);

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -31,6 +31,7 @@ import {
   Template,
   TextAttribute,
   Variable,
+  ContentBlock,
 } from '../r3_ast';
 
 /** Node that has a `Scope` associated with it. */
@@ -45,6 +46,7 @@ export type ScopedNode =
   | DeferredBlockLoading
   | DeferredBlockPlaceholder
   | Content
+  | ContentBlock
   | HostElement;
 
 /** Possible values that a reference can be resolved to. */

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -21,6 +21,7 @@ import {
   Comment,
   Component,
   Content,
+  ContentBlock,
   DeferredBlock,
   DeferredBlockError,
   DeferredBlockLoading,
@@ -353,6 +354,7 @@ class Scope implements Visitor {
       nodeOrNodes instanceof DeferredBlockError ||
       nodeOrNodes instanceof DeferredBlockPlaceholder ||
       nodeOrNodes instanceof DeferredBlockLoading ||
+      nodeOrNodes instanceof ContentBlock ||
       nodeOrNodes instanceof Content
     ) {
       nodeOrNodes.children.forEach((node) => node.visit(this));
@@ -437,6 +439,10 @@ class Scope implements Visitor {
 
   visitContent(content: Content) {
     this.ingestScopedNode(content);
+  }
+
+  visitContentBlock(block: ContentBlock) {
+    this.ingestScopedNode(block);
   }
 
   visitLetDeclaration(decl: LetDeclaration) {
@@ -649,6 +655,10 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
 
   visitContent(content: Content): void {
     content.children.forEach((child) => child.visit(this));
+  }
+
+  visitContentBlock(block: ContentBlock): void {
+    block.children.forEach((child) => child.visit(this));
   }
 
   visitComponent(node: Component): void {
@@ -1040,6 +1050,7 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
       nodeOrNodes instanceof DeferredBlockError ||
       nodeOrNodes instanceof DeferredBlockPlaceholder ||
       nodeOrNodes instanceof DeferredBlockLoading ||
+      nodeOrNodes instanceof ContentBlock ||
       nodeOrNodes instanceof Content
     ) {
       nodeOrNodes.children.forEach((node) => node.visit(this));
@@ -1132,6 +1143,10 @@ class TemplateBinder extends CombinedRecursiveAstVisitor {
 
   override visitContent(content: Content) {
     this.ingestScopedNode(content);
+  }
+
+  override visitContentBlock(block: ContentBlock) {
+    this.ingestScopedNode(block);
   }
 
   override visitLetDeclaration(decl: LetDeclaration) {

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -461,6 +461,11 @@ export enum ExpressionKind {
   TwoWayBindingSet,
 
   /**
+   * Renders foreign content (children of a foreign component) and extracts its root DOM nodes.
+   */
+  ForeignContent,
+
+  /**
    * Definition of an arrow function inside of an expression.
    */
   ArrowFunction,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -31,6 +31,7 @@ import {
 export type Expression =
   | LexicalReadExpr
   | ReferenceExpr
+  | ForeignContentExpr
   | ContextExpr
   | NextContextExpr
   | GetCurrentViewExpr
@@ -147,6 +148,37 @@ export class ReferenceExpr extends ExpressionBase {
 
   override clone(): ReferenceExpr {
     return new ReferenceExpr(this.target, this.targetSlot, this.offset);
+  }
+}
+
+/**
+ * Runtime operation to render foreign content (children of a foreign component)
+ * and extract its root DOM nodes.
+ */
+export class ForeignContentExpr extends ExpressionBase {
+  override readonly kind = ExpressionKind.ForeignContent;
+
+  constructor(
+    readonly childrenViewXref: XrefId,
+    readonly childrenViewHandle: SlotHandle,
+  ) {
+    super();
+  }
+
+  override visitExpression(): void {}
+
+  override isEquivalent(e: o.Expression): boolean {
+    return e instanceof ForeignContentExpr && e.childrenViewXref === this.childrenViewXref;
+  }
+
+  override isConstant(): boolean {
+    return false;
+  }
+
+  override transformInternalExpressions(): void {}
+
+  override clone(): ForeignContentExpr {
+    return new ForeignContentExpr(this.childrenViewXref, this.childrenViewHandle);
   }
 }
 

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -269,7 +269,7 @@ export class ViewCompilationUnit extends CompilationUnit {
    * Map of declared variables available within this view to the property on the context object
    * which they alias.
    */
-  readonly contextVariables = new Map<string, string>();
+  readonly contextVariables = new Map<string, string | number>();
 
   /**
    * Set of aliases available within this view. An alias is a variable whose provided expression is

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -307,6 +307,30 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
         quoted: isUnsafeObjectKey(input.name),
       });
     }
+
+    if (element.children.length > 0) {
+      const childView = unit.job.allocateView(unit.xref);
+      ingestNodes(childView, element.children);
+
+      const childrenTemplateOp = ir.createTemplateOp(
+        childView.xref,
+        ir.TemplateKind.NgTemplate,
+        null,
+        'Children',
+        ir.Namespace.HTML,
+        undefined,
+        element.startSourceSpan,
+        element.sourceSpan,
+      );
+      unit.create.push(childrenTemplateOp);
+
+      propEntries.push({
+        key: 'children',
+        value: new ir.ForeignContentExpr(childrenTemplateOp.xref, childrenTemplateOp.handle),
+        quoted: false,
+      });
+    }
+
     const props = propEntries.length > 0 ? o.literalMap(propEntries) : null;
 
     // Foreign components are created in the creation block. Updates are triggered reactively

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -269,6 +269,8 @@ function ingestNodes(unit: ViewCompilationUnit, template: t.Node[]): void {
       ingestForBlock(unit, node);
     } else if (node instanceof t.LetDeclaration) {
       ingestLetDeclaration(unit, node);
+    } else if (node instanceof t.ContentBlock) {
+      throw new Error(`@content blocks are only valid as direct children of foreign components.`);
     } else if (node instanceof t.Component) {
       // TODO(crisbeto): account for selectorless nodes.
     } else {
@@ -308,9 +310,43 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
       });
     }
 
-    if (element.children.length > 0) {
+    const contentBlocks: t.ContentBlock[] = [];
+    const childNodes: t.Node[] = [];
+
+    for (const child of element.children) {
+      if (child instanceof t.ContentBlock) {
+        contentBlocks.push(child);
+      } else {
+        childNodes.push(child);
+      }
+    }
+
+    for (const block of contentBlocks) {
+      const blockView = unit.job.allocateView(unit.xref);
+      ingestNodes(blockView, block.children);
+
+      const blockTemplateOp = ir.createTemplateOp(
+        blockView.xref,
+        ir.TemplateKind.NgTemplate,
+        null,
+        block.name.charAt(0).toUpperCase() + block.name.slice(1),
+        ir.Namespace.HTML,
+        undefined,
+        block.startSourceSpan,
+        block.sourceSpan,
+      );
+      unit.create.push(blockTemplateOp);
+
+      propEntries.push({
+        key: block.name,
+        value: new ir.ForeignContentExpr(blockTemplateOp.xref, blockTemplateOp.handle),
+        quoted: isUnsafeObjectKey(block.name),
+      });
+    }
+
+    if (childNodes.length > 0) {
       const childView = unit.job.allocateView(unit.xref);
-      ingestNodes(childView, element.children);
+      ingestNodes(childView, childNodes);
 
       const childrenTemplateOp = ir.createTemplateOp(
         childView.xref,

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -380,8 +380,9 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
     // Foreign components are created in the creation block. Updates are triggered reactively
     // through directly passed signal properties, alleviating the need for any explicit update
     // operations.
+    const constIndex = unit.job.addConst(foreignComp.component);
     unit.create.push(
-      ir.createForeignComponentOp(id, foreignComp.component, props, element.startSourceSpan),
+      ir.createForeignComponentOp(id, o.literal(constIndex), props, element.startSourceSpan),
     );
     return;
   }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -323,6 +323,14 @@ function ingestElement(unit: ViewCompilationUnit, element: t.Element): void {
 
     for (const block of contentBlocks) {
       const blockView = unit.job.allocateView(unit.xref);
+
+      // @content block variables map directly to the arguments array passed to the calling render
+      // function. We set the context variable's value to its index in the block's variables list
+      // so that code generation resolves it to its corresponding index in the arguments array.
+      for (let i = 0; i < block.variables.length; i++) {
+        blockView.contextVariables.set(block.variables[i].name, i);
+      }
+
       ingestNodes(blockView, block.children);
 
       const blockTemplateOp = ir.createTemplateOp(

--- a/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
@@ -261,7 +261,14 @@ function generateVariablesInScopeForView(
   for (const [name, value] of scopeView.contextVariables) {
     const context = new ir.ContextExpr(scope.view);
     // We either read the context, or, if the variable is CTX_REF, use the context directly.
-    const variable = value === ir.CTX_REF ? context : new o.ReadPropExpr(context, value);
+    let variable: o.Expression;
+    if (value === ir.CTX_REF) {
+      variable = context;
+    } else if (typeof value === 'number') {
+      variable = new o.ReadKeyExpr(context, o.literal(value));
+    } else {
+      variable = new o.ReadPropExpr(context, value);
+    }
     // Add the variable declaration.
     newOps.push(
       ir.createVariableOp(

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -788,6 +788,10 @@ function reifyIrExpression(unit: CompilationUnit, expr: o.Expression): o.Express
       return ng.nextContext(expr.steps);
     case ir.ExpressionKind.Reference:
       return ng.reference(expr.targetSlot.slot! + 1 + expr.offset);
+    case ir.ExpressionKind.ForeignContent:
+      return o
+        .importExpr(Identifiers.foreignContent)
+        .callFn([o.literal(expr.childrenViewHandle.slot!)]);
     case ir.ExpressionKind.LexicalRead:
       throw new Error(`AssertionError: unresolved LexicalRead of ${expr.name}`);
     case ir.ExpressionKind.TwoWayBindingSet:

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -789,9 +789,12 @@ function reifyIrExpression(unit: CompilationUnit, expr: o.Expression): o.Express
     case ir.ExpressionKind.Reference:
       return ng.reference(expr.targetSlot.slot! + 1 + expr.offset);
     case ir.ExpressionKind.ForeignContent:
-      return o
-        .importExpr(Identifiers.foreignContent)
-        .callFn([o.literal(expr.childrenViewHandle.slot!)]);
+      if (!(unit instanceof ViewCompilationUnit)) {
+        throw new Error(`AssertionError: must be compiling a component`);
+      }
+      const isFn = unit.job.views.get(expr.childrenViewXref)!.contextVariables.size > 0;
+      const identifier = isFn ? Identifiers.foreignContentFn : Identifiers.foreignContent;
+      return o.importExpr(identifier).callFn([o.literal(expr.childrenViewHandle.slot!)]);
     case ir.ExpressionKind.LexicalRead:
       throw new Error(`AssertionError: unresolved LexicalRead of ${expr.name}`);
     case ir.ExpressionKind.TwoWayBindingSet:

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -56,6 +56,16 @@ class R3AstSourceSpans implements t.Visitor<void> {
     this.visitAll([content.attributes, content.children]);
   }
 
+  visitContentBlock(block: t.ContentBlock) {
+    this.result.push([
+      'ContentBlock',
+      humanizeSpan(block.sourceSpan),
+      humanizeSpan(block.startSourceSpan),
+      humanizeSpan(block.endSourceSpan),
+    ]);
+    this.visitAll([block.children]);
+  }
+
   visitVariable(variable: t.Variable) {
     this.result.push([
       'Variable',

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -59,6 +59,11 @@ class R3AstHumanizer implements t.Visitor<void> {
     this.visitAll([content.attributes, content.children]);
   }
 
+  visitContentBlock(block: t.ContentBlock) {
+    this.result.push(['ContentBlock', block.name]);
+    this.visitAll([block.children]);
+  }
+
   visitVariable(variable: t.Variable) {
     this.result.push(['Variable', variable.name, variable.value]);
   }
@@ -3009,5 +3014,37 @@ describe('R3 template transform', () => {
     const template = `<ng-container *ngIf"test" [ngTemplateOutlet]="foo"></ng-container>`;
     const errors = parse(template, {ignoreError: true}).errors;
     expect(errors.length).toBe(0);
+  });
+
+  describe('@content blocks', () => {
+    it('should parse a valid @content block', () => {
+      expectFromHtml(`
+        @content(icon) {
+          <span>Icon content</span>
+        }
+      `).toEqual([
+        ['ContentBlock', 'icon'],
+        ['Element', 'span'],
+        ['Text', 'Icon content'],
+      ]);
+    });
+
+    it('should error on invalid name', () => {
+      expect(() => parse(`@content(inv-alid) {}`)).toThrowError(
+        /@content name must be a valid JavaScript identifier/,
+      );
+    });
+
+    it('should error if @content block has missing parameter', () => {
+      expect(() => parse(`@content {}`)).toThrowError(
+        /@content block must have exactly one parameter/,
+      );
+    });
+
+    it('should error if @content block has multiple parameters', () => {
+      expect(() => parse(`@content(icon, text) {}`)).toThrowError(
+        /@content block must have exactly one parameter/,
+      );
+    });
   });
 });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -61,7 +61,7 @@ class R3AstHumanizer implements t.Visitor<void> {
 
   visitContentBlock(block: t.ContentBlock) {
     this.result.push(['ContentBlock', block.name]);
-    this.visitAll([block.children]);
+    this.visitAll([block.variables, block.children]);
   }
 
   visitVariable(variable: t.Variable) {
@@ -3037,13 +3037,45 @@ describe('R3 template transform', () => {
 
     it('should error if @content block has missing parameter', () => {
       expect(() => parse(`@content {}`)).toThrowError(
-        /@content block must have exactly one parameter/,
+        /@content block must have one or two parameters/,
       );
     });
 
     it('should error if @content block has multiple parameters', () => {
       expect(() => parse(`@content(icon, text) {}`)).toThrowError(
-        /@content block must have exactly one parameter/,
+        /@content block must have exactly one name parameter/,
+      );
+    });
+
+    it('should parse a valid @content block with variables', () => {
+      expectFromHtml(`
+        @content(icon; let a, b) {
+          <span>Icon content</span>
+        }
+      `).toEqual([
+        ['ContentBlock', 'icon'],
+        ['Variable', 'a', ''],
+        ['Variable', 'b', ''],
+        ['Element', 'span'],
+        ['Text', 'Icon content'],
+      ]);
+    });
+
+    it('should error if a variable is assigned a value', () => {
+      expect(() => parse(`@content(icon; let a = 123) {}`)).toThrowError(
+        /@content block variables cannot be assigned a value/,
+      );
+      expect(() => parse(`@content(icon; let a, b = something) {}`)).toThrowError(
+        /@content block variables cannot be assigned a value/,
+      );
+    });
+
+    it('should error on invalid variable name', () => {
+      expect(() => parse(`@content(icon; let inv-alid) {}`)).toThrowError(
+        /Variable name "inv-alid" must be a valid JavaScript identifier/,
+      );
+      expect(() => parse(`@content(icon; let a, inv-alid) {}`)).toThrowError(
+        /Variable name "inv-alid" must be a valid JavaScript identifier/,
       );
     });
   });

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -258,6 +258,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     t.visitAll(this, ast.inputs);
     t.visitAll(this, ast.outputs);
   }
+
+  visitContentBlock(block: t.ContentBlock) {
+    t.visitAll(this, block.children);
+  }
 }
 
 /**

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -37,6 +37,7 @@ import type {
   TmplAstTextAttribute,
   TmplAstUnknownBlock,
   TmplAstVariable,
+  TmplAstContentBlock,
 } from '@angular/compiler';
 
 /**
@@ -89,6 +90,7 @@ export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
   visitComponent(component: TmplAstComponent): void {}
   visitDirective(directive: TmplAstDirective): void {}
   visitSwitchExhaustiveCheck(block: TmplAstSwitchExhaustiveCheck): void {}
+  visitContentBlock(block: TmplAstContentBlock): void {}
 
   /**
    * Visits all the provided nodes in order using this Visitor's visit methods.

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -151,6 +151,7 @@ export {
   ɵɵelementEnd,
   ɵɵelementStart,
   ɵɵforeignComponent,
+  ɵɵforeignContent,
   ɵɵenableBindings,
   ɵɵExternalStylesFeature,
   ɵɵFactoryDeclaration,

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -152,6 +152,7 @@ export {
   ɵɵelementStart,
   ɵɵforeignComponent,
   ɵɵforeignContent,
+  ɵɵforeignContentFn,
   ɵɵenableBindings,
   ɵɵExternalStylesFeature,
   ɵɵFactoryDeclaration,

--- a/packages/core/src/interface/foreign_component.ts
+++ b/packages/core/src/interface/foreign_component.ts
@@ -10,8 +10,21 @@
 export const RENDER: unique symbol = Symbol('RENDER');
 
 /**
- * Represents a component from another framework that Angular can import and render.
+ * A function used to render a foreign component in an Angular template.
+ *
+ * The function accepts the component's properties as its only argument. It should return an array
+ * of nodes rendered and owned by the foreign component. It may also return a callback to perform
+ * any necessary cleanup when the component is destroyed.
+ *
+ * @template TProps The properties of the foreign component.
  */
-export interface ForeignComponent {
-  readonly [RENDER]: Function;
+export type ForeignRenderFn<TProps> = (props: TProps) => [Node[], VoidFunction?];
+
+/**
+ * Represents a component from another framework that Angular can import and render.
+ *
+ * @template TProps The properties of the foreign component.
+ */
+export interface ForeignComponent<TProps> {
+  readonly [RENDER]: ForeignRenderFn<TProps>;
 }

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -648,7 +648,7 @@ export interface Component extends Directive {
    *
    * @internal // 3p-only
    */
-  foreignImports?: ForeignComponent[];
+  foreignImports?: ForeignComponent<any>[];
 
   /**
    * The `deferredImports` property specifies a standalone component's template dependencies,

--- a/packages/core/src/render3/collect_native_nodes.ts
+++ b/packages/core/src/render3/collect_native_nodes.ts
@@ -8,11 +8,19 @@
 
 import {assertParentView} from './assert';
 import {icuContainerIterate} from './i18n/i18n_tree_shaking';
-import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags, NATIVE} from './interfaces/container';
 import {TIcuContainerNode, TNode, TNodeType} from './interfaces/node';
 import {RNode} from './interfaces/renderer_dom';
 import {isLContainer} from './interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, HOST, LView, TVIEW, TView, TViewType} from './interfaces/view';
+import {
+  DECLARATION_COMPONENT_VIEW,
+  FLAGS,
+  HOST,
+  LView,
+  TVIEW,
+  TView,
+  TViewType,
+} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {getProjectionNodes} from './node_manipulation';
 import {getLViewParent, unwrapRNode} from './util/view_utils';
@@ -60,7 +68,7 @@ export function collectNativeNodes(
     // A given lNode can represent either a native node or a LContainer (when it is a host of a
     // ViewContainerRef). When we find a LContainer we need to descend into it to collect root nodes
     // from the views in this container.
-    if (isLContainer(lNode)) {
+    if (isLContainer(lNode) && !(lNode[FLAGS] & LContainerFlags.LogicalOnly)) {
       collectNativeNodesInLContainer(lNode, result);
     }
 

--- a/packages/core/src/render3/dom_node_manipulation.ts
+++ b/packages/core/src/render3/dom_node_manipulation.ts
@@ -46,7 +46,7 @@ export function createElementNode(
  */
 export function nativeInsertBefore(
   renderer: Renderer,
-  parent: RElement,
+  parent: RNode,
   child: RNode,
   beforeNode: RNode | null,
   isMove: boolean,

--- a/packages/core/src/render3/foreign_import.ts
+++ b/packages/core/src/render3/foreign_import.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ForeignComponent, RENDER} from '../interface/foreign_component';
+import {ForeignComponent, ForeignRenderFn, RENDER} from '../interface/foreign_component';
 
 /**
  * Returns a {@link ForeignComponent} for use in Angular components.
  *
+ * @template TProps The properties of the foreign component.
  * @param render A function that renders a foreign component.
  */
-export function foreignImport(render: Function): ForeignComponent {
+export function foreignImport<TProps>(render: ForeignRenderFn<TProps>): ForeignComponent<TProps> {
   return {[RENDER]: render};
 }

--- a/packages/core/src/render3/foreign_view.ts
+++ b/packages/core/src/render3/foreign_view.ts
@@ -106,8 +106,12 @@ export function createForeignView(lContainer: LContainer, index: number): Foreig
   // 5. "Render" the view by creating the head and tail nodes, populating their slots, and marking
   // the view as created. This last step is normally handled by `renderView()` for native Angular
   // views with template functions.
-  const headComment = (lView[headTNode.index] = renderer.createComment(''));
-  const tailComment = (lView[tailTNode.index] = renderer.createComment(''));
+  const headComment = (lView[headTNode.index] = renderer.createComment(
+    ngDevMode ? 'foreign-view-head' : '',
+  ));
+  const tailComment = (lView[tailTNode.index] = renderer.createComment(
+    ngDevMode ? 'foreign-view-tail' : '',
+  ));
   lView[FLAGS] &= ~LViewFlags.CreationMode;
 
   // 6. Insert the view into the container

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -85,6 +85,7 @@ export {
   ɵɵelementStart,
   ɵɵforeignComponent,
   ɵɵforeignContent,
+  ɵɵforeignContentFn,
   ɵɵgetCurrentView,
   ɵɵdomProperty,
   ɵɵinjectAttribute,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -84,6 +84,7 @@ export {
   ɵɵelementEnd,
   ɵɵelementStart,
   ɵɵforeignComponent,
+  ɵɵforeignContent,
   ɵɵgetCurrentView,
   ɵɵdomProperty,
   ɵɵinjectAttribute,

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -25,23 +25,25 @@ import {createAndRenderEmbeddedLView} from '../view_manipulation';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {assertLContainer} from '../assert';
 import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags} from '../interfaces/container';
+import {getConstant} from '../util/view_utils';
 
 /**
  * Creation phase instruction to render a foreign component.
  *
  * @param index The index of the container in the data array.
- * @param foreignComponent The matched foreign component.
+ * @param foreignComponentIndex The index of the matched foreign component in the constant pool.
  * @param props Aggregate properties and static attributes.
  * @codeGenApi
  */
 export function ɵɵforeignComponent(
   index: number,
-  foreignComponent: ForeignComponent<any>,
+  foreignComponentIndex: number,
   props?: any,
 ): void {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
+  const foreignComponent = getConstant<ForeignComponent<any>>(tView.consts, foreignComponentIndex)!;
 
   // 1. Get or create TNode for this container slot
   let tNode: TContainerNode;

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -6,7 +6,21 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ForeignComponent} from '../../interface/foreign_component';
+import {ForeignComponent, RENDER} from '../../interface/foreign_component';
+import {attachPatchData} from '../context_discovery';
+import {nativeInsertBefore} from '../dom_node_manipulation';
+import {createForeignView} from '../foreign_view';
+import {TContainerNode, TNodeType} from '../interfaces/node';
+import {HEADER_OFFSET, RENDERER} from '../interfaces/view';
+import {appendChild} from '../node_manipulation';
+import {getLView, getTView, setCurrentTNodeAsNotParent} from '../state';
+import {getOrCreateTNode} from '../tnode_manipulation';
+import {addToEndOfViewTree} from '../view/construction';
+import {createLContainer} from '../view/container';
+import {NodeInjector} from '../di';
+import {runInInjectionContext} from '../../di';
+import {Renderer} from '../interfaces/renderer';
+import {RNode} from '../interfaces/renderer_dom';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -16,10 +30,54 @@ import {ForeignComponent} from '../../interface/foreign_component';
  * @param props Aggregate properties and static attributes.
  * @codeGenApi
  */
-export function ɵɵforeignComponent<TProps>(
+export function ɵɵforeignComponent(
   index: number,
-  foreignComponent: ForeignComponent,
-  props: TProps,
+  foreignComponent: ForeignComponent<any>,
+  props?: any,
 ): void {
-  // No-op for now!
+  const lView = getLView();
+  const tView = getTView();
+  const adjustedIndex = index + HEADER_OFFSET;
+
+  // 1. Get or create TNode for this container slot
+  let tNode: TContainerNode;
+  if (tView.firstCreatePass) {
+    tNode = getOrCreateTNode(tView, adjustedIndex, TNodeType.Container, null, null);
+  } else {
+    tNode = tView.data[adjustedIndex] as TContainerNode;
+  }
+  // `getOrCreateTNode` unconditionally sets the current node as a parent node, which it is not.
+  setCurrentTNodeAsNotParent();
+
+  // 2. Create the anchor node in the DOM
+  const renderer = lView[RENDERER] as Renderer;
+  const comment = renderer.createComment(ngDevMode ? 'foreign-component' : '');
+  appendChild(tView, lView, comment, tNode);
+  attachPatchData(comment, lView);
+
+  // 3. Create the hosting LContainer
+  const lContainer = createLContainer(comment, lView, comment, tNode);
+  lView[adjustedIndex] = lContainer;
+  addToEndOfViewTree(lView, lContainer);
+
+  // 4. Create the Foreign View and insert it at index 0 of the container
+  const viewRef = createForeignView(lContainer, 0);
+
+  // 5. Call the RENDER function to get the nodes and DisposeFn
+  const injector = new NodeInjector(tNode, lView);
+  const [nodes, dispose] = runInInjectionContext(injector, () => foreignComponent[RENDER](props));
+
+  // 6. Insert the returned nodes into the foreign view, between its head and tail comment anchors.
+  const tail = viewRef.tail as RNode;
+  const parent = tail.parentNode;
+  if (parent) {
+    for (let i = 0; i < nodes.length; i++) {
+      nativeInsertBefore(renderer, parent, nodes[i], tail, false);
+    }
+  }
+
+  // 7. Register the DisposeFn in the foreign view's LView destroy hooks.
+  if (dispose) {
+    viewRef.onDestroy(dispose);
+  }
 }

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -13,7 +13,7 @@ import {createForeignView} from '../foreign_view';
 import {TContainerNode, TNodeType} from '../interfaces/node';
 import {HEADER_OFFSET, RENDERER} from '../interfaces/view';
 import {appendChild} from '../node_manipulation';
-import {getLView, getTView, setCurrentTNodeAsNotParent} from '../state';
+import {getLView, getTView, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
 import {addToEndOfViewTree} from '../view/construction';
 import {createLContainer} from '../view/container';
@@ -43,11 +43,12 @@ export function ɵɵforeignComponent(
   let tNode: TContainerNode;
   if (tView.firstCreatePass) {
     tNode = getOrCreateTNode(tView, adjustedIndex, TNodeType.Container, null, null);
+    // `getOrCreateTNode` unconditionally sets the current node as a parent node, which it is not.
+    setCurrentTNodeAsNotParent();
   } else {
     tNode = tView.data[adjustedIndex] as TContainerNode;
+    setCurrentTNode(tNode, false);
   }
-  // `getOrCreateTNode` unconditionally sets the current node as a parent node, which it is not.
-  setCurrentTNodeAsNotParent();
 
   // 2. Create the anchor node in the DOM
   const renderer = lView[RENDERER] as Renderer;

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -20,11 +20,11 @@ import {createLContainer, addLViewToLContainer} from '../view/container';
 import {NodeInjector} from '../di';
 import {runInInjectionContext} from '../../di';
 import {Renderer} from '../interfaces/renderer';
-import {RElement, RNode} from '../interfaces/renderer_dom';
+import {RNode} from '../interfaces/renderer_dom';
 import {createAndRenderEmbeddedLView} from '../view_manipulation';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {assertLContainer} from '../assert';
-import {LContainer, LContainerFlags} from '../interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer, LContainerFlags} from '../interfaces/container';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -114,4 +114,40 @@ export function ɵɵforeignContent(index: number): any[] {
   // Extract and return the root nodes of the created view
   const embeddedTView = embeddedLView[TVIEW];
   return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
+}
+
+/**
+ * Creation phase instruction to return a function for rendering foreign content dynamically
+ * with arguments.
+ *
+ * @param index The index of the container in the data array.
+ * @codeGenApi
+ */
+export function ɵɵforeignContentFn(index: number): (...args: any[]) => any[] {
+  const lView = getLView();
+  const adjustedIndex = index + HEADER_OFFSET;
+
+  // The template is already declared at adjustedIndex, so lContainer must exist.
+  const lContainer = lView[adjustedIndex] as LContainer;
+  ngDevMode && assertLContainer(lContainer);
+  lContainer[FLAGS] |= LContainerFlags.LogicalOnly;
+
+  const tView = getTView();
+  const tNode = tView.data[adjustedIndex] as TContainerNode;
+
+  return (...args: any[]) => {
+    // When the function is called, instantiate and render a new embedded view inside the container.
+    // The arguments are passed directly as the context of the view.
+    const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, args);
+    addLViewToLContainer(
+      lContainer,
+      embeddedLView,
+      lContainer.length - CONTAINER_HEADER_OFFSET,
+      /* addToDOM */ false,
+    );
+
+    // Extract and return the root nodes of the created view
+    const embeddedTView = embeddedLView[TVIEW];
+    return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
+  };
 }

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -11,16 +11,20 @@ import {attachPatchData} from '../context_discovery';
 import {nativeInsertBefore} from '../dom_node_manipulation';
 import {createForeignView} from '../foreign_view';
 import {TContainerNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, RENDERER} from '../interfaces/view';
+import {HEADER_OFFSET, RENDERER, TVIEW} from '../interfaces/view';
 import {appendChild} from '../node_manipulation';
 import {getLView, getTView, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
 import {addToEndOfViewTree} from '../view/construction';
-import {createLContainer} from '../view/container';
+import {createLContainer, addLViewToLContainer} from '../view/container';
 import {NodeInjector} from '../di';
 import {runInInjectionContext} from '../../di';
 import {Renderer} from '../interfaces/renderer';
 import {RNode} from '../interfaces/renderer_dom';
+import {createAndRenderEmbeddedLView} from '../view_manipulation';
+import {collectNativeNodes} from '../collect_native_nodes';
+import {assertLContainer} from '../assert';
+import {LContainer} from '../interfaces/container';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -81,4 +85,32 @@ export function ɵɵforeignComponent(
   if (dispose) {
     viewRef.onDestroy(dispose);
   }
+}
+
+/**
+ * Creation phase instruction to render foreign content (children of a foreign component)
+ * and extract its root DOM nodes.
+ *
+ * @param index The index of the container in the data array.
+ * @codeGenApi
+ */
+export function ɵɵforeignContent(index: number): any[] {
+  const lView = getLView();
+  const adjustedIndex = index + HEADER_OFFSET;
+
+  // The template is already declared at adjustedIndex, so lContainer must exist.
+  const lContainer = lView[adjustedIndex] as LContainer;
+  ngDevMode && assertLContainer(lContainer);
+
+  const tView = getTView();
+  const tNode = tView.data[adjustedIndex] as TContainerNode;
+
+  // Instantiate and render the embedded view inside the container,
+  // but do NOT add its elements to the DOM at the container anchor.
+  const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null);
+  addLViewToLContainer(lContainer, embeddedLView, 0, /* addToDOM */ false);
+
+  // Extract and return the root nodes of the created view
+  const embeddedTView = embeddedLView[TVIEW];
+  return collectNativeNodes(embeddedTView, embeddedLView, embeddedTView.firstChild, []);
 }

--- a/packages/core/src/render3/instructions/foreign_component.ts
+++ b/packages/core/src/render3/instructions/foreign_component.ts
@@ -11,7 +11,7 @@ import {attachPatchData} from '../context_discovery';
 import {nativeInsertBefore} from '../dom_node_manipulation';
 import {createForeignView} from '../foreign_view';
 import {TContainerNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, RENDERER, TVIEW} from '../interfaces/view';
+import {HEADER_OFFSET, RENDERER, TVIEW, FLAGS} from '../interfaces/view';
 import {appendChild} from '../node_manipulation';
 import {getLView, getTView, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {getOrCreateTNode} from '../tnode_manipulation';
@@ -20,11 +20,11 @@ import {createLContainer, addLViewToLContainer} from '../view/container';
 import {NodeInjector} from '../di';
 import {runInInjectionContext} from '../../di';
 import {Renderer} from '../interfaces/renderer';
-import {RNode} from '../interfaces/renderer_dom';
+import {RElement, RNode} from '../interfaces/renderer_dom';
 import {createAndRenderEmbeddedLView} from '../view_manipulation';
 import {collectNativeNodes} from '../collect_native_nodes';
 import {assertLContainer} from '../assert';
-import {LContainer} from '../interfaces/container';
+import {LContainer, LContainerFlags} from '../interfaces/container';
 
 /**
  * Creation phase instruction to render a foreign component.
@@ -77,7 +77,7 @@ export function ɵɵforeignComponent(
   const parent = tail.parentNode;
   if (parent) {
     for (let i = 0; i < nodes.length; i++) {
-      nativeInsertBefore(renderer, parent, nodes[i], tail, false);
+      nativeInsertBefore(renderer, parent, nodes[i], tail, true);
     }
   }
 
@@ -101,12 +101,13 @@ export function ɵɵforeignContent(index: number): any[] {
   // The template is already declared at adjustedIndex, so lContainer must exist.
   const lContainer = lView[adjustedIndex] as LContainer;
   ngDevMode && assertLContainer(lContainer);
+  lContainer[FLAGS] |= LContainerFlags.LogicalOnly;
 
   const tView = getTView();
   const tNode = tView.data[adjustedIndex] as TContainerNode;
 
-  // Instantiate and render the embedded view inside the container,
-  // but do NOT add its elements to the DOM at the container anchor.
+  // Instantiate and render the embedded view inside the container, but do not add its elements to
+  // the DOM at the container anchor since the nodes will be projected into a foreign view.
   const embeddedLView = createAndRenderEmbeddedLView(lView, tNode, null);
   addLViewToLContainer(lContainer, embeddedLView, 0, /* addToDOM */ false);
 

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -127,4 +127,10 @@ export const enum LContainerFlags {
    * This flag, once set, is never unset for the `LContainer`.
    */
   HasTransplantedViews = 1 << 1,
+
+  /**
+   * Flag to signify that this `LContainer` is logical-only and its views should not be added
+   * to or removed from the rendering tree by the platform renderer.
+   */
+  LogicalOnly = 1 << 2,
 }

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -9,6 +9,7 @@ import {Type} from '../../interface/type';
 import {KeyValueArray} from '../../util/array_utils';
 import {TStylingRange} from '../interfaces/styling';
 import {AttributeMarker} from './attribute_marker';
+import {ForeignComponent} from '../../interface/foreign_component';
 
 import {TIcu} from './i18n';
 import {CssSelector} from './projection';
@@ -226,8 +227,9 @@ export type TAttributes = (string | AttributeMarker | CssSelector)[];
  * - Attribute arrays.
  * - Local definition arrays.
  * - Translated messages (i18n).
+ * - Foreign components.
  */
-export type TConstants = (TAttributes | string)[];
+export type TConstants = (TAttributes | string | ForeignComponent<any>)[];
 
 /**
  * Factory function that returns an array of consts. Consts can be represented as a function in

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -57,6 +57,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵelement': r3.ɵɵelement,
   'ɵɵforeignComponent': r3.ɵɵforeignComponent,
   'ɵɵforeignContent': r3.ɵɵforeignContent,
+  'ɵɵforeignContentFn': r3.ɵɵforeignContentFn,
   'ɵɵelementContainerStart': r3.ɵɵelementContainerStart,
   'ɵɵelementContainerEnd': r3.ɵɵelementContainerEnd,
   'ɵɵdomElement': r3.ɵɵdomElement,

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -56,6 +56,7 @@ export const angularCoreEnv: {[name: string]: unknown} = (() => ({
   'ɵɵelementEnd': r3.ɵɵelementEnd,
   'ɵɵelement': r3.ɵɵelement,
   'ɵɵforeignComponent': r3.ɵɵforeignComponent,
+  'ɵɵforeignContent': r3.ɵɵforeignContent,
   'ɵɵelementContainerStart': r3.ɵɵelementContainerStart,
   'ɵɵelementContainerEnd': r3.ɵɵelementContainerEnd,
   'ɵɵdomElement': r3.ɵɵdomElement,

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -35,7 +35,13 @@ import {
   nativeRemoveNode,
 } from './dom_node_manipulation';
 import {icuContainerIterate} from './i18n/i18n_tree_shaking';
-import {CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS, NATIVE} from './interfaces/container';
+import {
+  CONTAINER_HEADER_OFFSET,
+  LContainer,
+  LContainerFlags,
+  MOVED_VIEWS,
+  NATIVE,
+} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {NodeInjectorFactory} from './interfaces/injector';
 import {unregisterLView} from './interfaces/lview_tracking';
@@ -1081,6 +1087,9 @@ function applyContainer(
       tNode,
       beforeNode,
     );
+  }
+  if ((lContainer[FLAGS] & LContainerFlags.LogicalOnly) !== 0) {
+    return;
   }
   for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
     const lView = lContainer[i] as LView;

--- a/packages/core/test/acceptance/foreign_component/BUILD.bazel
+++ b/packages/core/test/acceptance/foreign_component/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//tools:defaults.bzl", "angular_jasmine_test", "ng_project", "ng_web_test_suite")
+
+package(default_visibility = ["//visibility:private"])
+
+ng_project(
+    name = "foreign_component_test_lib",
+    testonly = True,
+    srcs = glob(["**/*.ts"]),
+    visibility = ["//:__pkg__"],
+    deps = [
+        "//packages/core",
+        "//packages/core/src/interface",
+        "//packages/core/testing",
+    ],
+)
+
+angular_jasmine_test(
+    name = "foreign_component",
+    data = [
+        ":foreign_component_test_lib",
+        "//:node_modules/source-map",
+    ],
+)
+
+ng_web_test_suite(
+    name = "foreign_component_web",
+    deps = [
+        ":foreign_component_test_lib",
+    ],
+)

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -23,29 +23,6 @@ function FancyButton(props: {children: Node[]}): Node[] {
   return [button];
 }
 
-// TODO: support this inline.
-function InnerComp(props: {renderHeader: (innerMsg: string) => Node[]; children: Node[]}): Node[] {
-  const inner = document.createElement('div');
-  inner.className = 'inner';
-
-  const headerDiv = document.createElement('div');
-  headerDiv.className = 'inner-header';
-  const headerNodes = props.renderHeader('Inner Msg');
-  for (const child of headerNodes) {
-    headerDiv.appendChild(child);
-  }
-  inner.appendChild(headerDiv);
-
-  const bodyDiv = document.createElement('div');
-  bodyDiv.className = 'inner-body';
-  for (const child of props.children) {
-    bodyDiv.appendChild(child);
-  }
-  inner.appendChild(bodyDiv);
-
-  return [inner];
-}
-
 describe('foreign components', () => {
   describe('content projection', () => {
     it('should update foreign content', async () => {
@@ -481,6 +458,31 @@ describe('foreign components', () => {
           outer.appendChild(node);
         }
         return [outer];
+      }
+
+      function InnerComp(props: {
+        renderHeader: (innerMsg: string) => Node[];
+        children: Node[];
+      }): Node[] {
+        const inner = document.createElement('div');
+        inner.className = 'inner';
+
+        const headerDiv = document.createElement('div');
+        headerDiv.className = 'inner-header';
+        const headerNodes = props.renderHeader('Inner Msg');
+        for (const child of headerNodes) {
+          headerDiv.appendChild(child);
+        }
+        inner.appendChild(headerDiv);
+
+        const bodyDiv = document.createElement('div');
+        bodyDiv.className = 'inner-body';
+        for (const child of props.children) {
+          bodyDiv.appendChild(child);
+        }
+        inner.appendChild(bodyDiv);
+
+        return [inner];
       }
 
       @Component({

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -23,6 +23,29 @@ function FancyButton(props: {children: Node[]}): Node[] {
   return [button];
 }
 
+// TODO: support this inline.
+function InnerComp(props: {renderHeader: (innerMsg: string) => Node[]; children: Node[]}): Node[] {
+  const inner = document.createElement('div');
+  inner.className = 'inner';
+
+  const headerDiv = document.createElement('div');
+  headerDiv.className = 'inner-header';
+  const headerNodes = props.renderHeader('Inner Msg');
+  for (const child of headerNodes) {
+    headerDiv.appendChild(child);
+  }
+  inner.appendChild(headerDiv);
+
+  const bodyDiv = document.createElement('div');
+  bodyDiv.className = 'inner-body';
+  for (const child of props.children) {
+    bodyDiv.appendChild(child);
+  }
+  inner.appendChild(bodyDiv);
+
+  return [inner];
+}
+
 describe('foreign components', () => {
   describe('content projection', () => {
     it('should update foreign content', async () => {
@@ -275,18 +298,18 @@ describe('foreign components', () => {
 
       expect(fixture.nativeElement.innerHTML).toBe(
         '' +
-          '<!--container-->' +
-          '<!--foreign-view-head-->' +
+          '<!--container-->' + // @content(children) (implicit)
+          '<!--foreign-view-head-->' + // <SimpleWrapper>
           '<div class="wrapper">' +
-          '<!--container-->' +
-          '<!--foreign-component-->' +
-          '<!--foreign-view-head-->' +
+          '<!--container-->' + // @content(children) (implicit)
+          '<!--foreign-component-->' + // TODO: fix after https://github.com/angular/angular/pull/69099.
+          '<!--foreign-view-head-->' + // <FancyButton>
           '<button>' +
           '<span id="text">Inside wrapper button</span>' +
           '</button>' +
-          '<!--foreign-view-tail-->' +
+          '<!--foreign-view-tail-->' + // </FancyButton>
           '</div>' +
-          '<!--foreign-view-tail-->' +
+          '<!--foreign-view-tail-->' + // </SimpleWrapper>
           '<!--foreign-component-->',
       );
     });
@@ -327,6 +350,178 @@ describe('foreign components', () => {
           '<!--foreign-view-tail-->' +
           '<!--foreign-component-->' +
           '</angular-wrapper>',
+      );
+    });
+
+    it('should support zero parameter callback', async () => {
+      function FancyList(props: {renderHeader: () => Node[]}): Node[] {
+        const div = document.createElement('div');
+        const headerNodes = props.renderHeader();
+
+        for (const node of headerNodes) {
+          div.appendChild(node);
+        }
+
+        return [div];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyList>
+            @content(renderHeader; let _) {
+              <span>Header Content</span>
+            }
+          </FancyList>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyList)],
+      })
+      class TestNoParamContentFn {}
+
+      const fixture = TestBed.createComponent(TestNoParamContentFn);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<!--container-->' + // for @content(renderHeader)
+          '<!--foreign-view-head-->' +
+          '<div><span>Header Content</span></div>' +
+          '<!--foreign-view-tail-->' +
+          '<!--foreign-component-->',
+      );
+    });
+
+    it('should support a single parameter callback', async () => {
+      function FancyList(props: {renderItem: (item: string) => Node[]}): Node[] {
+        const div = document.createElement('div');
+        const itemNodes = props.renderItem('Hello Single');
+
+        for (const node of itemNodes) {
+          div.appendChild(node);
+        }
+
+        return [div];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyList>
+            @content(renderItem; let item) {
+              <span>{{ item }}</span>
+            }
+          </FancyList>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyList)],
+      })
+      class TestOneParamContentFn {}
+
+      const fixture = TestBed.createComponent(TestOneParamContentFn);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<!--container-->' + // for @content(renderItem)
+          '<!--foreign-view-head-->' +
+          '<div><span>Hello Single</span></div>' +
+          '<!--foreign-view-tail-->' +
+          '<!--foreign-component-->',
+      );
+    });
+
+    it('should support multiple parameter callback', async () => {
+      function FancyTable(props: {
+        renderRow: (row: string, index: number, isLast: boolean) => Node[];
+      }): Node[] {
+        const div = document.createElement('div');
+        const nodes = props.renderRow('RowA', 0, false);
+
+        for (const node of nodes) {
+          div.appendChild(node);
+        }
+
+        return [div];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyTable>
+            @content(renderRow; let row, idx, isLast) {
+              <span>{{ idx }} - {{ row }} (Last: {{ isLast }})</span>
+            }
+          </FancyTable>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyTable)],
+      })
+      class TestManyParamsContentFn {}
+
+      const fixture = TestBed.createComponent(TestManyParamsContentFn);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<!--container-->' + // for @content(renderRow)
+          '<!--foreign-view-head-->' +
+          '<div><span>0 - RowA (Last: false)</span></div>' +
+          '<!--foreign-view-tail-->' +
+          '<!--foreign-component-->',
+      );
+    });
+
+    it('should support nested callbacks', async () => {
+      function OuterComp(props: {renderContent: (msg: string) => Node[]}): Node[] {
+        const outer = document.createElement('div');
+        outer.className = 'outer';
+        const nodes = props.renderContent('Outer Msg');
+        for (const node of nodes) {
+          outer.appendChild(node);
+        }
+        return [outer];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <OuterComp>
+            @content(renderContent; let message) {
+              <InnerComp>
+                @content(renderHeader; let innerMessage) {
+                  {{ message }} - {{ innerMessage }}
+                }
+                Body Content
+              </InnerComp>
+            }
+          </OuterComp>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(OuterComp), frameworkImport(InnerComp)],
+      })
+      class TestDeepNestedContentFn {}
+
+      const fixture = TestBed.createComponent(TestDeepNestedContentFn);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<!--container-->' + // @content(renderContent)
+          '<!--foreign-view-head-->' + // <OuterComp>
+          '<div class="outer">' +
+          '<!--container-->' + // @content(renderHeader)
+          '<!--container-->' + // @content(children) (implicit)
+          '<!--foreign-component-->' + // TODO: fix after https://github.com/angular/angular/pull/69099.
+          '<!--foreign-view-head-->' + // <InnerComp>
+          '<div class="inner">' +
+          '<div class="inner-header"> Outer Msg - Inner Msg </div>' +
+          '<div class="inner-body"> Body Content </div>' +
+          '</div>' +
+          '<!--foreign-view-tail-->' + // </InnerComp>
+          '</div>' +
+          '<!--foreign-view-tail-->' + // </OuterComp>
+          '<!--foreign-component-->',
       );
     });
   });

--- a/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
+++ b/packages/core/test/acceptance/foreign_component/foreign_component_spec.ts
@@ -1,0 +1,405 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, ElementRef, signal, viewChildren} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {ForeignComponent} from '../../../src/interface/foreign_component';
+import {foreignImport} from '../../../src/render3/foreign_import';
+
+function frameworkImport<TProps>(component: (props: TProps) => Node[]): ForeignComponent<TProps> {
+  return foreignImport((props) => [component(props)]);
+}
+
+function FancyButton(props: {children: Node[]}): Node[] {
+  const button = document.createElement('button');
+  for (const child of props.children) {
+    button.appendChild(child);
+  }
+  return [button];
+}
+
+describe('foreign components', () => {
+  describe('content projection', () => {
+    it('should update foreign content', async () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyButton>
+            <span id="icon">{{ buttonIcon() }}</span>
+          </FancyButton>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestUpdateForeignContent {
+        readonly buttonIcon = signal('⭐');
+      }
+
+      const fixture = TestBed.createComponent(TestUpdateForeignContent);
+      await fixture.whenStable();
+
+      const icon = fixture.nativeElement.querySelector('#icon');
+      expect(icon).toBeTruthy();
+      expect(icon.textContent).toBe('⭐');
+
+      fixture.componentInstance.buttonIcon.set('🔥');
+      await fixture.whenStable();
+
+      expect(icon.textContent).toBe('🔥');
+    });
+
+    it('should not reparent content to next to its original container when added to the DOM', async () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          @if (true) {
+            <FancyButton>
+              <span>⭐</span>
+            </FancyButton>
+          }
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestNoReparenting {}
+
+      const fixture = TestBed.createComponent(TestNoReparenting);
+
+      // Change detection triggers insertion of the @if view, which contains the foreign component.
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          // The container in which @content is initially rendered.
+          '<!--container-->' +
+          // The start of the foreign view created for the foreign component.
+          '<!--foreign-view-head-->' +
+          '<button>' +
+          '<span>⭐</span>' +
+          '</button>' +
+          // The end of the foreign view created for the foreign component.
+          '<!--foreign-view-tail-->' +
+          // The container in which the foreign view is rendered.
+          '<!--foreign-component-->' +
+          // The container anchor for the @if block.
+          '<!--container-->',
+      );
+    });
+
+    it('should support multiple @content blocks', async () => {
+      function Card(props: {header: Node[]; children: Node[]; footer: Node[]}): Node[] {
+        const card = document.createElement('div');
+        card.className = 'card';
+
+        const headerDiv = document.createElement('div');
+        headerDiv.className = 'header';
+        for (const child of props.header) {
+          headerDiv.appendChild(child);
+        }
+        card.appendChild(headerDiv);
+
+        const bodyDiv = document.createElement('div');
+        bodyDiv.className = 'body';
+        for (const child of props.children) {
+          bodyDiv.appendChild(child);
+        }
+        card.appendChild(bodyDiv);
+
+        const footerDiv = document.createElement('div');
+        footerDiv.className = 'footer';
+        for (const child of props.footer) {
+          footerDiv.appendChild(child);
+        }
+        card.appendChild(footerDiv);
+
+        return [card];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <Card>
+            @content(header) {
+              <h1>My Title</h1>
+            }
+            <p>Card body content</p>
+            @content(footer) {
+              <button>Close</button>
+            }
+          </Card>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(Card)],
+      })
+      class TestMultiContent {}
+
+      const fixture = TestBed.createComponent(TestMultiContent);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toContain(
+        '' +
+          // The start of the foreign view created for the foreign component.
+          '<!--foreign-view-head-->' +
+          '<div class="card">' +
+          '<div class="header">' +
+          '<h1>My Title</h1>' +
+          '</div>' +
+          '<div class="body">' +
+          '<p>Card body content</p>' +
+          '</div>' +
+          '<div class="footer">' +
+          '<button>Close</button>' +
+          '</div>' +
+          '</div>' +
+          // The end of the foreign view created for the foreign component.
+          '<!--foreign-view-tail-->' +
+          // The container in which the foreign view is rendered.
+          '<!--foreign-component-->',
+      );
+    });
+
+    it('should support conditional (@if) in projected foreign content', async () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyButton>
+            @if (show()) {
+              <span id="status">Active</span>
+            } @else {
+              <span id="status">Inactive</span>
+            }
+          </FancyButton>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestConditionalForeignContent {
+        readonly show = signal(true);
+      }
+
+      const fixture = TestBed.createComponent(TestConditionalForeignContent);
+      await fixture.whenStable();
+
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button).toBeTruthy();
+      expect(button.textContent).toContain('Active');
+      expect(button.textContent).not.toContain('Inactive');
+
+      fixture.componentInstance.show.set(false);
+      await fixture.whenStable();
+
+      expect(button.textContent).toContain('Inactive');
+      expect(button.textContent).not.toContain('Active');
+    });
+
+    it('should support loops (@for) in projected foreign content', async () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyButton>
+            @for (item of items(); track item) {
+              <span class="item">{{ item }}</span>
+            }
+          </FancyButton>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestForLoopForeignContent {
+        readonly items = signal(['A', 'B', 'C']);
+      }
+
+      const fixture = TestBed.createComponent(TestForLoopForeignContent);
+      await fixture.whenStable();
+
+      const button = fixture.nativeElement.querySelector('button');
+      expect(button).toBeTruthy();
+
+      let items = button.querySelectorAll('.item');
+      expect(items.length).toBe(3);
+      expect(items[0].textContent).toBe('A');
+      expect(items[1].textContent).toBe('B');
+      expect(items[2].textContent).toBe('C');
+
+      // 1. Reorder and remove
+      fixture.componentInstance.items.set(['C', 'A']);
+      await fixture.whenStable();
+
+      items = button.querySelectorAll('.item');
+      expect(items.length).toBe(2);
+      expect(items[0].textContent).toBe('C');
+      expect(items[1].textContent).toBe('A');
+
+      // 2. Add new item
+      fixture.componentInstance.items.set(['C', 'D', 'A']);
+      await fixture.whenStable();
+
+      items = button.querySelectorAll('.item');
+      expect(items.length).toBe(3);
+      expect(items[0].textContent).toBe('C');
+      expect(items[1].textContent).toBe('D');
+      expect(items[2].textContent).toBe('A');
+    });
+
+    it('should support projecting a foreign component into a foreign component', async () => {
+      function SimpleWrapper(props: {children: Node[]}): Node[] {
+        const div = document.createElement('div');
+        div.className = 'wrapper';
+        for (const child of props.children) {
+          div.appendChild(child);
+        }
+        return [div];
+      }
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <SimpleWrapper>
+            <FancyButton>
+              <span id="text">Inside wrapper button</span>
+            </FancyButton>
+          </SimpleWrapper>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(SimpleWrapper), frameworkImport(FancyButton)],
+      })
+      class TestNestedForeignComponents {}
+
+      const fixture = TestBed.createComponent(TestNestedForeignComponents);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<!--container-->' +
+          '<!--foreign-view-head-->' +
+          '<div class="wrapper">' +
+          '<!--container-->' +
+          '<!--foreign-component-->' +
+          '<!--foreign-view-head-->' +
+          '<button>' +
+          '<span id="text">Inside wrapper button</span>' +
+          '</button>' +
+          '<!--foreign-view-tail-->' +
+          '</div>' +
+          '<!--foreign-view-tail-->' +
+          '<!--foreign-component-->',
+      );
+    });
+
+    it('should support projecting a foreign component into an Angular component', async () => {
+      @Component({
+        selector: 'angular-wrapper',
+        template: `<ng-content />`,
+      })
+      class AngularWrapper {}
+
+      @Component({
+        selector: 'test-cmp',
+        imports: [AngularWrapper],
+        template: `
+          <angular-wrapper>
+            <FancyButton>
+              <span id="text">Inside Angular</span>
+            </FancyButton>
+          </angular-wrapper>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestProjectForeignIntoAngular {}
+
+      const fixture = TestBed.createComponent(TestProjectForeignIntoAngular);
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.innerHTML).toBe(
+        '' +
+          '<angular-wrapper>' +
+          '<!--container-->' +
+          '<!--foreign-view-head-->' +
+          '<button>' +
+          '<span id="text">Inside Angular</span>' +
+          '</button>' +
+          '<!--foreign-view-tail-->' +
+          '<!--foreign-component-->' +
+          '</angular-wrapper>',
+      );
+    });
+  });
+
+  describe('queries', () => {
+    it('should support querying elements inside projected foreign content', async () => {
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyButton>
+            @if (show()) {
+              <span #target id="icon">⭐</span>
+            }
+          </FancyButton>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestQueryForeignContent {
+        readonly show = signal(true);
+        readonly targets = viewChildren<ElementRef<HTMLSpanElement>>('target');
+      }
+
+      const fixture = TestBed.createComponent(TestQueryForeignContent);
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.targets().length).toBe(1);
+      expect(fixture.componentInstance.targets()[0].nativeElement.id).toBe('icon');
+
+      fixture.componentInstance.show.set(false);
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.targets().length).toBe(0);
+
+      fixture.componentInstance.show.set(true);
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.targets().length).toBe(1);
+      expect(fixture.componentInstance.targets()[0].nativeElement.id).toBe('icon');
+    });
+  });
+
+  describe('event handlers', () => {
+    it('should support event handlers on elements inside projected foreign content', async () => {
+      let clicked = false;
+
+      @Component({
+        selector: 'test-cmp',
+        template: `
+          <FancyButton>
+            <span id="icon" (click)="handleClick()">⭐</span>
+          </FancyButton>
+        `,
+        // @ts-ignore
+        foreignImports: [frameworkImport(FancyButton)],
+      })
+      class TestEventForeignContent {
+        handleClick() {
+          clicked = true;
+        }
+      }
+
+      const fixture = TestBed.createComponent(TestEventForeignContent);
+      await fixture.whenStable();
+
+      const icon = fixture.nativeElement.querySelector('#icon');
+      expect(icon).toBeTruthy();
+      expect(clicked).toBeFalse();
+
+      icon.click();
+      await fixture.whenStable();
+
+      expect(clicked).toBeTrue();
+    });
+  });
+});

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {ɵɵforeignComponent} from '../../src/render3/instructions/foreign_component';
+import {foreignImport} from '../../src/render3/foreign_import';
+import {destroyLView} from '../../src/render3/node_manipulation';
+import {ViewFixture} from './view_fixture';
+import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/instructions/element';
+import {inject, InjectionToken} from '../../src/di';
+import {ɵɵdefineDirective} from '../../src/render3/definition';
+import {ɵɵProvidersFeature} from '../../src/render3/features/providers_feature';
+
+describe('ɵɵforeignComponent', () => {
+  afterEach(ViewFixture.cleanUp);
+
+  it("should render a foreign component's native elements", () => {
+    const foreignComp = foreignImport(() => {
+      const el = document.createElement('div');
+      el.id = 'foreign-el';
+      el.textContent = 'Foreign Content';
+      return [[el]];
+    });
+
+    const fixture = new ViewFixture({
+      decls: 1,
+      vars: 0,
+      create: () => {
+        ɵɵforeignComponent(0, foreignComp);
+      },
+    });
+
+    expect(fixture.host.innerHTML).toContain('<div id="foreign-el">Foreign Content</div>');
+  });
+
+  it('should pass props to a foreign component', () => {
+    let passedProps: any = null;
+    const foreignComp = foreignImport<{name: string}>((props) => {
+      passedProps = props;
+      return [[]];
+    });
+
+    new ViewFixture({
+      decls: 1,
+      vars: 0,
+      create: () => {
+        ɵɵforeignComponent(0, foreignComp, {name: 'Angular'});
+      },
+    });
+
+    expect(passedProps).toEqual({name: 'Angular'});
+  });
+
+  it('should call the dispose function when the containing view is destroyed', () => {
+    let disposeCalled = false;
+    const foreignComp = foreignImport(() => {
+      return [
+        [],
+        () => {
+          disposeCalled = true;
+        },
+      ];
+    });
+
+    const fixture = new ViewFixture({
+      decls: 1,
+      vars: 0,
+      create: () => {
+        ɵɵforeignComponent(0, foreignComp);
+      },
+    });
+
+    expect(disposeCalled).toBeFalse();
+
+    destroyLView(fixture.tView, fixture.lView);
+
+    expect(disposeCalled).toBeTrue();
+  });
+
+  it('should render foreign view between sibling elements', () => {
+    const foreignComp = foreignImport(() => {
+      const el = document.createElement('div');
+      el.textContent = 'Foreign Content';
+      return [[el]];
+    });
+
+    const fixture = new ViewFixture({
+      decls: 3,
+      vars: 0,
+      create: () => {
+        ɵɵelement(0, 'p');
+        ɵɵforeignComponent(1, foreignComp);
+        ɵɵelement(2, 'span');
+      },
+    });
+
+    expect(fixture.host.innerHTML).toContain(
+      '' +
+        '<p></p>' +
+        '<!--foreign-view-head-->' +
+        '<div>Foreign Content</div>' +
+        '<!--foreign-view-tail-->' +
+        '<!--foreign-component-->' +
+        '<span></span>',
+    );
+  });
+
+  it('should render foreign view as a child of a parent element', () => {
+    const foreignComp = foreignImport(() => {
+      const el = document.createElement('span');
+      el.textContent = 'Foreign Content';
+      return [[el]];
+    });
+
+    const fixture = new ViewFixture({
+      decls: 2,
+      vars: 0,
+      create: () => {
+        ɵɵelementStart(0, 'div');
+        ɵɵforeignComponent(1, foreignComp);
+        ɵɵelementEnd();
+      },
+    });
+
+    expect(fixture.host.innerHTML).toContain(
+      '' +
+        '<div>' +
+        '<!--foreign-view-head-->' +
+        '<span>Foreign Content</span>' +
+        '<!--foreign-view-tail-->' +
+        '<!--foreign-component-->' +
+        '</div>',
+    );
+  });
+
+  it('should execute the RENDER function inside the template injection context', () => {
+    const TEST_TOKEN = new InjectionToken<string>('test-token');
+
+    const foreignComp = foreignImport(() => {
+      const value = inject(TEST_TOKEN, {optional: true}) ?? 'null';
+      const el = document.createElement('div');
+      el.id = 'foreign-el';
+      el.textContent = value;
+      return [[el]];
+    });
+
+    class ProviderDirective {
+      static ɵfac = () => new ProviderDirective();
+      static ɵdir = ɵɵdefineDirective({
+        type: ProviderDirective,
+        selectors: [['', 'provider-dir', '']],
+        features: [ɵɵProvidersFeature([{provide: TEST_TOKEN, useValue: 'templated-value'}])],
+      });
+    }
+
+    const fixture = new ViewFixture({
+      decls: 2,
+      vars: 0,
+      consts: [['provider-dir', '']],
+      directives: [ProviderDirective],
+      create: () => {
+        ɵɵelementStart(0, 'div', 0);
+        ɵɵforeignComponent(1, foreignComp);
+        ɵɵelementEnd();
+      },
+    });
+
+    expect(fixture.host.innerHTML).toContain('<div id="foreign-el">templated-value</div>');
+  });
+});

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -9,6 +9,7 @@
 import {
   ɵɵforeignComponent,
   ɵɵforeignContent,
+  ɵɵforeignContentFn,
 } from '../../src/render3/instructions/foreign_component';
 import {foreignImport} from '../../src/render3/foreign_import';
 import {destroyLView} from '../../src/render3/node_manipulation';
@@ -16,6 +17,8 @@ import {ViewFixture} from './view_fixture';
 import {ɵɵdomTemplate} from '../../src/render3/instructions/template';
 import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/instructions/element';
 import {ɵɵtext} from '../../src/render3/instructions/text';
+import {ɵɵadvance} from '../../src/render3/instructions/advance';
+import {ɵɵtextInterpolate2} from '../../src/render3/instructions/text_interpolation';
 import {inject, InjectionToken} from '../../src/di';
 import {ɵɵdefineDirective} from '../../src/render3/definition';
 import {ɵɵProvidersFeature} from '../../src/render3/features/providers_feature';
@@ -289,6 +292,58 @@ describe('ɵɵforeignComponent', () => {
         '<div id="desc-container"><p>Description Content</p></div>' +
         '<div id="children-container"><span>Main Children Content</span></div>' +
         '</div>',
+    );
+  });
+
+  it('should support passing ɵɵforeignContentFn to props', () => {
+    const foreignComp = foreignImport<{
+      renderItem: (item: string, idx: number) => Node[];
+    }>((props) => {
+      const div = document.createElement('div');
+      div.id = 'container';
+
+      const nodes1 = props.renderItem('First', 0);
+      const nodes2 = props.renderItem('Second', 1);
+
+      for (const node of nodes1) {
+        div.appendChild(node);
+      }
+      for (const node of nodes2) {
+        div.appendChild(node);
+      }
+
+      return [[div]];
+    });
+
+    const itemTemplate = (rf: number, ctx: any) => {
+      if (rf & 1) {
+        ɵɵelementStart(0, 'span');
+        ɵɵtext(1);
+        ɵɵelementEnd();
+      }
+      if (rf & 2) {
+        const item = ctx[0];
+        const index = ctx[1];
+        ɵɵadvance(1);
+        ɵɵtextInterpolate2('#', index, ': ', item);
+      }
+    };
+
+    const fixture = new ViewFixture({
+      decls: 2,
+      vars: 0,
+      create: () => {
+        ɵɵdomTemplate(0, itemTemplate, 2, 2);
+        ɵɵforeignComponent(1, foreignComp, {
+          renderItem: ɵɵforeignContentFn(0),
+        });
+      },
+    });
+
+    fixture.update(() => {});
+
+    expect(fixture.host.innerHTML).toContain(
+      '<div id="container"><span>#0: First</span><span>#1: Second</span></div>',
     );
   });
 });

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -210,36 +210,86 @@ describe('ɵɵforeignComponent', () => {
     expect(host2.innerHTML).toContain(expectedHtml);
   });
 
-  it('should render children using ɵɵforeignContent and pass root nodes to the children prop', () => {
-    const foreignComp = foreignImport<{children: Node[]}>((props) => {
-      const p = document.createElement('p');
-      // Domino doesn't implement Element.append().
-      for (const child of props.children) {
-        p.appendChild(child);
+  it('should support passing ɵɵforeignContent to props', () => {
+    const foreignComp = foreignImport<{
+      icon: Node[];
+      description: Node[];
+      children: Node[];
+    }>((props) => {
+      const div = document.createElement('div');
+      div.id = 'container';
+
+      const iconContainer = document.createElement('div');
+      iconContainer.id = 'icon-container';
+      for (const child of props.icon) {
+        iconContainer.appendChild(child);
       }
-      return [[p]];
+      div.appendChild(iconContainer);
+
+      const descContainer = document.createElement('div');
+      descContainer.id = 'desc-container';
+      for (const child of props.description) {
+        descContainer.appendChild(child);
+      }
+      div.appendChild(descContainer);
+
+      const mainChildren = document.createElement('div');
+      mainChildren.id = 'children-container';
+      for (const child of props.children) {
+        mainChildren.appendChild(child);
+      }
+      div.appendChild(mainChildren);
+
+      return [[div]];
     });
+
+    const iconTemplate = (rf: number, ctx: any) => {
+      if (rf & 1) {
+        ɵɵelementStart(0, 'span');
+        ɵɵtext(1, 'Icon Content');
+        ɵɵelementEnd();
+      }
+    };
+
+    const descriptionTemplate = (rf: number, ctx: any) => {
+      if (rf & 1) {
+        ɵɵelementStart(0, 'p');
+        ɵɵtext(1, 'Description Content');
+        ɵɵelementEnd();
+      }
+    };
 
     const childrenTemplate = (rf: number, ctx: any) => {
       if (rf & 1) {
         ɵɵelementStart(0, 'span');
-        ɵɵtext(1, 'Hello, world!');
+        ɵɵtext(1, 'Main Children Content');
         ɵɵelementEnd();
       }
     };
 
     const fixture = new ViewFixture({
-      decls: 2,
+      decls: 4,
       vars: 0,
       create: () => {
-        ɵɵdomTemplate(0, childrenTemplate, 2, 0);
-        ɵɵforeignComponent(1, foreignComp, {
-          children: ɵɵforeignContent(0),
+        ɵɵdomTemplate(0, iconTemplate, 2, 0);
+        ɵɵdomTemplate(1, descriptionTemplate, 2, 0);
+        ɵɵdomTemplate(2, childrenTemplate, 2, 0);
+        ɵɵforeignComponent(3, foreignComp, {
+          icon: ɵɵforeignContent(0),
+          description: ɵɵforeignContent(1),
+          children: ɵɵforeignContent(2),
         });
       },
     });
 
-    expect(fixture.host.innerHTML).toContain('' + '<p>' + '<span>Hello, world!</span>' + '</p>');
+    expect(fixture.host.innerHTML).toContain(
+      '' +
+        '<div id="container">' +
+        '<div id="icon-container"><span>Icon Content</span></div>' +
+        '<div id="desc-container"><p>Description Content</p></div>' +
+        '<div id="children-container"><span>Main Children Content</span></div>' +
+        '</div>',
+    );
   });
 });
 

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -14,6 +14,9 @@ import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/i
 import {inject, InjectionToken} from '../../src/di';
 import {ɵɵdefineDirective} from '../../src/render3/definition';
 import {ɵɵProvidersFeature} from '../../src/render3/features/providers_feature';
+import {createLView} from '../../src/render3/view/construction';
+import {renderView} from '../../src/render3/instructions/render';
+import {LView, LViewFlags, PARENT, RENDERER, T_HOST} from '../../src/render3/interfaces/view';
 
 describe('ɵɵforeignComponent', () => {
   afterEach(ViewFixture.cleanUp);
@@ -171,4 +174,58 @@ describe('ɵɵforeignComponent', () => {
 
     expect(fixture.host.innerHTML).toContain('<div id="foreign-el">templated-value</div>');
   });
+
+  it('should support reusing the same template between multiple view instances', () => {
+    const foreignComp1 = foreignImport(() => {
+      return [[document.createTextNode('foreign content')]];
+    });
+
+    const createFn = () => {
+      ɵɵelementStart(0, 'div');
+      ɵɵforeignComponent(1, foreignComp1);
+      ɵɵelementEnd();
+    };
+    const expectedHtml =
+      '' +
+      '<div>' +
+      '<!--foreign-view-head-->foreign content<!--foreign-view-tail-->' +
+      '<!--foreign-component-->' +
+      '</div>';
+
+    const fixture = new ViewFixture({
+      decls: 2,
+      vars: 0,
+      create: createFn,
+    });
+    expect(fixture.host.innerHTML).toContain(expectedHtml);
+
+    // Create second instance reusing the TView
+    const host2 = renderSecondInstance(fixture);
+    expect(fixture.host.innerHTML).toContain(expectedHtml);
+    expect(host2.innerHTML).toContain(expectedHtml);
+  });
 });
+
+function renderSecondInstance(fixture: ViewFixture): HTMLElement {
+  const hostLView = fixture.lView[PARENT] as LView;
+  const hostTNode = fixture.lView[T_HOST];
+  const hostRenderer = hostLView[RENDERER];
+  const host = hostRenderer.createElement('host-element') as HTMLElement;
+
+  const lView = createLView(
+    hostLView,
+    fixture.tView,
+    {},
+    LViewFlags.CheckAlways,
+    host,
+    hostTNode,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+
+  renderView(fixture.tView, lView, {});
+  return host;
+}

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -6,11 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵɵforeignComponent} from '../../src/render3/instructions/foreign_component';
+import {
+  ɵɵforeignComponent,
+  ɵɵforeignContent,
+} from '../../src/render3/instructions/foreign_component';
 import {foreignImport} from '../../src/render3/foreign_import';
 import {destroyLView} from '../../src/render3/node_manipulation';
 import {ViewFixture} from './view_fixture';
+import {ɵɵdomTemplate} from '../../src/render3/instructions/template';
 import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart} from '../../src/render3/instructions/element';
+import {ɵɵtext} from '../../src/render3/instructions/text';
 import {inject, InjectionToken} from '../../src/di';
 import {ɵɵdefineDirective} from '../../src/render3/definition';
 import {ɵɵProvidersFeature} from '../../src/render3/features/providers_feature';
@@ -203,6 +208,38 @@ describe('ɵɵforeignComponent', () => {
     const host2 = renderSecondInstance(fixture);
     expect(fixture.host.innerHTML).toContain(expectedHtml);
     expect(host2.innerHTML).toContain(expectedHtml);
+  });
+
+  it('should render children using ɵɵforeignContent and pass root nodes to the children prop', () => {
+    const foreignComp = foreignImport<{children: Node[]}>((props) => {
+      const p = document.createElement('p');
+      // Domino doesn't implement Element.append().
+      for (const child of props.children) {
+        p.appendChild(child);
+      }
+      return [[p]];
+    });
+
+    const childrenTemplate = (rf: number, ctx: any) => {
+      if (rf & 1) {
+        ɵɵelementStart(0, 'span');
+        ɵɵtext(1, 'Hello, world!');
+        ɵɵelementEnd();
+      }
+    };
+
+    const fixture = new ViewFixture({
+      decls: 2,
+      vars: 0,
+      create: () => {
+        ɵɵdomTemplate(0, childrenTemplate, 2, 0);
+        ɵɵforeignComponent(1, foreignComp, {
+          children: ɵɵforeignContent(0),
+        });
+      },
+    });
+
+    expect(fixture.host.innerHTML).toContain('' + '<p>' + '<span>Hello, world!</span>' + '</p>');
   });
 });
 

--- a/packages/core/test/render3/foreign_component_spec.ts
+++ b/packages/core/test/render3/foreign_component_spec.ts
@@ -40,8 +40,9 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 1,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
-        ɵɵforeignComponent(0, foreignComp);
+        ɵɵforeignComponent(0, 0);
       },
     });
 
@@ -58,8 +59,9 @@ describe('ɵɵforeignComponent', () => {
     new ViewFixture({
       decls: 1,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
-        ɵɵforeignComponent(0, foreignComp, {name: 'Angular'});
+        ɵɵforeignComponent(0, 0, {name: 'Angular'});
       },
     });
 
@@ -80,8 +82,9 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 1,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
-        ɵɵforeignComponent(0, foreignComp);
+        ɵɵforeignComponent(0, 0);
       },
     });
 
@@ -102,9 +105,10 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 3,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
         ɵɵelement(0, 'p');
-        ɵɵforeignComponent(1, foreignComp);
+        ɵɵforeignComponent(1, 0);
         ɵɵelement(2, 'span');
       },
     });
@@ -130,9 +134,10 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 2,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
         ɵɵelementStart(0, 'div');
-        ɵɵforeignComponent(1, foreignComp);
+        ɵɵforeignComponent(1, 0);
         ɵɵelementEnd();
       },
     });
@@ -171,11 +176,11 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 2,
       vars: 0,
-      consts: [['provider-dir', '']],
+      consts: [['provider-dir', ''], foreignComp],
       directives: [ProviderDirective],
       create: () => {
         ɵɵelementStart(0, 'div', 0);
-        ɵɵforeignComponent(1, foreignComp);
+        ɵɵforeignComponent(1, 1);
         ɵɵelementEnd();
       },
     });
@@ -190,7 +195,7 @@ describe('ɵɵforeignComponent', () => {
 
     const createFn = () => {
       ɵɵelementStart(0, 'div');
-      ɵɵforeignComponent(1, foreignComp1);
+      ɵɵforeignComponent(1, 0);
       ɵɵelementEnd();
     };
     const expectedHtml =
@@ -203,6 +208,7 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 2,
       vars: 0,
+      consts: [foreignComp1],
       create: createFn,
     });
     expect(fixture.host.innerHTML).toContain(expectedHtml);
@@ -273,11 +279,12 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 4,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
         ɵɵdomTemplate(0, iconTemplate, 2, 0);
         ɵɵdomTemplate(1, descriptionTemplate, 2, 0);
         ɵɵdomTemplate(2, childrenTemplate, 2, 0);
-        ɵɵforeignComponent(3, foreignComp, {
+        ɵɵforeignComponent(3, 0, {
           icon: ɵɵforeignContent(0),
           description: ɵɵforeignContent(1),
           children: ɵɵforeignContent(2),
@@ -332,9 +339,10 @@ describe('ɵɵforeignComponent', () => {
     const fixture = new ViewFixture({
       decls: 2,
       vars: 0,
+      consts: [foreignComp],
       create: () => {
         ɵɵdomTemplate(0, itemTemplate, 2, 2);
-        ɵɵforeignComponent(1, foreignComp, {
+        ɵɵforeignComponent(1, 0, {
           renderItem: ɵɵforeignContentFn(0),
         });
       },

--- a/packages/core/test/render3/foreign_view_spec.ts
+++ b/packages/core/test/render3/foreign_view_spec.ts
@@ -123,7 +123,17 @@ describe('foreign views', () => {
     vcr2.insert(viewRef);
 
     expect(fixture.nativeElement.innerHTML).toBe(
-      '<div></div><!--container--><div></div><!----><span></span><span></span><!----><!--container-->',
+      '' +
+        '<div></div>' +
+        // First <div> container
+        '<!--container-->' +
+        '<div></div>' +
+        // Foreign view
+        '<!--foreign-view-head-->' +
+        '<span></span><span></span>' +
+        '<!--foreign-view-tail-->' +
+        // Second <div> container
+        '<!--container-->',
     );
   });
 

--- a/packages/language-service/src/semantic_tokens.ts
+++ b/packages/language-service/src/semantic_tokens.ts
@@ -13,6 +13,7 @@ import {
   TmplAstBoundText,
   TmplAstComponent,
   TmplAstContent,
+  TmplAstContentBlock,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
@@ -139,6 +140,10 @@ class ClassificationVisitor implements TmplAstVisitor {
 
   visitContent(content: TmplAstContent) {
     this.visitAll(content.children);
+  }
+
+  visitContentBlock(block: TmplAstContentBlock) {
+    this.visitAll(block.children);
   }
 
   visitVariable(variable: TmplAstVariable) {}

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -24,6 +24,7 @@ import {
   TmplAstBoundText,
   TmplAstComponent,
   TmplAstContent,
+  TmplAstContentBlock,
   TmplAstDeferredBlock,
   TmplAstDeferredBlockError,
   TmplAstDeferredBlockLoading,
@@ -586,6 +587,10 @@ class TemplateTargetVisitor implements TmplAstVisitor {
   visitContent(content: TmplAstContent) {
     tmplAstVisitAll(this, content.attributes);
     this.visitAll(content.children);
+  }
+
+  visitContentBlock(block: TmplAstContentBlock) {
+    this.visitAll(block.children);
   }
 
   visitVariable(variable: TmplAstVariable) {


### PR DESCRIPTION
Currently, the template pipeline directly emits the raw expression for foreign component definitions (such as `frameworkImport(MyComponent)`) directly into the body of the generated template function. If a foreign component is defined inside a local scope or is non-exported (e.g. nested inside a test block), the emitted template function may not have access to that variable because `ɵɵdefineComponent` and its template functions are emitted at the top-level module scope. This previously caused reference errors during template compilation.

This commit updates the compilation pipeline to instead ingest foreign component references into the component's `consts` pool. The `ɵɵforeignComponent` runtime instruction is updated to accept an index into the constant pool rather than a raw expression. By routing the references through the `consts` pool, block-scoped classes and variables are appropriately captured by `ngtsc` without scoping errors, properly supporting nested/local foreign component usage.