### PR TITLE
refactor(devtools): convert router details panel to description list

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.html
@@ -1,6 +1,6 @@
 <!-- TODO: Reconsider the existence of this component. -->
-<th>{{ label() }}</th>
-<td>
+<dt>{{ label() }}</dt>
+<dd>
   @switch (type()) {
     @case ('flag') {
       <span [class]="rowValue() ? 'tag-active' : 'tag-inactive'">
@@ -45,7 +45,7 @@
       }
     }
   }
-</td>
+</dd>
 
 <ng-template #actionBtn let-value="value">
   @if (actionBtnType() !== 'none') {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.scss
@@ -2,6 +2,7 @@
 
 .tag-active,
 .tag-inactive {
+  display: inline-block;
   border-radius: 1rem;
   padding: 0.15rem 0.5rem;
   border: 1px solid;
@@ -46,7 +47,7 @@ button {
   }
 }
 
-td {
+dd {
   width: 100%;
 }
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.spec.ts
@@ -34,10 +34,10 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('dataKey', 'value');
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
-    const dataElements = fixture.debugElement.queryAll(By.css('td'));
+    const dataElements = fixture.debugElement.queryAll(By.css('dd'));
     expect(dataElements.length).toEqual(1);
     expect(dataElements[0].nativeElement.innerText).toEqual('Route Data');
   });
@@ -48,7 +48,7 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('dataKey', 'isActive');
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
     const dataElements = fixture.debugElement.queryAll(By.css('.tag-active'));
@@ -62,7 +62,7 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('dataKey', 'isLazy');
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
     const dataElements = fixture.debugElement.queryAll(By.css('.tag-inactive'));
@@ -77,7 +77,7 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('actionBtnType', 'view-source');
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
     const dataElements = fixture.debugElement.queryAll(By.css('button'));
@@ -92,7 +92,7 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('actionBtnDisabled', true);
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
     const dataElements = fixture.debugElement.queryAll(By.css('button'));
@@ -107,7 +107,7 @@ describe('RouteDetailsRowComponent', () => {
     fixture.componentRef.setInput('actionBtnType', 'view-source');
     await fixture.whenStable();
 
-    const labelElement = fixture.debugElement.query(By.css('th'));
+    const labelElement = fixture.debugElement.query(By.css('dt'));
     expect(labelElement.nativeElement.innerText).toEqual('Route Title');
 
     const dataElements = fixture.debugElement.queryAll(By.css('button'));

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-details-row.component.ts
@@ -25,6 +25,9 @@ export type ActionBtnType = 'none' | 'view-source' | 'navigate';
   templateUrl: './route-details-row.component.html',
   styleUrls: ['./route-details-row.component.scss'],
   imports: [NgTemplateOutlet, ButtonComponent, MatIcon, MatTooltip, ObjectTreeExplorerComponent],
+  host: {
+    'class': 'ng-dl-row',
+  },
 })
 export class RouteDetailsRowComponent {
   readonly label = input.required<string>();

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-tree.component.html
@@ -52,9 +52,9 @@
 
           <!-- TODO: Convert to a description list (<dl>) -->
           <div class="scrollable-wrapper">
-            <table class="ng-table">
+            <dl class="ng-dl">
               @if (!data.matcher) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Path"
                   dataKey="path"
@@ -62,9 +62,9 @@
                   actionBtnType="navigate"
                   [actionBtnTooltip]="'Navigate to ' + data.path"
                   (actionBtnClick)="navigateRoute(route)"
-                ></tr>
+                ></div>
               } @else {
-                <tr
+                <div
                   ng-route-details-row
                   label="Matcher"
                   dataKey="matcher"
@@ -72,11 +72,11 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewFunctionSource(data.matcher, 'matcher')"
-                ></tr>
+                ></div>
               }
 
               @if (!data.redirectTo) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Component"
                   dataKey="component"
@@ -85,9 +85,9 @@
                   actionBtnTooltip="View source"
                   [actionBtnDisabled]="!!data?.isLazy"
                   (actionBtnClick)="viewComponentSource(data.component)"
-                ></tr>
+                ></div>
               } @else {
-                <tr
+                <div
                   ng-route-details-row
                   label="Redirect to"
                   dataKey="redirectTo"
@@ -95,23 +95,28 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewFunctionSource(data.redirectTo, 'redirectTo')"
-                ></tr>
+                ></div>
               }
 
               @if (data.pathMatch) {
-                <tr ng-route-details-row label="Path Match" dataKey="pathMatch" [data]="data"></tr>
+                <div
+                  ng-route-details-row
+                  label="Path Match"
+                  dataKey="pathMatch"
+                  [data]="data"
+                ></div>
               }
               @if (data.data) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Data"
                   [renderValueAsJson]="true"
                   dataKey="data"
                   [data]="data"
-                ></tr>
+                ></div>
               }
               @if (data.resolvers) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Resolvers"
                   [renderValueAsJson]="true"
@@ -119,11 +124,11 @@
                   [data]="data"
                   actionBtnType="view-source"
                   (actionBtnClick)="viewSourceFromRouter($event, 'resolvers')"
-                ></tr>
+                ></div>
               }
 
               @if (data.canActivateGuards && data.canActivateGuards.length > 0) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Can Activate Guards"
                   type="list"
@@ -132,20 +137,20 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewSourceFromRouter($event, 'canActivate')"
-                ></tr>
+                ></div>
               }
               @if (data.canActivateChildGuards && data.canActivateChildGuards.length > 0) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Can Activate Child Guards"
                   type="list"
                   dataKey="canActivateChildGuards"
                   [data]="data"
                   (actionBtnClick)="viewSourceFromRouter($event, 'canActivateChild')"
-                ></tr>
+                ></div>
               }
               @if (data.canDeactivateGuards && data.canDeactivateGuards.length > 0) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Can DeActivate Guards"
                   type="list"
@@ -154,10 +159,10 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewSourceFromRouter($event, 'canDeactivate')"
-                ></tr>
+                ></div>
               }
               @if (data.canMatchGuards && data.canMatchGuards.length > 0) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Can Match Guards"
                   type="list"
@@ -166,11 +171,11 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewSourceFromRouter($event, 'canMatch')"
-                ></tr>
+                ></div>
               }
 
               @if (data.providers && data.providers.length > 0) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Providers"
                   type="list"
@@ -179,10 +184,10 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewSourceFromRouter($event, 'providers')"
-                ></tr>
+                ></div>
               }
               @if (data.title) {
-                <tr
+                <div
                   ng-route-details-row
                   label="Title"
                   dataKey="title"
@@ -190,11 +195,11 @@
                   actionBtnType="view-source"
                   actionBtnTooltip="View source"
                   (actionBtnClick)="viewFunctionSource(data.title, 'title')"
-                ></tr>
+                ></div>
               }
 
               @if (data.runGuardsAndResolvers) {
-                <tr
+                <div
                   ng-route-details-row
                   label="RunGuardsAndResolvers"
                   dataKey="runGuardsAndResolvers"
@@ -204,25 +209,31 @@
                   (actionBtnClick)="
                     viewFunctionSource(data.runGuardsAndResolvers, 'runGuardsAndResolvers')
                   "
-                ></tr>
+                ></div>
               }
 
-              <tr
+              <div
                 ng-route-details-row
                 label="Active"
                 type="flag"
                 dataKey="isActive"
                 [data]="data"
-              ></tr>
-              <tr
+              ></div>
+              <div
                 ng-route-details-row
                 label="Auxiliary"
                 type="flag"
                 dataKey="isAux"
                 [data]="data"
-              ></tr>
-              <tr ng-route-details-row label="Lazy" type="flag" dataKey="isLazy" [data]="data"></tr>
-            </table>
+              ></div>
+              <div
+                ng-route-details-row
+                label="Lazy"
+                type="flag"
+                dataKey="isLazy"
+                [data]="data"
+              ></div>
+            </dl>
           </div>
         </div>
       </as-split-area>

--- a/devtools/projects/ng-devtools/src/styles/BUILD.bazel
+++ b/devtools/projects/ng-devtools/src/styles/BUILD.bazel
@@ -15,6 +15,7 @@ sass_library(
     srcs = ["_global.scss"],
     deps = [
         ":colors",
+        ":dl",
         ":inputs",
         ":material_sass_deps",
         ":overrides",
@@ -57,6 +58,14 @@ sass_library(
     srcs = ["_tables.scss"],
     deps = [
         ":material_sass_deps",
+        ":typography",
+    ],
+)
+
+sass_library(
+    name = "dl",
+    srcs = ["_dl.scss"],
+    deps = [
         ":typography",
     ],
 )

--- a/devtools/projects/ng-devtools/src/styles/_dl.scss
+++ b/devtools/projects/ng-devtools/src/styles/_dl.scss
@@ -1,0 +1,30 @@
+/* Global description list styles */
+@use './typography';
+
+dl.ng-dl {
+  width: 100%;
+  margin: 0;
+
+  > .ng-dl-row {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--senary-contrast);
+    padding: 0.625rem 0.375rem;
+
+    dt {
+      @extend %body-bold-01;
+      margin: 0;
+      flex: 0 0 30%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    dd {
+      @extend %body-01;
+      margin: 0;
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+}

--- a/devtools/projects/ng-devtools/src/styles/_global.scss
+++ b/devtools/projects/ng-devtools/src/styles/_global.scss
@@ -8,6 +8,7 @@
 @use './theme' as th;
 @use './inputs';
 @use './tables';
+@use './dl';
 @use '../lib/devtools-tabs/directive-explorer/property-pane/property-view/property-view-body/prop-actions-menu/prop-actions-menu-cdk';
 
 @include mat.all-component-typographies();


### PR DESCRIPTION
Convert the router details panel in DevTools to use a description list (`<dl>`) instead of a table. This is semantically more correct for key-value metadata and improves accessibility.
