### PR TITLE
refactor(http): deprecate jsonp support

### DIFF
--- a/goldens/public-api/common/http/errors.api.md
+++ b/goldens/public-api/common/http/errors.api.md
@@ -26,11 +26,11 @@ export const enum RuntimeErrorCode {
     INTEGRITY_NOT_SUPPORTED_WITH_XHR = 2820,
     // (undocumented)
     INVALID_TIMEOUT_VALUE = 2822,
-    // (undocumented)
+    // @deprecated (undocumented)
     JSONP_HEADERS_NOT_SUPPORTED = 2812,
-    // (undocumented)
+    // @deprecated (undocumented)
     JSONP_WRONG_METHOD = 2810,
-    // (undocumented)
+    // @deprecated (undocumented)
     JSONP_WRONG_RESPONSE_TYPE = 2811,
     // (undocumented)
     KEEPALIVE_NOT_SUPPORTED_WITH_XHR = 2813,

--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -236,7 +236,9 @@ export class HttpClient {
     } & HttpClientCommonOptions): Observable<HttpResponse<T>>;
     head(url: string, options?: HttpClientCommonOptions): Observable<Object>;
     head<T>(url: string, options?: HttpClientCommonOptions): Observable<T>;
+    // @deprecated
     jsonp(url: string, callbackParam: string): Observable<Object>;
+    // @deprecated
     jsonp<T>(url: string, callbackParam: string): Observable<T>;
     options(url: string, options: {
         observe?: 'body';
@@ -1208,7 +1210,7 @@ export abstract class HttpXsrfTokenExtractor {
     static ɵprov: i0.ɵɵInjectableDeclaration<HttpXsrfTokenExtractor>;
 }
 
-// @public
+// @public @deprecated
 export class JsonpClientBackend implements HttpBackend {
     constructor(callbackMap: JsonpCallbackContext, document: any);
     handle(req: HttpRequest<never>): Observable<HttpEvent<any>>;
@@ -1218,7 +1220,7 @@ export class JsonpClientBackend implements HttpBackend {
     static ɵprov: i0.ɵɵInjectableDeclaration<JsonpClientBackend>;
 }
 
-// @public
+// @public @deprecated
 export class JsonpInterceptor {
     constructor(injector: EnvironmentInjector);
     intercept(initialRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
@@ -1240,7 +1242,7 @@ export function withInterceptors(interceptorFns: HttpInterceptorFn[]): HttpFeatu
 // @public
 export function withInterceptorsFromDi(): HttpFeature<HttpFeatureKind.LegacyInterceptors>;
 
-// @public
+// @public @deprecated
 export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport>;
 
 // @public

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -94,14 +94,6 @@ function addBody<T>(options: HttpClientCommonOptions, body: T | null): any {
  * this.httpClient.request('GET', this.heroesUrl + '?' + 'name=term', {responseType:'json'});
  * ```
  *
- *
- * ### JSONP Example
- * ```ts
- * requestJsonp(url, callback = 'callback') {
- *  return this.httpClient.jsonp(this.heroesURL, callback);
- * }
- * ```
- *
  * ### PATCH Example
  * ```ts
  * // PATCH one of the heroes' name
@@ -1478,6 +1470,7 @@ export class HttpClient {
    * @param callbackParam The callback function name.
    *
    * @return An `Observable` of the response object, with response body as an object.
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
    */
   jsonp(url: string, callbackParam: string): Observable<Object>;
 
@@ -1492,6 +1485,7 @@ export class HttpClient {
    * then the `JSONP` request can be rejected by the configured backend.
    *
    * @return An `Observable` of the response object, with response body in the requested type.
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
    */
   jsonp<T>(url: string, callbackParam: string): Observable<T>;
 
@@ -1511,7 +1505,7 @@ export class HttpClient {
    *
    * @param url The resource URL.
    * @param callbackParam The callback function name.
-   *
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
    */
   jsonp<T>(url: string, callbackParam: string): Observable<T> {
     return this.request<any>('JSONP', url, {

--- a/packages/common/http/src/errors.ts
+++ b/packages/common/http/src/errors.ts
@@ -21,8 +21,17 @@ export const enum RuntimeErrorCode {
   RESPONSE_IS_NOT_A_BLOB = 2807,
   RESPONSE_IS_NOT_A_STRING = 2808,
   UNHANDLED_OBSERVE_TYPE = 2809,
+  /**
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
+   */
   JSONP_WRONG_METHOD = 2810,
+  /**
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
+   */
   JSONP_WRONG_RESPONSE_TYPE = 2811,
+  /**
+   * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
+   */
   JSONP_HEADERS_NOT_SUPPORTED = 2812,
   KEEPALIVE_NOT_SUPPORTED_WITH_XHR = 2813,
   CACHE_NOT_SUPPORTED_WITH_XHR = 2814,

--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -60,7 +60,7 @@ export const JSONP_ERR_HEADERS_NOT_SUPPORTED = 'JSONP requests do not support he
  *
  * In the browser, this should always be the `window` object.
  *
- *
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 export abstract class JsonpCallbackContext {
   [key: string]: (data: any) => void;
@@ -72,7 +72,7 @@ export abstract class JsonpCallbackContext {
  * Ordinarily JSONP callbacks are stored on the `window` object, but this may not exist
  * in test environments. In that case, callbacks are stored on an anonymous object instead.
  *
- *
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 export function jsonpCallbackContext(): Object {
   if (typeof window === 'object') {
@@ -88,6 +88,7 @@ export function jsonpCallbackContext(): Object {
  * @see {@link HttpXhrBackend}
  *
  * @publicApi
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 @Injectable()
 export class JsonpClientBackend implements HttpBackend {
@@ -100,7 +101,14 @@ export class JsonpClientBackend implements HttpBackend {
   constructor(
     private callbackMap: JsonpCallbackContext,
     @Inject(DOCUMENT) private document: any,
-  ) {}
+  ) {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      console.warn(
+        'JSONP support is deprecated as it can cause XSS vulnerabilities, and will be removed ' +
+          'in a future version of Angular. Please use standard HTTP requests instead.',
+      );
+    }
+  }
 
   /**
    * Get the name of the next callback method, by incrementing the global `nextRequestId`.
@@ -286,6 +294,8 @@ export class JsonpClientBackend implements HttpBackend {
 
 /**
  * Identifies requests with the method JSONP and shifts them to the `JsonpClientBackend`.
+ *
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 export function jsonpInterceptorFn(
   req: HttpRequest<unknown>,
@@ -306,6 +316,7 @@ export function jsonpInterceptorFn(
  * @see {@link HttpInterceptor}
  *
  * @publicApi
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 @Injectable()
 export class JsonpInterceptor {

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -113,7 +113,7 @@ export class HttpClientModule {}
  * with method JSONP, where they are rejected.
  *
  * @publicApi
- * @deprecated `withJsonpSupport()` as providers instead
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Intent to remove in future versions of Angular.
  */
 @NgModule({
   providers: [withJsonpSupport().ɵproviders],

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -240,6 +240,7 @@ export function withNoXsrfProtection(): HttpFeature<HttpFeatureKind.NoXsrfProtec
  * Add JSONP support to the configuration of the current `HttpClient` instance.
  *
  * @see {@link provideHttpClient}
+ * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
 export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
   return makeHttpFeature(HttpFeatureKind.JsonpSupport, [


### PR DESCRIPTION
JSONP is deprecated because it is prone to Cross-Site Scripting (XSS) attacks. Since JSONP works by executing arbitrary scripts in the global context, it bypasses modern Content Security Policies (CSP) and can lead to severe security vulnerabilities if the server or endpoint is compromised.

DEPRECATED: `HttpClient.jsonp`, `HttpClientJsonpModule`, and related JSONP classes/functions are deprecated. Use standard HTTP requests instead.
