### PR TITLE
ci: fix expression injection in benchmark-compare workflow

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -63,12 +63,12 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: pnpm benchmarks prepare-for-github-action "$COMMENT_BODY"
 
-      - run: pnpm benchmarks run-compare "$COMPARE_SHA" "$BENCHMARK_TARGET"
+      - env:
+          COMPARE_SHA: ${{steps.info.outputs.compareSha}}
+          BENCHMARK_TARGET: ${{steps.info.outputs.benchmarkTarget}}
+        run: pnpm benchmarks run-compare "$COMPARE_SHA" "$BENCHMARK_TARGET"
         id: benchmark
         name: Running benchmark
-        env:
-          BENCHMARK_TARGET: ${{steps.info.outputs.benchmarkTarget}}
-          COMPARE_SHA: ${{steps.info.outputs.compareSha}}
 
       - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:


### PR DESCRIPTION
The benchmark-compare workflow passes step outputs (derived from user-controlled comment.body) directly into shell:

```yaml
run: pnpm benchmarks run-compare ${{steps.info.outputs.compareSha}} "${{steps.info.outputs.benchmarkTarget}}"
```

Fix: use env vars instead.

Ref: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections