### PR TITLE
docs: bump schematics-for-libraries example peer deps to v22

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -38,6 +38,10 @@ adev/src/content/aria/**/*.json
 adev/src/content/cli/**/*.json
 adev/src/content/cdk/**/*.json
 
+# Example package.json containing docregion (`// #docregion`) markers, which are
+# not valid JSON and cannot be processed by Prettier's json-stringify parser.
+adev/src/content/examples/schematics-for-libraries/projects/my-lib/package.json
+
 # Antigravity rules
 .agent/rules/agents.md
 

--- a/adev/src/content/examples/schematics-for-libraries/projects/my-lib/package.json
+++ b/adev/src/content/examples/schematics-for-libraries/projects/my-lib/package.json
@@ -9,8 +9,8 @@
     "postbuild": "copyfiles schematics/*/schema.json schematics/*/files/** schematics/collection.json ../../dist/my-lib/"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0"
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0"
   },
 // #docregion collection
   "schematics": "./schematics/collection.json",


### PR DESCRIPTION
The my-lib schematics-for-libraries example still declared `^21.0.0` peerDependencies, the only adev example left on the previous major. Bumps `@angular/common`/`@angular/core` to `^22.0.0`, matching the current major and this file's stable-`^N.0.0` bump pattern.

## PR Checklist

Please check that your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other

## What is the current behavior?

The `my-lib` schematics-for-libraries example declares Angular peerDependencies of `^21.0.0`. It's the only adev example still on the previous major; the tutorial/playground examples already track v22.

## What is the new behavior?

Bumps `@angular/common` and `@angular/core` to `^22.0.0`, matching the current major and this file's established stable-`^N.0.0` bump pattern.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No