### PR TITLE
Update reviewers list in .pullapprove.yml

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -283,13 +283,14 @@ groups:
     reviewers:
       users:
         - AleksanderBodurri
+        - csmick
         - ~devversion
         - dgp1130
+        - eduhmc
         - hawkgs
-        - hybrist
-        - ~josephperrott
         - JeanMeche
-        - milomg
+        - ~josephperrott
+        - ~milomg
 
   # =========================================================
   #  Dev-infra


### PR DESCRIPTION
Adds eduhmc and csmick to devtools reviewers, removes hybrist, and changes milomg to approving-only (~milomg).