### PR TITLE
fix(compiler): add base|href, frame|src, link|href to TRUSTED_TYPES_SINKS

### DIFF
--- a/packages/compiler/src/schema/trusted_types_sinks.ts
+++ b/packages/compiler/src/schema/trusted_types_sinks.ts
@@ -28,6 +28,13 @@ const TRUSTED_TYPES_SINKS = new Set<string>([
   'iframe|src',
   'object|codebase',
   'object|data',
+
+  // RESOURCE_URL sinks missing from original Trusted Types integration.
+  // These are classified as RESOURCE_URL in dom_security_schema.ts and must
+  // be blocked in i18n attribute bindings (same as embed|src, iframe|src).
+  'base|href',
+  'frame|src',
+  'link|href',
 ]);
 
 /**


### PR DESCRIPTION
Add three missing RESOURCE_URL entries to TRUSTED_TYPES_SINKS (incomplete CVE-2026-32635 fix).

Fixes #69163