### PR TITLE
fix(compiler): add missing URL-sanitized attribute pairs to security schema

### DIFF
--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -64,8 +64,19 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['form', ['action']],
 
       // The below two items are safe and should be removed but they require a G3 clean-up as a small number of tests fail.
-      ['img', ['src']],
-      ['video', ['src']],
+      ['img', ['src', 'srcset']],
+      ['video', ['src', 'poster']],
+
+      // Media elements that load external resources
+      ['audio', ['src']],
+      ['source', ['src', 'srcset']],
+      ['track', ['src']],
+
+      // Legacy HTML4 background attributes
+      ['body', ['background']],
+      ['table', ['background']],
+      ['td', ['background']],
+      ['th', ['background']],
     ]);
 
     registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
@@ -115,7 +126,12 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
       ['object', ['codebase', 'data']],
     ]);
 
-    registerContext(SecurityContext.URL, SVG_NAMESPACE, [['a', ['href', 'xlink:href']]]);
+    registerContext(SecurityContext.URL, SVG_NAMESPACE, [
+      ['a', ['href', 'xlink:href']],
+      ['image', ['href', 'xlink:href']],
+      ['feImage', ['href', 'xlink:href']],
+      ['use', ['href', 'xlink:href']],
+    ]);
 
     // Keep this in sync with SECURITY_SENSITIVE_ELEMENTS in packages/core/src/sanitization/sanitization.ts
     // The `unknown` elements refer to cases when we need to validate the input/binding in a directive (host bindings)

--- a/packages/compiler/src/schema/trusted_types_sinks.ts
+++ b/packages/compiler/src/schema/trusted_types_sinks.ts
@@ -28,6 +28,13 @@ const TRUSTED_TYPES_SINKS = new Set<string>([
   'iframe|src',
   'object|codebase',
   'object|data',
+
+  // RESOURCE_URL sinks missing from original Trusted Types integration.
+  // These are classified as RESOURCE_URL in dom_security_schema.ts and must
+  // be blocked in i18n attribute bindings (same as embed|src, iframe|src).
+  'base|href',
+  'frame|src',
+  'link|href',
 ]);
 
 /**


### PR DESCRIPTION
Add 12+ missing (tag, attr) pairs to URL sanitization list in dom_security_schema.ts.

SVG: use, image, feImage | Media: audio, source, track, video poster | Legacy: body/table/td/th background | img srcset

Related: CVE-2026-22610, CVE-2026-27970, CVE-2026-32635.