### PR TITLE
fix(core): require WebMCP tool descriptions

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -2139,7 +2139,7 @@ export interface WebMcpClient {
 
 // @public
 export interface WebMcpToolDescriptor<InputSchema extends JsonSchemaForInference> {
-    description?: string;
+    description: string;
     execute: WebMcpToolExecute<InputSchema>;
     inputSchema: InputSchema;
     name: string;

--- a/packages/core/src/webmcp/types.ts
+++ b/packages/core/src/webmcp/types.ts
@@ -66,7 +66,7 @@ export interface ToolDescriptor<InputSchema extends JsonSchemaForInference> {
   name: string;
 
   /** A description of what the tool does and how the agent should consider using it. */
-  description?: string;
+  description: string;
 
   /**
    * A schema which describes the input arguments expected by the {@link execute} function

--- a/packages/forms/signals/src/webmcp/tokens.ts
+++ b/packages/forms/signals/src/webmcp/tokens.ts
@@ -22,5 +22,5 @@ export const REGISTER_WEBMCP_FORM = new InjectionToken<RegisterWebMcpForm>(
  */
 export type RegisterWebMcpForm = (
   form: FieldTree<unknown>,
-  options: {name: string; description?: string},
+  options: {name: string; description: string},
 ) => void;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The WebMCP ModelContextTool dictionary marks description as required: https://webmachinelearning.github.io/webmcp/#modelcontexttool-dictionary

If not provided, an Angular app crashes on start in a browser that enables WebMCP.

## What is the new behavior?

Make the `description` field mandatory

## Does this PR introduce a breaking change?

- [x] Yes, but on an experimental API
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
