### PR TITLE
fix(core): treat iframe credentialless as security-sensitive

### DIFF
--- a/adev/src/content/reference/errors/NG0910.md
+++ b/adev/src/content/reference/errors/NG0910.md
@@ -8,6 +8,7 @@ You see this error when Angular detects an attribute binding or a property bindi
 - referrerPolicy
 - csp
 - fetchPriority
+- credentialless
 
 The mentioned attributes affect the security model setup for `<iframe>`s
 and it's important to apply them before setting the `src` or `srcdoc` attributes.

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -9944,6 +9944,33 @@ runInEachFileSystem((os: string) => {
         expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateAttribute)');
       });
 
+      it('should generate a validator fn for credentialless bindings when on <iframe>', () => {
+        env.write(
+          'test.ts',
+          `
+                import {Component} from '@angular/core';
+
+                @Component({
+                  template: \`
+                    <iframe src="http://angular.io"
+                      [credentialless]="true"
+                      [attr.credentialless]="''"
+                    ></iframe>
+                  \`
+                })
+                export class SomeComponent {}
+              `,
+        );
+
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).toContain(
+          'ɵɵdomProperty("credentialless", true, i0.ɵɵvalidateAttribute)',
+        );
+        expect(jsContents).toContain('ɵɵattribute("credentialless", "", i0.ɵɵvalidateAttribute)');
+      });
+
       it(
         'should generate an attribute binding instruction with a validator function ' +
           "(making sure it's case-insensitive, since this is allowed in Angular templates)",
@@ -10034,6 +10061,33 @@ runInEachFileSystem((os: string) => {
         // Similar to the above, but for an attribute binding (host attributes are
         // represented via `ɵɵattribute`).
         expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateAttribute)');
+      });
+
+      it('should generate a validator fn for credentialless host bindings on a directive', () => {
+        env.write(
+          'test.ts',
+          `
+              import {Directive} from '@angular/core';
+
+              @Directive({
+                selector: 'iframe[someDir]',
+                host: {
+                  '[credentialless]': 'true',
+                  '[attr.credentialless]': "''",
+                  'src': 'http://angular.io'
+                }
+              })
+              export class SomeDir {}
+            `,
+        );
+
+        env.driveMain();
+        const jsContents = env.getContents('test.js');
+
+        expect(jsContents).toContain(
+          'ɵɵdomProperty("credentialless", true, i0.ɵɵvalidateAttribute)',
+        );
+        expect(jsContents).toContain('ɵɵattribute("credentialless", "", i0.ɵɵvalidateAttribute)');
       });
 
       it(

--- a/packages/compiler/src/schema/dom_element_schema_registry.ts
+++ b/packages/compiler/src/schema/dom_element_schema_registry.ts
@@ -123,7 +123,7 @@ export const SCHEMA: string[] = [
   'head^[HTMLElement]|',
   'h1,h2,h3,h4,h5,h6^[HTMLElement]|align',
   'html^[HTMLElement]|version',
-  'iframe^[HTMLElement]|align,allow,!allowFullscreen,!allowPaymentRequest,csp,frameBorder,height,loading,longDesc,marginHeight,marginWidth,name,referrerPolicy,%sandbox,scrolling,src,srcdoc,width',
+  'iframe^[HTMLElement]|align,allow,!allowFullscreen,!allowPaymentRequest,csp,!credentialless,frameBorder,height,loading,longDesc,marginHeight,marginWidth,name,referrerPolicy,%sandbox,scrolling,src,srcdoc,width',
   'img^[HTMLElement]|align,alt,border,%crossOrigin,decoding,#height,#hspace,!isMap,loading,longDesc,lowsrc,name,referrerPolicy,sizes,src,srcset,useMap,#vspace,#width',
   'input^[HTMLElement]|accept,align,alt,autocomplete,!checked,!defaultChecked,defaultValue,dirName,!disabled,%files,formAction,formEnctype,formMethod,!formNoValidate,formTarget,#height,!incremental,!indeterminate,max,#maxLength,min,#minLength,!multiple,name,pattern,placeholder,!readOnly,!required,selectionDirection,#selectionEnd,#selectionStart,#size,src,step,type,useMap,value,%valueAsDate,#valueAsNumber,#width',
   'li^[HTMLElement]|type,#value',

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -138,9 +138,21 @@ export function SECURITY_SCHEMA(): SecuritySchema {
         'referrerPolicy',
         'csp',
         'fetchPriority',
+        'credentialless',
       ],
     ],
-    ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
+    [
+      'iframe',
+      [
+        'sandbox',
+        'allow',
+        'allowFullscreen',
+        'referrerPolicy',
+        'csp',
+        'fetchPriority',
+        'credentialless',
+      ],
+    ],
   ]);
 
   return _SECURITY_SCHEMA;

--- a/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
+++ b/packages/compiler/test/schema/dom_element_schema_registry_spec.ts
@@ -154,6 +154,9 @@ If 'onAnything' is a directive input, make sure the directive is imported by the
     expect(registry.securityContext('a', 'href', false)).toBe(SecurityContext.URL);
     expect(registry.securityContext('a', 'style', false)).toBe(SecurityContext.STYLE);
     expect(registry.securityContext('base', 'href', false)).toBe(SecurityContext.RESOURCE_URL);
+    expect(registry.securityContext('iframe', 'credentialless', false)).toBe(
+      SecurityContext.ATTRIBUTE_NO_BINDING,
+    );
 
     // SVG animate and set attributes
     expect(registry.securityContext(':svg:animate', 'to', false)).toBe(

--- a/packages/core/src/sanitization/dom_security_schema.ts
+++ b/packages/core/src/sanitization/dom_security_schema.ts
@@ -138,9 +138,21 @@ export function SECURITY_SCHEMA(): SecuritySchema {
         'referrerPolicy',
         'csp',
         'fetchPriority',
+        'credentialless',
       ],
     ],
-    ['iframe', ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority']],
+    [
+      'iframe',
+      [
+        'sandbox',
+        'allow',
+        'allowFullscreen',
+        'referrerPolicy',
+        'csp',
+        'fetchPriority',
+        'credentialless',
+      ],
+    ],
   ]);
 
   return _SECURITY_SCHEMA;

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -294,6 +294,7 @@ const SECURITY_SENSITIVE_ELEMENTS: Record<
     'referrerpolicy': true,
     'csp': true,
     'fetchpriority': true,
+    'credentialless': true,
   },
   ':svg:animate': {
     'attributename': true,

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -123,6 +123,7 @@ describe('iframe processing', () => {
     'referrerPolicy',
     'csp',
     'fetchPriority',
+    'credentialless',
   ];
 
   const TEST_IFRAME_URL = 'https://angular.io/assets/images/logos/angular/angular.png';


### PR DESCRIPTION
Mark the iframe `credentialless` attribute as security-sensitive so dynamic
bindings are handled consistently with other iframe attributes that affect the
initial navigation, such as `sandbox`, `allow`, `referrerPolicy`, `csp`, and
`fetchPriority`.

Because `credentialless` must be present before the iframe starts loading to
affect the navigation’s credential mode, late dynamic updates can leave the final
DOM looking correct while the initial request was not loaded credentiallessly.