### PR TITLE
[Backport 20.3.x] fix(http): preserve empty referrer option in HttpRequest

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -516,7 +516,7 @@ export class HttpRequest<T> {
         this.integrity = options.integrity;
       }
 
-      if (options.referrer) {
+      if (options.referrer !== undefined) {
         this.referrer = options.referrer;
       }
 
@@ -720,7 +720,8 @@ export class HttpRequest<T> {
     const mode = update.mode || this.mode;
     const redirect = update.redirect || this.redirect;
     const credentials = update.credentials || this.credentials;
-    const referrer = update.referrer || this.referrer;
+
+    const referrer = update.referrer ?? this.referrer;
     const integrity = update.integrity || this.integrity;
     // Carefully handle the transferCache to differentiate between
     // `false` and `undefined` in the update args.

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -95,6 +95,10 @@ describe('HttpRequest', () => {
       const req = new HttpRequest('GET', '/test', {referrer: 'about:client'});
       expect(req.referrer).toBe('about:client');
     });
+    it('should preserve an empty string referrer (used to suppress the Referer header)', () => {
+      const req = new HttpRequest('GET', '/test', {referrer: ''});
+      expect(req.referrer).toBe('');
+    });
   });
   describe('clone() copies the request', () => {
     const headers = new HttpHeaders({
@@ -168,6 +172,13 @@ describe('HttpRequest', () => {
     });
     it('and updates the referrer', () => {
       expect(req.clone({referrer: 'https://example.com'}).referrer).toBe('https://example.com');
+    });
+    it('and preserves an existing empty string referrer when the update omits it', () => {
+      const emptyReferrerReq = new HttpRequest('GET', '/test', {referrer: ''});
+      expect(emptyReferrerReq.clone().referrer).toBe('');
+    });
+    it('and can update the referrer to an empty string', () => {
+      expect(req.clone({referrer: ''}).referrer).toBe('');
     });
     it('and updates the integrity', () => {
       expect(req.clone({integrity: 'sha512-...'}).integrity).toBe('sha512-...');


### PR DESCRIPTION
 Backport of https://github.com/angular/angular/pull/69171