### PR TITLE
refactor(http): Add explicit mention of the dangerosity of JSONP on the API entries

### DIFF
--- a/adev/src/content/guide/http/setup.md
+++ b/adev/src/content/guide/http/setup.md
@@ -66,11 +66,17 @@ When you add `withRequestsMadeViaParent()`, `HttpClient` is configured to instea
 
 CRITICAL: You must configure an instance of `HttpClient` above the current injector, or this option is not valid and you'll get a runtime error when you try to use it.
 
-### `withJsonpSupport()`
+### `withDangerousJsonpSupport()`
 
-Including `withJsonpSupport` enables the `.jsonp()` method on `HttpClient`, which makes a GET request via the [JSONP convention](https://en.wikipedia.org/wiki/JSONP) for cross-domain loading of data.
+Including `withDangerousJsonpSupport` enables the `.jsonp()` method on `HttpClient`, which makes a GET request via the [JSONP convention](https://en.wikipedia.org/wiki/JSONP) for cross-domain loading of data.
 
-HELPFUL: Prefer using [CORS](https://developer.mozilla.org/docs/Web/HTTP/CORS) to make cross-domain requests instead of JSONP when possible.
+CRITICAL:
+JSONP works by loading and executing JavaScript from a remote origin
+via a <script> tag. Unlike standard XHR/fetch requests, the response
+is executed as code in the page's context, which bypasses normal
+same-origin protections and can lead to XSS-style attacks if the
+endpoint is compromised or untrusted.
+Please avoid using this and transition over to CORS-enabled APIs. This API would be removed in v23.
 
 ### `withXsrfConfiguration(...)`
 
@@ -89,7 +95,7 @@ This table lists the NgModules available from `@angular/common/http` and how the
 | **NgModule**                            | `provideHttpClient()` equivalent                         |
 | --------------------------------------- | -------------------------------------------------------- |
 | `HttpClientModule`                      | `provideHttpClient(withInterceptorsFromDi(), withXhr())` |
-| `HttpClientJsonpModule`                 | `withJsonpSupport()`                                     |
+| `DangerousHttpClientJsonpModule`        | `withDangerousJsonpSupport()`                            |
 | `HttpClientXsrfModule.withOptions(...)` | `withXsrfConfiguration(...)`                             |
 | `HttpClientXsrfModule.disable()`        | `withNoXsrfProtection()`                                 |
 

--- a/adev/src/content/reference/errors/NG02800.md
+++ b/adev/src/content/reference/errors/NG02800.md
@@ -3,9 +3,9 @@
 Angular produces this error when you attempt a `JSONP` request without providing the necessary support for it in the `HttpClient` configuration.
 To enable `JSONP` support, you can do one of the following:
 
-- add the `withJsonpSupport()` as an argument during the `provideHttpClient` function call (e.g. `provideHttpClient(withJsonpSupport())`) when `bootstrapApplication` is useddocs
-- import the `HttpClientJsonpModule` in your root AppModule, when NgModule-based bootstrap is used.
+- add the `withDangerousJsonpSupport()` as an argument during the `provideHttpClient` function call (e.g. `provideHttpClient(withDangerousJsonpSupport())`) when `bootstrapApplication` is useddocs
+- import the `DangerousHttpClientJsonpModule` in your root AppModule, when NgModule-based bootstrap is used.
 
 ## Debugging the error
 
-Make sure that the JSONP support is added into your application either by calling the `withJsonpSupport` function (when `provideHttpClient` is used) or importing the `HttpClientJsonpModule` module as described above.
+Make sure that the JSONP support is added into your application either by calling the `withDangerousJsonpSupport` function (when `provideHttpClient` is used) or importing the `DangerousHttpClientJsonpModule` module as described above.

--- a/goldens/public-api/common/http/index.api.md
+++ b/goldens/public-api/common/http/index.api.md
@@ -18,6 +18,16 @@ import { Signal } from '@angular/core';
 import { ValueEqualityFn } from '@angular/core';
 import { WritableResource } from '@angular/core';
 
+// @public @deprecated
+export class DangerousHttpClientJsonpModule {
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<DangerousHttpClientJsonpModule, never>;
+    // (undocumented)
+    static ɵinj: i0.ɵɵInjectorDeclaration<DangerousHttpClientJsonpModule>;
+    // (undocumented)
+    static ɵmod: i0.ɵɵNgModuleDeclaration<DangerousHttpClientJsonpModule, never, never, never>;
+}
+
 // @public
 export class FetchBackend implements HttpBackend {
     // (undocumented)
@@ -555,16 +565,6 @@ export interface HttpClientCommonOptions extends Omit<HttpRequestOptions, 'heade
     params?: HttpParams | {
         [param: string]: string | number | boolean | ReadonlyArray<string | number | boolean>;
     };
-}
-
-// @public @deprecated
-export class HttpClientJsonpModule {
-    // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientJsonpModule, never>;
-    // (undocumented)
-    static ɵinj: i0.ɵɵInjectorDeclaration<HttpClientJsonpModule>;
-    // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientJsonpModule, never, never, never>;
 }
 
 // @public @deprecated
@@ -1234,6 +1234,9 @@ export class JsonpInterceptor {
 export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): EnvironmentProviders;
 
 // @public @deprecated
+export function withDangerousJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport>;
+
+// @public @deprecated
 export function withFetch(): HttpFeature<HttpFeatureKind.Fetch>;
 
 // @public
@@ -1241,9 +1244,6 @@ export function withInterceptors(interceptorFns: HttpInterceptorFn[]): HttpFeatu
 
 // @public
 export function withInterceptorsFromDi(): HttpFeature<HttpFeatureKind.LegacyInterceptors>;
-
-// @public @deprecated
-export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport>;
 
 // @public
 export function withNoXsrfProtection(): HttpFeature<HttpFeatureKind.NoXsrfProtection>;

--- a/modules/playground/src/jsonp/main.ts
+++ b/modules/playground/src/jsonp/main.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {HttpClientJsonpModule, HttpClientModule} from '@angular/common/http';
+import {DangerousHttpClientJsonpModule, HttpClientModule} from '@angular/common/http';
 import {NgModule, provideZoneChangeDetection} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -15,7 +15,7 @@ import {JsonpCmp} from './app/jsonp_comp';
 @NgModule({
   bootstrap: [JsonpCmp],
   declarations: [JsonpCmp],
-  imports: [BrowserModule, HttpClientModule, HttpClientJsonpModule],
+  imports: [BrowserModule, HttpClientModule, DangerousHttpClientJsonpModule],
   providers: [provideZoneChangeDetection()],
 })
 export class ExampleModule {}

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -23,7 +23,13 @@ export {
   HttpInterceptorFn,
 } from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
-export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';
+export {
+  // 3p-only-start
+  DangerousHttpClientJsonpModule,
+  // 3p-only-end
+  HttpClientModule,
+  HttpClientXsrfModule,
+} from './src/module';
 export {
   HttpParameterCodec,
   HttpParams,
@@ -34,10 +40,12 @@ export {
   HttpFeature,
   HttpFeatureKind,
   provideHttpClient,
+  // 3p-only-start
+  withDangerousJsonpSupport,
+  // 3p-only-end
   withFetch,
   withInterceptors,
   withInterceptorsFromDi,
-  withJsonpSupport,
   withNoXsrfProtection,
   withRequestsMadeViaParent,
   withXhr,

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -1480,7 +1480,7 @@ export class HttpClient {
    * @param url The resource URL.
    * @param callbackParam The callback function name.
    *
-   * You must install a suitable interceptor, such as one provided by `HttpClientJsonpModule`.
+   * You must install a suitable interceptor, such as one provided by `DangerousHttpClientJsonpModule`.
    * If no such interceptor is reached,
    * then the `JSONP` request can be rejected by the configured backend.
    *

--- a/packages/common/http/src/module.ts
+++ b/packages/common/http/src/module.ts
@@ -11,8 +11,8 @@ import {ModuleWithProviders, NgModule} from '@angular/core';
 import {HTTP_INTERCEPTORS} from './interceptor';
 import {
   provideHttpClient,
+  withDangerousJsonpSupport,
   withInterceptorsFromDi,
-  withJsonpSupport,
   withNoXsrfProtection,
   withXhr,
   withXsrfConfiguration,
@@ -112,10 +112,17 @@ export class HttpClientModule {}
  * Without this module, Jsonp requests reach the backend
  * with method JSONP, where they are rejected.
  *
+ * IMPORTANT: JSONP works by loading and executing JavaScript from a remote origin
+ * via a `<script>` tag. Unlike standard XHR/fetch requests, the response
+ * is executed as code in the page's context, which bypasses normal
+ * same-origin protections and can lead to XSS-style attacks if the
+ * endpoint is compromised or untrusted.
+ * Please avoid using this and transition over to CORS-enabled APIs. This API would be removed in v23.
+ *
  * @publicApi
  * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Intent to remove in future versions of Angular.
  */
 @NgModule({
-  providers: [withJsonpSupport().ɵproviders],
+  providers: [withDangerousJsonpSupport().ɵproviders],
 })
-export class HttpClientJsonpModule {}
+export class DangerousHttpClientJsonpModule {}

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -92,7 +92,7 @@ function makeHttpFeature<KindT extends HttpFeatureKind>(
  * @see {@link withInterceptorsFromDi}
  * @see {@link withXsrfConfiguration}
  * @see {@link withNoXsrfProtection}
- * @see {@link withJsonpSupport}
+ * @see {@link withDangerousJsonpSupport}
  * @see {@link withRequestsMadeViaParent}
  * @see {@link withXhr}
  */
@@ -239,10 +239,17 @@ export function withNoXsrfProtection(): HttpFeature<HttpFeatureKind.NoXsrfProtec
 /**
  * Add JSONP support to the configuration of the current `HttpClient` instance.
  *
+ * IMPORTANT: JSONP works by loading and executing JavaScript from a remote origin
+ * via a `<script>` tag. Unlike standard XHR/fetch requests, the response
+ * is executed as code in the page's context, which bypasses normal
+ * same-origin protections and can lead to XSS-style attacks if the
+ * endpoint is compromised or untrusted.
+ * Please avoid using this and transition over to CORS-enabled APIs. This API would be removed in v23.
+ *
  * @see {@link provideHttpClient}
  * @deprecated 22.1 JSONP is deprecated as it can cause XSS vulnerabilities. Use standard HTTP requests instead. Intent to remove in future versions of Angular.
  */
-export function withJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
+export function withDangerousJsonpSupport(): HttpFeature<HttpFeatureKind.JsonpSupport> {
   return makeHttpFeature(HttpFeatureKind.JsonpSupport, [
     JsonpClientBackend,
     {provide: JsonpCallbackContext, useFactory: jsonpCallbackContext},

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -123,12 +123,12 @@ export class HttpXhrBackend implements HttpBackend {
    */
   handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
     // Quick check to give a better error message when a user attempts to use
-    // HttpClient.jsonp() without installing the HttpClientJsonpModule
+    // HttpClient.jsonp() without installing the DangerousHttpClientJsonpModule
     if (req.method === 'JSONP') {
       throw new RuntimeError(
         RuntimeErrorCode.MISSING_JSONP_MODULE,
         (typeof ngDevMode === 'undefined' || ngDevMode) &&
-          `Cannot make a JSONP request without JSONP support. To fix the problem, either add the \`withJsonpSupport()\` call (if \`provideHttpClient()\` is used) or import the \`HttpClientJsonpModule\` in the root NgModule.`,
+          `Cannot make a JSONP request without JSONP support. To fix the problem, either add the \`withDangerousJsonpSupport()\` call (if \`provideHttpClient()\` is used) or import the \`DangerousHttpClientJsonpModule\` in the root NgModule.`,
       );
     }
 

--- a/packages/common/http/test/provider_spec.ts
+++ b/packages/common/http/test/provider_spec.ts
@@ -6,6 +6,18 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {
+  ApplicationRef,
+  createEnvironmentInjector,
+  EnvironmentInjector,
+  ErrorHandler,
+  inject,
+  InjectionToken,
+  PLATFORM_ID,
+  Provider,
+} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {EMPTY, from, Observable} from 'rxjs';
 import {DOCUMENT, XhrFactory} from '../../index';
 import {
   FetchBackend,
@@ -22,33 +34,21 @@ import {
   JsonpClientBackend,
 } from '../index';
 import {HttpClientTestingModule, HttpTestingController, provideHttpClientTesting} from '../testing';
-import {
-  ApplicationRef,
-  createEnvironmentInjector,
-  EnvironmentInjector,
-  ErrorHandler,
-  inject,
-  InjectionToken,
-  PLATFORM_ID,
-  Provider,
-} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-import {EMPTY, Observable, from} from 'rxjs';
 
+import {resetFetchBackendWarningFlag} from '../src/backend';
 import {HttpInterceptorFn} from '../src/interceptor';
 import {
   HttpFeature,
   HttpFeatureKind,
   provideHttpClient,
+  withDangerousJsonpSupport,
   withInterceptors,
   withInterceptorsFromDi,
-  withJsonpSupport,
   withNoXsrfProtection,
   withRequestsMadeViaParent,
   withXhr,
   withXsrfConfiguration,
 } from '../src/provider';
-import {resetFetchBackendWarningFlag} from '../src/backend';
 
 describe('without provideHttpClientTesting', () => {
   it('should contribute to stability', async () => {
@@ -344,10 +344,10 @@ describe('provideHttpClient', () => {
       TestBed.inject(HttpTestingController).expectOne('/test?callback=JSONP_CALLBACK').flush('');
     });
 
-    it('should be enabled when using withJsonpSupport()', () => {
+    it('should be enabled when using withDangerousJsonpSupport()', () => {
       TestBed.configureTestingModule({
         providers: [
-          provideHttpClient(withJsonpSupport()),
+          provideHttpClient(withDangerousJsonpSupport()),
           provideHttpClientTesting(),
           FAKE_JSONP_BACKEND_PROVIDER,
         ],


### PR DESCRIPTION
In addition of deprecating JSONP support (#69116) we will remame both the provider function and the module to explicit that JSONP can be an attack vector and should be used with caution
While this is a breaking change, we consider this a hardening change. Also our investigation showed that this API is not widely used. 


BREAKING CHANGE: JSONP is considered a liability and its usage in not recommended. The API will be removed in v23. Please transition to CORS-enabled APIs instead.
