### PR TITLE
fix(migrations): resolve migration failure when tsconfig specifies rootDir

### DIFF
--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/BUILD.bazel
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/BUILD.bazel
@@ -1,10 +1,13 @@
-load("//tools:defaults.bzl", "ts_project")
+load("//tools:defaults.bzl", "jasmine_test", "ts_project")
 
 package(default_visibility = ["//packages/core/schematics:__subpackages__"])
 
 ts_project(
     name = "angular_devkit",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["*.spec.ts"],
+    ),
     deps = [
         "//:node_modules/@angular-devkit/core",
         "//:node_modules/@angular-devkit/schematics",
@@ -13,4 +16,20 @@ ts_project(
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tsurge",
     ],
+)
+
+ts_project(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":angular_devkit",
+        "//:node_modules/@angular-devkit/schematics",
+        "//packages/core/schematics/utils/tsurge",
+    ],
+)
+
+jasmine_test(
+    name = "test",
+    data = [":test_lib"],
 )

--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.spec.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {HostTree} from '@angular-devkit/schematics';
+import {UnitTestTree} from '@angular-devkit/schematics/testing/index.js';
+import {
+  confirmAsSerializable,
+  ProgramInfo,
+  projectFile,
+  Replacement,
+  Serializable,
+  TextUpdate,
+  TsurgeFunnelMigration,
+} from '../../index';
+import {runMigrationInDevkit} from './run_in_devkit';
+
+interface TestMigrationData {
+  replacements: Replacement[];
+}
+
+class TestMigration extends TsurgeFunnelMigration<TestMigrationData, TestMigrationData> {
+  override async analyze(info: ProgramInfo): Promise<Serializable<TestMigrationData>> {
+    const replacements: Replacement[] = [];
+
+    for (const sf of info.sourceFiles) {
+      const start = sf.text.indexOf('before');
+      if (start === -1) {
+        continue;
+      }
+
+      replacements.push(
+        new Replacement(
+          projectFile(sf, info),
+          new TextUpdate({position: start, end: start + 'before'.length, toInsert: 'after'}),
+        ),
+      );
+    }
+
+    return confirmAsSerializable({replacements});
+  }
+
+  override async combine(
+    unitA: TestMigrationData,
+    unitB: TestMigrationData,
+  ): Promise<Serializable<TestMigrationData>> {
+    return confirmAsSerializable({
+      replacements: [...unitA.replacements, ...unitB.replacements],
+    });
+  }
+
+  override async globalMeta(data: TestMigrationData): Promise<Serializable<TestMigrationData>> {
+    return confirmAsSerializable(data);
+  }
+
+  override async stats(): Promise<Serializable<unknown>> {
+    return confirmAsSerializable({});
+  }
+
+  override async migrate(data: TestMigrationData): Promise<{replacements: Replacement[]}> {
+    return {replacements: data.replacements};
+  }
+}
+
+describe('runMigrationInDevkit', () => {
+  let tree: UnitTestTree;
+
+  beforeEach(() => {
+    tree = new UnitTestTree(new HostTree());
+  });
+
+  it('applies replacements when no rootDir is specified', async () => {
+    tree.create(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {
+            root: '',
+            architect: {
+              build: {
+                options: {
+                  tsConfig: './tsconfig.app.json',
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    tree.create(
+      '/tsconfig.app.json',
+      JSON.stringify({
+        compilerOptions: {
+          module: 'preserve',
+          target: 'ES2022',
+          noLib: true,
+        },
+        include: ['src/**/*.ts'],
+      }),
+    );
+    tree.create('/src/app/app.ts', `export const value = 'before';\n`);
+
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new TestMigration(),
+    });
+
+    expect(tree.readContent('/src/app/app.ts')).toContain(`'after'`);
+  });
+
+  it('applies replacements to workspace-relative paths when tsconfig rootDir is narrower', async () => {
+    tree.create(
+      '/angular.json',
+      JSON.stringify({
+        version: 1,
+        projects: {
+          app: {
+            root: '',
+            architect: {
+              build: {
+                options: {
+                  tsConfig: './tsconfig.app.json',
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    tree.create(
+      '/tsconfig.app.json',
+      JSON.stringify({
+        compilerOptions: {
+          rootDir: './src',
+          module: 'preserve',
+          target: 'ES2022',
+          noLib: true,
+        },
+        include: ['src/**/*.ts'],
+      }),
+    );
+    tree.create('/src/app/app.ts', `export const value = 'before';\n`);
+
+    await runMigrationInDevkit({
+      tree,
+      getMigration: () => new TestMigration(),
+    });
+
+    expect(tree.readContent('/src/app/app.ts')).toContain(`'after'`);
+  });
+});

--- a/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.ts
+++ b/packages/core/schematics/utils/tsurge/helpers/angular_devkit/run_in_devkit.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {FileSystem, setFileSystem} from '@angular/compiler-cli';
+import {absoluteFrom, FileSystem, setFileSystem} from '@angular/compiler-cli';
 import {SchematicsException, Tree} from '@angular-devkit/schematics';
 import {DevkitMigrationFilesystem} from './devkit_filesystem';
 import {groupReplacementsByFile} from '../group_replacements';
@@ -79,6 +79,9 @@ export async function runMigrationInDevkit<Stats>(
   for (const tsconfigPath of tsconfigPaths) {
     config.beforeProgramCreation?.(tsconfigPath, MigrationStage.Analysis);
     const info = migration.createProgram(tsconfigPath, fs);
+    // Devkit tree updates need workspace-relative paths. Keep `sortedRootDirs`
+    // intact for logical file IDs, but make `rootRelativePath` resolve from `/`.
+    info.projectRoot = absoluteFrom(info.program.getCurrentDirectory());
 
     modifyProgramInfoToEnsureNonOverlappingFiles(tsconfigPath, info, compilationUnitAssignments);
 
@@ -107,6 +110,10 @@ export async function runMigrationInDevkit<Stats>(
     for (const tsconfigPath of tsconfigPaths) {
       config.beforeProgramCreation?.(tsconfigPath, MigrationStage.Migrate);
       const info = migration.createProgram(tsconfigPath, fs);
+      // Devkit tree updates need workspace-relative paths. Keep `sortedRootDirs`
+      // intact for logical file IDs, but make `rootRelativePath` resolve from `/`.
+      info.projectRoot = absoluteFrom(info.program.getCurrentDirectory());
+
       modifyProgramInfoToEnsureNonOverlappingFiles(tsconfigPath, info, compilationUnitAssignments);
 
       config.afterProgramCreation?.(info, fs, MigrationStage.Migrate);


### PR DESCRIPTION
When `rootDir` was set in a project's tsconfig (e.g. `rootDir: "src"`), tsurge-based migrations would fail because `projectRoot` was derived from `rootDir`, causing `rootRelativePath` to be computed relative to `src/` instead of the workspace root. This produced paths like `app/app.ts` instead of `src/app/app.ts`, which the DevKit tree could not resolve.

Fix by overriding `info.projectRoot` to `fs.pwd()` (always `/` in the DevKit filesystem) immediately after program creation, ensuring workspace-relative paths are used for all tree updates.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
