### PR TITLE
fix(docs-infra): reserve scrollbar gutter for mobile nav

### DIFF
--- a/adev/shared-docs/styles/_resets.scss
+++ b/adev/shared-docs/styles/_resets.scss
@@ -46,6 +46,7 @@
     margin: 0;
     overflow-y: auto;
     overflow-x: hidden;
+    scrollbar-gutter: stable;
   }
 
   html,


### PR DESCRIPTION
## Problem
Opening the mobile navigation hides vertical scrolling on `body`, which can remove the classic scrollbar gutter on Safari/desktop setups and change the viewport width mid-animation.

## Root cause
The docs shell already uses `body` as the scroll container. When the nav opens, `document.body.style.overflowY = 'hidden'` removes the scrollbar, so media queries around the breakpoint can see a different width.

## Solution
Reserve the scrollbar gutter on the existing body scroll container with `scrollbar-gutter: stable`, avoiding a larger scroll-root change while keeping the current scroll-lock behavior.

Fixes #69036.

## Tests
- `corepack pnpm exec prettier --check adev/shared-docs/styles/_resets.scss`
- `npx --yes sass@1.94.2 --no-source-map --load-path node_modules adev/shared-docs/styles/_resets.scss $env:TEMP\angular-resets.css`
- `git diff --check`