### PR TITLE
docs: Add link to all error codes

### DIFF
--- a/adev/src/content/reference/errors/overview.md
+++ b/adev/src/content/reference/errors/overview.md
@@ -60,3 +60,7 @@
 | `NG8003` | [Missing Reference Target](errors/NG8003)                  |
 | `NG8023` | [Multiple Components Match Same Element](errors/NG8023)    |
 | `NG8024` | [Conflicting Host Directive Binding](errors/NG8024)        |
+
+## Error codes without a guide
+
+Not every error code has a guide. The full list of error codes can be found at <https://github.com/angular/angular/blob/main/packages/core/src/errors.ts>.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When visiting https://angular.dev/errors you can't get a list of all the errors.

## What is the new behavior?

Adding a link to https://angular.dev/errors with all the errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
