### PR TITLE
feat(router): accept readonly arrays in route configuration APIs

### DIFF
--- a/goldens/public-api/router/index.api.md
+++ b/goldens/public-api/router/index.api.md
@@ -592,7 +592,7 @@ export abstract class PreloadingStrategy {
 export const PRIMARY_OUTLET = "primary";
 
 // @public
-export function provideRouter(routes: Routes, ...features: RouterFeatures[]): EnvironmentProviders;
+export function provideRouter(routes: Readonly<Routes>, ...features: readonly RouterFeatures[]): EnvironmentProviders;
 
 // @public
 export type QueryParamsHandling = 'merge' | 'preserve' | 'replace' | '';
@@ -726,7 +726,7 @@ export class Router {
     // @deprecated
     onSameUrlNavigation: OnSameUrlNavigation;
     parseUrl(url: string): UrlTree;
-    resetConfig(config: Routes): void;
+    resetConfig(config: Readonly<Routes>): void;
     // @deprecated
     routeReuseStrategy: RouteReuseStrategy;
     get routerState(): RouterState;
@@ -884,8 +884,8 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
 // @public
 export class RouterModule {
     constructor();
-    static forChild(routes: Routes): ModuleWithProviders<RouterModule>;
-    static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterModule>;
+    static forChild(routes: Readonly<Routes>): ModuleWithProviders<RouterModule>;
+    static forRoot(routes: Readonly<Routes>, config?: ExtraOptions): ModuleWithProviders<RouterModule>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterModule, never>;
     // (undocumented)

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -101,7 +101,7 @@ import {
  * @param features Optional features to configure additional router behaviors.
  * @returns A set of providers to setup a Router.
  */
-export function provideRouter(routes: Routes, ...features: RouterFeatures[]): EnvironmentProviders {
+export function provideRouter(routes: Readonly<Routes>, ...features: readonly RouterFeatures[]): EnvironmentProviders {
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     // Publish this util when the router is provided so that the devtools can use it.
     ɵpublishExternalGlobalUtil('ɵgetLoadedRoutes', getLoadedRoutes);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -377,7 +377,7 @@ export class Router {
    * ]);
    * ```
    */
-  resetConfig(config: Routes): void {
+  resetConfig(config: Readonly<Routes>): void {
     (typeof ngDevMode === 'undefined' || ngDevMode) && validateConfig(config);
     this.config = config.map(standardizeConfig);
     this.navigated = false;

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -124,7 +124,10 @@ export class RouterModule {
    * @return The new `NgModule`.
    *
    */
-  static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterModule> {
+  static forRoot(
+    routes: Readonly<Routes>,
+    config?: ExtraOptions,
+  ): ModuleWithProviders<RouterModule> {
     return {
       ngModule: RouterModule,
       providers: [
@@ -179,7 +182,7 @@ export class RouterModule {
    * @return The new NgModule.
    *
    */
-  static forChild(routes: Routes): ModuleWithProviders<RouterModule> {
+  static forChild(routes: Readonly<Routes>): ModuleWithProviders<RouterModule> {
     return {
       ngModule: RouterModule,
       providers: [{provide: ROUTES, multi: true, useValue: routes}],

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -58,7 +58,7 @@ export function getProvidersInjector(route: Route): EnvironmentInjector | undefi
 }
 
 export function validateConfig(
-  config: Routes,
+  config: Readonly<Routes>,
   parentPath: string = '',
   requireStandaloneComponents = false,
 ): void {

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -10,7 +10,7 @@ import {Component, inject, Injectable, InjectionToken, NgModule} from '@angular/
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {timeout} from '@angular/private/testing';
-import {Router, RouterModule} from '../index';
+import {provideRouter, Route, Router, RouterModule, withInMemoryScrolling} from '../index';
 
 @Component({template: '<div>simple standalone</div>'})
 export class SimpleStandaloneComponent {}
@@ -543,6 +543,36 @@ describe('standalone in Router API', () => {
       await TestBed.inject(Router).navigateByUrl('/parent/child');
       expect(TestBed.inject(Router).url).toContain('parent/child');
     });
+  });
+});
+
+describe('readonly route configuration', () => {
+  // These tests are primarily compile-time checks: passing a `ReadonlyArray<Route>` (or a readonly
+  // array of features) to the route configuration APIs should not require casting away `readonly`.
+  const readonlyRoutes: readonly Route[] = [{path: 'simple', component: SimpleStandaloneComponent}];
+
+  it('provideRouter accepts readonly routes and features arrays', () => {
+    const features = [withInMemoryScrolling()] as const;
+    TestBed.configureTestingModule({providers: [provideRouter(readonlyRoutes, ...features)]});
+
+    expect(TestBed.inject(Router).config).toEqual([...readonlyRoutes]);
+  });
+
+  it('RouterModule.forRoot and forChild accept a readonly routes array', () => {
+    TestBed.configureTestingModule({
+      imports: [RouterModule.forRoot(readonlyRoutes), RouterModule.forChild(readonlyRoutes)],
+    });
+
+    expect(TestBed.inject(Router)).toBeDefined();
+  });
+
+  it('Router.resetConfig accepts a readonly routes array', () => {
+    TestBed.configureTestingModule({providers: [provideRouter([])]});
+    const router = TestBed.inject(Router);
+
+    router.resetConfig(readonlyRoutes);
+
+    expect(router.config.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) -> Should I add to the JSDoc that it now accepts readonly arrays?

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The route-configuration APIs (`provideRouter`, `RouterModule.forRoot`, `RouterModule.forChild` and `Router.resetConfig`) accept a mutable `Routes` (`Route[]`) array. As a result, callers who define their routes as a readonly array — e.g. `const routes = [...] as const` or a value typed `ReadonlyArray<Route>` — get a type error and are forced to cast away the `readonly` modifier before passing the configuration.

Issue Number: N/A (I can create one if necessary)

## What is the new behavior?

These APIs now accept `Readonly<Routes>` (and `provideRouter` additionally accepts a readonly array of features). Since they only ever *read* the provided configuration — storing it via the `ROUTES` token or iterating over it in `validateConfig` / `resetConfig` — widening the parameter type is safe and lets callers pass readonly route arrays without casting.

This is a purely type-level, backwards-compatible change: mutable `Routes` arrays remain assignable to a `Readonly<Routes>` parameter, so existing code is unaffected. The internal `validateConfig` helper was also widened to `Readonly<Routes>` to support `Router.resetConfig`, and the public API goldens were updated accordingly.

```ts
// Now compiles without `as Routes` / removing `as const`:
const routes = [
  { path: '', component: HomeComponent },
  { path: 'about', component: AboutComponent },
] as const;

provideRouter(routes);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Affected public APIs (goldens updated in `goldens/public-api/router/index.api.md`):

- `provideRouter(routes: Readonly<Routes>, ...features: readonly RouterFeatures[])`
- `RouterModule.forRoot(routes: Readonly<Routes>, config?)`
- `RouterModule.forChild(routes: Readonly<Routes>)`
- `Router.resetConfig(config: Readonly<Routes>)`

Tests were added in `packages/router/test/standalone.spec.ts` to verify each API accepts a `ReadonlyArray<Route>` (and a readonly features array for `provideRouter`).