### PR TITLE
docs: disable overlay close-on-escape in Aria menubar examples

### DIFF
--- a/adev/src/content/examples/aria/menubar/src/basic/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/material/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/basic/retro/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/material/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/disabled/retro/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: 6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/material/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -462,6 +471,7 @@
                 [cdkConnectedOverlayPositions]="[
                   {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -498,6 +508,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -525,6 +536,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -6},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">

--- a/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
+++ b/adev/src/content/examples/aria/menubar/src/rtl/retro/app/app.html
@@ -16,6 +16,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #fileMenu="ngMenu">
@@ -61,6 +62,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #shareMenu="ngMenu">
@@ -130,6 +132,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #editMenu="ngMenu">
@@ -202,6 +205,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #viewMenu="ngMenu">
@@ -258,6 +262,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #insertMenu="ngMenu">
@@ -278,6 +283,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #imageMenu="ngMenu">
@@ -329,6 +335,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #chartMenu="ngMenu">
@@ -391,6 +398,7 @@
     [cdkConnectedOverlayPositions]="[
       {originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4},
     ]"
+    [cdkConnectedOverlayDisableClose]="true"
     cdkAttachPopoverAsChild
   >
     <div ngMenu #formatMenu="ngMenu">
@@ -411,6 +419,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #textMenu="ngMenu">
@@ -468,6 +477,7 @@
                     offsetX: -12,
                   },
                 ]"
+                [cdkConnectedOverlayDisableClose]="true"
                 cdkAttachPopoverAsChild
               >
                 <div ngMenu #sizeMenu="ngMenu">
@@ -504,6 +514,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #paragraphMenu="ngMenu">
@@ -531,6 +542,7 @@
           [cdkConnectedOverlayPositions]="[
             {originX: 'end', originY: 'top', overlayY: 'top', overlayX: 'start', offsetX: -12},
           ]"
+          [cdkConnectedOverlayDisableClose]="true"
           cdkAttachPopoverAsChild
         >
           <div ngMenu #alignMenu="ngMenu">


### PR DESCRIPTION
## What / Why

In the Aria menubar examples on angular.dev, the menus become permanently
unusable after this interaction:

1. Open a top-level menu (e.g. **File**) and move focus onto one of its items.
2. **Hold** the <kbd>Escape</kbd> key.
3. Mouse over the menubar.

Afterwards, several menus (e.g. **Insert**, **Format**) no longer open — neither
on hover nor on click.

## Root cause

Each menu is rendered in a `cdkConnectedOverlay`, which detaches the top-most
overlay on every <kbd>Escape</kbd> press (`disableClose` defaults to `false`).
The top-level menus are always attached, so a detached overlay never reattaches
and its `viewChild` reference becomes `undefined`. Holding Escape detaches the
overlays one by one, permanently breaking menus like **Insert** and **Format**.

This isn't a CDK bug — close-on-Escape is intentional `cdkConnectedOverlay`
behavior. The menu pattern should own open/close state, which is what the
combobox and toolbar examples already do via `cdkConnectedOverlayDisableClose`.

## Fix

Add `[cdkConnectedOverlayDisableClose]="true"` to the overlay templates across
the basic, disabled, and rtl menubar examples (and their material/retro
variants) — 9 files in total.

## Notes

The same fix is being applied to the matching examples in `angular/components`
(the two example sets are maintained separately). Only example templates change.
