### PR TITLE
docs: mention MDC migration requirement for legacy Material users

### DIFF
--- a/adev/src/app/features/update/recommendations.ts
+++ b/adev/src/app/features/update/recommendations.ts
@@ -2123,7 +2123,8 @@ export const RECOMMENDATIONS: Step[] = [
     level: ApplicationComplexity.Basic,
     material: true,
     step: 'update @angular/material',
-    action: 'Run `ng update @angular/material@17`.',
+    action:
+      'Run `ng update @angular/material@17`. If your application still uses legacy Angular Material components (deprecated in v15 and removed in v17), run `ng generate @angular/material:mdc-migration` before upgrading to Material v17.',
   },
   {
     possibleIn: 1700,


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows our guidelines
* [ ] Tests for the changes have been added (not applicable)
* [x] Docs have been added / updated

## PR Type

* [x] Documentation content changes

## What is the current behavior?

The Angular Update Guide currently instructs users to run:

ng update @angular/material@17

However, it does not mention that applications still using legacy Angular Material components may fail to upgrade because legacy components were deprecated in v15 and removed in v17.

Issue Number: N/A

## What is the new behavior?

Adds a note to the Angular Update Guide indicating that applications still using legacy Angular Material components should run:

ng generate @angular/material:mdc-migration

before upgrading to Angular Material v17.

This provides additional guidance for users upgrading applications that have not yet migrated to MDC-based components.

## Does this PR introduce a breaking change?

* [x] No

## Other information

Legacy Angular Material components were deprecated in v15 and removed in v17. This documentation update helps users understand a common upgrade failure scenario and points them to the existing MDC migration path.
