### PR TITLE
fix(vscode-extension): inspect tsdk configurations correctly

### DIFF
--- a/vscode-ng-language-service/client/src/client.ts
+++ b/vscode-ng-language-service/client/src/client.ts
@@ -630,19 +630,20 @@ export class AngularLanguageClient implements vscode.Disposable {
 
   private async getTsdkPath(): Promise<string> {
     const config = vscode.workspace.getConfiguration();
-    const tsdkInspect =
-      config.inspect<string>('js/ts.tsdk.path') ?? config.inspect<string>('typescript.tsdk');
-
-    if (!tsdkInspect) {
-      return '';
-    }
+    const jsTsTsdkInspect = config.inspect<string>('js/ts.tsdk.path');
+    const tsTsdkInspect = config.inspect<string>('typescript.tsdk');
 
     // 1. Check workspace/folder settings first (highest priority)
     // ONLY check or load workspace-level settings if the workspace is trusted
     if (vscode.workspace.isTrusted) {
-      const workspaceTsdk = (
-        tsdkInspect.workspaceValue ?? tsdkInspect.workspaceFolderValue
+      const jsTsWorkspaceTsdk = (
+        jsTsTsdkInspect?.workspaceValue ?? jsTsTsdkInspect?.workspaceFolderValue
       )?.trim();
+      const tsWorkspaceTsdk = (
+        tsTsdkInspect?.workspaceValue ?? tsTsdkInspect?.workspaceFolderValue
+      )?.trim();
+      const workspaceTsdk = jsTsWorkspaceTsdk || tsWorkspaceTsdk;
+
       if (workspaceTsdk) {
         const stateKey = `approvedTsdk:${workspaceTsdk}`;
         const isApproved = this.context.workspaceState.get<boolean>(stateKey);
@@ -660,7 +661,7 @@ export class AngularLanguageClient implements vscode.Disposable {
       }
     }
 
-    return tsdkInspect.globalValue?.trim() ?? '';
+    return jsTsTsdkInspect?.globalValue?.trim() ?? tsTsdkInspect?.globalValue?.trim() ?? '';
   }
 
   private async promptForTsdkApproval(workspaceTsdk: string, stateKey: string): Promise<void> {


### PR DESCRIPTION
Inspect both 'js/ts.tsdk.path' and 'typescript.tsdk' configurations separately, as the inspect method always returns a truthy object.

fixes #69145
