### PR TITLE
fix(core): don't use plain objects as maps for jsaction data

### DIFF
--- a/packages/core/primitives/event-dispatch/src/action_resolver.ts
+++ b/packages/core/primitives/event-dispatch/src/action_resolver.ts
@@ -19,7 +19,8 @@ import * as eventLib from './event';
  * Since maps from event to action are immutable we can use a single map
  * to represent the empty map.
  */
-const EMPTY_ACTION_MAP: {[key: string]: string} = {};
+// tslint:disable-next-line:no-toplevel-property-access
+const EMPTY_ACTION_MAP: {[key: string]: string} = /* @__PURE__ */ Object.create(null);
 
 /**
  * This regular expression matches a semicolon.
@@ -258,7 +259,7 @@ export class ActionResolver {
       } else {
         actionMap = cache.getParsed(jsactionAttribute);
         if (!actionMap) {
-          actionMap = {};
+          actionMap = Object.create(null) as {[key: string]: string | undefined};
           const values = jsactionAttribute.split(REGEXP_SEMICOLON);
           for (let idx = 0; idx < values.length; idx++) {
             const value = values[idx];

--- a/packages/core/primitives/event-dispatch/src/cache.ts
+++ b/packages/core/primitives/event-dispatch/src/cache.ts
@@ -11,7 +11,9 @@ import {Property} from './property';
 /**
  * Map from jsaction annotation to a parsed map from event name to action name.
  */
-const parseCache: {[key: string]: {[key: string]: string | undefined}} = {};
+// tslint:disable-next-line:no-toplevel-property-access
+const parseCache: {[key: string]: {[key: string]: string | undefined}} =
+  /* @__PURE__ */ Object.create(null);
 
 /**
  * Reads the jsaction parser cache from the given DOM Element.
@@ -25,7 +27,7 @@ export function get(element: Element): {[key: string]: string | undefined} | und
  * creates an empty one.
  */
 export function getDefaulted(element: Element): {[key: string]: string | undefined} {
-  const cache = get(element) ?? {};
+  const cache = get(element) ?? Object.create(null);
   set(element, cache);
   return cache;
 }

--- a/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
+++ b/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
@@ -1129,4 +1129,134 @@ describe('Dispatcher', () => {
       expect(eventInfoWrapper.getAction()).toBeUndefined();
     });
   });
+
+  describe('prototype pollution prevention', () => {
+    it('ignores __proto__ as event type in jsaction attribute', () => {
+      const container = getRequiredElementById('click-container');
+      const targetElement = getRequiredElementById('click-target-element');
+      const actionElement = getRequiredElementById('click-action-element');
+
+      // Simulate attacker-controlled jsaction attribute
+      actionElement.setAttribute('jsaction', '__proto__:evil;click:handleClick');
+      cache.clear(actionElement);
+
+      const eventContract = createEventContract({
+        container,
+        eventTypes: ['click'],
+      });
+      const dispatchDelegate = createDispatchDelegateSpy();
+      createDispatcher({dispatchDelegate, eventContract});
+
+      dispatchMouseEvent(targetElement);
+
+      // __proto__ key must not pollute Object.prototype
+      expect(({} as any).evil).toBeUndefined();
+
+      // Legitimate click action still resolves correctly
+      const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+      expect(eventInfoWrapper.getAction()?.name).toBe('handleClick');
+    });
+
+    it('ignores constructor as event type in jsaction attribute', () => {
+      const container = getRequiredElementById('click-container');
+      const targetElement = getRequiredElementById('click-target-element');
+      const actionElement = getRequiredElementById('click-action-element');
+
+      actionElement.setAttribute('jsaction', 'constructor:evil;click:handleClick');
+      cache.clear(actionElement);
+
+      const eventContract = createEventContract({
+        container,
+        eventTypes: ['click'],
+      });
+      const dispatchDelegate = createDispatchDelegateSpy();
+      createDispatcher({dispatchDelegate, eventContract});
+
+      dispatchMouseEvent(targetElement);
+
+      // constructor must not be shadowed on the action map
+      const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+      const action = eventInfoWrapper.getAction();
+      expect(action?.name).toBe('handleClick');
+
+      // Verify constructor was not written as an own property on the parsed map
+      // by checking that a freshly parsed map still has a normal constructor
+      expect(typeof {}.constructor).toBe('function');
+    });
+
+    it('ignores prototype as event type in jsaction attribute', () => {
+      const container = getRequiredElementById('click-container');
+      const targetElement = getRequiredElementById('click-target-element');
+      const actionElement = getRequiredElementById('click-action-element');
+
+      actionElement.setAttribute('jsaction', 'prototype:evil;click:handleClick');
+      cache.clear(actionElement);
+
+      const eventContract = createEventContract({
+        container,
+        eventTypes: ['click'],
+      });
+      const dispatchDelegate = createDispatchDelegateSpy();
+      createDispatcher({dispatchDelegate, eventContract});
+
+      dispatchMouseEvent(targetElement);
+
+      const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+      expect(eventInfoWrapper.getAction()?.name).toBe('handleClick');
+    });
+
+    it('does not pollute parseCache via __proto__ jsaction value', () => {
+      const container = getRequiredElementById('click-container');
+      const targetElement = getRequiredElementById('click-target-element');
+      const actionElement = getRequiredElementById('click-action-element');
+
+      // The full jsaction string itself is used as the parseCache key —
+      // if parseCache is a plain {}, setting parseCache["__proto__"] could
+      // affect Object.prototype in some engines.
+      actionElement.setAttribute('jsaction', '__proto__');
+      cache.clear(actionElement);
+
+      const eventContract = createEventContract({
+        container,
+        eventTypes: ['click'],
+      });
+      const dispatchDelegate = createDispatchDelegateSpy();
+      createDispatcher({dispatchDelegate, eventContract});
+
+      dispatchMouseEvent(targetElement);
+
+      // Object.prototype must be clean after parsing
+      expect(({} as any).click).toBeUndefined();
+      expect(({} as any).handleClick).toBeUndefined();
+    });
+
+    it('handles multiple dangerous keys mixed with legitimate ones', () => {
+      const container = getRequiredElementById('click-container');
+      const targetElement = getRequiredElementById('click-target-element');
+      const actionElement = getRequiredElementById('click-action-element');
+
+      actionElement.setAttribute(
+        'jsaction',
+        '__proto__:evil1;constructor:evil2;prototype:evil3;click:handleClick',
+      );
+      cache.clear(actionElement);
+
+      const eventContract = createEventContract({
+        container,
+        eventTypes: ['click'],
+      });
+      const dispatchDelegate = createDispatchDelegateSpy();
+      createDispatcher({dispatchDelegate, eventContract});
+
+      dispatchMouseEvent(targetElement);
+
+      // All dangerous keys skipped, legitimate action still works
+      expect(({} as any).evil1).toBeUndefined();
+      expect(({} as any).evil2).toBeUndefined();
+      expect(({} as any).evil3).toBeUndefined();
+
+      const eventInfoWrapper = dispatchDelegate.calls.mostRecent().args[0];
+      expect(eventInfoWrapper.getAction()?.name).toBe('handleClick');
+    });
+  });
 });

--- a/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
+++ b/packages/core/primitives/event-dispatch/test/dispatcher_test.ts
@@ -1129,4 +1129,26 @@ describe('Dispatcher', () => {
       expect(eventInfoWrapper.getAction()).toBeUndefined();
     });
   });
+
+  it('action map does not resolve Object.prototype properties as actions', () => {
+    const actionElement = getRequiredElementById('click-action-element');
+    const targetElement = getRequiredElementById('click-target-element');
+    const container = getRequiredElementById('click-container');
+
+    actionElement.setAttribute('jsaction', 'click:handleClick');
+    cache.clear(actionElement);
+
+    const actionResolver = new ActionResolver();
+    const eventInfo = createEventInfo({
+      eventType: 'toString',
+      event: new Event('toString'),
+      targetElement,
+      container,
+      timestamp: 0,
+    });
+
+    actionResolver.resolveAction(eventInfo);
+
+    expect(new EventInfoWrapper(eventInfo).getAction()).toBeUndefined();
+  });
 });


### PR DESCRIPTION
We were using plain `{}` objects to store jsaction's parsed action map
and its cache. The problem with plain objects is that they come with a
bunch of built-in stuff already on them (like `toString`, `constructor`,
`hasOwnProperty`) because of the prototype chain.

So if we ever look up a key that was never actually set — like an event
type or attribute string that happens to be named "toString" or
"constructor" — we don't get `undefined` back like we'd expect. We get
that built-in function instead! And since the code only checks
`!== undefined` to decide "is there an action here?", it ends up
thinking there IS one, when really there isn't.

To be clear, this isn't about someone maliciously writing
`__proto__`/`constructor` through the jsaction attribute — turns out
that doesn't actually do anything bad on a plain object (JS just
ignores it). This is purely about accidental lookups colliding with
stuff that was already there on the prototype.

The fix: use `Object.create(null)` instead of `{}`. That gives us an
object with no prototype at all, so there's nothing to accidentally
collide with — a lookup for a key we never set will always just be
`undefined`, like it should be.

Applied this to both places that were using `{}`:
* the parsed action map in `action_resolver.ts`
* the `parseCache` in `cache.ts`