### PR TITLE
fix(compiler): sanitize `href`/`xlink:href` attributes of any element…

### DIFF
--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -10,7 +10,7 @@ import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata, SecurityContex
 import {isNgContainer, isNgContent, splitNsName} from '../ml_parser/tags';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from '../template/pipeline/src/namespaces';
 import {dashCaseToCamelCase} from '../util';
-import {SECURITY_SCHEMA} from './dom_security_schema';
+import {checkSecurityContext, SECURITY_SCHEMA} from './dom_security_schema';
 import {ElementSchemaRegistry} from './element_schema_registry';
 
 const BOOLEAN = 'boolean';
@@ -453,16 +453,8 @@ export class DomElementSchemaRegistry extends ElementSchemaRegistry {
       propName = this.getMappedPropName(propName);
     }
 
-    const normalizedTag = normalizeTagName(tagName);
-    propName = propName.toLowerCase();
-
-    const securitySchema = SECURITY_SCHEMA();
-    const ctx =
-      securitySchema[normalizedTag + '|' + propName] ??
-      securitySchema['*|' + propName] ??
-      SecurityContext.NONE;
-
-    return ctx;
+    const [ns, name] = splitNsName(tagName, false);
+    return checkSecurityContext(name, propName, ns);
   }
 
   override getMappedPropName(propName: string): string {

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -71,39 +71,7 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
     registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
       // MathML namespace
       // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
-      ['annotation', ['href', 'xlink:href']],
-      ['annotation-xml', ['href', 'xlink:href']],
-      ['maction', ['href', 'xlink:href']],
-      ['malignmark', ['href', 'xlink:href']],
-      ['math', ['href', 'xlink:href']],
-      ['mroot', ['href', 'xlink:href']],
-      ['msqrt', ['href', 'xlink:href']],
-      ['merror', ['href', 'xlink:href']],
-      ['mfrac', ['href', 'xlink:href']],
-      ['mglyph', ['href', 'xlink:href']],
-      ['msub', ['href', 'xlink:href']],
-      ['msup', ['href', 'xlink:href']],
-      ['msubsup', ['href', 'xlink:href']],
-      ['mmultiscripts', ['href', 'xlink:href']],
-      ['mprescripts', ['href', 'xlink:href']],
-      ['mi', ['href', 'xlink:href']],
-      ['mn', ['href', 'xlink:href']],
-      ['mo', ['href', 'xlink:href']],
-      ['mpadded', ['href', 'xlink:href']],
-      ['mphantom', ['href', 'xlink:href']],
-      ['mrow', ['href', 'xlink:href']],
-      ['ms', ['href', 'xlink:href']],
-      ['mspace', ['href', 'xlink:href']],
-      ['mstyle', ['href', 'xlink:href']],
-      ['mtable', ['href', 'xlink:href']],
-      ['mtd', ['href', 'xlink:href']],
-      ['mtr', ['href', 'xlink:href']],
-      ['mtext', ['href', 'xlink:href']],
-      ['mover', ['href', 'xlink:href']],
-      ['munder', ['href', 'xlink:href']],
-      ['munderover', ['href', 'xlink:href']],
-      ['semantics', ['href', 'xlink:href']],
-      ['none', ['href', 'xlink:href']],
+      ['*', ['href', 'xlink:href']],
     ]);
 
     registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
@@ -161,12 +129,45 @@ function registerContext(
   specs: readonly [tagName: string, attributeNames: readonly string[]][],
 ): void {
   for (const [element, attributeNames] of specs) {
-    let tagName =
-      namespace && element !== '*' && element !== 'unknown' ? `:${namespace}:${element}` : element;
+    let tagName = element;
+    if (namespace && element !== 'unknown') {
+      tagName = `:${namespace}:${element}`;
+    }
     tagName = tagName.toLowerCase();
 
     for (const attr of attributeNames) {
       _SECURITY_SCHEMA[`${tagName}|${attr.toLowerCase()}`] = ctx;
     }
   }
+}
+
+/**
+ * Checks the SecurityContext for a given tag and property.
+ * @param tagName The tag name (e.g. 'div', or 'a')
+ * @param propName The property or attribute name
+ * @param namespace The namespace of the element, if any (e.g. 'svg' or 'math')
+ */
+export function checkSecurityContext(
+  tagName: string,
+  propName: string,
+  namespace?: string | null,
+): SecurityContext {
+  const securitySchema = SECURITY_SCHEMA();
+  propName = propName.toLowerCase();
+  tagName = tagName.toLowerCase();
+
+  let namespacedTag = tagName;
+  let nsWildcardTag: string | undefined;
+
+  if (namespace === SVG_NAMESPACE || namespace === MATH_ML_NAMESPACE) {
+    namespacedTag = `:${namespace}:${tagName}`;
+    nsWildcardTag = `:${namespace}:*`;
+  }
+
+  return (
+    securitySchema[namespacedTag + '|' + propName] ??
+    (nsWildcardTag !== undefined ? securitySchema[nsWildcardTag + '|' + propName] : undefined) ??
+    securitySchema['*|' + propName] ??
+    SecurityContext.NONE
+  );
 }

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SecurityContext} from '../../src/core';
 import {
   _ATTR_TO_PROP,
   DomElementSchemaRegistry,
   SCHEMA,
 } from '../../src/schema/dom_element_schema_registry';
-import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SecurityContext} from '../../src/core';
 
 import {Element} from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
@@ -174,6 +174,22 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext(':svg:a', 'xlink:href', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':svg:a', 'href', true)).toBe(SecurityContext.URL);
     expect(registry.securityContext(':svg:a', 'xlink:href', true)).toBe(SecurityContext.URL);
+
+    // MathML link attributes
+    expect(registry.securityContext(':math:math', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:math', 'xlink:href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:math', 'href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:math', 'xlink:href', true)).toBe(SecurityContext.URL);
+    // Making sure we're have a wild card match for MathML elements with the correct security context
+    expect(registry.securityContext(':math:foobar', 'href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:foobar', 'xlink:href', true)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:foobar', 'href', false)).toBe(SecurityContext.URL);
+    expect(registry.securityContext(':math:foobar', 'xlink:href', false)).toBe(SecurityContext.URL);
+    // Ensure MathML wildcard does not apply outside of the MathML namespace.
+    expect(registry.securityContext(':svg:foobar', 'href', false)).toBe(SecurityContext.NONE);
+    expect(registry.securityContext(':svg:foobar', 'xlink:href', false)).toBe(SecurityContext.NONE);
+
+    expect(registry.securityContext('p', 'href', false)).toBe(SecurityContext.NONE);
   });
 
   it('should detect properties on namespaced elements', () => {

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -9,17 +9,17 @@ import '../../util/ng_dev_mode';
 import '../../util/ng_i18n_closure_mode';
 
 import {XSS_SECURITY_URL} from '../../error_details_base_url';
+import {checkSecurityContext, SecurityContext} from '../../sanitization/dom_security_schema';
 import {getTemplateContent, VALID_ATTRS, VALID_ELEMENTS} from '../../sanitization/html_sanitizer';
 import {getInertBodyHelper} from '../../sanitization/inert_body';
-import {_sanitizeUrl} from '../../sanitization/url_sanitizer';
 import {
   ɵɵsanitizeHtml as _sanitizeHtml,
-  ɵɵsanitizeStyle as _sanitizeStyle,
-  ɵɵsanitizeScript as _sanitizeScript,
   ɵɵsanitizeResourceUrl as _sanitizeResourceUrl,
+  ɵɵsanitizeScript as _sanitizeScript,
+  ɵɵsanitizeStyle as _sanitizeStyle,
   ɵɵvalidateAttribute as _validateAttribute,
 } from '../../sanitization/sanitization';
-import {SECURITY_SCHEMA, SecurityContext} from '../../sanitization/dom_security_schema';
+import {_sanitizeUrl} from '../../sanitization/url_sanitizer';
 import {
   assertDefined,
   assertEqual,
@@ -56,6 +56,8 @@ import {SanitizerFn} from '../interfaces/sanitization';
 import {HEADER_OFFSET, LView, TView} from '../interfaces/view';
 import {getCurrentParentTNode, getCurrentTNode, setCurrentTNode} from '../state';
 
+import {createTNodeAtIndex} from '../tnode_manipulation';
+import {allocExpando} from '../view/construction';
 import {
   i18nCreateOpCodesToString,
   i18nRemoveOpCodesToString,
@@ -71,9 +73,6 @@ import {
   setTIcu,
   setTNodeInsertBeforeIndex,
 } from './i18n_util';
-import {createTNodeAtIndex} from '../tnode_manipulation';
-import {allocExpando} from '../view/construction';
-import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from '../namespaces';
 
 const BINDING_REGEXP = /�(\d+):?\d*�/gi;
 const ICU_REGEXP = /({\s*�\d+:?\d*�\s*,\s*\S{6}\s*,[\s\S]*})/gi;
@@ -1003,21 +1002,15 @@ function splitNsName(elementName: string, fatal: boolean = true): [string | null
   return [elementName.slice(1, colonIndex), elementName.slice(colonIndex + 1)];
 }
 
-function normalizeTagName(tagName: string): string {
-  const tagNameLower = tagName.toLowerCase();
-  const [ns, name] = splitNsName(tagNameLower, false);
-
-  return ns === SVG_NAMESPACE || ns === MATH_ML_NAMESPACE ? `:${ns}:${name}` : name;
-}
-
 function i18nResolveSanitizer(attrName: string, tagName?: string): SanitizerFn | null {
-  const lowerAttrName = attrName.toLowerCase();
-  const lowerTagName = tagName ? normalizeTagName(tagName) : '*';
-  const schema = SECURITY_SCHEMA();
-  const schemaContext =
-    schema[`${lowerTagName}|${lowerAttrName}`] ||
-    schema[`*|${lowerAttrName}`] ||
-    SecurityContext.NONE;
+  let schemaContext = SecurityContext.NONE;
+
+  if (tagName) {
+    const [ns, name] = splitNsName(tagName, false);
+    schemaContext = checkSecurityContext(name, attrName, ns);
+  } else {
+    schemaContext = checkSecurityContext('*', attrName);
+  }
 
   switch (schemaContext) {
     case SecurityContext.HTML:

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -71,39 +71,7 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
     registerContext(SecurityContext.URL, MATH_ML_NAMESPACE, [
       // MathML namespace
       // https://crsrc.org/c/third_party/blink/renderer/core/sanitizer/sanitizer.cc;l=753-768;drc=b3eb16372dcd3317d65e9e0265015e322494edcd;bpv=1;bpt=1
-      ['annotation', ['href', 'xlink:href']],
-      ['annotation-xml', ['href', 'xlink:href']],
-      ['maction', ['href', 'xlink:href']],
-      ['malignmark', ['href', 'xlink:href']],
-      ['math', ['href', 'xlink:href']],
-      ['mroot', ['href', 'xlink:href']],
-      ['msqrt', ['href', 'xlink:href']],
-      ['merror', ['href', 'xlink:href']],
-      ['mfrac', ['href', 'xlink:href']],
-      ['mglyph', ['href', 'xlink:href']],
-      ['msub', ['href', 'xlink:href']],
-      ['msup', ['href', 'xlink:href']],
-      ['msubsup', ['href', 'xlink:href']],
-      ['mmultiscripts', ['href', 'xlink:href']],
-      ['mprescripts', ['href', 'xlink:href']],
-      ['mi', ['href', 'xlink:href']],
-      ['mn', ['href', 'xlink:href']],
-      ['mo', ['href', 'xlink:href']],
-      ['mpadded', ['href', 'xlink:href']],
-      ['mphantom', ['href', 'xlink:href']],
-      ['mrow', ['href', 'xlink:href']],
-      ['ms', ['href', 'xlink:href']],
-      ['mspace', ['href', 'xlink:href']],
-      ['mstyle', ['href', 'xlink:href']],
-      ['mtable', ['href', 'xlink:href']],
-      ['mtd', ['href', 'xlink:href']],
-      ['mtr', ['href', 'xlink:href']],
-      ['mtext', ['href', 'xlink:href']],
-      ['mover', ['href', 'xlink:href']],
-      ['munder', ['href', 'xlink:href']],
-      ['munderover', ['href', 'xlink:href']],
-      ['semantics', ['href', 'xlink:href']],
-      ['none', ['href', 'xlink:href']],
+      ['*', ['href', 'xlink:href']],
     ]);
 
     registerContext(SecurityContext.RESOURCE_URL, /** Namespace */ undefined, [
@@ -161,12 +129,45 @@ function registerContext(
   specs: readonly [tagName: string, attributeNames: readonly string[]][],
 ): void {
   for (const [element, attributeNames] of specs) {
-    let tagName =
-      namespace && element !== '*' && element !== 'unknown' ? `:${namespace}:${element}` : element;
+    let tagName = element;
+    if (namespace && element !== 'unknown') {
+      tagName = `:${namespace}:${element}`;
+    }
     tagName = tagName.toLowerCase();
 
     for (const attr of attributeNames) {
       _SECURITY_SCHEMA[`${tagName}|${attr.toLowerCase()}`] = ctx;
     }
   }
+}
+
+/**
+ * Checks the SecurityContext for a given tag and property.
+ * @param tagName The tag name (e.g. 'div', or 'a')
+ * @param propName The property or attribute name
+ * @param namespace The namespace of the element, if any (e.g. 'svg' or 'math')
+ */
+export function checkSecurityContext(
+  tagName: string,
+  propName: string,
+  namespace?: string | null,
+): SecurityContext {
+  const securitySchema = SECURITY_SCHEMA();
+  propName = propName.toLowerCase();
+  tagName = tagName.toLowerCase();
+
+  let namespacedTag = tagName;
+  let nsWildcardTag: string | undefined;
+
+  if (namespace === SVG_NAMESPACE || namespace === MATH_ML_NAMESPACE) {
+    namespacedTag = `:${namespace}:${tagName}`;
+    nsWildcardTag = `:${namespace}:*`;
+  }
+
+  return (
+    securitySchema[namespacedTag + '|' + propName] ??
+    (nsWildcardTag !== undefined ? securitySchema[nsWildcardTag + '|' + propName] : undefined) ??
+    securitySchema['*|' + propName] ??
+    SecurityContext.NONE
+  );
 }


### PR DESCRIPTION
… of the MathML namespace

The ensures that future, present and past (and precated) elements of that namespace get sanitized.
