### PR TITLE
test(core): fix AI tools test flake

### DIFF
--- a/packages/core/test/debug/ai/registration_spec.ts
+++ b/packages/core/test/debug/ai/registration_spec.ts
@@ -9,8 +9,17 @@
 import {signalGraphTool} from '../../../src/debug/ai/signal_graph';
 import {registerAiTools} from '../../../src/debug/ai';
 import {DevtoolsToolDiscoveryEvent} from '../../../src/debug/ai/tool_definitions';
+import {destroyPlatform} from '../../../src/core';
 
 describe('registration', () => {
+  beforeEach(() => {
+    // Destroy any pre-existing platform created by other tests which wasn't properly destroyed.
+    // Creating a platform calls `registerAiTools` in its production code path and unregisters when the platform is destroyed.
+    // If a platform leaks between tests, then there is an extra active AI tools event listener which can break these tests.
+    // The easiest solution is to just destroy any leaked platforms to make sure the environment is stable before we run.
+    destroyPlatform();
+  });
+
   describe('registerAiTools', () => {
     it('should register the tools', () => {
       const unregister = registerAiTools();


### PR DESCRIPTION
This test flakes occasionally because it is called in production when a platform is created and unregistered when a platform is destroyed. However, not all tests properly clean up their platforms, meaning we can accidentally leak platforms between tests. If this happens, we end up have an event listener created from the production code path and a second event listener from the test. When the test emits the event, both listeners respond and it causes too many responses which fails the test.

Ideally, all tests would clean up the platforms correctly, but this seems difficult to guarantee for all Angular tests and is likely to break over time. The simplest solution is just destroy any leaked platform before the test starts. It's a bit elegant, but the safest option.

Tested against the seed from [this failing run](https://github.com/angular/angular/actions/runs/27037418994/job/79804817690) and also with `--runs_per_test 100`.