### PR TITLE
refactor(router): Add handling for ActivatedRoute-scoped injector

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1,6 +1,7 @@
 {
   "chunks": {
     "main": [
+      "ACTIVATED_ROUTE_INJECTOR_FEATURE",
       "AFTER_RENDER_SEQUENCES_TO_ADD",
       "ANIMATIONS",
       "ANIMATION_QUEUE",
@@ -572,6 +573,7 @@
       "diPublicInInjector",
       "directiveHostEndFirstCreatePass",
       "directiveHostFirstCreatePass",
+      "discardNewActivatedRoutes",
       "documentSupported",
       "domOnlyFirstCreatePass",
       "elementAttributeInternal",

--- a/packages/router/src/activated_route_injector_feature.ts
+++ b/packages/router/src/activated_route_injector_feature.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {InjectionToken} from '@angular/core';
+import {OperatorFunction} from 'rxjs';
+import type {NavigationTransition} from './navigation_transition';
+
+export interface ActivatedRouteInjectorFeature {
+  operator(): OperatorFunction<NavigationTransition, NavigationTransition>;
+}
+
+export const ACTIVATED_ROUTE_INJECTOR_FEATURE = new InjectionToken<ActivatedRouteInjectorFeature>(
+  typeof ngDevMode === 'undefined' || ngDevMode ? 'ActivatedRoute injector feature' : '',
+);

--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -21,21 +21,28 @@ export function createRouterState(
   routeReuseStrategy: RouteReuseStrategy,
   curr: RouterStateSnapshot,
   prevState: RouterState,
-): RouterState {
-  const root = createNode(routeReuseStrategy, curr._root, prevState ? prevState._root : undefined);
-  return new RouterState(root, curr);
+): {newlyCreatedRoutes: Set<ActivatedRoute>; state: RouterState} {
+  const newlyCreatedRoutes = new Set<ActivatedRoute>();
+  const root = createNode(
+    routeReuseStrategy,
+    curr._root,
+    prevState ? prevState._root : undefined,
+    newlyCreatedRoutes,
+  );
+  return {newlyCreatedRoutes, state: new RouterState(root, curr)};
 }
 
 function createNode(
   routeReuseStrategy: RouteReuseStrategy,
   curr: TreeNode<ActivatedRouteSnapshot>,
-  prevState?: TreeNode<ActivatedRoute>,
+  prevState: TreeNode<ActivatedRoute> | undefined,
+  newlyCreatedRoutes: Set<ActivatedRoute>,
 ): TreeNode<ActivatedRoute> {
   // reuse an activated route that is currently displayed on the screen
   if (prevState && routeReuseStrategy.shouldReuseRoute(curr.value, prevState.value.snapshot)) {
     const value = prevState.value;
     value._futureSnapshot = curr.value;
-    const children = createOrReuseChildren(routeReuseStrategy, curr, prevState);
+    const children = createOrReuseChildren(routeReuseStrategy, curr, prevState, newlyCreatedRoutes);
     return new TreeNode<ActivatedRoute>(value, children);
   } else {
     if (routeReuseStrategy.shouldAttach(curr.value)) {
@@ -44,13 +51,18 @@ function createNode(
       if (detachedRouteHandle !== null) {
         const tree = (detachedRouteHandle as DetachedRouteHandleInternal).route;
         tree.value._futureSnapshot = curr.value;
-        tree.children = curr.children.map((c) => createNode(routeReuseStrategy, c));
+        tree.children = curr.children.map((c) =>
+          createNode(routeReuseStrategy, c, undefined, newlyCreatedRoutes),
+        );
         return tree;
       }
     }
 
     const value = createActivatedRoute(curr.value);
-    const children = curr.children.map((c) => createNode(routeReuseStrategy, c));
+    newlyCreatedRoutes.add(value);
+    const children = curr.children.map((c) =>
+      createNode(routeReuseStrategy, c, undefined, newlyCreatedRoutes),
+    );
     return new TreeNode<ActivatedRoute>(value, children);
   }
 }
@@ -59,14 +71,15 @@ function createOrReuseChildren(
   routeReuseStrategy: RouteReuseStrategy,
   curr: TreeNode<ActivatedRouteSnapshot>,
   prevState: TreeNode<ActivatedRoute>,
+  newlyCreatedRoutes: Set<ActivatedRoute>,
 ) {
   return curr.children.map((child) => {
     for (const p of prevState.children) {
       if (routeReuseStrategy.shouldReuseRoute(child.value, p.value.snapshot)) {
-        return createNode(routeReuseStrategy, child, p);
+        return createNode(routeReuseStrategy, child, p, newlyCreatedRoutes);
       }
     }
-    return createNode(routeReuseStrategy, child);
+    return createNode(routeReuseStrategy, child, undefined, newlyCreatedRoutes);
   });
 }
 

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -83,6 +83,7 @@ import {UrlSerializer, UrlTree} from './url_tree';
 import {abortSignalToObservable} from './utils/abort_signal_to_observable';
 import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {CREATE_VIEW_TRANSITION} from './utils/view_transition';
+import {ACTIVATED_ROUTE_INJECTOR_FEATURE} from './activated_route_injector_feature';
 
 /**
  * @description
@@ -327,6 +328,7 @@ export interface NavigationTransition {
   targetRouterState: RouterState | null;
   guards: Checks;
   guardsResult: GuardResult | null;
+  newlyCreatedRoutes?: Set<ActivatedRoute>;
 
   routesRecognizeHandler: {deferredHandle?: Promise<void>};
   beforeActivateHandler: {deferredHandle?: Promise<void>};
@@ -367,6 +369,9 @@ export class NavigationTransitions {
   private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
   private readonly createViewTransition = inject(CREATE_VIEW_TRANSITION, {optional: true});
   private readonly navigationErrorHandler = inject(NAVIGATION_ERROR_HANDLER, {optional: true});
+  private readonly activatedRouteInjectorFeature = inject(ACTIVATED_ROUTE_INJECTOR_FEATURE, {
+    optional: true,
+  });
 
   navigationId = 0;
   get hasRequestedNavigation() {
@@ -740,18 +745,27 @@ export class NavigationTransitions {
           }),
 
           switchMap((t: NavigationTransition) => {
-            const targetRouterState = createRouterState(
+            const {newlyCreatedRoutes, state} = createRouterState(
               router.routeReuseStrategy,
               t.targetSnapshot!,
               t.currentRouterState,
             );
-            this.currentTransition = overallTransitionState = t = {...t, targetRouterState};
+            this.currentTransition =
+              overallTransitionState =
+              t =
+                {
+                  ...t,
+                  targetRouterState: state,
+                  newlyCreatedRoutes,
+                };
             this.currentNavigation.update((nav) => {
-              nav!.targetRouterState = targetRouterState;
+              nav!.targetRouterState = state;
               return nav;
             });
             return of(t);
           }),
+
+          this.activatedRouteInjectorFeature?.operator() ?? ((t) => t),
 
           switchTap(() => this.afterPreactivation()),
 
@@ -791,6 +805,9 @@ export class NavigationTransitions {
               (evt: Event) => this.events.next(evt),
               this.inputBindingEnabled,
             ).activate(this.rootContexts);
+
+            // Prevent any cleanup of newly created routes once activated.
+            t.newlyCreatedRoutes?.clear();
 
             if (!shouldContinueNavigation()) {
               return;
@@ -876,6 +893,7 @@ export class NavigationTransitions {
           }),
           catchError((e) => {
             completedOrAborted = true;
+            discardNewActivatedRoutes(overallTransitionState);
             // If the application is already destroyed, the catch block should not
             // execute anything in practice because other resources have already
             // been released and destroyed.
@@ -974,6 +992,7 @@ export class NavigationTransitions {
     reason: string,
     code: NavigationCancellationCode,
   ) {
+    discardNewActivatedRoutes(t);
     const navCancel = new NavigationCancel(
       t.id,
       this.urlSerializer.serialize(t.extractedUrl),
@@ -1025,4 +1044,13 @@ export class NavigationTransitions {
 
 export function isBrowserTriggeredNavigation(source: NavigationTrigger) {
   return source !== IMPERATIVE_NAVIGATION;
+}
+
+function discardNewActivatedRoutes(t: NavigationTransition): void {
+  if (!t.newlyCreatedRoutes) {
+    return;
+  }
+  for (const r of t.newlyCreatedRoutes) {
+    r._localInjector?.destroy();
+  }
 }

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -139,6 +139,12 @@ export class ActivateRoutes {
       context.attachRef = null;
       context.route = null;
     }
+    // Destroy `_localInjector` here when the route is
+    // unmounted by the Router. This method (`deactivateRouteAndOutlet`) is
+    // skipped when a route is being detached for `RouteReuseStrategy`, preserving
+    // its injector. Those preserved injectors are eventually managed and destroyed
+    // manually via `destroyDetachedRouteHandle()` or if the route is deactivated later rather than detached.
+    route.value._localInjector?.destroy();
   }
 
   private activateChildRoutes(

--- a/packages/router/src/operators/setup_activated_route_injectors.ts
+++ b/packages/router/src/operators/setup_activated_route_injectors.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {OperatorFunction} from 'rxjs';
+import {ActivatedRoute, ActivatedRouteSnapshot} from '../router_state';
+import {TreeNode} from '../utils/tree';
+import {NavigationTransition} from '../navigation_transition';
+import {createEnvironmentInjector} from '@angular/core';
+import {tap} from 'rxjs/operators';
+
+export function setupActivatedRouteInjectors(): OperatorFunction<
+  NavigationTransition,
+  NavigationTransition
+> {
+  return tap(({newlyCreatedRoutes, targetRouterState}) => {
+    if (!newlyCreatedRoutes || !targetRouterState) {
+      return;
+    }
+
+    // Obviously the easier way would be to just iterate newlyCreatedRoutes
+    // and create injectors for them. However, the feature will eventually
+    // want to do things for routes that are being reused.
+    const traverse = (stateNode: TreeNode<ActivatedRoute>) => {
+      const route = stateNode.value;
+      if (route) {
+        processRoute(route, newlyCreatedRoutes);
+      }
+
+      for (const childState of stateNode.children) {
+        traverse(childState);
+      }
+    };
+
+    traverse(targetRouterState._root);
+  });
+}
+
+function processRoute(route: ActivatedRoute, newlyCreatedRoutes: Set<ActivatedRoute>) {
+  // Only create injectors for routes with the feature enabled
+  const useActivatedRouteInjector = (route?.routeConfig as any)?.ɵUseActivatedRouteInjector;
+  if (!useActivatedRouteInjector) {
+    return;
+  }
+
+  if (newlyCreatedRoutes.has(route)) {
+    setupNewActivatedRouteInjector(route._futureSnapshot, route);
+  } else {
+    // TODO: Do something with injectors that already exist
+  }
+}
+
+function setupNewActivatedRouteInjector(snapshot: ActivatedRouteSnapshot, route: ActivatedRoute) {
+  if (ngDevMode && !!route._localInjector) {
+    throw new Error(
+      'invalid state: _localInjector should not exist on newly created ActivatedRoute yet',
+    );
+  }
+  route._localInjector = createEnvironmentInjector([], snapshot._environmentInjector);
+}

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -11,3 +11,4 @@ export {RestoredState as ɵRestoredState} from './navigation_transition';
 export {loadChildren as ɵloadChildren} from './router_config_loader';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {afterNextNavigation as ɵafterNextNavigation} from './utils/navigations';
+export {withActivatedRouteInjectors as ɵwithActivatedRouteInjectors} from './provide_router';

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -63,6 +63,8 @@ import {
   VIEW_TRANSITION_OPTIONS,
   ViewTransitionsFeatureOptions,
 } from './utils/view_transition';
+import {ACTIVATED_ROUTE_INJECTOR_FEATURE} from './activated_route_injector_feature';
+import {setupActivatedRouteInjectors} from './operators/setup_activated_route_injectors';
 
 /**
  * Sets up providers necessary to enable `Router` functionality for the application.
@@ -881,6 +883,20 @@ export function withViewTransitions(
     {
       provide: VIEW_TRANSITION_OPTIONS,
       useValue: {skipNextTransition: !!options?.skipInitialTransition, ...options},
+    },
+  ];
+  return routerFeature(RouterFeatureKind.ViewTransitionsFeature, providers);
+}
+
+export type ActivatedRouteInjectorFeature =
+  RouterFeature<RouterFeatureKind.ViewTransitionsFeature /* temporary - not public API. Must reuse existing */>;
+export function withActivatedRouteInjectors(): ActivatedRouteInjectorFeature {
+  const providers = [
+    {
+      provide: ACTIVATED_ROUTE_INJECTOR_FEATURE,
+      useValue: {
+        operator: setupActivatedRouteInjectors,
+      },
     },
   ];
   return routerFeature(RouterFeatureKind.ViewTransitionsFeature, providers);

--- a/packages/router/src/route_reuse_strategy.ts
+++ b/packages/router/src/route_reuse_strategy.ts
@@ -49,6 +49,12 @@ export function destroyDetachedRouteHandle(handle: DetachedRouteHandle): void {
   const internalHandle = handle as DetachedRouteHandleInternal;
   if (internalHandle && internalHandle.componentRef) {
     internalHandle.componentRef.destroy();
+    // It is critical to destroy the `_localInjector` here. When a route is detached
+    // by the `RouteReuseStrategy`, the `_localInjector` is retained because the
+    // ActivatedRoute object is stored and can be attached later.
+    // When the developer drops the handle (e.g., deciding not to reuse it),
+    // they must manually invoke `destroyDetachedRouteHandle` to prevent a memory leak.
+    internalHandle.route.value._localInjector?.destroy();
   }
 }
 

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -154,6 +154,14 @@ export class ActivatedRoute {
   /** An observable of the static and resolved data of this route. */
   public data: Observable<Data>;
 
+  /**
+   * Injector scoped to the lifetime of this ActivatedRoute object.
+   * Created only when features tied to ActivatedRoute lifetime are used.
+   *
+   * @internal
+   */
+  _localInjector?: EnvironmentInjector;
+
   /** @internal */
   constructor(
     /** @internal */

--- a/packages/router/test/activated_route_injector.spec.ts
+++ b/packages/router/test/activated_route_injector.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component, DestroyRef, Injectable} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  ActivatedRouteSnapshot,
+  BaseRouteReuseStrategy,
+  DetachedRouteHandle,
+  Route,
+  RouteReuseStrategy,
+  Router,
+  destroyDetachedRouteHandle,
+  provideRouter,
+  ɵwithActivatedRouteInjectors,
+} from '@angular/router';
+import {RouterTestingHarness} from '@angular/router/testing';
+
+describe('ActivatedRoute local injector', () => {
+  @Component({
+    template: 'home',
+  })
+  class HomeComponent {}
+
+  @Component({
+    template: 'away',
+  })
+  class AwayComponent {}
+
+  @Injectable({providedIn: 'root'})
+  class CustomReuseStrategy extends BaseRouteReuseStrategy {
+    storedHandles = new Map<Route, DetachedRouteHandle>();
+    shouldDetachVal = false;
+    shouldAttachVal = false;
+
+    override shouldDetach(route: ActivatedRouteSnapshot): boolean {
+      return this.shouldDetachVal;
+    }
+
+    override store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle | null): void {
+      if (route.routeConfig && handle) {
+        this.storedHandles.set(route.routeConfig, handle);
+      }
+    }
+
+    override shouldAttach(route: ActivatedRouteSnapshot): boolean {
+      return (
+        this.shouldAttachVal && !!route.routeConfig && this.storedHandles.has(route.routeConfig)
+      );
+    }
+
+    override retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle | null {
+      return (route.routeConfig && this.storedHandles.get(route.routeConfig)) || null;
+    }
+  }
+
+  let router: Router;
+  let strategy: CustomReuseStrategy;
+
+  async function setUpRouter(routes: Route[]): Promise<RouterTestingHarness> {
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter(routes, ɵwithActivatedRouteInjectors()),
+        {provide: RouteReuseStrategy, useClass: CustomReuseStrategy},
+      ],
+    });
+
+    router = TestBed.inject(Router);
+    strategy = TestBed.inject(RouteReuseStrategy) as CustomReuseStrategy;
+    return await RouterTestingHarness.create();
+  }
+
+  it('should create and destroy local injector for routes with ɵUseActivatedRouteInjector', async () => {
+    const harness = await setUpRouter([
+      {
+        path: 'home',
+        component: HomeComponent,
+        'ɵUseActivatedRouteInjector': true,
+      } as any,
+      {
+        path: 'away',
+        component: AwayComponent,
+      },
+    ]);
+
+    await harness.navigateByUrl('/home');
+
+    const homeRoute = router.routerState.root.firstChild!;
+    expect(homeRoute).not.toBeNull();
+    const localInjector = (homeRoute as any)._localInjector;
+    expect(localInjector).toBeDefined();
+
+    let destroyed = false;
+    localInjector!.get(DestroyRef).onDestroy(() => {
+      destroyed = true;
+    });
+
+    // Navigate away to trigger deactivation/cleanup
+    await harness.navigateByUrl('/away');
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('should NOT create local injector for routes without ɵUseActivatedRouteInjector', async () => {
+    const harness = await setUpRouter([
+      {
+        path: 'home',
+        component: HomeComponent,
+      },
+    ]);
+
+    await harness.navigateByUrl('/home');
+
+    const homeRoute = router.routerState.root.firstChild!;
+    expect(homeRoute).not.toBeNull();
+    expect((homeRoute as any)._localInjector).toBeUndefined();
+  });
+
+  it('should keep local injector alive when route is detached and destroy it when handle is destroyed', async () => {
+    const harness = await setUpRouter([
+      {
+        path: 'home',
+        component: HomeComponent,
+        'ɵUseActivatedRouteInjector': true,
+      } as any,
+      {
+        path: 'away',
+        component: AwayComponent,
+      },
+    ]);
+
+    strategy.shouldDetachVal = true;
+
+    await harness.navigateByUrl('/home');
+
+    const homeRoute = router.routerState.root.firstChild!;
+    const localInjector = (homeRoute as any)._localInjector;
+    expect(localInjector).toBeDefined();
+
+    let destroyed = false;
+    localInjector!.get(DestroyRef).onDestroy(() => {
+      destroyed = true;
+    });
+
+    // Navigate away to detach 'home'
+    await harness.navigateByUrl('/away');
+
+    // Verify it is detached and stored
+    const handle = strategy.storedHandles.get(router.config[0]);
+    expect(handle).toBeDefined();
+    // The injector must NOT be destroyed yet
+    expect(destroyed).toBe(false);
+
+    // Manually destroy the detached handle
+    destroyDetachedRouteHandle(handle!);
+
+    expect(destroyed).toBe(true);
+  });
+
+  it('should destroy local injectors if navigation fails during activation', async () => {
+    let throwingRoute: ActivatedRoute | null = null;
+    let localInjectorInConstructor: any = null;
+    let throwingRouteDestroyed = false;
+
+    @Component({
+      template: '',
+    })
+    class ThrowingComponent {
+      constructor(route: ActivatedRoute) {
+        throwingRoute = route;
+        localInjectorInConstructor = (route as any)._localInjector;
+        localInjectorInConstructor.get(DestroyRef).onDestroy(() => {
+          throwingRouteDestroyed = true;
+        });
+        throw new Error('Component instantiation error');
+      }
+    }
+
+    const harness = await setUpRouter([
+      {
+        path: 'home',
+        component: HomeComponent,
+        'ɵUseActivatedRouteInjector': true,
+      } as any,
+      {
+        path: 'throwing',
+        component: ThrowingComponent,
+        'ɵUseActivatedRouteInjector': true,
+      } as any,
+    ]);
+
+    await harness.navigateByUrl('/home');
+
+    const homeRoute = router.routerState.root.firstChild!;
+    const homeLocalInjector = (homeRoute as any)._localInjector;
+    expect(homeLocalInjector).toBeDefined();
+
+    let homeDestroyed = false;
+    homeLocalInjector!.get(DestroyRef).onDestroy(() => {
+      homeDestroyed = true;
+    });
+
+    // Attempt to navigate to /throwing. This will throw an error during activation.
+    let threw = false;
+    try {
+      await harness.navigateByUrl('/throwing');
+    } catch (e) {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    // Since the navigation failed, we should clean up:
+    // 1. Home was deactivated, so its injector should be destroyed.
+    expect(homeDestroyed).toBe(true);
+
+    // 2. The throwing route's injector was created during the transition but failed,
+    // so it should have been cleaned up (destroyed).
+    expect(localInjectorInConstructor).toBeDefined();
+    expect(throwingRouteDestroyed).toBe(true);
+  });
+});

--- a/packages/router/test/create_router_state.spec.ts
+++ b/packages/router/test/create_router_state.spec.ts
@@ -36,7 +36,7 @@ describe('create router state', () => {
   const emptyState = () => createEmptyState(RootComponent, TestBed.inject(EnvironmentInjector));
 
   it('should create new state', async () => {
-    const state = createRouterState(
+    const {state, newlyCreatedRoutes} = createRouterState(
       reuseStrategy,
       await createState(
         [
@@ -55,6 +55,12 @@ describe('create router state', () => {
     checkActivatedRoute(c[0], ComponentA);
     checkActivatedRoute(c[1], ComponentB, 'left');
     checkActivatedRoute(c[2], ComponentC, 'right');
+
+    expect(newlyCreatedRoutes.has(state.root)).toBe(false);
+    expect(newlyCreatedRoutes.has(c[0])).toBe(true);
+    expect(newlyCreatedRoutes.has(c[1])).toBe(true);
+    expect(newlyCreatedRoutes.has(c[2])).toBe(true);
+    expect(newlyCreatedRoutes.size).toBe(3);
   });
 
   it('should reuse existing nodes when it can', async () => {
@@ -64,13 +70,13 @@ describe('create router state', () => {
       {path: 'c', component: ComponentC, outlet: 'left'},
     ];
 
-    const prevState = createRouterState(
+    const {state: prevState, newlyCreatedRoutes: prevCreated} = createRouterState(
       reuseStrategy,
       await createState(config, 'a(left:b)'),
       emptyState(),
     );
     advanceState(prevState);
-    const state = createRouterState(
+    const {state, newlyCreatedRoutes} = createRouterState(
       reuseStrategy,
       await createState(config, 'a(left:c)'),
       prevState,
@@ -83,6 +89,16 @@ describe('create router state', () => {
     expect(prevC[0]).toBe(currC[0]);
     expect(prevC[1]).not.toBe(currC[1]);
     checkActivatedRoute(currC[1], ComponentC, 'left');
+
+    expect(prevCreated.has(prevState.root)).toBe(false);
+    expect(prevCreated.has(prevC[0])).toBe(true);
+    expect(prevCreated.has(prevC[1])).toBe(true);
+    expect(prevCreated.size).toBe(2);
+
+    expect(newlyCreatedRoutes.has(state.root)).toBe(false);
+    expect(newlyCreatedRoutes.has(currC[0])).toBe(false);
+    expect(newlyCreatedRoutes.has(currC[1])).toBe(true);
+    expect(newlyCreatedRoutes.size).toBe(1);
   });
 
   it('should handle componentless routes', async () => {
@@ -96,13 +112,13 @@ describe('create router state', () => {
       },
     ];
 
-    const prevState = createRouterState(
+    const {state: prevState} = createRouterState(
       reuseStrategy,
       await createState(config, 'a/1;p=11/(b//right:c)'),
       emptyState(),
     );
     advanceState(prevState);
-    const state = createRouterState(
+    const {state} = createRouterState(
       reuseStrategy,
       await createState(config, 'a/2;p=22/(b//right:c)'),
       prevState,
@@ -130,7 +146,7 @@ describe('create router state', () => {
     ];
     spyOn(reuseStrategy, 'retrieve');
 
-    const prevState = createRouterState(
+    const {state: prevState} = createRouterState(
       reuseStrategy,
       await createState(config, 'a(left:b)'),
       emptyState(),
@@ -146,7 +162,7 @@ describe('create router state', () => {
       {path: 'product/:id', component: ComponentB},
     ];
     spyOn(reuseStrategy, 'shouldReuseRoute').and.callThrough();
-    const previousState = createRouterState(
+    const {state: previousState} = createRouterState(
       reuseStrategy,
       await createState(config, ''),
       emptyState(),
@@ -169,6 +185,39 @@ describe('create router state', () => {
     expect(future1._routerState.url).toEqual(tree('product/30').toString());
     expect(current2._routerState.url).toEqual(tree('').toString());
     expect(future2._routerState.url).toEqual(tree('product/30').toString());
+  });
+
+  it('should not include attached routes in newlyCreatedRoutes', async () => {
+    const config = [{path: 'a', component: ComponentA}];
+
+    // First transition creates the route
+    const {state: state1, newlyCreatedRoutes: created1} = createRouterState(
+      reuseStrategy,
+      await createState(config, 'a'),
+      emptyState(),
+    );
+    const routeA = (state1 as any).firstChild(state1.root);
+    expect(created1.has(routeA)).toBe(true);
+
+    // Simulate detaching routeA
+    const detachedHandle = {
+      route: new TreeNode<ActivatedRoute>(routeA, []),
+    } as any;
+
+    spyOn(reuseStrategy, 'shouldAttach').and.returnValue(true);
+    spyOn(reuseStrategy, 'retrieve').and.returnValue(detachedHandle);
+
+    // Second transition attaches the route
+    const {state: state2, newlyCreatedRoutes: created2} = createRouterState(
+      reuseStrategy,
+      await createState(config, 'a'),
+      emptyState(),
+    );
+
+    const child2 = (state2 as any).firstChild(state2.root);
+    expect(child2).toBe(routeA); // attached route
+    expect(created2.has(routeA)).toBe(false); // not in newlyCreatedRoutes of the second transition
+    expect(created2.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
Add handling in navigation for creating and destroying injectors scoped to `ActivatedRoute` life.
The code for creating the injectors is certainly more complicated than it _could_ be since there's no actual feature built around this yet.

Keeps as much implementation code tree-shakeable as possible: Raw size: +764 bytes
Gzipped size: +182 bytes
