### PR TITLE
build(vscode-extension): disable make_latest on github release publication

### DIFF
--- a/vscode-ng-language-service/tools/release.mts
+++ b/vscode-ng-language-service/tools/release.mts
@@ -470,6 +470,7 @@ async function createGithubRelease(version: string, changelog: string): Promise<
     },
     body: JSON.stringify({
       draft: false,
+      make_latest: 'false',
     }),
   });
 


### PR DESCRIPTION
Previously, when releasing the VS Code extension, the draft release was created with make_latest: 'false', but the PATCH request that published the draft release omitted this option. As a result, GitHub automatically designated the published release as the 'latest' release.

This change explicitly passes make_latest: 'false' during the publish request to prevent it from automatically becoming the latest release.