### PR TITLE
escape anchor fragment in shadow DOM name selector

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -200,7 +200,8 @@ function findAnchorFromDocument(document: Document, target: string): HTMLElement
         // Note that `ShadowRoot` doesn't support `getElementsByName`
         // so we have to fall back to `querySelector`.
         const result =
-          shadowRoot.getElementById(target) || shadowRoot.querySelector(`[name="${target}"]`);
+          shadowRoot.getElementById(target) ||
+          shadowRoot.querySelector(`[name="${CSS.escape(target)}"]`);
         if (result) {
           return result;
         }

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -104,6 +104,22 @@ describe('BrowserViewportScroller', () => {
       cleanup();
     });
 
+    it('should scroll when a shadow DOM anchor name contains CSS selector metacharacters', () => {
+      const trickyName = 'a"]),(*';
+      const {anchorNode, cleanup} = createTallElementWithShadowRoot();
+      anchorNode.name = trickyName;
+      scroller.scrollToAnchor(trickyName);
+      expect(scroller.getScrollPosition()[1]).not.toEqual(0);
+      cleanup();
+    });
+
+    it('should not throw when the anchor would form an invalid shadow DOM selector', () => {
+      const {cleanup} = createTallElementWithShadowRoot();
+      expect(() => scroller.scrollToAnchor('"><script>')).not.toThrow();
+      expect(scroller.getScrollPosition()[1]).toEqual(0);
+      cleanup();
+    });
+
     it('should not allow overwriting position with options', () => {
       const {anchorNode, cleanup} = createTallElementWithShadowRoot();
       anchorNode.name = anchor;


### PR DESCRIPTION
`findAnchorFromDocument` drops the raw url fragment into ``[name="${target}"]`` for the shadow DOM lookup, so a fragment like `a"]),(*` (reachable through the router when `anchorScrolling` is on) breaks out of the attribute selector and makes `querySelector` throw or match unrelated nodes, and it also breaks legitimate anchor names containing a quote; wrap it in `CSS.escape` so the value stays inside the selector.