### PR TITLE
fix(common): use Object.hasOwn in I18nSelectPipe to handle null-prototype and shadowed mappings

### DIFF
--- a/packages/common/src/pipes/i18n_select_pipe.ts
+++ b/packages/common/src/pipes/i18n_select_pipe.ts
@@ -45,11 +45,11 @@ export class I18nSelectPipe implements PipeTransform {
       throw invalidPipeArgumentError(I18nSelectPipe, mapping);
     }
 
-    if (mapping.hasOwnProperty(value)) {
+    if (Object.hasOwn(mapping, value)) {
       return mapping[value];
     }
 
-    if (mapping.hasOwnProperty('other')) {
+    if (Object.hasOwn(mapping, 'other')) {
       return mapping['other'];
     }
 

--- a/packages/common/test/pipes/i18n_select_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_select_pipe_spec.ts
@@ -38,6 +38,22 @@ describe('I18nSelectPipe', () => {
       expect(() => pipe.transform('male', 'hey' as any)).toThrowError();
     });
 
+    it('should work with null-prototype mappings (Object.create(null))', () => {
+      const nullProtoMapping = Object.assign(Object.create(null), {
+        greeting: 'hello',
+        other: 'fallback',
+      }) as {[key: string]: string};
+      expect(pipe.transform('greeting', nullProtoMapping)).toEqual('hello');
+    });
+
+    it('should work when hasOwnProperty is shadowed by a mapping key', () => {
+      const shadowedMapping = {
+        hasOwnProperty: () => false,
+        greeting: 'hello',
+      } as unknown as {[key: string]: string};
+      expect(pipe.transform('greeting', shadowedMapping)).toEqual('hello');
+    });
+
     it('should be available as a standalone pipe', () => {
       @Component({
         selector: 'test-component',


### PR DESCRIPTION
`I18nSelectPipe.transform()` called `mapping.hasOwnProperty()` directly, which fails in two edge cases:

- Mappings created with `Object.create(null)` have no prototype and therefore no `hasOwnProperty` method, causing a TypeError at runtime.
- Mappings where a key literally named `hasOwnProperty` shadows the built-in method return incorrect results silently.

Replace both call sites with `Object.hasOwn(mapping, key)`, which delegates through `Object` directly and is immune to both issues.

Add two regression tests that demonstrate the broken behaviour before the fix and pass after it.