### PR TITLE
refactor(devtools): move ContainerType, DebugSignalGraphNode, Descrip…

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/client-event-subscribers.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ɵDebugSignalGraph as InternalDebugSignalGraph} from '@angular/core';
+import {ɵDebugSignalGraph as InternalDebugSignalGraph, ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
 import {debounceTime} from 'rxjs/operators';
 import {
   ComponentExplorerViewQuery,
   ComponentType,
-  DebugSignalGraphNode,
   DevToolsNode,
   DirectivePosition,
   DirectiveType,

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/BUILD.bazel
@@ -22,6 +22,7 @@ ts_test_library(
     ],
     deps = [
         ":state-serializer",
+        "//:node_modules/@angular/core",
         "//devtools/projects/protocol",
     ],
 )

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 
 import {getPropType} from './prop-type';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/prop-type.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 
 import {isSignal, safelyReadSignalValue} from '../utils/general';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ContainerType, Descriptor, NestedProp, PropType} from '../../../../protocol';
+import {
+  type ɵContainerType as ContainerType,
+  type ɵDescriptor as Descriptor,
+  ɵPropType as PropType,
+} from '@angular/core';
+import {NestedProp} from '../../../../protocol';
 
 import {isSignal, safelyReadSignalValue, unwrapSignal} from '../utils/general';
 

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 
 import {getDescriptor, getKeys} from './object-utils';
 import {deeplySerializeSelectedProperties, serializeDirectiveState} from './state-serializer';

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ContainerType, Descriptor, NestedProp, PropType} from '../../../../protocol';
+import {
+  type ɵContainerType as ContainerType,
+  type ɵDescriptor as Descriptor,
+  ɵPropType as PropType,
+} from '@angular/core';
+import {NestedProp} from '../../../../protocol';
 
 import {isSignal, unwrapSignal} from '../utils/general';
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/directive-explorer.spec.ts
@@ -9,16 +9,22 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {ApplicationOperations} from '../../application-operations';
-import {DirectivePosition, MessageBus, PropType, PropertyQueryTypes} from '../../../../../protocol';
+import {DirectivePosition, MessageBus, PropertyQueryTypes} from '../../../../../protocol';
 
 import {DirectiveExplorerComponent} from './directive-explorer.component';
 import {DirectiveForestComponent} from './directive-forest/directive-forest.component';
 import {IndexedNode} from './directive-forest/index-forest';
 
 import SpyObj = jasmine.SpyObj;
-import {By} from '@angular/platform-browser';
 import {FrameManager} from '../../application-services/frame_manager';
-import {Component, CUSTOM_ELEMENTS_SCHEMA, output, input, signal} from '@angular/core';
+import {
+  ɵPropType as PropType,
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  output,
+  input,
+  signal,
+} from '@angular/core';
 import {ElementPropertyResolver} from './property-resolver/element-property-resolver';
 import {BreadcrumbsComponent} from './directive-forest/breadcrumbs/breadcrumbs.component';
 import {PropertyPaneComponent} from './property-pane/property-pane.component';

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/for-loop-view/for-loop-data-serializer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-pane/for-loop-view/for-loop-data-serializer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Descriptor} from '../../../../../../../protocol';
+import type {ɵDescriptor as Descriptor} from '@angular/core';
 import {FlatNode} from '../../../../shared/object-tree-explorer/object-tree-types';
 
 export function buildForLoopDataTree(descriptors: Descriptor[]): FlatNode[] {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/arrayify-props.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/arrayify-props.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 
 import {arrayifyProps} from './arrayify-props';
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/arrayify-props.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/arrayify-props.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Descriptor} from '../../../../../../protocol';
+import type {ɵDescriptor as Descriptor} from '@angular/core';
 import {Property} from '../../../shared/object-tree-explorer/object-tree-types';
 
 export const arrayifyProps = (

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.spec.ts
@@ -6,8 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {ChangeDetectionStrategy, ɵFramework as Framework} from '@angular/core';
-import {Properties, PropType} from '../../../../../../protocol';
+import {
+  ChangeDetectionStrategy,
+  ɵFramework as Framework,
+  ɵPropType as PropType,
+} from '@angular/core';
+import {Properties} from '../../../../../../protocol';
 
 import {DirectivePropertyResolver} from './directive-property-resolver';
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/directive-property-resolver.ts
@@ -7,8 +7,8 @@
  */
 
 import {FlatTreeControl} from '@angular/cdk/tree';
+import type {ɵDescriptor as Descriptor} from '@angular/core';
 import {
-  Descriptor,
   DirectiveMetadata,
   DirectivePosition,
   Events,

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/element-property-resolver.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Properties, PropType} from '../../../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
+import {Properties} from '../../../../../../protocol';
 
 import {IndexedNode} from '../directive-forest/index-forest';
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/flatten.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/flatten.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {type ɵDescriptor as Descriptor, ɵPropType as PropType} from '@angular/core';
 import {MatTreeFlattener} from '@angular/material/tree';
-import {Descriptor, PropType} from '../../../../../../protocol';
 import {Observable} from 'rxjs';
 
 import {arrayifyProps} from './arrayify-props';

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {FlatTreeControl} from '@angular/cdk/tree';
-import {PropType} from '../../../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 
 import {getTreeFlattener} from './flatten';
 import {PropertyDataSource} from './property-data-source';

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-data-source.ts
@@ -8,15 +8,13 @@
 
 import {CollectionViewer, DataSource, SelectionChange} from '@angular/cdk/collections';
 import {FlatTreeControl} from '@angular/cdk/tree';
-import {DefaultIterableDiffer, TrackByFunction} from '@angular/core';
-import {MatTreeFlattener} from '@angular/material/tree';
 import {
-  Descriptor,
-  DirectivePosition,
-  Events,
-  MessageBus,
-  Properties,
-} from '../../../../../../protocol';
+  type ɵDescriptor as Descriptor,
+  DefaultIterableDiffer,
+  TrackByFunction,
+} from '@angular/core';
+import {MatTreeFlattener} from '@angular/material/tree';
+import {DirectivePosition, Events, MessageBus, Properties} from '../../../../../../protocol';
 import {BehaviorSubject, merge, Observable, Subscription} from 'rxjs';
 import {map} from 'rxjs/operators';
 

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-expanded-directive-properties.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-resolver/property-expanded-directive-properties.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Descriptor, NestedProp, PropType} from '../../../../../../protocol';
+import {type ɵDescriptor as Descriptor, ɵPropType as PropType} from '@angular/core';
+import {NestedProp} from '../../../../../../protocol';
 import {FlatNode} from '../../../shared/object-tree-explorer/object-tree-types';
 
 export const getExpandedDirectiveProperties = (data: FlatNode[]): NestedProp[] => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-data-serializer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-data-serializer.spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ɵPropType as PropType} from '@angular/core';
 import {buildRouteDataTree} from './route-data-serializer';
-import {PropType} from '../../../../../../protocol';
 
 describe('route-data-serializer', () => {
   describe('buildRouteDataTree', () => {

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-data-serializer.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/router-tree/router-details-row/route-data-serializer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 import {FlatNode} from '../../../shared/object-tree-explorer/object-tree-types';
 
 export function buildRouteDataTree(data: unknown, level = 0): FlatNode[] {

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-explorer.spec.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {ɵPropType as PropType} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatTreeNode} from '@angular/material/tree';
 import {By} from '@angular/platform-browser';
 
 import {ObjectTreeExplorerComponent} from './object-tree-explorer.component';
 import {FlatNode} from './object-tree-types';
-import {PropType} from '../../../../../protocol';
 
 const mockDataSource: FlatNode[] = [
   {

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-types.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/object-tree-types.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Descriptor} from '../../../../../protocol';
+import type {ɵDescriptor as Descriptor} from '@angular/core';
 
 /**
  * An object-tree-exlorer data source unit that represents an object.

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/prop-value-highlighter/prop-value-highlighter.directive.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/prop-value-highlighter/prop-value-highlighter.directive.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {computed, Directive, input} from '@angular/core';
+import {ɵPropType as PropType, computed, Directive, input} from '@angular/core';
 import {Property} from '../object-tree-types';
-import {PropType} from '../../../../../../protocol';
 
 /** Should be used in conjunction with prop-value-highlighter.scss */
 @Directive({

--- a/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-preview/property-preview.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/object-tree-explorer/property-preview/property-preview.component.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, computed, input, output} from '@angular/core';
-import {PropType} from '../../../../../../protocol';
+import {ɵPropType as PropType, Component, computed, input, output} from '@angular/core';
 import {FlatNode} from '../object-tree-types';
 import {PropValueHighlighterDirective} from '../prop-value-highlighter/prop-value-highlighter.directive';
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-details.component.ts
@@ -6,10 +6,16 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, computed, input, output} from '@angular/core';
+import {
+  type ɵDebugSignalGraphNode as DebugSignalGraphNode,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
 import {MatIcon} from '@angular/material/icon';
 
-import {DebugSignalGraphNode, ElementPosition} from '../../../../../protocol';
+import {ElementPosition} from '../../../../../protocol';
 import {SignalValueTreeComponent} from './signal-value-tree/signal-value-tree.component';
 import {ButtonComponent} from '../button/button.component';
 import {

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-data-source.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-data-source.ts
@@ -8,9 +8,9 @@
 
 import {CollectionViewer, DataSource, SelectionChange} from '@angular/cdk/collections';
 import {FlatTreeControl} from '@angular/cdk/tree';
+import type {ɵDescriptor as Descriptor} from '@angular/core';
 import {MatTreeFlattener} from '@angular/material/tree';
 import {
-  Descriptor,
   DirectivePosition,
   Events,
   MessageBus,

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-value-tree.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-details/signal-value-tree/signal-value-tree.component.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, computed, inject, input} from '@angular/core';
+import {ɵPropType as PropType, Component, computed, inject, input} from '@angular/core';
 import {FlatTreeControl} from '@angular/cdk/tree';
 import {MatTreeFlattener} from '@angular/material/tree';
 import {DataSource} from '@angular/cdk/collections';
 
-import {ElementPosition, MessageBus, PropType} from '../../../../../../protocol';
+import {ElementPosition, MessageBus} from '../../../../../../protocol';
 import {DevtoolsSignalNode} from '../../signal-graph';
 import {arrayifyProps, SignalDataSource} from './signal-data-source';
 import {ObjectTreeExplorerComponent} from '../../object-tree-explorer/object-tree-explorer.component';

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebugSignalGraph, Descriptor, PropType} from '../../../../../protocol';
+import {type ɵDescriptor as Descriptor, ɵPropType as PropType} from '@angular/core';
+import {DebugSignalGraph} from '../../../../../protocol';
 import {convertToDevtoolsSignalGraph} from './devtools-signal-graph';
 
 const dummyPreview: Descriptor = {

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/devtools-signal-graph.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebugSignalGraph, DebugSignalGraphNode} from '../../../../../protocol';
+import type {ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
+import {DebugSignalGraph} from '../../../../../protocol';
 import {
   DevtoolsClusterNodeType,
   DevtoolsSignalGraph,

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/signal-graph-types.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/signal-graph-types.ts
@@ -12,7 +12,8 @@
  * with  cluster information that allows the visualizer to render the so-called compound nodes.
  */
 
-import {DebugSignalGraphEdge, DebugSignalGraphNode} from '../../../../../protocol';
+import type {ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
+import {DebugSignalGraphEdge} from '../../../../../protocol';
 
 export type DevtoolsClusterNodeType = 'resource';
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/utils.spec.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/utils.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {PropType} from '../../../../../protocol';
+import {ɵPropType as PropType} from '@angular/core';
 import {DevtoolsSignalGraphNode} from './signal-graph-types';
 import {checkClusterMatch, getNodeLabel, getNodeNames, isClusterNode, isSignalNode} from './utils';
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signal-graph/utils.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signal-graph/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebugSignalGraphNode} from '../../../../../protocol';
+import type {ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
 import {
   DevtoolsClusterNode,
   DevtoolsSignalNode,

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signal-node-filter-fn-generator.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signal-node-filter-fn-generator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {DebugSignalGraphNode} from '../../../../../protocol';
+import {ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
 import {FilterFn, FilterFnGenerator} from '../filter/filter.component';
 import {DevtoolsClusterNodeType} from '../signal-graph';
 

--- a/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/signals-visualizer/signals-visualizer.ts
@@ -17,7 +17,7 @@ import {
   DevtoolsSignalNode,
   getNodeLabel,
 } from '../signal-graph';
-import {DebugSignalGraphNode} from '../../../../../protocol';
+import type {ɵDebugSignalGraphNode as DebugSignalGraphNode} from '@angular/core';
 import type {DagreCluster, DagreEdge, DagreNode, DagreRegularNode} from './visualizer-types';
 
 export type DependenciesHighlightEvent =

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -10,6 +10,8 @@ import {
   ɵAcxChangeDetectionStrategy as AcxChangeDetectionStrategy,
   ɵAcxViewEncapsulation as AcxViewEncapsulation,
   ChangeDetectionStrategy as AngularChangeDetectionStrategy,
+  type ɵDebugSignalGraphNode as DebugSignalGraphNode,
+  type ɵDescriptor as Descriptor,
   ViewEncapsulation as AngularViewEncapsulation,
   ɵFramework as Framework,
   InjectionToken,
@@ -17,23 +19,6 @@ import {
   Injector,
   Type,
 } from '@angular/core';
-
-export interface DebugSignalGraphNode {
-  id: string;
-  kind:
-    | 'signal'
-    | 'computed'
-    | 'effect'
-    | 'template'
-    | 'linkedSignal'
-    | 'afterRenderEffectPhase'
-    | 'childSignalProp' // Represents a signal passed as a prop to a child component in a CoW app
-    | 'unknown';
-  epoch: number;
-  label?: string;
-  preview: Descriptor;
-  debuggable: boolean;
-}
 
 export interface DebugSignalGraphEdge {
   /**
@@ -158,38 +143,6 @@ export interface InjectedService {
   value: unknown;
   flags?: InjectOptions;
   providedIn: Injector;
-}
-
-export type ContainerType = 'WritableSignal' | 'ReadonlySignal' | null;
-
-export enum PropType {
-  Number,
-  String,
-  Null,
-  Undefined,
-  Symbol,
-  HTMLNode,
-  Boolean,
-  BigInt,
-  Function,
-  Object,
-  Date,
-  Array,
-  Set,
-  Map,
-  Unknown,
-
-  // Special Type when an error occurs during property access
-  Error,
-}
-
-export interface Descriptor {
-  expandable: boolean;
-  value?: any;
-  editable: boolean;
-  type: PropType;
-  preview: string;
-  containerType: ContainerType;
 }
 
 export interface DirectivesProperties {

--- a/packages/core/primitives/devtools/index.ts
+++ b/packages/core/primitives/devtools/index.ts
@@ -6,5 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {ProfilerEvent, type Profiler} from './src/profiler_types';
+export type {ContainerType} from './src/container_type';
+export type {DebugSignalGraphNode} from './src/debug_signal_graph_node';
+export type {Descriptor} from './src/descriptor';
 export {Framework} from './src/framework';
+export {ProfilerEvent, type Profiler} from './src/profiler_types';
+export {PropType} from './src/prop_type';

--- a/packages/core/primitives/devtools/src/container_type.ts
+++ b/packages/core/primitives/devtools/src/container_type.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export type ContainerType = 'WritableSignal' | 'ReadonlySignal' | null;

--- a/packages/core/primitives/devtools/src/debug_signal_graph_node.ts
+++ b/packages/core/primitives/devtools/src/debug_signal_graph_node.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type {Descriptor} from './descriptor';
+
+export interface DebugSignalGraphNode {
+  id: string;
+  kind:
+    | 'signal'
+    | 'computed'
+    | 'effect'
+    | 'template'
+    | 'linkedSignal'
+    | 'afterRenderEffectPhase'
+    | 'childSignalProp' // Represents a signal passed as a prop to a child component in a CoW app
+    | 'unknown';
+  epoch: number;
+  label?: string;
+  preview: Descriptor;
+  debuggable: boolean;
+}

--- a/packages/core/primitives/devtools/src/descriptor.ts
+++ b/packages/core/primitives/devtools/src/descriptor.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type {ContainerType} from './container_type';
+import type {PropType} from './prop_type';
+
+export interface Descriptor {
+  expandable: boolean;
+  value?: any;
+  editable: boolean;
+  type: PropType;
+  preview: string;
+  containerType: ContainerType;
+}

--- a/packages/core/primitives/devtools/src/prop_type.ts
+++ b/packages/core/primitives/devtools/src/prop_type.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export enum PropType {
+  Number,
+  String,
+  Null,
+  Undefined,
+  Symbol,
+  HTMLNode,
+  Boolean,
+  BigInt,
+  Function,
+  Object,
+  Date,
+  Array,
+  Set,
+  Map,
+  Unknown,
+
+  // Special Type when an error occurs during property access
+  Error,
+}

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -22,6 +22,12 @@ export {
 } from '../primitives/dom-navigation';
 export {maybeUnwrapDefaultExport as ɵmaybeUnwrapDefaultExport} from './util/default_export';
 
+export {
+  type ContainerType as ɵContainerType,
+  type DebugSignalGraphNode as ɵDebugSignalGraphNode,
+  type Descriptor as ɵDescriptor,
+  PropType as ɵPropType,
+} from '../primitives/devtools';
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from '../primitives/signals';
 export {ANIMATIONS_DISABLED as ɵANIMATIONS_DISABLED} from './animation/interfaces';
 export {allLeavingAnimations as ɵallLeavingAnimations} from './animation/longest_animation';


### PR DESCRIPTION
…tor, and PropType to primitives

`DebugSignalGraphNode` is the return type of the `ng` global `getSignalGraph` function. It will be used by Client-Only Wiz and other frameworks that implement `getSignalGraph`. Movig it to primitives allows those frameworks to import and reference the type.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

These types are in devtools.

Issue Number: N/A

## What is the new behavior?

The types have been moved to primitives.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
