### PR TITLE
fix(http): preserve empty referrer option in HttpRequest

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -379,7 +379,7 @@ export class HttpRequest<T> implements HttpRequestOptions {
         this.integrity = options.integrity;
       }
 
-      if (options.referrer) {
+      if (options.referrer !== undefined) {
         this.referrer = options.referrer;
       }
 
@@ -555,7 +555,8 @@ export class HttpRequest<T> implements HttpRequestOptions {
     const mode = update.mode || this.mode;
     const redirect = update.redirect || this.redirect;
     const credentials = update.credentials || this.credentials;
-    const referrer = update.referrer || this.referrer;
+
+    const referrer = update.referrer ?? this.referrer;
     const integrity = update.integrity || this.integrity;
     const referrerPolicy = update.referrerPolicy || this.referrerPolicy;
     // Carefully handle the transferCache to differentiate between

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -95,6 +95,10 @@ describe('HttpRequest', () => {
       const req = new HttpRequest('GET', '/test', {referrer: 'about:client'});
       expect(req.referrer).toBe('about:client');
     });
+    it('should preserve an empty string referrer (used to suppress the Referer header)', () => {
+      const req = new HttpRequest('GET', '/test', {referrer: ''});
+      expect(req.referrer).toBe('');
+    });
     it('should allow setting referrerPolicy option', () => {
       const req = new HttpRequest('GET', '/test', {referrerPolicy: 'no-referrer'});
       expect(req.referrerPolicy).toBe('no-referrer');
@@ -193,6 +197,13 @@ describe('HttpRequest', () => {
     });
     it('and updates the referrer', () => {
       expect(req.clone({referrer: 'https://example.com'}).referrer).toBe('https://example.com');
+    });
+    it('and preserves an existing empty string referrer when the update omits it', () => {
+      const emptyReferrerReq = new HttpRequest('GET', '/test', {referrer: ''});
+      expect(emptyReferrerReq.clone().referrer).toBe('');
+    });
+    it('and can update the referrer to an empty string', () => {
+      expect(req.clone({referrer: ''}).referrer).toBe('');
     });
     it('and updates the integrity', () => {
       expect(req.clone({integrity: 'sha512-...'}).integrity).toBe('sha512-...');


### PR DESCRIPTION
Preserve `referrer: ''` when constructing and cloning HttpRequest.

An empty string is a valid Fetch referrer value and is documented by Angular as the way to omit referrer information for sensitive requests. The previous truthy checks treated it as if the option was not provided, causing requests to fall back to the browser default referrer behavior.

See https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#referrer
 