### PR TITLE
fix(compiler): more robust logic to check if regex can be optimized

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/GOLDEN_PARTIAL.js
@@ -981,6 +981,33 @@ export declare class TestComp {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: regular_expression_with_sticky_flag.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestComp {
+    value = '123';
+    static ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+    static ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: TestComp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `{{/^hello/y.test(value)}}`, isInline: true });
+}
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestComp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `{{/^hello/y.test(value)}}`,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: regular_expression_with_sticky_flag.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestComp {
+    value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: call_rest.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -318,6 +318,16 @@
       ]
     },
     {
+      "description": "should not optimize sticky regular expressions",
+      "inputFiles": ["regular_expression_with_sticky_flag.ts"],
+      "expectations": [
+        {
+          "failureMessage": "Invalid template",
+          "files": ["regular_expression_with_sticky_flag.js"]
+        }
+      ]
+    },
+    {
       "description": "should support rest arguments in a function call",
       "inputFiles": ["call_rest.ts"],
       "expectations": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag.js
@@ -1,0 +1,8 @@
+function TestComp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate(/^hello/y.test(ctx.value));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `{{/^hello/y.test(value)}}`,
+})
+export class TestComp {
+  value = '123';
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag_isolated.golden.d.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/regular_expression_with_sticky_flag_isolated.golden.d.ts
@@ -1,0 +1,6 @@
+import * as i0 from "@angular/core";
+export declare class TestComp {
+    value: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<TestComp, "ng-component", never, {}, {}, never, never, true, never>;
+}

--- a/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/regular_expression_optimization.ts
@@ -12,6 +12,9 @@ import * as ir from '../../ir';
 
 import type {CompilationJob} from '../compilation';
 
+/** Regex flags that can be safely optimized. */
+const SAFE_REGEX_FLAGS = new Set(['d', 'i', 'm', 's', 'u', 'v']);
+
 /** Optimizes regular expressions used in expressions. */
 export function optimizeRegularExpressions(job: CompilationJob): void {
   for (const view of job.units) {
@@ -19,11 +22,7 @@ export function optimizeRegularExpressions(job: CompilationJob): void {
       ir.transformExpressionsInOp(
         op,
         (expr) => {
-          if (
-            expr instanceof o.RegularExpressionLiteralExpr &&
-            // We can't optimize global regexes, because they're stateful.
-            (expr.flags === null || !expr.flags.includes('g'))
-          ) {
+          if (expr instanceof o.RegularExpressionLiteralExpr && canOptimizeRegex(expr)) {
             return job.pool.getSharedConstant(new RegularExpressionConstant(), expr);
           }
           return expr;
@@ -32,6 +31,20 @@ export function optimizeRegularExpressions(job: CompilationJob): void {
       );
     }
   }
+}
+
+function canOptimizeRegex(expr: o.RegularExpressionLiteralExpr): boolean {
+  if (!expr.flags) {
+    return true;
+  }
+
+  for (let i = 0; i < expr.flags.length; i++) {
+    if (!SAFE_REGEX_FLAGS.has(expr.flags[i])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 class RegularExpressionConstant extends GenericKeyFn implements SharedConstantDefinition {


### PR DESCRIPTION
Currently we only skip regex optimization if it has the `g` flag, however regexes can also have a state with the `y` flag.

These changes move to an allowlist model where we only optimize for a set of know flags.
